### PR TITLE
feat(conversation): harden hybrid lane runtime core

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -26,7 +26,7 @@ use super::config::{
     ResolvedTelegramChannelConfig,
 };
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
-use super::conversation::{ConversationTurnLoop, ProviderErrorMode};
+use super::conversation::{ConversationTurnCoordinator, ProviderErrorMode};
 
 #[cfg(feature = "channel-feishu")]
 mod feishu;
@@ -694,7 +694,7 @@ pub(super) async fn process_inbound_with_provider(
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<String> {
     let session_key = message.session.session_key();
-    ConversationTurnLoop::new()
+    ConversationTurnCoordinator::new()
         .handle_turn(
             config,
             &session_key,

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -7,7 +7,7 @@ use crate::context::{bootstrap_kernel_context, DEFAULT_TOKEN_TTL_S};
 use crate::CliResult;
 
 use super::config::{self, LoongClawConfig};
-use super::conversation::{ConversationTurnLoop, ProviderErrorMode};
+use super::conversation::{ConversationTurnCoordinator, ProviderErrorMode};
 #[cfg(feature = "memory-sqlite")]
 use super::memory;
 #[cfg(feature = "memory-sqlite")]
@@ -53,7 +53,7 @@ pub async fn run_cli_chat(config_path: Option<&str>, session_hint: Option<&str>)
         .unwrap_or("default")
         .to_owned();
     println!("session={session_id} (type /help for commands, /exit to quit)");
-    let turn_loop = ConversationTurnLoop::new();
+    let turn_coordinator = ConversationTurnCoordinator::new();
 
     loop {
         print!("you> ");
@@ -93,7 +93,7 @@ pub async fn run_cli_chat(config_path: Option<&str>, session_hint: Option<&str>)
             continue;
         }
 
-        let assistant_text = turn_loop
+        let assistant_text = turn_coordinator
             .handle_turn(
                 &config,
                 &session_id,

--- a/crates/app/src/config/conversation.rs
+++ b/crates/app/src/config/conversation.rs
@@ -474,14 +474,16 @@ mod tests {
 
     #[test]
     fn session_governor_trend_parameters_are_clamped_to_valid_ranges() {
-        let mut config = ConversationConfig::default();
-        config.safe_lane_session_governor_trend_min_samples = 0;
-        config.safe_lane_session_governor_trend_ewma_alpha = f64::NAN;
-        config.safe_lane_session_governor_trend_failure_ewma_threshold = 2.0;
-        config.safe_lane_session_governor_trend_backpressure_ewma_threshold = -1.0;
-        config.safe_lane_session_governor_recovery_success_streak = 0;
-        config.safe_lane_session_governor_recovery_max_failure_ewma = -3.0;
-        config.safe_lane_session_governor_recovery_max_backpressure_ewma = 4.0;
+        let config = ConversationConfig {
+            safe_lane_session_governor_trend_min_samples: 0,
+            safe_lane_session_governor_trend_ewma_alpha: f64::NAN,
+            safe_lane_session_governor_trend_failure_ewma_threshold: 2.0,
+            safe_lane_session_governor_trend_backpressure_ewma_threshold: -1.0,
+            safe_lane_session_governor_recovery_success_streak: 0,
+            safe_lane_session_governor_recovery_max_failure_ewma: -3.0,
+            safe_lane_session_governor_recovery_max_backpressure_ewma: 4.0,
+            ..ConversationConfig::default()
+        };
 
         assert_eq!(config.safe_lane_session_governor_trend_min_samples(), 1);
         assert_eq!(
@@ -512,8 +514,10 @@ mod tests {
 
     #[test]
     fn session_governor_trend_alpha_uses_open_interval_floor() {
-        let mut config = ConversationConfig::default();
-        config.safe_lane_session_governor_trend_ewma_alpha = 0.0;
+        let config = ConversationConfig {
+            safe_lane_session_governor_trend_ewma_alpha: 0.0,
+            ..ConversationConfig::default()
+        };
 
         assert_eq!(config.safe_lane_session_governor_trend_ewma_alpha(), 0.01);
     }

--- a/crates/app/src/config/conversation.rs
+++ b/crates/app/src/config/conversation.rs
@@ -1,0 +1,520 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationConfig {
+    #[serde(default)]
+    pub turn_loop: ConversationTurnLoopConfig,
+    #[serde(default = "default_true")]
+    pub hybrid_lane_enabled: bool,
+    #[serde(default)]
+    pub safe_lane_plan_execution_enabled: bool,
+    #[serde(default = "default_fast_lane_max_tool_steps_per_turn")]
+    pub fast_lane_max_tool_steps_per_turn: usize,
+    #[serde(default = "default_safe_lane_max_tool_steps_per_turn")]
+    pub safe_lane_max_tool_steps_per_turn: usize,
+    #[serde(default = "default_safe_lane_node_max_attempts")]
+    pub safe_lane_node_max_attempts: u8,
+    #[serde(default = "default_safe_lane_plan_max_wall_time_ms")]
+    pub safe_lane_plan_max_wall_time_ms: u64,
+    #[serde(default = "default_true")]
+    pub safe_lane_verify_output_non_empty: bool,
+    #[serde(default = "default_safe_lane_verify_min_output_chars")]
+    pub safe_lane_verify_min_output_chars: usize,
+    #[serde(default = "default_true")]
+    pub safe_lane_verify_require_status_prefix: bool,
+    #[serde(default = "default_true")]
+    pub safe_lane_verify_adaptive_anchor_escalation: bool,
+    #[serde(default = "default_safe_lane_verify_anchor_escalation_after_failures")]
+    pub safe_lane_verify_anchor_escalation_after_failures: u32,
+    #[serde(default = "default_safe_lane_verify_anchor_escalation_min_matches")]
+    pub safe_lane_verify_anchor_escalation_min_matches: usize,
+    #[serde(default = "default_true")]
+    pub safe_lane_emit_runtime_events: bool,
+    #[serde(default = "default_safe_lane_event_sample_every")]
+    pub safe_lane_event_sample_every: u32,
+    #[serde(default = "default_true")]
+    pub safe_lane_event_adaptive_sampling: bool,
+    #[serde(default = "default_safe_lane_event_adaptive_failure_threshold")]
+    pub safe_lane_event_adaptive_failure_threshold: u32,
+    #[serde(default = "default_safe_lane_verify_deny_markers")]
+    pub safe_lane_verify_deny_markers: Vec<String>,
+    #[serde(default = "default_safe_lane_replan_max_rounds")]
+    pub safe_lane_replan_max_rounds: u8,
+    #[serde(default = "default_safe_lane_replan_max_node_attempts")]
+    pub safe_lane_replan_max_node_attempts: u8,
+    #[serde(default = "default_true")]
+    pub safe_lane_session_governor_enabled: bool,
+    #[serde(default = "default_safe_lane_session_governor_window_turns")]
+    pub safe_lane_session_governor_window_turns: usize,
+    #[serde(default = "default_safe_lane_session_governor_failed_final_status_threshold")]
+    pub safe_lane_session_governor_failed_final_status_threshold: u32,
+    #[serde(default = "default_safe_lane_session_governor_backpressure_failure_threshold")]
+    pub safe_lane_session_governor_backpressure_failure_threshold: u32,
+    #[serde(default = "default_true")]
+    pub safe_lane_session_governor_trend_enabled: bool,
+    #[serde(default = "default_safe_lane_session_governor_trend_min_samples")]
+    pub safe_lane_session_governor_trend_min_samples: usize,
+    #[serde(default = "default_safe_lane_session_governor_trend_ewma_alpha")]
+    pub safe_lane_session_governor_trend_ewma_alpha: f64,
+    #[serde(default = "default_safe_lane_session_governor_trend_failure_ewma_threshold")]
+    pub safe_lane_session_governor_trend_failure_ewma_threshold: f64,
+    #[serde(default = "default_safe_lane_session_governor_trend_backpressure_ewma_threshold")]
+    pub safe_lane_session_governor_trend_backpressure_ewma_threshold: f64,
+    #[serde(default = "default_safe_lane_session_governor_recovery_success_streak")]
+    pub safe_lane_session_governor_recovery_success_streak: u32,
+    #[serde(default = "default_safe_lane_session_governor_recovery_max_failure_ewma")]
+    pub safe_lane_session_governor_recovery_max_failure_ewma: f64,
+    #[serde(default = "default_safe_lane_session_governor_recovery_max_backpressure_ewma")]
+    pub safe_lane_session_governor_recovery_max_backpressure_ewma: f64,
+    #[serde(default = "default_true")]
+    pub safe_lane_session_governor_force_no_replan: bool,
+    #[serde(default = "default_safe_lane_session_governor_force_node_max_attempts")]
+    pub safe_lane_session_governor_force_node_max_attempts: u8,
+    #[serde(default = "default_true")]
+    pub safe_lane_backpressure_guard_enabled: bool,
+    #[serde(default = "default_safe_lane_backpressure_max_total_attempts")]
+    pub safe_lane_backpressure_max_total_attempts: u64,
+    #[serde(default = "default_safe_lane_backpressure_max_replans")]
+    pub safe_lane_backpressure_max_replans: u32,
+    #[serde(default = "default_safe_lane_risk_threshold")]
+    pub safe_lane_risk_threshold: u32,
+    #[serde(default = "default_safe_lane_complexity_threshold")]
+    pub safe_lane_complexity_threshold: u32,
+    #[serde(default = "default_fast_lane_max_input_chars")]
+    pub fast_lane_max_input_chars: usize,
+    #[serde(default = "default_high_risk_keywords")]
+    pub high_risk_keywords: Vec<String>,
+}
+
+impl Default for ConversationConfig {
+    fn default() -> Self {
+        Self {
+            turn_loop: ConversationTurnLoopConfig::default(),
+            hybrid_lane_enabled: default_true(),
+            safe_lane_plan_execution_enabled: false,
+            fast_lane_max_tool_steps_per_turn: default_fast_lane_max_tool_steps_per_turn(),
+            safe_lane_max_tool_steps_per_turn: default_safe_lane_max_tool_steps_per_turn(),
+            safe_lane_node_max_attempts: default_safe_lane_node_max_attempts(),
+            safe_lane_plan_max_wall_time_ms: default_safe_lane_plan_max_wall_time_ms(),
+            safe_lane_verify_output_non_empty: default_true(),
+            safe_lane_verify_min_output_chars: default_safe_lane_verify_min_output_chars(),
+            safe_lane_verify_require_status_prefix: default_true(),
+            safe_lane_verify_adaptive_anchor_escalation: default_true(),
+            safe_lane_verify_anchor_escalation_after_failures:
+                default_safe_lane_verify_anchor_escalation_after_failures(),
+            safe_lane_verify_anchor_escalation_min_matches:
+                default_safe_lane_verify_anchor_escalation_min_matches(),
+            safe_lane_emit_runtime_events: default_true(),
+            safe_lane_event_sample_every: default_safe_lane_event_sample_every(),
+            safe_lane_event_adaptive_sampling: default_true(),
+            safe_lane_event_adaptive_failure_threshold:
+                default_safe_lane_event_adaptive_failure_threshold(),
+            safe_lane_verify_deny_markers: default_safe_lane_verify_deny_markers(),
+            safe_lane_replan_max_rounds: default_safe_lane_replan_max_rounds(),
+            safe_lane_replan_max_node_attempts: default_safe_lane_replan_max_node_attempts(),
+            safe_lane_session_governor_enabled: default_true(),
+            safe_lane_session_governor_window_turns:
+                default_safe_lane_session_governor_window_turns(),
+            safe_lane_session_governor_failed_final_status_threshold:
+                default_safe_lane_session_governor_failed_final_status_threshold(),
+            safe_lane_session_governor_backpressure_failure_threshold:
+                default_safe_lane_session_governor_backpressure_failure_threshold(),
+            safe_lane_session_governor_trend_enabled: default_true(),
+            safe_lane_session_governor_trend_min_samples:
+                default_safe_lane_session_governor_trend_min_samples(),
+            safe_lane_session_governor_trend_ewma_alpha:
+                default_safe_lane_session_governor_trend_ewma_alpha(),
+            safe_lane_session_governor_trend_failure_ewma_threshold:
+                default_safe_lane_session_governor_trend_failure_ewma_threshold(),
+            safe_lane_session_governor_trend_backpressure_ewma_threshold:
+                default_safe_lane_session_governor_trend_backpressure_ewma_threshold(),
+            safe_lane_session_governor_recovery_success_streak:
+                default_safe_lane_session_governor_recovery_success_streak(),
+            safe_lane_session_governor_recovery_max_failure_ewma:
+                default_safe_lane_session_governor_recovery_max_failure_ewma(),
+            safe_lane_session_governor_recovery_max_backpressure_ewma:
+                default_safe_lane_session_governor_recovery_max_backpressure_ewma(),
+            safe_lane_session_governor_force_no_replan: default_true(),
+            safe_lane_session_governor_force_node_max_attempts:
+                default_safe_lane_session_governor_force_node_max_attempts(),
+            safe_lane_backpressure_guard_enabled: default_true(),
+            safe_lane_backpressure_max_total_attempts:
+                default_safe_lane_backpressure_max_total_attempts(),
+            safe_lane_backpressure_max_replans: default_safe_lane_backpressure_max_replans(),
+            safe_lane_risk_threshold: default_safe_lane_risk_threshold(),
+            safe_lane_complexity_threshold: default_safe_lane_complexity_threshold(),
+            fast_lane_max_input_chars: default_fast_lane_max_input_chars(),
+            high_risk_keywords: default_high_risk_keywords(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationTurnLoopConfig {
+    #[serde(default = "default_turn_loop_max_rounds")]
+    pub max_rounds: usize,
+    #[serde(default = "default_turn_loop_max_tool_steps_per_round")]
+    pub max_tool_steps_per_round: usize,
+    #[serde(default = "default_turn_loop_max_repeated_tool_call_rounds")]
+    pub max_repeated_tool_call_rounds: usize,
+    #[serde(default = "default_turn_loop_max_ping_pong_cycles")]
+    pub max_ping_pong_cycles: usize,
+    #[serde(default = "default_turn_loop_max_same_tool_failure_rounds")]
+    pub max_same_tool_failure_rounds: usize,
+    #[serde(default = "default_turn_loop_max_followup_tool_payload_chars")]
+    pub max_followup_tool_payload_chars: usize,
+    #[serde(default = "default_turn_loop_max_followup_tool_payload_chars_total")]
+    pub max_followup_tool_payload_chars_total: usize,
+}
+
+impl Default for ConversationTurnLoopConfig {
+    fn default() -> Self {
+        Self {
+            max_rounds: default_turn_loop_max_rounds(),
+            max_tool_steps_per_round: default_turn_loop_max_tool_steps_per_round(),
+            max_repeated_tool_call_rounds: default_turn_loop_max_repeated_tool_call_rounds(),
+            max_ping_pong_cycles: default_turn_loop_max_ping_pong_cycles(),
+            max_same_tool_failure_rounds: default_turn_loop_max_same_tool_failure_rounds(),
+            max_followup_tool_payload_chars: default_turn_loop_max_followup_tool_payload_chars(),
+            max_followup_tool_payload_chars_total:
+                default_turn_loop_max_followup_tool_payload_chars_total(),
+        }
+    }
+}
+
+impl ConversationConfig {
+    pub fn normalized_high_risk_keywords(&self) -> Vec<String> {
+        self.high_risk_keywords
+            .iter()
+            .map(|keyword| keyword.trim().to_ascii_lowercase())
+            .filter(|keyword| !keyword.is_empty())
+            .collect()
+    }
+
+    pub fn fast_lane_max_tool_steps(&self) -> usize {
+        self.fast_lane_max_tool_steps_per_turn.max(1)
+    }
+
+    pub fn safe_lane_max_tool_steps(&self) -> usize {
+        self.safe_lane_max_tool_steps_per_turn.max(1)
+    }
+
+    pub fn safe_lane_event_sample_every(&self) -> u32 {
+        self.safe_lane_event_sample_every.max(1)
+    }
+
+    pub fn safe_lane_event_adaptive_failure_threshold(&self) -> u32 {
+        self.safe_lane_event_adaptive_failure_threshold.max(1)
+    }
+
+    pub fn safe_lane_verify_anchor_escalation_after_failures(&self) -> u32 {
+        self.safe_lane_verify_anchor_escalation_after_failures
+            .max(1)
+    }
+
+    pub fn safe_lane_verify_anchor_escalation_min_matches(&self) -> usize {
+        self.safe_lane_verify_anchor_escalation_min_matches.max(1)
+    }
+
+    pub fn safe_lane_backpressure_max_total_attempts(&self) -> u64 {
+        self.safe_lane_backpressure_max_total_attempts.max(1)
+    }
+
+    pub fn safe_lane_backpressure_max_replans(&self) -> u32 {
+        self.safe_lane_backpressure_max_replans.max(1)
+    }
+
+    pub fn safe_lane_session_governor_window_turns(&self) -> usize {
+        self.safe_lane_session_governor_window_turns.max(1)
+    }
+
+    pub fn safe_lane_session_governor_failed_final_status_threshold(&self) -> u32 {
+        self.safe_lane_session_governor_failed_final_status_threshold
+            .max(1)
+    }
+
+    pub fn safe_lane_session_governor_backpressure_failure_threshold(&self) -> u32 {
+        self.safe_lane_session_governor_backpressure_failure_threshold
+            .max(1)
+    }
+
+    pub fn safe_lane_session_governor_trend_min_samples(&self) -> usize {
+        self.safe_lane_session_governor_trend_min_samples.max(1)
+    }
+
+    pub fn safe_lane_session_governor_trend_ewma_alpha(&self) -> f64 {
+        clamp_open_unit_interval(
+            self.safe_lane_session_governor_trend_ewma_alpha,
+            default_safe_lane_session_governor_trend_ewma_alpha(),
+        )
+    }
+
+    pub fn safe_lane_session_governor_trend_failure_ewma_threshold(&self) -> f64 {
+        clamp_unit_interval(
+            self.safe_lane_session_governor_trend_failure_ewma_threshold,
+            default_safe_lane_session_governor_trend_failure_ewma_threshold(),
+        )
+    }
+
+    pub fn safe_lane_session_governor_trend_backpressure_ewma_threshold(&self) -> f64 {
+        clamp_unit_interval(
+            self.safe_lane_session_governor_trend_backpressure_ewma_threshold,
+            default_safe_lane_session_governor_trend_backpressure_ewma_threshold(),
+        )
+    }
+
+    pub fn safe_lane_session_governor_recovery_success_streak(&self) -> u32 {
+        self.safe_lane_session_governor_recovery_success_streak
+            .max(1)
+    }
+
+    pub fn safe_lane_session_governor_recovery_max_failure_ewma(&self) -> f64 {
+        clamp_unit_interval(
+            self.safe_lane_session_governor_recovery_max_failure_ewma,
+            default_safe_lane_session_governor_recovery_max_failure_ewma(),
+        )
+    }
+
+    pub fn safe_lane_session_governor_recovery_max_backpressure_ewma(&self) -> f64 {
+        clamp_unit_interval(
+            self.safe_lane_session_governor_recovery_max_backpressure_ewma,
+            default_safe_lane_session_governor_recovery_max_backpressure_ewma(),
+        )
+    }
+
+    pub fn safe_lane_session_governor_force_node_max_attempts(&self) -> u8 {
+        self.safe_lane_session_governor_force_node_max_attempts
+            .max(1)
+    }
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+const fn default_turn_loop_max_rounds() -> usize {
+    4
+}
+
+const fn default_turn_loop_max_tool_steps_per_round() -> usize {
+    1
+}
+
+const fn default_turn_loop_max_repeated_tool_call_rounds() -> usize {
+    2
+}
+
+const fn default_turn_loop_max_ping_pong_cycles() -> usize {
+    2
+}
+
+const fn default_turn_loop_max_same_tool_failure_rounds() -> usize {
+    3
+}
+
+const fn default_turn_loop_max_followup_tool_payload_chars() -> usize {
+    8_000
+}
+
+const fn default_turn_loop_max_followup_tool_payload_chars_total() -> usize {
+    20_000
+}
+
+const fn default_fast_lane_max_tool_steps_per_turn() -> usize {
+    1
+}
+
+const fn default_safe_lane_max_tool_steps_per_turn() -> usize {
+    1
+}
+
+const fn default_safe_lane_node_max_attempts() -> u8 {
+    2
+}
+
+const fn default_safe_lane_plan_max_wall_time_ms() -> u64 {
+    30_000
+}
+
+const fn default_safe_lane_verify_min_output_chars() -> usize {
+    8
+}
+
+const fn default_safe_lane_verify_anchor_escalation_after_failures() -> u32 {
+    2
+}
+
+const fn default_safe_lane_verify_anchor_escalation_min_matches() -> usize {
+    1
+}
+
+const fn default_safe_lane_replan_max_rounds() -> u8 {
+    1
+}
+
+const fn default_safe_lane_replan_max_node_attempts() -> u8 {
+    4
+}
+
+const fn default_safe_lane_session_governor_window_turns() -> usize {
+    96
+}
+
+const fn default_safe_lane_session_governor_failed_final_status_threshold() -> u32 {
+    3
+}
+
+const fn default_safe_lane_session_governor_backpressure_failure_threshold() -> u32 {
+    1
+}
+
+const fn default_safe_lane_session_governor_trend_min_samples() -> usize {
+    4
+}
+
+const fn default_safe_lane_session_governor_trend_ewma_alpha() -> f64 {
+    0.35
+}
+
+const fn default_safe_lane_session_governor_trend_failure_ewma_threshold() -> f64 {
+    0.60
+}
+
+const fn default_safe_lane_session_governor_trend_backpressure_ewma_threshold() -> f64 {
+    0.20
+}
+
+const fn default_safe_lane_session_governor_recovery_success_streak() -> u32 {
+    3
+}
+
+const fn default_safe_lane_session_governor_recovery_max_failure_ewma() -> f64 {
+    0.25
+}
+
+const fn default_safe_lane_session_governor_recovery_max_backpressure_ewma() -> f64 {
+    0.10
+}
+
+const fn default_safe_lane_session_governor_force_node_max_attempts() -> u8 {
+    1
+}
+
+const fn default_safe_lane_event_sample_every() -> u32 {
+    1
+}
+
+const fn default_safe_lane_event_adaptive_failure_threshold() -> u32 {
+    1
+}
+
+const fn default_safe_lane_backpressure_max_total_attempts() -> u64 {
+    32
+}
+
+const fn default_safe_lane_backpressure_max_replans() -> u32 {
+    8
+}
+
+const fn default_safe_lane_risk_threshold() -> u32 {
+    4
+}
+
+const fn default_safe_lane_complexity_threshold() -> u32 {
+    6
+}
+
+const fn default_fast_lane_max_input_chars() -> usize {
+    400
+}
+
+fn default_high_risk_keywords() -> Vec<String> {
+    [
+        "rm -rf",
+        "drop table",
+        "delete",
+        "credential",
+        "token",
+        "secret",
+        "prod",
+        "production",
+        "deploy",
+        "payment",
+        "wallet",
+    ]
+    .iter()
+    .map(|keyword| (*keyword).to_owned())
+    .collect()
+}
+
+fn default_safe_lane_verify_deny_markers() -> Vec<String> {
+    vec![
+        "tool_failure".to_owned(),
+        "provider_error".to_owned(),
+        "no_kernel_context".to_owned(),
+        "tool_not_found".to_owned(),
+    ]
+}
+
+fn clamp_unit_interval(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() {
+        value.clamp(0.0, 1.0)
+    } else {
+        fallback
+    }
+}
+
+fn clamp_open_unit_interval(value: f64, fallback: f64) -> f64 {
+    clamp_unit_interval(value, fallback).max(0.01)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_governor_trend_parameters_are_clamped_to_valid_ranges() {
+        let mut config = ConversationConfig::default();
+        config.safe_lane_session_governor_trend_min_samples = 0;
+        config.safe_lane_session_governor_trend_ewma_alpha = f64::NAN;
+        config.safe_lane_session_governor_trend_failure_ewma_threshold = 2.0;
+        config.safe_lane_session_governor_trend_backpressure_ewma_threshold = -1.0;
+        config.safe_lane_session_governor_recovery_success_streak = 0;
+        config.safe_lane_session_governor_recovery_max_failure_ewma = -3.0;
+        config.safe_lane_session_governor_recovery_max_backpressure_ewma = 4.0;
+
+        assert_eq!(config.safe_lane_session_governor_trend_min_samples(), 1);
+        assert_eq!(
+            config.safe_lane_session_governor_trend_ewma_alpha(),
+            default_safe_lane_session_governor_trend_ewma_alpha()
+        );
+        assert_eq!(
+            config.safe_lane_session_governor_trend_failure_ewma_threshold(),
+            1.0
+        );
+        assert_eq!(
+            config.safe_lane_session_governor_trend_backpressure_ewma_threshold(),
+            0.0
+        );
+        assert_eq!(
+            config.safe_lane_session_governor_recovery_success_streak(),
+            1
+        );
+        assert_eq!(
+            config.safe_lane_session_governor_recovery_max_failure_ewma(),
+            0.0
+        );
+        assert_eq!(
+            config.safe_lane_session_governor_recovery_max_backpressure_ewma(),
+            1.0
+        );
+    }
+
+    #[test]
+    fn session_governor_trend_alpha_uses_open_interval_floor() {
+        let mut config = ConversationConfig::default();
+        config.safe_lane_session_governor_trend_ewma_alpha = 0.0;
+
+        assert_eq!(config.safe_lane_session_governor_trend_ewma_alpha(), 0.01);
+    }
+}

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod channels;
+mod conversation;
 mod provider;
 mod runtime;
 mod shared;
@@ -12,12 +13,14 @@ pub use channels::{
     TelegramAccountConfig, TelegramChannelConfig,
 };
 #[allow(unused_imports)]
+pub use conversation::{ConversationConfig, ConversationTurnLoopConfig};
+#[allow(unused_imports)]
 pub use provider::{ProviderConfig, ProviderKind, ReasoningEffort};
 #[allow(unused_imports)]
 pub use runtime::{
     default_config_path, default_loongclaw_home, load, normalize_validation_locale,
     supported_validation_locales, validate_file, validate_file_with_locale, write, write_template,
-    ConfigValidationDiagnostic, ConversationConfig, ConversationTurnLoopConfig, LoongClawConfig,
+    ConfigValidationDiagnostic, LoongClawConfig,
 };
 #[allow(unused_imports)]
 pub use shared::expand_path;
@@ -754,6 +757,75 @@ max_followup_tool_payload_chars_total = 3200
                 .max_followup_tool_payload_chars_total,
             3200
         );
+    }
+
+    #[test]
+    fn conversation_defaults_are_stable() {
+        let config = ConversationConfig::default();
+        assert!(config.hybrid_lane_enabled);
+        assert!(!config.safe_lane_plan_execution_enabled);
+        assert_eq!(config.fast_lane_max_tool_steps_per_turn, 1);
+        assert_eq!(config.safe_lane_max_tool_steps_per_turn, 1);
+        assert_eq!(config.safe_lane_node_max_attempts, 2);
+        assert_eq!(config.safe_lane_plan_max_wall_time_ms, 30_000);
+        assert!(config.safe_lane_verify_output_non_empty);
+        assert_eq!(config.safe_lane_verify_min_output_chars, 8);
+        assert!(config.safe_lane_verify_require_status_prefix);
+        assert!(config.safe_lane_verify_adaptive_anchor_escalation);
+        assert_eq!(config.safe_lane_verify_anchor_escalation_after_failures, 2);
+        assert_eq!(config.safe_lane_verify_anchor_escalation_min_matches, 1);
+        assert!(config.safe_lane_emit_runtime_events);
+        assert_eq!(config.safe_lane_event_sample_every, 1);
+        assert!(config.safe_lane_event_adaptive_sampling);
+        assert_eq!(config.safe_lane_event_adaptive_failure_threshold, 1);
+        assert!(config
+            .safe_lane_verify_deny_markers
+            .iter()
+            .any(|marker| marker == "tool_failure"));
+        assert_eq!(config.safe_lane_replan_max_rounds, 1);
+        assert_eq!(config.safe_lane_replan_max_node_attempts, 4);
+        assert!(config.safe_lane_session_governor_enabled);
+        assert_eq!(config.safe_lane_session_governor_window_turns, 96);
+        assert_eq!(
+            config.safe_lane_session_governor_failed_final_status_threshold,
+            3
+        );
+        assert_eq!(
+            config.safe_lane_session_governor_backpressure_failure_threshold,
+            1
+        );
+        assert!(config.safe_lane_session_governor_trend_enabled);
+        assert_eq!(config.safe_lane_session_governor_trend_min_samples, 4);
+        assert_eq!(config.safe_lane_session_governor_trend_ewma_alpha, 0.35);
+        assert_eq!(
+            config.safe_lane_session_governor_trend_failure_ewma_threshold,
+            0.60
+        );
+        assert_eq!(
+            config.safe_lane_session_governor_trend_backpressure_ewma_threshold,
+            0.20
+        );
+        assert_eq!(config.safe_lane_session_governor_recovery_success_streak, 3);
+        assert_eq!(
+            config.safe_lane_session_governor_recovery_max_failure_ewma,
+            0.25
+        );
+        assert_eq!(
+            config.safe_lane_session_governor_recovery_max_backpressure_ewma,
+            0.10
+        );
+        assert!(config.safe_lane_session_governor_force_no_replan);
+        assert_eq!(config.safe_lane_session_governor_force_node_max_attempts, 1);
+        assert!(config.safe_lane_backpressure_guard_enabled);
+        assert_eq!(config.safe_lane_backpressure_max_total_attempts, 32);
+        assert_eq!(config.safe_lane_backpressure_max_replans, 8);
+        assert_eq!(config.safe_lane_risk_threshold, 4);
+        assert_eq!(config.safe_lane_complexity_threshold, 6);
+        assert_eq!(config.fast_lane_max_input_chars, 400);
+        assert!(config
+            .high_risk_keywords
+            .iter()
+            .any(|keyword| keyword == "production"));
     }
 
     #[test]

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -6,6 +6,7 @@ use crate::CliResult;
 
 use super::{
     channels::{CliChannelConfig, FeishuChannelConfig, TelegramChannelConfig},
+    conversation::ConversationConfig,
     provider::ProviderConfig,
     shared::{
         default_loongclaw_home as shared_default_loongclaw_home, expand_path,
@@ -62,50 +63,11 @@ pub struct LoongClawConfig {
     #[serde(default)]
     pub feishu: FeishuChannelConfig,
     #[serde(default)]
+    pub conversation: ConversationConfig,
+    #[serde(default)]
     pub tools: ToolConfig,
     #[serde(default)]
     pub memory: MemoryConfig,
-    #[serde(default)]
-    pub conversation: ConversationConfig,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct ConversationConfig {
-    #[serde(default)]
-    pub turn_loop: ConversationTurnLoopConfig,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConversationTurnLoopConfig {
-    #[serde(default = "default_turn_loop_max_rounds")]
-    pub max_rounds: usize,
-    #[serde(default = "default_turn_loop_max_tool_steps_per_round")]
-    pub max_tool_steps_per_round: usize,
-    #[serde(default = "default_turn_loop_max_repeated_tool_call_rounds")]
-    pub max_repeated_tool_call_rounds: usize,
-    #[serde(default = "default_turn_loop_max_ping_pong_cycles")]
-    pub max_ping_pong_cycles: usize,
-    #[serde(default = "default_turn_loop_max_same_tool_failure_rounds")]
-    pub max_same_tool_failure_rounds: usize,
-    #[serde(default = "default_turn_loop_max_followup_tool_payload_chars")]
-    pub max_followup_tool_payload_chars: usize,
-    #[serde(default = "default_turn_loop_max_followup_tool_payload_chars_total")]
-    pub max_followup_tool_payload_chars_total: usize,
-}
-
-impl Default for ConversationTurnLoopConfig {
-    fn default() -> Self {
-        Self {
-            max_rounds: default_turn_loop_max_rounds(),
-            max_tool_steps_per_round: default_turn_loop_max_tool_steps_per_round(),
-            max_repeated_tool_call_rounds: default_turn_loop_max_repeated_tool_call_rounds(),
-            max_ping_pong_cycles: default_turn_loop_max_ping_pong_cycles(),
-            max_same_tool_failure_rounds: default_turn_loop_max_same_tool_failure_rounds(),
-            max_followup_tool_payload_chars: default_turn_loop_max_followup_tool_payload_chars(),
-            max_followup_tool_payload_chars_total:
-                default_turn_loop_max_followup_tool_payload_chars_total(),
-        }
-    }
 }
 
 impl LoongClawConfig {
@@ -279,34 +241,6 @@ fn encode_toml_config(config: &LoongClawConfig) -> CliResult<String> {
 #[cfg(not(feature = "config-toml"))]
 fn encode_toml_config(_config: &LoongClawConfig) -> CliResult<String> {
     Err("config-toml feature is disabled for this build".to_owned())
-}
-
-const fn default_turn_loop_max_rounds() -> usize {
-    4
-}
-
-const fn default_turn_loop_max_tool_steps_per_round() -> usize {
-    1
-}
-
-const fn default_turn_loop_max_repeated_tool_call_rounds() -> usize {
-    2
-}
-
-const fn default_turn_loop_max_ping_pong_cycles() -> usize {
-    2
-}
-
-const fn default_turn_loop_max_same_tool_failure_rounds() -> usize {
-    3
-}
-
-const fn default_turn_loop_max_followup_tool_payload_chars() -> usize {
-    8_000
-}
-
-const fn default_turn_loop_max_followup_tool_payload_chars_total() -> usize {
-    20_000
 }
 
 fn template_secret_usage_comment() -> &'static str {

--- a/crates/app/src/conversation/analytics.rs
+++ b/crates/app/src/conversation/analytics.rs
@@ -1,0 +1,583 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SafeLaneFinalStatus {
+    Succeeded,
+    Failed,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SafeLaneMetricsSnapshot {
+    pub rounds_started: u32,
+    pub rounds_succeeded: u32,
+    pub rounds_failed: u32,
+    pub verify_failures: u32,
+    pub replans_triggered: u32,
+    pub total_attempts_used: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SafeLaneEventSummary {
+    pub lane_selected_events: u32,
+    pub round_started_events: u32,
+    pub round_completed_succeeded_events: u32,
+    pub round_completed_failed_events: u32,
+    pub verify_failed_events: u32,
+    pub verify_policy_adjusted_events: u32,
+    pub replan_triggered_events: u32,
+    pub final_status_events: u32,
+    pub session_governor_engaged_events: u32,
+    pub session_governor_force_no_replan_events: u32,
+    pub session_governor_failed_threshold_triggered_events: u32,
+    pub session_governor_backpressure_threshold_triggered_events: u32,
+    pub session_governor_trend_threshold_triggered_events: u32,
+    pub session_governor_recovery_threshold_triggered_events: u32,
+    pub session_governor_metrics_snapshots_seen: u32,
+    pub session_governor_latest_trend_samples: Option<u32>,
+    pub session_governor_latest_trend_min_samples: Option<u32>,
+    pub session_governor_latest_trend_failure_ewma_milli: Option<u32>,
+    pub session_governor_latest_trend_backpressure_ewma_milli: Option<u32>,
+    pub session_governor_latest_recovery_success_streak: Option<u32>,
+    pub session_governor_latest_recovery_success_streak_threshold: Option<u32>,
+    pub final_status: Option<SafeLaneFinalStatus>,
+    pub final_failure_code: Option<String>,
+    pub final_route_decision: Option<String>,
+    pub final_route_reason: Option<String>,
+    pub latest_metrics: Option<SafeLaneMetricsSnapshot>,
+    pub metrics_snapshots_seen: u32,
+    pub route_decision_counts: BTreeMap<String, u32>,
+    pub route_reason_counts: BTreeMap<String, u32>,
+    pub failure_code_counts: BTreeMap<String, u32>,
+    pub final_status_counts: BTreeMap<String, u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversationEventRecord {
+    pub event: String,
+    pub payload: Value,
+}
+
+pub fn parse_conversation_event(content: &str) -> Option<ConversationEventRecord> {
+    let parsed = serde_json::from_str::<Value>(content).ok()?;
+    if parsed.get("type")?.as_str()? != "conversation_event" {
+        return None;
+    }
+    let event = parsed.get("event")?.as_str()?.to_owned();
+    let payload = parsed.get("payload").cloned().unwrap_or(Value::Null);
+    Some(ConversationEventRecord { event, payload })
+}
+
+pub fn summarize_safe_lane_events<'a, I>(contents: I) -> SafeLaneEventSummary
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut summary = SafeLaneEventSummary::default();
+
+    for content in contents {
+        let Some(record) = parse_conversation_event(content) else {
+            continue;
+        };
+        if !is_safe_lane_event_name(record.event.as_str()) {
+            continue;
+        }
+
+        match record.event.as_str() {
+            "lane_selected" => {
+                summary.lane_selected_events = summary.lane_selected_events.saturating_add(1);
+            }
+            "plan_round_started" => {
+                summary.round_started_events = summary.round_started_events.saturating_add(1);
+            }
+            "plan_round_completed" => {
+                let is_succeeded = record
+                    .payload
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .map(|status| status == "succeeded")
+                    .unwrap_or(false);
+                if is_succeeded {
+                    summary.round_completed_succeeded_events =
+                        summary.round_completed_succeeded_events.saturating_add(1);
+                } else {
+                    summary.round_completed_failed_events =
+                        summary.round_completed_failed_events.saturating_add(1);
+                }
+            }
+            "verify_failed" => {
+                summary.verify_failed_events = summary.verify_failed_events.saturating_add(1);
+            }
+            "verify_policy_adjusted" => {
+                summary.verify_policy_adjusted_events =
+                    summary.verify_policy_adjusted_events.saturating_add(1);
+            }
+            "replan_triggered" => {
+                summary.replan_triggered_events = summary.replan_triggered_events.saturating_add(1);
+            }
+            "final_status" => {
+                summary.final_status_events = summary.final_status_events.saturating_add(1);
+                match record.payload.get("status").and_then(Value::as_str) {
+                    Some("succeeded") => {
+                        summary.final_status = Some(SafeLaneFinalStatus::Succeeded);
+                        bump_count(&mut summary.final_status_counts, "succeeded");
+                    }
+                    Some("failed") => {
+                        summary.final_status = Some(SafeLaneFinalStatus::Failed);
+                        bump_count(&mut summary.final_status_counts, "failed");
+                    }
+                    _ => {}
+                }
+                summary.final_failure_code = record
+                    .payload
+                    .get("failure_code")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned);
+                summary.final_route_decision = record
+                    .payload
+                    .get("route_decision")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned);
+                summary.final_route_reason = record
+                    .payload
+                    .get("route_reason")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned);
+            }
+            _ => {}
+        }
+
+        if let Some(route_decision) = record
+            .payload
+            .get("route_decision")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+        {
+            bump_count(&mut summary.route_decision_counts, route_decision);
+        }
+        if let Some(failure_code) = record
+            .payload
+            .get("failure_code")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+        {
+            bump_count(&mut summary.failure_code_counts, failure_code);
+        }
+        if let Some(route_reason) = record
+            .payload
+            .get("route_reason")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+        {
+            bump_count(&mut summary.route_reason_counts, route_reason);
+        }
+        fold_session_governor_summary(record.payload.get("session_governor"), &mut summary);
+
+        if let Some(metrics) = parse_metrics_snapshot(record.payload.get("metrics")) {
+            summary.metrics_snapshots_seen = summary.metrics_snapshots_seen.saturating_add(1);
+            summary.latest_metrics = Some(metrics);
+        }
+    }
+
+    summary
+}
+
+fn parse_metrics_snapshot(value: Option<&Value>) -> Option<SafeLaneMetricsSnapshot> {
+    let metrics = value?;
+    let has_any = [
+        "rounds_started",
+        "rounds_succeeded",
+        "rounds_failed",
+        "verify_failures",
+        "replans_triggered",
+        "total_attempts_used",
+    ]
+    .iter()
+    .any(|key| metrics.get(*key).is_some());
+    if !has_any {
+        return None;
+    }
+
+    Some(SafeLaneMetricsSnapshot {
+        rounds_started: read_u32(metrics, "rounds_started"),
+        rounds_succeeded: read_u32(metrics, "rounds_succeeded"),
+        rounds_failed: read_u32(metrics, "rounds_failed"),
+        verify_failures: read_u32(metrics, "verify_failures"),
+        replans_triggered: read_u32(metrics, "replans_triggered"),
+        total_attempts_used: metrics
+            .get("total_attempts_used")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+    })
+}
+
+fn is_safe_lane_event_name(event_name: &str) -> bool {
+    matches!(
+        event_name,
+        "lane_selected"
+            | "plan_round_started"
+            | "plan_round_completed"
+            | "verify_failed"
+            | "verify_policy_adjusted"
+            | "replan_triggered"
+            | "final_status"
+    )
+}
+
+fn read_u32(value: &Value, key: &str) -> u32 {
+    value
+        .get(key)
+        .and_then(Value::as_u64)
+        .map(|num| num.min(u32::MAX as u64) as u32)
+        .unwrap_or_default()
+}
+
+fn bump_count(map: &mut BTreeMap<String, u32>, key: &str) {
+    let entry = map.entry(key.to_owned()).or_insert(0);
+    *entry = entry.saturating_add(1);
+}
+
+fn fold_session_governor_summary(
+    session_governor: Option<&Value>,
+    summary: &mut SafeLaneEventSummary,
+) {
+    let Some(governor) = session_governor else {
+        return;
+    };
+    summary.session_governor_metrics_snapshots_seen = summary
+        .session_governor_metrics_snapshots_seen
+        .saturating_add(1);
+
+    if governor
+        .get("engaged")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        summary.session_governor_engaged_events =
+            summary.session_governor_engaged_events.saturating_add(1);
+    }
+    if governor
+        .get("force_no_replan")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        summary.session_governor_force_no_replan_events = summary
+            .session_governor_force_no_replan_events
+            .saturating_add(1);
+    }
+    if governor
+        .get("failed_threshold_triggered")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        summary.session_governor_failed_threshold_triggered_events = summary
+            .session_governor_failed_threshold_triggered_events
+            .saturating_add(1);
+    }
+    if governor
+        .get("backpressure_threshold_triggered")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        summary.session_governor_backpressure_threshold_triggered_events = summary
+            .session_governor_backpressure_threshold_triggered_events
+            .saturating_add(1);
+    }
+    if governor
+        .get("trend_threshold_triggered")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        summary.session_governor_trend_threshold_triggered_events = summary
+            .session_governor_trend_threshold_triggered_events
+            .saturating_add(1);
+    }
+    if governor
+        .get("recovery_threshold_triggered")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        summary.session_governor_recovery_threshold_triggered_events = summary
+            .session_governor_recovery_threshold_triggered_events
+            .saturating_add(1);
+    }
+
+    summary.session_governor_latest_trend_samples = read_u32_opt(governor, "trend_samples");
+    summary.session_governor_latest_trend_min_samples = read_u32_opt(governor, "trend_min_samples");
+    summary.session_governor_latest_trend_failure_ewma_milli =
+        read_f64_milli_opt(governor, "trend_failure_ewma");
+    summary.session_governor_latest_trend_backpressure_ewma_milli =
+        read_f64_milli_opt(governor, "trend_backpressure_ewma");
+    summary.session_governor_latest_recovery_success_streak =
+        read_u32_opt(governor, "recovery_success_streak");
+    summary.session_governor_latest_recovery_success_streak_threshold =
+        read_u32_opt(governor, "recovery_success_streak_threshold");
+}
+
+fn read_u32_opt(value: &Value, key: &str) -> Option<u32> {
+    value
+        .get(key)
+        .and_then(Value::as_u64)
+        .map(|num| num.min(u32::MAX as u64) as u32)
+}
+
+fn read_f64_milli_opt(value: &Value, key: &str) -> Option<u32> {
+    let raw = value.get(key)?.as_f64()?;
+    if !raw.is_finite() {
+        return None;
+    }
+    let clamped = raw.clamp(0.0, 1.0);
+    let milli = (clamped * 1000.0).round();
+    Some(milli.min(u32::MAX as f64) as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_conversation_event_rejects_non_event_payloads() {
+        assert!(parse_conversation_event("not-json").is_none());
+        assert!(parse_conversation_event(r#"{"type":"tool_outcome"}"#).is_none());
+    }
+
+    #[test]
+    fn summarize_safe_lane_events_counts_and_final_fields() {
+        let payloads = vec![
+            r#"{"type":"conversation_event","event":"lane_selected","payload":{"lane":"safe"}}"#,
+            r#"{"type":"conversation_event","event":"plan_round_started","payload":{"round":0}}"#,
+            r#"{"type":"conversation_event","event":"plan_round_completed","payload":{"round":0,"status":"failed"}}"#,
+            r#"{"type":"conversation_event","event":"verify_policy_adjusted","payload":{"round":0,"min_anchor_matches":1}}"#,
+            r#"{"type":"conversation_event","event":"replan_triggered","payload":{"round":0}}"#,
+            r#"{"type":"conversation_event","event":"final_status","payload":{"status":"failed","failure_code":"safe_lane_plan_verify_failed","route_decision":"terminal"}}"#,
+        ];
+        let summary = summarize_safe_lane_events(payloads.iter().copied());
+
+        assert_eq!(summary.lane_selected_events, 1);
+        assert_eq!(summary.round_started_events, 1);
+        assert_eq!(summary.round_completed_failed_events, 1);
+        assert_eq!(summary.verify_policy_adjusted_events, 1);
+        assert_eq!(summary.replan_triggered_events, 1);
+        assert_eq!(summary.final_status_events, 1);
+        assert_eq!(summary.final_status, Some(SafeLaneFinalStatus::Failed));
+        assert_eq!(
+            summary.final_failure_code.as_deref(),
+            Some("safe_lane_plan_verify_failed")
+        );
+        assert_eq!(summary.final_route_decision.as_deref(), Some("terminal"));
+        assert_eq!(
+            summary.route_decision_counts.get("terminal").copied(),
+            Some(1)
+        );
+        assert_eq!(
+            summary
+                .failure_code_counts
+                .get("safe_lane_plan_verify_failed")
+                .copied(),
+            Some(1)
+        );
+        assert_eq!(summary.final_status_counts.get("failed").copied(), Some(1));
+    }
+
+    #[test]
+    fn summarize_safe_lane_events_tracks_latest_metrics_snapshot() {
+        let payloads = vec![
+            json!({
+                "type": "conversation_event",
+                "event": "plan_round_started",
+                "payload": {
+                    "round": 0,
+                    "metrics": {
+                        "rounds_started": 1,
+                        "rounds_succeeded": 0,
+                        "rounds_failed": 0,
+                        "verify_failures": 0,
+                        "replans_triggered": 0,
+                        "total_attempts_used": 0
+                    }
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "final_status",
+                "payload": {
+                    "status": "succeeded",
+                    "metrics": {
+                        "rounds_started": 2,
+                        "rounds_succeeded": 1,
+                        "rounds_failed": 1,
+                        "verify_failures": 0,
+                        "replans_triggered": 1,
+                        "total_attempts_used": 4
+                    }
+                }
+            })
+            .to_string(),
+        ];
+        let summary = summarize_safe_lane_events(payloads.iter().map(String::as_str));
+        let metrics = summary.latest_metrics.expect("latest metrics");
+        assert_eq!(
+            metrics,
+            SafeLaneMetricsSnapshot {
+                rounds_started: 2,
+                rounds_succeeded: 1,
+                rounds_failed: 1,
+                verify_failures: 0,
+                replans_triggered: 1,
+                total_attempts_used: 4,
+            }
+        );
+        assert_eq!(summary.final_status, Some(SafeLaneFinalStatus::Succeeded));
+        assert_eq!(summary.metrics_snapshots_seen, 2);
+        assert_eq!(
+            summary.final_status_counts.get("succeeded").copied(),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn summarize_safe_lane_events_accepts_partial_metrics_payload() {
+        let payloads = vec![json!({
+            "type": "conversation_event",
+            "event": "verify_failed",
+            "payload": {
+                "round": 1,
+                "failure_code": "safe_lane_plan_verify_failed",
+                "metrics": {
+                    "verify_failures": 2
+                }
+            }
+        })
+        .to_string()];
+        let summary = summarize_safe_lane_events(payloads.iter().map(String::as_str));
+        let metrics = summary.latest_metrics.expect("latest metrics");
+        assert_eq!(metrics.verify_failures, 2);
+        assert_eq!(metrics.rounds_started, 0);
+        assert_eq!(metrics.total_attempts_used, 0);
+        assert_eq!(summary.metrics_snapshots_seen, 1);
+    }
+
+    #[test]
+    fn summarize_safe_lane_events_handles_sparse_sampled_stream() {
+        let payloads = vec![
+            r#"{"type":"conversation_event","event":"lane_selected","payload":{"lane":"safe"}}"#,
+            r#"{"type":"conversation_event","event":"final_status","payload":{"status":"failed","failure_code":"safe_lane_plan_node_retryable_error","route_decision":"terminal","route_reason":"session_governor_no_replan"}}"#,
+        ];
+        let summary = summarize_safe_lane_events(payloads.iter().copied());
+        assert_eq!(summary.lane_selected_events, 1);
+        assert_eq!(summary.round_started_events, 0);
+        assert_eq!(summary.final_status, Some(SafeLaneFinalStatus::Failed));
+        assert_eq!(
+            summary
+                .failure_code_counts
+                .get("safe_lane_plan_node_retryable_error")
+                .copied(),
+            Some(1)
+        );
+        assert_eq!(
+            summary.route_decision_counts.get("terminal").copied(),
+            Some(1)
+        );
+        assert_eq!(
+            summary
+                .route_reason_counts
+                .get("session_governor_no_replan")
+                .copied(),
+            Some(1)
+        );
+        assert_eq!(
+            summary.final_route_reason.as_deref(),
+            Some("session_governor_no_replan")
+        );
+    }
+
+    #[test]
+    fn summarize_safe_lane_events_tracks_session_governor_signals() {
+        let payloads = vec![
+            json!({
+                "type": "conversation_event",
+                "event": "lane_selected",
+                "payload": {
+                    "lane": "safe",
+                    "session_governor": {
+                        "engaged": true,
+                        "force_no_replan": true,
+                        "failed_threshold_triggered": true,
+                        "backpressure_threshold_triggered": false,
+                        "trend_threshold_triggered": true,
+                        "recovery_threshold_triggered": false,
+                        "trend_samples": 4,
+                        "trend_min_samples": 4,
+                        "trend_failure_ewma": 0.688,
+                        "trend_backpressure_ewma": 0.000,
+                        "recovery_success_streak": 0,
+                        "recovery_success_streak_threshold": 3
+                    }
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "plan_round_started",
+                "payload": {
+                    "round": 0,
+                    "session_governor": {
+                        "engaged": true,
+                        "force_no_replan": true,
+                        "failed_threshold_triggered": true,
+                        "backpressure_threshold_triggered": false,
+                        "trend_threshold_triggered": false,
+                        "recovery_threshold_triggered": true,
+                        "trend_samples": 5,
+                        "trend_min_samples": 4,
+                        "trend_failure_ewma": 0.250,
+                        "trend_backpressure_ewma": 0.063,
+                        "recovery_success_streak": 4,
+                        "recovery_success_streak_threshold": 3
+                    }
+                }
+            })
+            .to_string(),
+        ];
+
+        let summary = summarize_safe_lane_events(payloads.iter().map(String::as_str));
+        assert_eq!(summary.session_governor_engaged_events, 2);
+        assert_eq!(summary.session_governor_force_no_replan_events, 2);
+        assert_eq!(
+            summary.session_governor_failed_threshold_triggered_events,
+            2
+        );
+        assert_eq!(
+            summary.session_governor_backpressure_threshold_triggered_events,
+            0
+        );
+        assert_eq!(summary.session_governor_trend_threshold_triggered_events, 1);
+        assert_eq!(
+            summary.session_governor_recovery_threshold_triggered_events,
+            1
+        );
+        assert_eq!(summary.session_governor_metrics_snapshots_seen, 2);
+        assert_eq!(summary.session_governor_latest_trend_samples, Some(5));
+        assert_eq!(summary.session_governor_latest_trend_min_samples, Some(4));
+        assert_eq!(
+            summary.session_governor_latest_trend_failure_ewma_milli,
+            Some(250)
+        );
+        assert_eq!(
+            summary.session_governor_latest_trend_backpressure_ewma_milli,
+            Some(63)
+        );
+        assert_eq!(
+            summary.session_governor_latest_recovery_success_streak,
+            Some(4)
+        );
+        assert_eq!(
+            summary.session_governor_latest_recovery_success_streak_threshold,
+            Some(3)
+        );
+    }
+}

--- a/crates/app/src/conversation/analytics.rs
+++ b/crates/app/src/conversation/analytics.rs
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn summarize_safe_lane_events_counts_and_final_fields() {
-        let payloads = vec![
+        let payloads = [
             r#"{"type":"conversation_event","event":"lane_selected","payload":{"lane":"safe"}}"#,
             r#"{"type":"conversation_event","event":"plan_round_started","payload":{"round":0}}"#,
             r#"{"type":"conversation_event","event":"plan_round_completed","payload":{"round":0,"status":"failed"}}"#,
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn summarize_safe_lane_events_tracks_latest_metrics_snapshot() {
-        let payloads = vec![
+        let payloads = [
             json!({
                 "type": "conversation_event",
                 "event": "plan_round_started",
@@ -441,7 +441,7 @@ mod tests {
 
     #[test]
     fn summarize_safe_lane_events_accepts_partial_metrics_payload() {
-        let payloads = vec![json!({
+        let payloads = [json!({
             "type": "conversation_event",
             "event": "verify_failed",
             "payload": {
@@ -463,7 +463,7 @@ mod tests {
 
     #[test]
     fn summarize_safe_lane_events_handles_sparse_sampled_stream() {
-        let payloads = vec![
+        let payloads = [
             r#"{"type":"conversation_event","event":"lane_selected","payload":{"lane":"safe"}}"#,
             r#"{"type":"conversation_event","event":"final_status","payload":{"status":"failed","failure_code":"safe_lane_plan_node_retryable_error","route_decision":"terminal","route_reason":"session_governor_no_replan"}}"#,
         ];
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn summarize_safe_lane_events_tracks_session_governor_signals() {
-        let payloads = vec![
+        let payloads = [
             json!({
                 "type": "conversation_event",
                 "event": "lane_selected",

--- a/crates/app/src/conversation/lane_arbiter.rs
+++ b/crates/app/src/conversation/lane_arbiter.rs
@@ -1,0 +1,201 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionLane {
+    Fast,
+    Safe,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaneDecision {
+    pub lane: ExecutionLane,
+    pub risk_score: u32,
+    pub complexity_score: u32,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaneArbiterPolicy {
+    #[serde(default = "default_safe_lane_risk_threshold")]
+    pub safe_lane_risk_threshold: u32,
+    #[serde(default = "default_safe_lane_complexity_threshold")]
+    pub safe_lane_complexity_threshold: u32,
+    #[serde(default = "default_fast_lane_max_input_chars")]
+    pub fast_lane_max_input_chars: usize,
+    #[serde(default = "default_high_risk_keywords")]
+    pub high_risk_keywords: BTreeSet<String>,
+}
+
+impl Default for LaneArbiterPolicy {
+    fn default() -> Self {
+        Self {
+            safe_lane_risk_threshold: default_safe_lane_risk_threshold(),
+            safe_lane_complexity_threshold: default_safe_lane_complexity_threshold(),
+            fast_lane_max_input_chars: default_fast_lane_max_input_chars(),
+            high_risk_keywords: default_high_risk_keywords(),
+        }
+    }
+}
+
+impl LaneArbiterPolicy {
+    pub fn decide(&self, user_input: &str) -> LaneDecision {
+        let risk_score = self.risk_score(user_input);
+        let complexity_score = self.complexity_score(user_input);
+        let mut reasons = Vec::new();
+
+        if risk_score >= self.safe_lane_risk_threshold {
+            reasons.push(format!(
+                "risk_score_exceeded score={risk_score} threshold={}",
+                self.safe_lane_risk_threshold
+            ));
+        }
+        if complexity_score >= self.safe_lane_complexity_threshold {
+            reasons.push(format!(
+                "complexity_score_exceeded score={complexity_score} threshold={}",
+                self.safe_lane_complexity_threshold
+            ));
+        }
+        if user_input.chars().count() > self.fast_lane_max_input_chars {
+            reasons.push(format!(
+                "input_length_exceeded chars={} threshold={}",
+                user_input.chars().count(),
+                self.fast_lane_max_input_chars
+            ));
+        }
+
+        let lane = if reasons.is_empty() {
+            ExecutionLane::Fast
+        } else {
+            ExecutionLane::Safe
+        };
+
+        LaneDecision {
+            lane,
+            risk_score,
+            complexity_score,
+            reasons,
+        }
+    }
+
+    fn risk_score(&self, user_input: &str) -> u32 {
+        let normalized = user_input.to_ascii_lowercase();
+        self.high_risk_keywords
+            .iter()
+            .filter(|keyword| normalized.contains(keyword.as_str()))
+            .count()
+            .saturating_mul(2) as u32
+    }
+
+    fn complexity_score(&self, user_input: &str) -> u32 {
+        let normalized = user_input.to_ascii_lowercase();
+        let tokens = normalized.split_whitespace().count() as u32;
+        let connectors = [
+            " and ",
+            " then ",
+            " after ",
+            " before ",
+            " meanwhile ",
+            "同时",
+            "然后",
+            "接着",
+        ]
+        .iter()
+        .filter(|connector| normalized.contains(*connector))
+        .count() as u32;
+        let punctuation = user_input
+            .chars()
+            .filter(|c| matches!(c, ',' | ';' | ':' | '，' | '；' | '：'))
+            .count() as u32;
+
+        let token_component = if tokens > 50 {
+            6
+        } else if tokens > 30 {
+            4
+        } else if tokens > 15 {
+            2
+        } else {
+            0
+        };
+        token_component + connectors.saturating_mul(2) + punctuation.min(3)
+    }
+}
+
+const fn default_safe_lane_risk_threshold() -> u32 {
+    4
+}
+
+const fn default_safe_lane_complexity_threshold() -> u32 {
+    6
+}
+
+const fn default_fast_lane_max_input_chars() -> usize {
+    400
+}
+
+fn default_high_risk_keywords() -> BTreeSet<String> {
+    [
+        "rm -rf",
+        "drop table",
+        "delete",
+        "credential",
+        "token",
+        "secret",
+        "prod",
+        "production",
+        "deploy",
+        "payment",
+        "wallet",
+    ]
+    .iter()
+    .map(|keyword| (*keyword).to_owned())
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn low_risk_simple_request_routes_to_fast_lane() {
+        let policy = LaneArbiterPolicy::default();
+        let decision = policy.decide("read note.md and summarize briefly");
+        assert_eq!(decision.lane, ExecutionLane::Fast);
+        assert!(decision.reasons.is_empty());
+    }
+
+    #[test]
+    fn high_risk_keywords_route_to_safe_lane() {
+        let policy = LaneArbiterPolicy::default();
+        let decision = policy.decide("connect to production and deploy with secret token");
+        assert_eq!(decision.lane, ExecutionLane::Safe);
+        assert!(
+            decision
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("risk_score_exceeded")),
+            "expected risk reason, got: {:?}",
+            decision.reasons
+        );
+    }
+
+    #[test]
+    fn complex_multi_clause_request_routes_to_safe_lane() {
+        let policy = LaneArbiterPolicy::default();
+        let decision = policy.decide(
+            "first collect runtime evidence, then compare failure modes, and finally produce \
+             a mitigation matrix before generating rollout checks",
+        );
+        assert_eq!(decision.lane, ExecutionLane::Safe);
+        assert!(
+            decision
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("complexity_score_exceeded")),
+            "expected complexity reason, got: {:?}",
+            decision.reasons
+        );
+    }
+}

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -1,15 +1,28 @@
+pub mod analytics;
+mod lane_arbiter;
 mod persistence;
+pub mod plan_executor;
+pub mod plan_ir;
+pub mod plan_verifier;
 mod runtime;
+mod turn_coordinator;
 pub mod turn_engine;
 mod turn_loop;
 
-pub use turn_loop::ConversationTurnLoop;
-pub type ConversationOrchestrator = ConversationTurnLoop;
+pub use analytics::{
+    parse_conversation_event, summarize_safe_lane_events, ConversationEventRecord,
+    SafeLaneEventSummary, SafeLaneFinalStatus, SafeLaneMetricsSnapshot,
+};
+pub use lane_arbiter::{ExecutionLane, LaneArbiterPolicy, LaneDecision};
+pub type ConversationOrchestrator = ConversationTurnCoordinator;
 #[allow(unused_imports)]
 pub use runtime::{ConversationRuntime, DefaultConversationRuntime};
+pub use turn_coordinator::ConversationTurnCoordinator;
 pub use turn_engine::{
-    ProviderTurn, ToolDecision, ToolIntent, ToolOutcome, TurnEngine, TurnResult,
+    ProviderTurn, ToolDecision, ToolIntent, ToolOutcome, TurnEngine, TurnFailure, TurnFailureKind,
+    TurnResult,
 };
+pub use turn_loop::ConversationTurnLoop;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderErrorMode {

--- a/crates/app/src/conversation/persistence.rs
+++ b/crates/app/src/conversation/persistence.rs
@@ -1,4 +1,4 @@
-use serde_json::json;
+use serde_json::{json, Value};
 
 use crate::CliResult;
 use crate::KernelContext;
@@ -92,4 +92,21 @@ pub(super) async fn persist_error_turns<R: ConversationRuntime + ?Sized>(
         .persist_turn(session_id, "assistant", synthetic_reply, kernel_ctx)
         .await?;
     Ok(())
+}
+
+pub(super) async fn persist_conversation_event<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    event_name: &str,
+    payload: Value,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<()> {
+    let content = json!({
+        "type": "conversation_event",
+        "event": event_name,
+        "payload": payload,
+    });
+    runtime
+        .persist_turn(session_id, "assistant", &content.to_string(), kernel_ctx)
+        .await
 }

--- a/crates/app/src/conversation/plan_executor.rs
+++ b/crates/app/src/conversation/plan_executor.rs
@@ -127,13 +127,30 @@ impl PlanExecutor {
         let mut attempts_used = 0usize;
         let mut events = Vec::new();
         let started_at = Instant::now();
-        let ordered_nodes = ordered_indexes
+        let Some(ordered_nodes) = ordered_indexes
             .iter()
-            .map(|index| plan.nodes[*index].id.clone())
-            .collect::<Vec<_>>();
+            .map(|index| plan.nodes.get(*index).map(|node| node.id.clone()))
+            .collect::<Option<Vec<_>>>()
+        else {
+            return PlanRunReport {
+                status: PlanRunStatus::Failed(PlanRunFailure::TopologyResolutionFailed),
+                ordered_nodes: Vec::new(),
+                attempts_used: 0,
+                attempt_events: Vec::new(),
+                elapsed_ms: 0,
+            };
+        };
 
         for node_index in ordered_indexes {
-            let node = &plan.nodes[node_index];
+            let Some(node) = plan.nodes.get(node_index) else {
+                return PlanRunReport {
+                    status: PlanRunStatus::Failed(PlanRunFailure::TopologyResolutionFailed),
+                    ordered_nodes,
+                    attempts_used,
+                    attempt_events: events,
+                    elapsed_ms: started_at.elapsed().as_millis(),
+                };
+            };
 
             for attempt in 1..=node.max_attempts {
                 let elapsed_ms = started_at.elapsed().as_millis();
@@ -275,8 +292,9 @@ fn topological_order(plan: &PlanGraph) -> Option<Vec<usize>> {
     for edge in &plan.edges {
         let from = *node_index.get(edge.from.as_str())?;
         let to = *node_index.get(edge.to.as_str())?;
-        indegree[to] = indegree[to].saturating_add(1);
-        adjacency[from].push(to);
+        let degree = indegree.get_mut(to)?;
+        *degree = degree.saturating_add(1);
+        adjacency.get_mut(from)?.push(to);
     }
 
     let mut queue = VecDeque::new();
@@ -289,9 +307,10 @@ fn topological_order(plan: &PlanGraph) -> Option<Vec<usize>> {
     let mut order = Vec::new();
     while let Some(index) = queue.pop_front() {
         order.push(index);
-        for next in &adjacency[index] {
-            indegree[*next] = indegree[*next].saturating_sub(1);
-            if indegree[*next] == 0 {
+        for next in adjacency.get(index)? {
+            let next_degree = indegree.get_mut(*next)?;
+            *next_degree = next_degree.saturating_sub(1);
+            if *next_degree == 0 {
                 queue.push_back(*next);
             }
         }
@@ -312,12 +331,12 @@ mod tests {
 
     use super::*;
     use crate::conversation::plan_ir::{
-        PlanBudget, PlanEdge, PlanGraph, PlanNode, PlanNodeKind, RiskTier,
+        PlanBudget, PlanEdge, PlanGraph, PlanNode, PlanNodeKind, RiskTier, PLAN_GRAPH_VERSION,
     };
 
     fn sample_graph() -> PlanGraph {
         PlanGraph {
-            version: "hvgr.v1".to_owned(),
+            version: PLAN_GRAPH_VERSION.to_owned(),
             nodes: vec![
                 PlanNode {
                     id: "n1".to_owned(),

--- a/crates/app/src/conversation/plan_executor.rs
+++ b/crates/app/src/conversation/plan_executor.rs
@@ -1,0 +1,624 @@
+use std::collections::{BTreeMap, VecDeque};
+use std::time::Instant;
+
+use async_trait::async_trait;
+use tokio::time::{timeout, Duration};
+
+use super::plan_ir::{PlanGraph, PlanNode};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanRunStatus {
+    Succeeded,
+    Failed(PlanRunFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanRunFailure {
+    ValidationFailed(String),
+    TopologyResolutionFailed,
+    BudgetExceeded {
+        attempts_used: usize,
+        limit: usize,
+    },
+    WallTimeExceeded {
+        elapsed_ms: u128,
+        limit_ms: u64,
+    },
+    NodeFailed {
+        node_id: String,
+        attempts_used: u8,
+        last_error_kind: PlanNodeErrorKind,
+        last_error: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanNodeErrorKind {
+    Retryable,
+    PolicyDenied,
+    NonRetryable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanNodeError {
+    pub kind: PlanNodeErrorKind,
+    pub message: String,
+}
+
+impl PlanNodeError {
+    pub fn retryable(message: impl Into<String>) -> Self {
+        Self {
+            kind: PlanNodeErrorKind::Retryable,
+            message: message.into(),
+        }
+    }
+
+    pub fn policy_denied(message: impl Into<String>) -> Self {
+        Self {
+            kind: PlanNodeErrorKind::PolicyDenied,
+            message: message.into(),
+        }
+    }
+
+    pub fn non_retryable(message: impl Into<String>) -> Self {
+        Self {
+            kind: PlanNodeErrorKind::NonRetryable,
+            message: message.into(),
+        }
+    }
+}
+
+impl From<String> for PlanNodeError {
+    fn from(value: String) -> Self {
+        Self::non_retryable(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanNodeAttemptEvent {
+    pub node_id: String,
+    pub attempt: u8,
+    pub success: bool,
+    pub error_kind: Option<PlanNodeErrorKind>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanRunReport {
+    pub status: PlanRunStatus,
+    pub ordered_nodes: Vec<String>,
+    pub attempts_used: usize,
+    pub attempt_events: Vec<PlanNodeAttemptEvent>,
+    pub elapsed_ms: u128,
+}
+
+#[async_trait]
+pub trait PlanNodeExecutor: Send + Sync {
+    async fn execute(&self, node: &PlanNode, attempt: u8) -> Result<(), PlanNodeError>;
+}
+
+pub struct PlanExecutor;
+
+impl PlanExecutor {
+    pub async fn execute<E: PlanNodeExecutor>(plan: &PlanGraph, executor: &E) -> PlanRunReport {
+        if let Err(error) = plan.validate() {
+            return PlanRunReport {
+                status: PlanRunStatus::Failed(PlanRunFailure::ValidationFailed(error)),
+                ordered_nodes: Vec::new(),
+                attempts_used: 0,
+                attempt_events: Vec::new(),
+                elapsed_ms: 0,
+            };
+        }
+
+        let ordered_indexes = match topological_order(plan) {
+            Some(order) => order,
+            None => {
+                return PlanRunReport {
+                    status: PlanRunStatus::Failed(PlanRunFailure::TopologyResolutionFailed),
+                    ordered_nodes: Vec::new(),
+                    attempts_used: 0,
+                    attempt_events: Vec::new(),
+                    elapsed_ms: 0,
+                };
+            }
+        };
+
+        let mut attempts_used = 0usize;
+        let mut events = Vec::new();
+        let started_at = Instant::now();
+        let ordered_nodes = ordered_indexes
+            .iter()
+            .map(|index| plan.nodes[*index].id.clone())
+            .collect::<Vec<_>>();
+
+        for node_index in ordered_indexes {
+            let node = &plan.nodes[node_index];
+
+            for attempt in 1..=node.max_attempts {
+                let elapsed_ms = started_at.elapsed().as_millis();
+                if elapsed_ms > plan.budget.max_wall_time_ms as u128 {
+                    return PlanRunReport {
+                        status: PlanRunStatus::Failed(PlanRunFailure::WallTimeExceeded {
+                            elapsed_ms,
+                            limit_ms: plan.budget.max_wall_time_ms,
+                        }),
+                        ordered_nodes,
+                        attempts_used,
+                        attempt_events: events,
+                        elapsed_ms,
+                    };
+                }
+
+                if attempts_used >= plan.budget.max_total_attempts {
+                    return PlanRunReport {
+                        status: PlanRunStatus::Failed(PlanRunFailure::BudgetExceeded {
+                            attempts_used,
+                            limit: plan.budget.max_total_attempts,
+                        }),
+                        ordered_nodes,
+                        attempts_used,
+                        attempt_events: events,
+                        elapsed_ms,
+                    };
+                }
+                attempts_used = attempts_used.saturating_add(1);
+
+                let attempt_outcome = timeout(
+                    Duration::from_millis(node.timeout_ms.max(1)),
+                    executor.execute(node, attempt),
+                )
+                .await;
+                match attempt_outcome {
+                    Err(_) => {
+                        let timeout_error =
+                            normalize_node_error(PlanNodeError::retryable(format!(
+                                "node_timeout node={} timeout_ms={}",
+                                node.id, node.timeout_ms
+                            )));
+                        events.push(PlanNodeAttemptEvent {
+                            node_id: node.id.clone(),
+                            attempt,
+                            success: false,
+                            error_kind: Some(timeout_error.kind),
+                            error: Some(timeout_error.message.clone()),
+                        });
+                        if attempt == node.max_attempts {
+                            let elapsed_ms = started_at.elapsed().as_millis();
+                            return PlanRunReport {
+                                status: PlanRunStatus::Failed(PlanRunFailure::NodeFailed {
+                                    node_id: node.id.clone(),
+                                    attempts_used: attempt,
+                                    last_error_kind: timeout_error.kind,
+                                    last_error: timeout_error.message,
+                                }),
+                                ordered_nodes,
+                                attempts_used,
+                                attempt_events: events,
+                                elapsed_ms,
+                            };
+                        }
+                    }
+                    Ok(outcome) => match outcome {
+                        Ok(()) => {
+                            events.push(PlanNodeAttemptEvent {
+                                node_id: node.id.clone(),
+                                attempt,
+                                success: true,
+                                error_kind: None,
+                                error: None,
+                            });
+                            break;
+                        }
+                        Err(error) => {
+                            let normalized = normalize_node_error(error);
+                            events.push(PlanNodeAttemptEvent {
+                                node_id: node.id.clone(),
+                                attempt,
+                                success: false,
+                                error_kind: Some(normalized.kind),
+                                error: Some(normalized.message.clone()),
+                            });
+                            if attempt == node.max_attempts {
+                                let elapsed_ms = started_at.elapsed().as_millis();
+                                return PlanRunReport {
+                                    status: PlanRunStatus::Failed(PlanRunFailure::NodeFailed {
+                                        node_id: node.id.clone(),
+                                        attempts_used: attempt,
+                                        last_error_kind: normalized.kind,
+                                        last_error: normalized.message,
+                                    }),
+                                    ordered_nodes,
+                                    attempts_used,
+                                    attempt_events: events,
+                                    elapsed_ms,
+                                };
+                            }
+                        }
+                    },
+                }
+            }
+        }
+
+        PlanRunReport {
+            status: PlanRunStatus::Succeeded,
+            ordered_nodes,
+            attempts_used,
+            attempt_events: events,
+            elapsed_ms: started_at.elapsed().as_millis(),
+        }
+    }
+}
+
+fn normalize_node_error(error: PlanNodeError) -> PlanNodeError {
+    let trimmed = error.message.trim();
+    if trimmed.is_empty() {
+        return PlanNodeError {
+            kind: error.kind,
+            message: "node execution failed with empty reason".to_owned(),
+        };
+    }
+    PlanNodeError {
+        kind: error.kind,
+        message: trimmed.to_owned(),
+    }
+}
+
+fn topological_order(plan: &PlanGraph) -> Option<Vec<usize>> {
+    let mut node_index = BTreeMap::new();
+    for (index, node) in plan.nodes.iter().enumerate() {
+        node_index.insert(node.id.as_str(), index);
+    }
+
+    let mut indegree = vec![0usize; plan.nodes.len()];
+    let mut adjacency = vec![Vec::<usize>::new(); plan.nodes.len()];
+    for edge in &plan.edges {
+        let from = *node_index.get(edge.from.as_str())?;
+        let to = *node_index.get(edge.to.as_str())?;
+        indegree[to] = indegree[to].saturating_add(1);
+        adjacency[from].push(to);
+    }
+
+    let mut queue = VecDeque::new();
+    for (index, degree) in indegree.iter().enumerate() {
+        if *degree == 0 {
+            queue.push_back(index);
+        }
+    }
+
+    let mut order = Vec::new();
+    while let Some(index) = queue.pop_front() {
+        order.push(index);
+        for next in &adjacency[index] {
+            indegree[*next] = indegree[*next].saturating_sub(1);
+            if indegree[*next] == 0 {
+                queue.push_back(*next);
+            }
+        }
+    }
+    if order.len() == plan.nodes.len() {
+        Some(order)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::conversation::plan_ir::{
+        PlanBudget, PlanEdge, PlanGraph, PlanNode, PlanNodeKind, RiskTier,
+    };
+
+    fn sample_graph() -> PlanGraph {
+        PlanGraph {
+            version: "hvgr.v1".to_owned(),
+            nodes: vec![
+                PlanNode {
+                    id: "n1".to_owned(),
+                    kind: PlanNodeKind::Tool,
+                    label: "collect".to_owned(),
+                    tool_name: Some("file.read".to_owned()),
+                    timeout_ms: 1_000,
+                    max_attempts: 1,
+                    risk_tier: RiskTier::Low,
+                },
+                PlanNode {
+                    id: "n2".to_owned(),
+                    kind: PlanNodeKind::Verify,
+                    label: "verify".to_owned(),
+                    tool_name: None,
+                    timeout_ms: 1_000,
+                    max_attempts: 2,
+                    risk_tier: RiskTier::Medium,
+                },
+                PlanNode {
+                    id: "n3".to_owned(),
+                    kind: PlanNodeKind::Respond,
+                    label: "reply".to_owned(),
+                    tool_name: None,
+                    timeout_ms: 1_000,
+                    max_attempts: 1,
+                    risk_tier: RiskTier::Low,
+                },
+            ],
+            edges: vec![
+                PlanEdge {
+                    from: "n1".to_owned(),
+                    to: "n2".to_owned(),
+                },
+                PlanEdge {
+                    from: "n2".to_owned(),
+                    to: "n3".to_owned(),
+                },
+            ],
+            budget: PlanBudget {
+                max_nodes: 16,
+                max_total_attempts: 8,
+                max_wall_time_ms: 5_000,
+            },
+        }
+    }
+
+    struct RecordingExecutor {
+        calls: Mutex<Vec<String>>,
+        fail_once_nodes: Vec<String>,
+        seen_attempts: Mutex<BTreeMap<String, u8>>,
+        always_fail_node: Option<String>,
+    }
+
+    impl RecordingExecutor {
+        fn succeed_all() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                fail_once_nodes: Vec::new(),
+                seen_attempts: Mutex::new(BTreeMap::new()),
+                always_fail_node: None,
+            }
+        }
+
+        fn fail_once(node_id: &str) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                fail_once_nodes: vec![node_id.to_owned()],
+                seen_attempts: Mutex::new(BTreeMap::new()),
+                always_fail_node: None,
+            }
+        }
+
+        fn always_fail(node_id: &str) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                fail_once_nodes: Vec::new(),
+                seen_attempts: Mutex::new(BTreeMap::new()),
+                always_fail_node: Some(node_id.to_owned()),
+            }
+        }
+    }
+
+    struct TimeoutOnFirstAttemptExecutor {
+        timeout_node: String,
+    }
+
+    impl TimeoutOnFirstAttemptExecutor {
+        fn new(node_id: &str) -> Self {
+            Self {
+                timeout_node: node_id.to_owned(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PlanNodeExecutor for TimeoutOnFirstAttemptExecutor {
+        async fn execute(&self, node: &PlanNode, attempt: u8) -> Result<(), PlanNodeError> {
+            if node.id == self.timeout_node && attempt == 1 {
+                tokio::time::sleep(Duration::from_millis(node.timeout_ms.saturating_add(50))).await;
+            }
+            Ok(())
+        }
+    }
+
+    struct TimeoutAlwaysExecutor {
+        timeout_node: String,
+    }
+
+    impl TimeoutAlwaysExecutor {
+        fn new(node_id: &str) -> Self {
+            Self {
+                timeout_node: node_id.to_owned(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PlanNodeExecutor for TimeoutAlwaysExecutor {
+        async fn execute(&self, node: &PlanNode, _attempt: u8) -> Result<(), PlanNodeError> {
+            if node.id == self.timeout_node {
+                tokio::time::sleep(Duration::from_millis(node.timeout_ms.saturating_add(50))).await;
+            }
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl PlanNodeExecutor for RecordingExecutor {
+        async fn execute(&self, node: &PlanNode, attempt: u8) -> Result<(), PlanNodeError> {
+            self.calls
+                .lock()
+                .expect("calls lock")
+                .push(format!("{}#{attempt}", node.id));
+            self.seen_attempts
+                .lock()
+                .expect("attempt lock")
+                .insert(node.id.clone(), attempt);
+
+            if self
+                .always_fail_node
+                .as_ref()
+                .map(|target| target == &node.id)
+                .unwrap_or(false)
+            {
+                return Err(PlanNodeError::non_retryable(format!(
+                    "forced failure for {}",
+                    node.id
+                )));
+            }
+
+            if self.fail_once_nodes.iter().any(|target| target == &node.id) && attempt == 1 {
+                return Err(PlanNodeError::retryable(format!(
+                    "transient failure for {}",
+                    node.id
+                )));
+            }
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn executor_runs_nodes_in_topological_order() {
+        let graph = sample_graph();
+        let executor = RecordingExecutor::succeed_all();
+        let report = PlanExecutor::execute(&graph, &executor).await;
+
+        assert_eq!(report.status, PlanRunStatus::Succeeded);
+        assert_eq!(report.ordered_nodes, vec!["n1", "n2", "n3"]);
+        assert_eq!(report.attempts_used, 3);
+    }
+
+    #[tokio::test]
+    async fn executor_retries_and_recovers_before_node_budget_exhaustion() {
+        let graph = sample_graph();
+        let executor = RecordingExecutor::fail_once("n2");
+        let report = PlanExecutor::execute(&graph, &executor).await;
+
+        assert_eq!(report.status, PlanRunStatus::Succeeded);
+        assert_eq!(report.attempts_used, 4);
+        assert!(report.attempt_events.iter().any(|event| {
+            event.node_id == "n2"
+                && event.attempt == 1
+                && !event.success
+                && event.error_kind == Some(PlanNodeErrorKind::Retryable)
+        }));
+        assert!(report
+            .attempt_events
+            .iter()
+            .any(|event| event.node_id == "n2" && event.attempt == 2 && event.success));
+    }
+
+    #[tokio::test]
+    async fn executor_fails_when_node_retries_are_exhausted() {
+        let graph = sample_graph();
+        let executor = RecordingExecutor::always_fail("n2");
+        let report = PlanExecutor::execute(&graph, &executor).await;
+
+        match report.status {
+            PlanRunStatus::Failed(PlanRunFailure::NodeFailed {
+                node_id,
+                attempts_used,
+                last_error_kind,
+                ..
+            }) => {
+                assert_eq!(node_id, "n2");
+                assert_eq!(attempts_used, 2);
+                assert_eq!(last_error_kind, PlanNodeErrorKind::NonRetryable);
+            }
+            other => panic!("expected node failure, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn executor_retries_when_node_attempt_times_out() {
+        let mut graph = sample_graph();
+        graph.nodes[1].timeout_ms = 10;
+        graph.nodes[1].max_attempts = 2;
+        graph.budget.max_total_attempts = 8;
+
+        let executor = TimeoutOnFirstAttemptExecutor::new("n2");
+        let report = PlanExecutor::execute(&graph, &executor).await;
+
+        assert_eq!(report.status, PlanRunStatus::Succeeded);
+        assert_eq!(report.attempts_used, 4);
+        assert!(report.attempt_events.iter().any(|event| {
+            event.node_id == "n2"
+                && event.attempt == 1
+                && !event.success
+                && event.error_kind == Some(PlanNodeErrorKind::Retryable)
+                && event
+                    .error
+                    .as_ref()
+                    .map(|reason| reason.contains("node_timeout"))
+                    .unwrap_or(false)
+        }));
+        assert!(report
+            .attempt_events
+            .iter()
+            .any(|event| event.node_id == "n2" && event.attempt == 2 && event.success));
+    }
+
+    #[tokio::test]
+    async fn executor_fails_when_node_timeout_retries_are_exhausted() {
+        let mut graph = sample_graph();
+        graph.nodes[1].timeout_ms = 10;
+        graph.nodes[1].max_attempts = 1;
+        graph.budget.max_total_attempts = 8;
+
+        let executor = TimeoutAlwaysExecutor::new("n2");
+        let report = PlanExecutor::execute(&graph, &executor).await;
+
+        match report.status {
+            PlanRunStatus::Failed(PlanRunFailure::NodeFailed {
+                node_id,
+                attempts_used,
+                last_error_kind,
+                last_error,
+            }) => {
+                assert_eq!(node_id, "n2");
+                assert_eq!(attempts_used, 1);
+                assert_eq!(last_error_kind, PlanNodeErrorKind::Retryable);
+                assert!(
+                    last_error.contains("node_timeout"),
+                    "expected timeout reason, got: {last_error}"
+                );
+            }
+            other => panic!("expected timeout node failure, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn executor_rejects_plan_when_attempt_budget_is_below_theoretical_max() {
+        let mut graph = sample_graph();
+        graph.budget.max_total_attempts = 2;
+        let executor = RecordingExecutor::succeed_all();
+        let report = PlanExecutor::execute(&graph, &executor).await;
+
+        match report.status {
+            PlanRunStatus::Failed(PlanRunFailure::ValidationFailed(error)) => {
+                assert!(error.contains("attempt budget exceeded"), "error={error}");
+            }
+            other => panic!("expected validation failure, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn executor_fails_fast_for_invalid_graph() {
+        let mut graph = sample_graph();
+        graph.edges.push(PlanEdge {
+            from: "n1".to_owned(),
+            to: "n404".to_owned(),
+        });
+
+        let executor = RecordingExecutor::succeed_all();
+        let report = PlanExecutor::execute(&graph, &executor).await;
+        match report.status {
+            PlanRunStatus::Failed(PlanRunFailure::ValidationFailed(error)) => {
+                assert!(error.contains("unknown `to` node"), "error={error}");
+            }
+            other => panic!("expected validation failure, got: {other:?}"),
+        }
+    }
+}

--- a/crates/app/src/conversation/plan_ir.rs
+++ b/crates/app/src/conversation/plan_ir.rs
@@ -2,6 +2,8 @@ use std::collections::{BTreeMap, VecDeque};
 
 use serde::{Deserialize, Serialize};
 
+pub const PLAN_GRAPH_VERSION: &str = "hybrid_lane_plan.v1";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PlanNodeKind {
@@ -130,9 +132,20 @@ impl PlanGraph {
             if from_index == to_index {
                 return Err(format!("plan edge has self-loop at `{}`", edge.from));
             }
-            indegree[to_index] = indegree[to_index].saturating_add(1);
-            outdegree[from_index] = outdegree[from_index].saturating_add(1);
-            adjacency[from_index].push(to_index);
+            let Some(to_degree) = indegree.get_mut(to_index) else {
+                return Err("plan graph indegree index out of bounds".to_owned());
+            };
+            *to_degree = to_degree.saturating_add(1);
+
+            let Some(from_degree) = outdegree.get_mut(from_index) else {
+                return Err("plan graph outdegree index out of bounds".to_owned());
+            };
+            *from_degree = from_degree.saturating_add(1);
+
+            let Some(neighbors) = adjacency.get_mut(from_index) else {
+                return Err("plan graph adjacency index out of bounds".to_owned());
+            };
+            neighbors.push(to_index);
         }
 
         let entry_nodes = indegree.iter().filter(|degree| **degree == 0).count();
@@ -154,9 +167,15 @@ impl PlanGraph {
         let mut visited = 0usize;
         while let Some(index) = queue.pop_front() {
             visited = visited.saturating_add(1);
-            for next in &adjacency[index] {
-                remaining_indegree[*next] = remaining_indegree[*next].saturating_sub(1);
-                if remaining_indegree[*next] == 0 {
+            let Some(neighbors) = adjacency.get(index) else {
+                return Err("plan graph adjacency traversal index out of bounds".to_owned());
+            };
+            for next in neighbors {
+                let Some(next_degree) = remaining_indegree.get_mut(*next) else {
+                    return Err("plan graph indegree traversal index out of bounds".to_owned());
+                };
+                *next_degree = next_degree.saturating_sub(1);
+                if *next_degree == 0 {
                     queue.push_back(*next);
                 }
             }
@@ -174,7 +193,7 @@ mod tests {
 
     fn sample_graph() -> PlanGraph {
         PlanGraph {
-            version: "hvgr.v1".to_owned(),
+            version: PLAN_GRAPH_VERSION.to_owned(),
             nodes: vec![
                 PlanNode {
                     id: "n1".to_owned(),

--- a/crates/app/src/conversation/plan_ir.rs
+++ b/crates/app/src/conversation/plan_ir.rs
@@ -1,0 +1,285 @@
+use std::collections::{BTreeMap, VecDeque};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanNodeKind {
+    Tool,
+    Transform,
+    Verify,
+    Respond,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RiskTier {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanNode {
+    pub id: String,
+    pub kind: PlanNodeKind,
+    pub label: String,
+    pub tool_name: Option<String>,
+    pub timeout_ms: u64,
+    pub max_attempts: u8,
+    pub risk_tier: RiskTier,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanEdge {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanBudget {
+    pub max_nodes: usize,
+    pub max_total_attempts: usize,
+    pub max_wall_time_ms: u64,
+}
+
+impl Default for PlanBudget {
+    fn default() -> Self {
+        Self {
+            max_nodes: 16,
+            max_total_attempts: 32,
+            max_wall_time_ms: 60_000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanGraph {
+    pub version: String,
+    pub nodes: Vec<PlanNode>,
+    pub edges: Vec<PlanEdge>,
+    #[serde(default)]
+    pub budget: PlanBudget,
+}
+
+impl PlanGraph {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.nodes.is_empty() {
+            return Err("plan graph must include at least one node".to_owned());
+        }
+        if self.nodes.len() > self.budget.max_nodes {
+            return Err(format!(
+                "plan graph node budget exceeded actual={} limit={}",
+                self.nodes.len(),
+                self.budget.max_nodes
+            ));
+        }
+
+        let mut node_index = BTreeMap::new();
+        let mut total_attempts = 0usize;
+        for node in &self.nodes {
+            if node.id.trim().is_empty() {
+                return Err("plan node id must not be empty".to_owned());
+            }
+            if node.timeout_ms == 0 {
+                return Err(format!("plan node `{}` has invalid timeout_ms=0", node.id));
+            }
+            if node.max_attempts == 0 {
+                return Err(format!(
+                    "plan node `{}` has invalid max_attempts=0",
+                    node.id
+                ));
+            }
+            total_attempts = total_attempts.saturating_add(node.max_attempts as usize);
+            if node_index
+                .insert(node.id.clone(), node_index.len())
+                .is_some()
+            {
+                return Err(format!("duplicate plan node id `{}`", node.id));
+            }
+        }
+        if total_attempts > self.budget.max_total_attempts {
+            return Err(format!(
+                "plan attempt budget exceeded actual={} limit={}",
+                total_attempts, self.budget.max_total_attempts
+            ));
+        }
+
+        let mut indegree = vec![0usize; self.nodes.len()];
+        let mut outdegree = vec![0usize; self.nodes.len()];
+        let mut adjacency = vec![Vec::<usize>::new(); self.nodes.len()];
+        for edge in &self.edges {
+            let from_index = match node_index.get(&edge.from) {
+                Some(index) => *index,
+                None => {
+                    return Err(format!(
+                        "plan edge references unknown `from` node `{}`",
+                        edge.from
+                    ));
+                }
+            };
+            let to_index = match node_index.get(&edge.to) {
+                Some(index) => *index,
+                None => {
+                    return Err(format!(
+                        "plan edge references unknown `to` node `{}`",
+                        edge.to
+                    ))
+                }
+            };
+            if from_index == to_index {
+                return Err(format!("plan edge has self-loop at `{}`", edge.from));
+            }
+            indegree[to_index] = indegree[to_index].saturating_add(1);
+            outdegree[from_index] = outdegree[from_index].saturating_add(1);
+            adjacency[from_index].push(to_index);
+        }
+
+        let entry_nodes = indegree.iter().filter(|degree| **degree == 0).count();
+        if entry_nodes == 0 {
+            return Err("plan graph must include at least one entry node".to_owned());
+        }
+        let terminal_nodes = outdegree.iter().filter(|degree| **degree == 0).count();
+        if terminal_nodes == 0 {
+            return Err("plan graph must include at least one terminal node".to_owned());
+        }
+
+        let mut queue = VecDeque::new();
+        let mut remaining_indegree = indegree.clone();
+        for (index, degree) in remaining_indegree.iter().enumerate() {
+            if *degree == 0 {
+                queue.push_back(index);
+            }
+        }
+        let mut visited = 0usize;
+        while let Some(index) = queue.pop_front() {
+            visited = visited.saturating_add(1);
+            for next in &adjacency[index] {
+                remaining_indegree[*next] = remaining_indegree[*next].saturating_sub(1);
+                if remaining_indegree[*next] == 0 {
+                    queue.push_back(*next);
+                }
+            }
+        }
+        if visited != self.nodes.len() {
+            return Err("plan graph must be acyclic".to_owned());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_graph() -> PlanGraph {
+        PlanGraph {
+            version: "hvgr.v1".to_owned(),
+            nodes: vec![
+                PlanNode {
+                    id: "n1".to_owned(),
+                    kind: PlanNodeKind::Tool,
+                    label: "read context".to_owned(),
+                    tool_name: Some("file.read".to_owned()),
+                    timeout_ms: 3_000,
+                    max_attempts: 2,
+                    risk_tier: RiskTier::Low,
+                },
+                PlanNode {
+                    id: "n2".to_owned(),
+                    kind: PlanNodeKind::Verify,
+                    label: "validate output".to_owned(),
+                    tool_name: None,
+                    timeout_ms: 1_000,
+                    max_attempts: 1,
+                    risk_tier: RiskTier::Low,
+                },
+                PlanNode {
+                    id: "n3".to_owned(),
+                    kind: PlanNodeKind::Respond,
+                    label: "compose answer".to_owned(),
+                    tool_name: None,
+                    timeout_ms: 1_000,
+                    max_attempts: 1,
+                    risk_tier: RiskTier::Low,
+                },
+            ],
+            edges: vec![
+                PlanEdge {
+                    from: "n1".to_owned(),
+                    to: "n2".to_owned(),
+                },
+                PlanEdge {
+                    from: "n2".to_owned(),
+                    to: "n3".to_owned(),
+                },
+            ],
+            budget: PlanBudget::default(),
+        }
+    }
+
+    #[test]
+    fn valid_plan_graph_passes() {
+        let graph = sample_graph();
+        assert!(graph.validate().is_ok());
+    }
+
+    #[test]
+    fn duplicate_node_id_is_rejected() {
+        let mut graph = sample_graph();
+        graph.nodes.push(graph.nodes[0].clone());
+        let error = graph.validate().expect_err("duplicate node id should fail");
+        assert!(error.contains("duplicate plan node id"), "error: {error}");
+    }
+
+    #[test]
+    fn unknown_edge_reference_is_rejected() {
+        let mut graph = sample_graph();
+        graph.edges.push(PlanEdge {
+            from: "n3".to_owned(),
+            to: "n404".to_owned(),
+        });
+        let error = graph
+            .validate()
+            .expect_err("unknown edge node reference should fail");
+        assert!(error.contains("unknown `to` node"), "error: {error}");
+    }
+
+    #[test]
+    fn cyclic_graph_is_rejected() {
+        let mut graph = sample_graph();
+        graph.nodes.push(PlanNode {
+            id: "n4".to_owned(),
+            kind: PlanNodeKind::Respond,
+            label: "side terminal".to_owned(),
+            tool_name: None,
+            timeout_ms: 500,
+            max_attempts: 1,
+            risk_tier: RiskTier::Low,
+        });
+        graph.edges.push(PlanEdge {
+            from: "n3".to_owned(),
+            to: "n2".to_owned(),
+        });
+        let error = graph.validate().expect_err("cycle should fail");
+        assert!(error.contains("acyclic"), "error: {error}");
+    }
+
+    #[test]
+    fn attempt_budget_exceeded_is_rejected() {
+        let mut graph = sample_graph();
+        graph.budget.max_total_attempts = 2;
+        let error = graph
+            .validate()
+            .expect_err("attempt budget overflow should fail");
+        assert!(error.contains("attempt budget exceeded"), "error: {error}");
+    }
+
+    #[test]
+    fn zero_timeout_node_is_rejected() {
+        let mut graph = sample_graph();
+        graph.nodes[0].timeout_ms = 0;
+        let error = graph.validate().expect_err("zero timeout should fail");
+        assert!(error.contains("invalid timeout_ms=0"), "error: {error}");
+    }
+}

--- a/crates/app/src/conversation/plan_verifier.rs
+++ b/crates/app/src/conversation/plan_verifier.rs
@@ -219,8 +219,10 @@ mod tests {
 
     #[test]
     fn verifier_rejects_short_output() {
-        let mut policy = PlanVerificationPolicy::default();
-        policy.min_output_chars = 20;
+        let policy = PlanVerificationPolicy {
+            min_output_chars: 20,
+            ..PlanVerificationPolicy::default()
+        };
         let report = verify_output("[ok] {}", &PlanVerificationContext::default(), &policy);
         assert!(!report.passed);
         assert!(

--- a/crates/app/src/conversation/plan_verifier.rs
+++ b/crates/app/src/conversation/plan_verifier.rs
@@ -1,0 +1,301 @@
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanVerificationPolicy {
+    pub require_non_empty: bool,
+    pub min_output_chars: usize,
+    pub require_status_prefix: bool,
+    pub deny_markers: BTreeSet<String>,
+}
+
+impl Default for PlanVerificationPolicy {
+    fn default() -> Self {
+        Self {
+            require_non_empty: true,
+            min_output_chars: 8,
+            require_status_prefix: true,
+            deny_markers: default_deny_markers().into_iter().collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanVerificationContext {
+    pub expected_result_lines: usize,
+    pub semantic_anchors: BTreeSet<String>,
+    pub min_anchor_matches: usize,
+}
+
+impl Default for PlanVerificationContext {
+    fn default() -> Self {
+        Self {
+            expected_result_lines: 1,
+            semantic_anchors: BTreeSet::new(),
+            min_anchor_matches: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanVerificationFailureCode {
+    EmptyOutput,
+    OutputTooShort,
+    DenyMarkerDetected,
+    InsufficientResultLines,
+    MissingStatusPrefix,
+    FailureStatusDetected,
+    MissingSemanticAnchors,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanVerificationReport {
+    pub passed: bool,
+    pub failure_reasons: Vec<String>,
+    pub failure_codes: Vec<PlanVerificationFailureCode>,
+    pub observed_statuses: Vec<String>,
+    pub matched_anchors: Vec<String>,
+}
+
+pub fn verify_output(
+    output: &str,
+    context: &PlanVerificationContext,
+    policy: &PlanVerificationPolicy,
+) -> PlanVerificationReport {
+    let trimmed = output.trim();
+    let mut failure_reasons = Vec::new();
+    let mut failure_codes = Vec::new();
+
+    if trimmed.is_empty() {
+        if policy.require_non_empty {
+            failure_codes.push(PlanVerificationFailureCode::EmptyOutput);
+            failure_reasons.push("empty_output".to_owned());
+        }
+        return PlanVerificationReport {
+            passed: failure_reasons.is_empty(),
+            failure_reasons,
+            failure_codes,
+            observed_statuses: Vec::new(),
+            matched_anchors: Vec::new(),
+        };
+    }
+
+    let char_count = trimmed.chars().count();
+    if char_count < policy.min_output_chars {
+        failure_codes.push(PlanVerificationFailureCode::OutputTooShort);
+        failure_reasons.push(format!(
+            "output_too_short chars={char_count} min={}",
+            policy.min_output_chars
+        ));
+    }
+
+    let normalized = trimmed.to_ascii_lowercase();
+    for marker in &policy.deny_markers {
+        if marker.is_empty() {
+            continue;
+        }
+        if normalized.contains(marker.as_str()) {
+            failure_codes.push(PlanVerificationFailureCode::DenyMarkerDetected);
+            failure_reasons.push(format!("deny_marker_detected marker={marker}"));
+        }
+    }
+
+    let lines = trimmed
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    let expected_result_lines = context.expected_result_lines.max(1);
+    if lines.len() < expected_result_lines {
+        failure_codes.push(PlanVerificationFailureCode::InsufficientResultLines);
+        failure_reasons.push(format!(
+            "insufficient_result_lines actual={} expected>={expected_result_lines}",
+            lines.len()
+        ));
+    }
+
+    let mut observed_statuses = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        match parse_status_prefix(line) {
+            Some(status) => {
+                let normalized_status = status.to_ascii_lowercase();
+                observed_statuses.push(normalized_status.clone());
+                if looks_like_failure_status(normalized_status.as_str()) {
+                    failure_codes.push(PlanVerificationFailureCode::FailureStatusDetected);
+                    failure_reasons.push(format!(
+                        "failure_status_detected line_index={} status={normalized_status}",
+                        index + 1
+                    ));
+                }
+            }
+            None if policy.require_status_prefix => {
+                failure_codes.push(PlanVerificationFailureCode::MissingStatusPrefix);
+                failure_reasons.push(format!(
+                    "missing_status_prefix line_index={} content={}",
+                    index + 1,
+                    line
+                ));
+                break;
+            }
+            None => {}
+        }
+    }
+
+    let semantic_anchors = context
+        .semantic_anchors
+        .iter()
+        .map(|anchor| anchor.trim().to_ascii_lowercase())
+        .filter(|anchor| anchor.len() >= 3)
+        .collect::<BTreeSet<_>>();
+    let matched_anchors = semantic_anchors
+        .iter()
+        .filter(|anchor| normalized.contains(anchor.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if !semantic_anchors.is_empty() && context.min_anchor_matches > 0 {
+        let required_matches = context
+            .min_anchor_matches
+            .min(semantic_anchors.len())
+            .max(1);
+        if matched_anchors.len() < required_matches {
+            failure_codes.push(PlanVerificationFailureCode::MissingSemanticAnchors);
+            failure_reasons.push(format!(
+                "semantic_anchor_miss matched={} required>={required_matches}",
+                matched_anchors.len()
+            ));
+        }
+    }
+
+    PlanVerificationReport {
+        passed: failure_reasons.is_empty(),
+        failure_reasons,
+        failure_codes,
+        observed_statuses,
+        matched_anchors,
+    }
+}
+
+fn parse_status_prefix(line: &str) -> Option<&str> {
+    let remainder = line.strip_prefix('[')?;
+    let bracket_index = remainder.find(']')?;
+    let status = &remainder[..bracket_index];
+    if status.trim().is_empty() {
+        return None;
+    }
+    Some(status.trim())
+}
+
+fn looks_like_failure_status(status: &str) -> bool {
+    matches!(
+        status,
+        "error" | "denied" | "fail" | "failed" | "forbidden" | "timeout"
+    )
+}
+
+fn default_deny_markers() -> Vec<String> {
+    vec![
+        "tool_failure".to_owned(),
+        "provider_error".to_owned(),
+        "no_kernel_context".to_owned(),
+        "tool_not_found".to_owned(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verifier_accepts_well_formed_tool_output() {
+        let policy = PlanVerificationPolicy::default();
+        let context = PlanVerificationContext {
+            expected_result_lines: 2,
+            ..PlanVerificationContext::default()
+        };
+        let output = "[ok] {\"path\":\"note.md\"}\n[ok] {\"path\":\"checklist.md\"}";
+        let report = verify_output(output, &context, &policy);
+        assert!(report.passed, "report={report:?}");
+    }
+
+    #[test]
+    fn verifier_rejects_short_output() {
+        let mut policy = PlanVerificationPolicy::default();
+        policy.min_output_chars = 20;
+        let report = verify_output("[ok] {}", &PlanVerificationContext::default(), &policy);
+        assert!(!report.passed);
+        assert!(
+            report
+                .failure_reasons
+                .iter()
+                .any(|reason| reason.contains("output_too_short")),
+            "report={report:?}"
+        );
+    }
+
+    #[test]
+    fn verifier_rejects_output_with_deny_markers() {
+        let policy = PlanVerificationPolicy::default();
+        let report = verify_output(
+            "[ok] no_kernel_context",
+            &PlanVerificationContext::default(),
+            &policy,
+        );
+        assert!(!report.passed);
+        assert!(
+            report
+                .failure_reasons
+                .iter()
+                .any(|reason| reason.contains("deny_marker_detected")),
+            "report={report:?}"
+        );
+    }
+
+    #[test]
+    fn verifier_rejects_missing_status_prefix() {
+        let policy = PlanVerificationPolicy::default();
+        let report = verify_output("plain output", &PlanVerificationContext::default(), &policy);
+        assert!(!report.passed);
+        assert!(
+            report
+                .failure_reasons
+                .iter()
+                .any(|reason| reason.contains("missing_status_prefix")),
+            "report={report:?}"
+        );
+    }
+
+    #[test]
+    fn verifier_rejects_failure_status_lines() {
+        let policy = PlanVerificationPolicy::default();
+        let report = verify_output(
+            "[error] {\"msg\":\"failed\"}",
+            &PlanVerificationContext::default(),
+            &policy,
+        );
+        assert!(!report.passed);
+        assert!(
+            report
+                .failure_codes
+                .contains(&PlanVerificationFailureCode::FailureStatusDetected),
+            "report={report:?}"
+        );
+    }
+
+    #[test]
+    fn verifier_rejects_when_semantic_anchors_are_missing() {
+        let policy = PlanVerificationPolicy::default();
+        let context = PlanVerificationContext {
+            expected_result_lines: 1,
+            semantic_anchors: BTreeSet::from(["critical-note.md".to_owned()]),
+            min_anchor_matches: 1,
+        };
+        let report = verify_output("[ok] {\"path\":\"other.md\"}", &context, &policy);
+        assert!(!report.passed);
+        assert!(
+            report
+                .failure_codes
+                .contains(&PlanVerificationFailureCode::MissingSemanticAnchors),
+            "report={report:?}"
+        );
+    }
+}

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use async_trait::async_trait;
 use loongclaw_contracts::Capability;
-use serde_json::{json, Value};
+use serde_json::Value;
 
 use crate::CliResult;
 use crate::KernelContext;
@@ -54,13 +54,8 @@ impl ConversationRuntime for DefaultConversationRuntime {
         include_system_prompt: bool,
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<Vec<Value>> {
-        let mut messages = Vec::new();
-        if let Some(system_message) = provider::build_system_message(config, include_system_prompt)
-        {
-            messages.push(system_message);
-        }
-
         if let Some(ctx) = kernel_ctx {
+            let mut messages = provider::build_base_messages(config, include_system_prompt);
             #[cfg(feature = "memory-sqlite")]
             {
                 let request =
@@ -73,10 +68,11 @@ impl ConversationRuntime for DefaultConversationRuntime {
                     .map_err(|error| format!("load memory window via kernel failed: {error}"))?;
                 let turns = memory::decode_window_turns(&outcome.payload);
                 for turn in turns {
-                    messages.push(json!({
-                        "role": turn.role,
-                        "content": turn.content,
-                    }));
+                    provider::push_history_message(
+                        &mut messages,
+                        turn.role.as_str(),
+                        turn.content.as_str(),
+                    );
                 }
             }
             #[cfg(not(feature = "memory-sqlite"))]
@@ -85,9 +81,7 @@ impl ConversationRuntime for DefaultConversationRuntime {
             }
             return Ok(messages);
         }
-
-        messages.extend(provider::load_memory_window_messages(config, session_id)?);
-        Ok(messages)
+        provider::build_messages_for_session(config, session_id, include_system_prompt)
     }
 
     async fn request_completion(

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -21,12 +21,10 @@ use crate::KernelContext;
 
 struct FakeRuntime {
     seed_messages: Vec<Value>,
-    completion_responses: Mutex<VecDeque<Result<String, String>>>,
-    turn_responses: Mutex<VecDeque<Result<ProviderTurn, String>>>,
+    completion: Result<String, String>,
+    turn: Result<ProviderTurn, String>,
     persisted: Mutex<Vec<(String, String, String)>>,
     requested_messages: Mutex<Vec<Value>>,
-    turn_requested_messages: Mutex<Vec<Vec<Value>>>,
-    completion_requested_messages: Mutex<Vec<Vec<Value>>>,
     completion_calls: Mutex<usize>,
     turn_calls: Mutex<usize>,
 }
@@ -43,7 +41,15 @@ impl FakeRuntime {
                 })
             },
         );
-        Self::with_turns_and_completions(seed_messages, vec![turn], vec![completion])
+        Self {
+            seed_messages,
+            completion,
+            turn,
+            persisted: Mutex::new(Vec::new()),
+            requested_messages: Mutex::new(Vec::new()),
+            completion_calls: Mutex::new(0),
+            turn_calls: Mutex::new(0),
+        }
     }
 
     fn with_turn_and_completion(
@@ -51,26 +57,12 @@ impl FakeRuntime {
         turn: Result<ProviderTurn, String>,
         completion: Result<String, String>,
     ) -> Self {
-        Self::with_turns_and_completions(seed_messages, vec![turn], vec![completion])
-    }
-
-    fn with_turns(seed_messages: Vec<Value>, turns: Vec<Result<ProviderTurn, String>>) -> Self {
-        Self::with_turns_and_completions(seed_messages, turns, Vec::new())
-    }
-
-    fn with_turns_and_completions(
-        seed_messages: Vec<Value>,
-        turns: Vec<Result<ProviderTurn, String>>,
-        completions: Vec<Result<String, String>>,
-    ) -> Self {
         Self {
             seed_messages,
-            completion_responses: Mutex::new(VecDeque::from(completions)),
-            turn_responses: Mutex::new(VecDeque::from(turns)),
+            completion,
+            turn,
             persisted: Mutex::new(Vec::new()),
             requested_messages: Mutex::new(Vec::new()),
-            turn_requested_messages: Mutex::new(Vec::new()),
-            completion_requested_messages: Mutex::new(Vec::new()),
             completion_calls: Mutex::new(0),
             turn_calls: Mutex::new(0),
         }
@@ -97,16 +89,7 @@ impl ConversationRuntime for FakeRuntime {
         let mut calls = self.completion_calls.lock().expect("completion calls lock");
         *calls += 1;
         *self.requested_messages.lock().expect("request lock") = messages.to_vec();
-        self.completion_requested_messages
-            .lock()
-            .expect("completion request lock")
-            .push(messages.to_vec());
-        self.completion_responses
-            .lock()
-            .expect("completion response lock")
-            .pop_front()
-            .unwrap_or_else(|| Err("unexpected_completion_call".to_owned()))
-            .map_err(|error| error.to_owned())
+        self.completion.clone().map_err(|error| error.to_owned())
     }
 
     async fn request_turn(
@@ -117,16 +100,7 @@ impl ConversationRuntime for FakeRuntime {
         let mut calls = self.turn_calls.lock().expect("turn calls lock");
         *calls += 1;
         *self.requested_messages.lock().expect("request lock") = messages.to_vec();
-        self.turn_requested_messages
-            .lock()
-            .expect("turn request lock")
-            .push(messages.to_vec());
-        self.turn_responses
-            .lock()
-            .expect("turn response lock")
-            .pop_front()
-            .unwrap_or_else(|| Err("unexpected_turn_call".to_owned()))
-            .map_err(|error| error.to_owned())
+        self.turn.clone().map_err(|error| error.to_owned())
     }
 
     async fn persist_turn(
@@ -151,9 +125,9 @@ fn test_config() -> LoongClawConfig {
         cli: CliChannelConfig::default(),
         telegram: TelegramChannelConfig::default(),
         feishu: FeishuChannelConfig::default(),
+        conversation: ConversationConfig::default(),
         tools: ToolConfig::default(),
         memory: MemoryConfig::default(),
-        conversation: ConversationConfig::default(),
     }
 }
 
@@ -163,8 +137,8 @@ async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
         vec![json!({"role": "system", "content": "sys"})],
         Ok("assistant-reply".to_owned()),
     );
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
         .handle_turn_with_runtime(
             &test_config(),
             "session-1",
@@ -206,8 +180,8 @@ async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
 #[tokio::test]
 async fn handle_turn_with_runtime_propagates_error_without_persisting() {
     let runtime = FakeRuntime::new(vec![], Err("timeout".to_owned()));
-    let turn_loop = ConversationTurnLoop::new();
-    let error = turn_loop
+    let coordinator = ConversationTurnCoordinator::new();
+    let error = coordinator
         .handle_turn_with_runtime(
             &test_config(),
             "session-2",
@@ -226,8 +200,8 @@ async fn handle_turn_with_runtime_propagates_error_without_persisting() {
 #[tokio::test]
 async fn handle_turn_with_runtime_inline_mode_returns_synthetic_reply_and_persists() {
     let runtime = FakeRuntime::new(vec![], Err("timeout".to_owned()));
-    let turn_loop = ConversationTurnLoop::new();
-    let output = turn_loop
+    let coordinator = ConversationTurnCoordinator::new();
+    let output = coordinator
         .handle_turn_with_runtime(
             &test_config(),
             "session-3",
@@ -262,41 +236,35 @@ async fn handle_turn_with_runtime_inline_mode_returns_synthetic_reply_and_persis
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_tool_turn_runs_second_turn_for_natural_language_reply() {
+async fn handle_turn_with_runtime_tool_turn_uses_natural_language_completion_by_default() {
     use super::integration_tests::TurnTestHarness;
 
     let harness = TurnTestHarness::new();
     std::fs::write(
         harness.temp_dir.join("note.md"),
-        "hello from orchestrator test",
+        "hello from coordinator test",
     )
     .expect("seed test note");
 
-    let runtime = FakeRuntime::with_turns(
+    let runtime = FakeRuntime::with_turn_and_completion(
         vec![],
-        vec![
-            Ok(ProviderTurn {
-                assistant_text: "Reading the file now.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-tool".to_owned(),
-                    turn_id: "turn-tool".to_owned(),
-                    tool_call_id: "call-tool".to_owned(),
-                }],
-                raw_meta: Value::Null,
-            }),
-            Ok(ProviderTurn {
-                assistant_text: "Summary: the note says hello from orchestrator test.".to_owned(),
-                tool_intents: vec![],
-                raw_meta: Value::Null,
-            }),
-        ],
+        Ok(ProviderTurn {
+            assistant_text: "Reading the file now.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-tool".to_owned(),
+                turn_id: "turn-tool".to_owned(),
+                tool_call_id: "call-tool".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("Summary: the note says hello from coordinator test.".to_owned()),
     );
 
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
         .handle_turn_with_runtime(
             &test_config(),
             "session-tool",
@@ -308,10 +276,7 @@ async fn handle_turn_with_runtime_tool_turn_runs_second_turn_for_natural_languag
         .await
         .expect("tool turn should succeed");
 
-    assert_eq!(
-        reply,
-        "Summary: the note says hello from orchestrator test."
-    );
+    assert_eq!(reply, "Summary: the note says hello from coordinator test.");
     assert!(
         !reply.contains("[ok]"),
         "default reply should not contain raw tool marker, got: {reply}"
@@ -321,24 +286,9 @@ async fn handle_turn_with_runtime_tool_turn_runs_second_turn_for_natural_languag
             .completion_calls
             .lock()
             .expect("completion calls lock"),
-        0
+        1
     );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
-
-    let requested_turns = runtime
-        .turn_requested_messages
-        .lock()
-        .expect("turn request lock");
-    assert_eq!(requested_turns.len(), 2);
-    let second_turn_payload = serde_json::to_string(&requested_turns[1]).expect("serialize turns");
-    assert!(
-        second_turn_payload.contains("[tool_result]"),
-        "second turn should include tool result context, got: {second_turn_payload}"
-    );
-    assert!(
-        second_turn_payload.contains("Original request"),
-        "second turn should include followup prompt, got: {second_turn_payload}"
-    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
 
     let persisted = runtime.persisted.lock().expect("persisted lock");
     assert_eq!(persisted.len(), 2);
@@ -354,7 +304,7 @@ async fn handle_turn_with_runtime_tool_turn_raw_request_skips_second_pass_comple
     let harness = TurnTestHarness::new();
     std::fs::write(
         harness.temp_dir.join("note.md"),
-        "hello from orchestrator test",
+        "hello from coordinator test",
     )
     .expect("seed test note");
 
@@ -375,8 +325,8 @@ async fn handle_turn_with_runtime_tool_turn_raw_request_skips_second_pass_comple
         Ok("this must not be used".to_owned()),
     );
 
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
         .handle_turn_with_runtime(
             &test_config(),
             "session-tool-raw",
@@ -402,776 +352,1510 @@ async fn handle_turn_with_runtime_tool_turn_raw_request_skips_second_pass_comple
     assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_supports_multiple_tool_rounds_before_final_answer() {
-    use super::integration_tests::TurnTestHarness;
-
-    let harness = TurnTestHarness::new();
-    std::fs::write(harness.temp_dir.join("note_a.md"), "first note").expect("seed note_a");
-    std::fs::write(harness.temp_dir.join("note_b.md"), "second note").expect("seed note_b");
-
-    let runtime = FakeRuntime::with_turns(
-        vec![],
-        vec![
-            Ok(ProviderTurn {
-                assistant_text: "Reading note_a.md.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note_a.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-multi-tool".to_owned(),
-                    turn_id: "turn-1".to_owned(),
-                    tool_call_id: "call-1".to_owned(),
-                }],
-                raw_meta: Value::Null,
-            }),
-            Ok(ProviderTurn {
-                assistant_text: "Need note_b.md as well.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note_b.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-multi-tool".to_owned(),
-                    turn_id: "turn-2".to_owned(),
-                    tool_call_id: "call-2".to_owned(),
-                }],
-                raw_meta: Value::Null,
-            }),
-            Ok(ProviderTurn {
-                assistant_text: "Summary: note_a says first note; note_b says second note."
-                    .to_owned(),
-                tool_intents: vec![],
-                raw_meta: Value::Null,
-            }),
-        ],
-    );
-
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
-        .handle_turn_with_runtime(
-            &test_config(),
-            "session-multi-tool",
-            "read note_a.md and note_b.md then summarize",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            Some(&harness.kernel_ctx),
-        )
-        .await
-        .expect("multi-tool turn should succeed");
-
-    assert_eq!(
-        reply,
-        "Summary: note_a says first note; note_b says second note."
-    );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 3);
-    assert_eq!(
-        *runtime
-            .completion_calls
-            .lock()
-            .expect("completion calls lock"),
-        0
-    );
-
-    let requested_turns = runtime
-        .turn_requested_messages
-        .lock()
-        .expect("turn request lock");
-    assert_eq!(requested_turns.len(), 3);
-    let third_turn_payload = serde_json::to_string(&requested_turns[2]).expect("serialize turns");
-    let tool_result_mentions = third_turn_payload.matches("[tool_result]").count();
-    assert!(
-        tool_result_mentions >= 2,
-        "third turn should include at least two tool_result entries, got: {third_turn_payload}"
-    );
-}
-
 #[tokio::test]
-async fn handle_turn_with_runtime_repeated_tool_signature_guard_warns_then_triggers_completion() {
-    let repeated_tool_turn = || {
-        Ok(ProviderTurn {
-            assistant_text: "Reading the file again.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-loop-guard".to_owned(),
-                turn_id: "turn-loop-guard".to_owned(),
-                tool_call_id: "call-loop-guard".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        })
-    };
-
-    let runtime = FakeRuntime::with_turns_and_completions(
-        vec![],
-        vec![
-            repeated_tool_turn(),
-            repeated_tool_turn(),
-            repeated_tool_turn(),
-            repeated_tool_turn(),
-        ],
-        vec![Ok(
-            "I cannot access additional context, but here's what I found.".to_owned(),
-        )],
-    );
-
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
-        .handle_turn_with_runtime(
-            &test_config(),
-            "session-loop-guard",
-            "read note.md",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("loop guard fallback should succeed");
-
-    assert_eq!(
-        reply,
-        "I cannot access additional context, but here's what I found."
-    );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 4);
-    assert_eq!(
-        *runtime
-            .completion_calls
-            .lock()
-            .expect("completion calls lock"),
-        1
-    );
-
-    let completion_payloads = runtime
-        .completion_requested_messages
-        .lock()
-        .expect("completion requests lock");
-    assert_eq!(completion_payloads.len(), 1);
-    let serialized = serde_json::to_string(&completion_payloads[0]).expect("serialize completion");
-    assert!(
-        serialized.contains("[tool_loop_guard]"),
-        "completion fallback payload should include loop guard marker, got: {serialized}"
-    );
-    assert!(
-        serialized.contains("Detected tool-loop behavior across rounds."),
-        "completion fallback should include generic tool-loop guard prompt, got: {serialized}"
-    );
-    assert!(
-        serialized.contains("Loop guard reason:"),
-        "completion fallback should include loop guard reason section, got: {serialized}"
-    );
-    assert!(
-        serialized.matches("[tool_failure]").count() == 4,
-        "completion fallback should preserve the latest tool failure context before guard fallback, got: {serialized}"
-    );
-
-    let turn_payloads = runtime
-        .turn_requested_messages
-        .lock()
-        .expect("turn requests lock");
-    assert_eq!(turn_payloads.len(), 4);
-    let warning_turn_payload =
-        serde_json::to_string(&turn_payloads[3]).expect("serialize warning turn");
-    assert!(
-        warning_turn_payload.contains("[tool_loop_warning]"),
-        "warning turn payload should include loop warning marker before hard stop, got: {warning_turn_payload}"
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_ping_pong_loop_guard_triggers_completion() {
-    let turn_for = |path: &str, call_id: &str| {
-        Ok(ProviderTurn {
-            assistant_text: format!("Trying to read {path}."),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({ "path": path }),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-ping-pong-guard".to_owned(),
-                turn_id: format!("turn-ping-pong-{path}"),
-                tool_call_id: call_id.to_owned(),
-            }],
-            raw_meta: Value::Null,
-        })
-    };
-
-    let runtime = FakeRuntime::with_turns_and_completions(
-        vec![],
-        vec![
-            turn_for("note_a.md", "call-ping-a-1"),
-            turn_for("note_b.md", "call-ping-b-1"),
-            turn_for("note_a.md", "call-ping-a-2"),
-            turn_for("note_b.md", "call-ping-b-2"),
-            turn_for("note_a.md", "call-ping-a-3"),
-        ],
-        vec![Ok("Switching strategy after loop warning.".to_owned())],
-    );
-
-    let mut config = test_config();
-    config.conversation.turn_loop.max_rounds = 6;
-    config.conversation.turn_loop.max_repeated_tool_call_rounds = 8;
-    config.conversation.turn_loop.max_ping_pong_cycles = 2;
-    config.conversation.turn_loop.max_same_tool_failure_rounds = 8;
-
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
-        .handle_turn_with_runtime(
-            &config,
-            "session-ping-pong-guard",
-            "read note_a then note_b",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("ping-pong loop guard fallback should succeed");
-
-    assert_eq!(reply, "Switching strategy after loop warning.");
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 5);
-    assert_eq!(
-        *runtime
-            .completion_calls
-            .lock()
-            .expect("completion calls lock"),
-        1
-    );
-
-    let completion_payloads = runtime
-        .completion_requested_messages
-        .lock()
-        .expect("completion requests lock");
-    assert_eq!(completion_payloads.len(), 1);
-    let completion_payload =
-        serde_json::to_string(&completion_payloads[0]).expect("serialize completion");
-    assert!(
-        completion_payload.contains("[tool_loop_guard]"),
-        "completion payload should include loop guard marker, got: {completion_payload}"
-    );
-    assert!(
-        completion_payload.contains("Loop guard reason:"),
-        "completion payload should include loop guard reason section, got: {completion_payload}"
-    );
-    assert!(
-        completion_payload.matches("[tool_failure]").count() == 5,
-        "completion payload should include the latest tool failure payload before hard stop, got: {completion_payload}"
-    );
-    assert!(
-        completion_payload.contains("ping_pong_tool_patterns"),
-        "completion payload should include ping-pong reason, got: {completion_payload}"
-    );
-
-    let turn_payloads = runtime
-        .turn_requested_messages
-        .lock()
-        .expect("turn requests lock");
-    assert_eq!(turn_payloads.len(), 5);
-    let warning_turn_payload =
-        serde_json::to_string(&turn_payloads[4]).expect("serialize warning turn");
-    assert!(
-        warning_turn_payload.contains("[tool_loop_warning]"),
-        "warning turn payload should include loop warning marker, got: {warning_turn_payload}"
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_failure_streak_guard_triggers_completion() {
-    let turn_for = |path: &str, call_id: &str| {
-        Ok(ProviderTurn {
-            assistant_text: format!("Attempting read for {path}."),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({ "path": path }),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-failure-streak-guard".to_owned(),
-                turn_id: format!("turn-failure-streak-{path}"),
-                tool_call_id: call_id.to_owned(),
-            }],
-            raw_meta: Value::Null,
-        })
-    };
-
-    let runtime = FakeRuntime::with_turns_and_completions(
-        vec![],
-        vec![
-            turn_for("note_1.md", "call-failure-1"),
-            turn_for("note_2.md", "call-failure-2"),
-            turn_for("note_3.md", "call-failure-3"),
-            turn_for("note_4.md", "call-failure-4"),
-        ],
-        vec![Ok("Stopping after repeated tool failures.".to_owned())],
-    );
-
-    let mut config = test_config();
-    config.conversation.turn_loop.max_rounds = 5;
-    config.conversation.turn_loop.max_repeated_tool_call_rounds = 8;
-    config.conversation.turn_loop.max_ping_pong_cycles = 8;
-    config.conversation.turn_loop.max_same_tool_failure_rounds = 3;
-
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
-        .handle_turn_with_runtime(
-            &config,
-            "session-failure-streak-guard",
-            "read those notes",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("failure-streak loop guard fallback should succeed");
-
-    assert_eq!(reply, "Stopping after repeated tool failures.");
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 4);
-    assert_eq!(
-        *runtime
-            .completion_calls
-            .lock()
-            .expect("completion calls lock"),
-        1
-    );
-
-    let completion_payloads = runtime
-        .completion_requested_messages
-        .lock()
-        .expect("completion requests lock");
-    assert_eq!(completion_payloads.len(), 1);
-    let completion_payload =
-        serde_json::to_string(&completion_payloads[0]).expect("serialize completion");
-    assert!(
-        completion_payload.contains("[tool_loop_guard]"),
-        "completion payload should include loop guard marker, got: {completion_payload}"
-    );
-    assert!(
-        completion_payload.contains("Loop guard reason:"),
-        "completion payload should include loop guard reason section, got: {completion_payload}"
-    );
-    assert!(
-        completion_payload.matches("[tool_failure]").count() == 4,
-        "completion payload should include the latest tool failure payload before hard stop, got: {completion_payload}"
-    );
-    assert!(
-        completion_payload.contains("tool_failure_streak"),
-        "completion payload should include failure-streak reason, got: {completion_payload}"
-    );
-
-    let turn_payloads = runtime
-        .turn_requested_messages
-        .lock()
-        .expect("turn requests lock");
-    assert_eq!(turn_payloads.len(), 4);
-    let warning_turn_payload =
-        serde_json::to_string(&turn_payloads[3]).expect("serialize warning turn");
-    assert!(
-        warning_turn_payload.contains("[tool_loop_warning]"),
-        "warning turn payload should include loop warning marker, got: {warning_turn_payload}"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_truncates_large_tool_result_in_followup_payload() {
-    use super::integration_tests::TurnTestHarness;
-
-    let harness = TurnTestHarness::new();
-    let large_note = format!("BEGIN-UNIQUE-{}-END-UNIQUE", "x".repeat(1_600));
-    std::fs::write(harness.temp_dir.join("large_note.md"), large_note).expect("seed large note");
-
-    let runtime = FakeRuntime::with_turns(
-        vec![],
-        vec![
-            Ok(ProviderTurn {
-                assistant_text: "Reading large note.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "large_note.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-truncate-tool-result".to_owned(),
-                    turn_id: "turn-truncate-tool-result-1".to_owned(),
-                    tool_call_id: "call-truncate-tool-result-1".to_owned(),
-                }],
-                raw_meta: Value::Null,
-            }),
-            Ok(ProviderTurn {
-                assistant_text: "Summary completed.".to_owned(),
-                tool_intents: vec![],
-                raw_meta: Value::Null,
-            }),
-        ],
-    );
-
-    let mut config = test_config();
-    config
-        .conversation
-        .turn_loop
-        .max_followup_tool_payload_chars = 220;
-
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
-        .handle_turn_with_runtime(
-            &config,
-            "session-truncate-tool-result",
-            "read large_note.md and summarize",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            Some(&harness.kernel_ctx),
-        )
-        .await
-        .expect("tool-result truncation path should succeed");
-
-    assert_eq!(reply, "Summary completed.");
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
-
-    let requested_turns = runtime
-        .turn_requested_messages
-        .lock()
-        .expect("turn request lock");
-    assert_eq!(requested_turns.len(), 2);
-    let second_turn_payload = serde_json::to_string(&requested_turns[1]).expect("serialize turns");
-    assert!(
-        second_turn_payload.contains("[tool_result_truncated]"),
-        "followup payload should include tool-result truncation marker, got: {second_turn_payload}"
-    );
-    assert!(
-        second_turn_payload.contains("BEGIN-UNIQUE-"),
-        "followup payload should retain leading tool context, got: {second_turn_payload}"
-    );
-    assert!(
-        !second_turn_payload.contains("-END-UNIQUE"),
-        "followup payload should trim tail content when truncated, got: {second_turn_payload}"
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_truncates_large_tool_failure_in_followup_payload() {
-    let oversized_tool_name = format!("tool_{}", "z".repeat(900));
-    let runtime = FakeRuntime::with_turns(
-        vec![],
-        vec![
-            Ok(ProviderTurn {
-                assistant_text: "Attempting unknown tool.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: oversized_tool_name.clone(),
-                    args_json: json!({}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-truncate-tool-failure".to_owned(),
-                    turn_id: "turn-truncate-tool-failure-1".to_owned(),
-                    tool_call_id: "call-truncate-tool-failure-1".to_owned(),
-                }],
-                raw_meta: Value::Null,
-            }),
-            Ok(ProviderTurn {
-                assistant_text: "Fallback answer after tool failure.".to_owned(),
-                tool_intents: vec![],
-                raw_meta: Value::Null,
-            }),
-        ],
-    );
-
-    let mut config = test_config();
-    config
-        .conversation
-        .turn_loop
-        .max_followup_tool_payload_chars = 180;
-    config.conversation.turn_loop.max_repeated_tool_call_rounds = 5;
-
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
-        .handle_turn_with_runtime(
-            &config,
-            "session-truncate-tool-failure",
-            "run this tool",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("tool-failure truncation path should succeed");
-
-    assert_eq!(reply, "Fallback answer after tool failure.");
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
-
-    let requested_turns = runtime
-        .turn_requested_messages
-        .lock()
-        .expect("turn request lock");
-    assert_eq!(requested_turns.len(), 2);
-    let second_turn_payload = serde_json::to_string(&requested_turns[1]).expect("serialize turns");
-    assert!(
-        second_turn_payload.contains("[tool_failure_truncated]"),
-        "followup payload should include tool-failure truncation marker, got: {second_turn_payload}"
-    );
-    assert!(
-        second_turn_payload.contains("tool_not_found"),
-        "followup payload should retain failure type, got: {second_turn_payload}"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_enforces_total_followup_payload_budget_across_rounds() {
-    use super::integration_tests::TurnTestHarness;
-
-    let harness = TurnTestHarness::new();
-    std::fs::write(
-        harness.temp_dir.join("note_a.md"),
-        format!("NOTE-A-BEGIN-{}-NOTE-A-END", "a".repeat(1_200)),
-    )
-    .expect("seed note_a");
-    std::fs::write(
-        harness.temp_dir.join("note_b.md"),
-        format!("NOTE-B-BEGIN-{}-NOTE-B-END", "b".repeat(1_200)),
-    )
-    .expect("seed note_b");
-    std::fs::write(
-        harness.temp_dir.join("note_c.md"),
-        format!("NOTE-C-BEGIN-{}-NOTE-C-END", "c".repeat(1_200)),
-    )
-    .expect("seed note_c");
-
-    let runtime = FakeRuntime::with_turns(
-        vec![],
-        vec![
-            Ok(ProviderTurn {
-                assistant_text: "Reading note A.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note_a.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-total-budget".to_owned(),
-                    turn_id: "turn-total-budget-1".to_owned(),
-                    tool_call_id: "call-total-budget-1".to_owned(),
-                }],
-                raw_meta: Value::Null,
-            }),
-            Ok(ProviderTurn {
-                assistant_text: "Reading note B.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note_b.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-total-budget".to_owned(),
-                    turn_id: "turn-total-budget-2".to_owned(),
-                    tool_call_id: "call-total-budget-2".to_owned(),
-                }],
-                raw_meta: Value::Null,
-            }),
-            Ok(ProviderTurn {
-                assistant_text: "Reading note C.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note_c.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-total-budget".to_owned(),
-                    turn_id: "turn-total-budget-3".to_owned(),
-                    tool_call_id: "call-total-budget-3".to_owned(),
-                }],
-                raw_meta: Value::Null,
-            }),
-            Ok(ProviderTurn {
-                assistant_text: "Final synthesis after bounded context.".to_owned(),
-                tool_intents: vec![],
-                raw_meta: Value::Null,
-            }),
-        ],
-    );
-
-    let mut config = test_config();
-    config.conversation.turn_loop.max_rounds = 4;
-    config.conversation.turn_loop.max_repeated_tool_call_rounds = 8;
-    config.conversation.turn_loop.max_ping_pong_cycles = 8;
-    config.conversation.turn_loop.max_same_tool_failure_rounds = 8;
-    config
-        .conversation
-        .turn_loop
-        .max_followup_tool_payload_chars = 600;
-    config
-        .conversation
-        .turn_loop
-        .max_followup_tool_payload_chars_total = 120;
-
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
-        .handle_turn_with_runtime(
-            &config,
-            "session-total-budget",
-            "read all notes then summarize",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            Some(&harness.kernel_ctx),
-        )
-        .await
-        .expect("total followup payload budget path should succeed");
-
-    assert_eq!(reply, "Final synthesis after bounded context.");
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 4);
-
-    let requested_turns = runtime
-        .turn_requested_messages
-        .lock()
-        .expect("turn request lock");
-    assert_eq!(requested_turns.len(), 4);
-    let fourth_turn_payload = serde_json::to_string(&requested_turns[3]).expect("serialize turns");
-    assert!(
-        fourth_turn_payload.contains("[tool_result_truncated]"),
-        "fourth turn should still include truncation marker, got: {fourth_turn_payload}"
-    );
-    assert!(
-        fourth_turn_payload.contains("budget_exhausted=true"),
-        "fourth turn should report exhausted total payload budget, got: {fourth_turn_payload}"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_turn_loop_policy_override_allows_multiple_tool_steps() {
-    use super::integration_tests::TurnTestHarness;
-
-    let harness = TurnTestHarness::new();
-    std::fs::write(harness.temp_dir.join("note_a.md"), "first note").expect("seed note_a");
-    std::fs::write(harness.temp_dir.join("note_b.md"), "second note").expect("seed note_b");
-
+async fn handle_turn_with_runtime_safe_lane_honors_configured_tool_step_budget() {
     let runtime = FakeRuntime::with_turn_and_completion(
         vec![],
         Ok(ProviderTurn {
-            assistant_text: "Reading both notes.".to_owned(),
+            assistant_text: "Executing deployment checks.".to_owned(),
             tool_intents: vec![
                 ToolIntent {
                     tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note_a.md"}),
+                    args_json: json!({"path": "note.md"}),
                     source: "provider_tool_call".to_owned(),
-                    session_id: "session-step-override".to_owned(),
-                    turn_id: "turn-step-override".to_owned(),
-                    tool_call_id: "call-step-1".to_owned(),
+                    session_id: "session-safe-budget".to_owned(),
+                    turn_id: "turn-safe-budget".to_owned(),
+                    tool_call_id: "call-safe-budget-1".to_owned(),
                 },
                 ToolIntent {
                     tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note_b.md"}),
+                    args_json: json!({"path": "checklist.md"}),
                     source: "provider_tool_call".to_owned(),
-                    session_id: "session-step-override".to_owned(),
-                    turn_id: "turn-step-override".to_owned(),
-                    tool_call_id: "call-step-2".to_owned(),
+                    session_id: "session-safe-budget".to_owned(),
+                    turn_id: "turn-safe-budget".to_owned(),
+                    tool_call_id: "call-safe-budget-2".to_owned(),
                 },
             ],
             raw_meta: Value::Null,
         }),
-        Ok("this must not be used".to_owned()),
+        Ok("unused".to_owned()),
     );
 
     let mut config = test_config();
-    config.conversation.turn_loop.max_tool_steps_per_round = 2;
+    config.conversation.safe_lane_max_tool_steps_per_turn = 2;
 
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
         .handle_turn_with_runtime(
             &config,
-            "session-step-override",
-            "read note_a.md and note_b.md, return raw tool output",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            Some(&harness.kernel_ctx),
-        )
-        .await
-        .expect("multiple tool steps should be allowed by override");
-
-    assert!(
-        reply.matches("[ok]").count() >= 2,
-        "expected at least two tool outputs, got: {reply}"
-    );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
-    assert_eq!(
-        *runtime
-            .completion_calls
-            .lock()
-            .expect("completion calls lock"),
-        0
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_turn_loop_policy_override_allows_more_repeated_rounds() {
-    let repeated_tool_turn = || {
-        Ok(ProviderTurn {
-            assistant_text: "Trying file.read again.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-loop-override".to_owned(),
-                turn_id: "turn-loop-override".to_owned(),
-                tool_call_id: "call-loop-override".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        })
-    };
-
-    let runtime = FakeRuntime::with_turns(
-        vec![],
-        vec![
-            repeated_tool_turn(),
-            repeated_tool_turn(),
-            repeated_tool_turn(),
-            repeated_tool_turn(),
-            Ok(ProviderTurn {
-                assistant_text: "Final answer after four retries.".to_owned(),
-                tool_intents: vec![],
-                raw_meta: Value::Null,
-            }),
-        ],
-    );
-
-    let mut config = test_config();
-    config.conversation.turn_loop.max_rounds = 5;
-    config.conversation.turn_loop.max_repeated_tool_call_rounds = 4;
-    config.conversation.turn_loop.max_ping_pong_cycles = 8;
-    config.conversation.turn_loop.max_same_tool_failure_rounds = 8;
-
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
-        .handle_turn_with_runtime(
-            &config,
-            "session-loop-override",
-            "read note.md",
+            "session-safe-budget",
+            "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
             None,
         )
         .await
-        .expect("policy override should permit extra repeated rounds");
+        .expect("safe lane should execute with configured step budget");
 
-    assert_eq!(reply, "Final answer after four retries.");
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 5);
+    assert!(
+        reply.contains("no_kernel_context"),
+        "expected kernel-context denial once tool-step budget is honored, got: {reply}"
+    );
+    assert!(
+        !reply.contains("max_tool_steps_exceeded"),
+        "safe lane should not hit max_tool_steps after config override, got: {reply}"
+    );
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_safe_lane_plan_path_bypasses_turn_step_limit() {
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Executing deployment checks.".to_owned(),
+            tool_intents: vec![
+                ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "note.md"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-safe-plan".to_owned(),
+                    turn_id: "turn-safe-plan".to_owned(),
+                    tool_call_id: "call-safe-plan-1".to_owned(),
+                },
+                ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "checklist.md"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-safe-plan".to_owned(),
+                    turn_id: "turn-safe-plan".to_owned(),
+                    tool_call_id: "call-safe-plan-2".to_owned(),
+                },
+            ],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.safe_lane_max_tool_steps_per_turn = 1;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-plan",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("safe lane plan path should return inline tool error");
+
+    assert!(
+        reply.contains("no_kernel_context"),
+        "expected kernel-context denial from plan execution path, got: {reply}"
+    );
+    assert!(
+        !reply.contains("max_tool_steps_exceeded"),
+        "plan path should not use TurnEngine max_tool_steps gate, got: {reply}"
+    );
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_safe_lane_plan_persists_runtime_events_when_enabled() {
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Executing deployment checks.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe-events".to_owned(),
+                turn_id: "turn-safe-events".to_owned(),
+                tool_call_id: "call-safe-events-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.safe_lane_emit_runtime_events = true;
+    config.conversation.safe_lane_replan_max_rounds = 0;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let _reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-events",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("safe lane plan should produce a reply");
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let event_names = persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            parsed.get("event")?.as_str().map(ToOwned::to_owned)
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        event_names.iter().any(|name| name == "lane_selected"),
+        "expected lane_selected event, got: {event_names:?}"
+    );
+    assert!(
+        event_names.iter().any(|name| name == "plan_round_started"),
+        "expected plan_round_started event, got: {event_names:?}"
+    );
+    assert!(
+        event_names
+            .iter()
+            .any(|name| name == "plan_round_completed"),
+        "expected plan_round_completed event, got: {event_names:?}"
+    );
+    assert!(
+        event_names.iter().any(|name| name == "final_status"),
+        "expected final_status event, got: {event_names:?}"
+    );
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_safe_lane_plan_skips_runtime_events_when_disabled() {
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Executing deployment checks.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe-events-off".to_owned(),
+                turn_id: "turn-safe-events-off".to_owned(),
+                tool_call_id: "call-safe-events-off-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.safe_lane_emit_runtime_events = false;
+    config.conversation.safe_lane_replan_max_rounds = 0;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let _reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-events-off",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("safe lane plan should produce a reply");
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let event_count = persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            (parsed.get("type")?.as_str()? == "conversation_event").then_some(())
+        })
+        .count();
+    assert_eq!(event_count, 0, "unexpected runtime events: {persisted:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_safe_lane_plan_emits_kernel_runtime_audit_events() {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    std::fs::write(harness.temp_dir.join("note.md"), "safe lane audit probe")
+        .expect("write note fixture");
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Executing deployment checks.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe-audit-on".to_owned(),
+                turn_id: "turn-safe-audit-on".to_owned(),
+                tool_call_id: "call-safe-audit-on-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.safe_lane_emit_runtime_events = true;
+    config.conversation.safe_lane_replan_max_rounds = 0;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let _reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-audit-on",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("safe lane plan should produce a reply");
+
+    let events = harness.audit.snapshot();
+    let runtime_ops = events
+        .iter()
+        .filter_map(|event| match &event.kind {
+            loongclaw_kernel::AuditEventKind::PlaneInvoked {
+                pack_id,
+                plane,
+                tier,
+                primary_adapter,
+                operation,
+                ..
+            } if *plane == loongclaw_contracts::ExecutionPlane::Runtime
+                && operation.starts_with("conversation.safe_lane.") =>
+            {
+                Some((
+                    pack_id.to_owned(),
+                    *tier,
+                    primary_adapter.to_owned(),
+                    operation.to_owned(),
+                ))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        runtime_ops
+            .iter()
+            .any(|(_, _, _, operation)| operation == "conversation.safe_lane.lane_selected"),
+        "expected lane_selected runtime audit event, got: {runtime_ops:?}"
+    );
+    assert!(
+        runtime_ops
+            .iter()
+            .any(|(_, _, _, operation)| operation == "conversation.safe_lane.final_status"),
+        "expected final_status runtime audit event, got: {runtime_ops:?}"
+    );
+    assert!(
+        runtime_ops.iter().all(|(pack_id, tier, adapter, _)| {
+            pack_id == "test-pack"
+                && *tier == loongclaw_contracts::PlaneTier::Core
+                && adapter == "conversation.safe_lane"
+        }),
+        "unexpected runtime audit metadata: {runtime_ops:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_safe_lane_plan_does_not_emit_kernel_runtime_audit_when_disabled()
+{
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    std::fs::write(harness.temp_dir.join("note.md"), "safe lane audit disabled")
+        .expect("write note fixture");
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Executing deployment checks.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe-audit-off".to_owned(),
+                turn_id: "turn-safe-audit-off".to_owned(),
+                tool_call_id: "call-safe-audit-off-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.safe_lane_emit_runtime_events = false;
+    config.conversation.safe_lane_replan_max_rounds = 0;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let _reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-audit-off",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("safe lane plan should produce a reply");
+
+    let has_safe_lane_runtime_event = harness.audit.snapshot().iter().any(|event| {
+        matches!(
+            &event.kind,
+            loongclaw_kernel::AuditEventKind::PlaneInvoked {
+                plane: loongclaw_contracts::ExecutionPlane::Runtime,
+                operation,
+                ..
+            } if operation.starts_with("conversation.safe_lane.")
+        )
+    });
+
+    assert!(
+        !has_safe_lane_runtime_event,
+        "safe-lane runtime audit events should be disabled"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_safe_lane_plan_replans_after_transient_tool_failure() {
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
+    use loongclaw_kernel::CoreToolAdapter;
+
+    struct FlakyOnceToolAdapter {
+        calls: Arc<Mutex<usize>>,
+    }
+
+    #[async_trait]
+    impl CoreToolAdapter for FlakyOnceToolAdapter {
+        fn name(&self) -> &str {
+            "flaky-once-tools"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            let current_call = {
+                let mut calls = self.calls.lock().expect("flaky calls lock");
+                *calls = calls.saturating_add(1);
+                *calls
+            };
+            if current_call == 1 {
+                return Err(ToolPlaneError::Execution(
+                    "transient tool failure".to_owned(),
+                ));
+            }
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool": request.tool_name,
+                    "attempt": current_call
+                }),
+            })
+        }
+    }
+
+    let call_counter = Arc::new(Mutex::new(0usize));
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_tool_adapter(FlakyOnceToolAdapter {
+        calls: call_counter.clone(),
+    });
+    kernel
+        .set_default_core_tool_adapter("flaky-once-tools")
+        .expect("set default core tool adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Running checks.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe-replan".to_owned(),
+                turn_id: "turn-safe-replan".to_owned(),
+                tool_call_id: "call-safe-replan-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.safe_lane_node_max_attempts = 1;
+    config.conversation.safe_lane_replan_max_rounds = 1;
+    config.conversation.safe_lane_replan_max_node_attempts = 2;
+    config.conversation.safe_lane_event_sample_every = 2;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-replan",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&ctx),
+        )
+        .await
+        .expect("safe lane plan should recover via bounded replan");
+
+    assert!(
+        reply.contains("[ok]"),
+        "expected successful tool output after replan, got: {reply}"
+    );
+    assert!(
+        !reply.contains("transient tool failure"),
+        "final reply should not leak first transient failure after successful replan, got: {reply}"
+    );
+    let calls = *call_counter.lock().expect("call counter lock");
+    assert_eq!(calls, 2, "expected one failure + one replan success");
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let failed_round_payload = persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            if parsed.get("event")?.as_str()? != "plan_round_completed" {
+                return None;
+            }
+            let payload = parsed.get("payload")?;
+            if payload.get("status")?.as_str()? != "failed" {
+                return None;
+            }
+            Some(payload.clone())
+        })
+        .next()
+        .expect("failed plan_round_completed payload");
+    assert_eq!(failed_round_payload["failure_kind"], "retryable");
     assert_eq!(
-        *runtime
-            .completion_calls
-            .lock()
-            .expect("completion calls lock"),
-        0
+        failed_round_payload["failure_code"],
+        "safe_lane_plan_node_retryable_error"
+    );
+    assert_eq!(failed_round_payload["failure_retryable"], true);
+    assert_eq!(failed_round_payload["route_decision"], "replan");
+    assert_eq!(failed_round_payload["route_reason"], "retryable_failure");
+
+    let has_sampled_out_success_round = !persisted.iter().any(|(_, role, content)| {
+        if role != "assistant" {
+            return false;
+        }
+        let parsed = match serde_json::from_str::<Value>(content) {
+            Ok(value) => value,
+            Err(_) => return false,
+        };
+        if parsed.get("type").and_then(Value::as_str) != Some("conversation_event") {
+            return false;
+        }
+        if parsed.get("event").and_then(Value::as_str) != Some("plan_round_completed") {
+            return false;
+        }
+        let payload = match parsed.get("payload") {
+            Some(value) => value,
+            None => return false,
+        };
+        payload.get("status").and_then(Value::as_str) == Some("succeeded")
+            && payload.get("round").and_then(Value::as_u64) == Some(1)
+    });
+    assert!(
+        has_sampled_out_success_round,
+        "round-1 plan_round_completed should be sampled out"
+    );
+
+    let final_status_payload = persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            if parsed.get("event")?.as_str()? != "final_status" {
+                return None;
+            }
+            parsed.get("payload").cloned()
+        })
+        .next_back()
+        .expect("final_status payload");
+    assert_eq!(final_status_payload["status"], "succeeded");
+    assert_eq!(final_status_payload["metrics"]["rounds_started"], 2);
+    assert_eq!(final_status_payload["metrics"]["rounds_succeeded"], 1);
+    assert_eq!(final_status_payload["metrics"]["rounds_failed"], 1);
+    assert_eq!(final_status_payload["metrics"]["verify_failures"], 0);
+    assert_eq!(final_status_payload["metrics"]["replans_triggered"], 1);
+    assert!(
+        final_status_payload["metrics"]["total_attempts_used"]
+            .as_u64()
+            .unwrap_or_default()
+            >= 2
+    );
+
+    let summary = summarize_safe_lane_events(
+        persisted
+            .iter()
+            .filter_map(|(_, role, content)| (role == "assistant").then_some(content.as_str())),
+    );
+    assert_eq!(summary.final_status, Some(SafeLaneFinalStatus::Succeeded));
+    assert_eq!(summary.replan_triggered_events, 1);
+    assert_eq!(
+        summary
+            .latest_metrics
+            .as_ref()
+            .map(|metrics| metrics.rounds_started),
+        Some(2)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_safe_lane_backpressure_guard_blocks_retry_storm() {
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
+    use loongclaw_kernel::CoreToolAdapter;
+
+    struct FlakyAlwaysRetryableAdapter {
+        calls: Arc<Mutex<usize>>,
+    }
+
+    #[async_trait]
+    impl CoreToolAdapter for FlakyAlwaysRetryableAdapter {
+        fn name(&self) -> &str {
+            "flaky-always-retryable-tools"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            _request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            {
+                let mut calls = self.calls.lock().expect("flaky calls lock");
+                *calls = calls.saturating_add(1);
+            }
+            Err(ToolPlaneError::Execution(
+                "transient tool failure".to_owned(),
+            ))
+        }
+    }
+
+    let call_counter = Arc::new(Mutex::new(0usize));
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_tool_adapter(FlakyAlwaysRetryableAdapter {
+        calls: call_counter.clone(),
+    });
+    kernel
+        .set_default_core_tool_adapter("flaky-always-retryable-tools")
+        .expect("set default core tool adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Running checks.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe-backpressure".to_owned(),
+                turn_id: "turn-safe-backpressure".to_owned(),
+                tool_call_id: "call-safe-backpressure-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.safe_lane_node_max_attempts = 1;
+    config.conversation.safe_lane_replan_max_rounds = 3;
+    config.conversation.safe_lane_replan_max_node_attempts = 4;
+    config.conversation.safe_lane_backpressure_guard_enabled = true;
+    config
+        .conversation
+        .safe_lane_backpressure_max_total_attempts = 1;
+    config.conversation.safe_lane_backpressure_max_replans = 10;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-backpressure",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&ctx),
+        )
+        .await
+        .expect("safe lane should fail-fast under backpressure guard");
+
+    assert!(
+        reply.contains("safe_lane_plan_backpressure_guard"),
+        "expected explicit backpressure guard reason, got: {reply}"
+    );
+    let calls = *call_counter.lock().expect("call counter lock");
+    assert_eq!(
+        calls, 1,
+        "backpressure guard should block further replan retries"
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let final_status_payload = persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            if parsed.get("event")?.as_str()? != "final_status" {
+                return None;
+            }
+            parsed.get("payload").cloned()
+        })
+        .next_back()
+        .expect("final_status payload");
+    assert_eq!(
+        final_status_payload["route_reason"],
+        "backpressure_attempts_exhausted"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_safe_lane_verify_non_retryable_failure_skips_replan() {
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
+    use loongclaw_kernel::CoreToolAdapter;
+
+    struct DenyMarkerAdapter {
+        calls: Arc<Mutex<usize>>,
+    }
+
+    #[async_trait]
+    impl CoreToolAdapter for DenyMarkerAdapter {
+        fn name(&self) -> &str {
+            "deny-marker-tools"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            _request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            let current_call = {
+                let mut calls = self.calls.lock().expect("anchor mismatch calls lock");
+                *calls = calls.saturating_add(1);
+                *calls
+            };
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "attempt": current_call,
+                    "message": "simulated tool_not_found marker"
+                }),
+            })
+        }
+    }
+
+    let call_counter = Arc::new(Mutex::new(0usize));
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_tool_adapter(DenyMarkerAdapter {
+        calls: call_counter.clone(),
+    });
+    kernel
+        .set_default_core_tool_adapter("deny-marker-tools")
+        .expect("set default core tool adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Running checks.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe-verify-nonretryable".to_owned(),
+                turn_id: "turn-safe-verify-nonretryable".to_owned(),
+                tool_call_id: "call-safe-verify-nonretryable-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.safe_lane_node_max_attempts = 1;
+    config.conversation.safe_lane_replan_max_rounds = 3;
+    config.conversation.safe_lane_replan_max_node_attempts = 4;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-verify-nonretryable",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&ctx),
+        )
+        .await
+        .expect("safe lane should return verify failure");
+
+    assert!(
+        reply.contains("safe_lane_plan_verify_failed"),
+        "expected verify failure in reply, got: {reply}"
+    );
+    let calls = *call_counter.lock().expect("call counter lock");
+    assert_eq!(
+        calls, 1,
+        "non-retryable verify failure should not trigger replan tool re-execution"
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let verify_failed_payload = persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            if parsed.get("event")?.as_str()? != "verify_failed" {
+                return None;
+            }
+            parsed.get("payload").cloned()
+        })
+        .next_back()
+        .expect("verify_failed payload");
+    assert_eq!(verify_failed_payload["failure_kind"], "non_retryable");
+    assert_eq!(
+        verify_failed_payload["failure_code"],
+        "safe_lane_plan_verify_failed"
+    );
+    assert_eq!(verify_failed_payload["failure_retryable"], false);
+    assert_eq!(verify_failed_payload["route_decision"], "terminal");
+    assert_eq!(
+        verify_failed_payload["route_reason"],
+        "non_retryable_failure"
+    );
+
+    let final_status_payload = persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            if parsed.get("event")?.as_str()? != "final_status" {
+                return None;
+            }
+            parsed.get("payload").cloned()
+        })
+        .next_back()
+        .expect("final_status payload");
+    assert_eq!(final_status_payload["failure_kind"], "non_retryable");
+    assert_eq!(
+        final_status_payload["failure_code"],
+        "safe_lane_plan_verify_failed"
+    );
+    assert_eq!(final_status_payload["failure_retryable"], false);
+    assert_eq!(final_status_payload["route_decision"], "terminal");
+    assert_eq!(
+        final_status_payload["route_reason"],
+        "non_retryable_failure"
+    );
+    assert_eq!(final_status_payload["metrics"]["rounds_started"], 1);
+    assert_eq!(final_status_payload["metrics"]["rounds_succeeded"], 1);
+    assert_eq!(final_status_payload["metrics"]["rounds_failed"], 0);
+    assert_eq!(final_status_payload["metrics"]["verify_failures"], 1);
+    assert_eq!(final_status_payload["metrics"]["replans_triggered"], 0);
+
+    let summary = summarize_safe_lane_events(
+        persisted
+            .iter()
+            .filter_map(|(_, role, content)| (role == "assistant").then_some(content.as_str())),
+    );
+    assert_eq!(summary.final_status, Some(SafeLaneFinalStatus::Failed));
+    assert_eq!(
+        summary.final_failure_code.as_deref(),
+        Some("safe_lane_plan_verify_failed")
+    );
+    assert_eq!(summary.verify_failed_events, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_safe_lane_session_governor_forces_no_replan() {
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
+    use loongclaw_kernel::{CoreMemoryAdapter, CoreToolAdapter};
+
+    struct FlakyAlwaysRetryableAdapter {
+        calls: Arc<Mutex<usize>>,
+    }
+
+    #[async_trait]
+    impl CoreToolAdapter for FlakyAlwaysRetryableAdapter {
+        fn name(&self) -> &str {
+            "flaky-governor-tools"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            _request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            {
+                let mut calls = self.calls.lock().expect("flaky calls lock");
+                *calls = calls.saturating_add(1);
+            }
+            Err(ToolPlaneError::Execution(
+                "transient tool failure".to_owned(),
+            ))
+        }
+    }
+
+    struct ChronicFailureMemoryAdapter;
+
+    #[async_trait]
+    impl CoreMemoryAdapter for ChronicFailureMemoryAdapter {
+        fn name(&self) -> &str {
+            "chronic-failure-memory"
+        }
+
+        async fn execute_core_memory(
+            &self,
+            request: MemoryCoreRequest,
+        ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
+            if request.operation == "window" {
+                return Ok(MemoryCoreOutcome {
+                    status: "ok".to_owned(),
+                    payload: json!({
+                        "turns": [
+                            {
+                                "role": "assistant",
+                                "content": "{\"type\":\"conversation_event\",\"event\":\"final_status\",\"payload\":{\"status\":\"failed\",\"failure_code\":\"safe_lane_plan_node_retryable_error\",\"route_decision\":\"terminal\"}}",
+                                "ts": 1
+                            }
+                        ]
+                    }),
+                });
+            }
+            Ok(MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({}),
+            })
+        }
+    }
+
+    let call_counter = Arc::new(Mutex::new(0usize));
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::MemoryRead]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_memory_adapter(ChronicFailureMemoryAdapter);
+    kernel
+        .set_default_core_memory_adapter("chronic-failure-memory")
+        .expect("set default core memory adapter");
+    kernel.register_core_tool_adapter(FlakyAlwaysRetryableAdapter {
+        calls: call_counter.clone(),
+    });
+    kernel
+        .set_default_core_tool_adapter("flaky-governor-tools")
+        .expect("set default core tool adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Running checks.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe-governor".to_owned(),
+                turn_id: "turn-safe-governor".to_owned(),
+                tool_call_id: "call-safe-governor-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.safe_lane_node_max_attempts = 1;
+    config.conversation.safe_lane_replan_max_rounds = 3;
+    config.conversation.safe_lane_replan_max_node_attempts = 4;
+    config.conversation.safe_lane_session_governor_enabled = true;
+    config
+        .conversation
+        .safe_lane_session_governor_failed_final_status_threshold = 1;
+    config
+        .conversation
+        .safe_lane_session_governor_backpressure_failure_threshold = 9;
+    config
+        .conversation
+        .safe_lane_session_governor_force_no_replan = true;
+    config
+        .conversation
+        .safe_lane_session_governor_force_node_max_attempts = 1;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let _reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-governor",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&ctx),
+        )
+        .await
+        .expect("safe lane should fail without replan under governor");
+
+    let calls = *call_counter.lock().expect("call counter lock");
+    assert_eq!(calls, 1, "governor should suppress replans");
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let lane_selected_payload = persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            if parsed.get("event")?.as_str()? != "lane_selected" {
+                return None;
+            }
+            parsed.get("payload").cloned()
+        })
+        .next_back()
+        .expect("lane_selected payload");
+    assert_eq!(lane_selected_payload["session_governor"]["engaged"], true);
+    assert_eq!(
+        lane_selected_payload["session_governor"]["force_no_replan"],
+        true
+    );
+    assert_eq!(
+        lane_selected_payload["session_governor"]["failed_threshold_triggered"],
+        true
+    );
+    assert_eq!(
+        lane_selected_payload["session_governor"]["trend_enabled"],
+        true
+    );
+    assert_eq!(
+        lane_selected_payload["session_governor"]["trend_samples"],
+        1
+    );
+    assert_eq!(
+        lane_selected_payload["session_governor"]["trend_threshold_triggered"],
+        false
+    );
+    assert_eq!(
+        lane_selected_payload["session_governor"]["recovery_threshold_triggered"],
+        false
+    );
+    assert_eq!(
+        lane_selected_payload["session_governor"]["trend_failure_ewma"],
+        Value::Null
+    );
+
+    let round_started_payload = persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            if parsed.get("event")?.as_str()? != "plan_round_started" {
+                return None;
+            }
+            parsed.get("payload").cloned()
+        })
+        .next_back()
+        .expect("plan_round_started payload");
+    assert_eq!(round_started_payload["effective_max_rounds"], 0);
+    assert_eq!(round_started_payload["effective_max_node_attempts"], 1);
+
+    let final_status_payload = persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            if parsed.get("event")?.as_str()? != "final_status" {
+                return None;
+            }
+            parsed.get("payload").cloned()
+        })
+        .next_back()
+        .expect("final_status payload");
+    assert_eq!(
+        final_status_payload["route_reason"],
+        "session_governor_no_replan"
+    );
+    assert_eq!(
+        final_status_payload["failure_code"],
+        "safe_lane_plan_session_governor_no_replan"
+    );
+    assert_eq!(final_status_payload["metrics"]["replans_triggered"], 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_safe_lane_session_governor_requests_extended_history_window() {
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+    use loongclaw_kernel::{CoreMemoryAdapter, CoreToolAdapter};
+
+    struct NoopToolAdapter;
+
+    #[async_trait]
+    impl CoreToolAdapter for NoopToolAdapter {
+        fn name(&self) -> &str {
+            "noop-governor-tool"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            _request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, loongclaw_contracts::ToolPlaneError> {
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({"ok": true}),
+            })
+        }
+    }
+
+    struct CapturingMemoryAdapter {
+        invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
+    }
+
+    #[async_trait]
+    impl CoreMemoryAdapter for CapturingMemoryAdapter {
+        fn name(&self) -> &str {
+            "capturing-governor-memory"
+        }
+
+        async fn execute_core_memory(
+            &self,
+            request: MemoryCoreRequest,
+        ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
+            self.invocations
+                .lock()
+                .expect("memory invocations lock")
+                .push(request.clone());
+            if request.operation == "window" {
+                return Ok(MemoryCoreOutcome {
+                    status: "ok".to_owned(),
+                    payload: json!({
+                        "turns": []
+                    }),
+                });
+            }
+            Ok(MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({}),
+            })
+        }
+    }
+
+    let memory_invocations = Arc::new(Mutex::new(Vec::<MemoryCoreRequest>::new()));
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([
+            Capability::InvokeTool,
+            Capability::MemoryRead,
+            Capability::MemoryWrite,
+        ]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_tool_adapter(NoopToolAdapter);
+    kernel
+        .set_default_core_tool_adapter("noop-governor-tool")
+        .expect("set default core tool adapter");
+    kernel.register_core_memory_adapter(CapturingMemoryAdapter {
+        invocations: memory_invocations.clone(),
+    });
+    kernel
+        .set_default_core_memory_adapter("capturing-governor-memory")
+        .expect("set default core memory adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Running checks.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe-governor-window".to_owned(),
+                turn_id: "turn-safe-governor-window".to_owned(),
+                tool_call_id: "call-safe-governor-window-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.safe_lane_session_governor_enabled = true;
+    config.conversation.safe_lane_session_governor_window_turns = 200;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let _ = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-governor-window",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&ctx),
+        )
+        .await
+        .expect("safe lane turn should complete");
+
+    let captured = memory_invocations
+        .lock()
+        .expect("memory invocations lock")
+        .clone();
+    let window_request = captured
+        .iter()
+        .find(|request| request.operation == "window")
+        .expect("window request should be issued");
+    assert_eq!(
+        window_request.payload["session_id"],
+        "session-safe-governor-window"
+    );
+    assert_eq!(window_request.payload["limit"], 200);
+    assert_eq!(window_request.payload["allow_extended_limit"], true);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_safe_lane_replans_failed_subgraph_only() {
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
+    use loongclaw_kernel::CoreToolAdapter;
+
+    #[derive(Default)]
+    struct CallCounters {
+        note: usize,
+        checklist: usize,
+    }
+
+    struct FailChecklistOnceAdapter {
+        counters: Arc<Mutex<CallCounters>>,
+    }
+
+    #[async_trait]
+    impl CoreToolAdapter for FailChecklistOnceAdapter {
+        fn name(&self) -> &str {
+            "fail-checklist-once-tools"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            let path = request
+                .payload
+                .get("path")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            let (note_calls, checklist_calls) = {
+                let mut counters = self.counters.lock().expect("counters lock");
+                match path.as_str() {
+                    "note.md" => counters.note = counters.note.saturating_add(1),
+                    "checklist.md" => counters.checklist = counters.checklist.saturating_add(1),
+                    _ => {}
+                }
+                (counters.note, counters.checklist)
+            };
+
+            if path == "checklist.md" && checklist_calls == 1 {
+                return Err(ToolPlaneError::Execution(
+                    "transient checklist failure".to_owned(),
+                ));
+            }
+
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "path": path,
+                    "note_calls": note_calls,
+                    "checklist_calls": checklist_calls
+                }),
+            })
+        }
+    }
+
+    let counters = Arc::new(Mutex::new(CallCounters::default()));
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_tool_adapter(FailChecklistOnceAdapter {
+        counters: counters.clone(),
+    });
+    kernel
+        .set_default_core_tool_adapter("fail-checklist-once-tools")
+        .expect("set default core tool adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Running checks.".to_owned(),
+            tool_intents: vec![
+                ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "note.md"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-safe-subgraph".to_owned(),
+                    turn_id: "turn-safe-subgraph".to_owned(),
+                    tool_call_id: "call-safe-subgraph-1".to_owned(),
+                },
+                ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "checklist.md"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-safe-subgraph".to_owned(),
+                    turn_id: "turn-safe-subgraph".to_owned(),
+                    tool_call_id: "call-safe-subgraph-2".to_owned(),
+                },
+            ],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.safe_lane_node_max_attempts = 1;
+    config.conversation.safe_lane_replan_max_rounds = 1;
+    config.conversation.safe_lane_replan_max_node_attempts = 2;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-subgraph",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&ctx),
+        )
+        .await
+        .expect("safe lane should recover by replaying only failed subgraph");
+
+    assert!(
+        reply.contains("note.md"),
+        "expected note output, got: {reply}"
+    );
+    assert!(
+        reply.contains("checklist.md"),
+        "expected checklist output, got: {reply}"
+    );
+
+    let counters = counters.lock().expect("counters lock");
+    assert_eq!(counters.note, 1, "note.md should not be re-executed");
+    assert_eq!(
+        counters.checklist, 2,
+        "checklist.md should execute once + one replan retry"
     );
 }
 
 #[tokio::test]
 async fn handle_turn_with_runtime_tool_denial_returns_inline_reply_even_in_propagate_mode() {
-    let runtime = FakeRuntime::with_turns(
+    let runtime = FakeRuntime::with_turn_and_completion(
         vec![],
-        vec![
-            Ok(ProviderTurn {
-                assistant_text: "Reading the file now.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-denied".to_owned(),
-                    turn_id: "turn-denied".to_owned(),
-                    tool_call_id: "call-denied".to_owned(),
-                }],
-                raw_meta: Value::Null,
-            }),
-            Ok(ProviderTurn {
-                assistant_text: "MODEL_DENIED_REPLY".to_owned(),
-                tool_intents: vec![],
-                raw_meta: Value::Null,
-            }),
-        ],
+        Ok(ProviderTurn {
+            assistant_text: "Reading the file now.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-denied".to_owned(),
+                turn_id: "turn-denied".to_owned(),
+                tool_call_id: "call-denied".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("MODEL_DENIED_REPLY".to_owned()),
     );
 
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
         .handle_turn_with_runtime(
             &test_config(),
             "session-denied",
@@ -1197,10 +1881,9 @@ async fn handle_turn_with_runtime_tool_denial_returns_inline_reply_even_in_propa
             .completion_calls
             .lock()
             .expect("completion calls lock"),
-        0,
-        "tool-denied loop should continue with request_turn without completion fallback"
+        1,
+        "tool-denied fallback should run a completion pass for language-aware output"
     );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
 
     let persisted = runtime.persisted.lock().expect("persisted lock");
     assert_eq!(persisted.len(), 2);
@@ -1212,31 +1895,25 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
     use super::integration_tests::TurnTestHarness;
 
     let harness = TurnTestHarness::new();
-    let runtime = FakeRuntime::with_turns(
+    let runtime = FakeRuntime::with_turn_and_completion(
         vec![],
-        vec![
-            Ok(ProviderTurn {
-                assistant_text: "Reading the file now.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!("not an object"),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-tool-error".to_owned(),
-                    turn_id: "turn-tool-error".to_owned(),
-                    tool_call_id: "call-tool-error".to_owned(),
-                }],
-                raw_meta: Value::Null,
-            }),
-            Ok(ProviderTurn {
-                assistant_text: "MODEL_ERROR_REPLY".to_owned(),
-                tool_intents: vec![],
-                raw_meta: Value::Null,
-            }),
-        ],
+        Ok(ProviderTurn {
+            assistant_text: "Reading the file now.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!("not an object"),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-tool-error".to_owned(),
+                turn_id: "turn-tool-error".to_owned(),
+                tool_call_id: "call-tool-error".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("MODEL_ERROR_REPLY".to_owned()),
     );
 
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
         .handle_turn_with_runtime(
             &test_config(),
             "session-tool-error",
@@ -1263,10 +1940,9 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
             .completion_calls
             .lock()
             .expect("completion calls lock"),
-        0,
-        "tool-error loop should continue with request_turn without completion fallback"
+        1,
+        "tool-error fallback should run a completion pass for language-aware output"
     );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
 
     let persisted = runtime.persisted.lock().expect("persisted lock");
     assert_eq!(persisted.len(), 2);
@@ -1275,7 +1951,8 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
 
 #[tokio::test]
 async fn handle_turn_with_runtime_tool_failure_completion_error_uses_raw_reason_without_markers() {
-    let repeated_tool_turn = || {
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
         Ok(ProviderTurn {
             assistant_text: "Reading the file now.".to_owned(),
             tool_intents: vec![ToolIntent {
@@ -1287,27 +1964,14 @@ async fn handle_turn_with_runtime_tool_failure_completion_error_uses_raw_reason_
                 tool_call_id: "call-denied-fallback".to_owned(),
             }],
             raw_meta: Value::Null,
-        })
-    };
-
-    let runtime = FakeRuntime::with_turns_and_completions(
-        vec![],
-        vec![
-            repeated_tool_turn(),
-            repeated_tool_turn(),
-            repeated_tool_turn(),
-            repeated_tool_turn(),
-        ],
-        vec![Err("completion_unavailable".to_owned())],
+        }),
+        Err("completion_unavailable".to_owned()),
     );
 
-    let mut config = test_config();
-    config.conversation.turn_loop.max_repeated_tool_call_rounds = 8;
-
-    let turn_loop = ConversationTurnLoop::new();
-    let reply = turn_loop
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
         .handle_turn_with_runtime(
-            &config,
+            &test_config(),
             "session-denied-fallback",
             "read note.md",
             ProviderErrorMode::Propagate,
@@ -1340,7 +2004,6 @@ async fn handle_turn_with_runtime_tool_failure_completion_error_uses_raw_reason_
             .expect("completion calls lock"),
         1
     );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 4);
 }
 
 #[test]
@@ -1446,6 +2109,40 @@ fn turn_engine_unknown_tool_returns_tool_denied() {
 }
 
 #[test]
+fn turn_engine_unknown_tool_exposes_structured_policy_denial() {
+    use crate::conversation::turn_engine::{
+        ProviderTurn, ToolIntent, TurnEngine, TurnFailureKind, TurnResult,
+    };
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "nonexistent.tool".to_owned(),
+            args_json: serde_json::json!({}),
+            source: "provider_tool_call".to_owned(),
+            session_id: "s1".to_owned(),
+            turn_id: "t1".to_owned(),
+            tool_call_id: "c1".to_owned(),
+        }],
+        raw_meta: serde_json::Value::Null,
+    };
+
+    let result = engine.evaluate_turn(&turn);
+    match result {
+        TurnResult::ToolDenied(failure) => {
+            assert_eq!(failure.kind, TurnFailureKind::PolicyDenied);
+            assert_eq!(failure.code, "tool_not_found");
+            assert!(!failure.retryable);
+            assert!(
+                failure.reason.contains("tool_not_found"),
+                "failure={failure:?}"
+            );
+        }
+        other => panic!("expected ToolDenied, got {:?}", other),
+    }
+}
+
+#[test]
 fn turn_engine_exceeding_max_steps_returns_denied() {
     use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
     let engine = TurnEngine::new(1);
@@ -1524,6 +2221,143 @@ async fn turn_engine_execute_turn_no_kernel_returns_denied() {
         }
         other => panic!("expected ToolDenied, got {:?}", other),
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_tool_execution_error_is_marked_retryable() {
+    use crate::conversation::turn_engine::{
+        ProviderTurn, ToolIntent, TurnEngine, TurnFailureKind, TurnResult,
+    };
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
+    use loongclaw_kernel::CoreToolAdapter;
+
+    struct RetryableErrorToolAdapter;
+
+    #[async_trait]
+    impl CoreToolAdapter for RetryableErrorToolAdapter {
+        fn name(&self) -> &str {
+            "retryable-error-tools"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            _request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            Err(ToolPlaneError::Execution("transient failure".to_owned()))
+        }
+    }
+
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_tool_adapter(RetryableErrorToolAdapter);
+    kernel
+        .set_default_core_tool_adapter("retryable-error-tools")
+        .expect("set default");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "file.read".to_owned(),
+            args_json: json!({"path": "test.txt"}),
+            source: "provider_tool_call".to_owned(),
+            session_id: "s1".to_owned(),
+            turn_id: "t1".to_owned(),
+            tool_call_id: "c1".to_owned(),
+        }],
+        raw_meta: serde_json::Value::Null,
+    };
+
+    let result = engine.execute_turn(&turn, Some(&ctx)).await;
+    match result {
+        TurnResult::ToolError(failure) => {
+            assert_eq!(failure.kind, TurnFailureKind::Retryable);
+            assert_eq!(failure.code, "tool_execution_failed");
+            assert!(failure.retryable);
+            assert!(
+                failure.reason.contains("transient failure"),
+                "failure={failure:?}"
+            );
+        }
+        other => panic!("expected ToolError, got {:?}", other),
+    }
+}
+
+#[test]
+fn kernel_error_classification_table_is_stable() {
+    use crate::conversation::turn_engine::{classify_kernel_error, KernelFailureClass};
+    use loongclaw_contracts::{KernelError, PolicyError, RuntimePlaneError, ToolPlaneError};
+
+    let policy_error = KernelError::Policy(PolicyError::ToolCallDenied {
+        tool_name: "file.read".to_owned(),
+        reason: "blocked".to_owned(),
+    });
+    assert_eq!(
+        classify_kernel_error(&policy_error),
+        KernelFailureClass::PolicyDenied
+    );
+
+    let boundary_error = KernelError::PackCapabilityBoundary {
+        pack_id: "test-pack".to_owned(),
+        capability: Capability::InvokeTool,
+    };
+    assert_eq!(
+        classify_kernel_error(&boundary_error),
+        KernelFailureClass::PolicyDenied
+    );
+
+    let connector_error = KernelError::ConnectorNotAllowed {
+        connector: "shell".to_owned(),
+        pack_id: "test-pack".to_owned(),
+    };
+    assert_eq!(
+        classify_kernel_error(&connector_error),
+        KernelFailureClass::PolicyDenied
+    );
+
+    let retryable_tool_error =
+        KernelError::ToolPlane(ToolPlaneError::Execution("temporary outage".to_owned()));
+    assert_eq!(
+        classify_kernel_error(&retryable_tool_error),
+        KernelFailureClass::RetryableExecution
+    );
+
+    let non_retryable_tool_error = KernelError::ToolPlane(ToolPlaneError::NoDefaultCoreAdapter);
+    assert_eq!(
+        classify_kernel_error(&non_retryable_tool_error),
+        KernelFailureClass::NonRetryable
+    );
+
+    let runtime_error =
+        KernelError::RuntimePlane(RuntimePlaneError::Execution("runtime failure".to_owned()));
+    assert_eq!(
+        classify_kernel_error(&runtime_error),
+        KernelFailureClass::NonRetryable
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1894,18 +2728,18 @@ async fn persist_turn_routes_through_kernel_when_context_provided() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn build_messages_routes_window_through_kernel_when_context_provided() {
     let audit = Arc::new(InMemoryAuditSink::default());
-    let (ctx, invocations) = build_kernel_context(audit);
+    let (ctx, invocations) = build_kernel_context(audit.clone());
 
     let runtime = DefaultConversationRuntime;
     let config = test_config();
     let messages = runtime
-        .build_messages(&config, "session-k2", true, Some(&ctx))
+        .build_messages(&config, "session-k-window", true, Some(&ctx))
         .await
         .expect("build messages via kernel");
 
     assert!(
         !messages.is_empty(),
-        "messages should include at least system prompt"
+        "expected at least system prompt message, got: {messages:?}"
     );
     assert_eq!(messages[0]["role"], "system");
     assert!(
@@ -1916,11 +2750,27 @@ async fn build_messages_routes_window_through_kernel_when_context_provided() {
     );
 
     let captured = invocations.lock().expect("invocations lock");
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
+    assert_eq!(captured[0].payload["session_id"], "session-k-window");
+    assert_eq!(
+        captured[0].payload["limit"],
+        json!(config.memory.sliding_window)
+    );
+
+    let events = audit.snapshot();
+    let has_memory_plane = events.iter().any(|event| {
+        matches!(
+            &event.kind,
+            loongclaw_kernel::AuditEventKind::PlaneInvoked {
+                plane: loongclaw_contracts::ExecutionPlane::Memory,
+                ..
+            }
+        )
+    });
     assert!(
-        captured
-            .iter()
-            .any(|request| request.operation == crate::memory::MEMORY_OP_WINDOW),
-        "build_messages should route memory window through kernel memory plane"
+        has_memory_plane,
+        "audit should contain memory plane invocation"
     );
 }
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -24,7 +24,9 @@ use super::persistence::{
 use super::plan_executor::{
     PlanExecutor, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor, PlanRunFailure, PlanRunStatus,
 };
-use super::plan_ir::{PlanBudget, PlanEdge, PlanGraph, PlanNode, PlanNodeKind, RiskTier};
+use super::plan_ir::{
+    PlanBudget, PlanEdge, PlanGraph, PlanNode, PlanNodeKind, RiskTier, PLAN_GRAPH_VERSION,
+};
 use super::plan_verifier::{
     verify_output, PlanVerificationContext, PlanVerificationFailureCode, PlanVerificationPolicy,
     PlanVerificationReport,
@@ -748,7 +750,7 @@ fn should_emit_safe_lane_event(
         .get("round")
         .and_then(Value::as_u64)
         .unwrap_or_default();
-    round % (sample_every as u64) == 0
+    round.is_multiple_of(sample_every as u64)
 }
 
 fn is_safe_lane_critical_event(event_name: &str) -> bool {
@@ -857,9 +859,12 @@ fn build_safe_lane_plan_graph(
     });
 
     for pair in nodes.windows(2) {
+        let [from, to] = pair else {
+            continue;
+        };
         edges.push(PlanEdge {
-            from: pair[0].id.clone(),
-            to: pair[1].id.clone(),
+            from: from.id.clone(),
+            to: to.id.clone(),
         });
     }
 
@@ -869,7 +874,7 @@ fn build_safe_lane_plan_graph(
         .sum::<usize>()
         .max(1);
     PlanGraph {
-        version: "hvgr.v1".to_owned(),
+        version: PLAN_GRAPH_VERSION.to_owned(),
         nodes,
         edges,
         budget: PlanBudget {
@@ -1943,7 +1948,7 @@ mod tests {
 
     #[test]
     fn turn_failure_from_plan_failure_node_error_mapping_is_stable() {
-        let cases = vec![
+        let cases = [
             (
                 PlanNodeErrorKind::PolicyDenied,
                 TurnFailureKind::PolicyDenied,
@@ -1983,7 +1988,7 @@ mod tests {
 
     #[test]
     fn turn_failure_from_plan_failure_static_failure_mapping_is_stable() {
-        let failures = vec![
+        let failures = [
             PlanRunFailure::ValidationFailed("invalid".to_owned()),
             PlanRunFailure::TopologyResolutionFailed,
             PlanRunFailure::BudgetExceeded {
@@ -2208,7 +2213,7 @@ mod tests {
 
     #[test]
     fn summarize_governor_history_signals_extracts_failure_samples() {
-        let contents = vec![
+        let contents = [
             r#"{"type":"conversation_event","event":"final_status","payload":{"status":"failed","failure_code":"safe_lane_plan_backpressure_guard","route_reason":"backpressure_attempts_exhausted"}}"#,
             r#"{"type":"conversation_event","event":"final_status","payload":{"status":"succeeded"}}"#,
         ];

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1,0 +1,2462 @@
+use std::collections::BTreeSet;
+
+use async_trait::async_trait;
+use loongclaw_contracts::{
+    AuditEventKind, Capability, ExecutionPlane, MemoryCoreRequest, PlaneTier, ToolCoreRequest,
+};
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
+
+use crate::CliResult;
+use crate::KernelContext;
+
+use super::super::config::LoongClawConfig;
+#[cfg(feature = "memory-sqlite")]
+use super::super::memory;
+use super::analytics::{
+    parse_conversation_event, summarize_safe_lane_events, SafeLaneEventSummary,
+};
+use super::lane_arbiter::{ExecutionLane, LaneArbiterPolicy, LaneDecision};
+use super::persistence::{
+    format_provider_error_reply, persist_conversation_event, persist_error_turns,
+    persist_success_turns,
+};
+use super::plan_executor::{
+    PlanExecutor, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor, PlanRunFailure, PlanRunStatus,
+};
+use super::plan_ir::{PlanBudget, PlanEdge, PlanGraph, PlanNode, PlanNodeKind, RiskTier};
+use super::plan_verifier::{
+    verify_output, PlanVerificationContext, PlanVerificationFailureCode, PlanVerificationPolicy,
+    PlanVerificationReport,
+};
+use super::runtime::{ConversationRuntime, DefaultConversationRuntime};
+use super::turn_engine::{
+    classify_kernel_error, KernelFailureClass, ProviderTurn, ToolIntent, TurnEngine, TurnFailure,
+    TurnFailureKind, TurnResult,
+};
+use super::ProviderErrorMode;
+
+#[derive(Default)]
+pub struct ConversationTurnCoordinator;
+
+const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct SafeLaneExecutionMetrics {
+    rounds_started: u32,
+    rounds_succeeded: u32,
+    rounds_failed: u32,
+    verify_failures: u32,
+    replans_triggered: u32,
+    total_attempts_used: u64,
+}
+
+impl SafeLaneExecutionMetrics {
+    fn as_json(self) -> Value {
+        json!({
+            "rounds_started": self.rounds_started,
+            "rounds_succeeded": self.rounds_succeeded,
+            "rounds_failed": self.rounds_failed,
+            "verify_failures": self.verify_failures,
+            "replans_triggered": self.replans_triggered,
+            "total_attempts_used": self.total_attempts_used,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct SafeLaneAdaptiveVerifyPolicyState {
+    min_anchor_matches: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+struct SafeLaneSessionGovernorDecision {
+    engaged: bool,
+    history_window_turns: usize,
+    failed_final_status_events: u32,
+    failed_final_status_threshold: u32,
+    failed_threshold_triggered: bool,
+    backpressure_failure_events: u32,
+    backpressure_failure_threshold: u32,
+    backpressure_threshold_triggered: bool,
+    trend_enabled: bool,
+    trend_samples: usize,
+    trend_min_samples: usize,
+    trend_failure_ewma: Option<f64>,
+    trend_failure_ewma_threshold: f64,
+    trend_backpressure_ewma: Option<f64>,
+    trend_backpressure_ewma_threshold: f64,
+    trend_threshold_triggered: bool,
+    recovery_success_streak: u32,
+    recovery_success_streak_threshold: u32,
+    recovery_failure_ewma_threshold: f64,
+    recovery_backpressure_ewma_threshold: f64,
+    recovery_threshold_triggered: bool,
+    force_no_replan: bool,
+    forced_node_max_attempts: Option<u8>,
+}
+
+impl SafeLaneSessionGovernorDecision {
+    fn as_json(self) -> Value {
+        json!({
+            "engaged": self.engaged,
+            "history_window_turns": self.history_window_turns,
+            "failed_final_status_events": self.failed_final_status_events,
+            "failed_final_status_threshold": self.failed_final_status_threshold,
+            "failed_threshold_triggered": self.failed_threshold_triggered,
+            "backpressure_failure_events": self.backpressure_failure_events,
+            "backpressure_failure_threshold": self.backpressure_failure_threshold,
+            "backpressure_threshold_triggered": self.backpressure_threshold_triggered,
+            "trend_enabled": self.trend_enabled,
+            "trend_samples": self.trend_samples,
+            "trend_min_samples": self.trend_min_samples,
+            "trend_failure_ewma": self.trend_failure_ewma,
+            "trend_failure_ewma_threshold": self.trend_failure_ewma_threshold,
+            "trend_backpressure_ewma": self.trend_backpressure_ewma,
+            "trend_backpressure_ewma_threshold": self.trend_backpressure_ewma_threshold,
+            "trend_threshold_triggered": self.trend_threshold_triggered,
+            "recovery_success_streak": self.recovery_success_streak,
+            "recovery_success_streak_threshold": self.recovery_success_streak_threshold,
+            "recovery_failure_ewma_threshold": self.recovery_failure_ewma_threshold,
+            "recovery_backpressure_ewma_threshold": self.recovery_backpressure_ewma_threshold,
+            "recovery_threshold_triggered": self.recovery_threshold_triggered,
+            "force_no_replan": self.force_no_replan,
+            "forced_node_max_attempts": self.forced_node_max_attempts,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct SafeLaneGovernorHistorySignals {
+    summary: SafeLaneEventSummary,
+    final_status_failed_samples: Vec<bool>,
+    backpressure_failure_samples: Vec<bool>,
+}
+
+impl ConversationTurnCoordinator {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn handle_turn(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<String> {
+        let runtime = DefaultConversationRuntime;
+        self.handle_turn_with_runtime(
+            config, session_id, user_input, error_mode, &runtime, kernel_ctx,
+        )
+        .await
+    }
+
+    pub async fn handle_turn_with_runtime<R: ConversationRuntime + ?Sized>(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        runtime: &R,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<String> {
+        let mut messages = runtime
+            .build_messages(config, session_id, true, kernel_ctx)
+            .await?;
+        messages.push(json!({
+            "role": "user",
+            "content": user_input,
+        }));
+        let lane_policy = lane_policy_from_config(config);
+        let lane_decision = if config.conversation.hybrid_lane_enabled {
+            lane_policy.decide(user_input)
+        } else {
+            disabled_lane_decision(user_input)
+        };
+        let max_tool_steps = match lane_decision.lane {
+            ExecutionLane::Fast => config.conversation.fast_lane_max_tool_steps(),
+            ExecutionLane::Safe => config.conversation.safe_lane_max_tool_steps(),
+        };
+
+        let provider_result = runtime.request_turn(config, &messages).await;
+        match provider_result {
+            Ok(turn) => {
+                let had_tool_intents = !turn.tool_intents.is_empty();
+                let raw_tool_output_requested = user_requested_raw_tool_output(user_input);
+                let turn_result = if should_use_safe_lane_plan_path(config, &lane_decision, &turn) {
+                    execute_turn_with_safe_lane_plan(
+                        config,
+                        runtime,
+                        session_id,
+                        &lane_decision,
+                        &turn,
+                        kernel_ctx,
+                    )
+                    .await
+                } else {
+                    TurnEngine::new(max_tool_steps)
+                        .execute_turn(&turn, kernel_ctx)
+                        .await
+                };
+                let reply = match turn_result {
+                    TurnResult::FinalText(tool_text) if had_tool_intents => {
+                        let raw_reply = join_non_empty_lines(&[
+                            turn.assistant_text.as_str(),
+                            tool_text.as_str(),
+                        ]);
+                        if raw_tool_output_requested {
+                            raw_reply
+                        } else {
+                            let follow_up_messages = build_tool_followup_messages(
+                                &messages,
+                                turn.assistant_text.as_str(),
+                                tool_text.as_str(),
+                                user_input,
+                            );
+                            match runtime
+                                .request_completion(config, &follow_up_messages)
+                                .await
+                            {
+                                Ok(final_reply) => {
+                                    let trimmed = final_reply.trim();
+                                    if trimmed.is_empty() {
+                                        raw_reply
+                                    } else {
+                                        trimmed.to_owned()
+                                    }
+                                }
+                                Err(_) => raw_reply,
+                            }
+                        }
+                    }
+                    TurnResult::ToolDenied(failure)
+                        if had_tool_intents && !raw_tool_output_requested =>
+                    {
+                        let raw_reply = compose_assistant_reply(
+                            turn.assistant_text.as_str(),
+                            had_tool_intents,
+                            TurnResult::ToolDenied(failure.clone()),
+                        );
+                        let follow_up_messages = build_tool_failure_followup_messages(
+                            &messages,
+                            turn.assistant_text.as_str(),
+                            failure.reason.as_str(),
+                            user_input,
+                        );
+                        match runtime
+                            .request_completion(config, &follow_up_messages)
+                            .await
+                        {
+                            Ok(final_reply) => {
+                                let trimmed = final_reply.trim();
+                                if trimmed.is_empty() {
+                                    raw_reply
+                                } else {
+                                    trimmed.to_owned()
+                                }
+                            }
+                            Err(_) => raw_reply,
+                        }
+                    }
+                    TurnResult::ToolError(failure)
+                        if had_tool_intents && !raw_tool_output_requested =>
+                    {
+                        let raw_reply = compose_assistant_reply(
+                            turn.assistant_text.as_str(),
+                            had_tool_intents,
+                            TurnResult::ToolError(failure.clone()),
+                        );
+                        let follow_up_messages = build_tool_failure_followup_messages(
+                            &messages,
+                            turn.assistant_text.as_str(),
+                            failure.reason.as_str(),
+                            user_input,
+                        );
+                        match runtime
+                            .request_completion(config, &follow_up_messages)
+                            .await
+                        {
+                            Ok(final_reply) => {
+                                let trimmed = final_reply.trim();
+                                if trimmed.is_empty() {
+                                    raw_reply
+                                } else {
+                                    trimmed.to_owned()
+                                }
+                            }
+                            Err(_) => raw_reply,
+                        }
+                    }
+                    other => compose_assistant_reply(
+                        turn.assistant_text.as_str(),
+                        had_tool_intents,
+                        other,
+                    ),
+                };
+                persist_success_turns(runtime, session_id, user_input, &reply, kernel_ctx).await?;
+                Ok(reply)
+            }
+            Err(error) => match error_mode {
+                ProviderErrorMode::Propagate => Err(error),
+                ProviderErrorMode::InlineMessage => {
+                    let synthetic = format_provider_error_reply(&error);
+                    persist_error_turns(runtime, session_id, user_input, &synthetic, kernel_ctx)
+                        .await?;
+                    Ok(synthetic)
+                }
+            },
+        }
+    }
+}
+
+fn lane_policy_from_config(config: &LoongClawConfig) -> LaneArbiterPolicy {
+    let normalized_keywords = config.conversation.normalized_high_risk_keywords();
+    let high_risk_keywords = if normalized_keywords.is_empty() {
+        LaneArbiterPolicy::default().high_risk_keywords
+    } else {
+        normalized_keywords.into_iter().collect::<BTreeSet<_>>()
+    };
+
+    LaneArbiterPolicy {
+        safe_lane_risk_threshold: config.conversation.safe_lane_risk_threshold,
+        safe_lane_complexity_threshold: config.conversation.safe_lane_complexity_threshold,
+        fast_lane_max_input_chars: config.conversation.fast_lane_max_input_chars,
+        high_risk_keywords,
+    }
+}
+
+fn disabled_lane_decision(user_input: &str) -> LaneDecision {
+    LaneDecision {
+        lane: ExecutionLane::Fast,
+        risk_score: 0,
+        complexity_score: 0,
+        reasons: vec![format!(
+            "hybrid_lane_disabled chars={}",
+            user_input.chars().count()
+        )],
+    }
+}
+
+fn should_use_safe_lane_plan_path(
+    config: &LoongClawConfig,
+    lane_decision: &LaneDecision,
+    turn: &ProviderTurn,
+) -> bool {
+    config.conversation.safe_lane_plan_execution_enabled
+        && matches!(lane_decision.lane, ExecutionLane::Safe)
+        && !turn.tool_intents.is_empty()
+}
+
+async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    lane_decision: &LaneDecision,
+    turn: &ProviderTurn,
+    kernel_ctx: Option<&KernelContext>,
+) -> TurnResult {
+    let governor_history_signals =
+        load_safe_lane_history_signals_for_governor(config, session_id, kernel_ctx).await;
+    let governor = decide_safe_lane_session_governor(config, &governor_history_signals);
+
+    emit_safe_lane_event(
+        config,
+        runtime,
+        session_id,
+        "lane_selected",
+        json!({
+            "lane": "safe",
+            "risk_score": lane_decision.risk_score,
+            "complexity_score": lane_decision.complexity_score,
+            "reasons": lane_decision.reasons.clone(),
+            "tool_intents": turn.tool_intents.len(),
+            "session_governor": governor.as_json(),
+        }),
+        kernel_ctx,
+    )
+    .await;
+
+    let mut round = 0u8;
+    let max_rounds = if governor.force_no_replan {
+        0
+    } else {
+        config.conversation.safe_lane_replan_max_rounds
+    };
+    let mut tool_node_max_attempts = config.conversation.safe_lane_node_max_attempts.max(1);
+    if let Some(forced_node_max_attempts) = governor.forced_node_max_attempts {
+        tool_node_max_attempts = tool_node_max_attempts.min(forced_node_max_attempts.max(1));
+    }
+    let mut max_node_attempts = config
+        .conversation
+        .safe_lane_replan_max_node_attempts
+        .max(tool_node_max_attempts);
+    if let Some(forced_node_max_attempts) = governor.forced_node_max_attempts {
+        max_node_attempts = max_node_attempts.min(forced_node_max_attempts.max(1));
+    }
+    let mut plan_start_tool_index = 0usize;
+    let mut seed_tool_outputs = Vec::new();
+    let mut metrics = SafeLaneExecutionMetrics::default();
+    let mut adaptive_verify_policy = SafeLaneAdaptiveVerifyPolicyState::default();
+
+    loop {
+        let next_min_anchor_matches =
+            compute_safe_lane_verify_min_anchor_matches(config, metrics.verify_failures);
+        if next_min_anchor_matches != adaptive_verify_policy.min_anchor_matches {
+            adaptive_verify_policy.min_anchor_matches = next_min_anchor_matches;
+            if adaptive_verify_policy.min_anchor_matches > 0 {
+                emit_safe_lane_event(
+                    config,
+                    runtime,
+                    session_id,
+                    "verify_policy_adjusted",
+                    json!({
+                        "round": round,
+                        "policy": "adaptive_anchor_escalation",
+                        "min_anchor_matches": adaptive_verify_policy.min_anchor_matches,
+                        "verify_failures": metrics.verify_failures,
+                        "escalation_after_failures": config
+                            .conversation
+                            .safe_lane_verify_anchor_escalation_after_failures(),
+                        "metrics": metrics.as_json(),
+                    }),
+                    kernel_ctx,
+                )
+                .await;
+            }
+        }
+
+        metrics.rounds_started = metrics.rounds_started.saturating_add(1);
+        emit_safe_lane_event(
+            config,
+            runtime,
+            session_id,
+            "plan_round_started",
+            json!({
+                "round": round,
+                "start_tool_index": plan_start_tool_index,
+                "tool_node_max_attempts": tool_node_max_attempts,
+                "effective_max_rounds": max_rounds,
+                "effective_max_node_attempts": max_node_attempts,
+                "verify_min_anchor_matches": adaptive_verify_policy.min_anchor_matches,
+                "session_governor": governor.as_json(),
+                "metrics": metrics.as_json(),
+            }),
+            kernel_ctx,
+        )
+        .await;
+
+        let plan = build_safe_lane_plan_graph(
+            config,
+            lane_decision,
+            turn,
+            tool_node_max_attempts,
+            plan_start_tool_index,
+        );
+        let executor = SafeLanePlanNodeExecutor::new(
+            turn.tool_intents.as_slice(),
+            kernel_ctx,
+            config.conversation.safe_lane_verify_output_non_empty,
+            seed_tool_outputs.clone(),
+        );
+        let report = PlanExecutor::execute(&plan, &executor).await;
+        metrics.total_attempts_used = metrics
+            .total_attempts_used
+            .saturating_add(report.attempts_used as u64);
+
+        match report.status {
+            PlanRunStatus::Succeeded => {
+                metrics.rounds_succeeded = metrics.rounds_succeeded.saturating_add(1);
+                emit_safe_lane_event(
+                    config,
+                    runtime,
+                    session_id,
+                    "plan_round_completed",
+                    json!({
+                        "round": round,
+                        "status": "succeeded",
+                        "attempts_used": report.attempts_used,
+                        "elapsed_ms": report.elapsed_ms,
+                        "metrics": metrics.as_json(),
+                    }),
+                    kernel_ctx,
+                )
+                .await;
+                let tool_output = executor.joined_output().await;
+                let verify_report = verify_safe_lane_final_output(
+                    config,
+                    tool_output.as_str(),
+                    turn.tool_intents.as_slice(),
+                    adaptive_verify_policy,
+                );
+                if verify_report.passed {
+                    {
+                        emit_safe_lane_event(
+                            config,
+                            runtime,
+                            session_id,
+                            "final_status",
+                            json!({
+                                "status": "succeeded",
+                                "round": round,
+                                "metrics": metrics.as_json(),
+                            }),
+                            kernel_ctx,
+                        )
+                        .await;
+                        return TurnResult::FinalText(tool_output);
+                    }
+                } else {
+                    let verify_error = verify_report.failure_reasons.join(",");
+                    let failure_codes = verify_report
+                        .failure_codes
+                        .iter()
+                        .map(format_verification_failure_code)
+                        .collect::<Vec<_>>();
+                    let retryable_verify_failure =
+                        should_replan_for_verification_failure(&verify_report);
+                    let verify_failure = turn_failure_from_verify_failure(
+                        verify_error.as_str(),
+                        retryable_verify_failure,
+                    );
+                    metrics.verify_failures = metrics.verify_failures.saturating_add(1);
+                    let verify_route = apply_safe_lane_backpressure_guard(
+                        config,
+                        route_safe_lane_failure(&verify_failure, round, max_rounds),
+                        metrics,
+                    );
+                    let verify_route =
+                        apply_safe_lane_session_governor_route_override(verify_route, governor);
+                    {
+                        emit_safe_lane_event(
+                            config,
+                            runtime,
+                            session_id,
+                            "verify_failed",
+                            json!({
+                                "round": round,
+                                "error": verify_error.clone(),
+                                "failure_codes": failure_codes,
+                                "retryable": retryable_verify_failure,
+                                "failure_kind": format_turn_failure_kind(verify_failure.kind),
+                                "failure_code": verify_failure.code.clone(),
+                                "failure_retryable": verify_failure.retryable,
+                                "route_decision": format_safe_lane_route_decision(verify_route.decision),
+                                "route_reason": verify_route.reason,
+                                "metrics": metrics.as_json(),
+                            }),
+                            kernel_ctx,
+                        )
+                        .await;
+                        if matches!(
+                            verify_route.decision,
+                            SafeLaneFailureRouteDecision::Terminal
+                        ) {
+                            let terminal_failure = terminal_turn_failure_from_verify_failure(
+                                verify_error.as_str(),
+                                retryable_verify_failure,
+                                verify_route.reason,
+                            );
+                            emit_safe_lane_event(
+                                config,
+                                runtime,
+                                session_id,
+                                "final_status",
+                                json!({
+                                    "status": "failed",
+                                    "round": round,
+                                    "failure": summarize_verify_terminal_reason(verify_route.reason),
+                                    "failure_kind": format_turn_failure_kind(terminal_failure.kind),
+                                    "failure_code": terminal_failure.code.clone(),
+                                    "failure_retryable": terminal_failure.retryable,
+                                    "route_decision": format_safe_lane_route_decision(verify_route.decision),
+                                    "route_reason": verify_route.reason,
+                                    "metrics": metrics.as_json(),
+                                }),
+                                kernel_ctx,
+                            )
+                            .await;
+                            return TurnResult::ToolError(terminal_failure);
+                        }
+                        metrics.replans_triggered = metrics.replans_triggered.saturating_add(1);
+                        emit_safe_lane_event(
+                            config,
+                            runtime,
+                            session_id,
+                            "replan_triggered",
+                            json!({
+                                "round": round,
+                                "reason": "verify_failed",
+                                "detail": verify_error,
+                                "route_decision": format_safe_lane_route_decision(verify_route.decision),
+                                "route_reason": verify_route.reason,
+                                "metrics": metrics.as_json(),
+                            }),
+                            kernel_ctx,
+                        )
+                        .await;
+                    }
+                }
+            }
+            PlanRunStatus::Failed(failure) => {
+                metrics.rounds_failed = metrics.rounds_failed.saturating_add(1);
+                let round_failure_meta = turn_failure_from_plan_failure(&failure);
+                let route = apply_safe_lane_backpressure_guard(
+                    config,
+                    route_safe_lane_failure(&round_failure_meta, round, max_rounds),
+                    metrics,
+                );
+                let route = apply_safe_lane_session_governor_route_override(route, governor);
+                emit_safe_lane_event(
+                    config,
+                    runtime,
+                    session_id,
+                    "plan_round_completed",
+                    json!({
+                        "round": round,
+                        "status": "failed",
+                        "attempts_used": report.attempts_used,
+                        "elapsed_ms": report.elapsed_ms,
+                        "failure": summarize_plan_failure(&failure),
+                        "failure_kind": format_turn_failure_kind(round_failure_meta.kind),
+                        "failure_code": round_failure_meta.code.clone(),
+                        "failure_retryable": round_failure_meta.retryable,
+                        "route_decision": format_safe_lane_route_decision(route.decision),
+                        "route_reason": route.reason,
+                        "metrics": metrics.as_json(),
+                    }),
+                    kernel_ctx,
+                )
+                .await;
+                if matches!(route.decision, SafeLaneFailureRouteDecision::Replan) {
+                    let (next_start_tool_index, next_seed_outputs) =
+                        derive_replan_cursor(&failure, &executor, turn.tool_intents.len()).await;
+                    plan_start_tool_index = next_start_tool_index;
+                    seed_tool_outputs = next_seed_outputs;
+                    metrics.replans_triggered = metrics.replans_triggered.saturating_add(1);
+                    emit_safe_lane_event(
+                        config,
+                        runtime,
+                        session_id,
+                        "replan_triggered",
+                        json!({
+                            "round": round,
+                            "reason": summarize_plan_failure(&failure),
+                            "restart_tool_index": plan_start_tool_index,
+                            "seeded_outputs": seed_tool_outputs.len(),
+                            "route_decision": format_safe_lane_route_decision(route.decision),
+                            "route_reason": route.reason,
+                            "metrics": metrics.as_json(),
+                        }),
+                        kernel_ctx,
+                    )
+                    .await;
+                } else {
+                    let terminal_result =
+                        terminal_turn_result_from_plan_failure_with_route(failure.clone(), route);
+                    let failure_meta = terminal_result.failure();
+                    emit_safe_lane_event(
+                        config,
+                        runtime,
+                        session_id,
+                        "final_status",
+                        json!({
+                            "status": "failed",
+                            "round": round,
+                            "failure": summarize_plan_failure(&failure),
+                            "failure_kind": failure_meta
+                                .map(|failure| format_turn_failure_kind(failure.kind)),
+                            "failure_code": failure_meta.map(|failure| failure.code.clone()),
+                            "failure_retryable": failure_meta.map(|failure| failure.retryable),
+                            "route_decision": format_safe_lane_route_decision(route.decision),
+                            "route_reason": route.reason,
+                            "metrics": metrics.as_json(),
+                        }),
+                        kernel_ctx,
+                    )
+                    .await;
+                    return terminal_result;
+                }
+            }
+        }
+
+        round = round.saturating_add(1);
+        tool_node_max_attempts = tool_node_max_attempts
+            .saturating_add(1)
+            .min(max_node_attempts)
+            .max(1);
+    }
+}
+
+async fn emit_safe_lane_event<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    event_name: &str,
+    payload: Value,
+    kernel_ctx: Option<&KernelContext>,
+) {
+    if !should_emit_safe_lane_event(config, event_name, &payload) {
+        return;
+    }
+    let _ = persist_conversation_event(runtime, session_id, event_name, payload, kernel_ctx).await;
+    if let Some(ctx) = kernel_ctx {
+        let _ = ctx.kernel.record_audit_event(
+            Some(ctx.agent_id()),
+            AuditEventKind::PlaneInvoked {
+                pack_id: ctx.pack_id().to_owned(),
+                plane: ExecutionPlane::Runtime,
+                tier: PlaneTier::Core,
+                primary_adapter: "conversation.safe_lane".to_owned(),
+                delegated_core_adapter: None,
+                operation: format!("conversation.safe_lane.{event_name}"),
+                required_capabilities: Vec::new(),
+            },
+        );
+    }
+}
+
+fn should_emit_safe_lane_event(
+    config: &LoongClawConfig,
+    event_name: &str,
+    payload: &Value,
+) -> bool {
+    if !config.conversation.safe_lane_emit_runtime_events {
+        return false;
+    }
+
+    if is_safe_lane_critical_event(event_name) {
+        return true;
+    }
+
+    let sample_every = config.conversation.safe_lane_event_sample_every();
+    if sample_every <= 1 {
+        return true;
+    }
+
+    if config.conversation.safe_lane_event_adaptive_sampling
+        && safe_lane_failure_pressure(payload)
+            >= config
+                .conversation
+                .safe_lane_event_adaptive_failure_threshold() as u64
+    {
+        return true;
+    }
+
+    let round = payload
+        .get("round")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    round % (sample_every as u64) == 0
+}
+
+fn is_safe_lane_critical_event(event_name: &str) -> bool {
+    matches!(
+        event_name,
+        "lane_selected" | "verify_failed" | "final_status"
+    )
+}
+
+fn safe_lane_failure_pressure(payload: &Value) -> u64 {
+    let mut pressure = 0u64;
+
+    if payload
+        .get("status")
+        .and_then(Value::as_str)
+        .map(|status| status == "failed")
+        .unwrap_or(false)
+    {
+        pressure = pressure.saturating_add(1);
+    }
+
+    if payload
+        .get("failure_kind")
+        .and_then(Value::as_str)
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+    {
+        pressure = pressure.saturating_add(1);
+    }
+
+    if payload
+        .get("route_decision")
+        .and_then(Value::as_str)
+        .map(|decision| decision == "replan" || decision == "terminal")
+        .unwrap_or(false)
+    {
+        pressure = pressure.saturating_add(1);
+    }
+
+    if payload
+        .get("failure_code")
+        .and_then(Value::as_str)
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+    {
+        pressure = pressure.saturating_add(1);
+    }
+
+    if payload
+        .get("metrics")
+        .and_then(|metrics| metrics.get("verify_failures"))
+        .and_then(Value::as_u64)
+        .unwrap_or_default()
+        > 0
+    {
+        pressure = pressure.saturating_add(1);
+    }
+
+    pressure
+}
+
+fn build_safe_lane_plan_graph(
+    config: &LoongClawConfig,
+    lane_decision: &LaneDecision,
+    turn: &ProviderTurn,
+    tool_node_max_attempts: u8,
+    start_tool_index: usize,
+) -> PlanGraph {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+
+    let node_risk_tier = select_safe_lane_risk_tier(config, lane_decision);
+    let normalized_start = start_tool_index.min(turn.tool_intents.len());
+    for (index, intent) in turn.tool_intents.iter().enumerate().skip(normalized_start) {
+        nodes.push(PlanNode {
+            id: format!("tool-{}", index + 1),
+            kind: PlanNodeKind::Tool,
+            label: format!("invoke `{}`", intent.tool_name),
+            tool_name: Some(intent.tool_name.clone()),
+            timeout_ms: 3_000,
+            max_attempts: tool_node_max_attempts,
+            risk_tier: node_risk_tier,
+        });
+    }
+
+    if config.conversation.safe_lane_verify_output_non_empty {
+        nodes.push(PlanNode {
+            id: "verify-1".to_owned(),
+            kind: PlanNodeKind::Verify,
+            label: "verify non-empty tool outputs".to_owned(),
+            tool_name: None,
+            timeout_ms: 500,
+            max_attempts: 1,
+            risk_tier: RiskTier::Medium,
+        });
+    }
+
+    nodes.push(PlanNode {
+        id: "respond-1".to_owned(),
+        kind: PlanNodeKind::Respond,
+        label: "compose final response".to_owned(),
+        tool_name: None,
+        timeout_ms: 500,
+        max_attempts: 1,
+        risk_tier: RiskTier::Low,
+    });
+
+    for pair in nodes.windows(2) {
+        edges.push(PlanEdge {
+            from: pair[0].id.clone(),
+            to: pair[1].id.clone(),
+        });
+    }
+
+    let max_total_attempts = nodes
+        .iter()
+        .map(|node| node.max_attempts as usize)
+        .sum::<usize>()
+        .max(1);
+    PlanGraph {
+        version: "hvgr.v1".to_owned(),
+        nodes,
+        edges,
+        budget: PlanBudget {
+            max_nodes: 16,
+            max_total_attempts,
+            max_wall_time_ms: config.conversation.safe_lane_plan_max_wall_time_ms.max(1),
+        },
+    }
+}
+
+fn select_safe_lane_risk_tier(config: &LoongClawConfig, lane_decision: &LaneDecision) -> RiskTier {
+    let high_risk_bar = config
+        .conversation
+        .safe_lane_risk_threshold
+        .saturating_mul(2);
+    let high_complexity_bar = config
+        .conversation
+        .safe_lane_complexity_threshold
+        .saturating_mul(2);
+    if lane_decision.risk_score >= high_risk_bar
+        || lane_decision.complexity_score >= high_complexity_bar
+    {
+        RiskTier::High
+    } else if lane_decision.risk_score > 0 || lane_decision.complexity_score > 0 {
+        RiskTier::Medium
+    } else {
+        RiskTier::Low
+    }
+}
+
+fn verify_safe_lane_final_output(
+    config: &LoongClawConfig,
+    output: &str,
+    tool_intents: &[ToolIntent],
+    adaptive_policy: SafeLaneAdaptiveVerifyPolicyState,
+) -> PlanVerificationReport {
+    let policy = PlanVerificationPolicy {
+        require_non_empty: config.conversation.safe_lane_verify_output_non_empty,
+        min_output_chars: config.conversation.safe_lane_verify_min_output_chars,
+        require_status_prefix: config.conversation.safe_lane_verify_require_status_prefix,
+        deny_markers: config
+            .conversation
+            .safe_lane_verify_deny_markers
+            .iter()
+            .map(|marker| marker.trim().to_ascii_lowercase())
+            .filter(|marker| !marker.is_empty())
+            .collect(),
+    };
+    let semantic_anchors = collect_semantic_anchors(tool_intents);
+    let context = PlanVerificationContext {
+        expected_result_lines: tool_intents.len().max(1),
+        semantic_anchors,
+        min_anchor_matches: adaptive_policy.min_anchor_matches,
+    };
+    verify_output(output, &context, &policy)
+}
+
+fn compute_safe_lane_verify_min_anchor_matches(
+    config: &LoongClawConfig,
+    verify_failures: u32,
+) -> usize {
+    if !config
+        .conversation
+        .safe_lane_verify_adaptive_anchor_escalation
+    {
+        return 0;
+    }
+    if verify_failures
+        < config
+            .conversation
+            .safe_lane_verify_anchor_escalation_after_failures()
+    {
+        return 0;
+    }
+    config
+        .conversation
+        .safe_lane_verify_anchor_escalation_min_matches()
+}
+
+fn decide_safe_lane_session_governor(
+    config: &LoongClawConfig,
+    history: &SafeLaneGovernorHistorySignals,
+) -> SafeLaneSessionGovernorDecision {
+    let summary = &history.summary;
+    let history_window_turns = config
+        .conversation
+        .safe_lane_session_governor_window_turns();
+    let failed_final_status_events = summary
+        .final_status_counts
+        .get("failed")
+        .copied()
+        .unwrap_or_default();
+    let backpressure_failure_events = count_safe_lane_backpressure_failures(summary);
+    let failed_final_status_threshold = config
+        .conversation
+        .safe_lane_session_governor_failed_final_status_threshold();
+    let backpressure_failure_threshold = config
+        .conversation
+        .safe_lane_session_governor_backpressure_failure_threshold();
+    let failed_threshold_triggered = failed_final_status_events >= failed_final_status_threshold;
+    let backpressure_threshold_triggered =
+        backpressure_failure_events >= backpressure_failure_threshold;
+    let trend_enabled = config.conversation.safe_lane_session_governor_trend_enabled;
+    let trend_samples = history.final_status_failed_samples.len();
+    let trend_min_samples = config
+        .conversation
+        .safe_lane_session_governor_trend_min_samples();
+    let trend_failure_ewma_threshold = config
+        .conversation
+        .safe_lane_session_governor_trend_failure_ewma_threshold();
+    let trend_backpressure_ewma_threshold = config
+        .conversation
+        .safe_lane_session_governor_trend_backpressure_ewma_threshold();
+    let trend_ewma_alpha = config
+        .conversation
+        .safe_lane_session_governor_trend_ewma_alpha();
+    let trend_ready = trend_enabled && trend_samples >= trend_min_samples;
+    let trend_failure_ewma = if trend_ready {
+        compute_ewma_bool(
+            history.final_status_failed_samples.as_slice(),
+            trend_ewma_alpha,
+        )
+    } else {
+        None
+    };
+    let trend_backpressure_ewma = if trend_ready {
+        compute_ewma_bool(
+            history.backpressure_failure_samples.as_slice(),
+            trend_ewma_alpha,
+        )
+    } else {
+        None
+    };
+    let trend_threshold_triggered = trend_failure_ewma
+        .map(|value| value >= trend_failure_ewma_threshold)
+        .unwrap_or(false)
+        || trend_backpressure_ewma
+            .map(|value| value >= trend_backpressure_ewma_threshold)
+            .unwrap_or(false);
+
+    let recovery_success_streak = if trend_ready {
+        trailing_success_streak(history.final_status_failed_samples.as_slice())
+    } else {
+        0
+    };
+    let recovery_success_streak_threshold = config
+        .conversation
+        .safe_lane_session_governor_recovery_success_streak();
+    let recovery_failure_ewma_threshold = config
+        .conversation
+        .safe_lane_session_governor_recovery_max_failure_ewma();
+    let recovery_backpressure_ewma_threshold = config
+        .conversation
+        .safe_lane_session_governor_recovery_max_backpressure_ewma();
+    let recovery_threshold_triggered = trend_ready
+        && recovery_success_streak >= recovery_success_streak_threshold
+        && trend_failure_ewma
+            .map(|value| value <= recovery_failure_ewma_threshold)
+            .unwrap_or(false)
+        && trend_backpressure_ewma
+            .map(|value| value <= recovery_backpressure_ewma_threshold)
+            .unwrap_or(false);
+
+    let engaged = config.conversation.safe_lane_session_governor_enabled
+        && (failed_threshold_triggered
+            || backpressure_threshold_triggered
+            || trend_threshold_triggered)
+        && !recovery_threshold_triggered;
+
+    SafeLaneSessionGovernorDecision {
+        engaged,
+        history_window_turns,
+        failed_final_status_events,
+        failed_final_status_threshold,
+        failed_threshold_triggered,
+        backpressure_failure_events,
+        backpressure_failure_threshold,
+        backpressure_threshold_triggered,
+        trend_enabled,
+        trend_samples,
+        trend_min_samples,
+        trend_failure_ewma,
+        trend_failure_ewma_threshold,
+        trend_backpressure_ewma,
+        trend_backpressure_ewma_threshold,
+        trend_threshold_triggered,
+        recovery_success_streak,
+        recovery_success_streak_threshold,
+        recovery_failure_ewma_threshold,
+        recovery_backpressure_ewma_threshold,
+        recovery_threshold_triggered,
+        force_no_replan: engaged
+            && config
+                .conversation
+                .safe_lane_session_governor_force_no_replan,
+        forced_node_max_attempts: engaged.then(|| {
+            config
+                .conversation
+                .safe_lane_session_governor_force_node_max_attempts()
+        }),
+    }
+}
+
+async fn load_safe_lane_history_signals_for_governor(
+    config: &LoongClawConfig,
+    session_id: &str,
+    kernel_ctx: Option<&KernelContext>,
+) -> SafeLaneGovernorHistorySignals {
+    if !config.conversation.safe_lane_session_governor_enabled {
+        return SafeLaneGovernorHistorySignals::default();
+    }
+
+    let window_turns = config
+        .conversation
+        .safe_lane_session_governor_window_turns();
+    if let Some(ctx) = kernel_ctx {
+        let request = MemoryCoreRequest {
+            operation: "window".to_owned(),
+            payload: json!({
+                "session_id": session_id,
+                "limit": window_turns,
+                "allow_extended_limit": true,
+            }),
+        };
+        let caps = BTreeSet::from([Capability::MemoryRead]);
+        if let Ok(outcome) = ctx
+            .kernel
+            .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
+            .await
+        {
+            let assistant_contents =
+                collect_assistant_contents_from_memory_window_payload(outcome.payload.get("turns"));
+            return summarize_governor_history_signals(
+                assistant_contents.iter().map(String::as_str),
+            );
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        if let Ok(turns) = memory::window_direct_extended(session_id, window_turns) {
+            let assistant_contents = turns
+                .iter()
+                .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.as_str()))
+                .collect::<Vec<_>>();
+            return summarize_governor_history_signals(assistant_contents);
+        }
+    }
+
+    SafeLaneGovernorHistorySignals::default()
+}
+
+fn summarize_governor_history_signals<'a, I>(
+    assistant_contents: I,
+) -> SafeLaneGovernorHistorySignals
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut retained_contents = Vec::new();
+    let mut final_status_failed_samples = Vec::new();
+    let mut backpressure_failure_samples = Vec::new();
+
+    for content in assistant_contents {
+        retained_contents.push(content.to_owned());
+        let Some(record) = parse_conversation_event(content) else {
+            continue;
+        };
+        if record.event != "final_status" {
+            continue;
+        }
+        match record.payload.get("status").and_then(Value::as_str) {
+            Some("failed") => {
+                final_status_failed_samples.push(true);
+                backpressure_failure_samples
+                    .push(is_backpressure_final_status_payload(&record.payload));
+            }
+            Some("succeeded") => {
+                final_status_failed_samples.push(false);
+                backpressure_failure_samples.push(false);
+            }
+            _ => {}
+        }
+    }
+
+    SafeLaneGovernorHistorySignals {
+        summary: summarize_safe_lane_events(retained_contents.iter().map(String::as_str)),
+        final_status_failed_samples,
+        backpressure_failure_samples,
+    }
+}
+
+fn collect_assistant_contents_from_memory_window_payload(
+    turns_payload: Option<&Value>,
+) -> Vec<String> {
+    turns_payload
+        .and_then(Value::as_array)
+        .map(|turns| {
+            turns
+                .iter()
+                .filter_map(|turn| {
+                    (turn.get("role").and_then(Value::as_str) == Some("assistant"))
+                        .then_some(turn.get("content").and_then(Value::as_str))
+                        .flatten()
+                        .map(ToOwned::to_owned)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn count_safe_lane_backpressure_failures(summary: &SafeLaneEventSummary) -> u32 {
+    summary
+        .failure_code_counts
+        .get("safe_lane_plan_backpressure_guard")
+        .copied()
+        .unwrap_or_default()
+        .saturating_add(
+            summary
+                .failure_code_counts
+                .get("safe_lane_plan_verify_failed_backpressure_guard")
+                .copied()
+                .unwrap_or_default(),
+        )
+}
+
+fn is_backpressure_final_status_payload(payload: &Value) -> bool {
+    if payload
+        .get("failure_code")
+        .and_then(Value::as_str)
+        .map(|code| {
+            matches!(
+                code,
+                "safe_lane_plan_backpressure_guard"
+                    | "safe_lane_plan_verify_failed_backpressure_guard"
+            )
+        })
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    payload
+        .get("route_reason")
+        .and_then(Value::as_str)
+        .map(|reason| reason.starts_with("backpressure_"))
+        .unwrap_or(false)
+}
+
+fn compute_ewma_bool(samples: &[bool], alpha: f64) -> Option<f64> {
+    let mut iter = samples.iter();
+    let first = iter.next().copied()?;
+    let mut ewma = if first { 1.0 } else { 0.0 };
+    for sample in iter {
+        let value = if *sample { 1.0 } else { 0.0 };
+        ewma = (alpha * value) + ((1.0 - alpha) * ewma);
+    }
+    Some(ewma)
+}
+
+fn trailing_success_streak(failed_samples: &[bool]) -> u32 {
+    let mut streak = 0u32;
+    for failed in failed_samples.iter().rev() {
+        if *failed {
+            break;
+        }
+        streak = streak.saturating_add(1);
+    }
+    streak
+}
+
+fn apply_safe_lane_session_governor_route_override(
+    route: SafeLaneFailureRoute,
+    governor: SafeLaneSessionGovernorDecision,
+) -> SafeLaneFailureRoute {
+    if governor.force_no_replan && route.reason == "round_budget_exhausted" {
+        return SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: "session_governor_no_replan",
+        };
+    }
+    route
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SafeLaneFailureRouteDecision {
+    Replan,
+    Terminal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SafeLaneFailureRoute {
+    decision: SafeLaneFailureRouteDecision,
+    reason: &'static str,
+}
+
+fn route_safe_lane_failure(
+    failure: &TurnFailure,
+    round: u8,
+    max_rounds: u8,
+) -> SafeLaneFailureRoute {
+    if round >= max_rounds {
+        return SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: "round_budget_exhausted",
+        };
+    }
+
+    match failure.code.as_str() {
+        "safe_lane_plan_node_policy_denied"
+        | "kernel_policy_denied"
+        | "tool_not_found"
+        | "max_tool_steps_exceeded"
+        | "no_kernel_context" => {
+            return SafeLaneFailureRoute {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: "policy_denied",
+            };
+        }
+        "safe_lane_plan_verify_failed" => {
+            if failure.retryable {
+                return SafeLaneFailureRoute {
+                    decision: SafeLaneFailureRouteDecision::Replan,
+                    reason: "retryable_failure",
+                };
+            }
+            return SafeLaneFailureRoute {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: "non_retryable_failure",
+            };
+        }
+        "safe_lane_plan_node_retryable_error" | "tool_execution_failed" => {
+            if failure.retryable {
+                return SafeLaneFailureRoute {
+                    decision: SafeLaneFailureRouteDecision::Replan,
+                    reason: "retryable_failure",
+                };
+            }
+            return SafeLaneFailureRoute {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: "retryable_flag_false",
+            };
+        }
+        "safe_lane_plan_verify_failed_budget_exhausted" => {
+            return SafeLaneFailureRoute {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: "round_budget_exhausted",
+            };
+        }
+        "safe_lane_plan_validation_failed"
+        | "safe_lane_plan_topology_resolution_failed"
+        | "safe_lane_plan_budget_exceeded"
+        | "safe_lane_plan_wall_time_exceeded"
+        | "safe_lane_plan_node_non_retryable_error"
+        | "kernel_execution_failed" => {
+            return SafeLaneFailureRoute {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: "non_retryable_failure",
+            };
+        }
+        _ => {}
+    }
+
+    match failure.kind {
+        TurnFailureKind::Retryable if failure.retryable => SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Replan,
+            reason: "retryable_failure",
+        },
+        TurnFailureKind::Retryable => SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: "retryable_flag_false",
+        },
+        TurnFailureKind::PolicyDenied => SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: "policy_denied",
+        },
+        TurnFailureKind::NonRetryable => SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: "non_retryable_failure",
+        },
+        TurnFailureKind::ApprovalRequired => SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: "approval_required",
+        },
+        TurnFailureKind::Provider => SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: "provider_failure",
+        },
+    }
+}
+
+fn apply_safe_lane_backpressure_guard(
+    config: &LoongClawConfig,
+    route: SafeLaneFailureRoute,
+    metrics: SafeLaneExecutionMetrics,
+) -> SafeLaneFailureRoute {
+    if !config.conversation.safe_lane_backpressure_guard_enabled
+        || !matches!(route.decision, SafeLaneFailureRouteDecision::Replan)
+    {
+        return route;
+    }
+
+    if metrics.total_attempts_used
+        >= config
+            .conversation
+            .safe_lane_backpressure_max_total_attempts()
+    {
+        return SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: "backpressure_attempts_exhausted",
+        };
+    }
+
+    if metrics.replans_triggered >= config.conversation.safe_lane_backpressure_max_replans() {
+        return SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: "backpressure_replans_exhausted",
+        };
+    }
+
+    route
+}
+
+fn format_safe_lane_route_decision(decision: SafeLaneFailureRouteDecision) -> &'static str {
+    match decision {
+        SafeLaneFailureRouteDecision::Replan => "replan",
+        SafeLaneFailureRouteDecision::Terminal => "terminal",
+    }
+}
+
+fn summarize_verify_terminal_reason(route_reason: &str) -> &'static str {
+    match route_reason {
+        "round_budget_exhausted" => "verify_failed_budget_exhausted",
+        "backpressure_attempts_exhausted" | "backpressure_replans_exhausted" => {
+            "verify_failed_backpressure_guard"
+        }
+        "session_governor_no_replan" => "verify_failed_session_governor",
+        _ => "verify_failed_non_retryable",
+    }
+}
+
+fn should_replan_for_verification_failure(report: &PlanVerificationReport) -> bool {
+    !report.failure_codes.iter().any(|code| {
+        matches!(
+            code,
+            PlanVerificationFailureCode::DenyMarkerDetected
+                | PlanVerificationFailureCode::MissingStatusPrefix
+                | PlanVerificationFailureCode::MissingSemanticAnchors
+        )
+    })
+}
+
+fn format_verification_failure_code(code: &PlanVerificationFailureCode) -> &'static str {
+    match code {
+        PlanVerificationFailureCode::EmptyOutput => "empty_output",
+        PlanVerificationFailureCode::OutputTooShort => "output_too_short",
+        PlanVerificationFailureCode::DenyMarkerDetected => "deny_marker_detected",
+        PlanVerificationFailureCode::InsufficientResultLines => "insufficient_result_lines",
+        PlanVerificationFailureCode::MissingStatusPrefix => "missing_status_prefix",
+        PlanVerificationFailureCode::FailureStatusDetected => "failure_status_detected",
+        PlanVerificationFailureCode::MissingSemanticAnchors => "missing_semantic_anchors",
+    }
+}
+
+fn collect_semantic_anchors(tool_intents: &[ToolIntent]) -> BTreeSet<String> {
+    let mut anchors = BTreeSet::new();
+    for intent in tool_intents {
+        collect_value_anchors(None, &intent.args_json, &mut anchors);
+    }
+    anchors
+}
+
+fn collect_value_anchors(parent_key: Option<&str>, value: &Value, anchors: &mut BTreeSet<String>) {
+    match value {
+        Value::String(text) => {
+            if parent_key.map(is_anchor_key_allowed).unwrap_or(false) {
+                push_anchor_candidate(text.as_str(), anchors);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_value_anchors(parent_key, item, anchors);
+            }
+        }
+        Value::Object(map) => {
+            for (key, item) in map {
+                if is_sensitive_key(key.as_str()) {
+                    continue;
+                }
+                collect_value_anchors(Some(key.as_str()), item, anchors);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_anchor_key_allowed(key: &str) -> bool {
+    matches!(
+        key.trim().to_ascii_lowercase().as_str(),
+        "path"
+            | "file"
+            | "filename"
+            | "url"
+            | "endpoint"
+            | "target"
+            | "query"
+            | "operation"
+            | "command"
+            | "cwd"
+            | "dir"
+            | "directory"
+    )
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let normalized = key.trim().to_ascii_lowercase();
+    [
+        "token",
+        "secret",
+        "password",
+        "credential",
+        "api_key",
+        "apikey",
+        "auth",
+        "authorization",
+        "cookie",
+        "session",
+        "bearer",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker))
+}
+
+fn push_anchor_candidate(text: &str, anchors: &mut BTreeSet<String>) {
+    let normalized = text.trim().to_ascii_lowercase();
+    if normalized.len() < 3 || normalized.len() > 96 {
+        return;
+    }
+    if normalized.contains(' ') {
+        return;
+    }
+    anchors.insert(normalized.clone());
+    if let Some(last_segment) = normalized.rsplit('/').next() {
+        if last_segment.len() >= 3 {
+            anchors.insert(last_segment.to_owned());
+        }
+    }
+}
+
+async fn derive_replan_cursor(
+    failure: &PlanRunFailure,
+    executor: &SafeLanePlanNodeExecutor<'_>,
+    tool_count: usize,
+) -> (usize, Vec<String>) {
+    match failure {
+        PlanRunFailure::NodeFailed { node_id, .. } => {
+            if let Ok(index) = parse_tool_node_index(node_id.as_str()) {
+                if index < tool_count {
+                    return (index, executor.tool_outputs_snapshot().await);
+                }
+            }
+            (0, Vec::new())
+        }
+        _ => (0, Vec::new()),
+    }
+}
+
+fn summarize_plan_failure(failure: &PlanRunFailure) -> String {
+    match failure {
+        PlanRunFailure::ValidationFailed(error) => {
+            format!("validation_failed:{error}")
+        }
+        PlanRunFailure::TopologyResolutionFailed => "topology_resolution_failed".to_owned(),
+        PlanRunFailure::BudgetExceeded {
+            attempts_used,
+            limit,
+        } => {
+            format!("budget_exceeded attempts_used={attempts_used} limit={limit}")
+        }
+        PlanRunFailure::WallTimeExceeded {
+            elapsed_ms,
+            limit_ms,
+        } => {
+            format!("wall_time_exceeded elapsed_ms={elapsed_ms} limit_ms={limit_ms}")
+        }
+        PlanRunFailure::NodeFailed {
+            node_id,
+            last_error_kind,
+            last_error,
+            ..
+        } => {
+            format!("node_failed node={node_id} error_kind={last_error_kind:?} reason={last_error}")
+        }
+    }
+}
+
+fn format_turn_failure_kind(kind: TurnFailureKind) -> &'static str {
+    match kind {
+        TurnFailureKind::ApprovalRequired => "approval_required",
+        TurnFailureKind::PolicyDenied => "policy_denied",
+        TurnFailureKind::Retryable => "retryable",
+        TurnFailureKind::NonRetryable => "non_retryable",
+        TurnFailureKind::Provider => "provider",
+    }
+}
+
+fn turn_failure_from_plan_failure(failure: &PlanRunFailure) -> TurnFailure {
+    match failure {
+        PlanRunFailure::ValidationFailed(error) => TurnFailure::non_retryable(
+            "safe_lane_plan_validation_failed",
+            format!("safe_lane_plan_validation_failed: {error}"),
+        ),
+        PlanRunFailure::TopologyResolutionFailed => TurnFailure::non_retryable(
+            "safe_lane_plan_topology_resolution_failed",
+            "safe_lane_plan_topology_resolution_failed",
+        ),
+        PlanRunFailure::BudgetExceeded {
+            attempts_used,
+            limit,
+        } => TurnFailure::non_retryable(
+            "safe_lane_plan_budget_exceeded",
+            format!("safe_lane_plan_budget_exceeded attempts_used={attempts_used} limit={limit}"),
+        ),
+        PlanRunFailure::WallTimeExceeded {
+            elapsed_ms,
+            limit_ms,
+        } => TurnFailure::non_retryable(
+            "safe_lane_plan_wall_time_exceeded",
+            format!(
+                "safe_lane_plan_wall_time_exceeded elapsed_ms={elapsed_ms} limit_ms={limit_ms}"
+            ),
+        ),
+        PlanRunFailure::NodeFailed {
+            last_error,
+            last_error_kind,
+            ..
+        } => match last_error_kind {
+            PlanNodeErrorKind::PolicyDenied => {
+                TurnFailure::policy_denied("safe_lane_plan_node_policy_denied", last_error.clone())
+            }
+            PlanNodeErrorKind::Retryable => {
+                TurnFailure::retryable("safe_lane_plan_node_retryable_error", last_error.clone())
+            }
+            PlanNodeErrorKind::NonRetryable => TurnFailure::non_retryable(
+                "safe_lane_plan_node_non_retryable_error",
+                last_error.clone(),
+            ),
+        },
+    }
+}
+
+fn turn_failure_from_verify_failure(verify_error: &str, retryable: bool) -> TurnFailure {
+    let reason = format!("safe_lane_plan_verify_failed: {verify_error}");
+    if retryable {
+        TurnFailure::retryable("safe_lane_plan_verify_failed", reason)
+    } else {
+        TurnFailure::non_retryable("safe_lane_plan_verify_failed", reason)
+    }
+}
+
+fn terminal_turn_failure_from_verify_failure(
+    verify_error: &str,
+    retryable_signal: bool,
+    route_reason: &str,
+) -> TurnFailure {
+    let reason = format!("safe_lane_plan_verify_failed: {verify_error}");
+    match route_reason {
+        "round_budget_exhausted" if retryable_signal => {
+            // Retryable at signal layer, but terminal after exhausting rounds.
+            TurnFailure::non_retryable("safe_lane_plan_verify_failed_budget_exhausted", reason)
+        }
+        "backpressure_attempts_exhausted" | "backpressure_replans_exhausted" => {
+            TurnFailure::non_retryable("safe_lane_plan_verify_failed_backpressure_guard", reason)
+        }
+        "session_governor_no_replan" => {
+            TurnFailure::non_retryable("safe_lane_plan_verify_failed_session_governor", reason)
+        }
+        _ => TurnFailure::non_retryable("safe_lane_plan_verify_failed", reason),
+    }
+}
+
+fn turn_result_from_plan_failure(failure: PlanRunFailure) -> TurnResult {
+    let failure_meta = turn_failure_from_plan_failure(&failure);
+    if matches!(failure_meta.kind, TurnFailureKind::PolicyDenied) {
+        TurnResult::ToolDenied(failure_meta)
+    } else {
+        TurnResult::ToolError(failure_meta)
+    }
+}
+
+fn terminal_turn_result_from_plan_failure_with_route(
+    failure: PlanRunFailure,
+    route: SafeLaneFailureRoute,
+) -> TurnResult {
+    if matches!(
+        route.reason,
+        "backpressure_attempts_exhausted" | "backpressure_replans_exhausted"
+    ) {
+        let summary = summarize_plan_failure(&failure);
+        return TurnResult::ToolError(TurnFailure::non_retryable(
+            "safe_lane_plan_backpressure_guard",
+            format!("safe_lane_plan_backpressure_guard: {summary}"),
+        ));
+    }
+    if route.reason == "session_governor_no_replan" {
+        let summary = summarize_plan_failure(&failure);
+        return TurnResult::ToolError(TurnFailure::non_retryable(
+            "safe_lane_plan_session_governor_no_replan",
+            format!("safe_lane_plan_session_governor_no_replan: {summary}"),
+        ));
+    }
+    turn_result_from_plan_failure(failure)
+}
+
+struct SafeLanePlanNodeExecutor<'a> {
+    tool_intents: &'a [ToolIntent],
+    kernel_ctx: Option<&'a KernelContext>,
+    verify_output_non_empty: bool,
+    tool_outputs: Mutex<Vec<String>>,
+}
+
+impl<'a> SafeLanePlanNodeExecutor<'a> {
+    fn new(
+        tool_intents: &'a [ToolIntent],
+        kernel_ctx: Option<&'a KernelContext>,
+        verify_output_non_empty: bool,
+        seed_tool_outputs: Vec<String>,
+    ) -> Self {
+        Self {
+            tool_intents,
+            kernel_ctx,
+            verify_output_non_empty,
+            tool_outputs: Mutex::new(seed_tool_outputs),
+        }
+    }
+
+    async fn joined_output(&self) -> String {
+        self.tool_outputs.lock().await.join("\n")
+    }
+
+    async fn tool_outputs_snapshot(&self) -> Vec<String> {
+        self.tool_outputs.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl PlanNodeExecutor for SafeLanePlanNodeExecutor<'_> {
+    async fn execute(&self, node: &PlanNode, _attempt: u8) -> Result<(), PlanNodeError> {
+        match node.kind {
+            PlanNodeKind::Tool => {
+                let index = parse_tool_node_index(node.id.as_str())?;
+                let intent = self.tool_intents.get(index).ok_or_else(|| {
+                    PlanNodeError::non_retryable(format!(
+                        "missing tool intent for node `{}`",
+                        node.id
+                    ))
+                })?;
+                let output = execute_single_tool_intent(intent, self.kernel_ctx).await?;
+                self.tool_outputs.lock().await.push(output);
+                Ok(())
+            }
+            PlanNodeKind::Verify => {
+                if !self.verify_output_non_empty {
+                    return Ok(());
+                }
+                let outputs = self.tool_outputs.lock().await;
+                if outputs.is_empty() || outputs.iter().any(|line| line.trim().is_empty()) {
+                    return Err(PlanNodeError::non_retryable(
+                        "verify_failed:empty_tool_output".to_owned(),
+                    ));
+                }
+                Ok(())
+            }
+            PlanNodeKind::Transform | PlanNodeKind::Respond => Ok(()),
+        }
+    }
+}
+
+fn parse_tool_node_index(node_id: &str) -> Result<usize, PlanNodeError> {
+    let suffix = node_id
+        .strip_prefix("tool-")
+        .ok_or_else(|| PlanNodeError::non_retryable(format!("invalid tool node id `{node_id}`")))?;
+    let parsed = suffix.parse::<usize>().map_err(|error| {
+        PlanNodeError::non_retryable(format!("invalid tool node id `{node_id}`: {error}"))
+    })?;
+    if parsed == 0 {
+        return Err(PlanNodeError::non_retryable(format!(
+            "invalid tool node ordinal in `{node_id}`"
+        )));
+    }
+    Ok(parsed - 1)
+}
+
+async fn execute_single_tool_intent(
+    intent: &ToolIntent,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<String, PlanNodeError> {
+    if !crate::tools::is_known_tool_name(&intent.tool_name) {
+        return Err(PlanNodeError::policy_denied(format!(
+            "tool_not_found: {}",
+            intent.tool_name
+        )));
+    }
+    let ctx =
+        kernel_ctx.ok_or_else(|| PlanNodeError::policy_denied("no_kernel_context".to_owned()))?;
+    let request = ToolCoreRequest {
+        tool_name: intent.tool_name.clone(),
+        payload: intent.args_json.clone(),
+    };
+    let caps = BTreeSet::from([Capability::InvokeTool]);
+    let outcome = ctx
+        .kernel
+        .execute_tool_core(ctx.pack_id(), &ctx.token, &caps, None, request)
+        .await
+        .map_err(|error| {
+            let kind = match classify_kernel_error(&error) {
+                KernelFailureClass::PolicyDenied => PlanNodeErrorKind::PolicyDenied,
+                KernelFailureClass::RetryableExecution => PlanNodeErrorKind::Retryable,
+                KernelFailureClass::NonRetryable => PlanNodeErrorKind::NonRetryable,
+            };
+            PlanNodeError {
+                kind,
+                message: format!("{error}"),
+            }
+        })?;
+    Ok(format!("[{}] {}", outcome.status, outcome.payload))
+}
+
+fn build_tool_followup_messages(
+    base_messages: &[Value],
+    assistant_preface: &str,
+    tool_result_text: &str,
+    user_input: &str,
+) -> Vec<Value> {
+    let mut messages = base_messages.to_vec();
+    let preface = assistant_preface.trim();
+    if !preface.is_empty() {
+        messages.push(json!({
+            "role": "assistant",
+            "content": preface,
+        }));
+    }
+    messages.push(json!({
+        "role": "assistant",
+        "content": format!("[tool_result]\n{tool_result_text}"),
+    }));
+    messages.push(json!({
+        "role": "user",
+        "content": format!("{TOOL_FOLLOWUP_PROMPT}\n\nOriginal request:\n{user_input}"),
+    }));
+    messages
+}
+
+fn build_tool_failure_followup_messages(
+    base_messages: &[Value],
+    assistant_preface: &str,
+    tool_failure_reason: &str,
+    user_input: &str,
+) -> Vec<Value> {
+    let mut messages = base_messages.to_vec();
+    let preface = assistant_preface.trim();
+    if !preface.is_empty() {
+        messages.push(json!({
+            "role": "assistant",
+            "content": preface,
+        }));
+    }
+    messages.push(json!({
+        "role": "assistant",
+        "content": format!("[tool_failure]\n{tool_failure_reason}"),
+    }));
+    messages.push(json!({
+        "role": "user",
+        "content": format!("{TOOL_FOLLOWUP_PROMPT}\n\nOriginal request:\n{user_input}"),
+    }));
+    messages
+}
+
+fn user_requested_raw_tool_output(user_input: &str) -> bool {
+    let normalized = user_input.to_ascii_lowercase();
+    [
+        "raw",
+        "json",
+        "payload",
+        "verbatim",
+        "exact output",
+        "full output",
+        "tool output",
+        "[ok]",
+    ]
+    .iter()
+    .any(|signal| normalized.contains(signal))
+}
+
+fn compose_assistant_reply(
+    assistant_preface: &str,
+    had_tool_intents: bool,
+    turn_result: TurnResult,
+) -> String {
+    match turn_result {
+        TurnResult::FinalText(text) => {
+            if had_tool_intents {
+                join_non_empty_lines(&[assistant_preface, text.as_str()])
+            } else {
+                text
+            }
+        }
+        TurnResult::NeedsApproval(reason) => {
+            let inline = format!("[tool_approval_required] {}", reason.reason);
+            join_non_empty_lines(&[assistant_preface, inline.as_str()])
+        }
+        TurnResult::ToolDenied(failure) => {
+            join_non_empty_lines(&[assistant_preface, failure.reason.as_str()])
+        }
+        TurnResult::ToolError(failure) => {
+            join_non_empty_lines(&[assistant_preface, failure.reason.as_str()])
+        }
+        TurnResult::ProviderError(reason) => {
+            let inline = format_provider_error_reply(reason.reason.as_str());
+            join_non_empty_lines(&[assistant_preface, inline.as_str()])
+        }
+    }
+}
+
+fn join_non_empty_lines(parts: &[&str]) -> String {
+    parts
+        .iter()
+        .map(|part| part.trim())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_lane_route_retryable_failure_replans_with_remaining_budget() {
+        let failure = TurnFailure::retryable("safe_lane_plan_node_retryable_error", "transient");
+        let route = route_safe_lane_failure(&failure, 0, 1);
+
+        assert_eq!(route.decision, SafeLaneFailureRouteDecision::Replan);
+        assert_eq!(route.reason, "retryable_failure");
+    }
+
+    #[test]
+    fn safe_lane_route_retryable_failure_becomes_terminal_after_budget_exhaustion() {
+        let failure = TurnFailure::retryable("safe_lane_plan_node_retryable_error", "transient");
+        let route = route_safe_lane_failure(&failure, 1, 1);
+
+        assert_eq!(route.decision, SafeLaneFailureRouteDecision::Terminal);
+        assert_eq!(route.reason, "round_budget_exhausted");
+    }
+
+    #[test]
+    fn safe_lane_route_policy_denied_failure_is_terminal() {
+        let failure = TurnFailure::policy_denied("safe_lane_plan_node_policy_denied", "denied");
+        let route = route_safe_lane_failure(&failure, 0, 3);
+
+        assert_eq!(route.decision, SafeLaneFailureRouteDecision::Terminal);
+        assert_eq!(route.reason, "policy_denied");
+    }
+
+    #[test]
+    fn safe_lane_route_non_retryable_failure_is_terminal() {
+        let failure = TurnFailure::non_retryable("safe_lane_plan_node_non_retryable_error", "bad");
+        let route = route_safe_lane_failure(&failure, 0, 3);
+
+        assert_eq!(route.decision, SafeLaneFailureRouteDecision::Terminal);
+        assert_eq!(route.reason, "non_retryable_failure");
+    }
+
+    #[test]
+    fn turn_failure_from_plan_failure_node_error_mapping_is_stable() {
+        let cases = vec![
+            (
+                PlanNodeErrorKind::PolicyDenied,
+                TurnFailureKind::PolicyDenied,
+                "safe_lane_plan_node_policy_denied",
+                false,
+            ),
+            (
+                PlanNodeErrorKind::Retryable,
+                TurnFailureKind::Retryable,
+                "safe_lane_plan_node_retryable_error",
+                true,
+            ),
+            (
+                PlanNodeErrorKind::NonRetryable,
+                TurnFailureKind::NonRetryable,
+                "safe_lane_plan_node_non_retryable_error",
+                false,
+            ),
+        ];
+
+        for (node_kind, expected_kind, expected_code, expected_retryable) in cases {
+            let failure = PlanRunFailure::NodeFailed {
+                node_id: "tool-1".to_owned(),
+                attempts_used: 1,
+                last_error_kind: node_kind,
+                last_error: "boom".to_owned(),
+            };
+            let mapped = turn_failure_from_plan_failure(&failure);
+            assert_eq!(mapped.kind, expected_kind, "node_kind={node_kind:?}");
+            assert_eq!(mapped.code, expected_code, "node_kind={node_kind:?}");
+            assert_eq!(
+                mapped.retryable, expected_retryable,
+                "node_kind={node_kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn turn_failure_from_plan_failure_static_failure_mapping_is_stable() {
+        let failures = vec![
+            PlanRunFailure::ValidationFailed("invalid".to_owned()),
+            PlanRunFailure::TopologyResolutionFailed,
+            PlanRunFailure::BudgetExceeded {
+                attempts_used: 5,
+                limit: 4,
+            },
+            PlanRunFailure::WallTimeExceeded {
+                elapsed_ms: 1200,
+                limit_ms: 1000,
+            },
+        ];
+
+        for failure in failures {
+            let mapped = turn_failure_from_plan_failure(&failure);
+            assert_eq!(mapped.kind, TurnFailureKind::NonRetryable);
+            assert!(!mapped.retryable);
+            assert!(
+                mapped.code.starts_with("safe_lane_plan_"),
+                "unexpected code: {}",
+                mapped.code
+            );
+        }
+    }
+
+    #[test]
+    fn safe_lane_event_sampling_keeps_critical_events() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_emit_runtime_events = true;
+        config.conversation.safe_lane_event_sample_every = 3;
+
+        let emitted = should_emit_safe_lane_event(
+            &config,
+            "final_status",
+            &json!({
+                "round": 1
+            }),
+        );
+        assert!(emitted, "critical final_status event must always emit");
+    }
+
+    #[test]
+    fn safe_lane_event_sampling_skips_non_critical_rounds() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_emit_runtime_events = true;
+        config.conversation.safe_lane_event_sample_every = 2;
+        config.conversation.safe_lane_event_adaptive_sampling = false;
+
+        let emit_round_0 = should_emit_safe_lane_event(
+            &config,
+            "plan_round_started",
+            &json!({
+                "round": 0
+            }),
+        );
+        let emit_round_1 = should_emit_safe_lane_event(
+            &config,
+            "plan_round_started",
+            &json!({
+                "round": 1
+            }),
+        );
+
+        assert!(emit_round_0, "round 0 should pass sampling gate");
+        assert!(!emit_round_1, "round 1 should be sampled out");
+    }
+
+    #[test]
+    fn safe_lane_event_sampling_adaptive_mode_keeps_failure_pressure_events() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_emit_runtime_events = true;
+        config.conversation.safe_lane_event_sample_every = 4;
+        config.conversation.safe_lane_event_adaptive_sampling = true;
+        config
+            .conversation
+            .safe_lane_event_adaptive_failure_threshold = 1;
+
+        let emitted = should_emit_safe_lane_event(
+            &config,
+            "plan_round_completed",
+            &json!({
+                "round": 1,
+                "failure_code": "safe_lane_plan_node_retryable_error",
+                "route_decision": "replan",
+                "metrics": {
+                    "rounds_started": 2,
+                    "rounds_succeeded": 0,
+                    "rounds_failed": 1,
+                    "verify_failures": 0,
+                    "replans_triggered": 1,
+                    "total_attempts_used": 2
+                }
+            }),
+        );
+
+        assert!(
+            emitted,
+            "adaptive failure-pressure sampling should force emit for troubleshooting"
+        );
+    }
+
+    #[test]
+    fn safe_lane_event_sampling_adaptive_mode_can_be_disabled() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_emit_runtime_events = true;
+        config.conversation.safe_lane_event_sample_every = 4;
+        config.conversation.safe_lane_event_adaptive_sampling = false;
+        config
+            .conversation
+            .safe_lane_event_adaptive_failure_threshold = 1;
+
+        let emitted = should_emit_safe_lane_event(
+            &config,
+            "plan_round_completed",
+            &json!({
+                "round": 1,
+                "failure_code": "safe_lane_plan_node_retryable_error",
+                "route_decision": "replan",
+                "metrics": {
+                    "rounds_started": 2,
+                    "rounds_succeeded": 0,
+                    "rounds_failed": 1,
+                    "verify_failures": 0,
+                    "replans_triggered": 1,
+                    "total_attempts_used": 2
+                }
+            }),
+        );
+
+        assert!(
+            !emitted,
+            "with adaptive sampling disabled, round-based sampling should still drop this event"
+        );
+    }
+
+    #[test]
+    fn verify_anchor_policy_escalates_after_configured_failures() {
+        let mut config = LoongClawConfig::default();
+        config
+            .conversation
+            .safe_lane_verify_adaptive_anchor_escalation = true;
+        config
+            .conversation
+            .safe_lane_verify_anchor_escalation_after_failures = 2;
+        config
+            .conversation
+            .safe_lane_verify_anchor_escalation_min_matches = 1;
+
+        assert_eq!(compute_safe_lane_verify_min_anchor_matches(&config, 0), 0);
+        assert_eq!(compute_safe_lane_verify_min_anchor_matches(&config, 1), 0);
+        assert_eq!(compute_safe_lane_verify_min_anchor_matches(&config, 2), 1);
+        assert_eq!(compute_safe_lane_verify_min_anchor_matches(&config, 5), 1);
+    }
+
+    #[test]
+    fn verify_anchor_policy_escalation_can_be_disabled() {
+        let mut config = LoongClawConfig::default();
+        config
+            .conversation
+            .safe_lane_verify_adaptive_anchor_escalation = false;
+        config
+            .conversation
+            .safe_lane_verify_anchor_escalation_after_failures = 1;
+        config
+            .conversation
+            .safe_lane_verify_anchor_escalation_min_matches = 3;
+
+        assert_eq!(compute_safe_lane_verify_min_anchor_matches(&config, 5), 0);
+    }
+
+    #[test]
+    fn backpressure_guard_blocks_replan_when_attempt_budget_exhausted() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_backpressure_guard_enabled = true;
+        config
+            .conversation
+            .safe_lane_backpressure_max_total_attempts = 2;
+        config.conversation.safe_lane_backpressure_max_replans = 10;
+
+        let route = SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Replan,
+            reason: "retryable_failure",
+        };
+        let metrics = SafeLaneExecutionMetrics {
+            total_attempts_used: 2,
+            ..SafeLaneExecutionMetrics::default()
+        };
+        let guarded = apply_safe_lane_backpressure_guard(&config, route, metrics);
+        assert_eq!(guarded.decision, SafeLaneFailureRouteDecision::Terminal);
+        assert_eq!(guarded.reason, "backpressure_attempts_exhausted");
+    }
+
+    #[test]
+    fn backpressure_guard_blocks_replan_when_replan_budget_exhausted() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_backpressure_guard_enabled = true;
+        config
+            .conversation
+            .safe_lane_backpressure_max_total_attempts = 10;
+        config.conversation.safe_lane_backpressure_max_replans = 1;
+
+        let route = SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Replan,
+            reason: "retryable_failure",
+        };
+        let metrics = SafeLaneExecutionMetrics {
+            replans_triggered: 1,
+            ..SafeLaneExecutionMetrics::default()
+        };
+        let guarded = apply_safe_lane_backpressure_guard(&config, route, metrics);
+        assert_eq!(guarded.decision, SafeLaneFailureRouteDecision::Terminal);
+        assert_eq!(guarded.reason, "backpressure_replans_exhausted");
+    }
+
+    fn governor_history_with_summary(
+        summary: SafeLaneEventSummary,
+    ) -> SafeLaneGovernorHistorySignals {
+        SafeLaneGovernorHistorySignals {
+            summary,
+            ..SafeLaneGovernorHistorySignals::default()
+        }
+    }
+
+    #[test]
+    fn summarize_governor_history_signals_extracts_failure_samples() {
+        let contents = vec![
+            r#"{"type":"conversation_event","event":"final_status","payload":{"status":"failed","failure_code":"safe_lane_plan_backpressure_guard","route_reason":"backpressure_attempts_exhausted"}}"#,
+            r#"{"type":"conversation_event","event":"final_status","payload":{"status":"succeeded"}}"#,
+        ];
+
+        let signals = summarize_governor_history_signals(contents.iter().copied());
+        assert_eq!(signals.final_status_failed_samples, vec![true, false]);
+        assert_eq!(signals.backpressure_failure_samples, vec![true, false]);
+        assert_eq!(
+            signals
+                .summary
+                .failure_code_counts
+                .get("safe_lane_plan_backpressure_guard")
+                .copied(),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn session_governor_engages_on_failed_final_status_threshold() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_session_governor_enabled = true;
+        config
+            .conversation
+            .safe_lane_session_governor_failed_final_status_threshold = 2;
+        config
+            .conversation
+            .safe_lane_session_governor_backpressure_failure_threshold = 9;
+        config
+            .conversation
+            .safe_lane_session_governor_force_no_replan = true;
+        config
+            .conversation
+            .safe_lane_session_governor_force_node_max_attempts = 1;
+
+        let mut summary = SafeLaneEventSummary::default();
+        summary.final_status_counts.insert("failed".to_owned(), 2);
+
+        let history = governor_history_with_summary(summary);
+        let decision = decide_safe_lane_session_governor(&config, &history);
+        assert!(decision.engaged);
+        assert!(decision.failed_threshold_triggered);
+        assert!(!decision.backpressure_threshold_triggered);
+        assert!(decision.force_no_replan);
+        assert_eq!(decision.forced_node_max_attempts, Some(1));
+    }
+
+    #[test]
+    fn session_governor_engages_on_backpressure_threshold() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_session_governor_enabled = true;
+        config
+            .conversation
+            .safe_lane_session_governor_failed_final_status_threshold = 9;
+        config
+            .conversation
+            .safe_lane_session_governor_backpressure_failure_threshold = 2;
+        config
+            .conversation
+            .safe_lane_session_governor_force_node_max_attempts = 2;
+
+        let mut summary = SafeLaneEventSummary::default();
+        summary
+            .failure_code_counts
+            .insert("safe_lane_plan_backpressure_guard".to_owned(), 1);
+        summary.failure_code_counts.insert(
+            "safe_lane_plan_verify_failed_backpressure_guard".to_owned(),
+            1,
+        );
+
+        let history = governor_history_with_summary(summary);
+        let decision = decide_safe_lane_session_governor(&config, &history);
+        assert!(decision.engaged);
+        assert!(!decision.failed_threshold_triggered);
+        assert!(decision.backpressure_threshold_triggered);
+        assert_eq!(decision.backpressure_failure_events, 2);
+        assert_eq!(decision.forced_node_max_attempts, Some(2));
+    }
+
+    #[test]
+    fn session_governor_stays_disabled_when_thresholds_not_reached() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_session_governor_enabled = true;
+        config
+            .conversation
+            .safe_lane_session_governor_failed_final_status_threshold = 3;
+        config
+            .conversation
+            .safe_lane_session_governor_backpressure_failure_threshold = 2;
+
+        let mut summary = SafeLaneEventSummary::default();
+        summary.final_status_counts.insert("failed".to_owned(), 1);
+        summary
+            .failure_code_counts
+            .insert("safe_lane_plan_backpressure_guard".to_owned(), 1);
+
+        let history = governor_history_with_summary(summary);
+        let decision = decide_safe_lane_session_governor(&config, &history);
+        assert!(!decision.engaged);
+        assert!(!decision.force_no_replan);
+        assert_eq!(decision.forced_node_max_attempts, None);
+    }
+
+    #[test]
+    fn session_governor_engages_on_trend_threshold_when_counts_are_low() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_session_governor_enabled = true;
+        config
+            .conversation
+            .safe_lane_session_governor_failed_final_status_threshold = 9;
+        config
+            .conversation
+            .safe_lane_session_governor_backpressure_failure_threshold = 9;
+        config.conversation.safe_lane_session_governor_trend_enabled = true;
+        config
+            .conversation
+            .safe_lane_session_governor_trend_min_samples = 4;
+        config
+            .conversation
+            .safe_lane_session_governor_trend_ewma_alpha = 0.5;
+        config
+            .conversation
+            .safe_lane_session_governor_trend_failure_ewma_threshold = 0.60;
+        config
+            .conversation
+            .safe_lane_session_governor_trend_backpressure_ewma_threshold = 0.70;
+
+        let mut summary = SafeLaneEventSummary::default();
+        summary.final_status_counts.insert("failed".to_owned(), 1);
+        let history = SafeLaneGovernorHistorySignals {
+            summary,
+            final_status_failed_samples: vec![false, true, true, true],
+            backpressure_failure_samples: vec![false, false, false, false],
+        };
+
+        let decision = decide_safe_lane_session_governor(&config, &history);
+        assert!(decision.engaged);
+        assert!(!decision.failed_threshold_triggered);
+        assert!(!decision.backpressure_threshold_triggered);
+        assert!(decision.trend_threshold_triggered);
+        assert!(decision
+            .trend_failure_ewma
+            .map(|value| value > 0.60)
+            .unwrap_or(false));
+    }
+
+    #[test]
+    fn session_governor_recovery_threshold_can_suppress_engagement() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_session_governor_enabled = true;
+        config
+            .conversation
+            .safe_lane_session_governor_failed_final_status_threshold = 1;
+        config
+            .conversation
+            .safe_lane_session_governor_backpressure_failure_threshold = 9;
+        config.conversation.safe_lane_session_governor_trend_enabled = true;
+        config
+            .conversation
+            .safe_lane_session_governor_trend_min_samples = 4;
+        config
+            .conversation
+            .safe_lane_session_governor_trend_ewma_alpha = 0.5;
+        config
+            .conversation
+            .safe_lane_session_governor_trend_failure_ewma_threshold = 0.70;
+        config
+            .conversation
+            .safe_lane_session_governor_recovery_success_streak = 3;
+        config
+            .conversation
+            .safe_lane_session_governor_recovery_max_failure_ewma = 0.30;
+        config
+            .conversation
+            .safe_lane_session_governor_recovery_max_backpressure_ewma = 0.10;
+
+        let mut summary = SafeLaneEventSummary::default();
+        summary.final_status_counts.insert("failed".to_owned(), 1);
+        let history = SafeLaneGovernorHistorySignals {
+            summary,
+            final_status_failed_samples: vec![true, false, false, false, false],
+            backpressure_failure_samples: vec![true, false, false, false, false],
+        };
+
+        let decision = decide_safe_lane_session_governor(&config, &history);
+        assert!(decision.failed_threshold_triggered);
+        assert!(!decision.trend_threshold_triggered);
+        assert!(decision.recovery_threshold_triggered);
+        assert_eq!(decision.recovery_success_streak, 4);
+        assert!(!decision.engaged);
+    }
+
+    #[test]
+    fn session_governor_route_override_marks_no_replan_terminal_reason() {
+        let route = SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: "round_budget_exhausted",
+        };
+        let governor = SafeLaneSessionGovernorDecision {
+            force_no_replan: true,
+            ..SafeLaneSessionGovernorDecision::default()
+        };
+        let overridden = apply_safe_lane_session_governor_route_override(route, governor);
+        assert_eq!(overridden.reason, "session_governor_no_replan");
+    }
+
+    #[test]
+    fn terminal_verify_failure_uses_backpressure_error_code() {
+        let failure = terminal_turn_failure_from_verify_failure(
+            "retryable verify failure",
+            true,
+            "backpressure_attempts_exhausted",
+        );
+        assert_eq!(
+            failure.code,
+            "safe_lane_plan_verify_failed_backpressure_guard"
+        );
+        assert_eq!(failure.kind, TurnFailureKind::NonRetryable);
+    }
+
+    #[test]
+    fn terminal_verify_failure_uses_session_governor_error_code() {
+        let failure = terminal_turn_failure_from_verify_failure(
+            "retryable verify failure",
+            true,
+            "session_governor_no_replan",
+        );
+        assert_eq!(
+            failure.code,
+            "safe_lane_plan_verify_failed_session_governor"
+        );
+        assert_eq!(failure.kind, TurnFailureKind::NonRetryable);
+    }
+
+    #[test]
+    fn terminal_plan_failure_uses_session_governor_error_code() {
+        let failure = PlanRunFailure::NodeFailed {
+            node_id: "tool-1".to_owned(),
+            attempts_used: 1,
+            last_error_kind: PlanNodeErrorKind::Retryable,
+            last_error: "transient".to_owned(),
+        };
+        let route = SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: "session_governor_no_replan",
+        };
+        let result = terminal_turn_result_from_plan_failure_with_route(failure, route);
+        let meta = result.failure().expect("failure metadata");
+        assert_eq!(meta.code, "safe_lane_plan_session_governor_no_replan");
+        assert_eq!(meta.kind, TurnFailureKind::NonRetryable);
+    }
+}

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
+use std::fmt;
+use std::ops::Deref;
 
-use loongclaw_contracts::{Capability, KernelError, ToolCoreRequest};
+use loongclaw_contracts::{Capability, KernelError, ToolCoreRequest, ToolPlaneError};
 use serde::{Deserialize, Serialize};
 
 use crate::context::KernelContext;
@@ -40,13 +42,147 @@ pub struct ToolOutcome {
     pub audit_event_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnFailureKind {
+    ApprovalRequired,
+    PolicyDenied,
+    Retryable,
+    NonRetryable,
+    Provider,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnFailure {
+    pub kind: TurnFailureKind,
+    pub code: String,
+    pub reason: String,
+    pub retryable: bool,
+}
+
+impl TurnFailure {
+    pub fn approval_required(code: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            kind: TurnFailureKind::ApprovalRequired,
+            code: code.into(),
+            reason: reason.into(),
+            retryable: false,
+        }
+    }
+
+    pub fn policy_denied(code: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            kind: TurnFailureKind::PolicyDenied,
+            code: code.into(),
+            reason: reason.into(),
+            retryable: false,
+        }
+    }
+
+    pub fn retryable(code: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            kind: TurnFailureKind::Retryable,
+            code: code.into(),
+            reason: reason.into(),
+            retryable: true,
+        }
+    }
+
+    pub fn non_retryable(code: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            kind: TurnFailureKind::NonRetryable,
+            code: code.into(),
+            reason: reason.into(),
+            retryable: false,
+        }
+    }
+
+    pub fn provider(code: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            kind: TurnFailureKind::Provider,
+            code: code.into(),
+            reason: reason.into(),
+            retryable: false,
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.reason.as_str()
+    }
+}
+
+impl Deref for TurnFailure {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.reason.as_str()
+    }
+}
+
+impl fmt::Display for TurnFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.reason.as_str())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum TurnResult {
     FinalText(String),
-    NeedsApproval(String),
-    ToolDenied(String),
-    ToolError(String),
-    ProviderError(String),
+    NeedsApproval(TurnFailure),
+    ToolDenied(TurnFailure),
+    ToolError(TurnFailure),
+    ProviderError(TurnFailure),
+}
+
+impl TurnResult {
+    pub fn needs_approval(code: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::NeedsApproval(TurnFailure::approval_required(code, reason))
+    }
+
+    pub fn policy_denied(code: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::ToolDenied(TurnFailure::policy_denied(code, reason))
+    }
+
+    pub fn retryable_tool_error(code: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::ToolError(TurnFailure::retryable(code, reason))
+    }
+
+    pub fn non_retryable_tool_error(code: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::ToolError(TurnFailure::non_retryable(code, reason))
+    }
+
+    pub fn provider_error(code: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::ProviderError(TurnFailure::provider(code, reason))
+    }
+
+    pub fn failure(&self) -> Option<&TurnFailure> {
+        match self {
+            TurnResult::FinalText(_) => None,
+            TurnResult::NeedsApproval(failure)
+            | TurnResult::ToolDenied(failure)
+            | TurnResult::ToolError(failure)
+            | TurnResult::ProviderError(failure) => Some(failure),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KernelFailureClass {
+    PolicyDenied,
+    RetryableExecution,
+    NonRetryable,
+}
+
+pub(crate) fn classify_kernel_error(error: &KernelError) -> KernelFailureClass {
+    match error {
+        KernelError::Policy(_)
+        | KernelError::PackCapabilityBoundary { .. }
+        | KernelError::ConnectorNotAllowed { .. } => KernelFailureClass::PolicyDenied,
+        KernelError::ToolPlane(ToolPlaneError::Execution(_)) => {
+            KernelFailureClass::RetryableExecution
+        }
+        _ => KernelFailureClass::NonRetryable,
+    }
 }
 
 /// Single orchestration boundary for tool-call evaluation and execution.
@@ -72,18 +208,19 @@ impl TurnEngine {
 
         // Too many tool intents for current step limit
         if turn.tool_intents.len() > self.max_tool_steps {
-            return TurnResult::ToolDenied("max_tool_steps_exceeded".to_owned());
+            return TurnResult::policy_denied("max_tool_steps_exceeded", "max_tool_steps_exceeded");
         }
 
         // Check each tool intent
         for intent in &turn.tool_intents {
             if !crate::tools::is_known_tool_name(&intent.tool_name) {
-                return TurnResult::ToolDenied(format!("tool_not_found: {}", intent.tool_name));
+                let reason = format!("tool_not_found: {}", intent.tool_name);
+                return TurnResult::policy_denied("tool_not_found", reason);
             }
         }
 
         // All tools validated — execution requires a kernel context
-        TurnResult::NeedsApproval("kernel_context_required".to_owned())
+        TurnResult::needs_approval("kernel_context_required", "kernel_context_required")
     }
 
     /// Execute a provider turn with policy-gated tool execution through the kernel.
@@ -107,20 +244,21 @@ impl TurnEngine {
 
         // Too many tool intents for current step limit
         if turn.tool_intents.len() > self.max_tool_steps {
-            return TurnResult::ToolDenied("max_tool_steps_exceeded".to_owned());
+            return TurnResult::policy_denied("max_tool_steps_exceeded", "max_tool_steps_exceeded");
         }
 
         // Check each tool intent is known
         for intent in &turn.tool_intents {
             if !crate::tools::is_known_tool_name(&intent.tool_name) {
-                return TurnResult::ToolDenied(format!("tool_not_found: {}", intent.tool_name));
+                let reason = format!("tool_not_found: {}", intent.tool_name);
+                return TurnResult::policy_denied("tool_not_found", reason);
             }
         }
 
         // Require kernel context for execution
         let ctx = match kernel_ctx {
             Some(ctx) => ctx,
-            None => return TurnResult::ToolDenied("no_kernel_context".to_owned()),
+            None => return TurnResult::policy_denied("no_kernel_context", "no_kernel_context"),
         };
 
         // Execute each tool intent through the kernel
@@ -140,12 +278,17 @@ impl TurnEngine {
                     outputs.push(format!("[{}] {}", outcome.status, outcome.payload));
                 }
                 Err(e) => {
-                    // Classify by error variant, not by Display string
-                    return match &e {
-                        KernelError::Policy(_) | KernelError::PackCapabilityBoundary { .. } => {
-                            TurnResult::ToolDenied(format!("{e}"))
+                    let reason = format!("{e}");
+                    return match classify_kernel_error(&e) {
+                        KernelFailureClass::PolicyDenied => {
+                            TurnResult::policy_denied("kernel_policy_denied", reason)
                         }
-                        _ => TurnResult::ToolError(format!("{e}")),
+                        KernelFailureClass::RetryableExecution => {
+                            TurnResult::retryable_tool_error("tool_execution_failed", reason)
+                        }
+                        KernelFailureClass::NonRetryable => {
+                            TurnResult::non_retryable_tool_error("kernel_execution_failed", reason)
+                        }
                     };
                 }
             }

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -164,6 +164,19 @@ pub fn window_direct(
 }
 
 #[cfg(feature = "memory-sqlite")]
+pub fn window_direct_extended(
+    session_id: &str,
+    limit: usize,
+) -> Result<Vec<ConversationTurn>, String> {
+    sqlite::window_direct_with_options(
+        session_id,
+        limit,
+        true,
+        runtime_config::get_memory_runtime_config(),
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
 pub fn ensure_memory_db_ready(
     path: Option<PathBuf>,
     config: &runtime_config::MemoryRuntimeConfig,

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -83,13 +83,22 @@ pub(super) fn load_window(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "memory.window requires payload.session_id".to_owned())?;
+    let allow_extended_limit = payload
+        .get("allow_extended_limit")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let hard_limit_cap = if allow_extended_limit { 512 } else { 128 };
     let requested_limit = payload
         .get("limit")
         .and_then(Value::as_u64)
         .unwrap_or_else(default_window_size_u64)
-        .clamp(1, 128) as usize;
+        .clamp(1, hard_limit_cap) as usize;
     let default_window = default_window_size().max(1);
-    let window_limit = requested_limit.min(default_window);
+    let window_limit = if allow_extended_limit {
+        requested_limit
+    } else {
+        requested_limit.min(default_window)
+    };
 
     let path = resolve_db_path(config);
     ensure_sqlite_schema(&path)?;
@@ -131,6 +140,7 @@ pub(super) fn load_window(
             "operation": MEMORY_OP_WINDOW,
             "session_id": session_id,
             "limit": window_limit,
+            "allow_extended_limit": allow_extended_limit,
             "turns": turns,
             "db_path": path.display().to_string(),
         }),
@@ -189,7 +199,23 @@ pub(super) fn window_direct(
     limit: usize,
     config: &MemoryRuntimeConfig,
 ) -> Result<Vec<ConversationTurn>, String> {
-    let request = build_window_request(session_id, limit);
+    window_direct_with_options(session_id, limit, false, config)
+}
+
+pub(super) fn window_direct_with_options(
+    session_id: &str,
+    limit: usize,
+    allow_extended_limit: bool,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<ConversationTurn>, String> {
+    let request = MemoryCoreRequest {
+        operation: "window".to_owned(),
+        payload: json!({
+            "session_id": session_id,
+            "limit": limit,
+            "allow_extended_limit": allow_extended_limit,
+        }),
+    };
     let outcome = super::execute_memory_core_with_config(request, config)?;
     let turns_raw = outcome.payload.get("turns").cloned().unwrap_or(Value::Null);
     serde_json::from_value(turns_raw)

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use super::{
-    build_append_turn_request, build_window_request, runtime_config::MemoryRuntimeConfig,
-    MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION, MEMORY_OP_WINDOW,
+    build_append_turn_request, runtime_config::MemoryRuntimeConfig, MEMORY_OP_APPEND_TURN,
+    MEMORY_OP_CLEAR_SESSION, MEMORY_OP_WINDOW,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -468,9 +468,8 @@ mod tests {
     use super::payload_adaptation::{ReasoningField, TemperatureField, TokenLimitField};
     use super::*;
     use crate::config::{
-        ConversationConfig, FeishuChannelConfig, MemoryConfig, ProviderConfig, ReasoningEffort,
-        ProviderKind,
-        ToolConfig,
+        ConversationConfig, FeishuChannelConfig, MemoryConfig, ProviderConfig, ProviderKind,
+        ReasoningEffort, ToolConfig,
     };
     use serde_json::json;
 

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -586,13 +586,11 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(
-            history_contents.iter().any(|content| *content == "hello"),
+            history_contents.contains(&"hello"),
             "expected user content in history: {history_contents:?}"
         );
         assert!(
-            history_contents
-                .iter()
-                .any(|content| *content == "normal assistant reply"),
+            history_contents.contains(&"normal assistant reply"),
             "expected normal assistant content in history: {history_contents:?}"
         );
         assert!(
@@ -677,9 +675,7 @@ mod tests {
             "unknown role content should not be included: {history_contents:?}"
         );
         assert!(
-            history_contents
-                .iter()
-                .any(|content| *content == "visible reply"),
+            history_contents.contains(&"visible reply"),
             "assistant content should still be kept: {history_contents:?}"
         );
     }

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -36,7 +36,6 @@ pub fn build_system_message(
     if !include_system_prompt {
         return None;
     }
-
     let system = config.cli.system_prompt.trim();
     let snapshot = super::tools::capability_snapshot();
     let content = if system.is_empty() {
@@ -48,6 +47,50 @@ pub fn build_system_message(
         "role": "system",
         "content": content,
     }))
+}
+
+pub(crate) fn build_base_messages(
+    config: &LoongClawConfig,
+    include_system_prompt: bool,
+) -> Vec<Value> {
+    build_system_message(config, include_system_prompt)
+        .into_iter()
+        .collect()
+}
+
+pub(crate) fn push_history_message(messages: &mut Vec<Value>, role: &str, content: &str) {
+    if !is_supported_chat_role(role) {
+        return;
+    }
+    if should_skip_history_turn(role, content) {
+        return;
+    }
+    messages.push(json!({
+        "role": role,
+        "content": content,
+    }));
+}
+
+fn is_supported_chat_role(role: &str) -> bool {
+    matches!(role, "system" | "user" | "assistant" | "tool")
+}
+
+fn should_skip_history_turn(role: &str, content: &str) -> bool {
+    if role != "assistant" {
+        return false;
+    }
+    let parsed = match serde_json::from_str::<Value>(content) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    let event_type = parsed
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    matches!(
+        event_type,
+        "conversation_event" | "tool_decision" | "tool_outcome"
+    )
 }
 
 pub fn load_memory_window_messages(
@@ -63,10 +106,7 @@ pub fn load_memory_window_messages(
             .map_err(|error| format!("load memory window failed: {error}"))?;
         let mut messages = Vec::with_capacity(turns.len());
         for turn in turns {
-            messages.push(json!({
-                "role": turn.role,
-                "content": turn.content,
-            }));
+            push_history_message(&mut messages, turn.role.as_str(), turn.content.as_str());
         }
         Ok(messages)
     }
@@ -82,10 +122,7 @@ pub fn build_messages_for_session(
     session_id: &str,
     include_system_prompt: bool,
 ) -> CliResult<Vec<Value>> {
-    let mut messages = Vec::new();
-    if let Some(system_message) = build_system_message(config, include_system_prompt) {
-        messages.push(system_message);
-    }
+    let mut messages = build_base_messages(config, include_system_prompt);
     messages.extend(load_memory_window_messages(config, session_id)?);
     Ok(messages)
 }
@@ -431,7 +468,8 @@ mod tests {
     use super::payload_adaptation::{ReasoningField, TemperatureField, TokenLimitField};
     use super::*;
     use crate::config::{
-        FeishuChannelConfig, MemoryConfig, ProviderConfig, ProviderKind, ReasoningEffort,
+        ConversationConfig, FeishuChannelConfig, MemoryConfig, ProviderConfig, ReasoningEffort,
+        ProviderKind,
         ToolConfig,
     };
     use serde_json::json;
@@ -443,9 +481,9 @@ mod tests {
             cli: crate::config::CliChannelConfig::default(),
             telegram: crate::config::TelegramChannelConfig::default(),
             feishu: FeishuChannelConfig::default(),
+            conversation: ConversationConfig::default(),
             tools: ToolConfig::default(),
             memory: MemoryConfig::default(),
-            conversation: crate::config::ConversationConfig::default(),
         };
 
         let messages =
@@ -461,9 +499,9 @@ mod tests {
             cli: crate::config::CliChannelConfig::default(),
             telegram: crate::config::TelegramChannelConfig::default(),
             feishu: FeishuChannelConfig::default(),
+            conversation: ConversationConfig::default(),
             tools: ToolConfig::default(),
             memory: MemoryConfig::default(),
-            conversation: crate::config::ConversationConfig::default(),
         };
 
         let messages =
@@ -488,6 +526,164 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn build_messages_skips_internal_conversation_events_in_history_window() {
+        let mut config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            conversation: ConversationConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+        };
+
+        let session_id = format!(
+            "provider-history-filter-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos()
+        );
+        config.memory.sqlite_path = std::env::temp_dir()
+            .join(format!("{session_id}.sqlite3"))
+            .display()
+            .to_string();
+        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        };
+        crate::memory::append_turn_direct(&session_id, "user", "hello", &memory_config)
+            .expect("persist user turn");
+        crate::memory::append_turn_direct(
+            &session_id,
+            "assistant",
+            r#"{"type":"conversation_event","event":"lane_selected","payload":{"lane":"safe"}}"#,
+            &memory_config,
+        )
+        .expect("persist conversation event");
+        crate::memory::append_turn_direct(
+            &session_id,
+            "assistant",
+            r#"{"type":"tool_outcome","turn_id":"t1","tool_call_id":"c1","outcome":{"status":"ok"}}"#,
+            &memory_config,
+        )
+        .expect("persist tool outcome");
+        crate::memory::append_turn_direct(
+            &session_id,
+            "assistant",
+            "normal assistant reply",
+            &memory_config,
+        )
+        .expect("persist assistant reply");
+
+        let messages =
+            build_messages_for_session(&config, &session_id, true).expect("build messages");
+        let history_contents = messages
+            .iter()
+            .skip(1)
+            .filter_map(|message| message.get("content").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+
+        assert!(
+            history_contents.iter().any(|content| *content == "hello"),
+            "expected user content in history: {history_contents:?}"
+        );
+        assert!(
+            history_contents
+                .iter()
+                .any(|content| *content == "normal assistant reply"),
+            "expected normal assistant content in history: {history_contents:?}"
+        );
+        assert!(
+            history_contents
+                .iter()
+                .all(|content| !content.contains("\"type\":\"conversation_event\"")),
+            "conversation_event payload must be filtered out: {history_contents:?}"
+        );
+        assert!(
+            history_contents
+                .iter()
+                .all(|content| !content.contains("\"type\":\"tool_outcome\"")),
+            "tool_outcome payload must be filtered out: {history_contents:?}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn build_messages_skips_unknown_history_roles() {
+        let mut config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            conversation: ConversationConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+        };
+
+        let session_id = format!(
+            "provider-history-role-filter-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos()
+        );
+        config.memory.sqlite_path = std::env::temp_dir()
+            .join(format!("{session_id}.sqlite3"))
+            .display()
+            .to_string();
+        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        };
+        crate::memory::append_turn_direct(&session_id, "user", "hello", &memory_config)
+            .expect("persist user turn");
+        crate::memory::append_turn_direct(
+            &session_id,
+            "internal_event",
+            "should be hidden",
+            &memory_config,
+        )
+        .expect("persist unknown role turn");
+        crate::memory::append_turn_direct(
+            &session_id,
+            "assistant",
+            "visible reply",
+            &memory_config,
+        )
+        .expect("persist assistant turn");
+
+        let messages =
+            build_messages_for_session(&config, &session_id, true).expect("build messages");
+        let history_roles = messages
+            .iter()
+            .skip(1)
+            .filter_map(|message| message.get("role").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        let history_contents = messages
+            .iter()
+            .skip(1)
+            .filter_map(|message| message.get("content").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+
+        assert!(
+            history_roles.iter().all(|role| *role != "internal_event"),
+            "unknown roles should be filtered: {history_roles:?}"
+        );
+        assert!(
+            history_contents
+                .iter()
+                .all(|content| *content != "should be hidden"),
+            "unknown role content should not be included: {history_contents:?}"
+        );
+        assert!(
+            history_contents
+                .iter()
+                .any(|content| *content == "visible reply"),
+            "assistant content should still be kept: {history_contents:?}"
+        );
+    }
+
     #[test]
     fn completion_body_includes_reasoning_effort_when_configured() {
         let mut config = LoongClawConfig {
@@ -495,9 +691,9 @@ mod tests {
             cli: crate::config::CliChannelConfig::default(),
             telegram: crate::config::TelegramChannelConfig::default(),
             feishu: FeishuChannelConfig::default(),
+            conversation: ConversationConfig::default(),
             tools: ToolConfig::default(),
             memory: MemoryConfig::default(),
-            conversation: crate::config::ConversationConfig::default(),
         };
         config.provider.reasoning_effort = Some(ReasoningEffort::High);
 
@@ -558,9 +754,9 @@ mod tests {
             cli: crate::config::CliChannelConfig::default(),
             telegram: crate::config::TelegramChannelConfig::default(),
             feishu: FeishuChannelConfig::default(),
+            conversation: ConversationConfig::default(),
             tools: ToolConfig::default(),
             memory: MemoryConfig::default(),
-            conversation: crate::config::ConversationConfig::default(),
         };
 
         let body = build_completion_request_body(
@@ -616,9 +812,9 @@ mod tests {
             cli: crate::config::CliChannelConfig::default(),
             telegram: crate::config::TelegramChannelConfig::default(),
             feishu: FeishuChannelConfig::default(),
+            conversation: ConversationConfig::default(),
             tools: ToolConfig::default(),
             memory: MemoryConfig::default(),
-            conversation: crate::config::ConversationConfig::default(),
         };
 
         let body = build_turn_request_body(


### PR DESCRIPTION
## Summary
- harden deterministic lane selection for fast/safe execution
- add bounded safe-lane plan graph, executor, and verifier runtime primitives
- tighten failure taxonomy, replan routing, session-governor controls, and runtime analytics coverage
- update config/test coverage and lock the vulnerable `quinn-proto` dependency to a patched version

## Linked Issue
- Closes #5

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo audit
- cargo test -p loongclaw-app --all-features
- cargo test -p loongclaw-daemon --all-features -- --test-threads=1
- cargo test --workspace --all-features -- --test-threads=1

## Notes
- Base branch: `alpha-test`
- Observability and operator-facing diagnostics remain in stacked follow-up PR #8