### PR TITLE
feat(channel): add multi-account runtime routing substrate

### DIFF
--- a/crates/app/src/channel/feishu/adapter.rs
+++ b/crates/app/src/channel/feishu/adapter.rs
@@ -1,8 +1,11 @@
 use async_trait::async_trait;
 use serde_json::{json, Value};
 
-use crate::channel::{ChannelAdapter, ChannelInboundMessage};
-use crate::config::LoongClawConfig;
+use crate::channel::{
+    ChannelAdapter, ChannelInboundMessage, ChannelOutboundTarget, ChannelOutboundTargetKind,
+    ChannelPlatform,
+};
+use crate::config::ResolvedFeishuChannelConfig;
 use crate::CliResult;
 
 use super::payload::{
@@ -18,20 +21,18 @@ pub(super) struct FeishuAdapter {
 }
 
 impl FeishuAdapter {
-    pub(super) fn new(config: &LoongClawConfig) -> CliResult<Self> {
+    pub(super) fn new(config: &ResolvedFeishuChannelConfig) -> CliResult<Self> {
         let app_id = config
-            .feishu
             .app_id()
             .ok_or_else(|| "missing Feishu app id (feishu.app_id or env)".to_owned())?;
         let app_secret = config
-            .feishu
             .app_secret()
             .ok_or_else(|| "missing Feishu app secret (feishu.app_secret or env)".to_owned())?;
         Ok(Self {
             app_id,
             app_secret,
-            base_url: config.feishu.base_url.clone(),
-            receive_id_type: config.feishu.receive_id_type.clone(),
+            base_url: config.resolved_base_url(),
+            receive_id_type: config.receive_id_type.clone(),
             tenant_access_token: None,
         })
     }
@@ -70,7 +71,12 @@ impl FeishuAdapter {
         Ok(())
     }
 
-    pub(super) async fn send_card(&self, receive_id: &str, text: &str) -> CliResult<()> {
+    pub(super) async fn send_card(
+        &self,
+        target: &ChannelOutboundTarget,
+        text: &str,
+    ) -> CliResult<()> {
+        let receive_id = self.resolve_receive_id_target(target)?;
         let card = json!({
             "config": {
                 "wide_screen_mode": true
@@ -86,7 +92,7 @@ impl FeishuAdapter {
             .await
     }
 
-    pub(super) async fn send_reply(&self, message_id: &str, text: &str) -> CliResult<()> {
+    async fn send_reply(&self, message_id: &str, text: &str) -> CliResult<()> {
         let token = self.tenant_access_token.as_deref().ok_or_else(|| {
             "feishu tenant token is missing, call refresh_tenant_token first".to_owned()
         })?;
@@ -144,6 +150,25 @@ impl FeishuAdapter {
             .map_err(|error| format!("feishu send decode failed: {error}"))?;
         ensure_feishu_response_ok("feishu send", &payload)
     }
+
+    fn resolve_receive_id_target<'a>(
+        &self,
+        target: &'a ChannelOutboundTarget,
+    ) -> CliResult<&'a str> {
+        if target.platform != ChannelPlatform::Feishu {
+            return Err(format!(
+                "feishu adapter cannot send to {} target",
+                target.platform.as_str()
+            ));
+        }
+        if target.kind != ChannelOutboundTargetKind::ReceiveId {
+            return Err(format!(
+                "feishu direct send requires receive_id target, got {}",
+                target.kind.as_str()
+            ));
+        }
+        target.trimmed_id()
+    }
 }
 
 #[async_trait]
@@ -156,8 +181,26 @@ impl ChannelAdapter for FeishuAdapter {
         Err("feishu inbound is served via webhook mode (`feishu-serve`)".to_owned())
     }
 
-    async fn send_text(&self, target: &str, text: &str) -> CliResult<()> {
-        self.send_message(target, "text", json!({"text": text}))
-            .await
+    async fn send_text(&self, target: &ChannelOutboundTarget, text: &str) -> CliResult<()> {
+        if target.platform != ChannelPlatform::Feishu {
+            return Err(format!(
+                "feishu adapter cannot send to {} target",
+                target.platform.as_str()
+            ));
+        }
+
+        match target.kind {
+            ChannelOutboundTargetKind::MessageReply => {
+                self.send_reply(target.trimmed_id()?, text).await
+            }
+            ChannelOutboundTargetKind::ReceiveId => {
+                self.send_message(target.trimmed_id()?, "text", json!({"text": text}))
+                    .await
+            }
+            ChannelOutboundTargetKind::Conversation => Err(
+                "feishu adapter does not support conversation targets for outbound sends"
+                    .to_owned(),
+            ),
+        }
     }
 }

--- a/crates/app/src/channel/feishu/mod.rs
+++ b/crates/app/src/channel/feishu/mod.rs
@@ -1,9 +1,14 @@
 use std::path::Path;
+use std::sync::Arc;
 
 use axum::{routing::post, Router};
 
-use crate::channel::ChannelAdapter;
-use crate::config::LoongClawConfig;
+use crate::channel::{
+    runtime_state::ChannelOperationRuntimeTracker, ChannelAdapter, ChannelOutboundTarget,
+};
+use crate::config::{
+    ChannelDefaultAccountSelectionSource, LoongClawConfig, ResolvedFeishuChannelConfig,
+};
 use crate::CliResult;
 use crate::KernelContext;
 
@@ -16,37 +21,42 @@ use payload::normalize_webhook_path;
 use webhook::{feishu_webhook_handler, FeishuWebhookState};
 
 pub(super) async fn run_feishu_send(
-    config: &LoongClawConfig,
+    config: &ResolvedFeishuChannelConfig,
     receive_id: &str,
     text: &str,
     as_card: bool,
 ) -> CliResult<()> {
     let mut adapter = FeishuAdapter::new(config)?;
     adapter.refresh_tenant_token().await?;
+    let target = ChannelOutboundTarget::feishu_receive_id(receive_id);
 
     if as_card {
-        adapter.send_card(receive_id, text).await
+        adapter.send_card(&target, text).await
     } else {
-        adapter.send_text(receive_id, text).await
+        adapter.send_text(&target, text).await
     }
 }
 
 #[allow(clippy::print_stdout)] // CLI startup banner
 pub(super) async fn run_feishu_channel(
     config: &LoongClawConfig,
+    resolved: &ResolvedFeishuChannelConfig,
     resolved_path: &Path,
+    selected_by_default: bool,
+    default_account_source: ChannelDefaultAccountSelectionSource,
     bind_override: Option<&str>,
     path_override: Option<&str>,
     kernel_ctx: KernelContext,
+    runtime: Arc<ChannelOperationRuntimeTracker>,
 ) -> CliResult<()> {
-    let mut adapter = FeishuAdapter::new(config)?;
+    let mut adapter = FeishuAdapter::new(resolved)?;
     adapter.refresh_tenant_token().await?;
 
     let bind = bind_override
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_owned)
-        .unwrap_or_else(|| config.feishu.webhook_bind.trim().to_owned());
+        .unwrap_or_else(|| resolved.webhook_bind.trim().to_owned());
     if bind.is_empty() {
         return Err("feishu webhook bind address is empty".to_owned());
     }
@@ -55,10 +65,10 @@ pub(super) async fn run_feishu_channel(
         path_override
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .unwrap_or(config.feishu.webhook_path.as_str()),
+            .unwrap_or(resolved.webhook_path.as_str()),
     );
 
-    let state = FeishuWebhookState::new(config.clone(), adapter, kernel_ctx);
+    let state = FeishuWebhookState::new(config.clone(), resolved, adapter, kernel_ctx, runtime);
     let app = Router::new()
         .route(path.as_str(), post(feishu_webhook_handler))
         .with_state(state);
@@ -68,8 +78,12 @@ pub(super) async fn run_feishu_channel(
         .map_err(|error| format!("bind feishu webhook listener failed: {error}"))?;
 
     println!(
-        "feishu channel started (config={}, bind={}, path={})",
+        "feishu channel started (config={}, configured_account={}, account={}, selected_by_default={}, default_source={}, bind={}, path={})",
         resolved_path.display(),
+        resolved.configured_account_id,
+        resolved.account.label,
+        selected_by_default,
+        default_account_source.as_str(),
         bind,
         path
     );

--- a/crates/app/src/channel/feishu/payload/inbound.rs
+++ b/crates/app/src/channel/feishu/payload/inbound.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 
 use serde_json::Value;
 
+use crate::channel::{ChannelOutboundTarget, ChannelPlatform, ChannelSession};
 use crate::CliResult;
 
 use super::crypto::decrypt_payload_if_needed;
@@ -13,6 +14,7 @@ pub(in crate::channel::feishu) fn parse_feishu_webhook_payload(
     encrypt_key: Option<&str>,
     allowed_chat_ids: &BTreeSet<String>,
     ignore_bot_messages: bool,
+    account_id: &str,
 ) -> CliResult<FeishuWebhookAction> {
     let decrypted_payload = decrypt_payload_if_needed(payload, encrypt_key)?;
     let payload = decrypted_payload.as_ref().unwrap_or(payload);
@@ -102,8 +104,12 @@ pub(in crate::channel::feishu) fn parse_feishu_webhook_payload(
 
     Ok(FeishuWebhookAction::Inbound(FeishuInboundEvent {
         event_id,
-        session_id: format!("feishu:{chat_id}"),
-        message_id: message_id.to_owned(),
+        session: ChannelSession::with_account(
+            ChannelPlatform::Feishu,
+            account_id,
+            chat_id.to_owned(),
+        ),
+        reply_target: ChannelOutboundTarget::feishu_message_reply(message_id.to_owned()),
         text,
     }))
 }

--- a/crates/app/src/channel/feishu/payload/tests.rs
+++ b/crates/app/src/channel/feishu/payload/tests.rs
@@ -7,6 +7,7 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 
 use super::*;
+use crate::channel::{ChannelOutboundTarget, ChannelOutboundTargetKind, ChannelPlatform};
 
 #[test]
 fn feishu_url_verification_payload_parses() {
@@ -15,9 +16,15 @@ fn feishu_url_verification_payload_parses() {
         "token": "token-123",
         "challenge": "abc"
     });
-    let action =
-        parse_feishu_webhook_payload(&payload, Some("token-123"), None, &BTreeSet::new(), true)
-            .expect("parse feishu url verification");
+    let action = parse_feishu_webhook_payload(
+        &payload,
+        Some("token-123"),
+        None,
+        &BTreeSet::new(),
+        true,
+        "feishu_cli_a1b2c3",
+    )
+    .expect("parse feishu url verification");
 
     match action {
         FeishuWebhookAction::UrlVerification { challenge } => assert_eq!(challenge, "abc"),
@@ -47,14 +54,32 @@ fn feishu_message_event_parses_text_payload() {
     });
 
     let allowlist = BTreeSet::from([String::from("oc_123")]);
-    let action = parse_feishu_webhook_payload(&payload, Some("token-123"), None, &allowlist, true)
-        .expect("parse feishu event");
+    let action = parse_feishu_webhook_payload(
+        &payload,
+        Some("token-123"),
+        None,
+        &allowlist,
+        true,
+        "feishu_cli_a1b2c3",
+    )
+    .expect("parse feishu event");
 
     match action {
         FeishuWebhookAction::Inbound(event) => {
             assert_eq!(event.event_id, "evt_1");
-            assert_eq!(event.session_id, "feishu:oc_123");
-            assert_eq!(event.message_id, "om_123");
+            assert_eq!(
+                event.session.session_key(),
+                "feishu:feishu_cli_a1b2c3:oc_123"
+            );
+            assert_eq!(
+                event.reply_target,
+                ChannelOutboundTarget::feishu_message_reply("om_123")
+            );
+            assert_eq!(event.reply_target.platform, ChannelPlatform::Feishu);
+            assert_eq!(
+                event.reply_target.kind,
+                ChannelOutboundTargetKind::MessageReply
+            );
             assert_eq!(event.text, "hello loongclaw");
         }
         _ => panic!("unexpected action"),
@@ -77,9 +102,15 @@ fn feishu_token_mismatch_is_rejected() {
         "token": "token-x",
         "challenge": "abc"
     });
-    let error =
-        parse_feishu_webhook_payload(&payload, Some("token-y"), None, &BTreeSet::new(), true)
-            .expect_err("token mismatch should fail");
+    let error = parse_feishu_webhook_payload(
+        &payload,
+        Some("token-y"),
+        None,
+        &BTreeSet::new(),
+        true,
+        "feishu_cli_a1b2c3",
+    )
+    .expect_err("token mismatch should fail");
     assert!(error.contains("unauthorized"));
 }
 
@@ -100,9 +131,15 @@ fn feishu_non_text_message_is_ignored() {
             }
         }
     });
-    let action =
-        parse_feishu_webhook_payload(&payload, Some("token-123"), None, &BTreeSet::new(), true)
-            .expect("non-text payload should parse");
+    let action = parse_feishu_webhook_payload(
+        &payload,
+        Some("token-123"),
+        None,
+        &BTreeSet::new(),
+        true,
+        "feishu_cli_a1b2c3",
+    )
+    .expect("non-text payload should parse");
 
     assert!(matches!(action, FeishuWebhookAction::Ignore));
 }
@@ -157,14 +194,21 @@ fn feishu_encrypted_payload_parses_with_encrypt_key() {
         Some("encrypt-key"),
         &allowlist,
         true,
+        "feishu_cli_a1b2c3",
     )
     .expect("parse encrypted payload");
 
     match parsed {
         FeishuWebhookAction::Inbound(event) => {
             assert_eq!(event.event_id, "evt_encrypted_1");
-            assert_eq!(event.session_id, "feishu:oc_encrypt");
-            assert_eq!(event.message_id, "om_encrypt");
+            assert_eq!(
+                event.session.session_key(),
+                "feishu:feishu_cli_a1b2c3:oc_encrypt"
+            );
+            assert_eq!(
+                event.reply_target,
+                ChannelOutboundTarget::feishu_message_reply("om_encrypt")
+            );
             assert_eq!(event.text, "encrypted hello");
         }
         _ => panic!("unexpected action"),
@@ -174,9 +218,15 @@ fn feishu_encrypted_payload_parses_with_encrypt_key() {
 #[test]
 fn feishu_encrypted_payload_requires_encrypt_key() {
     let wrapper = json!({ "encrypt": "opaque" });
-    let error =
-        parse_feishu_webhook_payload(&wrapper, Some("token-123"), None, &BTreeSet::new(), true)
-            .expect_err("encrypted payload without key should fail");
+    let error = parse_feishu_webhook_payload(
+        &wrapper,
+        Some("token-123"),
+        None,
+        &BTreeSet::new(),
+        true,
+        "feishu_cli_a1b2c3",
+    )
+    .expect_err("encrypted payload without key should fail");
 
     assert!(error.contains("encrypt key is not configured"));
 }
@@ -201,9 +251,15 @@ fn feishu_message_event_is_ignored_when_allowlist_is_empty() {
         }
     });
 
-    let action =
-        parse_feishu_webhook_payload(&payload, Some("token-123"), None, &BTreeSet::new(), true)
-            .expect("parse feishu event");
+    let action = parse_feishu_webhook_payload(
+        &payload,
+        Some("token-123"),
+        None,
+        &BTreeSet::new(),
+        true,
+        "feishu_cli_a1b2c3",
+    )
+    .expect("parse feishu event");
     assert!(matches!(action, FeishuWebhookAction::Ignore));
 }
 
@@ -228,8 +284,9 @@ fn feishu_message_event_requires_verification_token_configuration() {
     });
 
     let allowlist = BTreeSet::from([String::from("oc_123")]);
-    let error = parse_feishu_webhook_payload(&payload, None, None, &allowlist, true)
-        .expect_err("missing verification token should fail");
+    let error =
+        parse_feishu_webhook_payload(&payload, None, None, &allowlist, true, "feishu_cli_a1b2c3")
+            .expect_err("missing verification token should fail");
 
     assert!(error.contains("verification token is not configured"));
 }

--- a/crates/app/src/channel/feishu/payload/types.rs
+++ b/crates/app/src/channel/feishu/payload/types.rs
@@ -1,8 +1,10 @@
+use crate::channel::{ChannelOutboundTarget, ChannelSession};
+
 #[derive(Debug, Clone)]
 pub(in crate::channel::feishu) struct FeishuInboundEvent {
     pub(in crate::channel::feishu) event_id: String,
-    pub(in crate::channel::feishu) session_id: String,
-    pub(in crate::channel::feishu) message_id: String,
+    pub(in crate::channel::feishu) session: ChannelSession,
+    pub(in crate::channel::feishu) reply_target: ChannelOutboundTarget,
     pub(in crate::channel::feishu) text: String,
 }
 

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -14,8 +14,11 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 
-use crate::channel::{process_inbound_with_provider, ChannelInboundMessage};
-use crate::config::LoongClawConfig;
+use crate::channel::{
+    process_inbound_with_provider, runtime_state::ChannelOperationRuntimeTracker, ChannelAdapter,
+    ChannelInboundMessage,
+};
+use crate::config::{LoongClawConfig, ResolvedFeishuChannelConfig};
 use crate::KernelContext;
 
 use super::adapter::FeishuAdapter;
@@ -25,35 +28,40 @@ use super::payload::FeishuWebhookAction;
 pub(super) struct FeishuWebhookState {
     config: LoongClawConfig,
     adapter: Arc<Mutex<FeishuAdapter>>,
+    account_id: String,
     verification_token: Option<String>,
     encrypt_key: Option<String>,
     allowed_chat_ids: BTreeSet<String>,
     ignore_bot_messages: bool,
     seen_events: Arc<Mutex<RecentIdCache>>,
     kernel_ctx: Arc<KernelContext>,
+    runtime: Arc<ChannelOperationRuntimeTracker>,
 }
 
 impl FeishuWebhookState {
     pub(super) fn new(
         config: LoongClawConfig,
+        resolved: &ResolvedFeishuChannelConfig,
         adapter: FeishuAdapter,
         kernel_ctx: KernelContext,
+        runtime: Arc<ChannelOperationRuntimeTracker>,
     ) -> Self {
         Self {
-            verification_token: config.feishu.verification_token(),
-            encrypt_key: config.feishu.encrypt_key(),
-            allowed_chat_ids: config
-                .feishu
+            account_id: resolved.account.id.clone(),
+            verification_token: resolved.verification_token(),
+            encrypt_key: resolved.encrypt_key(),
+            allowed_chat_ids: resolved
                 .allowed_chat_ids
                 .iter()
                 .map(|value| value.trim().to_owned())
                 .filter(|value| !value.is_empty())
                 .collect(),
-            ignore_bot_messages: config.feishu.ignore_bot_messages,
+            ignore_bot_messages: resolved.ignore_bot_messages,
             config,
             adapter: Arc::new(Mutex::new(adapter)),
             seen_events: Arc::new(Mutex::new(RecentIdCache::new(2_048))),
             kernel_ctx: Arc::new(kernel_ctx),
+            runtime,
         }
     }
 }
@@ -61,7 +69,20 @@ impl FeishuWebhookState {
 struct RecentIdCache {
     max_len: usize,
     queue: VecDeque<String>,
-    set: BTreeSet<String>,
+    states: std::collections::BTreeMap<String, RecentIdState>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecentIdState {
+    Processing,
+    Completed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecentIdReservation {
+    Accepted,
+    InProgressDuplicate,
+    CompletedDuplicate,
 }
 
 impl RecentIdCache {
@@ -69,27 +90,48 @@ impl RecentIdCache {
         Self {
             max_len: max_len.max(1),
             queue: VecDeque::new(),
-            set: BTreeSet::new(),
+            states: std::collections::BTreeMap::new(),
         }
     }
 
-    fn insert_if_new(&mut self, id: &str) -> bool {
+    fn begin_processing(&mut self, id: &str) -> RecentIdReservation {
         let id = id.trim();
         if id.is_empty() {
-            return false;
+            return RecentIdReservation::CompletedDuplicate;
         }
-        if self.set.contains(id) {
-            return false;
+        if let Some(state) = self.states.get(id) {
+            return match state {
+                RecentIdState::Processing => RecentIdReservation::InProgressDuplicate,
+                RecentIdState::Completed => RecentIdReservation::CompletedDuplicate,
+            };
         }
 
         self.queue.push_back(id.to_owned());
-        self.set.insert(id.to_owned());
+        self.states.insert(id.to_owned(), RecentIdState::Processing);
+        self.trim_to_max();
+        RecentIdReservation::Accepted
+    }
+
+    fn mark_completed(&mut self, id: &str) {
+        let id = id.trim();
+        if let Some(state) = self.states.get_mut(id) {
+            *state = RecentIdState::Completed;
+        }
+    }
+
+    fn release(&mut self, id: &str) {
+        let id = id.trim();
+        if self.states.remove(id).is_some() {
+            self.queue.retain(|entry| entry != id);
+        }
+    }
+
+    fn trim_to_max(&mut self) {
         while self.queue.len() > self.max_len {
             if let Some(removed) = self.queue.pop_front() {
-                self.set.remove(&removed);
+                self.states.remove(&removed);
             }
         }
-        true
     }
 }
 
@@ -149,6 +191,7 @@ async fn handle_feishu_webhook_payload(
         state.encrypt_key.as_deref(),
         &state.allowed_chat_ids,
         state.ignore_bot_messages,
+        state.account_id.as_str(),
     )
     .map_err(map_feishu_parse_error)?;
 
@@ -158,51 +201,83 @@ async fn handle_feishu_webhook_payload(
         FeishuWebhookAction::Inbound(event) => {
             {
                 let mut dedupe = state.seen_events.lock().await;
-                if !dedupe.insert_if_new(&event.event_id) {
+                if !matches!(
+                    dedupe.begin_processing(&event.event_id),
+                    RecentIdReservation::Accepted
+                ) {
                     return Ok(json!({"code": 0, "msg": "duplicate_event"}));
                 }
             }
 
-            let channel_message = ChannelInboundMessage {
-                session_id: event.session_id,
-                reply_target: event.message_id.clone(),
-                text: event.text,
-            };
-            let reply = process_inbound_with_provider(
-                &state.config,
-                &channel_message,
-                Some(&state.kernel_ctx),
-            )
-            .await
-            .map_err(|error| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("provider processing failed: {error}"),
-                )
-            })?;
-
-            let mut adapter = state.adapter.lock().await;
-            if let Err(first_error) = adapter.send_reply(&event.message_id, &reply).await {
-                adapter.refresh_tenant_token().await.map_err(|error| {
+            let event_id = event.event_id.clone();
+            let result = async {
+                state.runtime.mark_run_start().await.map_err(|error| {
                     (
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        format!(
-                            "feishu token refresh failed after send error `{first_error}`: {error}"
-                        ),
+                        format!("channel runtime start failed: {error}"),
                     )
                 })?;
-                adapter
-                    .send_reply(&event.message_id, &reply)
-                    .await
-                    .map_err(|error| {
+                let channel_message = ChannelInboundMessage {
+                    session: event.session,
+                    reply_target: event.reply_target,
+                    text: event.text,
+                    delivery: Default::default(),
+                };
+                let reply = process_inbound_with_provider(
+                    &state.config,
+                    &channel_message,
+                    Some(&state.kernel_ctx),
+                )
+                .await
+                .map_err(|error| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("provider processing failed: {error}"),
+                    )
+                })?;
+                let reply_target = channel_message.reply_target.clone();
+
+                let mut adapter = state.adapter.lock().await;
+                if let Err(first_error) = adapter.send_text(&reply_target, &reply).await {
+                    adapter.refresh_tenant_token().await.map_err(|error| {
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!(
+                                "feishu token refresh failed after send error `{first_error}`: {error}"
+                            ),
+                        )
+                    })?;
+                    adapter.send_text(&reply_target, &reply).await.map_err(|error| {
                         (
                             StatusCode::INTERNAL_SERVER_ERROR,
                             format!("feishu reply failed after token refresh: {error}"),
                         )
                     })?;
+                }
+
+                Ok(json!({"code": 0, "msg": "ok"}))
+            }
+            .await;
+            let runtime_end_result = state.runtime.mark_run_end().await;
+            let result = match (result, runtime_end_result) {
+                (Ok(reply), Ok(())) => Ok(reply),
+                (Err(error), _) => Err(error),
+                (Ok(_), Err(error)) => Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("channel runtime end failed: {error}"),
+                )),
+            };
+
+            {
+                let mut dedupe = state.seen_events.lock().await;
+                if result.is_ok() {
+                    dedupe.mark_completed(&event_id);
+                } else {
+                    dedupe.release(&event_id);
+                }
             }
 
-            Ok(json!({"code": 0, "msg": "ok"}))
+            result
         }
     }
 }
@@ -288,11 +363,50 @@ mod tests {
     #[test]
     fn recent_cache_deduplicates_and_rolls_window() {
         let mut cache = RecentIdCache::new(2);
-        assert!(cache.insert_if_new("a"));
-        assert!(!cache.insert_if_new("a"));
-        assert!(cache.insert_if_new("b"));
-        assert!(cache.insert_if_new("c"));
-        assert!(cache.insert_if_new("a"));
+        assert!(matches!(
+            cache.begin_processing("a"),
+            RecentIdReservation::Accepted
+        ));
+        cache.mark_completed("a");
+        assert!(matches!(
+            cache.begin_processing("a"),
+            RecentIdReservation::CompletedDuplicate
+        ));
+        assert!(matches!(
+            cache.begin_processing("b"),
+            RecentIdReservation::Accepted
+        ));
+        cache.mark_completed("b");
+        assert!(matches!(
+            cache.begin_processing("c"),
+            RecentIdReservation::Accepted
+        ));
+        cache.mark_completed("c");
+        assert!(matches!(
+            cache.begin_processing("a"),
+            RecentIdReservation::Accepted
+        ));
+    }
+
+    #[test]
+    fn recent_cache_releases_failed_events_for_retry() {
+        let mut cache = RecentIdCache::new(4);
+
+        assert!(matches!(
+            cache.begin_processing("evt-1"),
+            RecentIdReservation::Accepted
+        ));
+        assert!(matches!(
+            cache.begin_processing("evt-1"),
+            RecentIdReservation::InProgressDuplicate
+        ));
+
+        cache.release("evt-1");
+
+        assert!(matches!(
+            cache.begin_processing("evt-1"),
+            RecentIdReservation::Accepted
+        ));
     }
 
     #[test]

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -1,5 +1,13 @@
 #[cfg(feature = "channel-telegram")]
 use std::time::Duration;
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+use std::{
+    future::Future,
+    path::PathBuf,
+    pin::Pin,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
 use async_trait::async_trait;
@@ -13,22 +21,224 @@ use crate::CliResult;
 use crate::KernelContext;
 
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
-use super::config::LoongClawConfig;
+use super::config::{
+    ChannelResolvedAccountRoute, LoongClawConfig, ResolvedFeishuChannelConfig,
+    ResolvedTelegramChannelConfig,
+};
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
 use super::conversation::{ConversationTurnLoop, ProviderErrorMode};
 
 #[cfg(feature = "channel-feishu")]
 mod feishu;
+mod registry;
+mod runtime_state;
 #[cfg(feature = "channel-telegram")]
 mod telegram;
+
+pub use registry::{
+    channel_status_snapshots, list_channel_catalog, normalize_channel_platform,
+    ChannelCatalogEntry, ChannelCatalogOperation, ChannelOperationHealth, ChannelOperationStatus,
+    ChannelStatusSnapshot,
+};
+pub use runtime_state::ChannelOperationRuntime;
+use runtime_state::ChannelOperationRuntimeTracker;
+
+#[derive(Debug, Clone, Default)]
+pub struct ChannelDelivery {
+    #[allow(dead_code)]
+    pub ack_cursor: Option<String>,
+    #[allow(dead_code)]
+    pub source_message_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelPlatform {
+    Telegram,
+    Feishu,
+}
+
+impl ChannelPlatform {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Telegram => "telegram",
+            Self::Feishu => "feishu",
+        }
+    }
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelSession {
+    pub platform: ChannelPlatform,
+    pub account_id: Option<String>,
+    pub conversation_id: String,
+    pub thread_id: Option<String>,
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+impl ChannelSession {
+    pub fn new(platform: ChannelPlatform, conversation_id: impl Into<String>) -> Self {
+        Self {
+            platform,
+            account_id: None,
+            conversation_id: conversation_id.into(),
+            thread_id: None,
+        }
+    }
+
+    pub fn with_account(
+        platform: ChannelPlatform,
+        account_id: impl Into<String>,
+        conversation_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            platform,
+            account_id: Some(account_id.into()),
+            conversation_id: conversation_id.into(),
+            thread_id: None,
+        }
+    }
+
+    pub fn with_thread(
+        platform: ChannelPlatform,
+        conversation_id: impl Into<String>,
+        thread_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            platform,
+            account_id: None,
+            conversation_id: conversation_id.into(),
+            thread_id: Some(thread_id.into()),
+        }
+    }
+
+    pub fn with_account_and_thread(
+        platform: ChannelPlatform,
+        account_id: impl Into<String>,
+        conversation_id: impl Into<String>,
+        thread_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            platform,
+            account_id: Some(account_id.into()),
+            conversation_id: conversation_id.into(),
+            thread_id: Some(thread_id.into()),
+        }
+    }
+
+    pub fn session_key(&self) -> String {
+        let account_id = self
+            .account_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let conversation_id = self.conversation_id.trim();
+        let thread_id = self
+            .thread_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        match (account_id, thread_id) {
+            (Some(account_id), Some(thread_id)) => format!(
+                "{}:{account_id}:{conversation_id}:{thread_id}",
+                self.platform.as_str()
+            ),
+            (Some(account_id), None) => {
+                format!("{}:{account_id}:{conversation_id}", self.platform.as_str())
+            }
+            (None, Some(thread_id)) => {
+                format!("{}:{conversation_id}:{thread_id}", self.platform.as_str())
+            }
+            (None, None) => format!("{}:{conversation_id}", self.platform.as_str()),
+        }
+    }
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelOutboundTargetKind {
+    Conversation,
+    MessageReply,
+    ReceiveId,
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+impl ChannelOutboundTargetKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Conversation => "conversation",
+            Self::MessageReply => "message_reply",
+            Self::ReceiveId => "receive_id",
+        }
+    }
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelOutboundTarget {
+    pub platform: ChannelPlatform,
+    pub kind: ChannelOutboundTargetKind,
+    pub id: String,
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+impl ChannelOutboundTarget {
+    pub fn new(
+        platform: ChannelPlatform,
+        kind: ChannelOutboundTargetKind,
+        id: impl Into<String>,
+    ) -> Self {
+        Self {
+            platform,
+            kind,
+            id: id.into(),
+        }
+    }
+
+    pub fn telegram_chat(chat_id: i64) -> Self {
+        Self::new(
+            ChannelPlatform::Telegram,
+            ChannelOutboundTargetKind::Conversation,
+            chat_id.to_string(),
+        )
+    }
+
+    pub fn feishu_message_reply(message_id: impl Into<String>) -> Self {
+        Self::new(
+            ChannelPlatform::Feishu,
+            ChannelOutboundTargetKind::MessageReply,
+            message_id,
+        )
+    }
+
+    pub fn feishu_receive_id(receive_id: impl Into<String>) -> Self {
+        Self::new(
+            ChannelPlatform::Feishu,
+            ChannelOutboundTargetKind::ReceiveId,
+            receive_id,
+        )
+    }
+
+    pub fn trimmed_id(&self) -> CliResult<&str> {
+        let id = self.id.trim();
+        if id.is_empty() {
+            return Err(format!(
+                "channel target id is empty for {} {}",
+                self.platform.as_str(),
+                self.kind.as_str()
+            ));
+        }
+        Ok(id)
+    }
+}
 
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
 #[derive(Debug, Clone)]
 pub struct ChannelInboundMessage {
-    pub session_id: String,
-    #[allow(dead_code)]
-    pub reply_target: String,
+    pub session: ChannelSession,
+    pub reply_target: ChannelOutboundTarget,
     pub text: String,
+    pub delivery: ChannelDelivery,
 }
 
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
@@ -37,65 +247,356 @@ pub struct ChannelInboundMessage {
 pub trait ChannelAdapter {
     fn name(&self) -> &str;
     async fn receive_batch(&mut self) -> CliResult<Vec<ChannelInboundMessage>>;
-    async fn send_text(&self, target: &str, text: &str) -> CliResult<()>;
+    async fn send_text(&self, target: &ChannelOutboundTarget, text: &str) -> CliResult<()>;
+    async fn ack_inbound(&mut self, _message: &ChannelInboundMessage) -> CliResult<()> {
+        Ok(())
+    }
+    async fn complete_batch(&mut self) -> CliResult<()> {
+        Ok(())
+    }
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+type ChannelProcessFuture = Pin<Box<dyn Future<Output = CliResult<String>> + Send>>;
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+async fn process_channel_batch<A, F>(
+    adapter: &mut A,
+    batch: Vec<ChannelInboundMessage>,
+    runtime: Option<&ChannelOperationRuntimeTracker>,
+    mut process: F,
+) -> CliResult<bool>
+where
+    A: ChannelAdapter + Send + ?Sized,
+    F: FnMut(ChannelInboundMessage) -> ChannelProcessFuture,
+{
+    if batch.is_empty() {
+        adapter.complete_batch().await?;
+        return Ok(false);
+    }
+
+    for message in &batch {
+        if let Some(runtime) = runtime {
+            runtime.mark_run_start().await?;
+        }
+
+        let result = async {
+            let reply = process(message.clone()).await?;
+            adapter.send_text(&message.reply_target, &reply).await?;
+            adapter.ack_inbound(message).await?;
+            Ok::<(), String>(())
+        }
+        .await;
+
+        if let Some(runtime) = runtime {
+            runtime.mark_run_end().await?;
+        }
+
+        result?;
+    }
+
+    adapter.complete_batch().await?;
+    Ok(true)
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+#[derive(Debug, Clone)]
+struct ChannelCommandContext<R> {
+    resolved_path: PathBuf,
+    config: LoongClawConfig,
+    resolved: R,
+    route: ChannelResolvedAccountRoute,
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+impl<R> ChannelCommandContext<R> {
+    fn emit_route_notice(&self, platform: ChannelPlatform) {
+        if let Some(notice) = render_channel_route_notice(platform, &self.route) {
+            #[allow(clippy::print_stderr)]
+            {
+                eprintln!("warning: {notice}");
+            }
+        }
+    }
+}
+
+#[cfg(feature = "channel-telegram")]
+fn load_telegram_command_context(
+    config_path: Option<&str>,
+    account_id: Option<&str>,
+) -> CliResult<ChannelCommandContext<ResolvedTelegramChannelConfig>> {
+    let (resolved_path, config) = super::config::load(config_path)?;
+    build_telegram_command_context(resolved_path, config, account_id)
+}
+
+#[cfg(feature = "channel-telegram")]
+fn build_telegram_command_context(
+    resolved_path: PathBuf,
+    config: LoongClawConfig,
+    account_id: Option<&str>,
+) -> CliResult<ChannelCommandContext<ResolvedTelegramChannelConfig>> {
+    let resolved = config.telegram.resolve_account(account_id)?;
+    let route = config
+        .telegram
+        .resolved_account_route(account_id, resolved.configured_account_id.as_str());
+    if !resolved.enabled {
+        return Err(format!(
+            "telegram account `{}` is disabled by configuration",
+            resolved.configured_account_id
+        ));
+    }
+    Ok(ChannelCommandContext {
+        resolved_path,
+        config,
+        resolved,
+        route,
+    })
+}
+
+#[cfg(feature = "channel-feishu")]
+fn load_feishu_command_context(
+    config_path: Option<&str>,
+    account_id: Option<&str>,
+) -> CliResult<ChannelCommandContext<ResolvedFeishuChannelConfig>> {
+    let (resolved_path, config) = super::config::load(config_path)?;
+    build_feishu_command_context(resolved_path, config, account_id)
+}
+
+#[cfg(feature = "channel-feishu")]
+fn build_feishu_command_context(
+    resolved_path: PathBuf,
+    config: LoongClawConfig,
+    account_id: Option<&str>,
+) -> CliResult<ChannelCommandContext<ResolvedFeishuChannelConfig>> {
+    let resolved = config.feishu.resolve_account(account_id)?;
+    let route = config
+        .feishu
+        .resolved_account_route(account_id, resolved.configured_account_id.as_str());
+    if !resolved.enabled {
+        return Err(format!(
+            "feishu account `{}` is disabled by configuration",
+            resolved.configured_account_id
+        ));
+    }
+    Ok(ChannelCommandContext {
+        resolved_path,
+        config,
+        resolved,
+        route,
+    })
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+#[derive(Debug, Clone, Copy)]
+struct ChannelServeRuntimeSpec<'a> {
+    platform: ChannelPlatform,
+    operation_id: &'static str,
+    account_id: &'a str,
+    account_label: &'a str,
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+fn channel_runtime_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+fn ensure_channel_operation_runtime_slot_available_in_dir(
+    runtime_dir: &std::path::Path,
+    spec: ChannelServeRuntimeSpec<'_>,
+) -> CliResult<()> {
+    let Some(runtime) = runtime_state::load_channel_operation_runtime_for_account_from_dir(
+        runtime_dir,
+        spec.platform,
+        spec.operation_id,
+        spec.account_id,
+        channel_runtime_now_ms(),
+    ) else {
+        return Ok(());
+    };
+    if runtime.running_instances == 0 {
+        return Ok(());
+    }
+
+    let pid = runtime
+        .pid
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unknown".to_owned());
+    Err(format!(
+        "{} account `{}` already has an active {} runtime (pid={}, running_instances={}); stop the existing instance or wait for it to become stale before restarting",
+        spec.platform.as_str(),
+        spec.account_id,
+        spec.operation_id,
+        pid,
+        runtime.running_instances
+    ))
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+async fn with_channel_serve_runtime<T, F, Fut>(
+    spec: ChannelServeRuntimeSpec<'_>,
+    run: F,
+) -> CliResult<T>
+where
+    F: FnOnce(Arc<ChannelOperationRuntimeTracker>) -> Fut,
+    Fut: Future<Output = CliResult<T>>,
+{
+    ensure_channel_operation_runtime_slot_available_in_dir(
+        runtime_state::default_channel_runtime_state_dir().as_path(),
+        spec,
+    )?;
+    let runtime = Arc::new(
+        ChannelOperationRuntimeTracker::start(
+            spec.platform,
+            spec.operation_id,
+            spec.account_id,
+            spec.account_label,
+        )
+        .await?,
+    );
+    let result = run(runtime.clone()).await;
+    let shutdown_result = runtime.shutdown().await;
+    match result {
+        Err(error) => Err(error),
+        Ok(value) => {
+            shutdown_result?;
+            Ok(value)
+        }
+    }
+}
+
+#[cfg(test)]
+async fn with_channel_serve_runtime_in_dir<T, F, Fut>(
+    runtime_dir: &std::path::Path,
+    process_id: u32,
+    spec: ChannelServeRuntimeSpec<'_>,
+    run: F,
+) -> CliResult<T>
+where
+    F: FnOnce(Arc<ChannelOperationRuntimeTracker>) -> Fut,
+    Fut: Future<Output = CliResult<T>>,
+{
+    ensure_channel_operation_runtime_slot_available_in_dir(runtime_dir, spec)?;
+    let runtime = Arc::new(
+        runtime_state::start_channel_operation_runtime_tracker_for_test(
+            runtime_dir,
+            spec.platform,
+            spec.operation_id,
+            spec.account_id,
+            spec.account_label,
+            process_id,
+        )
+        .await?,
+    );
+    let result = run(runtime.clone()).await;
+    let shutdown_result = runtime.shutdown().await;
+    match result {
+        Err(error) => Err(error),
+        Ok(value) => {
+            shutdown_result?;
+            Ok(value)
+        }
+    }
 }
 
 #[allow(clippy::print_stdout)] // CLI startup banner
-pub async fn run_telegram_channel(config_path: Option<&str>, once: bool) -> CliResult<()> {
+pub async fn run_telegram_channel(
+    config_path: Option<&str>,
+    once: bool,
+    account_id: Option<&str>,
+) -> CliResult<()> {
     if !cfg!(feature = "channel-telegram") {
         return Err("telegram channel is disabled (enable feature `channel-telegram`)".to_owned());
     }
 
     #[cfg(not(feature = "channel-telegram"))]
     {
-        let _ = (config_path, once);
+        let _ = (config_path, once, account_id);
         return Err("telegram channel is disabled (enable feature `channel-telegram`)".to_owned());
     }
 
     #[cfg(feature = "channel-telegram")]
     {
-        let (resolved_path, config) = super::config::load(config_path)?;
-        if !config.telegram.enabled {
-            return Err("telegram channel is disabled by config.telegram.enabled=false".to_owned());
-        }
-        validate_telegram_security_config(&config)?;
-        apply_runtime_env(&config);
+        let context = load_telegram_command_context(config_path, account_id)?;
+        validate_telegram_security_config(&context.resolved)?;
+        apply_runtime_env(&context.config);
         let kernel_ctx = bootstrap_kernel_context("channel-telegram", DEFAULT_TOKEN_TTL_S)?;
-
-        let token = config.telegram.bot_token().ok_or_else(|| {
+        let token = context.resolved.bot_token().ok_or_else(|| {
             "telegram bot token missing (set telegram.bot_token or env)".to_owned()
         })?;
-        let mut adapter = telegram::TelegramAdapter::new(&config, token);
+        let route = context.route.clone();
+        let resolved_path = context.resolved_path.clone();
+        let resolved = context.resolved.clone();
+        let batch_config = context.config.clone();
+        let batch_kernel_ctx = Arc::new(crate::KernelContext {
+            kernel: kernel_ctx.kernel.clone(),
+            token: kernel_ctx.token.clone(),
+        });
+        let runtime_account_id = resolved.account.id.clone();
+        let runtime_account_label = resolved.account.label.clone();
 
-        println!(
-            "{} channel started (config={}, timeout={}s)",
-            adapter.name(),
-            resolved_path.display(),
-            config.telegram.polling_timeout_s
-        );
+        with_channel_serve_runtime(
+            ChannelServeRuntimeSpec {
+                platform: ChannelPlatform::Telegram,
+                operation_id: "serve",
+                account_id: runtime_account_id.as_str(),
+                account_label: runtime_account_label.as_str(),
+            },
+            move |runtime| async move {
+                let mut adapter = telegram::TelegramAdapter::new(&resolved, token);
+                context.emit_route_notice(ChannelPlatform::Telegram);
 
-        loop {
-            let batch = adapter.receive_batch().await?;
-            if batch.is_empty() && once {
-                break;
+                println!(
+                    "{} channel started (config={}, configured_account={}, account={}, selected_by_default={}, default_source={}, timeout={}s)",
+                    adapter.name(),
+                    resolved_path.display(),
+                    resolved.configured_account_id,
+                    resolved.account.label,
+                    route.selected_by_default(),
+                    route.default_account_source.as_str(),
+                    resolved.polling_timeout_s
+                );
+
+                loop {
+                    let batch = adapter.receive_batch().await?;
+                    let config = batch_config.clone();
+                    let kernel_ctx = batch_kernel_ctx.clone();
+                    let had_messages =
+                        process_channel_batch(&mut adapter, batch, Some(runtime.as_ref()), |message| {
+                            let config = config.clone();
+                            let kernel_ctx = kernel_ctx.clone();
+                            Box::pin(async move {
+                                process_inbound_with_provider(
+                                    &config,
+                                    &message,
+                                    Some(kernel_ctx.as_ref()),
+                                )
+                                .await
+                            })
+                        })
+                        .await?;
+                    if !had_messages && once {
+                        break;
+                    }
+                    if once {
+                        break;
+                    }
+                    sleep(Duration::from_millis(250)).await;
+                }
+                Ok(())
             }
-            for message in batch {
-                let reply =
-                    process_inbound_with_provider(&config, &message, Some(&kernel_ctx)).await?;
-                adapter.send_text(&message.reply_target, &reply).await?;
-            }
-            if once {
-                break;
-            }
-            sleep(Duration::from_millis(250)).await;
-        }
-        Ok(())
+        )
+        .await
     }
 }
 
 #[allow(clippy::print_stdout)] // CLI output
 pub async fn run_feishu_send(
     config_path: Option<&str>,
+    account_id: Option<&str>,
     receive_id: &str,
     text: &str,
     as_card: bool,
@@ -106,24 +607,25 @@ pub async fn run_feishu_send(
 
     #[cfg(not(feature = "channel-feishu"))]
     {
-        let _ = (config_path, receive_id, text, as_card);
+        let _ = (config_path, account_id, receive_id, text, as_card);
         return Err("feishu channel is disabled (enable feature `channel-feishu`)".to_owned());
     }
 
     #[cfg(feature = "channel-feishu")]
     {
-        let (resolved_path, config) = super::config::load(config_path)?;
-        if !config.feishu.enabled {
-            return Err("feishu channel is disabled by config.feishu.enabled=false".to_owned());
-        }
-        apply_runtime_env(&config);
-
-        feishu::run_feishu_send(&config, receive_id, text, as_card).await?;
+        let context = load_feishu_command_context(config_path, account_id)?;
+        apply_runtime_env(&context.config);
+        context.emit_route_notice(ChannelPlatform::Feishu);
+        feishu::run_feishu_send(&context.resolved, receive_id, text, as_card).await?;
 
         println!(
-            "feishu message sent (config={}, receive_id_type={})",
-            resolved_path.display(),
-            config.feishu.receive_id_type
+            "feishu message sent (config={}, configured_account={}, account={}, selected_by_default={}, default_source={}, receive_id_type={})",
+            context.resolved_path.display(),
+            context.resolved.configured_account_id,
+            context.resolved.account.label,
+            context.route.selected_by_default(),
+            context.route.default_account_source.as_str(),
+            context.resolved.receive_id_type
         );
         Ok(())
     }
@@ -131,6 +633,7 @@ pub async fn run_feishu_send(
 
 pub async fn run_feishu_channel(
     config_path: Option<&str>,
+    account_id: Option<&str>,
     bind_override: Option<&str>,
     path_override: Option<&str>,
 ) -> CliResult<()> {
@@ -140,26 +643,45 @@ pub async fn run_feishu_channel(
 
     #[cfg(not(feature = "channel-feishu"))]
     {
-        let _ = (config_path, bind_override, path_override);
+        let _ = (config_path, account_id, bind_override, path_override);
         return Err("feishu channel is disabled (enable feature `channel-feishu`)".to_owned());
     }
 
     #[cfg(feature = "channel-feishu")]
     {
-        let (resolved_path, config) = super::config::load(config_path)?;
-        if !config.feishu.enabled {
-            return Err("feishu channel is disabled by config.feishu.enabled=false".to_owned());
-        }
-        validate_feishu_security_config(&config)?;
-        apply_runtime_env(&config);
+        let context = load_feishu_command_context(config_path, account_id)?;
+        validate_feishu_security_config(&context.resolved)?;
+        apply_runtime_env(&context.config);
         let kernel_ctx = bootstrap_kernel_context("channel-feishu", DEFAULT_TOKEN_TTL_S)?;
+        let route = context.route.clone();
+        let resolved_path = context.resolved_path.clone();
+        let resolved = context.resolved.clone();
+        let config = context.config.clone();
+        let runtime_account_id = resolved.account.id.clone();
+        let runtime_account_label = resolved.account.label.clone();
 
-        feishu::run_feishu_channel(
-            &config,
-            &resolved_path,
-            bind_override,
-            path_override,
-            kernel_ctx,
+        with_channel_serve_runtime(
+            ChannelServeRuntimeSpec {
+                platform: ChannelPlatform::Feishu,
+                operation_id: "serve",
+                account_id: runtime_account_id.as_str(),
+                account_label: runtime_account_label.as_str(),
+            },
+            move |runtime| async move {
+                context.emit_route_notice(ChannelPlatform::Feishu);
+                feishu::run_feishu_channel(
+                    &config,
+                    &resolved,
+                    &resolved_path,
+                    route.selected_by_default(),
+                    route.default_account_source,
+                    bind_override,
+                    path_override,
+                    kernel_ctx,
+                    runtime.clone(),
+                )
+                .await
+            },
         )
         .await
     }
@@ -171,10 +693,11 @@ pub(super) async fn process_inbound_with_provider(
     message: &ChannelInboundMessage,
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<String> {
+    let session_key = message.session.session_key();
     ConversationTurnLoop::new()
         .handle_turn(
             config,
-            &message.session_id,
+            &session_key,
             &message.text,
             ProviderErrorMode::Propagate,
             kernel_ctx,
@@ -221,9 +744,25 @@ fn apply_runtime_env(config: &LoongClawConfig) {
     let _ = crate::memory::runtime_config::init_memory_runtime_config(memory_rt);
 }
 
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+fn render_channel_route_notice(
+    platform: ChannelPlatform,
+    route: &ChannelResolvedAccountRoute,
+) -> Option<String> {
+    if !route.uses_implicit_fallback_default() {
+        return None;
+    }
+    Some(format!(
+        "{} omitted --account and routed to configured account `{}` via fallback default selection; set {}.default_account or pass --account to avoid routing surprises",
+        platform.as_str(),
+        route.selected_configured_account_id,
+        platform.as_str()
+    ))
+}
+
 #[cfg(feature = "channel-telegram")]
-fn validate_telegram_security_config(config: &LoongClawConfig) -> CliResult<()> {
-    if config.telegram.allowed_chat_ids.is_empty() {
+fn validate_telegram_security_config(config: &ResolvedTelegramChannelConfig) -> CliResult<()> {
+    if config.allowed_chat_ids.is_empty() {
         return Err(
             "telegram.allowed_chat_ids is empty; configure at least one trusted chat id".to_owned(),
         );
@@ -232,9 +771,8 @@ fn validate_telegram_security_config(config: &LoongClawConfig) -> CliResult<()> 
 }
 
 #[cfg(feature = "channel-feishu")]
-fn validate_feishu_security_config(config: &LoongClawConfig) -> CliResult<()> {
+fn validate_feishu_security_config(config: &ResolvedFeishuChannelConfig) -> CliResult<()> {
     let has_allowlist = config
-        .feishu
         .allowed_chat_ids
         .iter()
         .any(|value| !value.trim().is_empty());
@@ -245,7 +783,6 @@ fn validate_feishu_security_config(config: &LoongClawConfig) -> CliResult<()> {
     }
 
     let has_verification_token = config
-        .feishu
         .verification_token()
         .map(|value| !value.trim().is_empty())
         .unwrap_or(false);
@@ -257,7 +794,6 @@ fn validate_feishu_security_config(config: &LoongClawConfig) -> CliResult<()> {
     }
 
     let has_encrypt_key = config
-        .feishu
         .encrypt_key()
         .map(|value| !value.trim().is_empty())
         .unwrap_or(false);
@@ -271,12 +807,448 @@ fn validate_feishu_security_config(config: &LoongClawConfig) -> CliResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use std::{
+        path::PathBuf,
+        sync::{Arc, Mutex},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_runtime_dir(suffix: &str) -> PathBuf {
+        let unique = format!(
+            "loongclaw-channel-mod-{suffix}-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        );
+        std::env::temp_dir().join(unique)
+    }
+
+    fn now_ms_for_test() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_millis() as u64
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[derive(Default)]
+    struct RecordingAdapter {
+        sent: Arc<Mutex<Vec<(ChannelOutboundTarget, String)>>>,
+        acked: Arc<Mutex<Vec<Option<String>>>>,
+        completed_batches: Arc<Mutex<usize>>,
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[async_trait]
+    impl ChannelAdapter for RecordingAdapter {
+        fn name(&self) -> &str {
+            "recording"
+        }
+
+        async fn receive_batch(&mut self) -> CliResult<Vec<ChannelInboundMessage>> {
+            Ok(Vec::new())
+        }
+
+        async fn send_text(&self, target: &ChannelOutboundTarget, text: &str) -> CliResult<()> {
+            self.sent
+                .lock()
+                .expect("sent log")
+                .push((target.clone(), text.to_owned()));
+            Ok(())
+        }
+
+        async fn ack_inbound(&mut self, message: &ChannelInboundMessage) -> CliResult<()> {
+            self.acked
+                .lock()
+                .expect("ack log")
+                .push(message.delivery.ack_cursor.clone());
+            Ok(())
+        }
+
+        async fn complete_batch(&mut self) -> CliResult<()> {
+            *self
+                .completed_batches
+                .lock()
+                .expect("completed batch count") += 1;
+            Ok(())
+        }
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[tokio::test]
+    async fn channel_adapter_default_ack_hooks_are_noop() {
+        #[derive(Default)]
+        struct NoopAdapter;
+
+        #[async_trait]
+        impl ChannelAdapter for NoopAdapter {
+            fn name(&self) -> &str {
+                "noop"
+            }
+
+            async fn receive_batch(&mut self) -> CliResult<Vec<ChannelInboundMessage>> {
+                Ok(Vec::new())
+            }
+
+            async fn send_text(
+                &self,
+                _target: &ChannelOutboundTarget,
+                _text: &str,
+            ) -> CliResult<()> {
+                Ok(())
+            }
+        }
+
+        let mut adapter = NoopAdapter;
+        let message = ChannelInboundMessage {
+            session: ChannelSession::new(ChannelPlatform::Telegram, "1"),
+            reply_target: ChannelOutboundTarget::telegram_chat(1),
+            text: "hello".to_owned(),
+            delivery: ChannelDelivery {
+                ack_cursor: Some("2".to_owned()),
+                source_message_id: Some("42".to_owned()),
+            },
+        };
+
+        adapter
+            .ack_inbound(&message)
+            .await
+            .expect("default ack hook should succeed");
+        adapter
+            .complete_batch()
+            .await
+            .expect("default batch completion hook should succeed");
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[tokio::test]
+    async fn process_channel_batch_acknowledges_after_successful_delivery() {
+        let mut adapter = RecordingAdapter::default();
+        let batch = vec![ChannelInboundMessage {
+            session: ChannelSession::new(ChannelPlatform::Telegram, "1"),
+            reply_target: ChannelOutboundTarget::telegram_chat(1),
+            text: "hello".to_owned(),
+            delivery: ChannelDelivery {
+                ack_cursor: Some("101".to_owned()),
+                source_message_id: Some("55".to_owned()),
+            },
+        }];
+
+        let had_messages = process_channel_batch(
+            &mut adapter,
+            batch,
+            None,
+            |message: ChannelInboundMessage| {
+                Box::pin(async move { Ok(format!("reply: {}", message.text)) })
+            },
+        )
+        .await
+        .expect("batch should process");
+
+        assert!(had_messages);
+        assert_eq!(
+            adapter.sent.lock().expect("sent log").as_slice(),
+            &[(
+                ChannelOutboundTarget::telegram_chat(1),
+                "reply: hello".to_owned(),
+            )]
+        );
+        assert_eq!(
+            adapter.acked.lock().expect("ack log").as_slice(),
+            &[Some("101".to_owned())]
+        );
+        assert_eq!(*adapter.completed_batches.lock().expect("completed"), 1);
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[test]
+    fn channel_session_key_is_stable() {
+        let session = ChannelSession::new(ChannelPlatform::Telegram, "123");
+        assert_eq!(session.session_key(), "telegram:123");
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[test]
+    fn channel_session_key_includes_thread_id_when_present() {
+        let session = ChannelSession::with_thread(ChannelPlatform::Feishu, "oc_123", "om_thread_1");
+        assert_eq!(session.session_key(), "feishu:oc_123:om_thread_1");
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[test]
+    fn channel_session_key_includes_account_identity_when_present() {
+        let session = ChannelSession::with_account(ChannelPlatform::Telegram, "bot_123456", "123");
+        assert_eq!(session.session_key(), "telegram:bot_123456:123");
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[test]
+    fn channel_session_key_includes_account_identity_and_thread_when_present() {
+        let session = ChannelSession::with_account_and_thread(
+            ChannelPlatform::Feishu,
+            "lark_cli_a1b2c3",
+            "oc_123",
+            "om_thread_1",
+        );
+        assert_eq!(
+            session.session_key(),
+            "feishu:lark_cli_a1b2c3:oc_123:om_thread_1"
+        );
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[test]
+    fn channel_outbound_target_preserves_platform_kind_and_id() {
+        let target = ChannelOutboundTarget::new(
+            ChannelPlatform::Feishu,
+            ChannelOutboundTargetKind::MessageReply,
+            "om_123",
+        );
+        assert_eq!(target.platform, ChannelPlatform::Feishu);
+        assert_eq!(target.kind, ChannelOutboundTargetKind::MessageReply);
+        assert_eq!(target.id, "om_123");
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[test]
+    fn render_channel_route_notice_warns_on_implicit_multi_account_fallback() {
+        let route = crate::config::ChannelResolvedAccountRoute {
+            requested_account_id: None,
+            configured_account_count: 2,
+            selected_configured_account_id: "alerts".to_owned(),
+            default_account_source: crate::config::ChannelDefaultAccountSelectionSource::Fallback,
+        };
+
+        let rendered = render_channel_route_notice(ChannelPlatform::Telegram, &route)
+            .expect("fallback route should warn");
+
+        assert!(rendered.contains("telegram"));
+        assert!(rendered.contains("alerts"));
+        assert!(rendered.contains("--account"));
+        assert!(rendered.contains("telegram.default_account"));
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[test]
+    fn render_channel_route_notice_is_silent_for_explicit_account_selection() {
+        let route = crate::config::ChannelResolvedAccountRoute {
+            requested_account_id: Some("work".to_owned()),
+            configured_account_count: 2,
+            selected_configured_account_id: "work".to_owned(),
+            default_account_source: crate::config::ChannelDefaultAccountSelectionSource::Fallback,
+        };
+
+        assert!(render_channel_route_notice(ChannelPlatform::Telegram, &route).is_none());
+    }
+
+    #[cfg(feature = "channel-telegram")]
+    #[test]
+    fn telegram_command_context_preserves_route_metadata() {
+        let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
+            "telegram": {
+                "enabled": true,
+                "accounts": {
+                    "Work": {
+                        "bot_token": "123456:work-token",
+                        "allowed_chat_ids": [1001]
+                    },
+                    "Alerts": {
+                        "bot_token": "654321:alerts-token",
+                        "allowed_chat_ids": [2002]
+                    }
+                }
+            }
+        }))
+        .expect("deserialize telegram context config");
+
+        let context =
+            build_telegram_command_context(PathBuf::from("/tmp/loongclaw.toml"), config, None)
+                .expect("build telegram command context");
+
+        assert_eq!(context.resolved_path, PathBuf::from("/tmp/loongclaw.toml"));
+        assert_eq!(context.resolved.configured_account_id, "alerts");
+        assert!(context.route.selected_by_default());
+        assert!(context.route.uses_implicit_fallback_default());
+    }
+
+    #[cfg(feature = "channel-feishu")]
+    #[test]
+    fn feishu_command_context_rejects_disabled_resolved_account() {
+        let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
+            "feishu": {
+                "enabled": true,
+                "accounts": {
+                    "Primary": {
+                        "enabled": false,
+                        "app_id": "cli_primary",
+                        "app_secret": "secret"
+                    }
+                }
+            }
+        }))
+        .expect("deserialize feishu context config");
+
+        let error = build_feishu_command_context(
+            PathBuf::from("/tmp/loongclaw.toml"),
+            config,
+            Some("Primary"),
+        )
+        .expect_err("disabled feishu account should fail");
+
+        assert!(error.contains("disabled"));
+        assert!(error.contains("primary"));
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[tokio::test]
+    async fn with_channel_serve_runtime_tracks_running_state_and_shutdown() {
+        let runtime_dir = temp_runtime_dir("serve-runtime-wrapper");
+        let runtime_dir_for_body = runtime_dir.clone();
+        let operation = ChannelServeRuntimeSpec {
+            platform: ChannelPlatform::Telegram,
+            operation_id: "serve",
+            account_id: "bot_123456",
+            account_label: "bot:123456",
+        };
+
+        let result = with_channel_serve_runtime_in_dir(
+            runtime_dir.as_path(),
+            9191,
+            operation,
+            |runtime| async move {
+                let live = runtime_state::load_channel_operation_runtime_for_account_from_dir(
+                    runtime_dir_for_body.as_path(),
+                    ChannelPlatform::Telegram,
+                    "serve",
+                    "bot_123456",
+                    0,
+                )
+                .expect("runtime should exist while serve body is running");
+                assert!(live.running);
+                assert_eq!(live.pid, Some(9191));
+                assert_eq!(live.account_id.as_deref(), Some("bot_123456"));
+                assert_eq!(live.account_label.as_deref(), Some("bot:123456"));
+                assert!(
+                    Arc::strong_count(&runtime) >= 1,
+                    "runtime handle should stay alive in serve body"
+                );
+                Ok::<_, String>("ok".to_owned())
+            },
+        )
+        .await
+        .expect("serve runtime wrapper should succeed");
+
+        assert_eq!(result, "ok");
+
+        let finished = runtime_state::load_channel_operation_runtime_for_account_from_dir(
+            runtime_dir.as_path(),
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            0,
+        )
+        .expect("runtime should remain readable after shutdown");
+        assert!(!finished.running);
+        assert_eq!(finished.pid, Some(9191));
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[tokio::test]
+    async fn with_channel_serve_runtime_rejects_duplicate_running_instance() {
+        let runtime_dir = temp_runtime_dir("serve-runtime-duplicate");
+        let now = now_ms_for_test();
+        runtime_state::write_runtime_state_for_test_with_account_and_pid(
+            runtime_dir.as_path(),
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            7001,
+            true,
+            true,
+            1,
+            Some(now),
+            Some(now),
+            Some(7001),
+        )
+        .expect("seed running runtime state");
+
+        let error = with_channel_serve_runtime_in_dir(
+            runtime_dir.as_path(),
+            9191,
+            ChannelServeRuntimeSpec {
+                platform: ChannelPlatform::Telegram,
+                operation_id: "serve",
+                account_id: "bot_123456",
+                account_label: "bot:123456",
+            },
+            |_runtime| async move { Ok::<_, String>("ok".to_owned()) },
+        )
+        .await
+        .expect_err("duplicate running instance should be rejected");
+
+        assert!(error.contains("already has an active serve runtime"));
+        assert!(error.contains("bot_123456"));
+        assert!(error.contains("7001"));
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[tokio::test]
+    async fn with_channel_serve_runtime_allows_takeover_when_previous_instance_is_stale() {
+        let runtime_dir = temp_runtime_dir("serve-runtime-stale-takeover");
+        let now = now_ms_for_test();
+        runtime_state::write_runtime_state_for_test_with_account_and_pid(
+            runtime_dir.as_path(),
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            7001,
+            true,
+            true,
+            1,
+            Some(now.saturating_sub(60_000)),
+            Some(now.saturating_sub(60_000)),
+            Some(7001),
+        )
+        .expect("seed stale runtime state");
+
+        let result = with_channel_serve_runtime_in_dir(
+            runtime_dir.as_path(),
+            9191,
+            ChannelServeRuntimeSpec {
+                platform: ChannelPlatform::Telegram,
+                operation_id: "serve",
+                account_id: "bot_123456",
+                account_label: "bot:123456",
+            },
+            |_runtime| async move { Ok::<_, String>("ok".to_owned()) },
+        )
+        .await
+        .expect("stale runtime should not block startup");
+
+        assert_eq!(result, "ok");
+
+        let runtime = runtime_state::load_channel_operation_runtime_for_account_from_dir(
+            runtime_dir.as_path(),
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            now_ms_for_test(),
+        )
+        .expect("runtime should remain readable after takeover");
+        assert_eq!(runtime.pid, Some(9191));
+    }
 
     #[cfg(feature = "channel-telegram")]
     #[test]
     fn telegram_security_validation_requires_allowlist() {
         let config = LoongClawConfig::default();
-        let error = validate_telegram_security_config(&config)
+        let resolved = config
+            .telegram
+            .resolve_account(None)
+            .expect("resolve telegram account");
+        let error = validate_telegram_security_config(&resolved)
             .expect_err("empty allowlist must be rejected");
         assert!(error.contains("allowed_chat_ids"));
     }
@@ -286,15 +1258,23 @@ mod tests {
     fn telegram_security_validation_accepts_configured_allowlist() {
         let mut config = LoongClawConfig::default();
         config.telegram.allowed_chat_ids = vec![123_i64];
-        assert!(validate_telegram_security_config(&config).is_ok());
+        let resolved = config
+            .telegram
+            .resolve_account(None)
+            .expect("resolve telegram account");
+        assert!(validate_telegram_security_config(&resolved).is_ok());
     }
 
     #[cfg(feature = "channel-feishu")]
     #[test]
     fn feishu_security_validation_requires_secrets_and_allowlist() {
         let config = LoongClawConfig::default();
+        let resolved = config
+            .feishu
+            .resolve_account(None)
+            .expect("resolve feishu account");
         let error =
-            validate_feishu_security_config(&config).expect_err("empty config must be rejected");
+            validate_feishu_security_config(&resolved).expect_err("empty config must be rejected");
         assert!(error.contains("allowed_chat_ids"));
     }
 
@@ -308,6 +1288,10 @@ mod tests {
         config.feishu.encrypt_key = Some("encrypt-key-123".to_owned());
         config.feishu.encrypt_key_env = None;
 
-        assert!(validate_feishu_security_config(&config).is_ok());
+        let resolved = config
+            .feishu
+            .resolve_account(None)
+            .expect("resolve feishu account");
+        assert!(validate_feishu_security_config(&resolved).is_ok());
     }
 }

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -1,0 +1,1084 @@
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::config::{
+    ChannelDefaultAccountSelectionSource, LoongClawConfig, ResolvedFeishuChannelConfig,
+    ResolvedTelegramChannelConfig,
+};
+
+use super::{runtime_state, ChannelOperationRuntime, ChannelPlatform};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct ChannelCatalogOperation {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub command: &'static str,
+    pub tracks_runtime: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChannelCatalogEntry {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub aliases: Vec<&'static str>,
+    pub transport: &'static str,
+    pub operations: Vec<ChannelCatalogOperation>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelOperationHealth {
+    Ready,
+    Disabled,
+    Unsupported,
+    Misconfigured,
+}
+
+impl ChannelOperationHealth {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Disabled => "disabled",
+            Self::Unsupported => "unsupported",
+            Self::Misconfigured => "misconfigured",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChannelOperationStatus {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub command: &'static str,
+    pub health: ChannelOperationHealth,
+    pub detail: String,
+    pub issues: Vec<String>,
+    pub runtime: Option<ChannelOperationRuntime>,
+}
+
+impl ChannelOperationStatus {
+    pub fn is_ready(&self) -> bool {
+        self.health == ChannelOperationHealth::Ready
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChannelStatusSnapshot {
+    pub id: &'static str,
+    pub configured_account_id: String,
+    pub configured_account_label: String,
+    pub is_default_account: bool,
+    pub default_account_source: ChannelDefaultAccountSelectionSource,
+    pub label: &'static str,
+    pub aliases: Vec<&'static str>,
+    pub transport: &'static str,
+    pub compiled: bool,
+    pub enabled: bool,
+    pub api_base_url: Option<String>,
+    pub notes: Vec<String>,
+    pub operations: Vec<ChannelOperationStatus>,
+}
+
+impl ChannelStatusSnapshot {
+    pub fn operation(&self, id: &str) -> Option<&ChannelOperationStatus> {
+        self.operations.iter().find(|operation| operation.id == id)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ChannelRegistryDescriptor {
+    platform: ChannelPlatform,
+    label: &'static str,
+    aliases: &'static [&'static str],
+    transport: &'static str,
+    operations: &'static [ChannelCatalogOperation],
+}
+
+const TELEGRAM_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
+    id: "serve",
+    label: "reply loop",
+    command: "telegram-serve",
+    tracks_runtime: true,
+};
+
+const TELEGRAM_OPERATIONS: &[ChannelCatalogOperation] = &[TELEGRAM_SERVE_OPERATION];
+
+const FEISHU_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
+    id: "send",
+    label: "direct send",
+    command: "feishu-send",
+    tracks_runtime: false,
+};
+
+const FEISHU_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
+    id: "serve",
+    label: "webhook reply server",
+    command: "feishu-serve",
+    tracks_runtime: true,
+};
+
+const FEISHU_OPERATIONS: &[ChannelCatalogOperation] =
+    &[FEISHU_SEND_OPERATION, FEISHU_SERVE_OPERATION];
+
+const CHANNEL_REGISTRY: &[ChannelRegistryDescriptor] = &[
+    ChannelRegistryDescriptor {
+        platform: ChannelPlatform::Telegram,
+        label: "Telegram",
+        aliases: &[],
+        transport: "telegram_bot_api_polling",
+        operations: TELEGRAM_OPERATIONS,
+    },
+    ChannelRegistryDescriptor {
+        platform: ChannelPlatform::Feishu,
+        label: "Feishu/Lark",
+        aliases: &["lark"],
+        transport: "feishu_openapi_webhook",
+        operations: FEISHU_OPERATIONS,
+    },
+];
+
+pub fn list_channel_catalog() -> Vec<ChannelCatalogEntry> {
+    CHANNEL_REGISTRY
+        .iter()
+        .map(|descriptor| ChannelCatalogEntry {
+            id: descriptor.platform.as_str(),
+            label: descriptor.label,
+            aliases: descriptor.aliases.to_vec(),
+            transport: descriptor.transport,
+            operations: descriptor.operations.to_vec(),
+        })
+        .collect()
+}
+
+pub fn normalize_channel_platform(raw: &str) -> Option<ChannelPlatform> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return None;
+    }
+
+    CHANNEL_REGISTRY.iter().find_map(|descriptor| {
+        if descriptor.platform.as_str() == normalized {
+            return Some(descriptor.platform);
+        }
+        descriptor
+            .aliases
+            .iter()
+            .copied()
+            .find(|alias| *alias == normalized)
+            .map(|_| descriptor.platform)
+    })
+}
+
+pub fn channel_status_snapshots(config: &LoongClawConfig) -> Vec<ChannelStatusSnapshot> {
+    channel_status_snapshots_with_now(
+        config,
+        runtime_state::default_channel_runtime_state_dir().as_path(),
+        now_ms(),
+    )
+}
+
+fn channel_status_snapshots_with_now(
+    config: &LoongClawConfig,
+    runtime_dir: &Path,
+    now_ms: u64,
+) -> Vec<ChannelStatusSnapshot> {
+    let mut snapshots = Vec::new();
+    for descriptor in CHANNEL_REGISTRY {
+        match descriptor.platform {
+            ChannelPlatform::Telegram => {
+                snapshots.extend(build_telegram_snapshots(
+                    descriptor,
+                    config,
+                    runtime_dir,
+                    now_ms,
+                ));
+            }
+            ChannelPlatform::Feishu => {
+                snapshots.extend(build_feishu_snapshots(
+                    descriptor,
+                    config,
+                    runtime_dir,
+                    now_ms,
+                ));
+            }
+        }
+    }
+    snapshots
+}
+
+fn build_telegram_snapshots(
+    descriptor: &ChannelRegistryDescriptor,
+    config: &LoongClawConfig,
+    runtime_dir: &Path,
+    now_ms: u64,
+) -> Vec<ChannelStatusSnapshot> {
+    let compiled = cfg!(feature = "channel-telegram");
+    let default_selection = config.telegram.default_configured_account_selection();
+    let default_configured_account_id = default_selection.id.clone();
+    let default_account_source = default_selection.source;
+    config
+        .telegram
+        .configured_account_ids()
+        .into_iter()
+        .map(|configured_account_id| {
+            let is_default_account = configured_account_id == default_configured_account_id;
+            match config
+                .telegram
+                .resolve_account(Some(configured_account_id.as_str()))
+            {
+                Ok(resolved) => build_telegram_snapshot_for_account(
+                    descriptor,
+                    compiled,
+                    resolved,
+                    is_default_account,
+                    default_account_source,
+                    runtime_dir,
+                    now_ms,
+                ),
+                Err(error) => build_invalid_telegram_snapshot(
+                    descriptor,
+                    compiled,
+                    configured_account_id.as_str(),
+                    is_default_account,
+                    default_account_source,
+                    error,
+                ),
+            }
+        })
+        .collect()
+}
+
+fn build_telegram_snapshot_for_account(
+    descriptor: &ChannelRegistryDescriptor,
+    compiled: bool,
+    resolved: ResolvedTelegramChannelConfig,
+    is_default_account: bool,
+    default_account_source: ChannelDefaultAccountSelectionSource,
+    runtime_dir: &Path,
+    now_ms: u64,
+) -> ChannelStatusSnapshot {
+    let mut issues = Vec::new();
+    if resolved.bot_token().is_none() {
+        issues.push("bot token is missing (telegram.bot_token or env)".to_owned());
+    }
+    if resolved.allowed_chat_ids.is_empty() {
+        issues.push("allowed_chat_ids is empty".to_owned());
+    }
+
+    let operation = if !compiled {
+        unsupported_operation(
+            TELEGRAM_SERVE_OPERATION,
+            "binary built without feature `channel-telegram`".to_owned(),
+        )
+    } else if !resolved.enabled {
+        disabled_operation(
+            TELEGRAM_SERVE_OPERATION,
+            "disabled by telegram account configuration".to_owned(),
+        )
+    } else if !issues.is_empty() {
+        misconfigured_operation(TELEGRAM_SERVE_OPERATION, issues)
+    } else {
+        ready_operation(TELEGRAM_SERVE_OPERATION)
+    };
+    let operation = attach_runtime(
+        ChannelPlatform::Telegram,
+        TELEGRAM_SERVE_OPERATION,
+        operation,
+        resolved.account.id.as_str(),
+        resolved.account.label.as_str(),
+        runtime_dir,
+        now_ms,
+    );
+
+    let mut notes = vec![
+        format!("configured_account_id={}", resolved.configured_account_id),
+        format!("configured_account={}", resolved.configured_account_label),
+        format!("account_id={}", resolved.account.id),
+        format!("account={}", resolved.account.label),
+        format!("polling_timeout_s={}", resolved.polling_timeout_s),
+    ];
+    if is_default_account {
+        notes.push("default_account=true".to_owned());
+    }
+    notes.push(format!(
+        "default_account_source={}",
+        default_account_source.as_str()
+    ));
+
+    ChannelStatusSnapshot {
+        id: descriptor.platform.as_str(),
+        configured_account_id: resolved.configured_account_id.clone(),
+        configured_account_label: resolved.configured_account_label.clone(),
+        is_default_account,
+        default_account_source,
+        label: descriptor.label,
+        aliases: descriptor.aliases.to_vec(),
+        transport: descriptor.transport,
+        compiled,
+        enabled: resolved.enabled,
+        api_base_url: Some(resolved.base_url.clone()),
+        notes,
+        operations: vec![operation],
+    }
+}
+
+fn build_feishu_snapshots(
+    descriptor: &ChannelRegistryDescriptor,
+    config: &LoongClawConfig,
+    runtime_dir: &Path,
+    now_ms: u64,
+) -> Vec<ChannelStatusSnapshot> {
+    let compiled = cfg!(feature = "channel-feishu");
+    let default_selection = config.feishu.default_configured_account_selection();
+    let default_configured_account_id = default_selection.id.clone();
+    let default_account_source = default_selection.source;
+    config
+        .feishu
+        .configured_account_ids()
+        .into_iter()
+        .map(|configured_account_id| {
+            let is_default_account = configured_account_id == default_configured_account_id;
+            match config
+                .feishu
+                .resolve_account(Some(configured_account_id.as_str()))
+            {
+                Ok(resolved) => build_feishu_snapshot_for_account(
+                    descriptor,
+                    compiled,
+                    resolved,
+                    is_default_account,
+                    default_account_source,
+                    runtime_dir,
+                    now_ms,
+                ),
+                Err(error) => build_invalid_feishu_snapshot(
+                    descriptor,
+                    compiled,
+                    configured_account_id.as_str(),
+                    is_default_account,
+                    default_account_source,
+                    error,
+                ),
+            }
+        })
+        .collect()
+}
+
+fn build_feishu_snapshot_for_account(
+    descriptor: &ChannelRegistryDescriptor,
+    compiled: bool,
+    resolved: ResolvedFeishuChannelConfig,
+    is_default_account: bool,
+    default_account_source: ChannelDefaultAccountSelectionSource,
+    runtime_dir: &Path,
+    now_ms: u64,
+) -> ChannelStatusSnapshot {
+    let mut send_issues = Vec::new();
+    if resolved.app_id().is_none() {
+        send_issues.push("app_id is missing".to_owned());
+    }
+    if resolved.app_secret().is_none() {
+        send_issues.push("app_secret is missing".to_owned());
+    }
+
+    let mut serve_issues = send_issues.clone();
+    if !resolved
+        .allowed_chat_ids
+        .iter()
+        .any(|value| !value.trim().is_empty())
+    {
+        serve_issues.push("allowed_chat_ids is empty".to_owned());
+    }
+    if resolved.verification_token().is_none() {
+        serve_issues.push("verification_token is missing".to_owned());
+    }
+    if resolved.encrypt_key().is_none() {
+        serve_issues.push("encrypt_key is missing".to_owned());
+    }
+
+    let send_operation = if !compiled {
+        unsupported_operation(
+            FEISHU_SEND_OPERATION,
+            "binary built without feature `channel-feishu`".to_owned(),
+        )
+    } else if !resolved.enabled {
+        disabled_operation(
+            FEISHU_SEND_OPERATION,
+            "disabled by feishu account configuration".to_owned(),
+        )
+    } else if !send_issues.is_empty() {
+        misconfigured_operation(FEISHU_SEND_OPERATION, send_issues)
+    } else {
+        ready_operation(FEISHU_SEND_OPERATION)
+    };
+
+    let serve_operation = if !compiled {
+        unsupported_operation(
+            FEISHU_SERVE_OPERATION,
+            "binary built without feature `channel-feishu`".to_owned(),
+        )
+    } else if !resolved.enabled {
+        disabled_operation(
+            FEISHU_SERVE_OPERATION,
+            "disabled by feishu account configuration".to_owned(),
+        )
+    } else if !serve_issues.is_empty() {
+        misconfigured_operation(FEISHU_SERVE_OPERATION, serve_issues)
+    } else {
+        ready_operation(FEISHU_SERVE_OPERATION)
+    };
+    let send_operation = attach_runtime(
+        ChannelPlatform::Feishu,
+        FEISHU_SEND_OPERATION,
+        send_operation,
+        resolved.account.id.as_str(),
+        resolved.account.label.as_str(),
+        runtime_dir,
+        now_ms,
+    );
+    let serve_operation = attach_runtime(
+        ChannelPlatform::Feishu,
+        FEISHU_SERVE_OPERATION,
+        serve_operation,
+        resolved.account.id.as_str(),
+        resolved.account.label.as_str(),
+        runtime_dir,
+        now_ms,
+    );
+
+    let mut notes = vec![
+        format!("configured_account_id={}", resolved.configured_account_id),
+        format!("configured_account={}", resolved.configured_account_label),
+        format!("account_id={}", resolved.account.id),
+        format!("account={}", resolved.account.label),
+        format!("receive_id_type={}", resolved.receive_id_type),
+        format!("webhook_bind={}", resolved.webhook_bind),
+        format!("webhook_path={}", resolved.webhook_path),
+    ];
+    if is_default_account {
+        notes.push("default_account=true".to_owned());
+    }
+    notes.push(format!(
+        "default_account_source={}",
+        default_account_source.as_str()
+    ));
+
+    ChannelStatusSnapshot {
+        id: descriptor.platform.as_str(),
+        configured_account_id: resolved.configured_account_id.clone(),
+        configured_account_label: resolved.configured_account_label.clone(),
+        is_default_account,
+        default_account_source,
+        label: descriptor.label,
+        aliases: descriptor.aliases.to_vec(),
+        transport: descriptor.transport,
+        compiled,
+        enabled: resolved.enabled,
+        api_base_url: Some(resolved.resolved_base_url()),
+        notes,
+        operations: vec![send_operation, serve_operation],
+    }
+}
+
+fn build_invalid_telegram_snapshot(
+    descriptor: &ChannelRegistryDescriptor,
+    compiled: bool,
+    configured_account_id: &str,
+    is_default_account: bool,
+    default_account_source: ChannelDefaultAccountSelectionSource,
+    error: String,
+) -> ChannelStatusSnapshot {
+    let operation = if !compiled {
+        unsupported_operation(
+            TELEGRAM_SERVE_OPERATION,
+            "binary built without feature `channel-telegram`".to_owned(),
+        )
+    } else {
+        misconfigured_operation(TELEGRAM_SERVE_OPERATION, vec![error.clone()])
+    };
+
+    let mut notes = vec![
+        format!("configured_account_id={configured_account_id}"),
+        format!("selection_error={error}"),
+    ];
+    if is_default_account {
+        notes.push("default_account=true".to_owned());
+    }
+    notes.push(format!(
+        "default_account_source={}",
+        default_account_source.as_str()
+    ));
+
+    ChannelStatusSnapshot {
+        id: descriptor.platform.as_str(),
+        configured_account_id: configured_account_id.to_owned(),
+        configured_account_label: configured_account_id.to_owned(),
+        is_default_account,
+        default_account_source,
+        label: descriptor.label,
+        aliases: descriptor.aliases.to_vec(),
+        transport: descriptor.transport,
+        compiled,
+        enabled: false,
+        api_base_url: None,
+        notes,
+        operations: vec![operation],
+    }
+}
+
+fn build_invalid_feishu_snapshot(
+    descriptor: &ChannelRegistryDescriptor,
+    compiled: bool,
+    configured_account_id: &str,
+    is_default_account: bool,
+    default_account_source: ChannelDefaultAccountSelectionSource,
+    error: String,
+) -> ChannelStatusSnapshot {
+    let send_operation = if !compiled {
+        unsupported_operation(
+            FEISHU_SEND_OPERATION,
+            "binary built without feature `channel-feishu`".to_owned(),
+        )
+    } else {
+        misconfigured_operation(FEISHU_SEND_OPERATION, vec![error.clone()])
+    };
+    let serve_operation = if !compiled {
+        unsupported_operation(
+            FEISHU_SERVE_OPERATION,
+            "binary built without feature `channel-feishu`".to_owned(),
+        )
+    } else {
+        misconfigured_operation(FEISHU_SERVE_OPERATION, vec![error.clone()])
+    };
+
+    let mut notes = vec![
+        format!("configured_account_id={configured_account_id}"),
+        format!("selection_error={error}"),
+    ];
+    if is_default_account {
+        notes.push("default_account=true".to_owned());
+    }
+    notes.push(format!(
+        "default_account_source={}",
+        default_account_source.as_str()
+    ));
+
+    ChannelStatusSnapshot {
+        id: descriptor.platform.as_str(),
+        configured_account_id: configured_account_id.to_owned(),
+        configured_account_label: configured_account_id.to_owned(),
+        is_default_account,
+        default_account_source,
+        label: descriptor.label,
+        aliases: descriptor.aliases.to_vec(),
+        transport: descriptor.transport,
+        compiled,
+        enabled: false,
+        api_base_url: None,
+        notes,
+        operations: vec![send_operation, serve_operation],
+    }
+}
+
+fn ready_operation(operation: ChannelCatalogOperation) -> ChannelOperationStatus {
+    ChannelOperationStatus {
+        id: operation.id,
+        label: operation.label,
+        command: operation.command,
+        health: ChannelOperationHealth::Ready,
+        detail: "ready".to_owned(),
+        issues: Vec::new(),
+        runtime: None,
+    }
+}
+
+fn disabled_operation(
+    operation: ChannelCatalogOperation,
+    detail: String,
+) -> ChannelOperationStatus {
+    ChannelOperationStatus {
+        id: operation.id,
+        label: operation.label,
+        command: operation.command,
+        health: ChannelOperationHealth::Disabled,
+        detail,
+        issues: Vec::new(),
+        runtime: None,
+    }
+}
+
+fn unsupported_operation(
+    operation: ChannelCatalogOperation,
+    detail: String,
+) -> ChannelOperationStatus {
+    ChannelOperationStatus {
+        id: operation.id,
+        label: operation.label,
+        command: operation.command,
+        health: ChannelOperationHealth::Unsupported,
+        detail: detail.clone(),
+        issues: vec![detail],
+        runtime: None,
+    }
+}
+
+fn misconfigured_operation(
+    operation: ChannelCatalogOperation,
+    issues: Vec<String>,
+) -> ChannelOperationStatus {
+    ChannelOperationStatus {
+        id: operation.id,
+        label: operation.label,
+        command: operation.command,
+        health: ChannelOperationHealth::Misconfigured,
+        detail: issues.join("; "),
+        issues,
+        runtime: None,
+    }
+}
+
+fn attach_runtime(
+    platform: ChannelPlatform,
+    operation: ChannelCatalogOperation,
+    mut status: ChannelOperationStatus,
+    account_id: &str,
+    account_label: &str,
+    runtime_dir: &Path,
+    now_ms: u64,
+) -> ChannelOperationStatus {
+    if operation.tracks_runtime {
+        status.runtime = runtime_state::load_channel_operation_runtime_for_account_from_dir(
+            runtime_dir,
+            platform,
+            operation.id,
+            account_id,
+            now_ms,
+        )
+        .map(|mut runtime| {
+            if runtime.account_id.is_none() {
+                runtime.account_id = Some(account_id.to_owned());
+            }
+            if runtime.account_label.is_none() {
+                runtime.account_label = Some(account_label.to_owned());
+            }
+            runtime
+        })
+        .or(Some(ChannelOperationRuntime {
+            running: false,
+            stale: false,
+            busy: false,
+            active_runs: 0,
+            last_run_activity_at: None,
+            last_heartbeat_at: None,
+            pid: None,
+            account_id: Some(account_id.to_owned()),
+            account_label: Some(account_label.to_owned()),
+            instance_count: 0,
+            running_instances: 0,
+            stale_instances: 0,
+        }));
+    }
+    status
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_channel_platform_maps_lark_alias_to_feishu() {
+        assert_eq!(
+            normalize_channel_platform("lark"),
+            Some(ChannelPlatform::Feishu)
+        );
+        assert_eq!(
+            normalize_channel_platform(" TELEGRAM "),
+            Some(ChannelPlatform::Telegram)
+        );
+        assert_eq!(normalize_channel_platform("discord"), None);
+    }
+
+    #[test]
+    fn channel_catalog_keeps_lark_alias_under_feishu_surface() {
+        let catalog = list_channel_catalog();
+        let feishu = catalog
+            .iter()
+            .find(|entry| entry.id == "feishu")
+            .expect("feishu catalog entry");
+
+        assert_eq!(feishu.aliases, vec!["lark"]);
+        assert_eq!(feishu.operations.len(), 2);
+        assert_eq!(feishu.operations[0].command, "feishu-send");
+        assert_eq!(feishu.operations[1].command, "feishu-serve");
+    }
+
+    #[test]
+    fn telegram_status_reports_ready_when_token_and_allowlist_are_configured() {
+        let mut config = LoongClawConfig::default();
+        config.telegram.enabled = true;
+        config.telegram.bot_token = Some("123456:token".to_owned());
+        config.telegram.allowed_chat_ids = vec![123];
+
+        let snapshots = channel_status_snapshots(&config);
+        let telegram = snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == "telegram")
+            .expect("telegram snapshot");
+        let serve = telegram
+            .operation("serve")
+            .expect("telegram serve operation");
+
+        assert_eq!(serve.health, ChannelOperationHealth::Ready);
+        assert!(serve.is_ready());
+        assert_eq!(
+            telegram.api_base_url.as_deref(),
+            Some("https://api.telegram.org")
+        );
+        assert!(!serve.runtime.as_ref().expect("telegram runtime").running);
+    }
+
+    #[test]
+    fn feishu_status_splits_direct_send_and_webhook_readiness() {
+        let mut config = LoongClawConfig::default();
+        config.feishu.enabled = true;
+        config.feishu.app_id = Some("app-id".to_owned());
+        config.feishu.app_secret = Some("app-secret".to_owned());
+
+        let snapshots = channel_status_snapshots(&config);
+        let feishu = snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == "feishu")
+            .expect("feishu snapshot");
+        let send = feishu.operation("send").expect("feishu send operation");
+        let serve = feishu.operation("serve").expect("feishu serve operation");
+
+        assert_eq!(send.health, ChannelOperationHealth::Ready);
+        assert_eq!(serve.health, ChannelOperationHealth::Misconfigured);
+        assert!(
+            serve
+                .issues
+                .iter()
+                .any(|issue| issue.contains("allowed_chat_ids")),
+            "serve issues should mention allowlist"
+        );
+        assert!(
+            serve
+                .issues
+                .iter()
+                .any(|issue| issue.contains("verification_token")),
+            "serve issues should mention verification token"
+        );
+        assert!(
+            serve
+                .issues
+                .iter()
+                .any(|issue| issue.contains("encrypt_key")),
+            "serve issues should mention encrypt key"
+        );
+        assert!(send.runtime.is_none());
+        assert_eq!(
+            serve.runtime.as_ref().expect("serve runtime").active_runs,
+            0
+        );
+    }
+
+    #[test]
+    fn channel_status_snapshots_merge_runtime_activity_for_serve_operations() {
+        let mut config = LoongClawConfig::default();
+        config.feishu.enabled = true;
+        config.feishu.app_id = Some("app-id".to_owned());
+        config.feishu.app_secret = Some("app-secret".to_owned());
+        config.feishu.allowed_chat_ids = vec!["oc_123".to_owned()];
+        config.feishu.verification_token = Some("token".to_owned());
+        config.feishu.encrypt_key = Some("encrypt".to_owned());
+
+        let runtime_dir = temp_runtime_dir("registry-runtime");
+        let now = now_ms();
+        runtime_state::write_runtime_state_for_test(
+            runtime_dir.as_path(),
+            ChannelPlatform::Feishu,
+            "serve",
+            true,
+            true,
+            2,
+            Some(now.saturating_sub(1_000)),
+            Some(now.saturating_sub(500)),
+            Some(4242),
+        )
+        .expect("write runtime state");
+
+        let snapshots = channel_status_snapshots_with_now(&config, runtime_dir.as_path(), now);
+        let feishu = snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == "feishu")
+            .expect("feishu snapshot");
+        let serve = feishu.operation("serve").expect("feishu serve operation");
+        let runtime = serve.runtime.as_ref().expect("runtime info");
+
+        assert!(runtime.running);
+        assert!(!runtime.stale);
+        assert!(runtime.busy);
+        assert_eq!(runtime.active_runs, 2);
+        assert_eq!(runtime.pid, Some(4242));
+    }
+
+    #[test]
+    fn channel_status_snapshots_report_resolved_account_identity_in_notes() {
+        let mut config = LoongClawConfig::default();
+        config.telegram.enabled = true;
+        config.telegram.bot_token = Some("123456:token".to_owned());
+        config.telegram.allowed_chat_ids = vec![123];
+
+        let snapshots = channel_status_snapshots(&config);
+        let telegram = snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == "telegram")
+            .expect("telegram snapshot");
+
+        assert!(
+            telegram
+                .notes
+                .iter()
+                .any(|note| note.contains("account_id=bot_123456")),
+            "telegram notes should expose the resolved account id"
+        );
+    }
+
+    #[test]
+    fn channel_status_snapshots_attach_account_identity_to_runtime_view() {
+        let mut config = LoongClawConfig::default();
+        config.feishu.enabled = true;
+        config.feishu.app_id = Some("cli_a1b2c3".to_owned());
+        config.feishu.app_secret = Some("app-secret".to_owned());
+        config.feishu.allowed_chat_ids = vec!["oc_123".to_owned()];
+        config.feishu.verification_token = Some("token".to_owned());
+        config.feishu.encrypt_key = Some("encrypt".to_owned());
+
+        let runtime_dir = temp_runtime_dir("registry-account-runtime");
+        let now = now_ms();
+        runtime_state::write_runtime_state_for_test_with_account_and_pid(
+            runtime_dir.as_path(),
+            ChannelPlatform::Feishu,
+            "serve",
+            "feishu_cli_a1b2c3",
+            4242,
+            true,
+            true,
+            2,
+            Some(now.saturating_sub(1_000)),
+            Some(now.saturating_sub(500)),
+            Some(4242),
+        )
+        .expect("write runtime state");
+
+        let snapshots = channel_status_snapshots_with_now(&config, runtime_dir.as_path(), now);
+        let feishu = snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == "feishu")
+            .expect("feishu snapshot");
+        let serve = feishu.operation("serve").expect("feishu serve operation");
+        let runtime = serve.runtime.as_ref().expect("runtime info");
+
+        assert_eq!(runtime.account_id.as_deref(), Some("feishu_cli_a1b2c3"));
+        assert_eq!(runtime.account_label.as_deref(), Some("feishu:cli_a1b2c3"));
+    }
+
+    #[test]
+    fn channel_status_snapshots_preserve_runtime_instance_counts() {
+        let mut config = LoongClawConfig::default();
+        config.telegram.enabled = true;
+        config.telegram.bot_token = Some("123456:token".to_owned());
+        config.telegram.allowed_chat_ids = vec![123];
+
+        let runtime_dir = temp_runtime_dir("registry-duplicate-runtime");
+        let now = now_ms();
+        runtime_state::write_runtime_state_for_test_with_account_and_pid(
+            runtime_dir.as_path(),
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            1001,
+            true,
+            true,
+            1,
+            Some(now.saturating_sub(300)),
+            Some(now.saturating_sub(100)),
+            Some(1001),
+        )
+        .expect("write first runtime state");
+        runtime_state::write_runtime_state_for_test_with_account_and_pid(
+            runtime_dir.as_path(),
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            1002,
+            true,
+            false,
+            0,
+            Some(now.saturating_sub(200)),
+            Some(now.saturating_sub(50)),
+            Some(1002),
+        )
+        .expect("write second runtime state");
+
+        let snapshots = channel_status_snapshots_with_now(&config, runtime_dir.as_path(), now);
+        let telegram = snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == "telegram")
+            .expect("telegram snapshot");
+        let serve = telegram
+            .operation("serve")
+            .expect("telegram serve operation");
+        let runtime = serve.runtime.as_ref().expect("runtime info");
+
+        assert_eq!(runtime.instance_count, 2);
+        assert_eq!(runtime.running_instances, 2);
+        assert_eq!(runtime.stale_instances, 0);
+    }
+
+    #[test]
+    fn multi_account_registry_emits_one_snapshot_per_configured_account() {
+        let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
+            "telegram": {
+                "enabled": true,
+                "default_account": "Work Bot",
+                "allowed_chat_ids": [1001],
+                "accounts": {
+                    "Work Bot": {
+                        "account_id": "Ops-Bot",
+                        "bot_token": "123456:token-work",
+                        "allowed_chat_ids": [2002]
+                    },
+                    "Personal": {
+                        "bot_token": "654321:token-personal",
+                        "allowed_chat_ids": [3003]
+                    }
+                }
+            }
+        }))
+        .expect("deserialize multi-account config");
+
+        let telegram = channel_status_snapshots(&config)
+            .into_iter()
+            .filter(|snapshot| snapshot.id == "telegram")
+            .collect::<Vec<_>>();
+
+        assert_eq!(telegram.len(), 2);
+        assert_eq!(telegram[0].configured_account_id, "personal");
+        assert_eq!(telegram[1].configured_account_id, "work-bot");
+        assert!(telegram[1]
+            .notes
+            .iter()
+            .any(|note| note == "configured_account_id=work-bot"));
+        assert!(telegram[1]
+            .notes
+            .iter()
+            .any(|note| note == "account_id=ops-bot"));
+    }
+
+    #[test]
+    fn multi_account_registry_marks_default_configured_account() {
+        let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
+            "telegram": {
+                "enabled": true,
+                "default_account": "Work Bot",
+                "allowed_chat_ids": [1001],
+                "accounts": {
+                    "Work Bot": {
+                        "account_id": "Ops-Bot",
+                        "bot_token": "123456:token-work",
+                        "allowed_chat_ids": [2002]
+                    },
+                    "Personal": {
+                        "bot_token": "654321:token-personal",
+                        "allowed_chat_ids": [3003]
+                    }
+                }
+            }
+        }))
+        .expect("deserialize multi-account config");
+
+        let telegram = channel_status_snapshots(&config)
+            .into_iter()
+            .filter(|snapshot| snapshot.id == "telegram")
+            .collect::<Vec<_>>();
+        let encoded = serde_json::to_value(&telegram).expect("serialize telegram snapshots");
+
+        assert!(telegram[1]
+            .notes
+            .iter()
+            .any(|note| note == "default_account=true"));
+        assert_eq!(
+            encoded[0]
+                .get("is_default_account")
+                .and_then(serde_json::Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            encoded[1]
+                .get("is_default_account")
+                .and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            encoded[1]
+                .get("default_account_source")
+                .and_then(serde_json::Value::as_str),
+            Some("explicit_default")
+        );
+    }
+
+    #[test]
+    fn multi_account_registry_records_fallback_default_account_source() {
+        let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
+            "telegram": {
+                "enabled": true,
+                "accounts": {
+                    "Work": {
+                        "bot_token": "123456:token-work",
+                        "allowed_chat_ids": [2002]
+                    },
+                    "Alerts": {
+                        "bot_token": "654321:token-alerts",
+                        "allowed_chat_ids": [3003]
+                    }
+                }
+            }
+        }))
+        .expect("deserialize multi-account config");
+
+        let telegram = channel_status_snapshots(&config)
+            .into_iter()
+            .filter(|snapshot| snapshot.id == "telegram")
+            .collect::<Vec<_>>();
+
+        assert!(telegram[0].is_default_account);
+        assert_eq!(
+            telegram[0].default_account_source,
+            ChannelDefaultAccountSelectionSource::Fallback
+        );
+        assert!(telegram[0]
+            .notes
+            .iter()
+            .any(|note| note == "default_account_source=fallback"));
+    }
+
+    fn temp_runtime_dir(suffix: &str) -> std::path::PathBuf {
+        let unique = format!(
+            "loongclaw-channel-registry-{suffix}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        );
+        std::env::temp_dir().join(unique)
+    }
+}

--- a/crates/app/src/channel/runtime_state.rs
+++ b/crates/app/src/channel/runtime_state.rs
@@ -1,0 +1,838 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use serde::{Deserialize, Serialize};
+use tokio::{task::JoinHandle, time::sleep};
+
+use crate::{config::default_loongclaw_home, CliResult};
+
+use super::ChannelPlatform;
+
+const CHANNEL_RUNTIME_HEARTBEAT_MS: u64 = 5_000;
+const CHANNEL_RUNTIME_STALE_MS: u64 = 15_000;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChannelOperationRuntime {
+    pub running: bool,
+    pub stale: bool,
+    pub busy: bool,
+    pub active_runs: usize,
+    pub last_run_activity_at: Option<u64>,
+    pub last_heartbeat_at: Option<u64>,
+    pub pid: Option<u32>,
+    pub account_id: Option<String>,
+    pub account_label: Option<String>,
+    pub instance_count: usize,
+    pub running_instances: usize,
+    pub stale_instances: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+struct PersistedChannelOperationRuntime {
+    running: bool,
+    busy: bool,
+    active_runs: usize,
+    last_run_activity_at: Option<u64>,
+    last_heartbeat_at: Option<u64>,
+    pid: Option<u32>,
+    account_id: Option<String>,
+    account_label: Option<String>,
+}
+
+impl PersistedChannelOperationRuntime {
+    fn to_runtime_view(&self, now_ms: u64) -> ChannelOperationRuntime {
+        let stale = self.running
+            && self
+                .last_heartbeat_at
+                .map(|heartbeat| now_ms.saturating_sub(heartbeat) > CHANNEL_RUNTIME_STALE_MS)
+                .unwrap_or(true);
+        ChannelOperationRuntime {
+            running: self.running && !stale,
+            stale,
+            busy: self.busy,
+            active_runs: self.active_runs,
+            last_run_activity_at: self.last_run_activity_at,
+            last_heartbeat_at: self.last_heartbeat_at,
+            pid: self.pid,
+            account_id: self.account_id.clone(),
+            account_label: self.account_label.clone(),
+            instance_count: 0,
+            running_instances: 0,
+            stale_instances: 0,
+        }
+    }
+}
+
+pub(crate) struct ChannelOperationRuntimeTracker {
+    path: PathBuf,
+    state: Arc<Mutex<PersistedChannelOperationRuntime>>,
+    stopped: Arc<AtomicBool>,
+    heartbeat_task: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl ChannelOperationRuntimeTracker {
+    pub(crate) async fn start(
+        platform: ChannelPlatform,
+        operation_id: &'static str,
+        account_id: &str,
+        account_label: &str,
+    ) -> CliResult<Self> {
+        Self::start_in_dir_with_account_and_pid(
+            &default_channel_runtime_state_dir(),
+            platform,
+            operation_id,
+            account_id,
+            account_label,
+            CHANNEL_RUNTIME_HEARTBEAT_MS,
+            std::process::id(),
+        )
+        .await
+    }
+
+    #[cfg(test)]
+    async fn start_in_dir_with_pid(
+        runtime_dir: &Path,
+        platform: ChannelPlatform,
+        operation_id: &'static str,
+        heartbeat_ms: u64,
+        process_id: u32,
+    ) -> CliResult<Self> {
+        Self::start_in_dir_impl(
+            runtime_dir,
+            platform,
+            operation_id,
+            None,
+            None,
+            heartbeat_ms,
+            process_id,
+        )
+        .await
+    }
+
+    async fn start_in_dir_with_account_and_pid(
+        runtime_dir: &Path,
+        platform: ChannelPlatform,
+        operation_id: &'static str,
+        account_id: &str,
+        account_label: &str,
+        heartbeat_ms: u64,
+        process_id: u32,
+    ) -> CliResult<Self> {
+        Self::start_in_dir_impl(
+            runtime_dir,
+            platform,
+            operation_id,
+            Some(account_id),
+            Some(account_label),
+            heartbeat_ms,
+            process_id,
+        )
+        .await
+    }
+
+    async fn start_in_dir_impl(
+        runtime_dir: &Path,
+        platform: ChannelPlatform,
+        operation_id: &'static str,
+        account_id: Option<&str>,
+        account_label: Option<&str>,
+        heartbeat_ms: u64,
+        process_id: u32,
+    ) -> CliResult<Self> {
+        let path = channel_operation_runtime_path(
+            runtime_dir,
+            platform,
+            operation_id,
+            account_id,
+            Some(process_id),
+        );
+        let initial = PersistedChannelOperationRuntime {
+            running: true,
+            busy: false,
+            active_runs: 0,
+            last_run_activity_at: None,
+            last_heartbeat_at: Some(now_ms()),
+            pid: Some(process_id),
+            account_id: normalize_optional_account_value(account_id),
+            account_label: normalize_optional_account_value(account_label),
+        };
+        write_runtime_state(&path, &initial)?;
+
+        let state = Arc::new(Mutex::new(initial));
+        let stopped = Arc::new(AtomicBool::new(false));
+        let heartbeat_state = state.clone();
+        let heartbeat_stopped = stopped.clone();
+        let heartbeat_path = path.clone();
+        let task = tokio::spawn(async move {
+            while !heartbeat_stopped.load(Ordering::SeqCst) {
+                sleep(Duration::from_millis(heartbeat_ms)).await;
+                if heartbeat_stopped.load(Ordering::SeqCst) {
+                    break;
+                }
+                let snapshot = {
+                    let Ok(mut state) = heartbeat_state.lock() else {
+                        break;
+                    };
+                    state.last_heartbeat_at = Some(now_ms());
+                    state.clone()
+                };
+                let _ = write_runtime_state(&heartbeat_path, &snapshot);
+            }
+        });
+
+        Ok(Self {
+            path,
+            state,
+            stopped,
+            heartbeat_task: Mutex::new(Some(task)),
+        })
+    }
+
+    pub(crate) async fn mark_run_start(&self) -> CliResult<()> {
+        self.update_state(|state| {
+            state.active_runs = state.active_runs.saturating_add(1);
+            state.busy = true;
+            let now = now_ms();
+            state.last_run_activity_at = Some(now);
+            state.last_heartbeat_at = Some(now);
+        })
+        .await
+    }
+
+    pub(crate) async fn mark_run_end(&self) -> CliResult<()> {
+        self.update_state(|state| {
+            state.active_runs = state.active_runs.saturating_sub(1);
+            state.busy = state.active_runs > 0;
+            let now = now_ms();
+            state.last_run_activity_at = Some(now);
+            state.last_heartbeat_at = Some(now);
+        })
+        .await
+    }
+
+    pub(crate) async fn shutdown(&self) -> CliResult<()> {
+        self.stopped.store(true, Ordering::SeqCst);
+        let task = self
+            .heartbeat_task
+            .lock()
+            .map_err(|error| format!("channel runtime heartbeat task lock poisoned: {error}"))?
+            .take();
+        if let Some(task) = task {
+            task.abort();
+        }
+        self.update_state(|state| {
+            state.running = false;
+            state.busy = false;
+            state.active_runs = 0;
+            state.last_heartbeat_at = Some(now_ms());
+        })
+        .await
+    }
+
+    async fn update_state(
+        &self,
+        mutate: impl FnOnce(&mut PersistedChannelOperationRuntime),
+    ) -> CliResult<()> {
+        let snapshot = {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|error| format!("channel runtime state lock poisoned: {error}"))?;
+            mutate(&mut state);
+            state.clone()
+        };
+        write_runtime_state(&self.path, &snapshot)
+    }
+}
+
+#[cfg(test)]
+pub(crate) async fn start_channel_operation_runtime_tracker_for_test(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &'static str,
+    account_id: &str,
+    account_label: &str,
+    process_id: u32,
+) -> CliResult<ChannelOperationRuntimeTracker> {
+    ChannelOperationRuntimeTracker::start_in_dir_with_account_and_pid(
+        runtime_dir,
+        platform,
+        operation_id,
+        account_id,
+        account_label,
+        CHANNEL_RUNTIME_HEARTBEAT_MS,
+        process_id,
+    )
+    .await
+}
+
+#[cfg(test)]
+pub(crate) fn load_channel_operation_runtime_from_dir(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    now_ms: u64,
+) -> Option<ChannelOperationRuntime> {
+    load_channel_operation_runtime_for_optional_account_from_dir(
+        runtime_dir,
+        platform,
+        operation_id,
+        None,
+        now_ms,
+    )
+}
+
+pub(crate) fn load_channel_operation_runtime_for_account_from_dir(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: &str,
+    now_ms: u64,
+) -> Option<ChannelOperationRuntime> {
+    load_channel_operation_runtime_for_optional_account_from_dir(
+        runtime_dir,
+        platform,
+        operation_id,
+        Some(account_id),
+        now_ms,
+    )
+}
+
+fn load_channel_operation_runtime_for_optional_account_from_dir(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: Option<&str>,
+    now_ms: u64,
+) -> Option<ChannelOperationRuntime> {
+    let prefix = channel_operation_runtime_file_prefix(platform, operation_id, account_id);
+    let mut candidates = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(runtime_dir) {
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_file() {
+                continue;
+            }
+            let file_name = entry.file_name();
+            let file_name = file_name.to_string_lossy();
+            if !matches_channel_operation_runtime_file(file_name.as_ref(), &prefix) {
+                continue;
+            }
+            if let Some(runtime) = read_runtime_state(entry.path().as_path(), now_ms) {
+                candidates.push(runtime);
+            }
+        }
+    }
+
+    if candidates.is_empty() && account_id.is_some() {
+        return load_channel_operation_runtime_for_optional_account_from_dir(
+            runtime_dir,
+            platform,
+            operation_id,
+            None,
+            now_ms,
+        );
+    }
+
+    if candidates.is_empty() {
+        let legacy_path =
+            channel_operation_runtime_path(runtime_dir, platform, operation_id, None, None);
+        if let Some(runtime) = read_runtime_state(&legacy_path, now_ms) {
+            candidates.push(runtime);
+        }
+    }
+
+    summarize_runtime_candidates(candidates)
+}
+
+pub(crate) fn default_channel_runtime_state_dir() -> PathBuf {
+    default_loongclaw_home().join("channel-runtime")
+}
+
+fn channel_operation_runtime_file_prefix(
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: Option<&str>,
+) -> String {
+    match normalize_optional_account_value(account_id) {
+        Some(account_id) => format!("{}-{operation_id}-{account_id}", platform.as_str()),
+        None => format!("{}-{operation_id}", platform.as_str()),
+    }
+}
+
+fn channel_operation_runtime_path(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: Option<&str>,
+    process_id: Option<u32>,
+) -> PathBuf {
+    let prefix = channel_operation_runtime_file_prefix(platform, operation_id, account_id);
+    match process_id {
+        Some(process_id) => runtime_dir.join(format!("{prefix}-{process_id}.json")),
+        None => runtime_dir.join(format!("{prefix}.json")),
+    }
+}
+
+fn matches_channel_operation_runtime_file(file_name: &str, prefix: &str) -> bool {
+    if file_name == format!("{prefix}.json") {
+        return true;
+    }
+
+    file_name
+        .strip_prefix(prefix)
+        .and_then(|suffix| suffix.strip_prefix('-'))
+        .and_then(|suffix| suffix.strip_suffix(".json"))
+        .map(|pid| !pid.is_empty() && pid.chars().all(|value| value.is_ascii_digit()))
+        .unwrap_or(false)
+}
+
+fn read_runtime_state(path: &Path, now_ms: u64) -> Option<ChannelOperationRuntime> {
+    let raw = fs::read_to_string(path).ok()?;
+    let state = serde_json::from_str::<PersistedChannelOperationRuntime>(&raw).ok()?;
+    Some(state.to_runtime_view(now_ms))
+}
+
+fn select_preferred_runtime(
+    candidates: Vec<ChannelOperationRuntime>,
+) -> Option<ChannelOperationRuntime> {
+    candidates.into_iter().max_by_key(|runtime| {
+        (
+            runtime.running,
+            !runtime.stale,
+            runtime.last_heartbeat_at.unwrap_or(0),
+            runtime.last_run_activity_at.unwrap_or(0),
+            runtime.pid.unwrap_or(0),
+        )
+    })
+}
+
+fn summarize_runtime_candidates(
+    candidates: Vec<ChannelOperationRuntime>,
+) -> Option<ChannelOperationRuntime> {
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let instance_count = candidates.len();
+    let running_instances = candidates.iter().filter(|runtime| runtime.running).count();
+    let stale_instances = candidates.iter().filter(|runtime| runtime.stale).count();
+    let mut preferred = select_preferred_runtime(candidates)?;
+    preferred.instance_count = instance_count;
+    preferred.running_instances = running_instances;
+    preferred.stale_instances = stale_instances;
+    Some(preferred)
+}
+
+fn normalize_optional_account_value(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn write_runtime_state(path: &Path, state: &PersistedChannelOperationRuntime) -> CliResult<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!("create channel runtime state directory failed: {error}")
+            })?;
+        }
+    }
+    let encoded = serde_json::to_string_pretty(state)
+        .map_err(|error| format!("serialize channel runtime state failed: {error}"))?;
+    fs::write(path, encoded).map_err(|error| format!("write channel runtime state failed: {error}"))
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+pub(crate) fn write_runtime_state_for_test(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    running: bool,
+    busy: bool,
+    active_runs: usize,
+    last_run_activity_at: Option<u64>,
+    last_heartbeat_at: Option<u64>,
+    pid: Option<u32>,
+) -> CliResult<()> {
+    let path = channel_operation_runtime_path(runtime_dir, platform, operation_id, None, None);
+    let state = PersistedChannelOperationRuntime {
+        running,
+        busy,
+        active_runs,
+        last_run_activity_at,
+        last_heartbeat_at,
+        pid,
+        account_id: None,
+        account_label: None,
+    };
+    write_runtime_state(&path, &state)
+}
+
+#[cfg(test)]
+pub(crate) fn write_runtime_state_for_test_with_pid(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    process_id: u32,
+    running: bool,
+    busy: bool,
+    active_runs: usize,
+    last_run_activity_at: Option<u64>,
+    last_heartbeat_at: Option<u64>,
+    pid: Option<u32>,
+) -> CliResult<()> {
+    let path =
+        channel_operation_runtime_path(runtime_dir, platform, operation_id, None, Some(process_id));
+    let state = PersistedChannelOperationRuntime {
+        running,
+        busy,
+        active_runs,
+        last_run_activity_at,
+        last_heartbeat_at,
+        pid,
+        account_id: None,
+        account_label: None,
+    };
+    write_runtime_state(&path, &state)
+}
+
+#[cfg(test)]
+pub(crate) fn write_runtime_state_for_test_with_account_and_pid(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: &str,
+    process_id: u32,
+    running: bool,
+    busy: bool,
+    active_runs: usize,
+    last_run_activity_at: Option<u64>,
+    last_heartbeat_at: Option<u64>,
+    pid: Option<u32>,
+) -> CliResult<()> {
+    let path = channel_operation_runtime_path(
+        runtime_dir,
+        platform,
+        operation_id,
+        Some(account_id),
+        Some(process_id),
+    );
+    let state = PersistedChannelOperationRuntime {
+        running,
+        busy,
+        active_runs,
+        last_run_activity_at,
+        last_heartbeat_at,
+        pid,
+        account_id: Some(account_id.to_owned()),
+        account_label: Some(test_account_label(account_id)),
+    };
+    write_runtime_state(&path, &state)
+}
+
+#[cfg(test)]
+fn test_account_label(account_id: &str) -> String {
+    match account_id.split_once('_') {
+        Some((platform, rest)) if !platform.is_empty() && !rest.is_empty() => {
+            format!("{platform}:{rest}")
+        }
+        _ => account_id.to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_runtime_dir(suffix: &str) -> PathBuf {
+        let unique = format!(
+            "loongclaw-channel-runtime-{suffix}-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        );
+        std::env::temp_dir().join(unique)
+    }
+
+    #[tokio::test]
+    async fn runtime_tracker_persists_run_activity_and_shutdown_state() {
+        let runtime_dir = temp_runtime_dir("tracker");
+        let tracker = ChannelOperationRuntimeTracker::start_in_dir_with_pid(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            "serve",
+            20,
+            4242,
+        )
+        .await
+        .expect("start runtime tracker");
+
+        tracker.mark_run_start().await.expect("mark run start");
+        tracker.mark_run_end().await.expect("mark run end");
+        sleep(Duration::from_millis(30)).await;
+        tracker.shutdown().await.expect("shutdown tracker");
+
+        let runtime = load_channel_operation_runtime_from_dir(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            "serve",
+            now_ms(),
+        )
+        .expect("load runtime state");
+
+        assert!(!runtime.running);
+        assert!(!runtime.busy);
+        assert_eq!(runtime.active_runs, 0);
+        assert!(runtime.last_run_activity_at.is_some());
+        assert!(runtime.last_heartbeat_at.is_some());
+        assert_eq!(runtime.pid, Some(4242));
+        let entries = fs::read_dir(&runtime_dir)
+            .expect("list runtime dir")
+            .map(|entry| {
+                entry
+                    .expect("runtime entry")
+                    .file_name()
+                    .into_string()
+                    .expect("utf-8 file name")
+            })
+            .collect::<Vec<_>>();
+        assert!(entries.contains(&"telegram-serve-4242.json".to_owned()));
+    }
+
+    #[test]
+    fn stale_runtime_is_marked_not_running() {
+        let runtime_dir = temp_runtime_dir("stale");
+        let now = now_ms();
+        write_runtime_state_for_test(
+            &runtime_dir,
+            ChannelPlatform::Feishu,
+            "serve",
+            true,
+            true,
+            1,
+            Some(now.saturating_sub(30_000)),
+            Some(now.saturating_sub(30_000)),
+            Some(99),
+        )
+        .expect("write stale runtime state");
+
+        let runtime = load_channel_operation_runtime_from_dir(
+            &runtime_dir,
+            ChannelPlatform::Feishu,
+            "serve",
+            now,
+        )
+        .expect("load runtime state");
+
+        assert!(!runtime.running);
+        assert!(runtime.stale);
+        assert!(runtime.busy);
+        assert_eq!(runtime.active_runs, 1);
+    }
+
+    #[test]
+    fn load_runtime_prefers_running_pid_scoped_state_over_newer_stopped_instance() {
+        let runtime_dir = temp_runtime_dir("pid-scoped-selection");
+        let now = now_ms();
+        write_runtime_state_for_test_with_pid(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            "serve",
+            1001,
+            true,
+            true,
+            2,
+            Some(now.saturating_sub(2_000)),
+            Some(now.saturating_sub(1_000)),
+            Some(1001),
+        )
+        .expect("write running pid-scoped runtime");
+        write_runtime_state_for_test_with_pid(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            "serve",
+            2002,
+            false,
+            false,
+            0,
+            Some(now.saturating_sub(100)),
+            Some(now.saturating_sub(100)),
+            Some(2002),
+        )
+        .expect("write stopped pid-scoped runtime");
+
+        let runtime = load_channel_operation_runtime_from_dir(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            "serve",
+            now,
+        )
+        .expect("load runtime state");
+
+        assert!(runtime.running);
+        assert!(!runtime.stale);
+        assert!(runtime.busy);
+        assert_eq!(runtime.active_runs, 2);
+        assert_eq!(runtime.pid, Some(1001));
+    }
+
+    #[test]
+    fn load_runtime_keeps_backward_compatibility_with_legacy_single_file() {
+        let runtime_dir = temp_runtime_dir("legacy-runtime");
+        let now = now_ms();
+        write_runtime_state_for_test(
+            &runtime_dir,
+            ChannelPlatform::Feishu,
+            "serve",
+            true,
+            true,
+            1,
+            Some(now.saturating_sub(500)),
+            Some(now.saturating_sub(200)),
+            Some(9090),
+        )
+        .expect("write legacy runtime state");
+
+        let runtime = load_channel_operation_runtime_from_dir(
+            &runtime_dir,
+            ChannelPlatform::Feishu,
+            "serve",
+            now,
+        )
+        .expect("load runtime state");
+
+        assert!(runtime.running);
+        assert_eq!(runtime.pid, Some(9090));
+    }
+
+    #[test]
+    fn load_runtime_reads_account_scoped_pid_file() {
+        let runtime_dir = temp_runtime_dir("account-runtime");
+        let now = now_ms();
+        write_runtime_state_for_test_with_account_and_pid(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            3003,
+            true,
+            true,
+            1,
+            Some(now.saturating_sub(250)),
+            Some(now.saturating_sub(100)),
+            Some(3003),
+        )
+        .expect("write account-scoped runtime state");
+
+        let runtime = load_channel_operation_runtime_for_account_from_dir(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            now,
+        )
+        .expect("load account runtime state");
+
+        assert!(runtime.running);
+        assert_eq!(runtime.pid, Some(3003));
+        assert_eq!(runtime.account_id.as_deref(), Some("bot_123456"));
+    }
+
+    #[test]
+    fn account_scoped_runtime_loader_falls_back_to_legacy_operation_files() {
+        let runtime_dir = temp_runtime_dir("account-runtime-legacy");
+        let now = now_ms();
+        write_runtime_state_for_test(
+            &runtime_dir,
+            ChannelPlatform::Feishu,
+            "serve",
+            true,
+            false,
+            0,
+            Some(now.saturating_sub(250)),
+            Some(now.saturating_sub(100)),
+            Some(8181),
+        )
+        .expect("write legacy runtime state");
+
+        let runtime = load_channel_operation_runtime_for_account_from_dir(
+            &runtime_dir,
+            ChannelPlatform::Feishu,
+            "serve",
+            "lark_cli_a1b2c3",
+            now,
+        )
+        .expect("load account runtime state via legacy fallback");
+
+        assert!(runtime.running);
+        assert_eq!(runtime.pid, Some(8181));
+    }
+
+    #[test]
+    fn account_scoped_runtime_loader_reports_duplicate_running_instances() {
+        let runtime_dir = temp_runtime_dir("account-runtime-duplicates");
+        let now = now_ms();
+        write_runtime_state_for_test_with_account_and_pid(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            3003,
+            true,
+            true,
+            1,
+            Some(now.saturating_sub(300)),
+            Some(now.saturating_sub(100)),
+            Some(3003),
+        )
+        .expect("write first running runtime state");
+        write_runtime_state_for_test_with_account_and_pid(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            4004,
+            true,
+            false,
+            0,
+            Some(now.saturating_sub(200)),
+            Some(now.saturating_sub(50)),
+            Some(4004),
+        )
+        .expect("write second running runtime state");
+
+        let runtime = load_channel_operation_runtime_for_account_from_dir(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            now,
+        )
+        .expect("load account runtime state");
+
+        assert_eq!(runtime.instance_count, 2);
+        assert_eq!(runtime.running_instances, 2);
+        assert_eq!(runtime.stale_instances, 0);
+        assert_eq!(runtime.pid, Some(4004));
+    }
+}

--- a/crates/app/src/channel/telegram.rs
+++ b/crates/app/src/channel/telegram.rs
@@ -7,31 +7,91 @@ use std::{
 use async_trait::async_trait;
 use serde_json::{json, Value};
 
-use crate::config::{self, LoongClawConfig};
+use crate::config::{self, ResolvedTelegramChannelConfig};
 use crate::CliResult;
 
-use super::{ChannelAdapter, ChannelInboundMessage};
+use super::{
+    ChannelAdapter, ChannelDelivery, ChannelInboundMessage, ChannelOutboundTarget,
+    ChannelOutboundTargetKind, ChannelPlatform, ChannelSession,
+};
 
 pub(super) struct TelegramAdapter {
+    account_id: String,
     token: String,
     base_url: String,
     timeout_s: u64,
-    offset_path: PathBuf,
-    next_offset: i64,
+    offset_tracker: TelegramOffsetTracker,
     allowlist: BTreeSet<i64>,
 }
 
-impl TelegramAdapter {
-    pub(super) fn new(config: &LoongClawConfig, token: String) -> Self {
-        let offset_path = config::default_loongclaw_home().join("telegram.offset");
-        let next_offset = load_offset(&offset_path).unwrap_or(0);
+struct TelegramOffsetTracker {
+    offset_path: PathBuf,
+    current_offset: i64,
+    pending_batch_offset: Option<i64>,
+}
+
+impl TelegramOffsetTracker {
+    fn new(offset_path: PathBuf, current_offset: i64) -> Self {
         Self {
-            token,
-            base_url: config.telegram.base_url.clone(),
-            timeout_s: config.telegram.polling_timeout_s.clamp(1, 50),
             offset_path,
-            next_offset,
-            allowlist: config.telegram.allowed_chat_ids.iter().copied().collect(),
+            current_offset,
+            pending_batch_offset: None,
+        }
+    }
+
+    fn current_offset(&self) -> i64 {
+        self.current_offset
+    }
+
+    fn remember_polled_offset(&mut self, next_offset: Option<i64>) -> CliResult<()> {
+        self.pending_batch_offset = match next_offset {
+            Some(next) if next > self.current_offset => Some(next),
+            _ => None,
+        };
+        Ok(())
+    }
+
+    fn ack_delivery(&mut self, ack_cursor: Option<&str>) -> CliResult<()> {
+        let Some(raw_cursor) = ack_cursor.map(str::trim).filter(|value| !value.is_empty()) else {
+            return Ok(());
+        };
+        let cursor = raw_cursor
+            .parse::<i64>()
+            .map_err(|error| format!("invalid telegram ack cursor `{raw_cursor}`: {error}"))?;
+        self.persist_if_newer(cursor)
+    }
+
+    fn complete_batch(&mut self) -> CliResult<()> {
+        if let Some(next_offset) = self.pending_batch_offset.take() {
+            self.persist_if_newer(next_offset)?;
+        }
+        Ok(())
+    }
+
+    fn persist_if_newer(&mut self, next_offset: i64) -> CliResult<()> {
+        if next_offset <= self.current_offset {
+            return Ok(());
+        }
+        save_offset(&self.offset_path, next_offset)?;
+        self.current_offset = next_offset;
+        Ok(())
+    }
+}
+
+impl TelegramAdapter {
+    pub(super) fn new(config: &ResolvedTelegramChannelConfig, token: String) -> Self {
+        let offset_home = config::default_loongclaw_home();
+        let offset_path =
+            telegram_offset_path_for_account(offset_home.as_path(), config.account.id.as_str());
+        let next_offset =
+            load_offset_for_account(offset_home.as_path(), config.account.id.as_str()).unwrap_or(0);
+        Self {
+            account_id: config.account.id.clone(),
+            token,
+            base_url: config.base_url.clone(),
+            timeout_s: config.polling_timeout_s.clamp(1, 50),
+            offset_tracker: TelegramOffsetTracker::new(offset_path, next_offset),
+            allowlist: config.allowed_chat_ids.iter().copied().collect(),
         }
     }
 
@@ -55,7 +115,7 @@ impl ChannelAdapter for TelegramAdapter {
         let url = self.api_url("getUpdates");
         let client = reqwest::Client::new();
         let body = json!({
-            "offset": self.next_offset,
+            "offset": self.offset_tracker.current_offset(),
             "timeout": self.timeout_s,
             "allowed_updates": ["message"],
         });
@@ -69,21 +129,35 @@ impl ChannelAdapter for TelegramAdapter {
             .await
             .map_err(|error| format!("telegram getUpdates decode failed: {error}"))?;
 
-        let (inbox, next_offset) =
-            parse_telegram_updates(&payload, &self.allowlist, self.next_offset)?;
-        if let Some(next) = next_offset {
-            self.next_offset = next;
-            save_offset(&self.offset_path, self.next_offset)?;
-        }
+        let (inbox, next_offset) = parse_telegram_updates(
+            &payload,
+            &self.allowlist,
+            self.offset_tracker.current_offset(),
+            self.account_id.as_str(),
+        )?;
+        self.offset_tracker.remember_polled_offset(next_offset)?;
 
         Ok(inbox)
     }
 
-    async fn send_text(&self, target: &str, text: &str) -> CliResult<()> {
+    async fn send_text(&self, target: &ChannelOutboundTarget, text: &str) -> CliResult<()> {
+        if target.platform != ChannelPlatform::Telegram {
+            return Err(format!(
+                "telegram adapter cannot send to {} target",
+                target.platform.as_str()
+            ));
+        }
+        if target.kind != ChannelOutboundTargetKind::Conversation {
+            return Err(format!(
+                "telegram adapter requires conversation target, got {}",
+                target.kind.as_str()
+            ));
+        }
+
         let chat_id = target
-            .trim()
+            .trimmed_id()?
             .parse::<i64>()
-            .map_err(|error| format!("invalid telegram chat id `{target}`: {error}"))?;
+            .map_err(|error| format!("invalid telegram chat id `{}`: {error}", target.id))?;
 
         let url = self.api_url("sendMessage");
         let client = reqwest::Client::new();
@@ -108,12 +182,22 @@ impl ChannelAdapter for TelegramAdapter {
         }
         Ok(())
     }
+
+    async fn ack_inbound(&mut self, message: &ChannelInboundMessage) -> CliResult<()> {
+        self.offset_tracker
+            .ack_delivery(message.delivery.ack_cursor.as_deref())
+    }
+
+    async fn complete_batch(&mut self) -> CliResult<()> {
+        self.offset_tracker.complete_batch()
+    }
 }
 
 pub(super) fn parse_telegram_updates(
     payload: &Value,
     allowlist: &BTreeSet<i64>,
     current_offset: i64,
+    account_id: &str,
 ) -> CliResult<(Vec<ChannelInboundMessage>, Option<i64>)> {
     if !payload.get("ok").and_then(Value::as_bool).unwrap_or(false) {
         return Err(format!("telegram getUpdates not ok: {payload}"));
@@ -156,9 +240,20 @@ pub(super) fn parse_telegram_updates(
         }
 
         inbox.push(ChannelInboundMessage {
-            session_id: format!("telegram:{chat_id}"),
-            reply_target: chat_id.to_string(),
+            session: ChannelSession::with_account(
+                ChannelPlatform::Telegram,
+                account_id,
+                chat_id.to_string(),
+            ),
+            reply_target: ChannelOutboundTarget::telegram_chat(chat_id),
             text,
+            delivery: ChannelDelivery {
+                ack_cursor: Some(update_id.saturating_add(1).to_string()),
+                source_message_id: message
+                    .get("message_id")
+                    .and_then(Value::as_i64)
+                    .map(|value| value.to_string()),
+            },
         });
     }
 
@@ -168,6 +263,17 @@ pub(super) fn parse_telegram_updates(
         None
     };
     Ok((inbox, next_offset))
+}
+
+fn telegram_offset_path_for_account(loongclaw_home: &Path, account_id: &str) -> PathBuf {
+    loongclaw_home
+        .join("telegram-offsets")
+        .join(format!("{}.offset", account_id.trim()))
+}
+
+fn load_offset_for_account(loongclaw_home: &Path, account_id: &str) -> Option<i64> {
+    let account_path = telegram_offset_path_for_account(loongclaw_home, account_id);
+    load_offset(&account_path).or_else(|| load_offset(&loongclaw_home.join("telegram.offset")))
 }
 
 fn load_offset(path: &Path) -> Option<i64> {
@@ -228,12 +334,17 @@ mod tests {
         });
 
         let allowlist = BTreeSet::from([123_i64]);
-        let (inbox, next_offset) =
-            parse_telegram_updates(&payload, &allowlist, 50).expect("parse telegram updates");
+        let (inbox, next_offset) = parse_telegram_updates(&payload, &allowlist, 50, "bot_123456")
+            .expect("parse telegram updates");
 
         assert_eq!(inbox.len(), 1);
-        assert_eq!(inbox[0].session_id, "telegram:123");
+        assert_eq!(inbox[0].session.session_key(), "telegram:bot_123456:123");
+        assert_eq!(
+            inbox[0].reply_target,
+            ChannelOutboundTarget::telegram_chat(123)
+        );
         assert_eq!(inbox[0].text, "hello");
+        assert_eq!(inbox[0].delivery.ack_cursor.as_deref(), Some("101"));
         assert_eq!(next_offset, Some(102));
     }
 
@@ -253,10 +364,88 @@ mod tests {
         });
 
         let allowlist = BTreeSet::new();
-        let (inbox, next_offset) =
-            parse_telegram_updates(&payload, &allowlist, 0).expect("parse telegram updates");
+        let (inbox, next_offset) = parse_telegram_updates(&payload, &allowlist, 0, "bot_123456")
+            .expect("parse telegram updates");
 
         assert!(inbox.is_empty());
         assert_eq!(next_offset, Some(9));
+    }
+
+    #[test]
+    fn telegram_batch_offset_is_not_persisted_until_ack() {
+        let unique = format!(
+            "loongclaw-telegram-batch-offset-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        );
+        let path = std::env::temp_dir().join(unique).join("offset.txt");
+        let mut tracker = TelegramOffsetTracker::new(path.clone(), 0);
+
+        tracker
+            .remember_polled_offset(Some(7))
+            .expect("remember polled offset");
+
+        assert_eq!(load_offset(&path), None);
+        assert_eq!(tracker.current_offset(), 0);
+
+        tracker.complete_batch().expect("complete batch");
+
+        assert_eq!(load_offset(&path), Some(7));
+        assert_eq!(tracker.current_offset(), 7);
+    }
+
+    #[test]
+    fn telegram_batch_acknowledges_messages_incrementally_and_flushes_trailing_offset() {
+        let unique = format!(
+            "loongclaw-telegram-ack-offset-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        );
+        let path = std::env::temp_dir().join(unique).join("offset.txt");
+        let mut tracker = TelegramOffsetTracker::new(path.clone(), 0);
+
+        tracker
+            .remember_polled_offset(Some(12))
+            .expect("remember polled offset");
+        tracker
+            .ack_delivery(Some("10"))
+            .expect("ack successful message");
+
+        assert_eq!(load_offset(&path), Some(10));
+        assert_eq!(tracker.current_offset(), 10);
+
+        tracker.complete_batch().expect("complete batch");
+
+        assert_eq!(load_offset(&path), Some(12));
+        assert_eq!(tracker.current_offset(), 12);
+    }
+
+    #[test]
+    fn telegram_offset_path_is_account_scoped() {
+        let home = std::env::temp_dir().join("loongclaw-telegram-account-offset");
+        let path = telegram_offset_path_for_account(home.as_path(), "bot_123456");
+
+        assert!(path.ends_with("telegram-offsets/bot_123456.offset"));
+    }
+
+    #[test]
+    fn telegram_offset_loader_falls_back_to_legacy_single_file() {
+        let unique = format!(
+            "loongclaw-telegram-legacy-offset-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        );
+        let home = std::env::temp_dir().join(unique);
+        let legacy_path = home.join("telegram.offset");
+        save_offset(&legacy_path, 77).expect("save legacy offset");
+
+        let offset = load_offset_for_account(home.as_path(), "bot_123456");
+        assert_eq!(offset, Some(77));
     }
 }

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -1,11 +1,13 @@
-#[cfg(feature = "channel-telegram")]
-use std::env;
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "channel-feishu")]
-use super::shared::read_secret_prefer_inline;
-use super::shared::{validate_env_pointer_field, ConfigValidationIssue, EnvPointerValidationHint};
+use crate::CliResult;
+
+use super::shared::{
+    read_secret_prefer_inline, validate_env_pointer_field, ConfigValidationCode,
+    ConfigValidationIssue, EnvPointerValidationHint,
+};
 
 const TELEGRAM_BOT_TOKEN_ENV: &str = "TELEGRAM_BOT_TOKEN";
 const FEISHU_APP_ID_ENV: &str = "FEISHU_APP_ID";
@@ -28,6 +30,10 @@ pub struct TelegramChannelConfig {
     #[serde(default)]
     pub enabled: bool,
     #[serde(default)]
+    pub account_id: Option<String>,
+    #[serde(default)]
+    pub default_account: Option<String>,
+    #[serde(default)]
     pub bot_token: Option<String>,
     #[serde(default)]
     pub bot_token_env: Option<String>,
@@ -37,12 +43,138 @@ pub struct TelegramChannelConfig {
     pub polling_timeout_s: u64,
     #[serde(default)]
     pub allowed_chat_ids: Vec<i64>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub accounts: BTreeMap<String, TelegramAccountConfig>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FeishuChannelConfig {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FeishuDomain {
+    #[default]
+    Feishu,
+    Lark,
+}
+
+impl FeishuDomain {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Feishu => "feishu",
+            Self::Lark => "lark",
+        }
+    }
+
+    pub fn default_base_url(self) -> &'static str {
+        match self {
+            Self::Feishu => "https://open.feishu.cn",
+            Self::Lark => "https://open.larksuite.com",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelAccountIdentitySource {
+    Configured,
+    DerivedCredential,
+    Default,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelDefaultAccountSelectionSource {
+    ExplicitDefault,
+    MappedDefault,
+    Fallback,
+    RuntimeIdentity,
+}
+
+impl ChannelDefaultAccountSelectionSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ExplicitDefault => "explicit_default",
+            Self::MappedDefault => "mapped_default",
+            Self::Fallback => "fallback",
+            Self::RuntimeIdentity => "runtime_identity",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChannelAccountIdentity {
+    pub id: String,
+    pub label: String,
+    pub source: ChannelAccountIdentitySource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChannelDefaultAccountSelection {
+    pub id: String,
+    pub source: ChannelDefaultAccountSelectionSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChannelResolvedAccountRoute {
+    pub requested_account_id: Option<String>,
+    pub configured_account_count: usize,
+    pub selected_configured_account_id: String,
+    pub default_account_source: ChannelDefaultAccountSelectionSource,
+}
+
+impl ChannelResolvedAccountRoute {
+    pub fn selected_by_default(&self) -> bool {
+        self.requested_account_id.is_none()
+    }
+
+    pub fn uses_implicit_fallback_default(&self) -> bool {
+        self.selected_by_default()
+            && self.configured_account_count > 1
+            && self.default_account_source == ChannelDefaultAccountSelectionSource::Fallback
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TelegramAccountConfig {
     #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub account_id: Option<String>,
+    #[serde(default)]
+    pub bot_token: Option<String>,
+    #[serde(default)]
+    pub bot_token_env: Option<String>,
+    #[serde(default)]
+    pub base_url: Option<String>,
+    #[serde(default)]
+    pub polling_timeout_s: Option<u64>,
+    #[serde(default)]
+    pub allowed_chat_ids: Option<Vec<i64>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedTelegramChannelConfig {
+    pub configured_account_id: String,
+    pub configured_account_label: String,
+    pub account: ChannelAccountIdentity,
     pub enabled: bool,
+    pub bot_token: Option<String>,
+    pub bot_token_env: Option<String>,
+    pub base_url: String,
+    pub polling_timeout_s: u64,
+    pub allowed_chat_ids: Vec<i64>,
+}
+
+impl ResolvedTelegramChannelConfig {
+    pub fn bot_token(&self) -> Option<String> {
+        read_secret_prefer_inline(self.bot_token.as_deref(), self.bot_token_env.as_deref())
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FeishuAccountConfig {
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub account_id: Option<String>,
     #[serde(default)]
     pub app_id: Option<String>,
     #[serde(default)]
@@ -51,8 +183,103 @@ pub struct FeishuChannelConfig {
     pub app_id_env: Option<String>,
     #[serde(default)]
     pub app_secret_env: Option<String>,
-    #[serde(default = "default_feishu_base_url")]
-    pub base_url: String,
+    #[serde(default)]
+    pub domain: Option<FeishuDomain>,
+    #[serde(default)]
+    pub base_url: Option<String>,
+    #[serde(default)]
+    pub receive_id_type: Option<String>,
+    #[serde(default)]
+    pub webhook_bind: Option<String>,
+    #[serde(default)]
+    pub webhook_path: Option<String>,
+    #[serde(default)]
+    pub verification_token: Option<String>,
+    #[serde(default)]
+    pub verification_token_env: Option<String>,
+    #[serde(default)]
+    pub encrypt_key: Option<String>,
+    #[serde(default)]
+    pub encrypt_key_env: Option<String>,
+    #[serde(default)]
+    pub allowed_chat_ids: Option<Vec<String>>,
+    #[serde(default)]
+    pub ignore_bot_messages: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedFeishuChannelConfig {
+    pub configured_account_id: String,
+    pub configured_account_label: String,
+    pub account: ChannelAccountIdentity,
+    pub enabled: bool,
+    pub app_id: Option<String>,
+    pub app_secret: Option<String>,
+    pub app_id_env: Option<String>,
+    pub app_secret_env: Option<String>,
+    pub domain: FeishuDomain,
+    pub base_url: Option<String>,
+    pub receive_id_type: String,
+    pub webhook_bind: String,
+    pub webhook_path: String,
+    pub verification_token: Option<String>,
+    pub verification_token_env: Option<String>,
+    pub encrypt_key: Option<String>,
+    pub encrypt_key_env: Option<String>,
+    pub allowed_chat_ids: Vec<String>,
+    pub ignore_bot_messages: bool,
+}
+
+impl ResolvedFeishuChannelConfig {
+    pub fn app_id(&self) -> Option<String> {
+        read_secret_prefer_inline(self.app_id.as_deref(), self.app_id_env.as_deref())
+    }
+
+    pub fn app_secret(&self) -> Option<String> {
+        read_secret_prefer_inline(self.app_secret.as_deref(), self.app_secret_env.as_deref())
+    }
+
+    pub fn verification_token(&self) -> Option<String> {
+        read_secret_prefer_inline(
+            self.verification_token.as_deref(),
+            self.verification_token_env.as_deref(),
+        )
+    }
+
+    pub fn encrypt_key(&self) -> Option<String> {
+        read_secret_prefer_inline(self.encrypt_key.as_deref(), self.encrypt_key_env.as_deref())
+    }
+
+    pub fn resolved_base_url(&self) -> String {
+        self.base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| self.domain.default_base_url().to_owned())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeishuChannelConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub account_id: Option<String>,
+    #[serde(default)]
+    pub default_account: Option<String>,
+    #[serde(default)]
+    pub app_id: Option<String>,
+    #[serde(default)]
+    pub app_secret: Option<String>,
+    #[serde(default)]
+    pub app_id_env: Option<String>,
+    #[serde(default)]
+    pub app_secret_env: Option<String>,
+    #[serde(default)]
+    pub domain: FeishuDomain,
+    #[serde(default)]
+    pub base_url: Option<String>,
     #[serde(default = "default_feishu_receive_id_type")]
     pub receive_id_type: String,
     #[serde(default = "default_feishu_webhook_bind")]
@@ -71,6 +298,8 @@ pub struct FeishuChannelConfig {
     pub allowed_chat_ids: Vec<String>,
     #[serde(default = "default_true")]
     pub ignore_bot_messages: bool,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub accounts: BTreeMap<String, FeishuAccountConfig>,
 }
 
 impl Default for CliChannelConfig {
@@ -87,11 +316,14 @@ impl Default for TelegramChannelConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            account_id: None,
+            default_account: None,
             bot_token: None,
             bot_token_env: Some(TELEGRAM_BOT_TOKEN_ENV.to_owned()),
             base_url: default_telegram_base_url(),
             polling_timeout_s: default_telegram_timeout_seconds(),
             allowed_chat_ids: Vec::new(),
+            accounts: BTreeMap::new(),
         }
     }
 }
@@ -99,36 +331,155 @@ impl Default for TelegramChannelConfig {
 impl TelegramChannelConfig {
     pub(super) fn validate(&self) -> Vec<ConfigValidationIssue> {
         let mut issues = Vec::new();
-        if let Err(issue) = validate_env_pointer_field(
+        validate_channel_account_integrity(
+            &mut issues,
+            "telegram",
+            self.default_account.as_deref(),
+            self.accounts.keys(),
+        );
+        validate_telegram_env_pointer(
+            &mut issues,
             "telegram.bot_token_env",
             self.bot_token_env.as_deref(),
-            EnvPointerValidationHint {
-                inline_field_path: "telegram.bot_token",
-                example_env_name: TELEGRAM_BOT_TOKEN_ENV,
-                detect_telegram_token_shape: true,
-            },
-        ) {
-            issues.push(issue);
+            "telegram.bot_token",
+        );
+        for (raw_account_id, account) in &self.accounts {
+            let account_id = normalize_account_id(raw_account_id);
+            let field_path = format!("telegram.accounts.{account_id}.bot_token_env");
+            let inline_field_path = format!("telegram.accounts.{account_id}.bot_token");
+            validate_telegram_env_pointer(
+                &mut issues,
+                field_path.as_str(),
+                account.bot_token_env.as_deref(),
+                inline_field_path.as_str(),
+            );
         }
         issues
     }
 
-    #[cfg(feature = "channel-telegram")]
     pub fn bot_token(&self) -> Option<String> {
-        if let Some(raw) = self.bot_token.as_deref() {
-            let value = raw.trim();
-            if !value.is_empty() {
-                return Some(value.to_owned());
-            }
+        read_secret_prefer_inline(self.bot_token.as_deref(), self.bot_token_env.as_deref())
+    }
+
+    pub fn configured_account_ids(&self) -> Vec<String> {
+        let ids = configured_account_ids(self.accounts.keys());
+        if ids.is_empty() {
+            return vec![self.default_configured_account_id()];
         }
-        if let Some(env_key) = self.bot_token_env.as_deref() {
-            let value = env::var(env_key).ok()?;
-            let trimmed = value.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_owned());
-            }
+        ids
+    }
+
+    pub fn default_configured_account_selection(&self) -> ChannelDefaultAccountSelection {
+        resolve_default_configured_account_selection(
+            self.accounts.keys(),
+            self.default_account.as_deref(),
+            self.resolved_account_identity().id.as_str(),
+        )
+    }
+
+    pub fn default_configured_account_id(&self) -> String {
+        self.default_configured_account_selection().id
+    }
+
+    pub fn resolved_account_route(
+        &self,
+        requested_account_id: Option<&str>,
+        selected_configured_account_id: &str,
+    ) -> ChannelResolvedAccountRoute {
+        resolve_channel_account_route(
+            self.accounts.keys(),
+            self.default_account.as_deref(),
+            self.resolved_account_identity().id.as_str(),
+            requested_account_id,
+            selected_configured_account_id,
+        )
+    }
+
+    pub fn resolve_account(
+        &self,
+        requested_account_id: Option<&str>,
+    ) -> CliResult<ResolvedTelegramChannelConfig> {
+        let configured = self.resolve_configured_account_selection(requested_account_id)?;
+        let account_override = configured
+            .account_key
+            .as_deref()
+            .and_then(|key| self.accounts.get(key));
+
+        let merged = TelegramChannelConfig {
+            enabled: self.enabled
+                && account_override
+                    .and_then(|account| account.enabled)
+                    .unwrap_or(true),
+            account_id: account_override
+                .and_then(|account| account.account_id.clone())
+                .or_else(|| self.account_id.clone()),
+            default_account: None,
+            bot_token: account_override
+                .and_then(|account| account.bot_token.clone())
+                .or_else(|| self.bot_token.clone()),
+            bot_token_env: account_override
+                .and_then(|account| account.bot_token_env.clone())
+                .or_else(|| self.bot_token_env.clone()),
+            base_url: account_override
+                .and_then(|account| account.base_url.clone())
+                .unwrap_or_else(|| self.base_url.clone()),
+            polling_timeout_s: account_override
+                .and_then(|account| account.polling_timeout_s)
+                .unwrap_or(self.polling_timeout_s),
+            allowed_chat_ids: account_override
+                .and_then(|account| account.allowed_chat_ids.clone())
+                .unwrap_or_else(|| self.allowed_chat_ids.clone()),
+            accounts: BTreeMap::new(),
+        };
+        let account = merged.resolved_account_identity();
+
+        Ok(ResolvedTelegramChannelConfig {
+            configured_account_id: configured.id,
+            configured_account_label: configured.label,
+            account,
+            enabled: merged.enabled,
+            bot_token: merged.bot_token,
+            bot_token_env: merged.bot_token_env,
+            base_url: merged.base_url,
+            polling_timeout_s: merged.polling_timeout_s,
+            allowed_chat_ids: merged.allowed_chat_ids,
+        })
+    }
+
+    pub fn resolved_account_identity(&self) -> ChannelAccountIdentity {
+        if let Some((id, label)) = resolve_configured_account_identity(self.account_id.as_deref()) {
+            return ChannelAccountIdentity {
+                id,
+                label,
+                source: ChannelAccountIdentitySource::Configured,
+            };
         }
-        None
+
+        if let Some(bot_id) = self
+            .bot_token()
+            .as_deref()
+            .and_then(resolve_telegram_bot_id_from_token)
+        {
+            return ChannelAccountIdentity {
+                id: format!("bot_{bot_id}"),
+                label: format!("bot:{bot_id}"),
+                source: ChannelAccountIdentitySource::DerivedCredential,
+            };
+        }
+
+        default_channel_account_identity()
+    }
+
+    fn resolve_configured_account_selection(
+        &self,
+        requested_account_id: Option<&str>,
+    ) -> CliResult<ResolvedConfiguredAccount> {
+        resolve_configured_account_selection(
+            self.accounts.keys(),
+            requested_account_id,
+            self.default_account.as_deref(),
+            self.resolved_account_identity().id.as_str(),
+        )
     }
 }
 
@@ -136,11 +487,14 @@ impl Default for FeishuChannelConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            account_id: None,
+            default_account: None,
             app_id: None,
             app_secret: None,
             app_id_env: Some(FEISHU_APP_ID_ENV.to_owned()),
             app_secret_env: Some(FEISHU_APP_SECRET_ENV.to_owned()),
-            base_url: default_feishu_base_url(),
+            domain: FeishuDomain::Feishu,
+            base_url: None,
             receive_id_type: default_feishu_receive_id_type(),
             webhook_bind: default_feishu_webhook_bind(),
             webhook_path: default_feishu_webhook_path(),
@@ -150,6 +504,7 @@ impl Default for FeishuChannelConfig {
             encrypt_key_env: Some(FEISHU_ENCRYPT_KEY_ENV.to_owned()),
             allowed_chat_ids: Vec::new(),
             ignore_bot_messages: true,
+            accounts: BTreeMap::new(),
         }
     }
 }
@@ -157,64 +512,74 @@ impl Default for FeishuChannelConfig {
 impl FeishuChannelConfig {
     pub(super) fn validate(&self) -> Vec<ConfigValidationIssue> {
         let mut issues = Vec::new();
-        if let Err(issue) = validate_env_pointer_field(
+        validate_channel_account_integrity(
+            &mut issues,
+            "feishu",
+            self.default_account.as_deref(),
+            self.accounts.keys(),
+        );
+        validate_feishu_env_pointer(
+            &mut issues,
             "feishu.app_id_env",
             self.app_id_env.as_deref(),
-            EnvPointerValidationHint {
-                inline_field_path: "feishu.app_id",
-                example_env_name: FEISHU_APP_ID_ENV,
-                detect_telegram_token_shape: false,
-            },
-        ) {
-            issues.push(issue);
-        }
-        if let Err(issue) = validate_env_pointer_field(
+            "feishu.app_id",
+        );
+        validate_feishu_env_pointer(
+            &mut issues,
             "feishu.app_secret_env",
             self.app_secret_env.as_deref(),
-            EnvPointerValidationHint {
-                inline_field_path: "feishu.app_secret",
-                example_env_name: FEISHU_APP_SECRET_ENV,
-                detect_telegram_token_shape: false,
-            },
-        ) {
-            issues.push(issue);
-        }
-        if let Err(issue) = validate_env_pointer_field(
+            "feishu.app_secret",
+        );
+        validate_feishu_env_pointer(
+            &mut issues,
             "feishu.verification_token_env",
             self.verification_token_env.as_deref(),
-            EnvPointerValidationHint {
-                inline_field_path: "feishu.verification_token",
-                example_env_name: FEISHU_VERIFICATION_TOKEN_ENV,
-                detect_telegram_token_shape: false,
-            },
-        ) {
-            issues.push(issue);
-        }
-        if let Err(issue) = validate_env_pointer_field(
+            "feishu.verification_token",
+        );
+        validate_feishu_env_pointer(
+            &mut issues,
             "feishu.encrypt_key_env",
             self.encrypt_key_env.as_deref(),
-            EnvPointerValidationHint {
-                inline_field_path: "feishu.encrypt_key",
-                example_env_name: FEISHU_ENCRYPT_KEY_ENV,
-                detect_telegram_token_shape: false,
-            },
-        ) {
-            issues.push(issue);
+            "feishu.encrypt_key",
+        );
+        for (raw_account_id, account) in &self.accounts {
+            let account_id = normalize_account_id(raw_account_id);
+            validate_feishu_env_pointer(
+                &mut issues,
+                format!("feishu.accounts.{account_id}.app_id_env").as_str(),
+                account.app_id_env.as_deref(),
+                format!("feishu.accounts.{account_id}.app_id").as_str(),
+            );
+            validate_feishu_env_pointer(
+                &mut issues,
+                format!("feishu.accounts.{account_id}.app_secret_env").as_str(),
+                account.app_secret_env.as_deref(),
+                format!("feishu.accounts.{account_id}.app_secret").as_str(),
+            );
+            validate_feishu_env_pointer(
+                &mut issues,
+                format!("feishu.accounts.{account_id}.verification_token_env").as_str(),
+                account.verification_token_env.as_deref(),
+                format!("feishu.accounts.{account_id}.verification_token").as_str(),
+            );
+            validate_feishu_env_pointer(
+                &mut issues,
+                format!("feishu.accounts.{account_id}.encrypt_key_env").as_str(),
+                account.encrypt_key_env.as_deref(),
+                format!("feishu.accounts.{account_id}.encrypt_key").as_str(),
+            );
         }
         issues
     }
 
-    #[cfg(feature = "channel-feishu")]
     pub fn app_id(&self) -> Option<String> {
         read_secret_prefer_inline(self.app_id.as_deref(), self.app_id_env.as_deref())
     }
 
-    #[cfg(feature = "channel-feishu")]
     pub fn app_secret(&self) -> Option<String> {
         read_secret_prefer_inline(self.app_secret.as_deref(), self.app_secret_env.as_deref())
     }
 
-    #[cfg(feature = "channel-feishu")]
     pub fn verification_token(&self) -> Option<String> {
         read_secret_prefer_inline(
             self.verification_token.as_deref(),
@@ -222,9 +587,179 @@ impl FeishuChannelConfig {
         )
     }
 
-    #[cfg(feature = "channel-feishu")]
     pub fn encrypt_key(&self) -> Option<String> {
         read_secret_prefer_inline(self.encrypt_key.as_deref(), self.encrypt_key_env.as_deref())
+    }
+
+    pub fn configured_account_ids(&self) -> Vec<String> {
+        let ids = configured_account_ids(self.accounts.keys());
+        if ids.is_empty() {
+            return vec![self.default_configured_account_id()];
+        }
+        ids
+    }
+
+    pub fn default_configured_account_selection(&self) -> ChannelDefaultAccountSelection {
+        resolve_default_configured_account_selection(
+            self.accounts.keys(),
+            self.default_account.as_deref(),
+            self.resolved_account_identity().id.as_str(),
+        )
+    }
+
+    pub fn default_configured_account_id(&self) -> String {
+        self.default_configured_account_selection().id
+    }
+
+    pub fn resolved_account_route(
+        &self,
+        requested_account_id: Option<&str>,
+        selected_configured_account_id: &str,
+    ) -> ChannelResolvedAccountRoute {
+        resolve_channel_account_route(
+            self.accounts.keys(),
+            self.default_account.as_deref(),
+            self.resolved_account_identity().id.as_str(),
+            requested_account_id,
+            selected_configured_account_id,
+        )
+    }
+
+    pub fn resolve_account(
+        &self,
+        requested_account_id: Option<&str>,
+    ) -> CliResult<ResolvedFeishuChannelConfig> {
+        let configured = self.resolve_configured_account_selection(requested_account_id)?;
+        let account_override = configured
+            .account_key
+            .as_deref()
+            .and_then(|key| self.accounts.get(key));
+
+        let merged = FeishuChannelConfig {
+            enabled: self.enabled
+                && account_override
+                    .and_then(|account| account.enabled)
+                    .unwrap_or(true),
+            account_id: account_override
+                .and_then(|account| account.account_id.clone())
+                .or_else(|| self.account_id.clone()),
+            default_account: None,
+            app_id: account_override
+                .and_then(|account| account.app_id.clone())
+                .or_else(|| self.app_id.clone()),
+            app_secret: account_override
+                .and_then(|account| account.app_secret.clone())
+                .or_else(|| self.app_secret.clone()),
+            app_id_env: account_override
+                .and_then(|account| account.app_id_env.clone())
+                .or_else(|| self.app_id_env.clone()),
+            app_secret_env: account_override
+                .and_then(|account| account.app_secret_env.clone())
+                .or_else(|| self.app_secret_env.clone()),
+            domain: account_override
+                .and_then(|account| account.domain)
+                .unwrap_or(self.domain),
+            base_url: account_override
+                .and_then(|account| account.base_url.clone())
+                .or_else(|| self.base_url.clone()),
+            receive_id_type: account_override
+                .and_then(|account| account.receive_id_type.clone())
+                .unwrap_or_else(|| self.receive_id_type.clone()),
+            webhook_bind: account_override
+                .and_then(|account| account.webhook_bind.clone())
+                .unwrap_or_else(|| self.webhook_bind.clone()),
+            webhook_path: account_override
+                .and_then(|account| account.webhook_path.clone())
+                .unwrap_or_else(|| self.webhook_path.clone()),
+            verification_token: account_override
+                .and_then(|account| account.verification_token.clone())
+                .or_else(|| self.verification_token.clone()),
+            verification_token_env: account_override
+                .and_then(|account| account.verification_token_env.clone())
+                .or_else(|| self.verification_token_env.clone()),
+            encrypt_key: account_override
+                .and_then(|account| account.encrypt_key.clone())
+                .or_else(|| self.encrypt_key.clone()),
+            encrypt_key_env: account_override
+                .and_then(|account| account.encrypt_key_env.clone())
+                .or_else(|| self.encrypt_key_env.clone()),
+            allowed_chat_ids: account_override
+                .and_then(|account| account.allowed_chat_ids.clone())
+                .unwrap_or_else(|| self.allowed_chat_ids.clone()),
+            ignore_bot_messages: account_override
+                .and_then(|account| account.ignore_bot_messages)
+                .unwrap_or(self.ignore_bot_messages),
+            accounts: BTreeMap::new(),
+        };
+        let account = merged.resolved_account_identity();
+
+        Ok(ResolvedFeishuChannelConfig {
+            configured_account_id: configured.id,
+            configured_account_label: configured.label,
+            account,
+            enabled: merged.enabled,
+            app_id: merged.app_id,
+            app_secret: merged.app_secret,
+            app_id_env: merged.app_id_env,
+            app_secret_env: merged.app_secret_env,
+            domain: merged.domain,
+            base_url: merged.base_url,
+            receive_id_type: merged.receive_id_type,
+            webhook_bind: merged.webhook_bind,
+            webhook_path: merged.webhook_path,
+            verification_token: merged.verification_token,
+            verification_token_env: merged.verification_token_env,
+            encrypt_key: merged.encrypt_key,
+            encrypt_key_env: merged.encrypt_key_env,
+            allowed_chat_ids: merged.allowed_chat_ids,
+            ignore_bot_messages: merged.ignore_bot_messages,
+        })
+    }
+
+    pub fn resolved_account_identity(&self) -> ChannelAccountIdentity {
+        if let Some((id, label)) = resolve_configured_account_identity(self.account_id.as_deref()) {
+            return ChannelAccountIdentity {
+                id,
+                label,
+                source: ChannelAccountIdentitySource::Configured,
+            };
+        }
+
+        if let Some(app_id) = self
+            .app_id()
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return ChannelAccountIdentity {
+                id: format!("{}_{}", self.domain.as_str(), normalize_account_id(app_id)),
+                label: format!("{}:{app_id}", self.domain.as_str()),
+                source: ChannelAccountIdentitySource::DerivedCredential,
+            };
+        }
+
+        default_channel_account_identity()
+    }
+
+    pub fn resolved_base_url(&self) -> String {
+        self.base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| self.domain.default_base_url().to_owned())
+    }
+
+    fn resolve_configured_account_selection(
+        &self,
+        requested_account_id: Option<&str>,
+    ) -> CliResult<ResolvedConfiguredAccount> {
+        resolve_configured_account_selection(
+            self.accounts.keys(),
+            requested_account_id,
+            self.default_account.as_deref(),
+            self.resolved_account_identity().id.as_str(),
+        )
     }
 }
 
@@ -234,10 +769,6 @@ fn default_telegram_base_url() -> String {
 
 const fn default_telegram_timeout_seconds() -> u64 {
     15
-}
-
-fn default_feishu_base_url() -> String {
-    "https://open.feishu.cn".to_owned()
 }
 
 fn default_feishu_receive_id_type() -> String {
@@ -262,4 +793,695 @@ fn default_exit_commands() -> Vec<String> {
 
 const fn default_true() -> bool {
     true
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedConfiguredAccount {
+    id: String,
+    label: String,
+    account_key: Option<String>,
+}
+
+fn default_channel_account_identity() -> ChannelAccountIdentity {
+    ChannelAccountIdentity {
+        id: "default".to_owned(),
+        label: "default".to_owned(),
+        source: ChannelAccountIdentitySource::Default,
+    }
+}
+
+fn resolve_configured_account_identity(raw: Option<&str>) -> Option<(String, String)> {
+    let label = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    Some((normalize_account_id(label), label.to_owned()))
+}
+
+fn resolve_telegram_bot_id_from_token(token: &str) -> Option<&str> {
+    let bot_id = token.split(':').next()?.trim();
+    if bot_id.is_empty() || !bot_id.chars().all(|value| value.is_ascii_digit()) {
+        return None;
+    }
+    Some(bot_id)
+}
+
+fn normalize_account_id(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "default".to_owned();
+    }
+
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut last_was_separator = false;
+    for value in trimmed.chars() {
+        if value.is_ascii_alphanumeric() {
+            normalized.push(value.to_ascii_lowercase());
+            last_was_separator = false;
+            continue;
+        }
+        if matches!(value, '_' | '-') {
+            if !normalized.is_empty() && !last_was_separator {
+                normalized.push(value);
+                last_was_separator = true;
+            }
+            continue;
+        }
+        if !normalized.is_empty() && !last_was_separator {
+            normalized.push('-');
+            last_was_separator = true;
+        }
+    }
+
+    while matches!(normalized.chars().last(), Some('-' | '_')) {
+        normalized.pop();
+    }
+
+    if normalized.is_empty() {
+        "default".to_owned()
+    } else {
+        normalized
+    }
+}
+
+fn validate_telegram_env_pointer(
+    issues: &mut Vec<ConfigValidationIssue>,
+    field_path: &str,
+    env_key: Option<&str>,
+    inline_field_path: &str,
+) {
+    if let Err(issue) = validate_env_pointer_field(
+        field_path,
+        env_key,
+        EnvPointerValidationHint {
+            inline_field_path,
+            example_env_name: TELEGRAM_BOT_TOKEN_ENV,
+            detect_telegram_token_shape: true,
+        },
+    ) {
+        issues.push(*issue);
+    }
+}
+
+fn validate_feishu_env_pointer(
+    issues: &mut Vec<ConfigValidationIssue>,
+    field_path: &str,
+    env_key: Option<&str>,
+    inline_field_path: &str,
+) {
+    let example_env_name = if field_path.ends_with("app_id_env") {
+        FEISHU_APP_ID_ENV
+    } else if field_path.ends_with("app_secret_env") {
+        FEISHU_APP_SECRET_ENV
+    } else if field_path.ends_with("verification_token_env") {
+        FEISHU_VERIFICATION_TOKEN_ENV
+    } else {
+        FEISHU_ENCRYPT_KEY_ENV
+    };
+    if let Err(issue) = validate_env_pointer_field(
+        field_path,
+        env_key,
+        EnvPointerValidationHint {
+            inline_field_path,
+            example_env_name,
+            detect_telegram_token_shape: false,
+        },
+    ) {
+        issues.push(*issue);
+    }
+}
+
+fn validate_channel_account_integrity<'a, I>(
+    issues: &mut Vec<ConfigValidationIssue>,
+    channel_key: &str,
+    default_account: Option<&str>,
+    keys: I,
+) where
+    I: IntoIterator<Item = &'a String>,
+{
+    let mut normalized_to_labels = BTreeMap::<String, Vec<String>>::new();
+    for raw_key in keys {
+        let label = raw_key.trim();
+        if label.is_empty() {
+            continue;
+        }
+        normalized_to_labels
+            .entry(normalize_account_id(label))
+            .or_default()
+            .push(label.to_owned());
+    }
+
+    for (normalized_account_id, labels) in &normalized_to_labels {
+        if labels.len() < 2 {
+            continue;
+        }
+        let mut extra_message_variables = BTreeMap::new();
+        extra_message_variables.insert(
+            "normalized_account_id".to_owned(),
+            normalized_account_id.clone(),
+        );
+        extra_message_variables.insert("raw_account_labels".to_owned(), labels.join(", "));
+        issues.push(ConfigValidationIssue {
+            code: ConfigValidationCode::DuplicateChannelAccountId,
+            field_path: format!("{channel_key}.accounts"),
+            inline_field_path: format!("{channel_key}.accounts.{normalized_account_id}"),
+            example_env_name: String::new(),
+            suggested_env_name: None,
+            extra_message_variables,
+        });
+    }
+
+    if normalized_to_labels.is_empty() {
+        return;
+    }
+
+    let Some(requested_default_account) = default_account
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+    let normalized_default_account = normalize_account_id(requested_default_account);
+    if normalized_to_labels.contains_key(&normalized_default_account) {
+        return;
+    }
+
+    let mut extra_message_variables = BTreeMap::new();
+    extra_message_variables.insert(
+        "requested_account_id".to_owned(),
+        normalized_default_account.clone(),
+    );
+    extra_message_variables.insert(
+        "configured_account_ids".to_owned(),
+        normalized_to_labels
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+    issues.push(ConfigValidationIssue {
+        code: ConfigValidationCode::UnknownChannelDefaultAccount,
+        field_path: format!("{channel_key}.default_account"),
+        inline_field_path: format!("{channel_key}.accounts"),
+        example_env_name: String::new(),
+        suggested_env_name: None,
+        extra_message_variables,
+    });
+}
+
+fn configured_account_ids<'a, I>(keys: I) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    let mut ids = keys
+        .into_iter()
+        .map(|value| normalize_account_id(value))
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+fn normalize_optional_account_id(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(normalize_account_id)
+}
+
+fn resolve_default_configured_account_selection_from_ids(
+    ids: &[String],
+    preferred: Option<&str>,
+    fallback: &str,
+) -> ChannelDefaultAccountSelection {
+    if let Some(preferred) = normalize_optional_account_id(preferred) {
+        if !ids.is_empty() && ids.iter().any(|value| value == &preferred) {
+            return ChannelDefaultAccountSelection {
+                id: preferred,
+                source: ChannelDefaultAccountSelectionSource::ExplicitDefault,
+            };
+        }
+    }
+    if ids.is_empty() {
+        return ChannelDefaultAccountSelection {
+            id: normalize_account_id(fallback),
+            source: ChannelDefaultAccountSelectionSource::RuntimeIdentity,
+        };
+    }
+    if ids.iter().any(|value| value == "default") {
+        return ChannelDefaultAccountSelection {
+            id: "default".to_owned(),
+            source: ChannelDefaultAccountSelectionSource::MappedDefault,
+        };
+    }
+    ChannelDefaultAccountSelection {
+        id: ids
+            .first()
+            .cloned()
+            .unwrap_or_else(|| normalize_account_id(fallback)),
+        source: ChannelDefaultAccountSelectionSource::Fallback,
+    }
+}
+
+fn resolve_default_configured_account_selection<'a, I>(
+    keys: I,
+    preferred: Option<&str>,
+    fallback: &str,
+) -> ChannelDefaultAccountSelection
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    let ids = configured_account_ids(keys);
+    resolve_default_configured_account_selection_from_ids(ids.as_slice(), preferred, fallback)
+}
+
+fn resolve_channel_account_route<'a, I>(
+    keys: I,
+    preferred: Option<&str>,
+    fallback: &str,
+    requested_account_id: Option<&str>,
+    selected_configured_account_id: &str,
+) -> ChannelResolvedAccountRoute
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    let ids = configured_account_ids(keys);
+    let default_selection =
+        resolve_default_configured_account_selection_from_ids(ids.as_slice(), preferred, fallback);
+    ChannelResolvedAccountRoute {
+        requested_account_id: normalize_optional_account_id(requested_account_id),
+        configured_account_count: ids.len(),
+        selected_configured_account_id: normalize_account_id(selected_configured_account_id),
+        default_account_source: default_selection.source,
+    }
+}
+
+fn resolve_configured_account_selection<'a, I>(
+    keys: I,
+    requested_account_id: Option<&str>,
+    preferred_default_account_id: Option<&str>,
+    fallback_id: &str,
+) -> CliResult<ResolvedConfiguredAccount>
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    let entries = keys
+        .into_iter()
+        .filter_map(|value| {
+            let raw_key = value.to_owned();
+            let label = value.trim();
+            if label.is_empty() {
+                return None;
+            }
+            Some((normalize_account_id(label), label.to_owned(), raw_key))
+        })
+        .collect::<Vec<_>>();
+    let configured_ids = entries
+        .iter()
+        .map(|(id, _, _)| id.clone())
+        .collect::<Vec<_>>();
+
+    if let Some(requested) = requested_account_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(normalize_account_id)
+    {
+        if entries.is_empty() {
+            return Ok(ResolvedConfiguredAccount {
+                label: requested.clone(),
+                id: requested,
+                account_key: None,
+            });
+        }
+        let Some((id, label, raw_key)) = entries.iter().find(|(id, _, _)| *id == requested) else {
+            return Err(format!(
+                "requested account `{requested}` is not configured (configured accounts: {})",
+                configured_ids.join(", ")
+            ));
+        };
+        return Ok(ResolvedConfiguredAccount {
+            id: id.clone(),
+            label: label.clone(),
+            account_key: Some(raw_key.clone()),
+        });
+    }
+
+    let default_id = resolve_default_configured_account_selection(
+        entries.iter().map(|(_, _, raw_key)| raw_key),
+        preferred_default_account_id,
+        fallback_id,
+    )
+    .id;
+    if let Some((id, label, raw_key)) = entries.iter().find(|(id, _, _)| *id == default_id) {
+        return Ok(ResolvedConfiguredAccount {
+            id: id.clone(),
+            label: label.clone(),
+            account_key: Some(raw_key.clone()),
+        });
+    }
+
+    Ok(ResolvedConfiguredAccount {
+        id: default_id.clone(),
+        label: default_id,
+        account_key: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn telegram_account_identity_prefers_explicit_account_id() {
+        let config: TelegramChannelConfig = serde_json::from_value(json!({
+            "account_id": "Ops-Bot",
+            "bot_token": "123456:token-value"
+        }))
+        .expect("deserialize telegram config");
+
+        let identity = config.resolved_account_identity();
+        assert_eq!(identity.id, "ops-bot");
+        assert_eq!(identity.label, "Ops-Bot");
+    }
+
+    #[test]
+    fn telegram_account_identity_derives_from_bot_token_prefix() {
+        let config = TelegramChannelConfig {
+            bot_token: Some("987654:token-value".to_owned()),
+            bot_token_env: None,
+            ..TelegramChannelConfig::default()
+        };
+
+        let identity = config.resolved_account_identity();
+        assert_eq!(identity.id, "bot_987654");
+        assert_eq!(identity.label, "bot:987654");
+    }
+
+    #[test]
+    fn feishu_account_identity_prefers_explicit_account_id() {
+        let config: FeishuChannelConfig = serde_json::from_value(json!({
+            "account_id": "Customer-Support",
+            "app_id": "cli_a1b2c3",
+            "domain": "lark"
+        }))
+        .expect("deserialize feishu config");
+
+        let identity = config.resolved_account_identity();
+        assert_eq!(identity.id, "customer-support");
+        assert_eq!(identity.label, "Customer-Support");
+    }
+
+    #[test]
+    fn feishu_account_identity_derives_from_domain_and_app_id() {
+        let config = FeishuChannelConfig {
+            app_id: Some("cli_a1b2c3".to_owned()),
+            app_id_env: None,
+            domain: FeishuDomain::Lark,
+            ..FeishuChannelConfig::default()
+        };
+
+        let identity = config.resolved_account_identity();
+        assert_eq!(identity.id, "lark_cli_a1b2c3");
+        assert_eq!(identity.label, "lark:cli_a1b2c3");
+    }
+
+    #[test]
+    fn telegram_multi_account_resolution_merges_base_and_account_overrides() {
+        let config: TelegramChannelConfig = serde_json::from_value(json!({
+            "enabled": true,
+            "bot_token_env": "BASE_TELEGRAM_TOKEN",
+            "polling_timeout_s": 25,
+            "allowed_chat_ids": [1001],
+            "default_account": "Work Bot",
+            "accounts": {
+                "Work Bot": {
+                    "account_id": "Ops-Bot",
+                    "bot_token_env": "WORK_TELEGRAM_TOKEN",
+                    "allowed_chat_ids": [2002]
+                },
+                "Personal": {
+                    "enabled": false,
+                    "bot_token_env": "PERSONAL_TELEGRAM_TOKEN"
+                }
+            }
+        }))
+        .expect("deserialize telegram multi-account config");
+
+        assert_eq!(
+            config.configured_account_ids(),
+            vec!["personal", "work-bot"]
+        );
+        assert_eq!(config.default_configured_account_id(), "work-bot");
+
+        let resolved = config
+            .resolve_account(None)
+            .expect("resolve default telegram account");
+        assert_eq!(resolved.configured_account_id, "work-bot");
+        assert_eq!(resolved.account.id, "ops-bot");
+        assert_eq!(resolved.account.label, "Ops-Bot");
+        assert_eq!(
+            resolved.bot_token_env.as_deref(),
+            Some("WORK_TELEGRAM_TOKEN")
+        );
+        assert_eq!(resolved.allowed_chat_ids, vec![2002]);
+        assert_eq!(resolved.polling_timeout_s, 25);
+
+        let disabled = config
+            .resolve_account(Some("Personal"))
+            .expect("resolve explicit telegram account");
+        assert_eq!(disabled.configured_account_id, "personal");
+        assert!(!disabled.enabled);
+        assert_eq!(disabled.allowed_chat_ids, vec![1001]);
+    }
+
+    #[test]
+    fn telegram_default_account_selection_source_tracks_explicit_default() {
+        let config: TelegramChannelConfig = serde_json::from_value(json!({
+            "default_account": "Work Bot",
+            "accounts": {
+                "Work Bot": {
+                    "bot_token_env": "WORK_TELEGRAM_TOKEN"
+                },
+                "Personal": {
+                    "bot_token_env": "PERSONAL_TELEGRAM_TOKEN"
+                }
+            }
+        }))
+        .expect("deserialize telegram config");
+
+        let selection = config.default_configured_account_selection();
+        assert_eq!(selection.id, "work-bot");
+        assert_eq!(
+            selection.source,
+            ChannelDefaultAccountSelectionSource::ExplicitDefault
+        );
+    }
+
+    #[test]
+    fn telegram_default_account_selection_source_tracks_mapped_default() {
+        let config: TelegramChannelConfig = serde_json::from_value(json!({
+            "accounts": {
+                "default": {
+                    "bot_token_env": "DEFAULT_TELEGRAM_TOKEN"
+                },
+                "Work": {
+                    "bot_token_env": "WORK_TELEGRAM_TOKEN"
+                }
+            }
+        }))
+        .expect("deserialize telegram config");
+
+        let selection = config.default_configured_account_selection();
+        assert_eq!(selection.id, "default");
+        assert_eq!(
+            selection.source,
+            ChannelDefaultAccountSelectionSource::MappedDefault
+        );
+    }
+
+    #[test]
+    fn telegram_default_account_selection_source_tracks_sorted_fallback() {
+        let config: TelegramChannelConfig = serde_json::from_value(json!({
+            "accounts": {
+                "Work": {
+                    "bot_token_env": "WORK_TELEGRAM_TOKEN"
+                },
+                "Alerts": {
+                    "bot_token_env": "ALERTS_TELEGRAM_TOKEN"
+                }
+            }
+        }))
+        .expect("deserialize telegram config");
+
+        let selection = config.default_configured_account_selection();
+        assert_eq!(selection.id, "alerts");
+        assert_eq!(
+            selection.source,
+            ChannelDefaultAccountSelectionSource::Fallback
+        );
+    }
+
+    #[test]
+    fn telegram_default_account_does_not_override_single_account_fallback_identity() {
+        let config: TelegramChannelConfig = serde_json::from_value(json!({
+            "enabled": true,
+            "default_account": "Work Bot",
+            "bot_token": "123456:token-value",
+            "allowed_chat_ids": [1001]
+        }))
+        .expect("deserialize single-account telegram config");
+
+        let selection = config.default_configured_account_selection();
+        assert_eq!(selection.id, "bot_123456");
+        assert_eq!(
+            selection.source,
+            ChannelDefaultAccountSelectionSource::RuntimeIdentity
+        );
+
+        let resolved = config
+            .resolve_account(None)
+            .expect("resolve single-account telegram config");
+        assert_eq!(resolved.configured_account_id, "bot_123456");
+        assert_eq!(resolved.account.id, "bot_123456");
+    }
+
+    #[test]
+    fn telegram_resolved_account_route_flags_implicit_multi_account_fallback() {
+        let config: TelegramChannelConfig = serde_json::from_value(json!({
+            "accounts": {
+                "Work": {
+                    "bot_token_env": "WORK_TELEGRAM_TOKEN"
+                },
+                "Alerts": {
+                    "bot_token_env": "ALERTS_TELEGRAM_TOKEN"
+                }
+            }
+        }))
+        .expect("deserialize telegram config");
+
+        let resolved = config
+            .resolve_account(None)
+            .expect("resolve default telegram account");
+        let route = config.resolved_account_route(None, resolved.configured_account_id.as_str());
+
+        assert!(route.selected_by_default());
+        assert_eq!(route.selected_configured_account_id, "alerts");
+        assert_eq!(route.configured_account_count, 2);
+        assert_eq!(
+            route.default_account_source,
+            ChannelDefaultAccountSelectionSource::Fallback
+        );
+        assert!(route.uses_implicit_fallback_default());
+    }
+
+    #[test]
+    fn telegram_resolved_account_route_does_not_flag_explicit_account_request() {
+        let config: TelegramChannelConfig = serde_json::from_value(json!({
+            "accounts": {
+                "Work": {
+                    "bot_token_env": "WORK_TELEGRAM_TOKEN"
+                },
+                "Alerts": {
+                    "bot_token_env": "ALERTS_TELEGRAM_TOKEN"
+                }
+            }
+        }))
+        .expect("deserialize telegram config");
+
+        let resolved = config
+            .resolve_account(Some("Work"))
+            .expect("resolve explicit telegram account");
+        let route =
+            config.resolved_account_route(Some("Work"), resolved.configured_account_id.as_str());
+
+        assert!(!route.selected_by_default());
+        assert_eq!(route.requested_account_id.as_deref(), Some("work"));
+        assert_eq!(route.selected_configured_account_id, "work");
+        assert!(!route.uses_implicit_fallback_default());
+    }
+
+    #[test]
+    fn feishu_multi_account_resolution_merges_base_and_account_overrides() {
+        let config: FeishuChannelConfig = serde_json::from_value(json!({
+            "enabled": true,
+            "app_id_env": "BASE_FEISHU_APP_ID",
+            "app_secret_env": "BASE_FEISHU_APP_SECRET",
+            "verification_token_env": "BASE_FEISHU_VERIFY",
+            "encrypt_key_env": "BASE_FEISHU_ENCRYPT",
+            "receive_id_type": "chat_id",
+            "webhook_bind": "127.0.0.1:8080",
+            "webhook_path": "/feishu/events",
+            "allowed_chat_ids": ["oc_base"],
+            "default_account": "Lark Prod",
+            "accounts": {
+                "Lark Prod": {
+                    "domain": "lark",
+                    "app_id": "cli_lark_123",
+                    "app_secret": "secret",
+                    "verification_token": "verify",
+                    "encrypt_key": "encrypt",
+                    "allowed_chat_ids": ["oc_lark"]
+                },
+                "Feishu Backup": {
+                    "enabled": false,
+                    "app_id": "cli_backup_456",
+                    "app_secret": "secret"
+                }
+            }
+        }))
+        .expect("deserialize feishu multi-account config");
+
+        assert_eq!(
+            config.configured_account_ids(),
+            vec!["feishu-backup", "lark-prod"]
+        );
+        assert_eq!(config.default_configured_account_id(), "lark-prod");
+
+        let resolved = config
+            .resolve_account(None)
+            .expect("resolve default feishu account");
+        assert_eq!(resolved.configured_account_id, "lark-prod");
+        assert_eq!(resolved.domain, FeishuDomain::Lark);
+        assert_eq!(resolved.account.id, "lark_cli_lark_123");
+        assert_eq!(resolved.account.label, "lark:cli_lark_123");
+        assert_eq!(resolved.allowed_chat_ids, vec!["oc_lark".to_owned()]);
+        assert_eq!(resolved.receive_id_type, "chat_id");
+        assert_eq!(resolved.resolved_base_url(), "https://open.larksuite.com");
+
+        let disabled = config
+            .resolve_account(Some("Feishu Backup"))
+            .expect("resolve explicit feishu account");
+        assert_eq!(disabled.configured_account_id, "feishu-backup");
+        assert!(!disabled.enabled);
+        assert_eq!(disabled.allowed_chat_ids, vec!["oc_base".to_owned()]);
+    }
+
+    #[test]
+    fn feishu_resolved_account_route_tracks_explicit_default_without_fallback_warning() {
+        let config: FeishuChannelConfig = serde_json::from_value(json!({
+            "default_account": "Lark Prod",
+            "accounts": {
+                "Lark Prod": {
+                    "domain": "lark",
+                    "app_id": "cli_lark_123",
+                    "app_secret": "secret"
+                },
+                "Feishu Backup": {
+                    "app_id": "cli_backup_456",
+                    "app_secret": "secret"
+                }
+            }
+        }))
+        .expect("deserialize feishu config");
+
+        let resolved = config
+            .resolve_account(None)
+            .expect("resolve default feishu account");
+        let route = config.resolved_account_route(None, resolved.configured_account_id.as_str());
+
+        assert!(route.selected_by_default());
+        assert_eq!(route.selected_configured_account_id, "lark-prod");
+        assert_eq!(
+            route.default_account_source,
+            ChannelDefaultAccountSelectionSource::ExplicitDefault
+        );
+        assert!(!route.uses_implicit_fallback_default());
+    }
 }

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -5,7 +5,12 @@ mod shared;
 mod tools_memory;
 
 #[allow(unused_imports)]
-pub use channels::{CliChannelConfig, FeishuChannelConfig, TelegramChannelConfig};
+pub use channels::{
+    ChannelDefaultAccountSelection, ChannelDefaultAccountSelectionSource,
+    ChannelResolvedAccountRoute, CliChannelConfig, FeishuAccountConfig, FeishuChannelConfig,
+    FeishuDomain, ResolvedFeishuChannelConfig, ResolvedTelegramChannelConfig,
+    TelegramAccountConfig, TelegramChannelConfig,
+};
 #[allow(unused_imports)]
 pub use provider::{ProviderConfig, ProviderKind, ReasoningEffort};
 #[allow(unused_imports)]
@@ -380,6 +385,85 @@ kind = "kimi_coding"
     }
 
     #[test]
+    fn config_validation_rejects_duplicate_normalized_telegram_account_ids() {
+        let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
+            "telegram": {
+                "accounts": {
+                    "Work Bot": {
+                        "bot_token_env": "WORK_TELEGRAM_TOKEN"
+                    },
+                    "work-bot": {
+                        "bot_token_env": "WORK_TELEGRAM_TOKEN_DUP"
+                    }
+                }
+            }
+        }))
+        .expect("deserialize telegram duplicate-account config");
+
+        let error = config
+            .validate()
+            .expect_err("duplicate normalized telegram account ids should fail");
+        assert!(error.contains("config.channel_account.duplicate_id"));
+        assert!(error.contains("telegram.accounts"));
+        assert!(error.contains("work-bot"));
+        assert!(error.contains("Work Bot"));
+    }
+
+    #[test]
+    fn config_validation_rejects_duplicate_normalized_feishu_account_ids() {
+        let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
+            "feishu": {
+                "accounts": {
+                    "Lark Prod": {
+                        "app_id_env": "LARK_APP_ID",
+                        "app_secret_env": "LARK_APP_SECRET"
+                    },
+                    "lark-prod": {
+                        "app_id_env": "LARK_APP_ID_DUP",
+                        "app_secret_env": "LARK_APP_SECRET_DUP"
+                    }
+                }
+            }
+        }))
+        .expect("deserialize feishu duplicate-account config");
+
+        let error = config
+            .validate()
+            .expect_err("duplicate normalized feishu account ids should fail");
+        assert!(error.contains("config.channel_account.duplicate_id"));
+        assert!(error.contains("feishu.accounts"));
+        assert!(error.contains("lark-prod"));
+        assert!(error.contains("Lark Prod"));
+    }
+
+    #[test]
+    fn config_validation_rejects_unknown_telegram_default_account() {
+        let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
+            "telegram": {
+                "default_account": "missing",
+                "accounts": {
+                    "alpha": {
+                        "bot_token_env": "ALPHA_TELEGRAM_TOKEN"
+                    },
+                    "beta": {
+                        "bot_token_env": "BETA_TELEGRAM_TOKEN"
+                    }
+                }
+            }
+        }))
+        .expect("deserialize telegram unknown-default config");
+
+        let error = config
+            .validate()
+            .expect_err("unknown telegram default account should fail");
+        assert!(error.contains("config.channel_account.unknown_default"));
+        assert!(error.contains("telegram.default_account"));
+        assert!(error.contains("missing"));
+        assert!(error.contains("alpha"));
+        assert!(error.contains("beta"));
+    }
+
+    #[test]
     fn config_validation_accepts_shell_style_env_names() {
         let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("KIMI_CODING_API_KEY".to_owned());
@@ -549,7 +633,9 @@ kind = "kimi_coding"
     #[test]
     fn feishu_defaults_are_stable() {
         let config = FeishuChannelConfig::default();
-        assert_eq!(config.base_url, "https://open.feishu.cn");
+        assert_eq!(config.domain, FeishuDomain::Feishu);
+        assert_eq!(config.base_url, None);
+        assert_eq!(config.resolved_base_url(), "https://open.feishu.cn");
         assert_eq!(config.receive_id_type, "chat_id");
         assert_eq!(config.webhook_bind, "127.0.0.1:8080");
         assert_eq!(config.webhook_path, "/feishu/events");
@@ -558,6 +644,28 @@ kind = "kimi_coding"
             Some("FEISHU_ENCRYPT_KEY")
         );
         assert!(config.ignore_bot_messages);
+    }
+
+    #[test]
+    fn feishu_lark_domain_uses_lark_base_url_when_base_url_not_set() {
+        let config = FeishuChannelConfig {
+            domain: FeishuDomain::Lark,
+            base_url: None,
+            ..FeishuChannelConfig::default()
+        };
+
+        assert_eq!(config.resolved_base_url(), "https://open.larksuite.com");
+    }
+
+    #[test]
+    fn feishu_explicit_base_url_overrides_domain_default() {
+        let config = FeishuChannelConfig {
+            domain: FeishuDomain::Lark,
+            base_url: Some("https://example.internal".to_owned()),
+            ..FeishuChannelConfig::default()
+        };
+
+        assert_eq!(config.resolved_base_url(), "https://example.internal");
     }
 
     #[test]

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -149,7 +149,7 @@ impl ProviderConfig {
                 detect_telegram_token_shape: false,
             },
         ) {
-            issues.push(issue);
+            issues.push(*issue);
         }
         let oauth_example = self
             .kind
@@ -164,7 +164,7 @@ impl ProviderConfig {
                 detect_telegram_token_shape: false,
             },
         ) {
-            issues.push(issue);
+            issues.push(*issue);
         }
         issues
     }

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -431,6 +431,50 @@ api_key_env = "$OPENAI_API_KEY"
 
     #[test]
     #[cfg(feature = "config-toml")]
+    fn validate_file_returns_channel_account_diagnostics() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let temp_dir =
+            std::env::temp_dir().join(format!("loongclaw-config-channel-account-{unique}"));
+        std::fs::create_dir_all(&temp_dir).expect("create temp directory");
+        let config_path = temp_dir.join("config.toml");
+        let raw = r#"
+[telegram.accounts."Work Bot"]
+bot_token_env = "WORK_TELEGRAM_TOKEN"
+
+[telegram.accounts."work-bot"]
+bot_token_env = "WORK_TELEGRAM_TOKEN_DUP"
+"#;
+        std::fs::write(&config_path, raw).expect("write test config");
+
+        let (_, diagnostics) = validate_file(Some(config_path.to_string_lossy().as_ref()))
+            .expect("validate_file should parse and return diagnostics");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "config.channel_account.duplicate_id");
+        assert_eq!(
+            diagnostics[0].problem_type,
+            "urn:loongclaw:problem:config.channel_account.duplicate_id"
+        );
+        assert_eq!(diagnostics[0].field_path, "telegram.accounts");
+        assert_eq!(
+            diagnostics[0]
+                .message_variables
+                .get("normalized_account_id"),
+            Some(&"work-bot".to_owned())
+        );
+        assert_eq!(
+            diagnostics[0].message_variables.get("raw_account_labels"),
+            Some(&"Work Bot, work-bot".to_owned())
+        );
+
+        std::fs::remove_file(&config_path).ok();
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
     fn validate_file_locale_tag_aliases_normalize_to_en() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -46,6 +46,8 @@ pub(super) enum ConfigValidationCode {
     PercentWrapped,
     SecretLiteral,
     InvalidName,
+    DuplicateChannelAccountId,
+    UnknownChannelDefaultAccount,
 }
 
 impl ConfigValidationCode {
@@ -56,6 +58,12 @@ impl ConfigValidationCode {
             ConfigValidationCode::PercentWrapped => "config.env_pointer.percent_wrapped",
             ConfigValidationCode::SecretLiteral => "config.env_pointer.secret_literal",
             ConfigValidationCode::InvalidName => "config.env_pointer.invalid_name",
+            ConfigValidationCode::DuplicateChannelAccountId => {
+                "config.channel_account.duplicate_id"
+            }
+            ConfigValidationCode::UnknownChannelDefaultAccount => {
+                "config.channel_account.unknown_default"
+            }
         }
     }
 
@@ -76,6 +84,12 @@ impl ConfigValidationCode {
             ConfigValidationCode::InvalidName => {
                 "urn:loongclaw:problem:config.env_pointer.invalid_name"
             }
+            ConfigValidationCode::DuplicateChannelAccountId => {
+                "urn:loongclaw:problem:config.channel_account.duplicate_id"
+            }
+            ConfigValidationCode::UnknownChannelDefaultAccount => {
+                "urn:loongclaw:problem:config.channel_account.unknown_default"
+            }
         }
     }
 
@@ -86,6 +100,12 @@ impl ConfigValidationCode {
             ConfigValidationCode::PercentWrapped => "config.env_pointer.percent_wrapped.title",
             ConfigValidationCode::SecretLiteral => "config.env_pointer.secret_literal.title",
             ConfigValidationCode::InvalidName => "config.env_pointer.invalid_name.title",
+            ConfigValidationCode::DuplicateChannelAccountId => {
+                "config.channel_account.duplicate_id.title"
+            }
+            ConfigValidationCode::UnknownChannelDefaultAccount => {
+                "config.channel_account.unknown_default.title"
+            }
         }
     }
 
@@ -106,6 +126,10 @@ impl ConfigValidationCode {
             ConfigValidationCode::PercentWrapped => "Percent-Wrapped Env Pointer Notation",
             ConfigValidationCode::SecretLiteral => "Secret Literal Used In Env Pointer",
             ConfigValidationCode::InvalidName => "Invalid Env Pointer Name",
+            ConfigValidationCode::DuplicateChannelAccountId => {
+                "Duplicate Normalized Channel Account ID"
+            }
+            ConfigValidationCode::UnknownChannelDefaultAccount => "Unknown Channel Default Account",
         }
     }
 
@@ -126,6 +150,12 @@ impl ConfigValidationCode {
             ConfigValidationCode::InvalidName => {
                 "[{code}] {field_path} is not a valid environment variable name reference. use `{field_path}` with a name like `{example_env_name}`"
             }
+            ConfigValidationCode::DuplicateChannelAccountId => {
+                "[{code}] {field_path} contains duplicate configured accounts that normalize to `{normalized_account_id}`: {raw_account_labels}. rename one of the account keys so each normalized account id is unique"
+            }
+            ConfigValidationCode::UnknownChannelDefaultAccount => {
+                "[{code}] {field_path} points to `{requested_account_id}`, but configured accounts are: {configured_account_ids}. set `{field_path}` to one of the configured account ids"
+            }
         }
     }
 }
@@ -137,6 +167,7 @@ pub(super) struct ConfigValidationIssue {
     pub inline_field_path: String,
     pub example_env_name: String,
     pub suggested_env_name: Option<String>,
+    pub extra_message_variables: BTreeMap<String, String>,
 }
 
 impl ConfigValidationIssue {
@@ -166,6 +197,7 @@ impl ConfigValidationIssue {
             .as_deref()
             .unwrap_or(self.example_env_name.as_str());
         variables.insert("suggested_env_name".to_owned(), suggested.to_owned());
+        variables.extend(self.extra_message_variables.clone());
         variables
     }
 
@@ -218,6 +250,14 @@ const EN_VALIDATION_MESSAGE_CATALOG: &[ConfigValidationCatalogEntry] = &[
         "Invalid Env Pointer Name",
     ),
     ConfigValidationCatalogEntry::new(
+        "config.channel_account.duplicate_id.title",
+        "Duplicate Normalized Channel Account ID",
+    ),
+    ConfigValidationCatalogEntry::new(
+        "config.channel_account.unknown_default.title",
+        "Unknown Channel Default Account",
+    ),
+    ConfigValidationCatalogEntry::new(
         "config.env_pointer.assignment",
         "[{code}] {field_path} expects an environment variable name, not `KEY=VALUE`. use `{field_path} = \"{suggested_env_name}\"` and place the secret value in that env var",
     ),
@@ -236,6 +276,14 @@ const EN_VALIDATION_MESSAGE_CATALOG: &[ConfigValidationCatalogEntry] = &[
     ConfigValidationCatalogEntry::new(
         "config.env_pointer.invalid_name",
         "[{code}] {field_path} is not a valid environment variable name reference. use `{field_path}` with a name like `{example_env_name}`",
+    ),
+    ConfigValidationCatalogEntry::new(
+        "config.channel_account.duplicate_id",
+        "[{code}] {field_path} contains duplicate configured accounts that normalize to `{normalized_account_id}`: {raw_account_labels}. rename one of the account keys so each normalized account id is unique",
+    ),
+    ConfigValidationCatalogEntry::new(
+        "config.channel_account.unknown_default",
+        "[{code}] {field_path} points to `{requested_account_id}`, but configured accounts are: {configured_account_ids}. set `{field_path}` to one of the configured account ids",
     ),
 ];
 
@@ -309,7 +357,7 @@ pub(super) fn validate_env_pointer_field(
     field_path: &str,
     env_key: Option<&str>,
     hint: EnvPointerValidationHint<'_>,
-) -> Result<(), ConfigValidationIssue> {
+) -> Result<(), Box<ConfigValidationIssue>> {
     let Some(raw) = env_key else {
         return Ok(());
     };
@@ -319,24 +367,26 @@ pub(super) fn validate_env_pointer_field(
     }
 
     if let Some((name, _value)) = parse_env_assignment(trimmed) {
-        return Err(ConfigValidationIssue {
+        return Err(Box::new(ConfigValidationIssue {
             code: ConfigValidationCode::Assignment,
             field_path: field_path.to_owned(),
             inline_field_path: hint.inline_field_path.to_owned(),
             example_env_name: hint.example_env_name.to_owned(),
             suggested_env_name: Some(name.to_owned()),
-        });
+            extra_message_variables: BTreeMap::new(),
+        }));
     }
 
     if let Some(raw_name) = trimmed.strip_prefix('$') {
         let suggested = normalize_dollar_prefixed_env_name(raw_name, hint.example_env_name);
-        return Err(ConfigValidationIssue {
+        return Err(Box::new(ConfigValidationIssue {
             code: ConfigValidationCode::DollarPrefix,
             field_path: field_path.to_owned(),
             inline_field_path: hint.inline_field_path.to_owned(),
             example_env_name: hint.example_env_name.to_owned(),
             suggested_env_name: Some(suggested),
-        });
+            extra_message_variables: BTreeMap::new(),
+        }));
     }
 
     if let Some(raw_name) = parse_percent_wrapped_env_name(trimmed) {
@@ -345,33 +395,36 @@ pub(super) fn validate_env_pointer_field(
         } else {
             raw_name.to_owned()
         };
-        return Err(ConfigValidationIssue {
+        return Err(Box::new(ConfigValidationIssue {
             code: ConfigValidationCode::PercentWrapped,
             field_path: field_path.to_owned(),
             inline_field_path: hint.inline_field_path.to_owned(),
             example_env_name: hint.example_env_name.to_owned(),
             suggested_env_name: Some(suggested),
-        });
+            extra_message_variables: BTreeMap::new(),
+        }));
     }
 
     if looks_like_secret_literal(trimmed, hint.detect_telegram_token_shape) {
-        return Err(ConfigValidationIssue {
+        return Err(Box::new(ConfigValidationIssue {
             code: ConfigValidationCode::SecretLiteral,
             field_path: field_path.to_owned(),
             inline_field_path: hint.inline_field_path.to_owned(),
             example_env_name: hint.example_env_name.to_owned(),
             suggested_env_name: None,
-        });
+            extra_message_variables: BTreeMap::new(),
+        }));
     }
 
     if !looks_like_compatible_env_name(trimmed) {
-        return Err(ConfigValidationIssue {
+        return Err(Box::new(ConfigValidationIssue {
             code: ConfigValidationCode::InvalidName,
             field_path: field_path.to_owned(),
             inline_field_path: hint.inline_field_path.to_owned(),
             example_env_name: hint.example_env_name.to_owned(),
             suggested_env_name: Some(hint.example_env_name.to_owned()),
-        });
+            extra_message_variables: BTreeMap::new(),
+        }));
     }
 
     Ok(())
@@ -483,7 +536,6 @@ fn normalize_dollar_prefixed_env_name(raw: &str, fallback: &str) -> String {
     trimmed.to_owned()
 }
 
-#[cfg(feature = "channel-feishu")]
 pub(super) fn read_secret_prefer_inline(
     inline: Option<&str>,
     env_key: Option<&str>,
@@ -534,6 +586,7 @@ mod tests {
             inline_field_path: "provider.api_key".to_owned(),
             example_env_name: "OPENAI_API_KEY".to_owned(),
             suggested_env_name: Some("OPENAI_API_KEY".to_owned()),
+            extra_message_variables: BTreeMap::new(),
         };
         assert_eq!(
             issue.title(ConfigValidationLocale::En),

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
@@ -23,7 +23,7 @@ enum DoctorCheckLevel {
 
 #[derive(Debug, Clone)]
 struct DoctorCheck {
-    name: &'static str,
+    name: String,
     level: DoctorCheckLevel,
     detail: String,
 }
@@ -33,6 +33,12 @@ struct DoctorSummary {
     pass: usize,
     warn: usize,
     fail: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DoctorChannelCheckSpec {
+    config_name: &'static str,
+    runtime_name: Option<&'static str>,
 }
 
 pub(crate) async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
@@ -47,7 +53,7 @@ pub(crate) async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<(
     let has_provider_credentials = config.provider.authorization_header().is_some();
     if has_provider_credentials {
         checks.push(DoctorCheck {
-            name: "provider credentials",
+            name: "provider credentials".to_owned(),
             level: DoctorCheckLevel::Pass,
             detail: "provider credentials are available".to_owned(),
         });
@@ -72,7 +78,7 @@ pub(crate) async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<(
             )
         };
         checks.push(DoctorCheck {
-            name: "provider credentials",
+            name: "provider credentials".to_owned(),
             level: DoctorCheckLevel::Warn,
             detail,
         });
@@ -80,25 +86,25 @@ pub(crate) async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<(
 
     if options.skip_model_probe {
         checks.push(DoctorCheck {
-            name: "provider model probe",
+            name: "provider model probe".to_owned(),
             level: DoctorCheckLevel::Warn,
             detail: "skipped by --skip-model-probe".to_owned(),
         });
     } else if !has_provider_credentials {
         checks.push(DoctorCheck {
-            name: "provider model probe",
+            name: "provider model probe".to_owned(),
             level: DoctorCheckLevel::Warn,
             detail: "skipped because credentials are missing".to_owned(),
         });
     } else {
         match mvp::provider::fetch_available_models(&config).await {
             Ok(models) => checks.push(DoctorCheck {
-                name: "provider model probe",
+                name: "provider model probe".to_owned(),
                 level: DoctorCheckLevel::Pass,
                 detail: format!("{} model(s) available", models.len()),
             }),
             Err(error) => checks.push(DoctorCheck {
-                name: "provider model probe",
+                name: "provider model probe".to_owned(),
                 level: DoctorCheckLevel::Fail,
                 detail: error,
             }),
@@ -124,7 +130,7 @@ pub(crate) async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<(
         .is_empty()
     {
         checks.push(DoctorCheck {
-            name: "tool file root policy",
+            name: "tool file root policy".to_owned(),
             level: DoctorCheckLevel::Warn,
             detail: "tools.file_root is empty (falls back to current working directory)".to_owned(),
         });
@@ -139,7 +145,7 @@ pub(crate) async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<(
         }
     } else {
         checks.push(DoctorCheck {
-            name: "tool file root policy",
+            name: "tool file root policy".to_owned(),
             level: DoctorCheckLevel::Pass,
             detail: "tools.file_root is configured".to_owned(),
         });
@@ -153,9 +159,7 @@ pub(crate) async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<(
         "create tool file root",
     ));
 
-    checks.push(check_telegram_channel(&config));
-    let feishu_checks = check_feishu_channel(&config);
-    checks.extend(feishu_checks);
+    checks.extend(check_channel_surfaces(&config));
 
     if options.fix && config_mutated {
         let path = config_path
@@ -222,13 +226,13 @@ fn check_directory_ready(
     if directory.exists() {
         if directory.is_dir() {
             return DoctorCheck {
-                name,
+                name: name.to_owned(),
                 level: DoctorCheckLevel::Pass,
                 detail: directory.display().to_string(),
             };
         }
         return DoctorCheck {
-            name,
+            name: name.to_owned(),
             level: DoctorCheckLevel::Fail,
             detail: format!("{} exists but is not a directory", directory.display()),
         };
@@ -236,7 +240,7 @@ fn check_directory_ready(
 
     if !fix {
         return DoctorCheck {
-            name,
+            name: name.to_owned(),
             level: DoctorCheckLevel::Fail,
             detail: format!(
                 "{} is missing (rerun with --fix to create it)",
@@ -249,107 +253,181 @@ fn check_directory_ready(
         Ok(()) => {
             fixes.push(format!("{fix_label}: {}", directory.display()));
             DoctorCheck {
-                name,
+                name: name.to_owned(),
                 level: DoctorCheckLevel::Pass,
                 detail: format!("created {}", directory.display()),
             }
         }
         Err(error) => DoctorCheck {
-            name,
+            name: name.to_owned(),
             level: DoctorCheckLevel::Fail,
             detail: format!("failed to create {}: {error}", directory.display()),
         },
     }
 }
 
-fn check_telegram_channel(config: &mvp::config::LoongClawConfig) -> DoctorCheck {
-    if !config.telegram.enabled {
-        return DoctorCheck {
-            name: "telegram channel",
-            level: DoctorCheckLevel::Warn,
-            detail: "disabled".to_owned(),
-        };
+fn check_channel_surfaces(config: &mvp::config::LoongClawConfig) -> Vec<DoctorCheck> {
+    let snapshots = mvp::channel::channel_status_snapshots(config);
+    build_channel_surface_checks(&snapshots)
+}
+
+fn build_channel_surface_checks(
+    snapshots: &[mvp::channel::ChannelStatusSnapshot],
+) -> Vec<DoctorCheck> {
+    let mut checks = Vec::new();
+    let mut counts = BTreeMap::new();
+    for snapshot in snapshots {
+        *counts.entry(snapshot.id).or_insert(0_usize) += 1;
     }
-    let token = resolve_secret_value(
-        config.telegram.bot_token.as_deref(),
-        config.telegram.bot_token_env.as_deref(),
-    );
-    if token.is_some() {
-        DoctorCheck {
-            name: "telegram channel",
-            level: DoctorCheckLevel::Pass,
-            detail: "bot token resolved".to_owned(),
+
+    for snapshot in snapshots {
+        let scoped = counts.get(snapshot.id).copied().unwrap_or(0) > 1;
+        if snapshot.is_default_account
+            && scoped
+            && snapshot.default_account_source
+                == mvp::config::ChannelDefaultAccountSelectionSource::Fallback
+        {
+            checks.push(DoctorCheck {
+                name: format!("{} default account policy", snapshot.id),
+                level: DoctorCheckLevel::Warn,
+                detail: format!(
+                    "multiple configured accounts are using fallback default selection; omitting --account currently routes to `{}`. set default_account explicitly to avoid routing surprises",
+                    snapshot.configured_account_label
+                ),
+            });
         }
-    } else {
-        DoctorCheck {
-            name: "telegram channel",
-            level: DoctorCheckLevel::Fail,
-            detail: "enabled but bot token is missing (telegram.bot_token or env)".to_owned(),
+        for operation in &snapshot.operations {
+            let Some(spec) = doctor_check_spec(snapshot.id, operation.id) else {
+                continue;
+            };
+            checks.push(DoctorCheck {
+                name: scoped_doctor_check_name(spec.config_name, snapshot, scoped),
+                level: doctor_check_level_for_health(operation.health),
+                detail: operation.detail.clone(),
+            });
+
+            if let Some(runtime_name) = spec.runtime_name {
+                if operation.health == mvp::channel::ChannelOperationHealth::Ready {
+                    checks.push(build_channel_runtime_check(
+                        scoped_doctor_check_name(runtime_name, snapshot, scoped).as_str(),
+                        operation,
+                    ));
+                }
+            }
         }
+    }
+
+    checks
+}
+
+fn scoped_doctor_check_name(
+    base_name: &str,
+    snapshot: &mvp::channel::ChannelStatusSnapshot,
+    scoped: bool,
+) -> String {
+    if !scoped {
+        return base_name.to_owned();
+    }
+    format!("{base_name} [{}]", snapshot.configured_account_label)
+}
+
+fn doctor_check_spec(channel_id: &str, operation_id: &str) -> Option<DoctorChannelCheckSpec> {
+    match (channel_id, operation_id) {
+        ("telegram", "serve") => Some(DoctorChannelCheckSpec {
+            config_name: "telegram channel",
+            runtime_name: Some("telegram channel runtime"),
+        }),
+        ("feishu", "send") => Some(DoctorChannelCheckSpec {
+            config_name: "feishu channel",
+            runtime_name: None,
+        }),
+        ("feishu", "serve") => Some(DoctorChannelCheckSpec {
+            config_name: "feishu webhook verification",
+            runtime_name: Some("feishu webhook runtime"),
+        }),
+        _ => None,
     }
 }
 
-fn check_feishu_channel(config: &mvp::config::LoongClawConfig) -> Vec<DoctorCheck> {
-    if !config.feishu.enabled {
-        return vec![DoctorCheck {
-            name: "feishu channel",
-            level: DoctorCheckLevel::Warn,
-            detail: "disabled".to_owned(),
-        }];
+fn doctor_check_level_for_health(health: mvp::channel::ChannelOperationHealth) -> DoctorCheckLevel {
+    match health {
+        mvp::channel::ChannelOperationHealth::Ready => DoctorCheckLevel::Pass,
+        mvp::channel::ChannelOperationHealth::Disabled => DoctorCheckLevel::Warn,
+        mvp::channel::ChannelOperationHealth::Unsupported
+        | mvp::channel::ChannelOperationHealth::Misconfigured => DoctorCheckLevel::Fail,
     }
+}
 
-    let app_id = resolve_secret_value(
-        config.feishu.app_id.as_deref(),
-        config.feishu.app_id_env.as_deref(),
+fn build_channel_runtime_check(
+    name: &str,
+    operation: &mvp::channel::ChannelOperationStatus,
+) -> DoctorCheck {
+    let Some(runtime) = operation.runtime.as_ref() else {
+        return DoctorCheck {
+            name: name.to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: "ready but runtime tracking is unavailable".to_owned(),
+        };
+    };
+
+    let detail_tail = format!(
+        "account={} account_id={} pid={} busy={} active_runs={} instance_count={} running_instances={} stale_instances={} last_run_activity_at={} last_heartbeat_at={}",
+        runtime
+            .account_label
+            .as_deref()
+            .unwrap_or("-"),
+        runtime
+            .account_id
+            .as_deref()
+            .unwrap_or("-"),
+        runtime
+            .pid
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_owned()),
+        runtime.busy,
+        runtime.active_runs,
+        runtime.instance_count,
+        runtime.running_instances,
+        runtime.stale_instances,
+        runtime
+            .last_run_activity_at
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_owned()),
+        runtime
+            .last_heartbeat_at
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_owned()),
     );
-    let app_secret = resolve_secret_value(
-        config.feishu.app_secret.as_deref(),
-        config.feishu.app_secret_env.as_deref(),
-    );
-    let mut checks = Vec::new();
-    if app_id.is_some() && app_secret.is_some() {
-        checks.push(DoctorCheck {
-            name: "feishu channel",
-            level: DoctorCheckLevel::Pass,
-            detail: "app credentials resolved".to_owned(),
-        });
-    } else {
-        let mut missing = Vec::new();
-        if app_id.is_none() {
-            missing.push("app_id");
-        }
-        if app_secret.is_none() {
-            missing.push("app_secret");
-        }
-        checks.push(DoctorCheck {
-            name: "feishu channel",
+
+    if runtime.stale {
+        return DoctorCheck {
+            name: name.to_owned(),
             level: DoctorCheckLevel::Fail,
-            detail: format!("enabled but missing {}", missing.join(", ")),
-        });
+            detail: format!("stale runtime detected ({detail_tail})"),
+        };
     }
 
-    let verification_token = resolve_secret_value(
-        config.feishu.verification_token.as_deref(),
-        config.feishu.verification_token_env.as_deref(),
-    );
-    let encrypt_key = resolve_secret_value(
-        config.feishu.encrypt_key.as_deref(),
-        config.feishu.encrypt_key_env.as_deref(),
-    );
-    if verification_token.is_none() && encrypt_key.is_none() {
-        checks.push(DoctorCheck {
-            name: "feishu webhook verification",
-            level: DoctorCheckLevel::Warn,
-            detail: "verification token and encrypt key are both missing".to_owned(),
-        });
-    } else {
-        checks.push(DoctorCheck {
-            name: "feishu webhook verification",
+    if runtime.running {
+        if runtime.running_instances > 1 {
+            return DoctorCheck {
+                name: name.to_owned(),
+                level: DoctorCheckLevel::Warn,
+                detail: format!("multiple runtime instances detected ({detail_tail})"),
+            };
+        }
+
+        return DoctorCheck {
+            name: name.to_owned(),
             level: DoctorCheckLevel::Pass,
-            detail: "verification token or encrypt key is configured".to_owned(),
-        });
+            detail: format!("running ({detail_tail})"),
+        };
     }
-    checks
+
+    DoctorCheck {
+        name: name.to_owned(),
+        level: DoctorCheckLevel::Warn,
+        detail: format!("ready but not currently running ({detail_tail})"),
+    }
 }
 
 fn maybe_apply_provider_env_fix(
@@ -440,7 +518,10 @@ fn ensure_env_binding(
     true
 }
 
+#[cfg(test)]
 pub(crate) fn resolve_secret_value(inline: Option<&str>, env_key: Option<&str>) -> Option<String> {
+    use std::env;
+
     if let Some(value) = inline.map(str::trim).filter(|value| !value.is_empty()) {
         return Some(value.to_owned());
     }
@@ -504,6 +585,10 @@ fn check_level_json(level: DoctorCheckLevel) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvp::channel::{
+        ChannelOperationHealth, ChannelOperationRuntime, ChannelOperationStatus,
+        ChannelStatusSnapshot,
+    };
 
     #[test]
     fn resolve_secret_prefers_inline_value() {
@@ -525,5 +610,315 @@ mod tests {
         assert!(changed);
         assert_eq!(slot.as_deref(), Some("OPENAI_API_KEY"));
         assert_eq!(fixes.len(), 1);
+    }
+
+    #[test]
+    fn build_channel_surface_checks_warns_when_ready_serve_operation_is_not_running() {
+        let snapshots = vec![ChannelStatusSnapshot {
+            id: "telegram",
+            configured_account_id: "bot_123456".to_owned(),
+            configured_account_label: "bot_123456".to_owned(),
+            is_default_account: true,
+            default_account_source:
+                mvp::config::ChannelDefaultAccountSelectionSource::RuntimeIdentity,
+            label: "Telegram",
+            aliases: Vec::new(),
+            transport: "telegram_bot_api_polling",
+            compiled: true,
+            enabled: true,
+            api_base_url: Some("https://api.telegram.org".to_owned()),
+            notes: Vec::new(),
+            operations: vec![ChannelOperationStatus {
+                id: "serve",
+                label: "reply loop",
+                command: "telegram-serve",
+                health: ChannelOperationHealth::Ready,
+                detail: "ready".to_owned(),
+                issues: Vec::new(),
+                runtime: Some(ChannelOperationRuntime {
+                    running: false,
+                    stale: false,
+                    busy: false,
+                    active_runs: 0,
+                    last_run_activity_at: None,
+                    last_heartbeat_at: None,
+                    pid: None,
+                    account_id: Some("bot_123456".to_owned()),
+                    account_label: Some("bot:123456".to_owned()),
+                    instance_count: 1,
+                    running_instances: 0,
+                    stale_instances: 0,
+                }),
+            }],
+        }];
+
+        let checks = build_channel_surface_checks(&snapshots);
+
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "telegram channel runtime"
+                    && check.level == DoctorCheckLevel::Warn
+                    && check.detail.contains("not currently running")
+                    && check.detail.contains("account=bot:123456")
+            }),
+            "ready telegram serve operation should emit runtime warning when not running"
+        );
+    }
+
+    #[test]
+    fn build_channel_surface_checks_fails_when_ready_serve_operation_is_stale() {
+        let snapshots = vec![ChannelStatusSnapshot {
+            id: "feishu",
+            configured_account_id: "feishu_cli_a1b2c3".to_owned(),
+            configured_account_label: "feishu_cli_a1b2c3".to_owned(),
+            is_default_account: true,
+            default_account_source:
+                mvp::config::ChannelDefaultAccountSelectionSource::RuntimeIdentity,
+            label: "Feishu/Lark",
+            aliases: vec!["lark"],
+            transport: "feishu_openapi_webhook",
+            compiled: true,
+            enabled: true,
+            api_base_url: Some("https://open.feishu.cn".to_owned()),
+            notes: Vec::new(),
+            operations: vec![ChannelOperationStatus {
+                id: "serve",
+                label: "webhook reply server",
+                command: "feishu-serve",
+                health: ChannelOperationHealth::Ready,
+                detail: "ready".to_owned(),
+                issues: Vec::new(),
+                runtime: Some(ChannelOperationRuntime {
+                    running: false,
+                    stale: true,
+                    busy: true,
+                    active_runs: 1,
+                    last_run_activity_at: Some(1_700_000_000_000),
+                    last_heartbeat_at: Some(1_700_000_005_000),
+                    pid: Some(4242),
+                    account_id: Some("feishu_cli_a1b2c3".to_owned()),
+                    account_label: Some("feishu:cli_a1b2c3".to_owned()),
+                    instance_count: 1,
+                    running_instances: 0,
+                    stale_instances: 1,
+                }),
+            }],
+        }];
+
+        let checks = build_channel_surface_checks(&snapshots);
+
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "feishu webhook runtime"
+                    && check.level == DoctorCheckLevel::Fail
+                    && check.detail.contains("stale")
+                    && check.detail.contains("pid=4242")
+                    && check.detail.contains("account=feishu:cli_a1b2c3")
+            }),
+            "stale feishu serve runtime should fail doctor checks"
+        );
+    }
+
+    #[test]
+    fn build_channel_surface_checks_warns_when_multiple_runtime_instances_are_running() {
+        let snapshots = vec![ChannelStatusSnapshot {
+            id: "telegram",
+            configured_account_id: "bot_123456".to_owned(),
+            configured_account_label: "bot_123456".to_owned(),
+            is_default_account: true,
+            default_account_source:
+                mvp::config::ChannelDefaultAccountSelectionSource::RuntimeIdentity,
+            label: "Telegram",
+            aliases: Vec::new(),
+            transport: "telegram_bot_api_polling",
+            compiled: true,
+            enabled: true,
+            api_base_url: Some("https://api.telegram.org".to_owned()),
+            notes: Vec::new(),
+            operations: vec![ChannelOperationStatus {
+                id: "serve",
+                label: "reply loop",
+                command: "telegram-serve",
+                health: ChannelOperationHealth::Ready,
+                detail: "ready".to_owned(),
+                issues: Vec::new(),
+                runtime: Some(ChannelOperationRuntime {
+                    running: true,
+                    stale: false,
+                    busy: true,
+                    active_runs: 1,
+                    last_run_activity_at: Some(1_700_000_000_000),
+                    last_heartbeat_at: Some(1_700_000_005_000),
+                    pid: Some(3003),
+                    account_id: Some("bot_123456".to_owned()),
+                    account_label: Some("bot:123456".to_owned()),
+                    instance_count: 2,
+                    running_instances: 2,
+                    stale_instances: 0,
+                }),
+            }],
+        }];
+
+        let checks = build_channel_surface_checks(&snapshots);
+
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "telegram channel runtime"
+                    && check.level == DoctorCheckLevel::Warn
+                    && check.detail.contains("multiple runtime instances")
+                    && check.detail.contains("running_instances=2")
+            }),
+            "duplicate running telegram runtimes should emit runtime warning"
+        );
+    }
+
+    #[test]
+    fn build_channel_surface_checks_scopes_names_for_multi_account_snapshots() {
+        let snapshots = vec![
+            ChannelStatusSnapshot {
+                id: "telegram",
+                configured_account_id: "ops".to_owned(),
+                configured_account_label: "ops".to_owned(),
+                is_default_account: true,
+                default_account_source:
+                    mvp::config::ChannelDefaultAccountSelectionSource::ExplicitDefault,
+                label: "Telegram",
+                aliases: Vec::new(),
+                transport: "telegram_bot_api_polling",
+                compiled: true,
+                enabled: true,
+                api_base_url: Some("https://api.telegram.org".to_owned()),
+                notes: vec!["configured_account_id=ops".to_owned()],
+                operations: vec![ChannelOperationStatus {
+                    id: "serve",
+                    label: "reply loop",
+                    command: "telegram-serve",
+                    health: ChannelOperationHealth::Ready,
+                    detail: "ready".to_owned(),
+                    issues: Vec::new(),
+                    runtime: Some(ChannelOperationRuntime {
+                        running: true,
+                        stale: false,
+                        busy: false,
+                        active_runs: 0,
+                        last_run_activity_at: None,
+                        last_heartbeat_at: None,
+                        pid: Some(2001),
+                        account_id: Some("bot_123456".to_owned()),
+                        account_label: Some("bot:123456".to_owned()),
+                        instance_count: 1,
+                        running_instances: 1,
+                        stale_instances: 0,
+                    }),
+                }],
+            },
+            ChannelStatusSnapshot {
+                id: "telegram",
+                configured_account_id: "personal".to_owned(),
+                configured_account_label: "personal".to_owned(),
+                is_default_account: false,
+                default_account_source:
+                    mvp::config::ChannelDefaultAccountSelectionSource::ExplicitDefault,
+                label: "Telegram",
+                aliases: Vec::new(),
+                transport: "telegram_bot_api_polling",
+                compiled: true,
+                enabled: true,
+                api_base_url: Some("https://api.telegram.org".to_owned()),
+                notes: vec!["configured_account_id=personal".to_owned()],
+                operations: vec![ChannelOperationStatus {
+                    id: "serve",
+                    label: "reply loop",
+                    command: "telegram-serve",
+                    health: ChannelOperationHealth::Ready,
+                    detail: "ready".to_owned(),
+                    issues: Vec::new(),
+                    runtime: Some(ChannelOperationRuntime {
+                        running: false,
+                        stale: false,
+                        busy: false,
+                        active_runs: 0,
+                        last_run_activity_at: None,
+                        last_heartbeat_at: None,
+                        pid: None,
+                        account_id: Some("bot_654321".to_owned()),
+                        account_label: Some("bot:654321".to_owned()),
+                        instance_count: 0,
+                        running_instances: 0,
+                        stale_instances: 0,
+                    }),
+                }],
+            },
+        ];
+
+        let checks = build_channel_surface_checks(&snapshots);
+
+        assert!(checks
+            .iter()
+            .any(|check| check.name == "telegram channel [ops]"));
+        assert!(checks
+            .iter()
+            .any(|check| check.name == "telegram channel runtime [personal]"));
+    }
+
+    #[test]
+    fn build_channel_surface_checks_warns_when_multi_account_default_uses_fallback() {
+        let snapshots = vec![
+            ChannelStatusSnapshot {
+                id: "telegram",
+                configured_account_id: "alerts".to_owned(),
+                configured_account_label: "alerts".to_owned(),
+                is_default_account: true,
+                default_account_source: mvp::config::ChannelDefaultAccountSelectionSource::Fallback,
+                label: "Telegram",
+                aliases: Vec::new(),
+                transport: "telegram_bot_api_polling",
+                compiled: true,
+                enabled: true,
+                api_base_url: Some("https://api.telegram.org".to_owned()),
+                notes: vec!["default_account_source=fallback".to_owned()],
+                operations: vec![ChannelOperationStatus {
+                    id: "serve",
+                    label: "reply loop",
+                    command: "telegram-serve",
+                    health: ChannelOperationHealth::Ready,
+                    detail: "ready".to_owned(),
+                    issues: Vec::new(),
+                    runtime: None,
+                }],
+            },
+            ChannelStatusSnapshot {
+                id: "telegram",
+                configured_account_id: "work".to_owned(),
+                configured_account_label: "work".to_owned(),
+                is_default_account: false,
+                default_account_source: mvp::config::ChannelDefaultAccountSelectionSource::Fallback,
+                label: "Telegram",
+                aliases: Vec::new(),
+                transport: "telegram_bot_api_polling",
+                compiled: true,
+                enabled: true,
+                api_base_url: Some("https://api.telegram.org".to_owned()),
+                notes: vec!["default_account_source=fallback".to_owned()],
+                operations: vec![ChannelOperationStatus {
+                    id: "serve",
+                    label: "reply loop",
+                    command: "telegram-serve",
+                    health: ChannelOperationHealth::Ready,
+                    detail: "ready".to_owned(),
+                    issues: Vec::new(),
+                    runtime: None,
+                }],
+            },
+        ];
+
+        let checks = build_channel_surface_checks(&snapshots);
+
+        assert!(checks.iter().any(|check| {
+            check.name == "telegram default account policy"
+                && check.level == DoctorCheckLevel::Warn
+                && check.detail.contains("alerts")
+                && check.detail.contains("default_account")
+        }));
     }
 }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -189,6 +189,13 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         skip_model_probe: bool,
     },
+    /// List compiled channel surfaces, aliases, and readiness status
+    Channels {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Fetch and print currently available provider model list
     ListModels {
         #[arg(long)]
@@ -209,11 +216,15 @@ enum Commands {
         config: Option<String>,
         #[arg(long, default_value_t = false)]
         once: bool,
+        #[arg(long)]
+        account: Option<String>,
     },
     /// Send one Feishu message or card
     FeishuSend {
         #[arg(long)]
         config: Option<String>,
+        #[arg(long)]
+        account: Option<String>,
         #[arg(long)]
         receive_id: String,
         #[arg(long)]
@@ -225,6 +236,8 @@ enum Commands {
     FeishuServe {
         #[arg(long)]
         config: Option<String>,
+        #[arg(long)]
+        account: Option<String>,
         #[arg(long)]
         bind: Option<String>,
         #[arg(long)]
@@ -349,21 +362,45 @@ async fn main() {
             })
             .await
         }
+        Commands::Channels { config, json } => run_channels_cli(config.as_deref(), json),
         Commands::ListModels { config, json } => run_list_models_cli(config.as_deref(), json).await,
         Commands::Chat { config, session } => {
             run_chat_cli(config.as_deref(), session.as_deref()).await
         }
-        Commands::TelegramServe { config, once } => {
-            run_telegram_serve_cli(config.as_deref(), once).await
-        }
+        Commands::TelegramServe {
+            config,
+            once,
+            account,
+        } => run_telegram_serve_cli(config.as_deref(), once, account.as_deref()).await,
         Commands::FeishuSend {
             config,
+            account,
             receive_id,
             text,
             card,
-        } => run_feishu_send_cli(config.as_deref(), &receive_id, &text, card).await,
-        Commands::FeishuServe { config, bind, path } => {
-            run_feishu_serve_cli(config.as_deref(), bind.as_deref(), path.as_deref()).await
+        } => {
+            run_feishu_send_cli(
+                config.as_deref(),
+                account.as_deref(),
+                &receive_id,
+                &text,
+                card,
+            )
+            .await
+        }
+        Commands::FeishuServe {
+            config,
+            account,
+            bind,
+            path,
+        } => {
+            run_feishu_serve_cli(
+                config.as_deref(),
+                account.as_deref(),
+                bind.as_deref(),
+                path.as_deref(),
+            )
+            .await
         }
     };
     if let Err(error) = result {
@@ -700,29 +737,137 @@ async fn run_list_models_cli(config_path: Option<&str>, as_json: bool) -> CliRes
     Ok(())
 }
 
+fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
+    let (resolved_path, config) = mvp::config::load(config_path)?;
+    let snapshots = mvp::channel::channel_status_snapshots(&config);
+
+    if as_json {
+        let payload = json!({
+            "config": resolved_path.display().to_string(),
+            "channels": snapshots,
+        });
+        let pretty = serde_json::to_string_pretty(&payload)
+            .map_err(|error| format!("serialize channel status output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!(
+        "{}",
+        render_channel_snapshots_text(&resolved_path.display().to_string(), &snapshots)
+    );
+    Ok(())
+}
+
+fn render_channel_snapshots_text(
+    config_path: &str,
+    snapshots: &[mvp::channel::ChannelStatusSnapshot],
+) -> String {
+    let mut lines = vec![format!("config={config_path}")];
+    for snapshot in snapshots {
+        let aliases = if snapshot.aliases.is_empty() {
+            "-".to_owned()
+        } else {
+            snapshot.aliases.join(",")
+        };
+        let api_base_url = snapshot.api_base_url.as_deref().unwrap_or("-");
+        lines.push(format!(
+            "{} [{}] configured_account={} default_account={} default_source={} compiled={} enabled={} aliases={} api_base_url={}",
+            snapshot.label,
+            snapshot.id,
+            snapshot.configured_account_id,
+            snapshot.is_default_account,
+            snapshot.default_account_source.as_str(),
+            snapshot.compiled,
+            snapshot.enabled,
+            aliases,
+            api_base_url
+        ));
+        lines.push(format!("  transport={}", snapshot.transport));
+        lines.push(format!(
+            "  configured_account_label={}",
+            snapshot.configured_account_label
+        ));
+        for note in &snapshot.notes {
+            lines.push(format!("  note: {note}"));
+        }
+        for operation in &snapshot.operations {
+            lines.push(format!(
+                "  op {} ({}) {}: {}",
+                operation.id,
+                operation.command,
+                operation.health.as_str(),
+                operation.detail
+            ));
+            if let Some(runtime) = &operation.runtime {
+                lines.push(format!(
+                    "    runtime account={} account_id={} running={} stale={} busy={} active_runs={} instance_count={} running_instances={} stale_instances={} last_run_activity_at={} last_heartbeat_at={} pid={}",
+                    runtime
+                        .account_label
+                        .as_deref()
+                        .unwrap_or("-"),
+                    runtime
+                        .account_id
+                        .as_deref()
+                        .unwrap_or("-"),
+                    runtime.running,
+                    runtime.stale,
+                    runtime.busy,
+                    runtime.active_runs,
+                    runtime.instance_count,
+                    runtime.running_instances,
+                    runtime.stale_instances,
+                    runtime
+                        .last_run_activity_at
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "-".to_owned()),
+                    runtime
+                        .last_heartbeat_at
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "-".to_owned()),
+                    runtime
+                        .pid
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "-".to_owned())
+                ));
+            }
+            for issue in &operation.issues {
+                lines.push(format!("    issue: {issue}"));
+            }
+        }
+    }
+    lines.join("\n")
+}
+
 async fn run_chat_cli(config_path: Option<&str>, session: Option<&str>) -> CliResult<()> {
     mvp::chat::run_cli_chat(config_path, session).await
 }
 
-async fn run_telegram_serve_cli(config_path: Option<&str>, once: bool) -> CliResult<()> {
-    mvp::channel::run_telegram_channel(config_path, once).await
+async fn run_telegram_serve_cli(
+    config_path: Option<&str>,
+    once: bool,
+    account: Option<&str>,
+) -> CliResult<()> {
+    mvp::channel::run_telegram_channel(config_path, once, account).await
 }
 
 async fn run_feishu_send_cli(
     config_path: Option<&str>,
+    account: Option<&str>,
     receive_id: &str,
     text: &str,
     as_card: bool,
 ) -> CliResult<()> {
-    mvp::channel::run_feishu_send(config_path, receive_id, text, as_card).await
+    mvp::channel::run_feishu_send(config_path, account, receive_id, text, as_card).await
 }
 
 async fn run_feishu_serve_cli(
     config_path: Option<&str>,
+    account: Option<&str>,
     bind_override: Option<&str>,
     path_override: Option<&str>,
 ) -> CliResult<()> {
-    mvp::channel::run_feishu_channel(config_path, bind_override, path_override).await
+    mvp::channel::run_feishu_channel(config_path, account, bind_override, path_override).await
 }
 
 fn parse_json_payload(raw: &str, context: &str) -> CliResult<Value> {

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -59,3 +59,81 @@ fn resolve_validate_output_rejects_conflicting_json_and_output_flags() {
         .expect_err("conflicting flags should fail");
     assert!(error.contains("conflicts"));
 }
+
+#[test]
+fn render_channel_snapshots_text_reports_aliases_and_operation_health() {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.feishu.enabled = true;
+    config.feishu.app_id = Some("cli_a1b2c3".to_owned());
+    config.feishu.app_secret = Some("app-secret".to_owned());
+
+    let snapshots = mvp::channel::channel_status_snapshots(&config);
+    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots);
+
+    assert!(rendered.contains("config=/tmp/loongclaw.toml"));
+    assert!(rendered.contains("Feishu/Lark [feishu]"));
+    assert!(rendered.contains("aliases=lark"));
+    assert!(rendered.contains("account=feishu:cli_a1b2c3"));
+    assert!(rendered.contains("op send (feishu-send) ready"));
+    assert!(rendered.contains("op serve (feishu-serve) misconfigured"));
+    assert!(rendered.contains("running=false"));
+}
+
+#[test]
+fn render_channel_snapshots_text_reports_configured_accounts_for_multi_account_channels() {
+    let config: mvp::config::LoongClawConfig = serde_json::from_value(serde_json::json!({
+        "telegram": {
+            "enabled": true,
+            "default_account": "Work Bot",
+            "allowed_chat_ids": [1001],
+            "accounts": {
+                "Work Bot": {
+                    "account_id": "Ops-Bot",
+                    "bot_token": "123456:token-work",
+                    "allowed_chat_ids": [2002]
+                },
+                "Personal": {
+                    "bot_token": "654321:token-personal",
+                    "allowed_chat_ids": [3003]
+                }
+            }
+        }
+    }))
+    .expect("deserialize multi-account config");
+
+    let snapshots = mvp::channel::channel_status_snapshots(&config);
+    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots);
+
+    assert!(rendered.contains("configured_account=work-bot"));
+    assert!(rendered.contains("configured_account=personal"));
+}
+
+#[test]
+fn render_channel_snapshots_text_reports_default_account_marker() {
+    let config: mvp::config::LoongClawConfig = serde_json::from_value(serde_json::json!({
+        "telegram": {
+            "enabled": true,
+            "default_account": "Work Bot",
+            "allowed_chat_ids": [1001],
+            "accounts": {
+                "Work Bot": {
+                    "account_id": "Ops-Bot",
+                    "bot_token": "123456:token-work",
+                    "allowed_chat_ids": [2002]
+                },
+                "Personal": {
+                    "bot_token": "654321:token-personal",
+                    "allowed_chat_ids": [3003]
+                }
+            }
+        }
+    }))
+    .expect("deserialize multi-account config");
+
+    let snapshots = mvp::channel::channel_status_snapshots(&config);
+    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots);
+
+    assert!(rendered.contains("configured_account=work-bot"));
+    assert!(rendered.contains("default_account=true"));
+    assert!(rendered.contains("default_source=explicit_default"));
+}

--- a/docs/plans/2026-03-11-channel-account-hardening-phase-9-design.md
+++ b/docs/plans/2026-03-11-channel-account-hardening-phase-9-design.md
@@ -1,0 +1,103 @@
+# Channel Account Hardening Phase 9 Design
+
+**Scope**
+
+Phase 9 hardens the Telegram and Feishu/Lark multi-account substrate that
+Phase 8 introduced.
+
+This phase still does not add Discord transport work. It closes the remaining
+config-integrity gap that would otherwise leak ambiguous account state into any
+future Discord adapter, supervisor, or monitor layer.
+
+**Problem Statement**
+
+After Phase 8, LoongClaw can configure and select multiple Telegram and
+Feishu/Lark accounts. That closes the largest architectural gap with
+OpenClaw's channel model, but two integrity problems remain:
+
+- normalized account-id collisions are silently deduplicated
+- `default_account` silently falls back when it points at a missing account
+
+Those behaviors are convenient in the short term but dangerous in the system
+that LoongClaw is becoming:
+
+- operator intent can drift from runtime selection without any hard signal
+- `channels` and `doctor` can display a plausible status for the wrong logical
+  account
+- later channel plugins such as Discord would inherit the same ambiguity
+
+**Reference Findings**
+
+OpenClaw treats account selection as real channel architecture, not cosmetic
+config sugar:
+
+- shared account helpers normalize account ids before default resolution
+- `defaultAccount` is expected to route work intentionally across Telegram,
+  Feishu, and Discord
+- upstream changelog entries repeatedly tighten default-account behavior and
+  preserve account-resolution errors instead of hiding them
+
+The useful conclusion is not "clone every fallback exactly". The useful
+conclusion is that account selection is upstream-critical and must stay
+observable and deterministic.
+
+**Chosen Design**
+
+Phase 9 makes config ambiguity fail early and makes the chosen default account
+visible everywhere operators inspect channel state.
+
+The design has three rules:
+
+1. normalized configured account ids must be unique
+2. when `accounts` is non-empty, `default_account` must resolve to one of those
+   configured ids
+3. status surfaces must explicitly mark which configured account is the default
+
+This keeps valid configs fully compatible while blocking ambiguous configs
+before runtime startup.
+
+**Validation Rules**
+
+For both `telegram` and `feishu`:
+
+- normalize configured account ids with the same normalization logic used for
+  runtime selection
+- if two raw keys normalize to the same id, emit a structured validation
+  diagnostic and fail config validation
+- if `default_account` is set while `accounts` is non-empty, normalize it and
+  require it to match one configured account id
+- if `accounts` is empty, do not let `default_account` invent a synthetic
+  configured-account id; single-account fallback should stay derived from the
+  resolved runtime identity or `default`
+
+**Operator Surface Changes**
+
+`ChannelStatusSnapshot` should grow a boolean marker for default-account
+selection. That marker should appear in:
+
+- JSON output from `loongclawd channels --json`
+- text output from `loongclawd channels`
+- snapshot notes used by `doctor` and other diagnostics
+
+The goal is not cosmetic labeling. The goal is to make it obvious which
+configured account would be selected when `--account` is omitted.
+
+**Why This Is The Right Next Step**
+
+Discord is still downstream of this substrate. Without Phase 9, Discord would
+inherit the same hidden ambiguity LoongClaw currently tolerates in Telegram and
+Feishu/Lark:
+
+- duplicate logical accounts collapsing to one normalized id
+- invalid defaults silently changing target selection
+- operator surfaces missing the actual default route
+
+Phase 9 keeps the current scope narrow and causal:
+
+- fail ambiguous config before runtime
+- make default routing explicit in operator views
+- preserve the multi-account architecture already implemented
+
+That is the last low-level account-integrity step before LoongClaw should spend
+more effort on shared runtime/supervisor substrate or any Discord-specific
+adapter work.

--- a/docs/plans/2026-03-11-channel-account-hardening-phase-9.md
+++ b/docs/plans/2026-03-11-channel-account-hardening-phase-9.md
@@ -1,0 +1,133 @@
+# Channel Account Hardening Phase 9 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Reject ambiguous multi-account channel configs and expose default
+account selection explicitly in operator-facing channel status.
+
+**Architecture:** Extend structured config validation with channel-account
+integrity diagnostics, then annotate channel status snapshots with
+default-account visibility while keeping valid runtime selection behavior
+unchanged.
+
+**Tech Stack:** Rust, serde, clap
+
+---
+
+### Task 1: Add failing config validation tests
+
+**Files:**
+- Modify: `crates/app/src/config/mod.rs`
+- Modify: `crates/app/src/config/runtime.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- duplicate normalized Telegram account ids are rejected
+- duplicate normalized Feishu account ids are rejected
+- invalid `default_account` is rejected when accounts are configured
+- structured diagnostics expose the new validation codes and account variables
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app config_validation_rejects_duplicate_normalized
+cargo test -p loongclaw-app validate_file_returns_channel_account_diagnostics
+```
+
+Expected: FAIL before implementation.
+
+### Task 2: Add failing default-visibility tests
+
+**Files:**
+- Modify: `crates/app/src/channel/registry.rs`
+- Modify: `crates/daemon/src/tests/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- channel snapshots mark which configured account is the default
+- `channels` text output prints the default-account marker
+- single-account fallback does not invent a synthetic configured account from
+  `default_account`
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app channel_status_snapshots_mark_default
+cargo test -p loongclaw-daemon render_channel_snapshots_text_reports_default
+```
+
+Expected: FAIL before implementation.
+
+### Task 3: Implement channel-account config validation
+
+**Files:**
+- Modify: `crates/app/src/config/shared.rs`
+- Modify: `crates/app/src/config/channels.rs`
+
+**Step 1: Extend validation code catalog**
+
+Add generic channel-account validation codes for:
+
+- duplicate normalized account ids
+- unknown default account
+
+**Step 2: Implement validation helpers**
+
+Use the same normalization logic as runtime routing to:
+
+- detect collisions across raw account keys
+- reject unknown defaults when account maps exist
+
+**Step 3: Keep valid behavior stable**
+
+Ensure valid configs still resolve accounts exactly as before.
+
+### Task 4: Implement default-account visibility
+
+**Files:**
+- Modify: `crates/app/src/channel/registry.rs`
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+
+**Step 1: Annotate snapshots**
+
+Add `is_default_account` to `ChannelStatusSnapshot` and include a note for it.
+
+**Step 2: Render the marker**
+
+Update text and JSON surfaces so operators can see which configured account is
+the default selection.
+
+### Task 5: Verification
+
+Run:
+
+```bash
+cargo test -p loongclaw-app multi_account
+cargo test -p loongclaw-app config::
+cargo test -p loongclaw-app channel::
+cargo test -p loongclaw-daemon tests::
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: PASS
+
+### Expected Remaining Gap After Phase 9
+
+After this phase, the next unresolved channel architecture gap is no longer
+account selection integrity. It is the shared long-running runtime substrate
+needed for richer adapters such as Discord:
+
+- monitor/supervisor traits
+- event stream lifecycle management
+- multi-account concurrent runtime orchestration

--- a/docs/plans/2026-03-11-channel-account-identity-phase-7-design.md
+++ b/docs/plans/2026-03-11-channel-account-identity-phase-7-design.md
@@ -1,0 +1,197 @@
+# Channel Account Identity Phase 7 Design
+
+**Scope**
+
+Phase 7 adds account-aware identity to LoongClaw's existing Telegram and
+Feishu/Lark channel surface without attempting full OpenClaw-style multi-account
+routing yet.
+
+This phase is intentionally narrower than "add Discord" and intentionally
+broader than "rename a runtime file":
+
+- it introduces a resolved channel account identity model
+- it threads that identity through session keys and persisted runtime state
+- it makes operator surfaces show which account a runtime belongs to
+- it fixes Telegram offset persistence so account state does not collide
+
+It still does not add account maps, account selection CLI flags, or concurrent
+multi-account fanout loops.
+
+**Problem Statement**
+
+LoongClaw's channel abstraction is now stronger than before:
+
+- typed platform/session/target model
+- readiness registry
+- persisted runtime state
+- runtime-aware `channels` and `doctor`
+- pid-safe runtime persistence
+
+But the current identity model is still too coarse:
+
+- `ChannelSession` keys are only `platform + conversation [+ thread]`
+- runtime files are only `platform + operation [+ pid]`
+- Telegram offsets are stored in one global `telegram.offset`
+
+That means LoongClaw still cannot distinguish:
+
+- one Telegram bot from another
+- one Feishu app from another
+- one Feishu account on `feishu` from another on `lark`
+
+OpenClaw's Telegram, Feishu, and Discord layers all resolve account-aware
+monitor state before they publish runtime health. LoongClaw does not need the
+full OpenClaw stack yet, but it does need the same identity seam if it wants to
+avoid collisions and eventually support Discord correctly.
+
+**Reference Findings From OpenClaw**
+
+OpenClaw's account modules point to the same architectural rule across
+Telegram, Feishu, and Discord:
+
+- account resolution must happen before runtime publication
+- monitor lifecycle is account-scoped, not just platform-scoped
+- session/routing state depends on that account identity
+
+Its Discord support is not "just another adapter". It sits on top of:
+
+- account resolution
+- runtime plumbing
+- monitor lifecycle
+- routing/session policies
+
+LoongClaw should therefore finish account-aware identity first instead of
+pretending Discord can be bolted on safely right now.
+
+**Chosen Design**
+
+Introduce a resolved `ChannelAccountIdentity` for Telegram and Feishu/Lark with
+three properties:
+
+- `id`: stable machine key used in persisted files and session keys
+- `label`: human-readable identity shown in CLI and doctor output
+- `source`: how the identity was resolved
+
+Resolution rules:
+
+1. Prefer explicit config `account_id` if the operator sets one.
+2. Otherwise derive a stable non-secret identity from the configured
+   credentials:
+   - Telegram: `bot_<bot_id>` from the token prefix before `:`
+   - Feishu/Lark: `<domain>_<app_id>` from domain + app id
+3. If credentials are not yet available, fall back to `default`.
+
+This gives LoongClaw a future-compatible account seam immediately while keeping
+today's single-account config shape.
+
+**Config Changes**
+
+Add optional `account_id` to:
+
+- `telegram`
+- `feishu`
+
+This is not multi-account config yet. It is a stable override for persistence
+and operator visibility.
+
+**Runtime Persistence Changes**
+
+Persist runtime by:
+
+- platform
+- operation
+- account identity
+- pid
+
+Example file names:
+
+- `telegram-serve-bot_123456-4242.json`
+- `feishu-serve-lark_cli_a1b2c3-5151.json`
+
+Loader behavior:
+
+- prefer account-aware files for the requested account
+- remain backward compatible with old files that only use
+  `platform + operation [+ pid]`
+- if no account-aware file exists, still accept legacy runtime files
+
+This keeps older installations readable while moving new writes onto the
+correcter identity model.
+
+**Telegram Offset Changes**
+
+Telegram offset persistence must move from a global singleton file to an
+account-scoped file:
+
+- new path pattern: `telegram-offsets/<account_id>.offset`
+- legacy fallback: if the new file is absent, still read `telegram.offset`
+
+This change matters as much as runtime persistence because offset state is part
+of channel identity, not just transport mechanics.
+
+**Session Key Changes**
+
+`ChannelSession` should include account identity so conversation memory is
+scoped by both platform and serving account.
+
+Example:
+
+- old: `telegram:123`
+- new: `telegram:bot_123456:123`
+
+This prevents two different bots or apps from sharing the same conversation
+window just because the chat ID happens to match.
+
+**Operator Surface Changes**
+
+Expose resolved account identity in:
+
+- `channels` text rendering
+- `channels --json`
+- `doctor` runtime detail strings
+- channel readiness notes
+
+This does not yet mean multiple account rows. It means the current row tells the
+operator exactly which account the runtime view belongs to.
+
+**Why This Is The Right Next Step**
+
+This phase solves the highest-value remaining structural gap before Discord:
+
+- runtime state becomes account-aware
+- session memory becomes account-aware
+- Telegram offset persistence becomes account-aware
+- operator diagnostics gain explicit identity context
+
+That is enough to make the current single-account surface safer and enough to
+prepare the next layer of work:
+
+- multi-account config maps
+- per-account registry aggregation
+- shared monitor abstractions
+- eventual Discord integration
+
+**Compatibility**
+
+Phase 7 should preserve these compat rules:
+
+- old runtime files remain readable
+- old Telegram offset file remains readable as fallback
+- configs without `account_id` continue to work
+
+Behavior that intentionally changes:
+
+- new session keys become account-scoped
+- new runtime writes become account-scoped
+- new Telegram offset writes become account-scoped
+
+**Deferred Work**
+
+Phase 7 still defers:
+
+- full `accounts` maps for Telegram and Feishu
+- default-account selection semantics
+- CLI account-selection flags
+- runtime aggregation across multiple configured accounts
+- generic channel monitor trait
+- Discord channel implementation

--- a/docs/plans/2026-03-11-channel-account-identity-phase-7.md
+++ b/docs/plans/2026-03-11-channel-account-identity-phase-7.md
@@ -1,0 +1,172 @@
+# Channel Account Identity Phase 7 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make Telegram and Feishu/Lark channel runtime, session, and offset
+state account-aware while preserving backward compatibility for existing config
+and persisted state.
+
+**Architecture:** Add a resolved account identity model at the config layer,
+thread it into channel session keys and runtime persistence, then surface that
+identity through registry and doctor output. Keep the config shape single-account
+for now, but make the identity model future-compatible with later multi-account
+expansion.
+
+**Tech Stack:** Rust, Tokio, serde
+
+---
+
+### Task 1: Add failing config/account identity tests
+
+**Files:**
+- Modify: `crates/app/src/config/channels.rs`
+- Modify: `crates/app/src/config/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+
+- Telegram resolves `account_id` from explicit config when set
+- Telegram otherwise derives `bot_<bot_id>` from a token
+- Feishu resolves `account_id` from explicit config when set
+- Feishu otherwise derives `<domain>_<app_id>`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app config::`
+
+Expected: FAIL because account identity resolution does not exist yet
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- optional `account_id` on Telegram/Feishu config
+- resolved account identity helpers
+- tests for sanitization and fallback behavior
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app config::`
+
+Expected: PASS
+
+### Task 2: Add failing session-key and Telegram offset tests
+
+**Files:**
+- Modify: `crates/app/src/channel/mod.rs`
+- Modify: `crates/app/src/channel/telegram.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+
+- `ChannelSession` includes account identity in `session_key()`
+- Telegram offset files are written under an account-specific path
+- Telegram can still read legacy `telegram.offset` when account-specific state
+  is absent
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app channel::telegram::tests:: channel::tests::`
+
+Expected: FAIL because account identity is not threaded into sessions or offset
+storage
+
+**Step 3: Write minimal implementation**
+
+Add account identity to `ChannelSession` and update Telegram offset path
+resolution with legacy fallback.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app channel::telegram::tests:: channel::tests::`
+
+Expected: PASS
+
+### Task 3: Add failing account-aware runtime and registry tests
+
+**Files:**
+- Modify: `crates/app/src/channel/runtime_state.rs`
+- Modify: `crates/app/src/channel/registry.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/daemon/src/tests/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+
+- runtime files are written/read using account-aware keys
+- registry snapshots expose the resolved account identity
+- channels text rendering includes account information
+- doctor runtime details include account information
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app channel::runtime_state::tests:: channel::registry::tests::`
+
+Expected: FAIL because runtime and registry are still platform-scoped only
+
+**Step 3: Write minimal implementation**
+
+Thread resolved account identity into runtime tracker construction, runtime
+loading, registry snapshots, and CLI/doctor rendering.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app channel::runtime_state::tests:: channel::registry::tests::`
+
+Expected: PASS
+
+### Task 4: Run targeted verification
+
+**Files:**
+- Modify only as needed by previous tasks
+
+**Step 1: Run app channel/config tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app config::
+cargo test -p loongclaw-app channel::
+```
+
+Expected: PASS
+
+**Step 2: Run daemon tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon tests::
+```
+
+Expected: PASS
+
+### Task 5: Run full quality gates
+
+**Files:**
+- No new files expected
+
+**Step 1: Run workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace --all-features
+```
+
+Expected: PASS
+
+**Step 2: Run lint and format gates**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: PASS

--- a/docs/plans/2026-03-11-channel-default-routing-phase-10-design.md
+++ b/docs/plans/2026-03-11-channel-default-routing-phase-10-design.md
@@ -1,0 +1,110 @@
+# Channel Default Routing Phase 10 Design
+
+**Scope**
+
+Phase 10 makes the default-account routing decision observable and actionable.
+
+Phase 9 already blocks ambiguous config integrity errors such as duplicate
+normalized account ids and unknown `default_account` references. What remains
+is a softer but still operationally important ambiguity: when LoongClaw falls
+back to a default account implicitly, operators cannot currently tell whether
+that default came from an explicit config choice, a compatibility mapping, or a
+sorted fallback.
+
+**Problem Statement**
+
+Today `channels` and `doctor` can tell an operator which configured account is
+currently treated as the default, but not why.
+
+That missing "why" matters because these states are not equivalent:
+
+- `default_account` explicitly points at one configured account
+- one configured account is literally named `default`
+- there is only one configured account, so fallback is harmless
+- there are multiple configured accounts, and LoongClaw is silently picking the
+  first sorted id
+- there are no configured accounts, and the effective configured-account view is
+  derived from runtime identity compatibility
+
+Only one of those is truly risky for routing: the multi-account sorted fallback.
+That is also the exact Telegram case OpenClaw warns about upstream.
+
+**Reference Findings**
+
+OpenClaw already models default-account provenance explicitly in Feishu:
+
+- `explicit-default`
+- `mapped-default`
+- `fallback`
+
+OpenClaw's Telegram account layer emits a warning when:
+
+- there are multiple configured accounts
+- no explicit `defaultAccount` is set
+- no configured `default` account exists
+- routing therefore falls back to the first sorted configured account id
+
+That is the right standard for LoongClaw too. Not because LoongClaw must mimic
+every upstream detail, but because it expresses the real operational risk.
+
+**Chosen Design**
+
+Add a first-class default-account selection source to LoongClaw's channel
+config/runtime substrate.
+
+For Telegram and Feishu/Lark, resolve:
+
+- `explicit_default`
+- `mapped_default`
+- `fallback`
+- `runtime_identity`
+
+The default-account id remains what it is today; this phase adds provenance.
+
+**Selection Semantics**
+
+1. If `accounts` is non-empty and `default_account` matches a configured account
+   after normalization:
+   - source = `explicit_default`
+2. Else if `accounts` is non-empty and one configured account id is `default`:
+   - source = `mapped_default`
+3. Else if `accounts` is non-empty:
+   - source = `fallback`
+   - selected id = first sorted configured account id
+4. Else:
+   - source = `runtime_identity`
+   - selected id = single-account compatibility identity already used by
+     Phase 9
+
+**Operator Surface Changes**
+
+`ChannelStatusSnapshot` should include:
+
+- `default_account_source`
+- `is_default_account`
+
+`channels` text output should show both the current default marker and the
+selection source.
+
+`doctor` should warn only in the genuinely risky case:
+
+- multi-account channel
+- default snapshot source = `fallback`
+
+That warning should tell the operator that omitting `--account` depends on a
+sorted fallback and should recommend setting `default_account` explicitly.
+
+**Why This Is The Right Next Step**
+
+This phase tightens account routing without overreaching into runtime
+supervision or Discord adapter work.
+
+It gives LoongClaw:
+
+- explicit default-routing provenance
+- actionable operator warnings for risky fallback routing
+- a cleaner substrate for future multi-account supervisors and Discord
+
+After this phase, the next major missing layer is no longer default-account
+semantics. It is the shared runtime orchestration substrate for long-lived
+channel workers.

--- a/docs/plans/2026-03-11-channel-default-routing-phase-10.md
+++ b/docs/plans/2026-03-11-channel-default-routing-phase-10.md
@@ -1,0 +1,91 @@
+# Channel Default Routing Phase 10 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make LoongClaw's default-account routing source explicit and surface
+the risky implicit multi-account fallback through `channels` and `doctor`.
+
+**Architecture:** Add a reusable default-account selection result with
+provenance in channel config, propagate that provenance into status snapshots,
+and emit doctor warnings only when multiple configured accounts rely on a
+sorted fallback default.
+
+**Tech Stack:** Rust, serde, clap
+
+---
+
+### Task 1: Add failing default-selection provenance tests
+
+**Files:**
+- Modify: `crates/app/src/config/channels.rs`
+
+Add tests that prove:
+
+- explicit `default_account` resolves to `explicit_default`
+- a configured `default` account resolves to `mapped_default`
+- single-account compatibility resolves to `runtime_identity`
+- multi-account implicit routing resolves to `fallback`
+
+Run:
+
+```bash
+cargo test -p loongclaw-app default_account_selection_source
+```
+
+Expected: FAIL before implementation.
+
+### Task 2: Add failing operator-surface tests
+
+**Files:**
+- Modify: `crates/app/src/channel/registry.rs`
+- Modify: `crates/daemon/src/tests/mod.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+
+Add tests that prove:
+
+- snapshots serialize `default_account_source`
+- `channels` text output shows the source
+- `doctor` warns when multi-account routing depends on fallback default
+
+Run:
+
+```bash
+cargo test -p loongclaw-app default_account_source
+cargo test -p loongclaw-daemon default_account_source
+```
+
+Expected: FAIL before implementation.
+
+### Task 3: Implement default-account selection provenance
+
+**Files:**
+- Modify: `crates/app/src/config/channels.rs`
+- Modify: `crates/app/src/config/mod.rs`
+
+Implement a reusable selection result and source enum shared by Telegram and
+Feishu/Lark default-account resolution.
+
+### Task 4: Implement channel status and doctor warnings
+
+**Files:**
+- Modify: `crates/app/src/channel/registry.rs`
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+
+Propagate selection provenance into channel snapshots, notes, text output, and
+doctor checks.
+
+### Task 5: Verification
+
+Run:
+
+```bash
+cargo test -p loongclaw-app config::
+cargo test -p loongclaw-app channel::
+cargo test -p loongclaw-daemon tests::
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: PASS

--- a/docs/plans/2026-03-11-channel-doctor-runtime-phase-5-design.md
+++ b/docs/plans/2026-03-11-channel-doctor-runtime-phase-5-design.md
@@ -1,0 +1,95 @@
+# Channel Doctor Runtime Phase 5 Design
+
+**Scope**
+
+Phase 5 upgrades `loongclawd doctor` from configuration-only channel checks to
+runtime-aware diagnostics for tracked serve operations.
+
+It does not add new channel transports. It closes the operator feedback loop
+opened by Phase 4 runtime persistence.
+
+**Problem Statement**
+
+After Phase 4, LoongClaw could persist serve runtime state and expose it through
+`loongclawd channels`, but `doctor` still treated channels as a pure readiness
+problem. That left two operator workflows misaligned:
+
+- `channels` could say a serve loop was stale or not running
+- `doctor` could still report the same channel as healthy because config was valid
+
+This split was no longer defensible once runtime state existed.
+
+**Reference Findings From OpenClaw**
+
+OpenClaw keeps channel configuration checks and live monitor state separate.
+That separation matters because "configured correctly" and "currently healthy"
+are different claims.
+
+Discord in OpenClaw is also a strong warning against overloading config checks
+with runtime meaning. Its monitor stack depends on richer runtime surfaces:
+
+- live gateway/session ownership
+- route/session state
+- activity tracking
+- thread binding and allowlist policy
+
+LoongClaw is not ready for Discord until its operator surfaces can already carry
+that separation cleanly for simpler channels.
+
+**Chosen Design**
+
+Keep the existing config-derived doctor checks, but add separate runtime checks
+for serve operations whose registry entries expose `runtime`.
+
+Mapping in this phase:
+
+- Telegram `serve`
+  - config check: `telegram channel`
+  - runtime check: `telegram channel runtime`
+- Feishu `serve`
+  - config check: `feishu webhook verification`
+  - runtime check: `feishu webhook runtime`
+- Feishu `send`
+  - config check only
+
+Runtime check semantics for ready serve operations:
+
+- `running=true` and `stale=false` -> `Pass`
+- `stale=true` -> `Fail`
+- `running=false` and not stale -> `Warn`
+- missing runtime payload -> `Warn`
+
+**Why Separate Checks**
+
+Keeping config and runtime separate avoids three failure modes:
+
+1. A stale process does not get hidden behind a green config check.
+2. An intentionally stopped but correctly configured serve loop shows as a warn,
+   not a fail.
+3. Future channels can add runtime checks without changing the meaning of the
+   existing configuration checks.
+
+**Why This Should Happen Before Discord**
+
+Discord in OpenClaw is not a thin transport adapter. It depends on a monitor
+runtime that already knows how to distinguish:
+
+- configured vs. connected
+- connected vs. active
+- active vs. stale
+- per-session/thread state vs. global transport state
+
+LoongClaw needed the same operator-level separation on Telegram and Feishu
+before Discord would be architecturally safe to add.
+
+**Deferred Work**
+
+This phase still defers:
+
+- doctor autofix for runtime issues
+- account-scoped runtime doctor rows
+- runtime-aware JSON substructure beyond the current text detail field
+- Discord monitor diagnostics
+
+Those depend on the next layer: account-aware runtime identity and a generic
+channel monitor abstraction.

--- a/docs/plans/2026-03-11-channel-doctor-runtime-phase-5.md
+++ b/docs/plans/2026-03-11-channel-doctor-runtime-phase-5.md
@@ -1,0 +1,55 @@
+# Channel Doctor Runtime Phase 5 Implementation Plan
+
+**Goal:** Make `loongclawd doctor` consume the same runtime-aware channel
+snapshots as `loongclawd channels`, so operator diagnostics reflect both config
+readiness and serve-loop liveness.
+
+**Architecture:** Reuse shared channel snapshots from `loongclaw-app::channel`,
+then derive two check classes in daemon:
+
+- config checks
+- runtime checks
+
+Do not duplicate Telegram/Feishu liveness rules in daemon-specific code beyond
+the final doctor severity mapping.
+
+**Tech Stack:** Rust
+
+### Task 1: Add failing doctor tests
+
+Add tests that prove:
+
+- a ready tracked serve operation that is not running becomes a runtime `Warn`
+- a ready tracked serve operation with `stale=true` becomes a runtime `Fail`
+
+### Task 2: Split doctor channel checks into config and runtime
+
+Refactor doctor channel logic so:
+
+- config checks still follow `Ready/Disabled/Unsupported/Misconfigured`
+- runtime checks are emitted only for ready tracked serve operations
+- runtime check names are distinct from config check names
+
+### Task 3: Include useful runtime detail
+
+Runtime doctor details should carry enough evidence for operators to act:
+
+- `pid`
+- `busy`
+- `active_runs`
+- `last_run_activity_at`
+- `last_heartbeat_at`
+
+### Task 4: Verify broadly
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon build_channel_surface_checks_
+cargo test -p loongclaw-daemon tests::
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected result: PASS

--- a/docs/plans/2026-03-11-channel-multi-account-phase-8-design.md
+++ b/docs/plans/2026-03-11-channel-multi-account-phase-8-design.md
@@ -1,0 +1,165 @@
+# Channel Multi-Account Phase 8 Design
+
+**Scope**
+
+Phase 8 upgrades LoongClaw's Telegram and Feishu/Lark channel stack from
+"account-aware identity" to actual multi-account configuration and selection.
+
+This phase is still intentionally narrower than "implement Discord". It does
+not add a Discord adapter, gateway, or monitor loop. It finishes the account
+resolution substrate that OpenClaw already relies on across Telegram, Feishu,
+and Discord.
+
+**Problem Statement**
+
+After Phase 7, LoongClaw can:
+
+- derive a stable account identity from credentials
+- scope runtime files by account identity
+- scope Telegram offsets by account identity
+- expose account-aware runtime info in `channels` and `doctor`
+
+But LoongClaw still cannot do what OpenClaw's channel layers assume is normal:
+
+- configure multiple accounts under one channel
+- choose an explicit default account
+- select one account at runtime from CLI
+- show operator status per configured account instead of one platform-wide row
+
+That means LoongClaw still behaves like a single-account system with nicer
+labels. OpenClaw's Telegram, Feishu, and Discord implementations already sit on
+top of a stricter pattern:
+
+- account maps
+- default-account resolution
+- merged per-account config
+- explicit account selection
+- per-account status surfaces
+
+Discord is downstream of that substrate. LoongClaw should finish that substrate
+before any Discord work continues.
+
+**Reference Findings From OpenClaw**
+
+OpenClaw's Telegram and Feishu account modules share the same structure:
+
+- `accounts` map stores per-account overrides
+- `defaultAccount` resolves omitted account selection
+- base config and account config are merged before runtime work starts
+- helpers can list account ids, resolve default account id, and resolve one
+  selected account
+
+OpenClaw's Discord module follows the same pattern, not a special-case pattern.
+That matters because the next missing layer in LoongClaw is architectural, not
+transport-specific.
+
+The useful conclusion is:
+
+- Telegram, Feishu, and Discord all want one reusable account-resolution seam
+- LoongClaw should implement that seam now for Telegram and Feishu
+- Discord should wait until that seam is proven by config, startup, and
+  operator surfaces
+
+**Chosen Design**
+
+Add actual account selection support for Telegram and Feishu/Lark while keeping
+Phase 7's credential-derived identity model intact.
+
+This phase separates two concepts:
+
+1. configured account selector
+   - chosen from `accounts.<id>` or fallback default selection
+   - used by CLI selection and per-account status rows
+2. resolved runtime identity
+   - derived from merged config via explicit `account_id`, credential-derived
+     identity, or `default`
+   - used by session keys, runtime files, and Telegram offset persistence
+
+This split preserves Phase 7 runtime compatibility while still enabling
+OpenClaw-style multi-account config and selection.
+
+**Config Changes**
+
+Add to both `telegram` and `feishu`:
+
+- `default_account`
+- `accounts`
+
+Add account override structs for both channels. Account override structs use
+optional fields so they can override only the fields they need.
+
+Examples of fields that remain overrideable per account:
+
+- `enabled`
+- `account_id`
+- credentials / env pointers
+- network endpoint settings
+- allowlists
+- Feishu webhook and receive-id settings
+
+Top-level fields remain the base config. Account entries override them after
+selection.
+
+**Account Resolution Rules**
+
+For each channel:
+
+1. If `accounts` is non-empty:
+   - valid configured account ids are the normalized account-map keys
+   - omitted selection resolves to `default_account` when present and valid
+   - otherwise fall back to the first sorted configured account id
+2. If `accounts` is empty:
+   - omitted selection resolves to current single-account behavior
+   - the fallback configured account id remains compatible with Phase 7
+3. After a configured account is selected:
+   - merge base config with account override
+   - resolve runtime account identity from the merged config
+
+**CLI Changes**
+
+Add explicit account selection flags:
+
+- `telegram-serve --account <id>`
+- `feishu-send --account <id>`
+- `feishu-serve --account <id>`
+
+If `--account` is omitted, runtime selection uses the configured default-account
+rules above.
+
+**Operator Surface Changes**
+
+`channels` and `doctor` should move from one row per platform to one row per
+configured account selection.
+
+Each row should expose both:
+
+- configured account selection id
+- resolved runtime identity
+
+This preserves Phase 7 observability while finally showing multiple configured
+accounts separately.
+
+**What This Phase Deliberately Does Not Solve**
+
+This phase still does not add:
+
+- multi-account concurrent serve fanout in one process
+- Feishu multi-account shared webhook multiplexing
+- generic monitor traits for websocket-style channels
+- Discord adapter/runtime implementation
+
+Those are later phases. Phase 8 is the last major config/runtime substrate step
+before Discord becomes technically reasonable.
+
+**Why This Is The Right Next Step**
+
+Phase 8 closes the largest remaining gap between LoongClaw and OpenClaw's
+channel architecture:
+
+- config becomes truly multi-account
+- startup becomes explicitly account-selectable
+- registry becomes per-account instead of per-platform
+- `doctor` and `channels` stop hiding account multiplicity
+
+Once this exists, the next remaining Discord blocker is no longer basic account
+resolution. It becomes the heavier runtime and monitor substrate Discord needs.

--- a/docs/plans/2026-03-11-channel-multi-account-phase-8.md
+++ b/docs/plans/2026-03-11-channel-multi-account-phase-8.md
@@ -1,0 +1,121 @@
+# Channel Multi-Account Phase 8 Implementation Plan
+
+**Goal:** Add OpenClaw-style multi-account configuration and default-account
+selection for Telegram and Feishu/Lark, wire CLI account selection through
+runtime startup, and expose per-account channel status in `channels` and
+`doctor`.
+
+**Architecture:** Keep Phase 7 runtime identity semantics, but add a new
+configured-account selection layer. Resolve one configured account, merge base
+config with account overrides, derive runtime identity from the merged config,
+and report channel status per configured account.
+
+**Tech Stack:** Rust, serde, clap, tokio
+
+### Task 1: Add failing multi-account config tests
+
+**Files:**
+- Modify: `crates/app/src/config/channels.rs`
+
+Add tests that prove:
+
+- Telegram lists configured account ids from `accounts`
+- Telegram resolves `default_account`
+- Telegram merges top-level config with account overrides
+- Feishu does the same
+- single-account fallback remains compatible
+
+Run:
+
+```bash
+cargo test -p loongclaw-app config::channels::tests::multi_account
+```
+
+Expected: FAIL before implementation.
+
+### Task 2: Add failing per-account registry and doctor tests
+
+**Files:**
+- Modify: `crates/app/src/channel/registry.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/src/tests/mod.rs`
+
+Add tests that prove:
+
+- `channel_status_snapshots()` emits one snapshot per configured account
+- snapshots expose configured account selection ids
+- `doctor` scopes duplicate check names by account when multiple accounts exist
+- `channels` text rendering shows configured account selection ids
+
+Run:
+
+```bash
+cargo test -p loongclaw-app channel::registry::tests::multi_account
+cargo test -p loongclaw-daemon multi_account
+```
+
+Expected: FAIL before implementation.
+
+### Task 3: Implement config selection helpers
+
+**Files:**
+- Modify: `crates/app/src/config/channels.rs`
+- Modify: `crates/app/src/config/mod.rs`
+
+Implement:
+
+- `default_account` and `accounts` for Telegram and Feishu
+- account override structs
+- helpers to list configured account ids
+- helpers to resolve default account ids
+- helpers to resolve one merged account config
+
+### Task 4: Implement CLI account selection and startup wiring
+
+**Files:**
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/app/src/channel/mod.rs`
+- Modify: `crates/app/src/channel/telegram.rs`
+- Modify: `crates/app/src/channel/feishu/mod.rs`
+- Modify: `crates/app/src/channel/feishu/adapter.rs`
+- Modify: `crates/app/src/channel/feishu/webhook.rs`
+
+Implement:
+
+- `--account` on `telegram-serve`, `feishu-send`, and `feishu-serve`
+- resolved account selection passed into adapter/runtime startup
+- merged config used instead of raw top-level config
+
+### Task 5: Implement per-account registry and doctor surfaces
+
+**Files:**
+- Modify: `crates/app/src/channel/registry.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/src/main.rs`
+
+Implement:
+
+- one channel snapshot per configured account
+- configured account metadata in JSON/text output
+- account-scoped doctor check naming when one platform exposes multiple accounts
+
+### Task 6: Verification
+
+Run:
+
+```bash
+cargo test -p loongclaw-app config::
+cargo test -p loongclaw-app channel::
+cargo test -p loongclaw-daemon tests::
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: PASS
+
+### Expected Remaining Gap After Phase 8
+
+Even after Phase 8, LoongClaw will still need a stronger shared monitor/event
+substrate before Discord is worth implementing. This plan intentionally stops
+before that layer.

--- a/docs/plans/2026-03-11-channel-registry-phase-3-design.md
+++ b/docs/plans/2026-03-11-channel-registry-phase-3-design.md
@@ -1,0 +1,87 @@
+# Channel Registry Phase 3 Design
+
+**Scope**
+
+Phase 3 adds a lightweight channel registry and readiness surface for LoongClaw.
+It intentionally stops short of a full persistent run-state monitor. The goal is
+to give Telegram and Feishu/Lark a shared catalog, alias normalization path, and
+operator-visible readiness model before introducing more channels.
+
+**Why This Phase Exists**
+
+After Phase 1 reliability fixes and Phase 2 runtime/session abstraction, LoongClaw
+still lacked one of OpenClaw's most important structural seams: a shared channel
+directory that can answer basic questions consistently:
+
+- what channels exist
+- which aliases normalize to which surface
+- which operations each channel exposes
+- whether a given operation is ready, disabled, unsupported, or misconfigured
+
+OpenClaw does this with a registry plus runtime state plumbing. LoongClaw did not.
+Telegram and Feishu checks were still duplicated across daemon CLI and channel adapters.
+
+**Reference Findings From OpenClaw**
+
+OpenClaw separates:
+
+- channel identity / aliases / metadata
+- runtime busy-state updates
+- operator-facing selection and status surfaces
+
+The `registry.ts` layer is the keystone because it normalizes channel IDs and
+prevents every caller from re-encoding channel knowledge ad hoc.
+
+**Chosen Design**
+
+Add a shared channel registry in the app crate with:
+
+- `ChannelCatalogEntry`
+- `ChannelCatalogOperation`
+- `normalize_channel_platform(...)`
+- `channel_status_snapshots(...)`
+
+Each status snapshot reports:
+
+- channel identity and aliases
+- transport family
+- compile-time availability
+- config enablement
+- API base URL and operator notes
+- per-operation health
+
+Per-operation health is explicit:
+
+- `ready`
+- `disabled`
+- `unsupported`
+- `misconfigured`
+
+This lets Feishu model two different operational surfaces under one channel:
+
+- `send`
+- `serve`
+
+That distinction matters because Feishu direct send only needs app credentials,
+while webhook serving additionally needs allowlist and webhook verification inputs.
+
+**Why This Is The Right Next Step**
+
+This phase is the smallest meaningful step toward OpenClaw's runtime model:
+
+- it removes duplicated channel readiness logic
+- it gives `lark -> feishu` aliasing a first-class home
+- it creates a stable metadata seam for a future run-state heartbeat
+- it keeps Discord deferred until the shared operator surface exists
+
+**Deferred Work**
+
+This phase intentionally defers:
+
+- persistent active-run tracking / heartbeat timestamps
+- background monitor daemons
+- account-scoped multi-instance registry entries
+- Discord integration
+- hot-reloadable external channel plugins
+
+Those are easier and safer after registry/status semantics exist.

--- a/docs/plans/2026-03-11-channel-registry-phase-3.md
+++ b/docs/plans/2026-03-11-channel-registry-phase-3.md
@@ -1,0 +1,57 @@
+# Channel Registry Phase 3 Implementation Plan
+
+**Goal:** Add a shared channel catalog and readiness snapshot layer, then expose it through daemon CLI and doctor checks.
+
+**Architecture:** Centralize channel identity, aliases, operation metadata, and readiness evaluation in `loongclaw-app::channel`. Consume that surface from `loongclaw-daemon` instead of duplicating Telegram/Feishu channel knowledge in multiple places.
+
+**Tech Stack:** Rust, serde, clap
+
+### Task 1: Add registry and readiness tests
+
+Add tests that prove:
+
+- `lark` normalizes to the Feishu surface
+- the catalog keeps Lark as a Feishu alias
+- Telegram readiness becomes `ready` when token and allowlist are configured
+- Feishu direct send and webhook serve can report different readiness states
+
+### Task 2: Implement shared channel registry
+
+Add:
+
+- catalog metadata
+- alias normalization
+- per-operation health snapshots
+
+Make the shared snapshot represent the actual operational surfaces:
+
+- Telegram: `serve`
+- Feishu/Lark: `send`, `serve`
+
+### Task 3: Expose channel status in daemon CLI
+
+Add a `channels` command that prints:
+
+- channel identity
+- aliases
+- transport
+- API base URL
+- per-operation health, command name, and issues
+
+Also add a daemon test that proves the new text output includes aliases and operation status.
+
+### Task 4: Replace duplicated doctor channel checks
+
+Use the shared readiness snapshots to drive doctor channel checks so the daemon no longer reimplements Telegram/Feishu config logic separately.
+
+### Task 5: Verify locally
+
+Run:
+
+```bash
+cargo test -p loongclaw-app channel::
+cargo test -p loongclaw-daemon tests::
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```

--- a/docs/plans/2026-03-11-channel-reliability-design.md
+++ b/docs/plans/2026-03-11-channel-reliability-design.md
@@ -1,0 +1,52 @@
+# Channel Reliability Phase 1 Design
+
+**Scope**
+
+This design covers the first implementation phase for LoongClaw channel hardening after the
+Telegram / Feishu / Lark / Discord comparison study.
+
+The goal is not to reproduce OpenClaw's full channel platform in one pass. The goal is to
+remove the highest-risk delivery bugs in the current MVP and introduce one small channel-runtime
+contract improvement that future Feishu/Lark and Discord work can build on without rework.
+
+**Problems Being Solved**
+
+1. Telegram currently persists the next polling offset before provider execution and outbound send
+   have completed. A failure after polling can silently drop updates.
+2. Feishu webhook dedupe currently marks an event as seen before provider execution and outbound
+   reply have completed. A failure after dedupe can cause later retries to be ignored.
+3. The current channel contract has no delivery acknowledgement hook, so reliability semantics are
+   trapped inside each adapter and cannot evolve cleanly.
+
+**Chosen Design**
+
+Introduce a minimal delivery-ack layer instead of a large runtime rewrite:
+
+- Extend `ChannelInboundMessage` with optional delivery metadata.
+- Extend `ChannelAdapter` with default no-op hooks for:
+  - per-message acknowledgement
+  - end-of-batch completion
+- Teach the Telegram adapter to:
+  - keep polled offsets pending until processing succeeds
+  - acknowledge successfully handled messages incrementally
+  - advance trailing ignored updates only when the batch completes
+- Teach the Feishu webhook dedupe cache to distinguish `processing` from `completed`
+  and to release failed events so platform retries can be processed again.
+
+**Why This Approach**
+
+- It fixes the worst correctness bugs now.
+- It avoids a risky, wide refactor of conversation/runtime boundaries in one patch.
+- It creates a small but real seam for later channel-runtime enrichment.
+- It preserves existing user-facing behavior except where retry/drop semantics improve.
+
+**Deferred Work**
+
+This phase intentionally does not implement:
+
+- Feishu/Lark unified domain/config model
+- Telegram webhook / callback query / topic routing
+- Discord adapter
+- full `ChannelEvent` / `OutboundMessage` runtime redesign
+
+Those remain Phase 2+ work after the reliability layer is stable.

--- a/docs/plans/2026-03-11-channel-reliability-phase-1.md
+++ b/docs/plans/2026-03-11-channel-reliability-phase-1.md
@@ -1,0 +1,182 @@
+# Channel Reliability Phase 1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate the current Telegram and Feishu silent-drop paths and add a minimal channel delivery acknowledgement seam for future channel-runtime work.
+
+**Architecture:** Add a lightweight delivery metadata path to `ChannelInboundMessage` plus default adapter acknowledgement hooks. Use those hooks to delay Telegram offset persistence until successful processing and to convert Feishu dedupe from fire-once to retry-safe processing state.
+
+**Tech Stack:** Rust, async-trait, tokio, axum, reqwest, serde_json
+
+---
+
+### Task 1: Document and expose the minimal delivery contract
+
+**Files:**
+- Modify: `crates/app/src/channel/mod.rs`
+- Test: `crates/app/src/channel/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add a unit test that constructs a `ChannelInboundMessage` with delivery metadata and verifies the
+default adapter acknowledgement hooks are no-op success paths.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app channel::tests::channel_adapter_default_ack_hooks_are_noop`
+
+Expected: FAIL because the delivery metadata and acknowledgement hooks do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- a delivery metadata struct on `ChannelInboundMessage`
+- default no-op `ack_inbound` and `complete_batch` methods on `ChannelAdapter`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app channel::tests::channel_adapter_default_ack_hooks_are_noop`
+
+Expected: PASS
+
+### Task 2: Make Telegram offset persistence retry-safe
+
+**Files:**
+- Modify: `crates/app/src/channel/telegram.rs`
+- Modify: `crates/app/src/channel/mod.rs`
+- Test: `crates/app/src/channel/telegram.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+
+- polling a batch does not immediately persist the next offset
+- acknowledging one delivered message advances offset only through that message
+- completing an empty or partially ignored batch advances the trailing offset
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app channel::telegram::tests::telegram_batch_offset_is_not_persisted_until_ack`
+
+Expected: FAIL because polling currently writes offset immediately.
+
+**Step 3: Write minimal implementation**
+
+Update Telegram polling state to keep batch offset pending, acknowledge successful messages, and
+flush the trailing cursor only on batch completion.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app channel::telegram::tests::telegram_batch_offset_is_not_persisted_until_ack`
+
+Expected: PASS
+
+### Task 3: Make Feishu dedupe retry-safe
+
+**Files:**
+- Modify: `crates/app/src/channel/feishu/webhook.rs`
+- Test: `crates/app/src/channel/feishu/webhook.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+
+- the cache distinguishes `processing` and `completed`
+- duplicate events are suppressed while an event is in progress
+- a failed event can be released and accepted on retry
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app channel::feishu::webhook::tests::recent_cache_releases_failed_events_for_retry`
+
+Expected: FAIL because the cache only supports seen/not-seen semantics.
+
+**Step 3: Write minimal implementation**
+
+Replace the simple `insert_if_new` cache with processing/completed state helpers, and wire the
+webhook handler to confirm success or release on error.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app channel::feishu::webhook::tests::recent_cache_releases_failed_events_for_retry`
+
+Expected: PASS
+
+### Task 4: Wire the new delivery hooks into the Telegram loop
+
+**Files:**
+- Modify: `crates/app/src/channel/mod.rs`
+- Test: `crates/app/src/channel/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add a test adapter that records hook calls and verify the channel loop acknowledges each message
+only after successful send and completes the batch after a successful pass.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app channel::tests::telegram_loop_acknowledges_after_successful_delivery`
+
+Expected: FAIL because the loop does not invoke acknowledgement hooks.
+
+**Step 3: Write minimal implementation**
+
+Call `ack_inbound` after each successful message send and `complete_batch` when the loop finishes
+the batch without error.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app channel::tests::telegram_loop_acknowledges_after_successful_delivery`
+
+Expected: PASS
+
+### Task 5: Verify the scoped change set
+
+**Files:**
+- Modify: `docs/plans/2026-03-11-channel-reliability-design.md`
+- Modify: `docs/plans/2026-03-11-channel-reliability-phase-1.md`
+
+**Step 1: Run targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app channel::telegram::
+cargo test -p loongclaw-app channel::feishu::webhook::
+cargo test -p loongclaw-app channel::tests::
+```
+
+Expected: PASS
+
+**Step 2: Run broader crate verification**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app
+```
+
+Expected: PASS
+
+**Step 3: Run formatting**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+```
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-03-11-channel-reliability-design.md \
+        docs/plans/2026-03-11-channel-reliability-phase-1.md \
+        crates/app/src/channel/mod.rs \
+        crates/app/src/channel/telegram.rs \
+        crates/app/src/channel/feishu/webhook.rs
+git commit -m "fix: harden channel delivery reliability"
+```

--- a/docs/plans/2026-03-11-channel-runtime-context-phase-12-design.md
+++ b/docs/plans/2026-03-11-channel-runtime-context-phase-12-design.md
@@ -1,0 +1,74 @@
+# Channel Runtime Context Phase 12 Design
+
+**Scope**
+
+Phase 12 extracts the repeated runtime-entry preparation logic for Telegram and
+Feishu/Lark into a shared channel command context and a shared serve-runtime
+lifecycle wrapper.
+
+Phase 11 already made route provenance visible inside runtime entrypoints.
+What remains is structural duplication:
+
+- load config
+- resolve account
+- derive route metadata
+- reject disabled account
+- apply runtime env
+- emit fallback-route warning
+- start account-scoped runtime tracker
+- run serve body
+- shutdown tracker
+
+That sequence is now duplicated across Telegram and Feishu serve flows, and
+partially duplicated in Feishu send.
+
+**Problem Statement**
+
+LoongClaw is already more advanced than `alpha-test` in multi-account channel
+semantics, but the runtime entry substrate is still hand-wired per channel.
+
+That creates three concrete risks:
+
+- Telegram / Feishu can drift in operator-facing startup semantics
+- future supervisor work has no shared execution seam to plug into
+- a Discord adapter would be tempted to copy another bespoke runtime path
+
+**Chosen Design**
+
+Add two shared layers in `crates/app/src/channel/mod.rs`:
+
+1. `ChannelCommandContext<R>`
+   - owns `resolved_path`
+   - owns loaded `LoongClawConfig`
+   - owns channel-specific resolved account config
+   - owns `ChannelResolvedAccountRoute`
+
+2. `with_channel_serve_runtime(...)`
+   - starts `ChannelOperationRuntimeTracker`
+   - passes the tracker into the serve body
+   - always attempts shutdown
+   - preserves the original serve failure if serve and shutdown both fail
+
+**Behavior**
+
+For Telegram and Feishu:
+
+- build a typed command context from config load + account resolution
+- reject disabled accounts during context construction
+- use the context to print the route notice and runtime banner fields
+- wrap long-lived serve execution in the shared runtime lifecycle helper
+
+Feishu send also uses the shared command context even though it does not start a
+runtime tracker.
+
+**Why This Is The Right Next Step**
+
+This phase does not overreach into a full supervisor yet.
+
+Instead, it creates the missing execution seam between:
+
+- config/account semantics
+- operator/runtime warnings
+- long-lived runtime lifecycle
+
+That seam is the minimal substrate a future supervisor and Discord adapter need.

--- a/docs/plans/2026-03-11-channel-runtime-context-phase-12.md
+++ b/docs/plans/2026-03-11-channel-runtime-context-phase-12.md
@@ -1,0 +1,57 @@
+# Channel Runtime Context Phase 12 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extract shared runtime-entry preparation and serve-lifecycle handling
+for Telegram and Feishu/Lark channels.
+
+**Architecture:** Introduce a typed `ChannelCommandContext` for config load,
+resolved-account data, and route provenance, then introduce a shared
+`with_channel_serve_runtime` wrapper that owns tracker startup/shutdown around
+serve bodies.
+
+**Tech Stack:** Rust, tokio, serde
+
+---
+
+### Task 1: Add failing tests for shared context and serve runtime
+
+**Files:**
+- Modify: `crates/app/src/channel/mod.rs`
+- Modify: `crates/app/src/channel/runtime_state.rs`
+
+Add tests that prove:
+
+- command-context builders preserve route metadata and reject disabled accounts
+- shared serve runtime persists running state during execution and shutdown state
+  after execution
+
+### Task 2: Implement shared command context
+
+**Files:**
+- Modify: `crates/app/src/channel/mod.rs`
+
+Add `ChannelCommandContext<R>` plus typed Telegram / Feishu builders that
+centralize config load, account resolution, route derivation, and disabled
+account rejection.
+
+### Task 3: Implement shared serve runtime wrapper
+
+**Files:**
+- Modify: `crates/app/src/channel/mod.rs`
+- Modify: `crates/app/src/channel/runtime_state.rs`
+
+Add a shared runtime lifecycle wrapper and migrate Telegram / Feishu serve flows
+to use it.
+
+### Task 4: Verification
+
+Run:
+
+```bash
+cargo test -p loongclaw-app channel::
+cargo test -p loongclaw-app config::
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```

--- a/docs/plans/2026-03-11-channel-runtime-multiprocess-phase-6-design.md
+++ b/docs/plans/2026-03-11-channel-runtime-multiprocess-phase-6-design.md
@@ -1,0 +1,96 @@
+# Channel Runtime Multiprocess Phase 6 Design
+
+**Scope**
+
+Phase 6 hardens channel runtime persistence so multiple instances of the same
+channel operation do not overwrite each other on disk.
+
+It does not add user-visible multi-account routing yet. It fixes the lower-level
+state model that multi-account routing and future Discord monitor work depend on.
+
+**Problem Statement**
+
+Phase 4 moved LoongClaw from "readiness only" to persisted serve runtime state,
+but its first storage model was still too coarse:
+
+- one file per `platform + operation`
+
+That solved Telegram and Feishu overwriting each other, but it still let two
+instances of the same operation trample one another:
+
+- two `telegram-serve` processes
+- two `feishu-serve` processes
+- future per-account serve loops on the same machine
+
+This is a real architectural problem because the persisted runtime surface is
+supposed to be the foundation for:
+
+- operator liveness diagnosis
+- account-aware channel serve state
+- eventual Discord monitor integration
+
+If same-operation instances can overwrite one another, all three layers become
+untrustworthy.
+
+**Reference Findings From OpenClaw**
+
+OpenClaw does not model channel runtime as one global singleton blob. Telegram,
+Feishu, and Discord all resolve account- and monitor-specific runtime state
+before they publish health or activity.
+
+Its account resolution layers for Telegram, Feishu, and Discord all point in the
+same direction: monitor state must be instance-aware before richer transports can
+be added safely.
+
+**Chosen Design**
+
+Switch persisted runtime storage from:
+
+- one file per `platform + operation`
+
+to:
+
+- one file per `platform + operation + pid`
+
+Examples:
+
+- `telegram-serve-4242.json`
+- `feishu-serve-5151.json`
+
+Loader behavior:
+
+- scan all matching runtime files for the requested operation
+- support both pid-scoped files and legacy single-file state
+- prefer a currently running instance over a newer stopped instance
+- otherwise prefer the freshest observed instance
+
+This keeps the public runtime view stable while removing same-operation overwrite
+hazards.
+
+**Why This Is The Right Next Step**
+
+LoongClaw still does not have OpenClaw-style account maps for Telegram and
+Feishu, so full account-aware runtime identity would be premature at the CLI
+surface. But the storage layer can and should be fixed now because:
+
+- it removes existing correctness risk
+- it preserves backward compatibility
+- it creates the right seam for future account IDs without redesigning runtime
+  persistence again
+
+**Compatibility**
+
+Phase 6 must remain backward compatible with any Phase 4 runtime files already
+written on disk. Loader compatibility is therefore mandatory.
+
+**Deferred Work**
+
+This phase still defers:
+
+- explicit account IDs in runtime identity
+- runtime aggregation for multiple simultaneous healthy instances
+- duplicate-instance warnings in `channels` or `doctor`
+- Discord runtime integration
+
+Those depend on a later phase that adds account-aware or monitor-aware runtime
+identity above this pid-safe storage base.

--- a/docs/plans/2026-03-11-channel-runtime-multiprocess-phase-6.md
+++ b/docs/plans/2026-03-11-channel-runtime-multiprocess-phase-6.md
@@ -1,0 +1,50 @@
+# Channel Runtime Multiprocess Phase 6 Implementation Plan
+
+**Goal:** Prevent same-operation channel serve instances from overwriting each
+other's persisted runtime state while preserving the current operator-facing
+runtime view.
+
+**Architecture:** Keep `ChannelOperationRuntime` stable, but change persistence
+to pid-scoped files and teach the loader to select the preferred current runtime
+candidate across multiple files.
+
+**Tech Stack:** Rust
+
+### Task 1: Add failing tests for pid-scoped runtime files
+
+Add tests that prove:
+
+- runtime tracker writes `platform-operation-pid.json`
+- loader prefers a live pid-scoped runtime over a newer stopped instance
+- loader still reads legacy single-file runtime state
+
+### Task 2: Change runtime persistence layout
+
+Update runtime tracker start/write paths so the file name is keyed by:
+
+- platform
+- operation
+- pid
+
+### Task 3: Add multi-file runtime loading
+
+Update runtime loading so it:
+
+- scans all matching runtime files for an operation
+- accepts both pid-scoped and legacy file names
+- picks the preferred current candidate deterministically
+
+### Task 4: Verify broadly
+
+Run:
+
+```bash
+cargo test -p loongclaw-app channel::runtime_state::tests::
+cargo test -p loongclaw-app channel::
+cargo test -p loongclaw-daemon tests::
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected result: PASS

--- a/docs/plans/2026-03-11-channel-runtime-phase-2-design.md
+++ b/docs/plans/2026-03-11-channel-runtime-phase-2-design.md
@@ -1,0 +1,119 @@
+# Channel Runtime Phase 2 Design
+
+**Scope**
+
+This phase extends the earlier channel reliability work with one additional abstraction layer.
+It does not attempt to reproduce OpenClaw's full plugin runtime. It focuses on the smallest
+runtime concepts that remove current stringly-typed channel behavior and prepare LoongClaw for
+future Telegram and Feishu/Lark expansion.
+
+**Problem Statement**
+
+LoongClaw still models channel traffic with raw strings:
+
+- `session_id` is a formatted string assembled independently by each adapter.
+- `reply_target` is a raw string whose meaning depends on the adapter.
+- Feishu and Lark are not modeled as first-class variants of the same protocol surface.
+
+This creates two concrete problems:
+
+1. Channel adapters must encode transport meaning in ad hoc strings, which makes later thread,
+   topic, and account-aware routing harder to add safely.
+2. Feishu/Lark configuration cannot cleanly represent "same channel protocol, different domain"
+   the way OpenClaw does.
+
+**Reference Findings From OpenClaw**
+
+OpenClaw consistently separates:
+
+- channel identity and registry metadata
+- plugin runtime state
+- inbound normalization
+- outbound target resolution
+- per-channel domain or account configuration
+
+Its Feishu plugin explicitly treats `lark` as an alias/domain variant of the same channel instead
+of a separate implementation surface.
+
+**Chosen Design**
+
+Introduce two small abstractions now:
+
+1. A structured channel message surface in `crates/app/src/channel/mod.rs`
+   - `ChannelPlatform`
+   - `ChannelSession`
+   - `ChannelOutboundTarget`
+   - `ChannelOutboundTargetKind`
+
+2. A structured Feishu domain model in `crates/app/src/config/channels.rs`
+   - `FeishuDomain::{Feishu, Lark}`
+   - optional `base_url`
+   - `resolved_base_url()` helper
+
+**What Changes**
+
+`ChannelInboundMessage` will stop carrying raw `session_id` and raw `reply_target` values.
+Instead it will carry:
+
+- `session: ChannelSession`
+- `reply_target: ChannelOutboundTarget`
+
+`ChannelSession` will remain intentionally small in this phase:
+
+- `platform`
+- `conversation_id`
+- `thread_id`
+
+It will expose a deterministic `session_key()` used by the existing conversation runtime.
+
+`ChannelOutboundTarget` will make the current target semantics explicit:
+
+- Telegram inbound replies target a conversation chat id
+- Feishu inbound replies target a reply-to message id
+- Feishu direct sends target a receive id
+
+This keeps the current runtime behavior unchanged while eliminating the current string ambiguity.
+
+**Why This Design**
+
+This is the narrowest design that creates real reuse:
+
+- It improves type safety without forcing a full channel event bus rewrite.
+- It provides a stable place to add thread/topic/session-scope logic later.
+- It lets Feishu and Lark share one configuration model immediately.
+- It avoids taking on Discord before the shared runtime seam exists.
+
+**Alternatives Considered**
+
+**Option 1: Keep raw strings and only document conventions**
+
+Rejected because it preserves the exact ambiguity that caused the current divergence.
+
+**Option 2: Full `ChannelEvent` and `OutboundEnvelope` runtime rewrite now**
+
+Rejected for this phase because it is too wide and would mix design work with several user-facing
+behavior changes at once.
+
+**Option 3: Add Discord first and abstract later**
+
+Rejected because Discord is the largest consumer of a shared runtime seam. Adding it before the
+seam would increase divergence, not reduce it.
+
+**Behavioral Intent**
+
+This phase is intended to be behavior-preserving except for:
+
+- explicit Feishu/Lark domain resolution when `domain = "lark"` is configured
+- clearer target validation errors if a channel adapter receives the wrong target kind
+
+**Deferred Work**
+
+This phase still defers:
+
+- Telegram webhook and callback actions
+- Feishu websocket mode and account multiplexing
+- Discord runtime integration
+- account-scoped channel registry and hot-reload system
+- fully generic `ChannelEvent` / `ChannelCommand` envelopes
+
+Those become safer after this phase because the core identity and target types exist.

--- a/docs/plans/2026-03-11-channel-runtime-phase-2.md
+++ b/docs/plans/2026-03-11-channel-runtime-phase-2.md
@@ -1,0 +1,170 @@
+# Channel Runtime Phase 2 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace stringly-typed channel session and target handling with small structured runtime types, and model Feishu/Lark as a single domain-aware channel configuration surface.
+
+**Architecture:** Introduce typed channel platform, session, and outbound target types in the channel module while keeping the existing conversation runtime keyed by a derived session string. Add a domain-aware Feishu config model so `lark` becomes a first-class configuration variant with explicit base URL resolution.
+
+**Tech Stack:** Rust, serde, async-trait, tokio, axum, reqwest
+
+---
+
+### Task 1: Add failing tests for structured channel runtime types
+
+**Files:**
+- Modify: `crates/app/src/channel/mod.rs`
+- Test: `crates/app/src/channel/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+
+- `ChannelSession` derives a stable session key from platform and conversation id
+- optional thread id extends the key deterministically
+- `ChannelOutboundTarget` preserves platform, target kind, and id
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app channel::tests::channel_session_key_is_stable`
+
+Expected: FAIL because the structured runtime types do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- `ChannelPlatform`
+- `ChannelSession`
+- `ChannelOutboundTargetKind`
+- `ChannelOutboundTarget`
+
+with helper constructors and a `session_key()` method.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app channel::tests::channel_session_key_is_stable`
+
+Expected: PASS
+
+### Task 2: Convert existing channel loop and adapters to structured targets
+
+**Files:**
+- Modify: `crates/app/src/channel/mod.rs`
+- Modify: `crates/app/src/channel/telegram.rs`
+- Modify: `crates/app/src/channel/feishu/adapter.rs`
+- Modify: `crates/app/src/channel/feishu/payload/types.rs`
+- Modify: `crates/app/src/channel/feishu/payload/inbound.rs`
+- Modify: `crates/app/src/channel/feishu/webhook.rs`
+- Test: `crates/app/src/channel/mod.rs`
+- Test: `crates/app/src/channel/telegram.rs`
+- Test: `crates/app/src/channel/feishu/payload/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add or update tests to prove:
+
+- `process_channel_batch` delivers through structured outbound targets
+- Telegram inbound messages create a telegram conversation target
+- Feishu inbound messages create a reply-message target instead of a raw string
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app channel::tests::process_channel_batch_acknowledges_after_successful_delivery`
+
+Expected: FAIL because adapters and loop still depend on raw string targets.
+
+**Step 3: Write minimal implementation**
+
+Update:
+
+- `ChannelInboundMessage`
+- `ChannelAdapter::send_text`
+- provider handoff to use `message.session.session_key()`
+- Telegram parser and sender
+- Feishu inbound payload normalization and sender
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app channel::tests::process_channel_batch_acknowledges_after_successful_delivery
+cargo test -p loongclaw-app channel::telegram::tests::
+cargo test -p loongclaw-app channel::feishu::payload::tests::
+```
+
+Expected: PASS
+
+### Task 3: Add failing tests for Feishu/Lark domain-aware configuration
+
+**Files:**
+- Modify: `crates/app/src/config/channels.rs`
+- Modify: `crates/app/src/config/mod.rs`
+- Test: `crates/app/src/config/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+
+- default Feishu config resolves to the Feishu domain URL
+- `domain = "lark"` resolves to the Lark domain URL when no explicit base URL is set
+- explicit `base_url` overrides the domain default
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app config::tests::feishu_lark_domain_uses_lark_base_url_when_base_url_not_set`
+
+Expected: FAIL because the domain model does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- `FeishuDomain`
+- optional `base_url`
+- `resolved_base_url()`
+
+and switch Feishu adapter construction to the resolved URL helper.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app config::tests::feishu_defaults_are_stable
+cargo test -p loongclaw-app config::tests::feishu_lark_domain_uses_lark_base_url_when_base_url_not_set
+cargo test -p loongclaw-app config::tests::feishu_explicit_base_url_overrides_domain_default
+```
+
+Expected: PASS
+
+### Task 4: Re-run targeted and broad verification
+
+**Files:**
+- Modify: `docs/plans/2026-03-11-channel-runtime-phase-2-design.md`
+- Modify: `docs/plans/2026-03-11-channel-runtime-phase-2.md`
+
+**Step 1: Run targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app channel::
+cargo test -p loongclaw-app config::tests::feishu_
+```
+
+Expected: PASS
+
+**Step 2: Run broad verification**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: PASS

--- a/docs/plans/2026-03-11-channel-runtime-routing-phase-11-design.md
+++ b/docs/plans/2026-03-11-channel-runtime-routing-phase-11-design.md
@@ -1,0 +1,79 @@
+# Channel Runtime Routing Phase 11 Design
+
+**Scope**
+
+Phase 11 pushes default-account provenance from static operator surfaces into the
+actual runtime entrypoints for Telegram and Feishu/Lark.
+
+Phase 10 made default selection observable in `channels` and `doctor`, but the
+runtime commands themselves still silently accept risky implicit routing when an
+operator omits `--account` in a multi-account setup.
+
+**Problem Statement**
+
+Today LoongClaw can tell an operator after the fact that default routing came
+from a fallback selection, but it does not use that provenance when launching:
+
+- `telegram-serve`
+- `feishu-send`
+- `feishu-serve`
+
+That leaves a real operational gap:
+
+- the configuration layer knows a selected account came from fallback
+- `doctor` can warn about it
+- the runtime command still proceeds without an inline warning
+
+This is exactly the moment where a routing surprise matters most.
+
+**Reference Direction**
+
+OpenClaw Telegram warns at runtime only in the risky case:
+
+- multiple configured accounts
+- no explicit `defaultAccount`
+- no configured `accounts.default`
+- operator omitted account selection
+
+LoongClaw should now do the same thing with its own stronger provenance model.
+
+**Chosen Design**
+
+Add a reusable resolved-route view that captures:
+
+- requested account id, if any
+- selected configured account id
+- configured account count
+- default-account selection source
+
+From that route view, derive one shared predicate:
+
+- `uses_implicit_fallback_default`
+
+This predicate becomes the runtime gate for inline warnings.
+
+**Behavior**
+
+For Telegram and Feishu/Lark:
+
+1. Build a resolved route view after account resolution.
+2. If the operator explicitly passed `--account`, do not warn.
+3. If only one configured account exists, do not warn.
+4. If the default source is `explicit_default`, `mapped_default`, or
+   `runtime_identity`, do not warn.
+5. If the operator omitted `--account` and the selected account comes from
+   multi-account fallback routing:
+   - emit a warning before launch/send
+   - include the selected configured account id
+   - recommend setting `<channel>.default_account` or passing `--account`
+
+Also surface the route source inline in runtime banners so runtime behavior and
+`channels` / `doctor` stay consistent.
+
+**Why This Phase Matters**
+
+This is the smallest meaningful slice of a shared channel supervisor substrate.
+
+It does not attempt to build a full supervisor yet, but it does establish a
+shared runtime-routing context that future long-lived channel workers and a
+Discord adapter can reuse instead of re-implementing account-routing heuristics.

--- a/docs/plans/2026-03-11-channel-runtime-routing-phase-11.md
+++ b/docs/plans/2026-03-11-channel-runtime-routing-phase-11.md
@@ -1,0 +1,50 @@
+# Channel Runtime Routing Phase 11 Implementation Plan
+
+**Goal:** Reuse default-account provenance inside runtime entrypoints so risky
+implicit multi-account fallback routing becomes visible at launch time.
+
+### Task 1: Add failing route-context tests
+
+**Files:**
+- Modify: `crates/app/src/config/channels.rs`
+- Modify: `crates/app/src/channel/mod.rs`
+
+Add tests that prove:
+
+- a resolved route flags implicit multi-account fallback when `--account` is
+  omitted
+- explicit account selection suppresses that flag
+- explicit default and mapped default do not trigger fallback warnings
+- runtime warning rendering only emits output in the risky case
+
+### Task 2: Implement shared resolved-route abstraction
+
+**Files:**
+- Modify: `crates/app/src/config/channels.rs`
+- Modify: `crates/app/src/config/mod.rs`
+
+Implement a reusable account-route view and expose it for Telegram and
+Feishu/Lark config resolution.
+
+### Task 3: Wire route context into runtime entrypoints
+
+**Files:**
+- Modify: `crates/app/src/channel/mod.rs`
+- Modify: `crates/app/src/channel/feishu/mod.rs`
+
+Use the shared route view to:
+
+- emit inline warnings for risky fallback routing
+- add route-source metadata to runtime startup / send output
+
+### Task 4: Verification
+
+Run:
+
+```bash
+cargo test -p loongclaw-app config::
+cargo test -p loongclaw-app channel::
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```

--- a/docs/plans/2026-03-11-channel-runtime-state-phase-4-design.md
+++ b/docs/plans/2026-03-11-channel-runtime-state-phase-4-design.md
@@ -1,0 +1,143 @@
+# Channel Runtime State Phase 4 Design
+
+**Scope**
+
+Phase 4 adds persisted runtime activity state for long-running channel serve
+operations. It does not attempt a full OpenClaw plugin monitor port. It focuses
+on the smallest runtime seam that closes the current operator gap in LoongClaw:
+readiness was visible after Phase 3, but liveness was not.
+
+**Problem Statement**
+
+Before this phase, the `alpha-test` channel implementation could answer:
+
+- whether Telegram or Feishu/Lark was compiled
+- whether a channel was enabled
+- whether the required config existed
+
+It could not answer:
+
+- whether a serve loop was actually running
+- whether a running loop had gone stale
+- whether work was actively flowing through the channel
+- which process owned the current serve loop
+
+That left LoongClaw materially behind OpenClaw's monitor layer. Operators could
+see "ready" and still have no evidence that a Telegram poller or Feishu webhook
+server was alive.
+
+**Reference Findings From OpenClaw**
+
+OpenClaw keeps three concerns separate:
+
+- channel identity and alias normalization
+- monitor lifecycle state
+- operator-facing status surfaces
+
+The important runtime pattern is not the exact storage mechanism. The important
+pattern is that long-running monitors publish a small shared activity surface:
+
+- `busy`
+- `activeRuns`
+- `lastRunActivityAt`
+
+Its monitor implementations update that surface from the long-lived Telegram and
+Feishu monitor lifecycles instead of from one-shot send commands. That makes the
+status surface trustworthy for operators.
+
+**Findings From LoongClaw Alpha-Test**
+
+Compared with `origin/alpha-test`, LoongClaw still had four channel gaps:
+
+1. `ChannelInboundMessage` and reply routing were still stringly typed.
+2. Telegram and Feishu serve loops had no shared runtime tracker.
+3. Feishu webhook dedupe had no failed-event release path.
+4. Daemon surfaces could report readiness, but not live runtime state.
+
+Phases 1 through 3 closed the first three structural prerequisites:
+
+- reliable Telegram offset acknowledgement
+- reliable Feishu dedupe retry semantics
+- typed session/target abstractions
+- shared registry and readiness snapshots
+
+Phase 4 can therefore stay narrow and only solve runtime liveness.
+
+**Chosen Design**
+
+Add a persisted `ChannelOperationRuntimeTracker` with one JSON file per tracked
+operation under `~/.loongclaw/channel-runtime/`.
+
+Persisted fields:
+
+- `running`
+- `busy`
+- `active_runs`
+- `last_run_activity_at`
+- `last_heartbeat_at`
+- `pid`
+
+Derived operator view:
+
+- `running`
+- `stale`
+- `busy`
+- `active_runs`
+- `last_run_activity_at`
+- `last_heartbeat_at`
+- `pid`
+
+Only operations marked with `tracks_runtime = true` participate. In this phase:
+
+- Telegram `serve`
+- Feishu `serve`
+
+Feishu `send` intentionally does not publish runtime state because it is a
+short-lived request path, not a monitor lifecycle.
+
+**Why Per-Operation Files**
+
+A single shared file would create an avoidable cross-process overwrite problem
+because Telegram and Feishu serve loops can run independently. One file per
+`platform + operation` keeps the write pattern simple and avoids introducing a
+premature coordinator or lock server.
+
+**Lifecycle Rules**
+
+- tracker start writes `running=true`, `busy=false`, `active_runs=0`
+- run start increments `active_runs`, sets `busy=true`, and updates timestamps
+- run end decrements `active_runs`, recomputes `busy`, and updates timestamps
+- background heartbeat refreshes `last_heartbeat_at`
+- shutdown clears `running`, `busy`, and `active_runs`
+- stale runtime is computed from heartbeat age instead of trusted blindly
+
+**Integration Points**
+
+- `process_channel_batch(...)` updates runtime for Telegram serve work
+- `feishu_webhook_handler(...)` updates runtime around provider processing
+- channel registry merges persisted runtime into serve operation snapshots
+- `loongclawd channels` renders runtime lines for tracked operations
+
+**Why This Is The Right Next Step**
+
+This preserves the staged progression implied by OpenClaw:
+
+- Phase 2 gave LoongClaw typed channel identities
+- Phase 3 gave LoongClaw a shared registry and readiness surface
+- Phase 4 adds a minimal runtime liveness seam
+
+That is enough to support real operator diagnosis without overcommitting to a
+full plugin-monitor runtime that the rest of LoongClaw does not yet have.
+
+**Deferred Work**
+
+This phase intentionally defers:
+
+- account-scoped runtime keys for multi-account Telegram/Feishu
+- generic event envelopes shared by all future channels
+- Discord runtime integration
+- websocket or push-mode Feishu monitor variants
+- aggregated cross-channel supervisor state
+
+Those should follow only after LoongClaw has a shared monitor/event seam that is
+generic enough to carry Discord safely.

--- a/docs/plans/2026-03-11-channel-runtime-state-phase-4.md
+++ b/docs/plans/2026-03-11-channel-runtime-state-phase-4.md
@@ -1,0 +1,86 @@
+# Channel Runtime State Phase 4 Implementation Plan
+
+**Goal:** Add persisted serve-operation runtime state, merge it into channel
+registry snapshots, and expose it through daemon CLI without widening the
+current channel architecture beyond Telegram and Feishu/Lark.
+
+**Architecture:** Keep OpenClaw's separation of concerns:
+
+- channel registry owns identity and readiness
+- runtime tracker owns liveness and activity
+- daemon CLI owns operator presentation
+
+Store one runtime file per tracked operation so independent serve processes do
+not trample each other.
+
+**Tech Stack:** Rust, serde, tokio, axum, clap
+
+### Task 1: Add runtime tracker and failing tests
+
+Add tests that prove:
+
+- runtime tracker persists run activity and shutdown state
+- stale heartbeat data is reported as `running=false` and `stale=true`
+
+Implement:
+
+- `ChannelOperationRuntime`
+- `ChannelOperationRuntimeTracker`
+- persisted runtime load/write helpers
+
+### Task 2: Merge runtime into registry snapshots
+
+Extend channel catalog operations with `tracks_runtime` and merge runtime state
+into tracked operations only.
+
+Required behavior:
+
+- Telegram `serve` exposes runtime
+- Feishu `serve` exposes runtime
+- Feishu `send` keeps `runtime=None`
+- missing runtime files degrade to a stable default runtime view
+
+### Task 3: Instrument long-running serve operations
+
+Wire runtime tracking into:
+
+- `run_telegram_channel(...)`
+- `process_channel_batch(...)`
+- `run_feishu_channel(...)`
+- `feishu_webhook_handler(...)`
+
+Required behavior:
+
+- lifecycle start/shutdown updates are persisted
+- in-flight run counts are incremented and decremented correctly
+- failed Feishu webhook processing still releases dedupe state for retry
+
+### Task 4: Expose runtime in operator surfaces
+
+Update `loongclawd channels` text output to include:
+
+- `running`
+- `stale`
+- `busy`
+- `active_runs`
+- `last_run_activity_at`
+- `last_heartbeat_at`
+- `pid`
+
+Update daemon tests so the new runtime text surface stays stable.
+
+### Task 5: Hardening and verification
+
+Harden the runtime tracker so background state locks do not panic the process.
+
+Run:
+
+```bash
+cargo test -p loongclaw-app channel::
+cargo test -p loongclaw-daemon tests::
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected result: PASS

--- a/docs/plans/2026-03-11-channel-serve-ownership-phase-13-design.md
+++ b/docs/plans/2026-03-11-channel-serve-ownership-phase-13-design.md
@@ -1,0 +1,58 @@
+# Channel Serve Ownership Phase 13 Design
+
+**Scope**
+
+Phase 13 adds a shared serve-start ownership gate for long-lived channel workers.
+
+Phase 12 extracted shared command-context construction and shared serve runtime
+startup/shutdown. What still remains unsafe is duplicate startup:
+
+- the same Telegram account can be launched twice
+- the same Feishu/Lark webhook account can be launched twice
+- runtime status can report duplicates, but startup still allows them
+
+**Problem Statement**
+
+Duplicate long-lived channel workers are not just noisy. They create real
+behavioral hazards:
+
+- duplicate Telegram polling can race ack offsets
+- duplicate Feishu webhook servers can create routing ambiguity
+- operators get warned only after duplicate state exists
+
+The runtime state layer already knows how to summarize running vs. stale
+instances. The missing piece is to use that information as a startup gate.
+
+**Chosen Design**
+
+Add a shared ownership check inside the serve-runtime wrapper:
+
+1. Before starting a new runtime tracker, inspect account-scoped runtime state
+   for the same platform + operation + account.
+2. If an active running instance exists, reject startup.
+3. If only stale or stopped instances exist, allow startup.
+
+The ownership gate should be shared for Telegram and Feishu serve flows by
+living inside `with_channel_serve_runtime(...)`.
+
+**Behavior**
+
+- reject when a running instance already exists for the same account/operation
+- include account id, pid when available, and running instance count in the
+  error
+- allow takeover when the previous instance is stale
+
+**Why This Matters**
+
+This is the first real supervisor policy, not just shared plumbing.
+
+It upgrades the runtime wrapper from:
+
+- "start a tracker around a serve body"
+
+to:
+
+- "enforce single active ownership for a serve slot"
+
+That is the correct next increment before adding restart/backoff and richer
+supervisor state transitions.

--- a/docs/plans/2026-03-11-channel-serve-ownership-phase-13.md
+++ b/docs/plans/2026-03-11-channel-serve-ownership-phase-13.md
@@ -1,0 +1,42 @@
+# Channel Serve Ownership Phase 13 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent duplicate active `serve` workers for the same channel account.
+
+**Architecture:** Reuse account-scoped runtime-state summaries before tracker
+startup and block `with_channel_serve_runtime(...)` when an active owner already
+holds the serve slot. Permit startup when prior state is stale.
+
+**Tech Stack:** Rust, tokio, serde
+
+---
+
+### Task 1: Add failing ownership-gate tests
+
+**Files:**
+- Modify: `crates/app/src/channel/mod.rs`
+
+Add tests that prove:
+
+- duplicate active runtime blocks shared serve wrapper startup
+- stale runtime state does not block startup
+
+### Task 2: Implement ownership gate
+
+**Files:**
+- Modify: `crates/app/src/channel/mod.rs`
+
+Implement a shared pre-start ownership check and apply it inside the shared
+serve runtime wrapper.
+
+### Task 3: Verification
+
+Run:
+
+```bash
+cargo test -p loongclaw-app channel::
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```


### PR DESCRIPTION
## Summary
- add multi-account channel config resolution and default-account provenance for Telegram and Feishu/Lark
- add shared channel command/runtime substrate, registry snapshots, `loongclawd channels`, and runtime-aware `doctor` output
- harden Telegram offset acknowledgements, Feishu webhook dedupe retry behavior, and serve ownership checks
- add phased channel design notes under `docs/plans/`

## Verification
- cargo fmt --all -- --check
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings

## Follow-up
- #9
