### PR TITLE
fix(memory): honor explicit window limit over env fallback

### DIFF
--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -235,8 +235,13 @@ mod tests {
         };
 
         for idx in 0..3 {
-            append_turn_direct("window-limit-session", "user", &format!("turn-{idx}"), &config)
-                .expect("append_turn_direct should succeed");
+            append_turn_direct(
+                "window-limit-session",
+                "user",
+                &format!("turn-{idx}"),
+                &config,
+            )
+            .expect("append_turn_direct should succeed");
         }
 
         std::env::set_var("LOONGCLAW_SLIDING_WINDOW", "1");
@@ -270,8 +275,13 @@ mod tests {
         };
 
         for idx in 0..130 {
-            append_turn_direct("window-default-session", "user", &format!("turn-{idx}"), &config)
-                .expect("append_turn_direct should succeed");
+            append_turn_direct(
+                "window-default-session",
+                "user",
+                &format!("turn-{idx}"),
+                &config,
+            )
+            .expect("append_turn_direct should succeed");
         }
 
         std::env::set_var("LOONGCLAW_SLIDING_WINDOW", "3");

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -216,4 +216,93 @@ mod tests {
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir(&tmp);
     }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn explicit_window_limit_ignores_env_default() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-test-memory-window-limit-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&tmp);
+        let db_path = tmp.join("limit-override.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+        };
+
+        for idx in 0..3 {
+            append_turn_direct("window-limit-session", "user", &format!("turn-{idx}"), &config)
+                .expect("append_turn_direct should succeed");
+        }
+
+        std::env::set_var("LOONGCLAW_SLIDING_WINDOW", "1");
+        let turns = window_direct("window-limit-session", 2, &config)
+            .expect("window_direct should honor the explicit limit");
+        std::env::remove_var("LOONGCLAW_SLIDING_WINDOW");
+
+        assert_eq!(turns.len(), 2);
+        assert_eq!(turns[0].content, "turn-1");
+        assert_eq!(turns[1].content, "turn-2");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn missing_window_limit_uses_env_default_and_caps_high_limits() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-test-memory-window-default-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&tmp);
+        let db_path = tmp.join("default-and-cap.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+        };
+
+        for idx in 0..130 {
+            append_turn_direct("window-default-session", "user", &format!("turn-{idx}"), &config)
+                .expect("append_turn_direct should succeed");
+        }
+
+        std::env::set_var("LOONGCLAW_SLIDING_WINDOW", "3");
+        let default_window = execute_memory_core_with_config(
+            MemoryCoreRequest {
+                operation: "window".to_owned(),
+                payload: json!({
+                    "session_id": "window-default-session",
+                }),
+            },
+            &config,
+        )
+        .expect("window load without explicit limit should succeed");
+        std::env::remove_var("LOONGCLAW_SLIDING_WINDOW");
+
+        let default_turns: Vec<ConversationTurn> = serde_json::from_value(
+            default_window
+                .payload
+                .get("turns")
+                .cloned()
+                .expect("turns payload should be present"),
+        )
+        .expect("turns payload should decode");
+        assert_eq!(default_turns.len(), 3);
+        assert_eq!(default_window.payload["limit"], json!(3));
+
+        let capped_turns = window_direct("window-default-session", 999, &config)
+            .expect("window_direct should clamp large limits");
+        assert_eq!(capped_turns.len(), 128);
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir(&tmp);
+    }
 }

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -80,13 +80,11 @@ pub(super) fn load_window(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "memory.window requires payload.session_id".to_owned())?;
-    let requested_limit = payload
+    let window_limit = payload
         .get("limit")
         .and_then(Value::as_u64)
-        .unwrap_or_else(default_window_size_u64)
-        .clamp(1, 128) as usize;
-    let default_window = default_window_size().max(1);
-    let window_limit = requested_limit.min(default_window);
+        .map(|limit| limit.clamp(1, 128) as usize)
+        .unwrap_or_else(default_window_size);
 
     let path = resolve_db_path(config);
     ensure_sqlite_schema(&path)?;
@@ -221,10 +219,6 @@ fn default_window_size() -> usize {
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(12)
-}
-
-fn default_window_size_u64() -> u64 {
-    default_window_size() as u64
 }
 
 fn unix_ts_now() -> i64 {


### PR DESCRIPTION
 ## Summary

  - Explicit memory window limits were being reduced by ambient `LOONGCLAW_SLIDING_WINDOW`.
  - This change makes caller-provided limits win, while keeping env/default behavior only as fallback when no limit is supplied.
  - The hard cap at `128` remains unchanged.
  - Regression tests were added for explicit-limit precedence, default fallback, and cap behavior.

  ## Scope

  - [x] Small and focused
  - [ ] Includes docs updates (if needed)
  - [x] No unrelated refactors

  ## Risk Track

  - [x] Track A (routine/low-risk)
  - [ ] Track B (higher-risk/policy-impacting)

  ## Validation

  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
  - [x] `cargo test --workspace --all-features`
  - [ ] Additional scenario/benchmark checks (if applicable)

  Additional validation run:
  - [x] `cargo test --workspace`

  ## Linked Issues
Closes #