### PR TITLE
refactor(alpha-test): deep architecture hardening and module decomposition

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,6 +26,11 @@ tasks:
     cmds:
       - cargo test --workspace --all-features
 
+  test:daemon:stress:
+    desc: Stress daemon test binary across thread modes to catch intermittent regressions
+    cmds:
+      - ./scripts/stress_daemon_tests.sh 10 default,2,1
+
   smoke:
     desc: Run representative spec-runner smoke scenarios
     cmds:
@@ -47,6 +52,16 @@ tasks:
     desc: Validate doc governance in strict release mode (missing .docs artifacts fail)
     cmds:
       - LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
+
+  check:architecture:
+    desc: Validate architecture boundary budgets and memory-operation abstraction
+    cmds:
+      - scripts/check_architecture_boundaries.sh
+
+  check:architecture:strict:
+    desc: Fail on any architecture boundary budget violations
+    cmds:
+      - LOONGCLAW_ARCH_STRICT=1 scripts/check_architecture_boundaries.sh
 
   check:deny:
     desc: Run cargo-deny (advisories, bans, sources)

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -1,4 +1,7 @@
+use std::collections::BTreeSet;
 use std::io::{self, Write};
+
+use loongclaw_contracts::Capability;
 
 use crate::context::{bootstrap_kernel_context, DEFAULT_TOKEN_TTL_S};
 use crate::CliResult;
@@ -78,9 +81,15 @@ pub async fn run_cli_chat(config_path: Option<&str>, session_hint: Option<&str>)
         }
         if input == "/history" {
             #[cfg(feature = "memory-sqlite")]
-            print_history(&session_id, config.memory.sliding_window, &memory_config)?;
+            print_history(
+                &session_id,
+                config.memory.sliding_window,
+                Some(&kernel_ctx),
+                &memory_config,
+            )
+            .await?;
             #[cfg(not(feature = "memory-sqlite"))]
-            print_history(&session_id, config.memory.sliding_window)?;
+            print_history(&session_id, config.memory.sliding_window, Some(&kernel_ctx)).await?;
             continue;
         }
 
@@ -119,13 +128,38 @@ fn print_help() {
 }
 
 #[allow(clippy::print_stdout)] // CLI output
-fn print_history(
+async fn print_history(
     session_id: &str,
     limit: usize,
+    kernel_ctx: Option<&crate::KernelContext>,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
+        if let Some(ctx) = kernel_ctx {
+            let request = memory::build_window_request(session_id, limit);
+            let caps = BTreeSet::from([Capability::MemoryRead]);
+            let outcome = ctx
+                .kernel
+                .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
+                .await
+                .map_err(|error| format!("load history via kernel failed: {error}"))?;
+            let turns = memory::decode_window_turns(&outcome.payload);
+            if turns.is_empty() {
+                println!("(no history yet)");
+                return Ok(());
+            }
+            for turn in turns {
+                println!(
+                    "[{}] {}: {}",
+                    turn.ts.unwrap_or_default(),
+                    turn.role,
+                    turn.content
+                );
+            }
+            return Ok(());
+        }
+
         let turns = memory::window_direct(session_id, limit, memory_config)
             .map_err(|error| format!("load history failed: {error}"))?;
         if turns.is_empty() {
@@ -140,7 +174,7 @@ fn print_history(
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = (session_id, limit);
+        let _ = (session_id, limit, kernel_ctx);
         println!("history unavailable: memory-sqlite feature disabled");
         Ok(())
     }

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use async_trait::async_trait;
-use loongclaw_contracts::{Capability, MemoryCoreRequest};
+use loongclaw_contracts::Capability;
 use serde_json::{json, Value};
 
 use crate::CliResult;
@@ -16,7 +16,7 @@ pub struct DefaultConversationRuntime;
 
 #[async_trait]
 pub trait ConversationRuntime: Send + Sync {
-    fn build_messages(
+    async fn build_messages(
         &self,
         config: &LoongClawConfig,
         session_id: &str,
@@ -47,20 +47,47 @@ pub trait ConversationRuntime: Send + Sync {
 
 #[async_trait]
 impl ConversationRuntime for DefaultConversationRuntime {
-    // TODO(task-11): Route memory window loading through kernel when kernel_ctx is Some.
-    // Currently `build_messages_for_session` couples system-prompt construction with
-    // memory window loading in a single function. Routing the memory portion through
-    // kernel requires splitting that function into (a) system prompt building and
-    // (b) memory window loading. Deferred to avoid invasive refactoring of the
-    // provider module.
-    fn build_messages(
+    async fn build_messages(
         &self,
         config: &LoongClawConfig,
         session_id: &str,
         include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<Vec<Value>> {
-        provider::build_messages_for_session(config, session_id, include_system_prompt)
+        let mut messages = Vec::new();
+        if let Some(system_message) = provider::build_system_message(config, include_system_prompt)
+        {
+            messages.push(system_message);
+        }
+
+        if let Some(ctx) = kernel_ctx {
+            #[cfg(feature = "memory-sqlite")]
+            {
+                let request =
+                    memory::build_window_request(session_id, config.memory.sliding_window);
+                let caps = BTreeSet::from([Capability::MemoryRead]);
+                let outcome = ctx
+                    .kernel
+                    .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
+                    .await
+                    .map_err(|error| format!("load memory window via kernel failed: {error}"))?;
+                let turns = memory::decode_window_turns(&outcome.payload);
+                for turn in turns {
+                    messages.push(json!({
+                        "role": turn.role,
+                        "content": turn.content,
+                    }));
+                }
+            }
+            #[cfg(not(feature = "memory-sqlite"))]
+            {
+                let _ = (ctx, session_id, config);
+            }
+            return Ok(messages);
+        }
+
+        messages.extend(provider::load_memory_window_messages(config, session_id)?);
+        Ok(messages)
     }
 
     async fn request_completion(
@@ -87,14 +114,7 @@ impl ConversationRuntime for DefaultConversationRuntime {
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<()> {
         if let Some(ctx) = kernel_ctx {
-            let request = MemoryCoreRequest {
-                operation: "append_turn".to_owned(),
-                payload: json!({
-                    "session_id": session_id,
-                    "role": role,
-                    "content": content,
-                }),
-            };
+            let request = memory::build_append_turn_request(session_id, role, content);
             let caps = BTreeSet::from([Capability::MemoryWrite]);
             ctx.kernel
                 .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -79,7 +79,7 @@ impl FakeRuntime {
 
 #[async_trait]
 impl ConversationRuntime for FakeRuntime {
-    fn build_messages(
+    async fn build_messages(
         &self,
         _config: &LoongClawConfig,
         _session_id: &str,
@@ -1831,13 +1831,26 @@ impl CoreMemoryAdapter for SharedTestMemoryAdapter {
         &self,
         request: MemoryCoreRequest,
     ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
+        let payload = if request.operation == crate::memory::MEMORY_OP_WINDOW {
+            json!({
+                "turns": [
+                    {
+                        "role": "assistant",
+                        "content": "history-from-kernel",
+                        "ts": 1
+                    }
+                ]
+            })
+        } else {
+            json!({})
+        };
         self.invocations
             .lock()
             .expect("invocations lock")
             .push(request);
         Ok(MemoryCoreOutcome {
             status: "ok".to_owned(),
-            payload: json!({}),
+            payload,
         })
     }
 }
@@ -1856,7 +1869,7 @@ async fn persist_turn_routes_through_kernel_when_context_provided() {
     // Verify the memory adapter received the request.
     let captured = invocations.lock().expect("invocations lock");
     assert_eq!(captured.len(), 1);
-    assert_eq!(captured[0].operation, "append_turn");
+    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_APPEND_TURN);
     assert_eq!(captured[0].payload["session_id"], "session-k1");
     assert_eq!(captured[0].payload["role"], "user");
     assert_eq!(captured[0].payload["content"], "kernel-hello");
@@ -1875,6 +1888,39 @@ async fn persist_turn_routes_through_kernel_when_context_provided() {
     assert!(
         has_memory_plane,
         "audit should contain memory plane invocation"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn build_messages_routes_window_through_kernel_when_context_provided() {
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (ctx, invocations) = build_kernel_context(audit);
+
+    let runtime = DefaultConversationRuntime;
+    let config = test_config();
+    let messages = runtime
+        .build_messages(&config, "session-k2", true, Some(&ctx))
+        .await
+        .expect("build messages via kernel");
+
+    assert!(
+        !messages.is_empty(),
+        "messages should include at least system prompt"
+    );
+    assert_eq!(messages[0]["role"], "system");
+    assert!(
+        messages
+            .iter()
+            .any(|message| message["content"] == "history-from-kernel"),
+        "messages should include history loaded from kernel window payload"
+    );
+
+    let captured = invocations.lock().expect("invocations lock");
+    assert!(
+        captured
+            .iter()
+            .any(|request| request.operation == crate::memory::MEMORY_OP_WINDOW),
+        "build_messages should route memory window through kernel memory plane"
     );
 }
 

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -47,7 +47,9 @@ impl ConversationTurnLoop {
         runtime: &R,
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<String> {
-        let mut messages = runtime.build_messages(config, session_id, true, kernel_ctx)?;
+        let mut messages = runtime
+            .build_messages(config, session_id, true, kernel_ctx)
+            .await?;
         messages.push(json!({
             "role": "user",
             "content": user_input,

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -2,7 +2,7 @@
 use std::path::PathBuf;
 
 use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
-use serde_json::json;
+use serde_json::{json, Value};
 
 mod kernel_adapter;
 pub mod runtime_config;
@@ -13,6 +13,38 @@ pub use kernel_adapter::MvpMemoryAdapter;
 #[cfg(feature = "memory-sqlite")]
 pub use sqlite::ConversationTurn;
 
+pub const MEMORY_OP_APPEND_TURN: &str = "append_turn";
+pub const MEMORY_OP_WINDOW: &str = "window";
+pub const MEMORY_OP_CLEAR_SESSION: &str = "clear_session";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowTurn {
+    pub role: String,
+    pub content: String,
+    pub ts: Option<i64>,
+}
+
+pub fn build_append_turn_request(session_id: &str, role: &str, content: &str) -> MemoryCoreRequest {
+    MemoryCoreRequest {
+        operation: MEMORY_OP_APPEND_TURN.to_owned(),
+        payload: json!({
+            "session_id": session_id,
+            "role": role,
+            "content": content,
+        }),
+    }
+}
+
+pub fn build_window_request(session_id: &str, limit: usize) -> MemoryCoreRequest {
+    MemoryCoreRequest {
+        operation: MEMORY_OP_WINDOW.to_owned(),
+        payload: json!({
+            "session_id": session_id,
+            "limit": limit,
+        }),
+    }
+}
+
 pub fn execute_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
     execute_memory_core_with_config(request, runtime_config::get_memory_runtime_config())
 }
@@ -22,9 +54,9 @@ pub fn execute_memory_core_with_config(
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<MemoryCoreOutcome, String> {
     match request.operation.as_str() {
-        "append_turn" => append_turn(request, config),
-        "window" => load_window(request, config),
-        "clear_session" => clear_session(request, config),
+        MEMORY_OP_APPEND_TURN => append_turn(request, config),
+        MEMORY_OP_WINDOW => load_window(request, config),
+        MEMORY_OP_CLEAR_SESSION => clear_session(request, config),
         _ => Ok(MemoryCoreOutcome {
             status: "ok".to_owned(),
             payload: json!({
@@ -34,6 +66,28 @@ pub fn execute_memory_core_with_config(
             }),
         }),
     }
+}
+
+pub fn decode_window_turns(payload: &Value) -> Vec<WindowTurn> {
+    payload
+        .get("turns")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|turn| WindowTurn {
+            role: turn
+                .get("role")
+                .and_then(Value::as_str)
+                .unwrap_or("assistant")
+                .to_owned(),
+            content: turn
+                .get("content")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned(),
+            ts: turn.get("ts").and_then(Value::as_i64),
+        })
+        .collect()
 }
 
 fn append_turn(
@@ -130,6 +184,36 @@ mod tests {
         .expect("fallback operation should succeed");
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["adapter"], "kv-core");
+    }
+
+    #[test]
+    fn decode_window_turns_tolerates_partial_payload_shape() {
+        let payload = json!({
+            "turns": [
+                {"role": "user", "content": "hello", "ts": 1},
+                {"role": "assistant"},
+                {"content": "only-content"},
+                {}
+            ]
+        });
+        let turns = decode_window_turns(&payload);
+        assert_eq!(turns.len(), 4);
+        assert_eq!(turns[0].role, "user");
+        assert_eq!(turns[0].content, "hello");
+        assert_eq!(turns[0].ts, Some(1));
+        assert_eq!(turns[1].role, "assistant");
+        assert_eq!(turns[1].content, "");
+        assert_eq!(turns[2].role, "assistant");
+        assert_eq!(turns[2].content, "only-content");
+        assert_eq!(turns[3].role, "assistant");
+        assert_eq!(turns[3].content, "");
+    }
+
+    #[test]
+    fn decode_window_turns_returns_empty_for_missing_turns() {
+        assert!(decode_window_turns(&json!({})).is_empty());
+        assert!(decode_window_turns(&json!({"turns": null})).is_empty());
+        assert!(decode_window_turns(&json!({"turns": "invalid"})).is_empty());
     }
 
     #[tokio::test]

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -8,7 +8,10 @@ use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use super::runtime_config::MemoryRuntimeConfig;
+use super::{
+    build_append_turn_request, build_window_request, runtime_config::MemoryRuntimeConfig,
+    MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION, MEMORY_OP_WINDOW,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConversationTurn {
@@ -57,7 +60,7 @@ pub(super) fn append_turn(
         status: "ok".to_owned(),
         payload: json!({
             "adapter": "sqlite-core",
-            "operation": "append_turn",
+            "operation": MEMORY_OP_APPEND_TURN,
             "session_id": session_id,
             "role": role,
             "ts": ts,
@@ -125,7 +128,7 @@ pub(super) fn load_window(
         status: "ok".to_owned(),
         payload: json!({
             "adapter": "sqlite-core",
-            "operation": "window",
+            "operation": MEMORY_OP_WINDOW,
             "session_id": session_id,
             "limit": window_limit,
             "turns": turns,
@@ -163,7 +166,7 @@ pub(super) fn clear_session(
         status: "ok".to_owned(),
         payload: json!({
             "adapter": "sqlite-core",
-            "operation": "clear_session",
+            "operation": MEMORY_OP_CLEAR_SESSION,
             "session_id": session_id,
             "deleted_rows": affected,
         }),
@@ -176,14 +179,7 @@ pub(super) fn append_turn_direct(
     content: &str,
     config: &MemoryRuntimeConfig,
 ) -> Result<(), String> {
-    let request = MemoryCoreRequest {
-        operation: "append_turn".to_owned(),
-        payload: json!({
-            "session_id": session_id,
-            "role": role,
-            "content": content,
-        }),
-    };
+    let request = build_append_turn_request(session_id, role, content);
     super::execute_memory_core_with_config(request, config)?;
     Ok(())
 }
@@ -193,13 +189,7 @@ pub(super) fn window_direct(
     limit: usize,
     config: &MemoryRuntimeConfig,
 ) -> Result<Vec<ConversationTurn>, String> {
-    let request = MemoryCoreRequest {
-        operation: "window".to_owned(),
-        payload: json!({
-            "session_id": session_id,
-            "limit": limit,
-        }),
-    };
+    let request = build_window_request(session_id, limit);
     let outcome = super::execute_memory_core_with_config(request, config)?;
     let turns_raw = outcome.payload.get("turns").cloned().unwrap_or(Value::Null);
     serde_json::from_value(turns_raw)

--- a/crates/app/src/provider/error_policy.rs
+++ b/crates/app/src/provider/error_policy.rs
@@ -1,0 +1,71 @@
+use crate::CliResult;
+
+use crate::config::{LoongClawConfig, ProviderConfig, ProviderKind};
+
+pub(super) fn provider_request_failed_for_all_models(last_error: Option<String>) -> String {
+    last_error.unwrap_or_else(|| "provider request failed for every model candidate".to_owned())
+}
+
+pub(super) fn validate_provider_feature_gate(config: &LoongClawConfig) -> CliResult<()> {
+    match config.provider.kind {
+        ProviderKind::Volcengine => {
+            if !cfg!(feature = "provider-volcengine") {
+                return Err(
+                    "volcengine provider is disabled (enable feature `provider-volcengine`)"
+                        .to_owned(),
+                );
+            }
+        }
+        _ => {
+            if !cfg!(feature = "provider-openai") {
+                return Err(
+                    "openai-compatible provider family is disabled (enable feature `provider-openai`)"
+                        .to_owned(),
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn validate_provider_configuration(config: &LoongClawConfig) -> CliResult<()> {
+    if config.provider.kind == ProviderKind::Kimi
+        && provider_uses_kimi_coding_endpoint(&config.provider)
+    {
+        return Err(
+            "kimi provider cannot target Kimi Coding endpoints; use `kind = \"kimi_coding\"`"
+                .to_owned(),
+        );
+    }
+
+    if config.provider.kind == ProviderKind::KimiCoding {
+        if let Some(user_agent) = config.provider.header_value("user-agent") {
+            if !is_kimi_cli_user_agent(user_agent) {
+                return Err(format!(
+                    "kimi_coding provider requires a `User-Agent` header starting with `KimiCLI/`; got `{user_agent}`"
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn provider_uses_kimi_coding_endpoint(provider: &ProviderConfig) -> bool {
+    is_kimi_coding_endpoint(provider.endpoint().as_str())
+        || provider
+            .endpoint
+            .as_deref()
+            .is_some_and(is_kimi_coding_endpoint)
+}
+
+fn is_kimi_coding_endpoint(endpoint: &str) -> bool {
+    endpoint
+        .trim()
+        .to_ascii_lowercase()
+        .contains("://api.kimi.com/coding/")
+}
+
+fn is_kimi_cli_user_agent(user_agent: &str) -> bool {
+    user_agent.trim().starts_with("KimiCLI/")
+}

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -5,36 +5,55 @@ use tokio::time::sleep;
 
 use crate::CliResult;
 
-use super::config::{LoongClawConfig, ProviderConfig, ProviderKind, ReasoningEffort};
+use super::config::LoongClawConfig;
 #[cfg(feature = "memory-sqlite")]
 use super::memory;
 
+mod error_policy;
+mod model_selection;
+mod payload_adaptation;
 mod policy;
 mod shape;
 mod transport;
 
+use error_policy::{
+    provider_request_failed_for_all_models, validate_provider_configuration,
+    validate_provider_feature_gate,
+};
+use model_selection::{fetch_available_models_with_policy, resolve_request_models};
+use payload_adaptation::{
+    adapt_payload_mode_for_error, build_completion_request_body, build_turn_request_body,
+    parse_provider_api_error, should_disable_tool_schema_for_error, should_try_next_model_on_error,
+    CompletionPayloadMode,
+};
+
 pub use shape::extract_provider_turn;
 
-pub fn build_messages_for_session(
+pub fn build_system_message(
     config: &LoongClawConfig,
-    session_id: &str,
     include_system_prompt: bool,
-) -> CliResult<Vec<Value>> {
-    let mut messages = Vec::new();
-    if include_system_prompt {
-        let system = config.cli.system_prompt.trim();
-        let snapshot = super::tools::capability_snapshot();
-        let content = if system.is_empty() {
-            snapshot
-        } else {
-            format!("{system}\n\n{snapshot}")
-        };
-        messages.push(json!({
-            "role": "system",
-            "content": content,
-        }));
+) -> Option<Value> {
+    if !include_system_prompt {
+        return None;
     }
 
+    let system = config.cli.system_prompt.trim();
+    let snapshot = super::tools::capability_snapshot();
+    let content = if system.is_empty() {
+        snapshot
+    } else {
+        format!("{system}\n\n{snapshot}")
+    };
+    Some(json!({
+        "role": "system",
+        "content": content,
+    }))
+}
+
+pub fn load_memory_window_messages(
+    config: &LoongClawConfig,
+    session_id: &str,
+) -> CliResult<Vec<Value>> {
     #[cfg(feature = "memory-sqlite")]
     {
         let mem_config = super::memory::runtime_config::MemoryRuntimeConfig {
@@ -42,17 +61,32 @@ pub fn build_messages_for_session(
         };
         let turns = memory::window_direct(session_id, config.memory.sliding_window, &mem_config)
             .map_err(|error| format!("load memory window failed: {error}"))?;
+        let mut messages = Vec::with_capacity(turns.len());
         for turn in turns {
             messages.push(json!({
                 "role": turn.role,
                 "content": turn.content,
             }));
         }
+        Ok(messages)
     }
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = session_id;
+        let _ = (config, session_id);
+        Ok(Vec::new())
     }
+}
+
+pub fn build_messages_for_session(
+    config: &LoongClawConfig,
+    session_id: &str,
+    include_system_prompt: bool,
+) -> CliResult<Vec<Value>> {
+    let mut messages = Vec::new();
+    if let Some(system_message) = build_system_message(config, include_system_prompt) {
+        messages.push(system_message);
+    }
+    messages.extend(load_memory_window_messages(config, session_id)?);
     Ok(messages)
 }
 
@@ -65,22 +99,17 @@ pub async fn request_completion(config: &LoongClawConfig, messages: &[Value]) ->
     let request_policy = policy::ProviderRequestPolicy::from_config(&config.provider);
     let client = build_http_client(&request_policy)?;
     let model_candidates = resolve_request_models(config, &headers, &request_policy).await?;
-    let auto_model_mode = config.provider.model_selection_requires_fetch();
+    let request_context = ProviderRequestContext {
+        endpoint: &endpoint,
+        headers: &headers,
+        request_policy: &request_policy,
+        client: &client,
+        auto_model_mode: config.provider.model_selection_requires_fetch(),
+    };
 
     let mut last_error = None;
     for (index, model) in model_candidates.iter().enumerate() {
-        match request_completion_with_model(
-            config,
-            messages,
-            model,
-            auto_model_mode,
-            &endpoint,
-            &headers,
-            &request_policy,
-            &client,
-        )
-        .await
-        {
+        match request_completion_with_model(config, messages, model, &request_context).await {
             Ok(content) => return Ok(content),
             Err(model_error) => {
                 if model_error.try_next_model && index + 1 < model_candidates.len() {
@@ -91,8 +120,7 @@ pub async fn request_completion(config: &LoongClawConfig, messages: &[Value]) ->
             }
         }
     }
-    Err(last_error
-        .unwrap_or_else(|| "provider request failed for every model candidate".to_owned()))
+    Err(provider_request_failed_for_all_models(last_error))
 }
 
 pub async fn request_turn(
@@ -107,22 +135,17 @@ pub async fn request_turn(
     let request_policy = policy::ProviderRequestPolicy::from_config(&config.provider);
     let client = build_http_client(&request_policy)?;
     let model_candidates = resolve_request_models(config, &headers, &request_policy).await?;
-    let auto_model_mode = config.provider.model_selection_requires_fetch();
+    let request_context = ProviderRequestContext {
+        endpoint: &endpoint,
+        headers: &headers,
+        request_policy: &request_policy,
+        client: &client,
+        auto_model_mode: config.provider.model_selection_requires_fetch(),
+    };
 
     let mut last_error = None;
     for (index, model) in model_candidates.iter().enumerate() {
-        match request_turn_with_model(
-            config,
-            messages,
-            model,
-            auto_model_mode,
-            &endpoint,
-            &headers,
-            &request_policy,
-            &client,
-        )
-        .await
-        {
+        match request_turn_with_model(config, messages, model, &request_context).await {
             Ok(turn) => return Ok(turn),
             Err(model_error) => {
                 if model_error.try_next_model && index + 1 < model_candidates.len() {
@@ -133,8 +156,7 @@ pub async fn request_turn(
             }
         }
     }
-    Err(last_error
-        .unwrap_or_else(|| "provider request failed for every model candidate".to_owned()))
+    Err(provider_request_failed_for_all_models(last_error))
 }
 
 pub async fn fetch_available_models(config: &LoongClawConfig) -> CliResult<Vec<String>> {
@@ -152,447 +174,39 @@ fn build_http_client(request_policy: &policy::ProviderRequestPolicy) -> CliResul
         .map_err(|error| format!("build provider http client failed: {error}"))
 }
 
-fn build_completion_request_body(
-    config: &LoongClawConfig,
-    messages: &[Value],
-    model: &str,
-    payload_mode: CompletionPayloadMode,
-) -> Value {
-    let transport_mode = ProviderTransportMode::for_provider(&config.provider);
-    let mut body = serde_json::Map::new();
-    body.insert("model".to_owned(), json!(model));
-    body.insert("messages".to_owned(), Value::Array(messages.to_vec()));
-    body.insert("stream".to_owned(), Value::Bool(false));
-    if payload_mode.temperature_field == TemperatureField::Include {
-        body.insert("temperature".to_owned(), json!(config.provider.temperature));
-    }
-
-    if let Some(limit) = config.provider.max_tokens {
-        match payload_mode.token_field {
-            TokenLimitField::MaxCompletionTokens => {
-                body.insert("max_completion_tokens".to_owned(), json!(limit));
-            }
-            TokenLimitField::MaxTokens => {
-                body.insert("max_tokens".to_owned(), json!(limit));
-            }
-            TokenLimitField::Omit => {}
-        }
-    }
-
-    if let Some(reasoning_effort) = config.provider.reasoning_effort {
-        match payload_mode.reasoning_field {
-            ReasoningField::ReasoningEffort => {
-                body.insert(
-                    "reasoning_effort".to_owned(),
-                    json!(reasoning_effort.as_str()),
-                );
-            }
-            ReasoningField::ReasoningObject => {
-                body.insert(
-                    "reasoning".to_owned(),
-                    json!({
-                        "effort": reasoning_effort.as_str()
-                    }),
-                );
-            }
-            ReasoningField::Omit => {}
-        }
-    }
-
-    if transport_mode == ProviderTransportMode::KimiApi {
-        if let Some(extra_body) = kimi_extra_body(config.provider.reasoning_effort) {
-            body.insert("extra_body".to_owned(), extra_body);
-        }
-    }
-
-    Value::Object(body)
-}
-
-fn build_turn_request_body(
-    config: &LoongClawConfig,
-    messages: &[Value],
-    model: &str,
-    payload_mode: CompletionPayloadMode,
-    include_tool_schema: bool,
-    tool_definitions: &[Value],
-) -> Value {
-    let mut body = build_completion_request_body(config, messages, model, payload_mode);
-    if include_tool_schema && !tool_definitions.is_empty() {
-        if let Some(object) = body.as_object_mut() {
-            object.insert("tools".to_owned(), Value::Array(tool_definitions.to_vec()));
-            object.insert("tool_choice".to_owned(), json!("auto"));
-        }
-    }
-    body
-}
-
-async fn resolve_request_models(
-    config: &LoongClawConfig,
-    headers: &reqwest::header::HeaderMap,
-    request_policy: &policy::ProviderRequestPolicy,
-) -> CliResult<Vec<String>> {
-    if let Some(model) = config.provider.resolved_model() {
-        return Ok(vec![model]);
-    }
-    let available = fetch_available_models_with_policy(config, headers, request_policy).await?;
-    let ordered = rank_model_candidates(&config.provider, &available);
-    if ordered.is_empty() {
-        return Err("provider model-list is empty; set provider.model explicitly".to_owned());
-    }
-    Ok(ordered)
-}
-
-async fn fetch_available_models_with_policy(
-    config: &LoongClawConfig,
-    headers: &reqwest::header::HeaderMap,
-    request_policy: &policy::ProviderRequestPolicy,
-) -> CliResult<Vec<String>> {
-    let endpoint = config.provider.models_endpoint();
-    let client = build_http_client(request_policy)?;
-
-    let mut attempt = 0usize;
-    let mut backoff_ms = request_policy.initial_backoff_ms;
-    loop {
-        attempt += 1;
-        let mut req = client.get(endpoint.clone()).headers(headers.clone());
-        if let Some(auth_header) = config.provider.authorization_header() {
-            req = req.header(reqwest::header::AUTHORIZATION, auth_header);
-        }
-
-        match req.send().await {
-            Ok(response) => {
-                let status = response.status();
-                let response_body = transport::decode_response_body(response)
-                    .await
-                    .map_err(|error| {
-                        format!(
-                            "provider model-list decode failed on attempt {attempt}/{max_attempts}: {error}",
-                            max_attempts = request_policy.max_attempts
-                        )
-                    })?;
-
-                if status.is_success() {
-                    let models = shape::extract_model_ids(&response_body);
-                    if models.is_empty() {
-                        return Err(format!(
-                            "provider model-list returned no models from endpoint `{endpoint}`"
-                        ));
-                    }
-                    return Ok(models);
-                }
-
-                let status_code = status.as_u16();
-                if attempt < request_policy.max_attempts && policy::should_retry_status(status_code)
-                {
-                    sleep(Duration::from_millis(backoff_ms)).await;
-                    backoff_ms = policy::next_backoff_ms(backoff_ms, request_policy.max_backoff_ms);
-                    continue;
-                }
-
-                return Err(format!(
-                    "provider model-list returned status {status_code} on attempt {attempt}/{max_attempts}: {response_body}",
-                    max_attempts = request_policy.max_attempts
-                ));
-            }
-            Err(error) => {
-                if attempt < request_policy.max_attempts && policy::should_retry_error(&error) {
-                    sleep(Duration::from_millis(backoff_ms)).await;
-                    backoff_ms = policy::next_backoff_ms(backoff_ms, request_policy.max_backoff_ms);
-                    continue;
-                }
-                return Err(format!(
-                    "provider model-list request failed on attempt {attempt}/{max_attempts}: {error}",
-                    max_attempts = request_policy.max_attempts
-                ));
-            }
-        }
-    }
-}
-
-fn rank_model_candidates(provider: &ProviderConfig, available: &[String]) -> Vec<String> {
-    let mut ordered = Vec::new();
-    for raw in &provider.preferred_models {
-        let trimmed = raw.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if let Some(matched) = available.iter().find(|model| *model == trimmed) {
-            push_unique_model(&mut ordered, matched);
-            continue;
-        }
-        if let Some(matched) = available
-            .iter()
-            .find(|model| model.eq_ignore_ascii_case(trimmed))
-        {
-            push_unique_model(&mut ordered, matched);
-        }
-    }
-
-    for model in available {
-        push_unique_model(&mut ordered, model);
-    }
-    ordered
-}
-
-fn push_unique_model(out: &mut Vec<String>, model: &str) {
-    if out.iter().any(|existing| existing == model) {
-        return;
-    }
-    out.push(model.to_owned());
-}
-
 #[derive(Debug)]
 struct ModelRequestError {
     message: String,
     try_next_model: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ProviderTransportMode {
-    OpenAiChatCompletions,
-    KimiApi,
+struct ProviderRequestContext<'a> {
+    endpoint: &'a str,
+    headers: &'a reqwest::header::HeaderMap,
+    request_policy: &'a policy::ProviderRequestPolicy,
+    client: &'a reqwest::Client,
+    auto_model_mode: bool,
 }
 
-impl ProviderTransportMode {
-    fn for_provider(provider: &ProviderConfig) -> Self {
-        match provider.kind {
-            ProviderKind::KimiCoding => Self::KimiApi,
-            _ => Self::OpenAiChatCompletions,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TokenLimitField {
-    MaxCompletionTokens,
-    MaxTokens,
-    Omit,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReasoningField {
-    ReasoningEffort,
-    ReasoningObject,
-    Omit,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TemperatureField {
-    Include,
-    Omit,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct CompletionPayloadMode {
-    token_field: TokenLimitField,
-    reasoning_field: ReasoningField,
-    temperature_field: TemperatureField,
-}
-
-impl CompletionPayloadMode {
-    fn default_for(provider: &ProviderConfig) -> Self {
-        let token_field = if provider.max_tokens.is_some() {
-            if provider.kind == ProviderKind::Openai {
-                TokenLimitField::MaxCompletionTokens
-            } else {
-                TokenLimitField::MaxTokens
-            }
-        } else {
-            TokenLimitField::Omit
-        };
-
-        let reasoning_field = if provider.reasoning_effort.is_some() {
-            ReasoningField::ReasoningEffort
-        } else {
-            ReasoningField::Omit
-        };
-
-        Self {
-            token_field,
-            reasoning_field,
-            temperature_field: TemperatureField::Include,
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-struct ProviderApiError {
-    code: Option<String>,
-    param: Option<String>,
-    message: Option<String>,
-}
-
-fn parse_provider_api_error(body: &Value) -> ProviderApiError {
-    let error = body.get("error").unwrap_or(body);
-    ProviderApiError {
-        code: error
-            .get("code")
-            .and_then(Value::as_str)
-            .map(str::to_lowercase),
-        param: error
-            .get("param")
-            .and_then(Value::as_str)
-            .map(str::to_lowercase),
-        message: error
-            .get("message")
-            .and_then(Value::as_str)
-            .map(str::to_lowercase),
-    }
-}
-
-fn is_parameter_unsupported(error: &ProviderApiError, parameter: &str) -> bool {
-    let param = parameter.to_lowercase();
-    if error.param.as_deref() == Some(param.as_str()) {
-        return true;
-    }
-
-    let message = error.message.as_deref().unwrap_or_default();
-    if !(message.contains("unknown parameter")
-        || message.contains("unsupported parameter")
-        || message.contains("not supported"))
-    {
-        return false;
-    }
-    message.contains(param.as_str())
-}
-
-fn should_disable_tool_schema_for_error(error: &ProviderApiError) -> bool {
-    if is_parameter_unsupported(error, "tools") || is_parameter_unsupported(error, "tool_choice") {
-        return true;
-    }
-
-    let message = error.message.as_deref().unwrap_or_default();
-    message.contains("tools are not supported")
-        || message.contains("tool use is not supported")
-        || message.contains("function calling is not supported")
-}
-
-fn should_try_next_model_on_error(error: &ProviderApiError) -> bool {
-    if let Some(code) = error.code.as_deref() {
-        if matches!(
-            code,
-            "model_not_found" | "unsupported_model" | "invalid_model" | "not_found_error"
-        ) {
-            return true;
-        }
-    }
-    if error.param.as_deref() == Some("model") {
-        return true;
-    }
-
-    let message = error.message.as_deref().unwrap_or_default();
-    message.contains("only supports")
-        || message.contains("only available")
-        || message.contains("this endpoint")
-        || message.contains("/v1/responses")
-        || message.contains("model does not exist")
-}
-
-fn adapt_payload_mode_for_error(
-    current: CompletionPayloadMode,
-    provider: &ProviderConfig,
-    error: &ProviderApiError,
-) -> Option<CompletionPayloadMode> {
-    if provider.max_tokens.is_some() {
-        if is_parameter_unsupported(error, "max_tokens") {
-            return Some(match current.token_field {
-                TokenLimitField::MaxTokens => CompletionPayloadMode {
-                    token_field: TokenLimitField::MaxCompletionTokens,
-                    ..current
-                },
-                TokenLimitField::MaxCompletionTokens => CompletionPayloadMode {
-                    token_field: TokenLimitField::Omit,
-                    ..current
-                },
-                TokenLimitField::Omit => current,
-            });
-        }
-
-        if is_parameter_unsupported(error, "max_completion_tokens") {
-            return Some(match current.token_field {
-                TokenLimitField::MaxCompletionTokens => CompletionPayloadMode {
-                    token_field: TokenLimitField::MaxTokens,
-                    ..current
-                },
-                TokenLimitField::MaxTokens => CompletionPayloadMode {
-                    token_field: TokenLimitField::Omit,
-                    ..current
-                },
-                TokenLimitField::Omit => current,
-            });
-        }
-    }
-
-    if provider.reasoning_effort.is_some() {
-        if is_parameter_unsupported(error, "reasoning_effort") {
-            return Some(match current.reasoning_field {
-                ReasoningField::ReasoningEffort => CompletionPayloadMode {
-                    reasoning_field: ReasoningField::ReasoningObject,
-                    ..current
-                },
-                ReasoningField::ReasoningObject => CompletionPayloadMode {
-                    reasoning_field: ReasoningField::Omit,
-                    ..current
-                },
-                ReasoningField::Omit => current,
-            });
-        }
-
-        if is_parameter_unsupported(error, "reasoning") {
-            return Some(match current.reasoning_field {
-                ReasoningField::ReasoningObject => CompletionPayloadMode {
-                    reasoning_field: ReasoningField::ReasoningEffort,
-                    ..current
-                },
-                ReasoningField::ReasoningEffort => CompletionPayloadMode {
-                    reasoning_field: ReasoningField::Omit,
-                    ..current
-                },
-                ReasoningField::Omit => current,
-            });
-        }
-    }
-
-    let temperature_rejected = is_parameter_unsupported(error, "temperature")
-        || (error.param.as_deref() == Some("temperature")
-            && error
-                .message
-                .as_deref()
-                .unwrap_or_default()
-                .contains("only the default"));
-    if temperature_rejected {
-        return Some(match current.temperature_field {
-            TemperatureField::Include => CompletionPayloadMode {
-                temperature_field: TemperatureField::Omit,
-                ..current
-            },
-            TemperatureField::Omit => current,
-        });
-    }
-
-    None
-}
-
-#[allow(clippy::too_many_arguments)]
 async fn request_completion_with_model(
     config: &LoongClawConfig,
     messages: &[Value],
     model: &str,
-    auto_model_mode: bool,
-    endpoint: &str,
-    headers: &reqwest::header::HeaderMap,
-    request_policy: &policy::ProviderRequestPolicy,
-    client: &reqwest::Client,
+    request_context: &ProviderRequestContext<'_>,
 ) -> Result<String, ModelRequestError> {
     let mut attempt = 0usize;
-    let mut backoff_ms = request_policy.initial_backoff_ms;
+    let mut backoff_ms = request_context.request_policy.initial_backoff_ms;
     let mut payload_mode = CompletionPayloadMode::default_for(&config.provider);
     let mut tried_payload_modes = vec![payload_mode];
 
     loop {
         attempt += 1;
         let body = build_completion_request_body(config, messages, model, payload_mode);
-        let mut req = client.post(endpoint).headers(headers.clone()).json(&body);
+        let mut req = request_context
+            .client
+            .post(request_context.endpoint)
+            .headers(request_context.headers.clone())
+            .json(&body);
         if let Some(auth_header) = config.provider.authorization_header() {
             req = req.header(reqwest::header::AUTHORIZATION, auth_header);
         }
@@ -605,7 +219,7 @@ async fn request_completion_with_model(
                     .map_err(|error| ModelRequestError {
                         message: format!(
                             "provider response decode failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                            max_attempts = request_policy.max_attempts
+                            max_attempts = request_context.request_policy.max_attempts
                         ),
                         try_next_model: false,
                     })?;
@@ -615,7 +229,7 @@ async fn request_completion_with_model(
                         ModelRequestError {
                             message: format!(
                                 "provider response missing choices[0].message.content for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}",
-                                max_attempts = request_policy.max_attempts
+                                max_attempts = request_context.request_policy.max_attempts
                             ),
                             try_next_model: false,
                         }
@@ -635,14 +249,18 @@ async fn request_completion_with_model(
                 }
 
                 let status_code = status.as_u16();
-                if attempt < request_policy.max_attempts && policy::should_retry_status(status_code)
+                if attempt < request_context.request_policy.max_attempts
+                    && policy::should_retry_status(status_code)
                 {
                     sleep(Duration::from_millis(backoff_ms)).await;
-                    backoff_ms = policy::next_backoff_ms(backoff_ms, request_policy.max_backoff_ms);
+                    backoff_ms = policy::next_backoff_ms(
+                        backoff_ms,
+                        request_context.request_policy.max_backoff_ms,
+                    );
                     continue;
                 }
 
-                if auto_model_mode && should_try_next_model_on_error(&api_error) {
+                if request_context.auto_model_mode && should_try_next_model_on_error(&api_error) {
                     return Err(ModelRequestError {
                         message: format!(
                             "model `{model}` rejected by provider endpoint; trying next candidate. status {status_code}: {response_body}"
@@ -654,21 +272,26 @@ async fn request_completion_with_model(
                 return Err(ModelRequestError {
                     message: format!(
                         "provider returned status {status_code} for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}",
-                        max_attempts = request_policy.max_attempts
+                        max_attempts = request_context.request_policy.max_attempts
                     ),
                     try_next_model: false,
                 });
             }
             Err(error) => {
-                if attempt < request_policy.max_attempts && policy::should_retry_error(&error) {
+                if attempt < request_context.request_policy.max_attempts
+                    && policy::should_retry_error(&error)
+                {
                     sleep(Duration::from_millis(backoff_ms)).await;
-                    backoff_ms = policy::next_backoff_ms(backoff_ms, request_policy.max_backoff_ms);
+                    backoff_ms = policy::next_backoff_ms(
+                        backoff_ms,
+                        request_context.request_policy.max_backoff_ms,
+                    );
                     continue;
                 }
                 return Err(ModelRequestError {
                     message: format!(
                         "provider request failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                        max_attempts = request_policy.max_attempts
+                        max_attempts = request_context.request_policy.max_attempts
                     ),
                     try_next_model: false,
                 });
@@ -677,19 +300,14 @@ async fn request_completion_with_model(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn request_turn_with_model(
     config: &LoongClawConfig,
     messages: &[Value],
     model: &str,
-    auto_model_mode: bool,
-    endpoint: &str,
-    headers: &reqwest::header::HeaderMap,
-    request_policy: &policy::ProviderRequestPolicy,
-    client: &reqwest::Client,
+    request_context: &ProviderRequestContext<'_>,
 ) -> Result<crate::conversation::turn_engine::ProviderTurn, ModelRequestError> {
     let mut attempt = 0usize;
-    let mut backoff_ms = request_policy.initial_backoff_ms;
+    let mut backoff_ms = request_context.request_policy.initial_backoff_ms;
     let mut payload_mode = CompletionPayloadMode::default_for(&config.provider);
     let mut tried_payload_modes = vec![payload_mode];
     let tool_definitions = super::tools::provider_tool_definitions();
@@ -705,7 +323,11 @@ async fn request_turn_with_model(
             include_tool_schema,
             &tool_definitions,
         );
-        let mut req = client.post(endpoint).headers(headers.clone()).json(&body);
+        let mut req = request_context
+            .client
+            .post(request_context.endpoint)
+            .headers(request_context.headers.clone())
+            .json(&body);
         if let Some(auth_header) = config.provider.authorization_header() {
             req = req.header(reqwest::header::AUTHORIZATION, auth_header);
         }
@@ -718,7 +340,7 @@ async fn request_turn_with_model(
                     .map_err(|error| ModelRequestError {
                         message: format!(
                             "provider response decode failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                            max_attempts = request_policy.max_attempts
+                            max_attempts = request_context.request_policy.max_attempts
                         ),
                         try_next_model: false,
                     })?;
@@ -728,7 +350,7 @@ async fn request_turn_with_model(
                         ModelRequestError {
                             message: format!(
                                 "provider response missing choices[0].message for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}",
-                                max_attempts = request_policy.max_attempts
+                                max_attempts = request_context.request_policy.max_attempts
                             ),
                             try_next_model: false,
                         }
@@ -752,14 +374,18 @@ async fn request_turn_with_model(
                 }
 
                 let status_code = status.as_u16();
-                if attempt < request_policy.max_attempts && policy::should_retry_status(status_code)
+                if attempt < request_context.request_policy.max_attempts
+                    && policy::should_retry_status(status_code)
                 {
                     sleep(Duration::from_millis(backoff_ms)).await;
-                    backoff_ms = policy::next_backoff_ms(backoff_ms, request_policy.max_backoff_ms);
+                    backoff_ms = policy::next_backoff_ms(
+                        backoff_ms,
+                        request_context.request_policy.max_backoff_ms,
+                    );
                     continue;
                 }
 
-                if auto_model_mode && should_try_next_model_on_error(&api_error) {
+                if request_context.auto_model_mode && should_try_next_model_on_error(&api_error) {
                     return Err(ModelRequestError {
                         message: format!(
                             "model `{model}` rejected by provider endpoint; trying next candidate. status {status_code}: {response_body}"
@@ -771,21 +397,26 @@ async fn request_turn_with_model(
                 return Err(ModelRequestError {
                     message: format!(
                         "provider returned status {status_code} for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}",
-                        max_attempts = request_policy.max_attempts
+                        max_attempts = request_context.request_policy.max_attempts
                     ),
                     try_next_model: false,
                 });
             }
             Err(error) => {
-                if attempt < request_policy.max_attempts && policy::should_retry_error(&error) {
+                if attempt < request_context.request_policy.max_attempts
+                    && policy::should_retry_error(&error)
+                {
                     sleep(Duration::from_millis(backoff_ms)).await;
-                    backoff_ms = policy::next_backoff_ms(backoff_ms, request_policy.max_backoff_ms);
+                    backoff_ms = policy::next_backoff_ms(
+                        backoff_ms,
+                        request_context.request_policy.max_backoff_ms,
+                    );
                     continue;
                 }
                 return Err(ModelRequestError {
                     message: format!(
                         "provider request failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                        max_attempts = request_policy.max_attempts
+                        max_attempts = request_context.request_policy.max_attempts
                     ),
                     try_next_model: false,
                 });
@@ -794,92 +425,14 @@ async fn request_turn_with_model(
     }
 }
 
-fn validate_provider_feature_gate(config: &LoongClawConfig) -> CliResult<()> {
-    match config.provider.kind {
-        ProviderKind::Volcengine => {
-            if !cfg!(feature = "provider-volcengine") {
-                return Err(
-                    "volcengine provider is disabled (enable feature `provider-volcengine`)"
-                        .to_owned(),
-                );
-            }
-        }
-        _ => {
-            if !cfg!(feature = "provider-openai") {
-                return Err(
-                    "openai-compatible provider family is disabled (enable feature `provider-openai`)"
-                        .to_owned(),
-                );
-            }
-        }
-    }
-    Ok(())
-}
-
-fn validate_provider_configuration(config: &LoongClawConfig) -> CliResult<()> {
-    if config.provider.kind == ProviderKind::Kimi
-        && provider_uses_kimi_coding_endpoint(&config.provider)
-    {
-        return Err(
-            "kimi provider cannot target Kimi Coding endpoints; use `kind = \"kimi_coding\"`"
-                .to_owned(),
-        );
-    }
-
-    if config.provider.kind == ProviderKind::KimiCoding {
-        if let Some(user_agent) = config.provider.header_value("user-agent") {
-            if !is_kimi_cli_user_agent(user_agent) {
-                return Err(format!(
-                    "kimi_coding provider requires a `User-Agent` header starting with `KimiCLI/`; got `{user_agent}`"
-                ));
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn provider_uses_kimi_coding_endpoint(provider: &ProviderConfig) -> bool {
-    is_kimi_coding_endpoint(provider.endpoint().as_str())
-        || provider
-            .endpoint
-            .as_deref()
-            .is_some_and(is_kimi_coding_endpoint)
-}
-
-fn is_kimi_coding_endpoint(endpoint: &str) -> bool {
-    endpoint
-        .trim()
-        .to_ascii_lowercase()
-        .contains("://api.kimi.com/coding/")
-}
-
-fn is_kimi_cli_user_agent(user_agent: &str) -> bool {
-    user_agent.trim().starts_with("KimiCLI/")
-}
-
-fn kimi_extra_body(reasoning_effort: Option<ReasoningEffort>) -> Option<Value> {
-    let reasoning_effort = reasoning_effort?;
-    let thinking_type = match reasoning_effort {
-        ReasoningEffort::None => "disabled",
-        ReasoningEffort::Minimal
-        | ReasoningEffort::Low
-        | ReasoningEffort::Medium
-        | ReasoningEffort::High
-        | ReasoningEffort::Xhigh => "enabled",
-    };
-    Some(json!({
-        "thinking": {
-            "type": thinking_type
-        }
-    }))
-}
-
 #[cfg(test)]
 mod tests {
+    use super::model_selection::rank_model_candidates;
+    use super::payload_adaptation::{ReasoningField, TemperatureField, TokenLimitField};
     use super::*;
     use crate::config::{
-        FeishuChannelConfig, MemoryConfig, ProviderConfig, ReasoningEffort, ToolConfig,
+        FeishuChannelConfig, MemoryConfig, ProviderConfig, ProviderKind, ReasoningEffort,
+        ToolConfig,
     };
     use serde_json::json;
 

--- a/crates/app/src/provider/model_selection.rs
+++ b/crates/app/src/provider/model_selection.rs
@@ -1,0 +1,126 @@
+use std::time::Duration;
+
+use tokio::time::sleep;
+
+use crate::{config::ProviderConfig, CliResult};
+
+use super::{build_http_client, policy, shape, transport};
+use crate::config::LoongClawConfig;
+
+pub(super) async fn resolve_request_models(
+    config: &LoongClawConfig,
+    headers: &reqwest::header::HeaderMap,
+    request_policy: &policy::ProviderRequestPolicy,
+) -> CliResult<Vec<String>> {
+    if let Some(model) = config.provider.resolved_model() {
+        return Ok(vec![model]);
+    }
+    let available = fetch_available_models_with_policy(config, headers, request_policy).await?;
+    let ordered = rank_model_candidates(&config.provider, &available);
+    if ordered.is_empty() {
+        return Err("provider model-list is empty; set provider.model explicitly".to_owned());
+    }
+    Ok(ordered)
+}
+
+pub(super) async fn fetch_available_models_with_policy(
+    config: &LoongClawConfig,
+    headers: &reqwest::header::HeaderMap,
+    request_policy: &policy::ProviderRequestPolicy,
+) -> CliResult<Vec<String>> {
+    let endpoint = config.provider.models_endpoint();
+    let client = build_http_client(request_policy)?;
+
+    let mut attempt = 0usize;
+    let mut backoff_ms = request_policy.initial_backoff_ms;
+    loop {
+        attempt += 1;
+        let mut req = client.get(endpoint.clone()).headers(headers.clone());
+        if let Some(auth_header) = config.provider.authorization_header() {
+            req = req.header(reqwest::header::AUTHORIZATION, auth_header);
+        }
+
+        match req.send().await {
+            Ok(response) => {
+                let status = response.status();
+                let response_body = transport::decode_response_body(response)
+                    .await
+                    .map_err(|error| {
+                        format!(
+                            "provider model-list decode failed on attempt {attempt}/{max_attempts}: {error}",
+                            max_attempts = request_policy.max_attempts
+                        )
+                    })?;
+
+                if status.is_success() {
+                    let models = shape::extract_model_ids(&response_body);
+                    if models.is_empty() {
+                        return Err(format!(
+                            "provider model-list returned no models from endpoint `{endpoint}`"
+                        ));
+                    }
+                    return Ok(models);
+                }
+
+                let status_code = status.as_u16();
+                if attempt < request_policy.max_attempts && policy::should_retry_status(status_code)
+                {
+                    sleep(Duration::from_millis(backoff_ms)).await;
+                    backoff_ms = policy::next_backoff_ms(backoff_ms, request_policy.max_backoff_ms);
+                    continue;
+                }
+
+                return Err(format!(
+                    "provider model-list returned status {status_code} on attempt {attempt}/{max_attempts}: {response_body}",
+                    max_attempts = request_policy.max_attempts
+                ));
+            }
+            Err(error) => {
+                if attempt < request_policy.max_attempts && policy::should_retry_error(&error) {
+                    sleep(Duration::from_millis(backoff_ms)).await;
+                    backoff_ms = policy::next_backoff_ms(backoff_ms, request_policy.max_backoff_ms);
+                    continue;
+                }
+                return Err(format!(
+                    "provider model-list request failed on attempt {attempt}/{max_attempts}: {error}",
+                    max_attempts = request_policy.max_attempts
+                ));
+            }
+        }
+    }
+}
+
+pub(super) fn rank_model_candidates(
+    provider: &ProviderConfig,
+    available: &[String],
+) -> Vec<String> {
+    let mut ordered = Vec::new();
+    for raw in &provider.preferred_models {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(matched) = available.iter().find(|model| *model == trimmed) {
+            push_unique_model(&mut ordered, matched);
+            continue;
+        }
+        if let Some(matched) = available
+            .iter()
+            .find(|model| model.eq_ignore_ascii_case(trimmed))
+        {
+            push_unique_model(&mut ordered, matched);
+        }
+    }
+
+    for model in available {
+        push_unique_model(&mut ordered, model);
+    }
+    ordered
+}
+
+fn push_unique_model(out: &mut Vec<String>, model: &str) {
+    if out.iter().any(|existing| existing == model) {
+        return;
+    }
+    out.push(model.to_owned());
+}

--- a/crates/app/src/provider/payload_adaptation.rs
+++ b/crates/app/src/provider/payload_adaptation.rs
@@ -1,0 +1,320 @@
+use serde_json::{json, Value};
+
+use crate::config::{LoongClawConfig, ProviderConfig, ProviderKind, ReasoningEffort};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderTransportMode {
+    OpenAiChatCompletions,
+    KimiApi,
+}
+
+impl ProviderTransportMode {
+    fn for_provider(provider: &ProviderConfig) -> Self {
+        match provider.kind {
+            ProviderKind::KimiCoding => Self::KimiApi,
+            _ => Self::OpenAiChatCompletions,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TokenLimitField {
+    MaxCompletionTokens,
+    MaxTokens,
+    Omit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ReasoningField {
+    ReasoningEffort,
+    ReasoningObject,
+    Omit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TemperatureField {
+    Include,
+    Omit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct CompletionPayloadMode {
+    pub(super) token_field: TokenLimitField,
+    pub(super) reasoning_field: ReasoningField,
+    pub(super) temperature_field: TemperatureField,
+}
+
+impl CompletionPayloadMode {
+    pub(super) fn default_for(provider: &ProviderConfig) -> Self {
+        let token_field = if provider.max_tokens.is_some() {
+            if provider.kind == ProviderKind::Openai {
+                TokenLimitField::MaxCompletionTokens
+            } else {
+                TokenLimitField::MaxTokens
+            }
+        } else {
+            TokenLimitField::Omit
+        };
+
+        let reasoning_field = if provider.reasoning_effort.is_some() {
+            ReasoningField::ReasoningEffort
+        } else {
+            ReasoningField::Omit
+        };
+
+        Self {
+            token_field,
+            reasoning_field,
+            temperature_field: TemperatureField::Include,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct ProviderApiError {
+    pub(super) code: Option<String>,
+    pub(super) param: Option<String>,
+    pub(super) message: Option<String>,
+}
+
+pub(super) fn build_completion_request_body(
+    config: &LoongClawConfig,
+    messages: &[Value],
+    model: &str,
+    payload_mode: CompletionPayloadMode,
+) -> Value {
+    let transport_mode = ProviderTransportMode::for_provider(&config.provider);
+    let mut body = serde_json::Map::new();
+    body.insert("model".to_owned(), json!(model));
+    body.insert("messages".to_owned(), Value::Array(messages.to_vec()));
+    body.insert("stream".to_owned(), Value::Bool(false));
+    if payload_mode.temperature_field == TemperatureField::Include {
+        body.insert("temperature".to_owned(), json!(config.provider.temperature));
+    }
+
+    if let Some(limit) = config.provider.max_tokens {
+        match payload_mode.token_field {
+            TokenLimitField::MaxCompletionTokens => {
+                body.insert("max_completion_tokens".to_owned(), json!(limit));
+            }
+            TokenLimitField::MaxTokens => {
+                body.insert("max_tokens".to_owned(), json!(limit));
+            }
+            TokenLimitField::Omit => {}
+        }
+    }
+
+    if let Some(reasoning_effort) = config.provider.reasoning_effort {
+        match payload_mode.reasoning_field {
+            ReasoningField::ReasoningEffort => {
+                body.insert(
+                    "reasoning_effort".to_owned(),
+                    json!(reasoning_effort.as_str()),
+                );
+            }
+            ReasoningField::ReasoningObject => {
+                body.insert(
+                    "reasoning".to_owned(),
+                    json!({
+                        "effort": reasoning_effort.as_str()
+                    }),
+                );
+            }
+            ReasoningField::Omit => {}
+        }
+    }
+
+    if transport_mode == ProviderTransportMode::KimiApi {
+        if let Some(extra_body) = kimi_extra_body(config.provider.reasoning_effort) {
+            body.insert("extra_body".to_owned(), extra_body);
+        }
+    }
+
+    Value::Object(body)
+}
+
+pub(super) fn build_turn_request_body(
+    config: &LoongClawConfig,
+    messages: &[Value],
+    model: &str,
+    payload_mode: CompletionPayloadMode,
+    include_tool_schema: bool,
+    tool_definitions: &[Value],
+) -> Value {
+    let mut body = build_completion_request_body(config, messages, model, payload_mode);
+    if include_tool_schema && !tool_definitions.is_empty() {
+        if let Some(object) = body.as_object_mut() {
+            object.insert("tools".to_owned(), Value::Array(tool_definitions.to_vec()));
+            object.insert("tool_choice".to_owned(), json!("auto"));
+        }
+    }
+    body
+}
+
+pub(super) fn parse_provider_api_error(body: &Value) -> ProviderApiError {
+    let error = body.get("error").unwrap_or(body);
+    ProviderApiError {
+        code: error
+            .get("code")
+            .and_then(Value::as_str)
+            .map(str::to_lowercase),
+        param: error
+            .get("param")
+            .and_then(Value::as_str)
+            .map(str::to_lowercase),
+        message: error
+            .get("message")
+            .and_then(Value::as_str)
+            .map(str::to_lowercase),
+    }
+}
+
+fn is_parameter_unsupported(error: &ProviderApiError, parameter: &str) -> bool {
+    let param = parameter.to_lowercase();
+    if error.param.as_deref() == Some(param.as_str()) {
+        return true;
+    }
+
+    let message = error.message.as_deref().unwrap_or_default();
+    if !(message.contains("unknown parameter")
+        || message.contains("unsupported parameter")
+        || message.contains("not supported"))
+    {
+        return false;
+    }
+    message.contains(param.as_str())
+}
+
+pub(super) fn should_disable_tool_schema_for_error(error: &ProviderApiError) -> bool {
+    if is_parameter_unsupported(error, "tools") || is_parameter_unsupported(error, "tool_choice") {
+        return true;
+    }
+
+    let message = error.message.as_deref().unwrap_or_default();
+    message.contains("tools are not supported")
+        || message.contains("tool use is not supported")
+        || message.contains("function calling is not supported")
+}
+
+pub(super) fn should_try_next_model_on_error(error: &ProviderApiError) -> bool {
+    if let Some(code) = error.code.as_deref() {
+        if matches!(
+            code,
+            "model_not_found" | "unsupported_model" | "invalid_model" | "not_found_error"
+        ) {
+            return true;
+        }
+    }
+    if error.param.as_deref() == Some("model") {
+        return true;
+    }
+
+    let message = error.message.as_deref().unwrap_or_default();
+    message.contains("only supports")
+        || message.contains("only available")
+        || message.contains("this endpoint")
+        || message.contains("/v1/responses")
+        || message.contains("model does not exist")
+}
+
+pub(super) fn adapt_payload_mode_for_error(
+    current: CompletionPayloadMode,
+    provider: &ProviderConfig,
+    error: &ProviderApiError,
+) -> Option<CompletionPayloadMode> {
+    if provider.max_tokens.is_some() {
+        if is_parameter_unsupported(error, "max_tokens") {
+            return Some(match current.token_field {
+                TokenLimitField::MaxTokens => CompletionPayloadMode {
+                    token_field: TokenLimitField::MaxCompletionTokens,
+                    ..current
+                },
+                TokenLimitField::MaxCompletionTokens => CompletionPayloadMode {
+                    token_field: TokenLimitField::Omit,
+                    ..current
+                },
+                TokenLimitField::Omit => current,
+            });
+        }
+
+        if is_parameter_unsupported(error, "max_completion_tokens") {
+            return Some(match current.token_field {
+                TokenLimitField::MaxCompletionTokens => CompletionPayloadMode {
+                    token_field: TokenLimitField::MaxTokens,
+                    ..current
+                },
+                TokenLimitField::MaxTokens => CompletionPayloadMode {
+                    token_field: TokenLimitField::Omit,
+                    ..current
+                },
+                TokenLimitField::Omit => current,
+            });
+        }
+    }
+
+    if provider.reasoning_effort.is_some() {
+        if is_parameter_unsupported(error, "reasoning_effort") {
+            return Some(match current.reasoning_field {
+                ReasoningField::ReasoningEffort => CompletionPayloadMode {
+                    reasoning_field: ReasoningField::ReasoningObject,
+                    ..current
+                },
+                ReasoningField::ReasoningObject => CompletionPayloadMode {
+                    reasoning_field: ReasoningField::Omit,
+                    ..current
+                },
+                ReasoningField::Omit => current,
+            });
+        }
+
+        if is_parameter_unsupported(error, "reasoning") {
+            return Some(match current.reasoning_field {
+                ReasoningField::ReasoningObject => CompletionPayloadMode {
+                    reasoning_field: ReasoningField::ReasoningEffort,
+                    ..current
+                },
+                ReasoningField::ReasoningEffort => CompletionPayloadMode {
+                    reasoning_field: ReasoningField::Omit,
+                    ..current
+                },
+                ReasoningField::Omit => current,
+            });
+        }
+    }
+
+    let temperature_rejected = is_parameter_unsupported(error, "temperature")
+        || (error.param.as_deref() == Some("temperature")
+            && error
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("only the default"));
+    if temperature_rejected {
+        return Some(match current.temperature_field {
+            TemperatureField::Include => CompletionPayloadMode {
+                temperature_field: TemperatureField::Omit,
+                ..current
+            },
+            TemperatureField::Omit => current,
+        });
+    }
+
+    None
+}
+
+fn kimi_extra_body(reasoning_effort: Option<ReasoningEffort>) -> Option<Value> {
+    let reasoning_effort = reasoning_effort?;
+    let thinking_type = match reasoning_effort {
+        ReasoningEffort::None => "disabled",
+        ReasoningEffort::Minimal
+        | ReasoningEffort::Low
+        | ReasoningEffort::Medium
+        | ReasoningEffort::High
+        | ReasoningEffort::Xhigh => "enabled",
+    };
+    Some(json!({
+        "thinking": {
+            "type": thinking_type
+        }
+    }))
+}

--- a/crates/spec/src/spec_execution.rs
+++ b/crates/spec/src/spec_execution.rs
@@ -1,31 +1,46 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
-    io::Write,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
-use ed25519_dalek::{Signature as Ed25519Signature, Verifier, VerifyingKey};
 use kernel::{
-    ArchitectureBoundaryPolicy, AuditEventKind, AutoProvisionAgent, AutoProvisionRequest,
-    BootstrapPolicy, BootstrapTaskStatus, BridgeSupportMatrix, Clock, CodebaseAwarenessConfig,
-    CodebaseAwarenessEngine, ConnectorCommand, InMemoryAuditSink, IntegrationCatalog,
-    LoongClawKernel, MemoryCoreRequest, MemoryExtensionRequest, PluginActivationPlan,
-    PluginActivationStatus, PluginBootstrapExecutor, PluginBridgeKind, PluginDescriptor,
-    PluginScanReport, PluginScanner, PluginTranslationReport, PluginTranslator, RuntimeCoreRequest,
-    RuntimeExtensionRequest, StaticPolicyEngine, SystemClock, TaskIntent, ToolCoreRequest,
-    ToolExtensionRequest,
+    ArchitectureBoundaryPolicy, ArchitectureGuardReport, AuditEventKind, AutoProvisionAgent,
+    AutoProvisionRequest, BootstrapPolicy, BootstrapReport, BootstrapTaskStatus,
+    BridgeSupportMatrix, Clock, CodebaseAwarenessConfig, CodebaseAwarenessEngine,
+    CodebaseAwarenessSnapshot, ConnectorCommand, InMemoryAuditSink, IntegrationCatalog,
+    LoongClawKernel, MemoryCoreRequest, MemoryExtensionRequest, PluginAbsorbReport,
+    PluginActivationPlan, PluginActivationStatus, PluginBootstrapExecutor, PluginBridgeKind,
+    PluginDescriptor, PluginScanReport, PluginScanner, PluginTranslationReport, PluginTranslator,
+    ProvisionPlan, RuntimeCoreRequest, RuntimeExtensionRequest, StaticPolicyEngine, SystemClock,
+    TaskIntent, ToolCoreRequest, ToolExtensionRequest,
 };
 use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
-use wasmparser::{Parser as WasmParser, Payload as WasmPayload};
 
 use crate::programmatic::execute_programmatic_tool_call;
 use crate::spec_runtime::*;
-use crate::{CliResult, BUNDLED_APPROVAL_RISK_PROFILE, BUNDLED_SECURITY_SCAN_PROFILE};
+use crate::CliResult;
+
+mod approval_policy;
+mod bridge_support_policy;
+mod security_scan_eval;
+mod security_scan_policy;
+mod tool_search;
+use approval_policy::evaluate_approval_guard;
+use bridge_support_policy::bridge_support_policy_checksum;
+use security_scan_eval::evaluate_plugin_security_scan;
+use security_scan_policy::{
+    apply_security_scan_delta, emit_security_scan_siem_record, security_scan_process_allowlist,
+};
+use tool_search::execute_tool_search;
+
+pub use approval_policy::operation_risk_profile;
+pub use bridge_support_policy::{
+    bridge_support_policy_sha256, security_scan_profile_message, security_scan_profile_sha256,
+};
+pub use security_scan_policy::{load_security_scan_profile_from_path, security_scan_policy};
 
 pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunReport {
     let mut spec = spec;
@@ -142,11 +157,10 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
     }
 
     if let Some(reason) = blocked_reason.clone() {
-        return SpecRunReport {
-            pack_id: spec.pack.pack_id,
-            agent_id: spec.agent_id,
-            operation_kind: "blocked",
-            blocked_reason: Some(reason.clone()),
+        return build_blocked_spec_run_report(
+            spec.pack.pack_id,
+            spec.agent_id,
+            reason,
             approval_guard,
             bridge_support_checksum,
             bridge_support_sha256,
@@ -158,19 +172,12 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
             plugin_bootstrap_reports,
             plugin_bootstrap_queue,
             plugin_absorb_reports,
-            security_scan_report: security_scan_report.clone(),
+            security_scan_report,
             auto_provision_plan,
-            outcome: json!({
-                "status": "blocked",
-                "reason": reason,
-            }),
             integration_catalog,
-            audit_events: if include_audit {
-                Some(audit_sink.snapshot())
-            } else {
-                None
-            },
-        };
+            include_audit,
+            &audit_sink,
+        );
     }
 
     if let Some(plugin_scan) = &spec.plugin_scan {
@@ -323,11 +330,10 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
     }
 
     if let Some(reason) = blocked_reason.clone() {
-        return SpecRunReport {
-            pack_id: spec.pack.pack_id,
-            agent_id: spec.agent_id,
-            operation_kind: "blocked",
-            blocked_reason: Some(reason.clone()),
+        return build_blocked_spec_run_report(
+            spec.pack.pack_id,
+            spec.agent_id,
+            reason,
             approval_guard,
             bridge_support_checksum,
             bridge_support_sha256,
@@ -339,19 +345,12 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
             plugin_bootstrap_reports,
             plugin_bootstrap_queue,
             plugin_absorb_reports,
-            security_scan_report: security_scan_report.clone(),
+            security_scan_report,
             auto_provision_plan,
-            outcome: json!({
-                "status": "blocked",
-                "reason": reason,
-            }),
             integration_catalog,
-            audit_events: if include_audit {
-                Some(audit_sink.snapshot())
-            } else {
-                None
-            },
-        };
+            include_audit,
+            &audit_sink,
+        );
     }
 
     if let Some(auto) = &spec.auto_provision {
@@ -397,11 +396,10 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
     }
 
     if let Some(reason) = blocked_reason.clone() {
-        return SpecRunReport {
-            pack_id: spec.pack.pack_id,
-            agent_id: spec.agent_id,
-            operation_kind: "blocked",
-            blocked_reason: Some(reason.clone()),
+        return build_blocked_spec_run_report(
+            spec.pack.pack_id,
+            spec.agent_id,
+            reason,
             approval_guard,
             bridge_support_checksum,
             bridge_support_sha256,
@@ -415,17 +413,10 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
             plugin_absorb_reports,
             security_scan_report,
             auto_provision_plan,
-            outcome: json!({
-                "status": "blocked",
-                "reason": reason,
-            }),
             integration_catalog,
-            audit_events: if include_audit {
-                Some(audit_sink.snapshot())
-            } else {
-                None
-            },
-        };
+            include_audit,
+            &audit_sink,
+        );
     }
 
     let shared_catalog = Arc::new(Mutex::new(integration_catalog.clone()));
@@ -434,11 +425,10 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
 
     if let Err(error) = kernel.register_pack(spec.pack.clone()) {
         let reason = format!("spec pack registration failed: {error}");
-        return SpecRunReport {
-            pack_id: spec.pack.pack_id,
-            agent_id: spec.agent_id,
-            operation_kind: "blocked",
-            blocked_reason: Some(reason.clone()),
+        return build_blocked_spec_run_report(
+            spec.pack.pack_id,
+            spec.agent_id,
+            reason,
             approval_guard,
             bridge_support_checksum,
             bridge_support_sha256,
@@ -452,24 +442,16 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
             plugin_absorb_reports,
             security_scan_report,
             auto_provision_plan,
-            outcome: json!({
-                "status": "blocked",
-                "reason": reason,
-            }),
             integration_catalog,
-            audit_events: if include_audit {
-                Some(audit_sink.snapshot())
-            } else {
-                None
-            },
-        };
+            include_audit,
+            &audit_sink,
+        );
     }
     if let Err(error) = apply_default_selection(&mut kernel, spec.defaults.as_ref()) {
-        return SpecRunReport {
-            pack_id: spec.pack.pack_id,
-            agent_id: spec.agent_id,
-            operation_kind: "blocked",
-            blocked_reason: Some(error.clone()),
+        return build_blocked_spec_run_report(
+            spec.pack.pack_id,
+            spec.agent_id,
+            error,
             approval_guard,
             bridge_support_checksum,
             bridge_support_sha256,
@@ -483,28 +465,20 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
             plugin_absorb_reports,
             security_scan_report,
             auto_provision_plan,
-            outcome: json!({
-                "status": "blocked",
-                "reason": error,
-            }),
             integration_catalog,
-            audit_events: if include_audit {
-                Some(audit_sink.snapshot())
-            } else {
-                None
-            },
-        };
+            include_audit,
+            &audit_sink,
+        );
     }
 
     let token = match kernel.issue_token(&spec.pack.pack_id, &spec.agent_id, spec.ttl_s) {
         Ok(token) => token,
         Err(error) => {
             let reason = format!("token issue for spec failed: {error}");
-            return SpecRunReport {
-                pack_id: spec.pack.pack_id,
-                agent_id: spec.agent_id,
-                operation_kind: "blocked",
-                blocked_reason: Some(reason.clone()),
+            return build_blocked_spec_run_report(
+                spec.pack.pack_id,
+                spec.agent_id,
+                reason,
                 approval_guard,
                 bridge_support_checksum,
                 bridge_support_sha256,
@@ -518,17 +492,10 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
                 plugin_absorb_reports,
                 security_scan_report,
                 auto_provision_plan,
-                outcome: json!({
-                    "status": "blocked",
-                    "reason": reason,
-                }),
                 integration_catalog,
-                audit_events: if include_audit {
-                    Some(audit_sink.snapshot())
-                } else {
-                    None
-                },
-            };
+                include_audit,
+                &audit_sink,
+            );
         }
     };
 
@@ -545,11 +512,10 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
     {
         Ok(result) => result,
         Err(error) => {
-            return SpecRunReport {
-                pack_id: spec.pack.pack_id,
-                agent_id: spec.agent_id,
-                operation_kind: "blocked",
-                blocked_reason: Some(error.clone()),
+            return build_blocked_spec_run_report(
+                spec.pack.pack_id,
+                spec.agent_id,
+                error,
                 approval_guard,
                 bridge_support_checksum,
                 bridge_support_sha256,
@@ -563,17 +529,10 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
                 plugin_absorb_reports,
                 security_scan_report,
                 auto_provision_plan,
-                outcome: json!({
-                    "status": "blocked",
-                    "reason": error,
-                }),
                 integration_catalog,
-                audit_events: if include_audit {
-                    Some(audit_sink.snapshot())
-                } else {
-                    None
-                },
-            };
+                include_audit,
+                &audit_sink,
+            );
         }
     };
 
@@ -605,6 +564,63 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
     }
 }
 
+fn blocked_outcome(reason: &str) -> Value {
+    json!({
+        "status": "blocked",
+        "reason": reason,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_blocked_spec_run_report(
+    pack_id: String,
+    agent_id: String,
+    reason: String,
+    approval_guard: ApprovalDecisionReport,
+    bridge_support_checksum: Option<String>,
+    bridge_support_sha256: Option<String>,
+    self_awareness: Option<CodebaseAwarenessSnapshot>,
+    architecture_guard: Option<ArchitectureGuardReport>,
+    plugin_scan_reports: Vec<PluginScanReport>,
+    plugin_translation_reports: Vec<PluginTranslationReport>,
+    plugin_activation_plans: Vec<PluginActivationPlan>,
+    plugin_bootstrap_reports: Vec<BootstrapReport>,
+    plugin_bootstrap_queue: Vec<String>,
+    plugin_absorb_reports: Vec<PluginAbsorbReport>,
+    security_scan_report: Option<SecurityScanReport>,
+    auto_provision_plan: Option<ProvisionPlan>,
+    integration_catalog: IntegrationCatalog,
+    include_audit: bool,
+    audit_sink: &Arc<InMemoryAuditSink>,
+) -> SpecRunReport {
+    SpecRunReport {
+        pack_id,
+        agent_id,
+        operation_kind: "blocked",
+        blocked_reason: Some(reason.clone()),
+        approval_guard,
+        bridge_support_checksum,
+        bridge_support_sha256,
+        self_awareness,
+        architecture_guard,
+        plugin_scan_reports,
+        plugin_translation_reports,
+        plugin_activation_plans,
+        plugin_bootstrap_reports,
+        plugin_bootstrap_queue,
+        plugin_absorb_reports,
+        security_scan_report,
+        auto_provision_plan,
+        outcome: blocked_outcome(&reason),
+        integration_catalog,
+        audit_events: if include_audit {
+            Some(audit_sink.snapshot())
+        } else {
+            None
+        },
+    }
+}
+
 #[derive(Debug, Default)]
 struct SecurityScanDelta {
     scanned_plugins: usize,
@@ -613,208 +629,6 @@ struct SecurityScanDelta {
     low_findings: usize,
     findings: Vec<SecurityFinding>,
     block_reason: Option<String>,
-}
-
-pub fn security_scan_policy(spec: &RunnerSpec) -> Result<Option<SecurityScanSpec>, String> {
-    let Some(mut policy) = spec
-        .bridge_support
-        .as_ref()
-        .filter(|bridge| bridge.enabled)
-        .and_then(|bridge| bridge.security_scan.clone())
-    else {
-        return Ok(None);
-    };
-
-    if !policy.enabled {
-        return Ok(None);
-    }
-
-    validate_security_scan_policy(&policy)?;
-
-    let profile = resolve_security_scan_profile(&policy)?;
-
-    if policy.high_risk_metadata_keywords.is_empty() {
-        policy.high_risk_metadata_keywords = profile.high_risk_metadata_keywords;
-    }
-
-    if policy.wasm.blocked_import_prefixes.is_empty() {
-        policy.wasm.blocked_import_prefixes = profile.wasm.blocked_import_prefixes;
-    }
-
-    if policy.wasm.max_module_bytes == 0 {
-        policy.wasm.max_module_bytes = profile.wasm.max_module_bytes;
-    }
-
-    if policy.wasm.allowed_path_prefixes.is_empty() {
-        policy.wasm.allowed_path_prefixes = profile.wasm.allowed_path_prefixes;
-    }
-
-    if policy.wasm.required_sha256_by_plugin.is_empty() {
-        policy.wasm.required_sha256_by_plugin = profile.wasm.required_sha256_by_plugin;
-    }
-
-    Ok(Some(policy))
-}
-
-fn validate_security_scan_policy(policy: &SecurityScanSpec) -> Result<(), String> {
-    if policy.profile_sha256.is_some() && policy.profile_path.is_none() {
-        return Err(
-            "security scan profile_sha256 requires security_scan.profile_path to be set".to_owned(),
-        );
-    }
-    if policy.profile_signature.is_some() && policy.profile_path.is_none() {
-        return Err(
-            "security scan profile_signature requires security_scan.profile_path to be set"
-                .to_owned(),
-        );
-    }
-    if let Some(signature) = policy.profile_signature.as_ref() {
-        if signature.public_key_base64.trim().is_empty() {
-            return Err(
-                "security scan profile_signature.public_key_base64 cannot be empty".to_owned(),
-            );
-        }
-        if signature.signature_base64.trim().is_empty() {
-            return Err(
-                "security scan profile_signature.signature_base64 cannot be empty".to_owned(),
-            );
-        }
-    }
-    if let Some(export) = policy.siem_export.as_ref().filter(|value| value.enabled) {
-        if export.path.trim().is_empty() {
-            return Err("security scan siem_export.path cannot be empty when enabled".to_owned());
-        }
-    }
-    if policy.runtime.execute_wasm_component && policy.runtime.allowed_path_prefixes.is_empty() {
-        return Err(
-            "security scan runtime.execute_wasm_component requires runtime.allowed_path_prefixes to be configured".to_owned(),
-        );
-    }
-    Ok(())
-}
-
-fn resolve_security_scan_profile(policy: &SecurityScanSpec) -> Result<SecurityScanProfile, String> {
-    if let Some(path) = policy.profile_path.as_deref() {
-        let profile = load_security_scan_profile_from_path(path);
-        match profile {
-            Ok(profile) => {
-                if let Some(expected_sha256) = policy.profile_sha256.as_deref() {
-                    let actual_sha256 = security_scan_profile_sha256(&profile);
-                    if !expected_sha256.eq_ignore_ascii_case(&actual_sha256) {
-                        return Err(format!(
-                            "security scan profile sha256 mismatch for {path}: expected {expected_sha256}, actual {actual_sha256}",
-                        ));
-                    }
-                }
-                if let Some(signature) = policy.profile_signature.as_ref() {
-                    verify_security_scan_profile_signature(&profile, signature).map_err(|error| {
-                        format!(
-                            "security scan profile signature verification failed for {path}: {error}"
-                        )
-                    })?;
-                }
-                return Ok(profile);
-            }
-            Err(error) if policy.profile_sha256.is_some() || policy.profile_signature.is_some() => {
-                return Err(format!(
-                    "failed to load security scan profile at {path} while profile integrity is pinned: {error}",
-                ));
-            }
-            Err(_) => {}
-        }
-    }
-
-    Ok(bundled_security_scan_profile())
-}
-
-pub fn load_security_scan_profile_from_path(path: &str) -> Result<SecurityScanProfile, String> {
-    let content =
-        fs::read_to_string(path).map_err(|error| format!("read profile failed: {error}"))?;
-    serde_json::from_str::<SecurityScanProfile>(&content)
-        .map_err(|error| format!("parse profile failed: {error}"))
-}
-
-fn bundled_security_scan_profile() -> SecurityScanProfile {
-    BUNDLED_SECURITY_SCAN_PROFILE
-        .get_or_init(|| {
-            let raw = include_str!("../config/security-scan-medium-balanced.json");
-            // Bundled JSON is compile-time embedded and validated by tests.
-            // Fall back to serde defaults if parsing ever fails.
-            serde_json::from_str(raw)
-                .or_else(|_| serde_json::from_str::<SecurityScanProfile>("{}"))
-                .unwrap_or_else(|_| SecurityScanProfile {
-                    high_risk_metadata_keywords: Vec::new(),
-                    wasm: WasmSecurityScanSpec::default(),
-                })
-        })
-        .clone()
-}
-
-fn verify_security_scan_profile_signature(
-    profile: &SecurityScanProfile,
-    signature: &SecurityProfileSignatureSpec,
-) -> Result<(), String> {
-    let algorithm = signature.algorithm.trim().to_ascii_lowercase();
-    if algorithm != "ed25519" {
-        return Err(format!(
-            "unsupported profile signature algorithm: {algorithm} (expected ed25519)"
-        ));
-    }
-
-    let public_key_bytes = BASE64_STANDARD
-        .decode(signature.public_key_base64.trim())
-        .map_err(|error| format!("invalid public_key_base64: {error}"))?;
-    let public_key_bytes: [u8; 32] = public_key_bytes
-        .as_slice()
-        .try_into()
-        .map_err(|_err| "invalid ed25519 public key length (expected 32 bytes)".to_owned())?;
-    let verifying_key = VerifyingKey::from_bytes(&public_key_bytes)
-        .map_err(|error| format!("invalid ed25519 public key bytes: {error}"))?;
-
-    let signature_bytes = BASE64_STANDARD
-        .decode(signature.signature_base64.trim())
-        .map_err(|error| format!("invalid signature_base64: {error}"))?;
-    let signature_bytes: [u8; 64] = signature_bytes
-        .as_slice()
-        .try_into()
-        .map_err(|_err| "invalid ed25519 signature length (expected 64 bytes)".to_owned())?;
-    let signature = Ed25519Signature::from_bytes(&signature_bytes);
-
-    let message = security_scan_profile_message(profile);
-    verifying_key
-        .verify(&message, &signature)
-        .map_err(|error| format!("ed25519 verification failed: {error}"))
-}
-
-fn security_scan_process_allowlist(spec: &RunnerSpec) -> BTreeSet<String> {
-    spec.bridge_support
-        .as_ref()
-        .filter(|bridge| bridge.enabled)
-        .map(|bridge| {
-            bridge
-                .allowed_process_commands
-                .iter()
-                .map(|value| value.trim().to_ascii_lowercase())
-                .filter(|value| !value.is_empty())
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn apply_security_scan_delta(report: &mut SecurityScanReport, delta: SecurityScanDelta) {
-    report.scanned_plugins = report.scanned_plugins.saturating_add(delta.scanned_plugins);
-    report.high_findings = report.high_findings.saturating_add(delta.high_findings);
-    report.medium_findings = report.medium_findings.saturating_add(delta.medium_findings);
-    report.low_findings = report.low_findings.saturating_add(delta.low_findings);
-    report.total_findings = report
-        .high_findings
-        .saturating_add(report.medium_findings)
-        .saturating_add(report.low_findings);
-    report.findings.extend(delta.findings);
-    if let Some(reason) = delta.block_reason {
-        report.blocked = true;
-        report.block_reason = Some(reason);
-    }
 }
 
 fn emit_security_scan_audit_event(
@@ -859,659 +673,6 @@ fn emit_security_scan_audit_event(
             },
         )
         .map_err(|error| format!("failed to record security scan audit event: {error}"))
-}
-
-fn emit_security_scan_siem_record(
-    pack_id: &str,
-    agent_id: &str,
-    report: &SecurityScanReport,
-    export: &SecuritySiemExportSpec,
-) -> Result<SecuritySiemExportReport, String> {
-    let mut findings = report.findings.clone();
-    let mut truncated_findings = 0usize;
-
-    if export.include_findings {
-        if let Some(limit) = export.max_findings_per_record {
-            if findings.len() > limit {
-                truncated_findings = findings.len().saturating_sub(limit);
-                findings.truncate(limit);
-            }
-        }
-    } else {
-        truncated_findings = report.findings.len();
-        findings.clear();
-    }
-
-    let categories: Vec<String> = report
-        .findings
-        .iter()
-        .map(|finding| finding.category.clone())
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect();
-    let finding_ids: Vec<String> = report
-        .findings
-        .iter()
-        .map(|finding| finding.correlation_id.clone())
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect();
-
-    let record = json!({
-        "event_type": "security_scan_report",
-        "ts_epoch_s": current_epoch_s(),
-        "pack_id": pack_id,
-        "agent_id": agent_id,
-        "blocked": report.blocked,
-        "block_reason": report.block_reason.clone(),
-        "counts": {
-            "scanned_plugins": report.scanned_plugins,
-            "total_findings": report.total_findings,
-            "high_findings": report.high_findings,
-            "medium_findings": report.medium_findings,
-            "low_findings": report.low_findings,
-        },
-        "categories": categories,
-        "finding_ids": finding_ids,
-        "truncated_findings": truncated_findings,
-        "findings": findings,
-    });
-
-    let path = Path::new(&export.path);
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            fs::create_dir_all(parent)
-                .map_err(|error| format!("create siem export directory failed: {error}"))?;
-        }
-    }
-
-    let mut file = fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .map_err(|error| format!("open siem export file failed: {error}"))?;
-    serde_json::to_writer(&mut file, &record)
-        .map_err(|error| format!("serialize siem export record failed: {error}"))?;
-    file.write_all(b"\n")
-        .map_err(|error| format!("flush siem export record failed: {error}"))?;
-
-    Ok(SecuritySiemExportReport {
-        enabled: true,
-        path: export.path.clone(),
-        success: true,
-        exported_records: 1,
-        exported_findings: findings.len(),
-        truncated_findings,
-        error: None,
-    })
-}
-
-fn build_security_finding(
-    severity: SecurityFindingSeverity,
-    category: impl Into<String>,
-    plugin_id: impl Into<String>,
-    source_path: impl Into<String>,
-    message: impl Into<String>,
-    evidence: Value,
-) -> SecurityFinding {
-    let category = category.into();
-    let plugin_id = plugin_id.into();
-    let source_path = source_path.into();
-    let message = message.into();
-    let correlation_id = security_finding_correlation_id(
-        &severity,
-        &category,
-        &plugin_id,
-        &source_path,
-        &message,
-        &evidence,
-    );
-
-    SecurityFinding {
-        correlation_id,
-        severity,
-        category,
-        plugin_id,
-        source_path,
-        message,
-        evidence,
-    }
-}
-
-fn security_finding_correlation_id(
-    severity: &SecurityFindingSeverity,
-    category: &str,
-    plugin_id: &str,
-    source_path: &str,
-    message: &str,
-    evidence: &Value,
-) -> String {
-    let canonical = json!({
-        "severity": severity,
-        "category": category,
-        "plugin_id": plugin_id,
-        "source_path": source_path,
-        "message": message,
-        "evidence": evidence,
-    });
-    let Ok(payload) = serde_json::to_vec(&canonical) else {
-        return "sf-0000000000000000".to_owned();
-    };
-    let digest = Sha256::digest(&payload);
-    let full = hex_lower(&digest);
-    format!("sf-{}", &full[..16])
-}
-
-fn evaluate_plugin_security_scan(
-    report: &PluginScanReport,
-    policy: &SecurityScanSpec,
-    process_allowlist: &BTreeSet<String>,
-) -> SecurityScanDelta {
-    let mut delta = SecurityScanDelta::default();
-    let metadata_keywords = normalize_signal_list(policy.high_risk_metadata_keywords.clone());
-    let blocked_import_prefixes =
-        normalize_signal_list(policy.wasm.blocked_import_prefixes.clone());
-    let allowed_path_prefixes = normalize_allowed_path_prefixes(&policy.wasm.allowed_path_prefixes);
-
-    for descriptor in &report.descriptors {
-        delta.scanned_plugins = delta.scanned_plugins.saturating_add(1);
-        let bridge_kind = descriptor_bridge_kind(descriptor);
-        let metadata_finding = scan_descriptor_metadata_keywords(descriptor, &metadata_keywords);
-        accumulate_security_findings(&mut delta, metadata_finding);
-
-        match bridge_kind {
-            PluginBridgeKind::ProcessStdio => {
-                let findings = scan_process_stdio_security(descriptor, process_allowlist);
-                accumulate_security_findings(&mut delta, findings);
-            }
-            PluginBridgeKind::NativeFfi => {
-                let finding = build_security_finding(
-                    SecurityFindingSeverity::Medium,
-                    "native_ffi_review",
-                    descriptor.manifest.plugin_id.clone(),
-                    descriptor.path.clone(),
-                    "native_ffi plugin requires manual review and stronger sandboxing",
-                    json!({
-                        "bridge_kind": bridge_kind.as_str(),
-                        "recommendation": "prefer wasm_component for untrusted community plugins",
-                    }),
-                );
-                accumulate_security_findings(&mut delta, vec![finding]);
-            }
-            PluginBridgeKind::WasmComponent if policy.wasm.enabled => {
-                let findings = scan_wasm_plugin_security(
-                    descriptor,
-                    &policy.wasm,
-                    &blocked_import_prefixes,
-                    &allowed_path_prefixes,
-                );
-                accumulate_security_findings(&mut delta, findings);
-            }
-            PluginBridgeKind::HttpJson
-            | PluginBridgeKind::McpServer
-            | PluginBridgeKind::Unknown
-            | PluginBridgeKind::WasmComponent => {}
-        }
-    }
-
-    if policy.block_on_high && delta.high_findings > 0 {
-        delta.block_reason = Some(format!(
-            "security scan blocked {} high-risk finding(s)",
-            delta.high_findings
-        ));
-    }
-
-    delta
-}
-
-fn accumulate_security_findings(delta: &mut SecurityScanDelta, findings: Vec<SecurityFinding>) {
-    for finding in findings {
-        match finding.severity {
-            SecurityFindingSeverity::High => {
-                delta.high_findings = delta.high_findings.saturating_add(1)
-            }
-            SecurityFindingSeverity::Medium => {
-                delta.medium_findings = delta.medium_findings.saturating_add(1)
-            }
-            SecurityFindingSeverity::Low => {
-                delta.low_findings = delta.low_findings.saturating_add(1)
-            }
-        }
-        delta.findings.push(finding);
-    }
-}
-
-fn scan_descriptor_metadata_keywords(
-    descriptor: &PluginDescriptor,
-    keywords: &[String],
-) -> Vec<SecurityFinding> {
-    if keywords.is_empty() {
-        return Vec::new();
-    }
-
-    let mut haystack_parts = Vec::new();
-    for (key, value) in &descriptor.manifest.metadata {
-        haystack_parts.push(key.to_ascii_lowercase());
-        haystack_parts.push(value.to_ascii_lowercase());
-    }
-    let haystack = haystack_parts.join(" ");
-
-    keywords
-        .iter()
-        .filter(|keyword| haystack.contains(keyword.as_str()))
-        .map(|keyword| {
-            build_security_finding(
-                SecurityFindingSeverity::Medium,
-                "metadata_keyword",
-                descriptor.manifest.plugin_id.clone(),
-                descriptor.path.clone(),
-                format!("metadata contains high-risk keyword: {keyword}"),
-                json!({
-                    "keyword": keyword,
-                    "metadata": descriptor.manifest.metadata.clone(),
-                }),
-            )
-        })
-        .collect()
-}
-
-fn scan_process_stdio_security(
-    descriptor: &PluginDescriptor,
-    process_allowlist: &BTreeSet<String>,
-) -> Vec<SecurityFinding> {
-    let mut findings = Vec::new();
-    let command = descriptor.manifest.metadata.get("command").cloned();
-
-    match command {
-        Some(command) => {
-            if !is_process_command_allowed(&command, process_allowlist) {
-                findings.push(build_security_finding(
-                    SecurityFindingSeverity::High,
-                    "process_command_not_allowlisted",
-                    descriptor.manifest.plugin_id.clone(),
-                    descriptor.path.clone(),
-                    format!("process_stdio command {command} is not in runtime allowlist"),
-                    json!({
-                        "command": command,
-                        "allowlist": process_allowlist,
-                    }),
-                ));
-            }
-        }
-        None => findings.push(build_security_finding(
-            SecurityFindingSeverity::Medium,
-            "process_command_missing",
-            descriptor.manifest.plugin_id.clone(),
-            descriptor.path.clone(),
-            "process_stdio plugin does not declare metadata.command",
-            json!({
-                "recommendation": "declare a fixed command and keep bridge allowlist strict",
-            }),
-        )),
-    }
-
-    findings
-}
-
-fn normalize_wasm_sha256_pin(raw: &str) -> Result<String, String> {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return Err("wasm sha256 pin must not be empty".to_owned());
-    }
-
-    let lowered = trimmed.to_ascii_lowercase();
-    let digest = lowered.strip_prefix("sha256:").unwrap_or(&lowered).trim();
-    if digest.len() != 64 || !digest.chars().all(|ch| ch.is_ascii_hexdigit()) {
-        return Err(
-            "wasm sha256 pin must be 64 hex characters (optional prefix `sha256:`)".to_owned(),
-        );
-    }
-
-    Ok(digest.to_owned())
-}
-
-fn scan_wasm_plugin_security(
-    descriptor: &PluginDescriptor,
-    policy: &WasmSecurityScanSpec,
-    blocked_import_prefixes: &[String],
-    allowed_path_prefixes: &[PathBuf],
-) -> Vec<SecurityFinding> {
-    let mut findings = Vec::new();
-    let artifact = descriptor_wasm_artifact(descriptor);
-    let Some(raw_artifact) = artifact else {
-        findings.push(build_security_finding(
-            SecurityFindingSeverity::High,
-            "wasm_artifact_missing",
-            descriptor.manifest.plugin_id.clone(),
-            descriptor.path.clone(),
-            "wasm plugin does not declare metadata.component/metadata.wasm_path/endpoint artifact",
-            json!({}),
-        ));
-        return findings;
-    };
-
-    if raw_artifact.starts_with("http://") || raw_artifact.starts_with("https://") {
-        findings.push(build_security_finding(
-            SecurityFindingSeverity::High,
-            "wasm_remote_artifact",
-            descriptor.manifest.plugin_id.clone(),
-            descriptor.path.clone(),
-            "remote wasm artifact cannot be statically verified for local hotplug safety",
-            json!({
-                "artifact": raw_artifact,
-            }),
-        ));
-        return findings;
-    }
-
-    let artifact_path = resolve_plugin_relative_path(&descriptor.path, &raw_artifact);
-    let normalized_artifact_path = normalize_path_for_policy(&artifact_path);
-    if !allowed_path_prefixes.is_empty()
-        && !allowed_path_prefixes
-            .iter()
-            .any(|prefix| normalized_artifact_path.starts_with(prefix))
-    {
-        findings.push(build_security_finding(
-            SecurityFindingSeverity::High,
-            "wasm_artifact_path_not_allowed",
-            descriptor.manifest.plugin_id.clone(),
-            descriptor.path.clone(),
-            "wasm artifact path is outside allowed_path_prefixes",
-            json!({
-                "artifact_path": normalized_artifact_path.display().to_string(),
-                "allowed_path_prefixes": allowed_path_prefixes
-                    .iter()
-                    .map(|prefix| prefix.display().to_string())
-                    .collect::<Vec<_>>(),
-            }),
-        ));
-        return findings;
-    }
-
-    let bytes = match fs::read(&normalized_artifact_path) {
-        Ok(bytes) => bytes,
-        Err(error) => {
-            findings.push(build_security_finding(
-                SecurityFindingSeverity::High,
-                "wasm_artifact_unreadable",
-                descriptor.manifest.plugin_id.clone(),
-                descriptor.path.clone(),
-                "wasm artifact cannot be read from filesystem",
-                json!({
-                    "artifact_path": normalized_artifact_path.display().to_string(),
-                    "error": error.to_string(),
-                }),
-            ));
-            return findings;
-        }
-    };
-
-    if bytes.len() > policy.max_module_bytes {
-        findings.push(build_security_finding(
-            SecurityFindingSeverity::High,
-            "wasm_module_too_large",
-            descriptor.manifest.plugin_id.clone(),
-            descriptor.path.clone(),
-            format!(
-                "wasm module size {} exceeds max_module_bytes {}",
-                bytes.len(),
-                policy.max_module_bytes
-            ),
-            json!({
-                "artifact_path": normalized_artifact_path.display().to_string(),
-                "module_size_bytes": bytes.len(),
-                "max_module_bytes": policy.max_module_bytes,
-            }),
-        ));
-    }
-
-    if !bytes.starts_with(&[0x00, 0x61, 0x73, 0x6d]) {
-        findings.push(build_security_finding(
-            SecurityFindingSeverity::High,
-            "wasm_magic_header_invalid",
-            descriptor.manifest.plugin_id.clone(),
-            descriptor.path.clone(),
-            "artifact does not contain valid wasm magic header",
-            json!({
-                "artifact_path": normalized_artifact_path.display().to_string(),
-            }),
-        ));
-        return findings;
-    }
-
-    let digest = Sha256::digest(&bytes);
-    let digest_hex = hex_lower(&digest);
-
-    let expected_sha256 = {
-        let mut metadata_pins = Vec::new();
-        for key in [
-            "component_sha256",
-            "component_sha256_pin",
-            "component_sha256_hex",
-        ] {
-            let Some(raw_pin) = descriptor.manifest.metadata.get(key) else {
-                continue;
-            };
-            match normalize_wasm_sha256_pin(raw_pin) {
-                Ok(pin) => metadata_pins.push((format!("metadata.{key}"), pin)),
-                Err(reason) => findings.push(build_security_finding(
-                    SecurityFindingSeverity::High,
-                    "wasm_sha256_pin_invalid",
-                    descriptor.manifest.plugin_id.clone(),
-                    descriptor.path.clone(),
-                    "wasm sha256 pin format is invalid",
-                    json!({
-                        "source": format!("metadata.{key}"),
-                        "pin": raw_pin,
-                        "reason": reason,
-                    }),
-                )),
-            }
-        }
-
-        let metadata_pin = if let Some((source, pin)) = metadata_pins.first() {
-            if let Some((conflict_source, conflict_pin)) =
-                metadata_pins.iter().find(|(_, candidate)| candidate != pin)
-            {
-                findings.push(build_security_finding(
-                    SecurityFindingSeverity::High,
-                    "wasm_sha256_pin_conflict",
-                    descriptor.manifest.plugin_id.clone(),
-                    descriptor.path.clone(),
-                    "multiple metadata wasm sha256 pins conflict with each other",
-                    json!({
-                        "first_source": source,
-                        "first_sha256": pin,
-                        "conflict_source": conflict_source,
-                        "conflict_sha256": conflict_pin,
-                    }),
-                ));
-                None
-            } else {
-                Some(pin.clone())
-            }
-        } else {
-            None
-        };
-
-        let policy_pin = if let Some(raw_pin) = policy
-            .required_sha256_by_plugin
-            .get(&descriptor.manifest.plugin_id)
-        {
-            match normalize_wasm_sha256_pin(raw_pin) {
-                Ok(pin) => Some(pin),
-                Err(reason) => {
-                    findings.push(build_security_finding(
-                        SecurityFindingSeverity::High,
-                        "wasm_sha256_pin_invalid",
-                        descriptor.manifest.plugin_id.clone(),
-                        descriptor.path.clone(),
-                        "wasm sha256 pin format is invalid",
-                        json!({
-                            "source": "security_scan.wasm.required_sha256_by_plugin",
-                            "pin": raw_pin,
-                            "reason": reason,
-                        }),
-                    ));
-                    None
-                }
-            }
-        } else {
-            None
-        };
-
-        match (metadata_pin, policy_pin) {
-            (Some(metadata_pin), Some(policy_pin)) => {
-                if metadata_pin != policy_pin {
-                    findings.push(build_security_finding(
-                        SecurityFindingSeverity::High,
-                        "wasm_sha256_pin_conflict",
-                        descriptor.manifest.plugin_id.clone(),
-                        descriptor.path.clone(),
-                        "metadata wasm sha256 pin conflicts with required_sha256_by_plugin pin",
-                        json!({
-                            "metadata_sha256": metadata_pin,
-                            "policy_sha256": policy_pin,
-                        }),
-                    ));
-                    None
-                } else {
-                    Some(policy_pin)
-                }
-            }
-            (Some(metadata_pin), None) => Some(metadata_pin),
-            (None, Some(policy_pin)) => Some(policy_pin),
-            (None, None) => {
-                if policy.require_hash_pin {
-                    findings.push(build_security_finding(
-                        SecurityFindingSeverity::High,
-                        "wasm_sha256_pin_missing",
-                        descriptor.manifest.plugin_id.clone(),
-                        descriptor.path.clone(),
-                        "wasm hash pin is required but missing for plugin",
-                        json!({
-                            "required_sha256_by_plugin": policy.required_sha256_by_plugin,
-                        }),
-                    ));
-                }
-                None
-            }
-        }
-    };
-
-    if let Some(expected) = expected_sha256 {
-        if !expected.eq_ignore_ascii_case(&digest_hex) {
-            findings.push(build_security_finding(
-                SecurityFindingSeverity::High,
-                "wasm_sha256_mismatch",
-                descriptor.manifest.plugin_id.clone(),
-                descriptor.path.clone(),
-                "wasm sha256 does not match required pin",
-                json!({
-                    "expected_sha256": expected,
-                    "actual_sha256": digest_hex,
-                }),
-            ));
-        }
-    }
-
-    let imports = match parse_wasm_import_modules(&bytes) {
-        Ok(imports) => imports,
-        Err(error) => {
-            findings.push(build_security_finding(
-                SecurityFindingSeverity::High,
-                "wasm_parse_failed",
-                descriptor.manifest.plugin_id.clone(),
-                descriptor.path.clone(),
-                "wasm parser failed while reading module imports",
-                json!({
-                    "artifact_path": normalized_artifact_path.display().to_string(),
-                    "error": error,
-                }),
-            ));
-            return findings;
-        }
-    };
-
-    for module_name in &imports {
-        let module_name_lower = module_name.to_ascii_lowercase();
-        if !policy.allow_wasi && module_name_lower.starts_with("wasi") {
-            findings.push(build_security_finding(
-                SecurityFindingSeverity::High,
-                "wasm_wasi_import_blocked",
-                descriptor.manifest.plugin_id.clone(),
-                descriptor.path.clone(),
-                "wasi import is blocked by wasm security policy",
-                json!({
-                    "import_module": module_name,
-                }),
-            ));
-        }
-        if blocked_import_prefixes
-            .iter()
-            .any(|prefix| module_name_lower.starts_with(prefix))
-        {
-            findings.push(build_security_finding(
-                SecurityFindingSeverity::High,
-                "wasm_import_prefix_blocked",
-                descriptor.manifest.plugin_id.clone(),
-                descriptor.path.clone(),
-                "wasm import module matched blocked prefix",
-                json!({
-                    "import_module": module_name,
-                    "blocked_import_prefixes": blocked_import_prefixes,
-                }),
-            ));
-        }
-    }
-
-    findings.push(build_security_finding(
-        SecurityFindingSeverity::Low,
-        "wasm_digest_observed",
-        descriptor.manifest.plugin_id.clone(),
-        descriptor.path.clone(),
-        "wasm artifact digest captured for audit",
-        json!({
-            "artifact_path": normalized_artifact_path.display().to_string(),
-            "sha256": digest_hex,
-            "imports": imports,
-        }),
-    ));
-
-    findings
-}
-
-fn parse_wasm_import_modules(bytes: &[u8]) -> Result<Vec<String>, String> {
-    let mut modules = Vec::new();
-    for payload in WasmParser::new(0).parse_all(bytes) {
-        match payload {
-            Ok(WasmPayload::ImportSection(section)) => {
-                for import in section.into_imports() {
-                    let import = import.map_err(|error| error.to_string())?;
-                    modules.push(import.module.to_owned());
-                }
-            }
-            Ok(_) => {}
-            Err(error) => return Err(error.to_string()),
-        }
-    }
-    Ok(modules)
-}
-
-fn descriptor_wasm_artifact(descriptor: &PluginDescriptor) -> Option<String> {
-    descriptor
-        .manifest
-        .metadata
-        .get("component")
-        .cloned()
-        .or_else(|| descriptor.manifest.metadata.get("wasm_path").cloned())
-        .or_else(|| {
-            descriptor
-                .manifest
-                .endpoint
-                .clone()
-                .filter(|value| value.to_ascii_lowercase().ends_with(".wasm"))
-        })
 }
 
 pub fn resolve_plugin_relative_path(source_path: &str, artifact: &str) -> PathBuf {
@@ -1640,784 +801,6 @@ fn bridge_runtime_policy(
         wasm_required_sha256_by_plugin,
         enforce_execution_success: bridge.enforce_execution_success,
     }
-}
-
-fn evaluate_approval_guard(spec: &RunnerSpec) -> ApprovalDecisionReport {
-    let policy = spec.approval.clone().unwrap_or_default();
-    let now_epoch_s = current_epoch_s();
-    let operation_key = operation_approval_key(&spec.operation);
-    let operation_kind = operation_approval_kind(&spec.operation);
-    let target_in_scope = is_operation_in_approval_scope(&spec.operation, policy.scope);
-    let denylisted = is_operation_preapproved(&operation_key, &policy.denied_calls);
-
-    let (risk_level, matched_keywords, risk_score) =
-        match operation_risk_profile(&spec.operation, &policy) {
-            (ApprovalRiskLevel::High, matched, score) => (ApprovalRiskLevel::High, matched, score),
-            (_, _, score) => (ApprovalRiskLevel::Low, Vec::new(), score),
-        };
-
-    if denylisted {
-        return ApprovalDecisionReport {
-            mode: policy.mode,
-            strategy: policy.strategy,
-            scope: policy.scope,
-            now_epoch_s,
-            operation_key,
-            operation_kind,
-            risk_level,
-            risk_score,
-            denylisted: true,
-            requires_human_approval: true,
-            approved: false,
-            reason: "operation is denylisted by human approval policy".to_owned(),
-            matched_keywords,
-        };
-    }
-
-    let one_time_full_access_active = policy.one_time_full_access_granted
-        && policy
-            .one_time_full_access_expires_at_epoch_s
-            .map(|deadline| now_epoch_s <= deadline)
-            .unwrap_or(true)
-        && policy
-            .one_time_full_access_remaining_uses
-            .map(|remaining| remaining > 0)
-            .unwrap_or(true);
-
-    let one_time_full_access_rejected_reason = if policy.one_time_full_access_granted {
-        if let Some(deadline) = policy.one_time_full_access_expires_at_epoch_s {
-            if now_epoch_s > deadline {
-                Some(format!(
-                    "one-time full access grant expired at {deadline}, now is {now_epoch_s}"
-                ))
-            } else {
-                None
-            }
-        } else if matches!(policy.one_time_full_access_remaining_uses, Some(0)) {
-            Some("one-time full access grant has no remaining uses".to_owned())
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-
-    let requires_human_approval = if !target_in_scope {
-        false
-    } else {
-        match policy.mode {
-            HumanApprovalMode::Disabled => false,
-            HumanApprovalMode::MediumBalanced => matches!(risk_level, ApprovalRiskLevel::High),
-            HumanApprovalMode::Strict => true,
-        }
-    };
-
-    let (approved, reason) = if !requires_human_approval {
-        (
-            true,
-            "operation is allowed by default medium-balanced approval policy".to_owned(),
-        )
-    } else {
-        match policy.strategy {
-            HumanApprovalStrategy::OneTimeFullAccess if one_time_full_access_active => (
-                true,
-                "human granted one-time full access for this execution".to_owned(),
-            ),
-            HumanApprovalStrategy::PerCall
-                if is_operation_preapproved(&operation_key, &policy.approved_calls) =>
-            {
-                (
-                    true,
-                    format!("operation {operation_key} is pre-approved by human policy"),
-                )
-            }
-            HumanApprovalStrategy::PerCall => (
-                false,
-                format!(
-                    "human approval required for high-risk operation {operation_key}; \
-                     add to approval.approved_calls or switch to one_time_full_access"
-                ),
-            ),
-            HumanApprovalStrategy::OneTimeFullAccess => (false, one_time_full_access_rejected_reason
-                .unwrap_or_else(|| {
-                    format!(
-                        "human one-time full access is not granted for high-risk operation {operation_key}"
-                    )
-                })),
-        }
-    };
-
-    ApprovalDecisionReport {
-        mode: policy.mode,
-        strategy: policy.strategy,
-        scope: policy.scope,
-        now_epoch_s,
-        operation_key,
-        operation_kind,
-        risk_level,
-        risk_score,
-        denylisted: false,
-        requires_human_approval,
-        approved,
-        reason,
-        matched_keywords,
-    }
-}
-
-fn operation_approval_key(operation: &OperationSpec) -> String {
-    match operation {
-        OperationSpec::Task { task_id, .. } => format!("task:{task_id}"),
-        OperationSpec::ConnectorLegacy {
-            connector_name,
-            operation,
-            ..
-        } => {
-            format!("connector_legacy:{connector_name}:{operation}")
-        }
-        OperationSpec::ConnectorCore {
-            connector_name,
-            operation,
-            ..
-        } => {
-            format!("connector_core:{connector_name}:{operation}")
-        }
-        OperationSpec::ConnectorExtension {
-            connector_name,
-            operation,
-            extension,
-            ..
-        } => {
-            format!("connector_extension:{extension}:{connector_name}:{operation}")
-        }
-        OperationSpec::RuntimeCore { action, .. } => format!("runtime_core:{action}"),
-        OperationSpec::RuntimeExtension {
-            extension, action, ..
-        } => {
-            format!("runtime_extension:{extension}:{action}")
-        }
-        OperationSpec::ToolCore { tool_name, .. } => format!("tool_core:{tool_name}"),
-        OperationSpec::ToolExtension {
-            extension,
-            extension_action,
-            ..
-        } => {
-            format!("tool_extension:{extension}:{extension_action}")
-        }
-        OperationSpec::MemoryCore { operation, .. } => format!("memory_core:{operation}"),
-        OperationSpec::MemoryExtension {
-            extension,
-            operation,
-            ..
-        } => {
-            format!("memory_extension:{extension}:{operation}")
-        }
-        OperationSpec::ToolSearch { query, .. } => format!("tool_search:{query}"),
-        OperationSpec::ProgrammaticToolCall { caller, .. } => {
-            format!("programmatic_tool_call:{caller}")
-        }
-    }
-}
-
-fn operation_approval_kind(operation: &OperationSpec) -> &'static str {
-    match operation {
-        OperationSpec::Task { .. } => "task",
-        OperationSpec::ConnectorLegacy { .. } => "connector_legacy",
-        OperationSpec::ConnectorCore { .. } => "connector_core",
-        OperationSpec::ConnectorExtension { .. } => "connector_extension",
-        OperationSpec::RuntimeCore { .. } => "runtime_core",
-        OperationSpec::RuntimeExtension { .. } => "runtime_extension",
-        OperationSpec::ToolCore { .. } => "tool_core",
-        OperationSpec::ToolExtension { .. } => "tool_extension",
-        OperationSpec::MemoryCore { .. } => "memory_core",
-        OperationSpec::MemoryExtension { .. } => "memory_extension",
-        OperationSpec::ToolSearch { .. } => "tool_search",
-        OperationSpec::ProgrammaticToolCall { .. } => "programmatic_tool_call",
-    }
-}
-
-fn is_operation_in_approval_scope(operation: &OperationSpec, scope: HumanApprovalScope) -> bool {
-    match scope {
-        HumanApprovalScope::ToolCalls => matches!(
-            operation,
-            OperationSpec::ToolCore { .. }
-                | OperationSpec::ToolExtension { .. }
-                | OperationSpec::ProgrammaticToolCall { .. }
-        ),
-        HumanApprovalScope::AllOperations => true,
-    }
-}
-
-pub fn operation_risk_profile(
-    operation: &OperationSpec,
-    policy: &HumanApprovalSpec,
-) -> (ApprovalRiskLevel, Vec<String>, u8) {
-    let profile = resolve_approval_risk_profile(policy);
-    let keywords = normalize_signal_list(profile.high_risk_keywords);
-    let high_risk_tool_names = normalize_signal_list(profile.high_risk_tool_names);
-    let high_risk_payload_keys = normalize_signal_list(profile.high_risk_payload_keys);
-    let scoring = sanitize_risk_scoring(profile.scoring);
-
-    let haystack = operation_risk_haystack(operation);
-    let haystack_lower = haystack.to_ascii_lowercase();
-
-    let matched_keywords: Vec<String> = keywords
-        .iter()
-        .filter(|keyword| haystack_lower.contains(keyword.as_str()))
-        .cloned()
-        .collect();
-
-    let matched_tool_name = operation_tool_name(operation)
-        .map(|name| name.trim().to_ascii_lowercase())
-        .filter(|name| high_risk_tool_names.iter().any(|value| value == name))
-        .map(|name| vec![format!("tool:{name}")])
-        .unwrap_or_default();
-
-    let payload_keys = operation_payload_keys(operation);
-    let matched_payload_keys: Vec<String> = payload_keys
-        .iter()
-        .map(|key| key.trim().to_ascii_lowercase())
-        .filter(|key| high_risk_payload_keys.iter().any(|value| value == key))
-        .map(|key| format!("payload_key:{key}"))
-        .collect();
-
-    let mut matched = Vec::new();
-    matched.extend(matched_keywords.clone());
-    matched.extend(matched_tool_name.clone());
-    matched.extend(matched_payload_keys.clone());
-    matched.sort();
-    matched.dedup();
-
-    let keyword_score = (matched_keywords.len().min(scoring.keyword_hit_cap) as u16)
-        * u16::from(scoring.keyword_weight);
-    let tool_score = if matched_tool_name.is_empty() {
-        0
-    } else {
-        u16::from(scoring.tool_name_weight)
-    };
-    let payload_key_score = (matched_payload_keys.len().min(scoring.payload_key_hit_cap) as u16)
-        * u16::from(scoring.payload_key_weight);
-    let risk_score = keyword_score
-        .saturating_add(tool_score)
-        .saturating_add(payload_key_score)
-        .min(100) as u8;
-
-    if matched.is_empty() || risk_score < scoring.high_risk_threshold {
-        (ApprovalRiskLevel::Low, Vec::new(), 0)
-    } else {
-        (ApprovalRiskLevel::High, matched, risk_score)
-    }
-}
-
-fn resolve_approval_risk_profile(policy: &HumanApprovalSpec) -> ApprovalRiskProfile {
-    let mut profile = policy
-        .risk_profile_path
-        .as_deref()
-        .and_then(load_approval_risk_profile_from_path)
-        .unwrap_or_else(bundled_approval_risk_profile);
-
-    if !policy.high_risk_keywords.is_empty() {
-        profile.high_risk_keywords = policy.high_risk_keywords.clone();
-    }
-    if !policy.high_risk_tool_names.is_empty() {
-        profile.high_risk_tool_names = policy.high_risk_tool_names.clone();
-    }
-    if !policy.high_risk_payload_keys.is_empty() {
-        profile.high_risk_payload_keys = policy.high_risk_payload_keys.clone();
-    }
-
-    profile
-}
-
-fn load_approval_risk_profile_from_path(path: &str) -> Option<ApprovalRiskProfile> {
-    let content = fs::read_to_string(path).ok()?;
-    serde_json::from_str::<ApprovalRiskProfile>(&content).ok()
-}
-
-fn bundled_approval_risk_profile() -> ApprovalRiskProfile {
-    BUNDLED_APPROVAL_RISK_PROFILE
-        .get_or_init(|| {
-            let raw = include_str!("../config/approval-medium-balanced.json");
-            // Bundled JSON is compile-time embedded and validated by tests.
-            // Fall back to serde defaults if parsing ever fails.
-            serde_json::from_str(raw)
-                .or_else(|_| serde_json::from_str::<ApprovalRiskProfile>("{}"))
-                .unwrap_or_else(|_| ApprovalRiskProfile {
-                    high_risk_keywords: Vec::new(),
-                    high_risk_tool_names: Vec::new(),
-                    high_risk_payload_keys: Vec::new(),
-                    scoring: ApprovalRiskScoring::default(),
-                })
-        })
-        .clone()
-}
-
-fn normalize_signal_list(list: Vec<String>) -> Vec<String> {
-    let mut normalized: Vec<String> = list
-        .into_iter()
-        .map(|value| value.trim().to_ascii_lowercase())
-        .filter(|value| !value.is_empty())
-        .collect();
-    normalized.sort();
-    normalized.dedup();
-    normalized
-}
-
-fn sanitize_risk_scoring(mut scoring: ApprovalRiskScoring) -> ApprovalRiskScoring {
-    if scoring.keyword_hit_cap == 0 {
-        scoring.keyword_hit_cap = 1;
-    }
-    if scoring.payload_key_hit_cap == 0 {
-        scoring.payload_key_hit_cap = 1;
-    }
-    if scoring.high_risk_threshold == 0 {
-        scoring.high_risk_threshold = 20;
-    }
-    scoring
-}
-
-fn operation_tool_name(operation: &OperationSpec) -> Option<&str> {
-    match operation {
-        OperationSpec::ToolCore { tool_name, .. } => Some(tool_name.as_str()),
-        OperationSpec::ToolExtension {
-            extension_action, ..
-        } => Some(extension_action.as_str()),
-        OperationSpec::ProgrammaticToolCall { caller, .. } => Some(caller.as_str()),
-        _ => None,
-    }
-}
-
-fn operation_payload_keys(operation: &OperationSpec) -> Vec<String> {
-    match operation {
-        OperationSpec::Task { payload, .. }
-        | OperationSpec::ConnectorLegacy { payload, .. }
-        | OperationSpec::ConnectorCore { payload, .. }
-        | OperationSpec::ConnectorExtension { payload, .. }
-        | OperationSpec::RuntimeCore { payload, .. }
-        | OperationSpec::RuntimeExtension { payload, .. }
-        | OperationSpec::ToolCore { payload, .. }
-        | OperationSpec::ToolExtension { payload, .. }
-        | OperationSpec::MemoryCore { payload, .. }
-        | OperationSpec::MemoryExtension { payload, .. } => {
-            let mut keys = Vec::new();
-            collect_json_keys(payload, &mut keys);
-            keys
-        }
-        OperationSpec::ToolSearch { .. } => {
-            let mut keys = Vec::new();
-            keys.extend(
-                ["query", "limit", "include_deferred", "include_examples"]
-                    .iter()
-                    .map(|value| (*value).to_owned()),
-            );
-            keys
-        }
-        OperationSpec::ProgrammaticToolCall {
-            allowed_connectors,
-            connector_rate_limits,
-            connector_circuit_breakers,
-            concurrency,
-            steps,
-            ..
-        } => {
-            let mut keys = Vec::new();
-            keys.extend(
-                [
-                    "caller",
-                    "max_calls",
-                    "include_intermediate",
-                    "connector_rate_limits",
-                    "connector_circuit_breakers",
-                    "concurrency",
-                    "return_step",
-                    "steps",
-                ]
-                .iter()
-                .map(|value| (*value).to_owned()),
-            );
-            keys.push("max_in_flight".to_owned());
-            keys.push(concurrency.max_in_flight.to_string());
-            keys.push("min_in_flight".to_owned());
-            keys.push(concurrency.min_in_flight.to_string());
-            keys.push("fairness".to_owned());
-            keys.push(concurrency.fairness.as_str().to_owned());
-            keys.push("adaptive_budget".to_owned());
-            keys.push(concurrency.adaptive_budget.to_string());
-            keys.push("high_weight".to_owned());
-            keys.push(concurrency.high_weight.to_string());
-            keys.push("normal_weight".to_owned());
-            keys.push(concurrency.normal_weight.to_string());
-            keys.push("low_weight".to_owned());
-            keys.push(concurrency.low_weight.to_string());
-            keys.push("adaptive_recovery_successes".to_owned());
-            keys.push(concurrency.adaptive_recovery_successes.to_string());
-            keys.push("adaptive_upshift_step".to_owned());
-            keys.push(concurrency.adaptive_upshift_step.to_string());
-            keys.push("adaptive_downshift_step".to_owned());
-            keys.push(concurrency.adaptive_downshift_step.to_string());
-            keys.push("adaptive_reduce_on".to_owned());
-            for rule in &concurrency.adaptive_reduce_on {
-                keys.push(rule.as_str().to_owned());
-            }
-            keys.extend(allowed_connectors.iter().cloned());
-            for (connector_name, limit) in connector_rate_limits {
-                keys.push("connector_name".to_owned());
-                keys.push(connector_name.clone());
-                keys.push("min_interval_ms".to_owned());
-                keys.push(limit.min_interval_ms.to_string());
-            }
-            for (connector_name, policy) in connector_circuit_breakers {
-                keys.push("connector_name".to_owned());
-                keys.push(connector_name.clone());
-                keys.push("failure_threshold".to_owned());
-                keys.push(policy.failure_threshold.to_string());
-                keys.push("cooldown_ms".to_owned());
-                keys.push(policy.cooldown_ms.to_string());
-                keys.push("half_open_max_calls".to_owned());
-                keys.push(policy.half_open_max_calls.to_string());
-                keys.push("success_threshold".to_owned());
-                keys.push(policy.success_threshold.to_string());
-            }
-            for step in steps {
-                keys.push("step_id".to_owned());
-                match step {
-                    ProgrammaticStep::SetLiteral { value, .. } => {
-                        collect_json_keys(value, &mut keys);
-                    }
-                    ProgrammaticStep::JsonPointer { .. } => {
-                        keys.push("pointer".to_owned());
-                    }
-                    ProgrammaticStep::ConnectorCall {
-                        connector_name,
-                        operation,
-                        priority_class,
-                        retry,
-                        payload,
-                        ..
-                    } => {
-                        keys.push("connector_name".to_owned());
-                        keys.push("operation".to_owned());
-                        keys.push("priority_class".to_owned());
-                        keys.push(connector_name.clone());
-                        keys.push(operation.clone());
-                        keys.push(priority_class.as_str().to_owned());
-                        if let Some(retry) = retry {
-                            keys.push("retry".to_owned());
-                            keys.push("max_attempts".to_owned());
-                            keys.push("initial_backoff_ms".to_owned());
-                            keys.push("max_backoff_ms".to_owned());
-                            keys.push("jitter_ratio".to_owned());
-                            keys.push("adaptive_jitter".to_owned());
-                            keys.push(retry.max_attempts.to_string());
-                            keys.push(retry.initial_backoff_ms.to_string());
-                            keys.push(retry.max_backoff_ms.to_string());
-                            keys.push(retry.jitter_ratio.to_string());
-                            keys.push(retry.adaptive_jitter.to_string());
-                        }
-                        collect_json_keys(payload, &mut keys);
-                    }
-                    ProgrammaticStep::ConnectorBatch {
-                        parallel,
-                        continue_on_error,
-                        calls,
-                        ..
-                    } => {
-                        keys.push("parallel".to_owned());
-                        keys.push(parallel.to_string());
-                        keys.push("continue_on_error".to_owned());
-                        keys.push(continue_on_error.to_string());
-                        keys.push("calls".to_owned());
-                        for call in calls {
-                            keys.push("call_id".to_owned());
-                            keys.push(call.call_id.clone());
-                            keys.push("connector_name".to_owned());
-                            keys.push("operation".to_owned());
-                            keys.push("priority_class".to_owned());
-                            keys.push(call.connector_name.clone());
-                            keys.push(call.operation.clone());
-                            keys.push(call.priority_class.as_str().to_owned());
-                            if let Some(retry) = &call.retry {
-                                keys.push("retry".to_owned());
-                                keys.push("max_attempts".to_owned());
-                                keys.push("initial_backoff_ms".to_owned());
-                                keys.push("max_backoff_ms".to_owned());
-                                keys.push("jitter_ratio".to_owned());
-                                keys.push("adaptive_jitter".to_owned());
-                                keys.push(retry.max_attempts.to_string());
-                                keys.push(retry.initial_backoff_ms.to_string());
-                                keys.push(retry.max_backoff_ms.to_string());
-                                keys.push(retry.jitter_ratio.to_string());
-                                keys.push(retry.adaptive_jitter.to_string());
-                            }
-                            collect_json_keys(&call.payload, &mut keys);
-                        }
-                    }
-                    ProgrammaticStep::Conditional {
-                        from_step,
-                        pointer,
-                        equals,
-                        exists,
-                        when_true,
-                        when_false,
-                        ..
-                    } => {
-                        keys.push("from_step".to_owned());
-                        keys.push(from_step.clone());
-                        if let Some(pointer) = pointer {
-                            keys.push("pointer".to_owned());
-                            keys.push(pointer.clone());
-                        }
-                        if let Some(equals) = equals {
-                            keys.push("equals".to_owned());
-                            collect_json_keys(equals, &mut keys);
-                        }
-                        if let Some(exists) = exists {
-                            keys.push("exists".to_owned());
-                            keys.push(exists.to_string());
-                        }
-                        keys.push("when_true".to_owned());
-                        collect_json_keys(when_true, &mut keys);
-                        if let Some(when_false) = when_false {
-                            keys.push("when_false".to_owned());
-                            collect_json_keys(when_false, &mut keys);
-                        }
-                    }
-                }
-            }
-            keys
-        }
-    }
-}
-
-fn collect_json_keys(value: &Value, keys: &mut Vec<String>) {
-    match value {
-        Value::Object(map) => {
-            for (key, child) in map {
-                keys.push(key.clone());
-                collect_json_keys(child, keys);
-            }
-        }
-        Value::Array(list) => {
-            for child in list {
-                collect_json_keys(child, keys);
-            }
-        }
-        Value::String(_) | Value::Null | Value::Bool(_) | Value::Number(_) => {}
-    }
-}
-
-fn operation_risk_haystack(operation: &OperationSpec) -> String {
-    let mut text = String::new();
-    text.push_str(operation_approval_kind(operation));
-    text.push(' ');
-    text.push_str(&operation_approval_key(operation));
-    text.push(' ');
-    for value in operation_payload_strings(operation) {
-        text.push_str(&value);
-        text.push(' ');
-    }
-    text
-}
-
-fn operation_payload_strings(operation: &OperationSpec) -> Vec<String> {
-    match operation {
-        OperationSpec::Task { payload, .. }
-        | OperationSpec::ConnectorLegacy { payload, .. }
-        | OperationSpec::ConnectorCore { payload, .. }
-        | OperationSpec::ConnectorExtension { payload, .. }
-        | OperationSpec::RuntimeCore { payload, .. }
-        | OperationSpec::RuntimeExtension { payload, .. }
-        | OperationSpec::ToolCore { payload, .. }
-        | OperationSpec::ToolExtension { payload, .. }
-        | OperationSpec::MemoryCore { payload, .. }
-        | OperationSpec::MemoryExtension { payload, .. } => {
-            let mut values = Vec::new();
-            collect_json_strings(payload, &mut values);
-            values
-        }
-        OperationSpec::ToolSearch {
-            query,
-            limit,
-            include_deferred,
-            include_examples,
-        } => {
-            let values = vec![
-                query.clone(),
-                limit.to_string(),
-                include_deferred.to_string(),
-                include_examples.to_string(),
-            ];
-            values
-        }
-        OperationSpec::ProgrammaticToolCall {
-            caller,
-            max_calls,
-            include_intermediate,
-            allowed_connectors,
-            connector_rate_limits,
-            connector_circuit_breakers,
-            concurrency,
-            return_step,
-            steps,
-        } => {
-            let mut values = vec![
-                caller.clone(),
-                max_calls.to_string(),
-                include_intermediate.to_string(),
-                concurrency.max_in_flight.to_string(),
-                concurrency.min_in_flight.to_string(),
-                concurrency.fairness.as_str().to_owned(),
-                concurrency.adaptive_budget.to_string(),
-                concurrency.high_weight.to_string(),
-                concurrency.normal_weight.to_string(),
-                concurrency.low_weight.to_string(),
-                concurrency.adaptive_recovery_successes.to_string(),
-                concurrency.adaptive_upshift_step.to_string(),
-                concurrency.adaptive_downshift_step.to_string(),
-            ];
-            for rule in &concurrency.adaptive_reduce_on {
-                values.push(rule.as_str().to_owned());
-            }
-            values.extend(allowed_connectors.iter().cloned());
-            for (connector_name, limit) in connector_rate_limits {
-                values.push(connector_name.clone());
-                values.push(limit.min_interval_ms.to_string());
-            }
-            for (connector_name, policy) in connector_circuit_breakers {
-                values.push(connector_name.clone());
-                values.push(policy.failure_threshold.to_string());
-                values.push(policy.cooldown_ms.to_string());
-                values.push(policy.half_open_max_calls.to_string());
-                values.push(policy.success_threshold.to_string());
-            }
-            if let Some(return_step) = return_step {
-                values.push(return_step.clone());
-            }
-            for step in steps {
-                match step {
-                    ProgrammaticStep::SetLiteral { step_id, value } => {
-                        values.push(step_id.clone());
-                        collect_json_strings(value, &mut values);
-                    }
-                    ProgrammaticStep::JsonPointer {
-                        step_id,
-                        from_step,
-                        pointer,
-                    } => {
-                        values.push(step_id.clone());
-                        values.push(from_step.clone());
-                        values.push(pointer.clone());
-                    }
-                    ProgrammaticStep::ConnectorCall {
-                        step_id,
-                        connector_name,
-                        operation,
-                        priority_class,
-                        retry,
-                        payload,
-                        ..
-                    } => {
-                        values.push(step_id.clone());
-                        values.push(connector_name.clone());
-                        values.push(operation.clone());
-                        values.push(priority_class.as_str().to_owned());
-                        if let Some(retry) = retry {
-                            values.push(retry.max_attempts.to_string());
-                            values.push(retry.initial_backoff_ms.to_string());
-                            values.push(retry.max_backoff_ms.to_string());
-                            values.push(retry.jitter_ratio.to_string());
-                            values.push(retry.adaptive_jitter.to_string());
-                        }
-                        collect_json_strings(payload, &mut values);
-                    }
-                    ProgrammaticStep::ConnectorBatch {
-                        step_id,
-                        parallel,
-                        continue_on_error,
-                        calls,
-                    } => {
-                        values.push(step_id.clone());
-                        values.push(parallel.to_string());
-                        values.push(continue_on_error.to_string());
-                        for call in calls {
-                            values.push(call.call_id.clone());
-                            values.push(call.connector_name.clone());
-                            values.push(call.operation.clone());
-                            values.push(call.priority_class.as_str().to_owned());
-                            if let Some(retry) = &call.retry {
-                                values.push(retry.max_attempts.to_string());
-                                values.push(retry.initial_backoff_ms.to_string());
-                                values.push(retry.max_backoff_ms.to_string());
-                                values.push(retry.jitter_ratio.to_string());
-                                values.push(retry.adaptive_jitter.to_string());
-                            }
-                            collect_json_strings(&call.payload, &mut values);
-                        }
-                    }
-                    ProgrammaticStep::Conditional {
-                        step_id,
-                        from_step,
-                        pointer,
-                        equals,
-                        exists,
-                        when_true,
-                        when_false,
-                    } => {
-                        values.push(step_id.clone());
-                        values.push(from_step.clone());
-                        if let Some(pointer) = pointer {
-                            values.push(pointer.clone());
-                        }
-                        if let Some(exists) = exists {
-                            values.push(exists.to_string());
-                        }
-                        if let Some(equals) = equals {
-                            collect_json_strings(equals, &mut values);
-                        }
-                        collect_json_strings(when_true, &mut values);
-                        if let Some(when_false) = when_false {
-                            collect_json_strings(when_false, &mut values);
-                        }
-                    }
-                }
-            }
-            values
-        }
-    }
-}
-
-fn collect_json_strings(value: &Value, values: &mut Vec<String>) {
-    match value {
-        Value::String(string) => values.push(string.clone()),
-        Value::Array(array) => {
-            for entry in array {
-                collect_json_strings(entry, values);
-            }
-        }
-        Value::Object(map) => {
-            for (key, entry) in map {
-                values.push(key.clone());
-                collect_json_strings(entry, values);
-            }
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) => {}
-    }
-}
-
-fn is_operation_preapproved(operation_key: &str, approvals: &[String]) -> bool {
-    let operation_key_lower = operation_key.to_ascii_lowercase();
-    approvals.iter().any(|raw| {
-        let normalized = raw.trim().to_ascii_lowercase();
-        if normalized.is_empty() {
-            return false;
-        }
-        if normalized == "*" {
-            return true;
-        }
-        if let Some(prefix) = normalized.strip_suffix('*') {
-            return operation_key_lower.starts_with(prefix);
-        }
-        normalized == operation_key_lower
-    })
 }
 
 pub fn current_epoch_s() -> u64 {
@@ -2618,167 +1001,6 @@ fn enrich_scan_report_with_translation(
         matched_plugins: descriptors.len(),
         descriptors,
     }
-}
-
-fn bridge_support_policy_checksum(bridge: &BridgeSupportSpec) -> String {
-    let encoded = bridge_support_policy_canonical_json(bridge);
-    fnv1a64_hex(encoded.as_bytes())
-}
-
-pub fn bridge_support_policy_sha256(bridge: &BridgeSupportSpec) -> String {
-    let encoded = bridge_support_policy_canonical_json(bridge);
-    let digest = Sha256::digest(encoded.as_bytes());
-    hex_lower(&digest)
-}
-
-fn bridge_support_policy_canonical_json(bridge: &BridgeSupportSpec) -> String {
-    let mut bridges = bridge.supported_bridges.clone();
-    bridges.sort();
-
-    let mut adapter_families = bridge.supported_adapter_families.clone();
-    adapter_families.sort();
-    let mut allowed_commands = bridge.allowed_process_commands.clone();
-    allowed_commands.sort();
-    let security_scan = canonical_security_scan_value(bridge.security_scan.as_ref());
-
-    let canonical = json!({
-        "supported_bridges": bridges,
-        "supported_adapter_families": adapter_families,
-        "enforce_supported": bridge.enforce_supported,
-        "execute_process_stdio": bridge.execute_process_stdio,
-        "execute_http_json": bridge.execute_http_json,
-        "allowed_process_commands": allowed_commands,
-        "enforce_execution_success": bridge.enforce_execution_success,
-        "security_scan": security_scan,
-    });
-
-    serde_json::to_string(&canonical).unwrap_or_default()
-}
-
-fn canonical_security_scan_value(security_scan: Option<&SecurityScanSpec>) -> Value {
-    let Some(scan) = security_scan else {
-        return Value::Null;
-    };
-
-    let mut keywords = scan.high_risk_metadata_keywords.clone();
-    keywords.sort();
-
-    let mut blocked_import_prefixes = scan.wasm.blocked_import_prefixes.clone();
-    blocked_import_prefixes.sort();
-
-    let mut allowed_path_prefixes = scan.wasm.allowed_path_prefixes.clone();
-    allowed_path_prefixes.sort();
-
-    let required_sha256_by_plugin = scan
-        .wasm
-        .required_sha256_by_plugin
-        .iter()
-        .map(|(plugin, digest)| (plugin.clone(), digest.clone()))
-        .collect::<BTreeMap<_, _>>();
-    let profile_signature =
-        canonical_security_scan_profile_signature_value(scan.profile_signature.as_ref());
-    let siem_export = canonical_security_scan_siem_export_value(scan.siem_export.as_ref());
-    let runtime = canonical_security_scan_runtime_value(&scan.runtime);
-
-    json!({
-        "enabled": scan.enabled,
-        "block_on_high": scan.block_on_high,
-        "profile_path": scan.profile_path,
-        "profile_sha256": scan.profile_sha256,
-        "profile_signature": profile_signature,
-        "siem_export": siem_export,
-        "runtime": runtime,
-        "high_risk_metadata_keywords": keywords,
-        "wasm": {
-            "enabled": scan.wasm.enabled,
-            "max_module_bytes": scan.wasm.max_module_bytes,
-            "allow_wasi": scan.wasm.allow_wasi,
-            "blocked_import_prefixes": blocked_import_prefixes,
-            "allowed_path_prefixes": allowed_path_prefixes,
-            "require_hash_pin": scan.wasm.require_hash_pin,
-            "required_sha256_by_plugin": required_sha256_by_plugin,
-        },
-    })
-}
-
-fn canonical_security_scan_profile_signature_value(
-    signature: Option<&SecurityProfileSignatureSpec>,
-) -> Value {
-    let Some(signature) = signature else {
-        return Value::Null;
-    };
-    json!({
-        "algorithm": signature.algorithm.trim().to_ascii_lowercase(),
-        "public_key_base64": signature.public_key_base64,
-        "signature_base64": signature.signature_base64,
-    })
-}
-
-fn canonical_security_scan_siem_export_value(export: Option<&SecuritySiemExportSpec>) -> Value {
-    let Some(export) = export else {
-        return Value::Null;
-    };
-    json!({
-        "enabled": export.enabled,
-        "path": export.path,
-        "include_findings": export.include_findings,
-        "max_findings_per_record": export.max_findings_per_record,
-        "fail_on_error": export.fail_on_error,
-    })
-}
-
-fn canonical_security_scan_runtime_value(runtime: &SecurityRuntimeExecutionSpec) -> Value {
-    let mut allowed_path_prefixes = runtime.allowed_path_prefixes.clone();
-    allowed_path_prefixes.sort();
-
-    json!({
-        "execute_wasm_component": runtime.execute_wasm_component,
-        "allowed_path_prefixes": allowed_path_prefixes,
-        "max_component_bytes": runtime.max_component_bytes,
-        "fuel_limit": runtime.fuel_limit,
-    })
-}
-
-fn canonical_security_scan_profile_value(profile: &SecurityScanProfile) -> Value {
-    let mut keywords = profile.high_risk_metadata_keywords.clone();
-    keywords.sort();
-
-    let mut blocked_import_prefixes = profile.wasm.blocked_import_prefixes.clone();
-    blocked_import_prefixes.sort();
-
-    let mut allowed_path_prefixes = profile.wasm.allowed_path_prefixes.clone();
-    allowed_path_prefixes.sort();
-
-    let required_sha256_by_plugin = profile
-        .wasm
-        .required_sha256_by_plugin
-        .iter()
-        .map(|(plugin, digest)| (plugin.clone(), digest.clone()))
-        .collect::<BTreeMap<_, _>>();
-
-    json!({
-        "high_risk_metadata_keywords": keywords,
-        "wasm": {
-            "enabled": profile.wasm.enabled,
-            "max_module_bytes": profile.wasm.max_module_bytes,
-            "allow_wasi": profile.wasm.allow_wasi,
-            "blocked_import_prefixes": blocked_import_prefixes,
-            "allowed_path_prefixes": allowed_path_prefixes,
-            "require_hash_pin": profile.wasm.require_hash_pin,
-            "required_sha256_by_plugin": required_sha256_by_plugin,
-        }
-    })
-}
-
-pub fn security_scan_profile_sha256(profile: &SecurityScanProfile) -> String {
-    let encoded = security_scan_profile_message(profile);
-    let digest = Sha256::digest(&encoded);
-    hex_lower(&digest)
-}
-
-pub fn security_scan_profile_message(profile: &SecurityScanProfile) -> Vec<u8> {
-    let canonical = canonical_security_scan_profile_value(profile);
-    serde_json::to_vec(&canonical).unwrap_or_default()
 }
 
 fn fnv1a64_hex(bytes: &[u8]) -> String {
@@ -3181,357 +1403,6 @@ async fn execute_spec_operation(
             Ok(("programmatic_tool_call", outcome))
         }
     }
-}
-
-fn execute_tool_search(
-    integration_catalog: &IntegrationCatalog,
-    plugin_scan_reports: &[PluginScanReport],
-    plugin_translation_reports: &[PluginTranslationReport],
-    query: &str,
-    limit: usize,
-    include_deferred: bool,
-    include_examples: bool,
-) -> Vec<ToolSearchResult> {
-    let mut entries: BTreeMap<String, ToolSearchEntry> = BTreeMap::new();
-    let mut translation_by_key: BTreeMap<
-        (String, String),
-        (PluginBridgeKind, String, String, String),
-    > = BTreeMap::new();
-
-    for report in plugin_translation_reports {
-        for entry in &report.entries {
-            translation_by_key.insert(
-                (entry.source_path.clone(), entry.plugin_id.clone()),
-                (
-                    entry.runtime.bridge_kind,
-                    entry.runtime.adapter_family.clone(),
-                    entry.runtime.entrypoint_hint.clone(),
-                    entry.runtime.source_language.clone(),
-                ),
-            );
-        }
-    }
-
-    for provider in integration_catalog.providers() {
-        let channel_endpoint = integration_catalog
-            .channels_for_provider(&provider.provider_id)
-            .into_iter()
-            .find(|channel| channel.enabled)
-            .map(|channel| channel.endpoint)
-            .unwrap_or_default();
-        let bridge_kind = detect_provider_bridge_kind(&provider, &channel_endpoint);
-        let tool_id = format!("{}::{}", provider.provider_id, provider.connector_name);
-        let summary = provider.metadata.get("summary").cloned();
-        let tags = metadata_tags(&provider.metadata);
-        let input_examples = metadata_examples(&provider.metadata, "input_examples_json");
-        let output_examples = metadata_examples(&provider.metadata, "output_examples_json");
-        let deferred = metadata_bool(&provider.metadata, "defer_loading").unwrap_or(false);
-        let mut adapter_family = provider.metadata.get("adapter_family").cloned();
-        let mut entrypoint_hint = provider
-            .metadata
-            .get("entrypoint")
-            .or_else(|| provider.metadata.get("entrypoint_hint"))
-            .cloned();
-        let mut source_language = provider.metadata.get("source_language").cloned();
-        let mut resolved_bridge_kind = bridge_kind;
-
-        if let (Some(source_path), Some(plugin_id)) = (
-            provider.metadata.get("plugin_source_path"),
-            provider.metadata.get("plugin_id"),
-        ) {
-            if let Some((bridge, adapter, entrypoint, language)) =
-                translation_by_key.get(&(source_path.clone(), plugin_id.clone()))
-            {
-                resolved_bridge_kind = *bridge;
-                adapter_family = Some(adapter.clone());
-                entrypoint_hint = Some(entrypoint.clone());
-                source_language = Some(language.clone());
-            }
-        }
-
-        entries.insert(
-            tool_id.clone(),
-            ToolSearchEntry {
-                tool_id,
-                plugin_id: provider.metadata.get("plugin_id").cloned(),
-                connector_name: provider.connector_name.clone(),
-                provider_id: provider.provider_id.clone(),
-                source_path: provider.metadata.get("plugin_source_path").cloned(),
-                bridge_kind: resolved_bridge_kind,
-                adapter_family,
-                entrypoint_hint,
-                source_language,
-                summary,
-                tags,
-                input_examples,
-                output_examples,
-                deferred,
-                loaded: true,
-            },
-        );
-    }
-
-    for report in plugin_scan_reports {
-        for descriptor in &report.descriptors {
-            let manifest = &descriptor.manifest;
-            let tool_id = format!("{}::{}", manifest.provider_id, manifest.connector_name);
-            let translation =
-                translation_by_key.get(&(descriptor.path.clone(), manifest.plugin_id.clone()));
-            let bridge_kind = translation
-                .map(|(bridge, _, _, _)| *bridge)
-                .unwrap_or_else(|| descriptor_bridge_kind(descriptor));
-            let adapter_family = translation.map(|(_, adapter, _, _)| adapter.clone());
-            let entrypoint_hint = translation.map(|(_, _, entrypoint, _)| entrypoint.clone());
-            let source_language = translation.map(|(_, _, _, language)| language.clone());
-
-            let entry = entries
-                .entry(tool_id.clone())
-                .or_insert_with(|| ToolSearchEntry {
-                    tool_id: tool_id.clone(),
-                    plugin_id: Some(manifest.plugin_id.clone()),
-                    connector_name: manifest.connector_name.clone(),
-                    provider_id: manifest.provider_id.clone(),
-                    source_path: Some(descriptor.path.clone()),
-                    bridge_kind,
-                    adapter_family: adapter_family.clone(),
-                    entrypoint_hint: entrypoint_hint.clone(),
-                    source_language: source_language.clone(),
-                    summary: manifest.summary.clone(),
-                    tags: manifest.tags.clone(),
-                    input_examples: manifest.input_examples.clone(),
-                    output_examples: manifest.output_examples.clone(),
-                    deferred: manifest.defer_loading,
-                    loaded: false,
-                });
-
-            if entry.plugin_id.is_none() {
-                entry.plugin_id = Some(manifest.plugin_id.clone());
-            }
-            if entry.source_path.is_none() {
-                entry.source_path = Some(descriptor.path.clone());
-            }
-            if entry.summary.is_none() {
-                entry.summary = manifest.summary.clone();
-            }
-            if entry.adapter_family.is_none() {
-                entry.adapter_family = adapter_family.clone();
-            }
-            if entry.entrypoint_hint.is_none() {
-                entry.entrypoint_hint = entrypoint_hint.clone();
-            }
-            if entry.source_language.is_none() {
-                entry.source_language = source_language.clone();
-            }
-            if entry.input_examples.is_empty() {
-                entry.input_examples = manifest.input_examples.clone();
-            }
-            if entry.output_examples.is_empty() {
-                entry.output_examples = manifest.output_examples.clone();
-            }
-            for tag in &manifest.tags {
-                if !entry.tags.iter().any(|existing| existing == tag) {
-                    entry.tags.push(tag.clone());
-                }
-            }
-            if !entry.loaded {
-                entry.deferred = manifest.defer_loading;
-                entry.bridge_kind = bridge_kind;
-            }
-        }
-    }
-
-    let query_normalized = query.trim().to_ascii_lowercase();
-    let tokens: Vec<String> = query_normalized
-        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '-')
-        .map(str::trim)
-        .filter(|token| !token.is_empty())
-        .map(str::to_owned)
-        .collect();
-
-    let mut ranked: Vec<(u32, ToolSearchEntry)> = entries
-        .into_values()
-        .filter(|entry| include_deferred || !entry.deferred || entry.loaded)
-        .filter_map(|entry| {
-            let score = tool_search_score(&entry, &query_normalized, &tokens);
-            if query_normalized.is_empty() || score > 0 {
-                Some((score, entry))
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    ranked.sort_by(|(left_score, left), (right_score, right)| {
-        right_score
-            .cmp(left_score)
-            .then_with(|| right.loaded.cmp(&left.loaded))
-            .then_with(|| left.tool_id.cmp(&right.tool_id))
-    });
-
-    let capped_limit = limit.clamp(1, 50);
-    ranked
-        .into_iter()
-        .take(capped_limit)
-        .map(|(score, entry)| ToolSearchResult {
-            tool_id: entry.tool_id,
-            plugin_id: entry.plugin_id,
-            connector_name: entry.connector_name,
-            provider_id: entry.provider_id,
-            source_path: entry.source_path,
-            bridge_kind: entry.bridge_kind.as_str().to_owned(),
-            adapter_family: entry.adapter_family,
-            entrypoint_hint: entry.entrypoint_hint,
-            source_language: entry.source_language,
-            score,
-            deferred: entry.deferred,
-            loaded: entry.loaded,
-            summary: entry.summary,
-            tags: entry.tags,
-            input_examples: if include_examples {
-                entry.input_examples
-            } else {
-                Vec::new()
-            },
-            output_examples: if include_examples {
-                entry.output_examples
-            } else {
-                Vec::new()
-            },
-        })
-        .collect()
-}
-
-fn metadata_tags(metadata: &BTreeMap<String, String>) -> Vec<String> {
-    if let Some(raw_json) = metadata.get("tags_json") {
-        if let Ok(values) = serde_json::from_str::<Vec<String>>(raw_json) {
-            return values;
-        }
-    }
-
-    metadata
-        .get("tags")
-        .map(|raw| {
-            raw.split([',', ';'])
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(str::to_owned)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default()
-}
-
-fn metadata_examples(metadata: &BTreeMap<String, String>, key: &str) -> Vec<Value> {
-    metadata
-        .get(key)
-        .and_then(|raw| serde_json::from_str::<Vec<Value>>(raw).ok())
-        .unwrap_or_default()
-}
-
-fn metadata_bool(metadata: &BTreeMap<String, String>, key: &str) -> Option<bool> {
-    metadata
-        .get(key)
-        .and_then(|raw| match raw.trim().to_ascii_lowercase().as_str() {
-            "true" | "1" | "yes" | "y" | "on" => Some(true),
-            "false" | "0" | "no" | "n" | "off" => Some(false),
-            _ => None,
-        })
-}
-
-fn tool_search_score(entry: &ToolSearchEntry, query: &str, tokens: &[String]) -> u32 {
-    if query.is_empty() {
-        return if entry.loaded { 10 } else { 5 };
-    }
-
-    let connector = entry.connector_name.to_ascii_lowercase();
-    let provider = entry.provider_id.to_ascii_lowercase();
-    let tool_id = entry.tool_id.to_ascii_lowercase();
-    let summary = entry
-        .summary
-        .as_deref()
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    let source_path = entry
-        .source_path
-        .as_deref()
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    let adapter_family = entry
-        .adapter_family
-        .as_deref()
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    let entrypoint_hint = entry
-        .entrypoint_hint
-        .as_deref()
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    let source_language = entry
-        .source_language
-        .as_deref()
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    let tags: Vec<String> = entry
-        .tags
-        .iter()
-        .map(|tag| tag.to_ascii_lowercase())
-        .collect();
-
-    let mut score = 0_u32;
-    if connector == query {
-        score = score.saturating_add(150);
-    } else if connector.contains(query) {
-        score = score.saturating_add(110);
-    }
-    if provider == query {
-        score = score.saturating_add(120);
-    } else if provider.contains(query) {
-        score = score.saturating_add(80);
-    }
-    if tool_id.contains(query) {
-        score = score.saturating_add(60);
-    }
-    if summary.contains(query) {
-        score = score.saturating_add(55);
-    }
-    if source_path.contains(query) {
-        score = score.saturating_add(35);
-    }
-    if adapter_family.contains(query) {
-        score = score.saturating_add(18);
-    }
-    if entrypoint_hint.contains(query) {
-        score = score.saturating_add(12);
-    }
-    if source_language.contains(query) {
-        score = score.saturating_add(10);
-    }
-    if tags.iter().any(|tag| tag == query) {
-        score = score.saturating_add(45);
-    } else if tags.iter().any(|tag| tag.contains(query)) {
-        score = score.saturating_add(25);
-    }
-
-    let haystack = format!(
-        "{} {} {} {} {} {} {} {}",
-        connector,
-        provider,
-        tool_id,
-        summary,
-        adapter_family,
-        entrypoint_hint,
-        source_language,
-        tags.join(" ")
-    );
-    for token in tokens {
-        if haystack.contains(token) {
-            score = score.saturating_add(8);
-        }
-    }
-
-    if entry.loaded {
-        score = score.saturating_add(4);
-    }
-    score
 }
 
 fn apply_default_selection(

--- a/crates/spec/src/spec_execution/approval_policy.rs
+++ b/crates/spec/src/spec_execution/approval_policy.rs
@@ -1,0 +1,781 @@
+use std::fs;
+
+use serde_json::Value;
+
+use crate::spec_runtime::*;
+use crate::BUNDLED_APPROVAL_RISK_PROFILE;
+
+pub(super) fn evaluate_approval_guard(spec: &RunnerSpec) -> ApprovalDecisionReport {
+    let policy = spec.approval.clone().unwrap_or_default();
+    let now_epoch_s = super::current_epoch_s();
+    let operation_key = operation_approval_key(&spec.operation);
+    let operation_kind = operation_approval_kind(&spec.operation);
+    let target_in_scope = is_operation_in_approval_scope(&spec.operation, policy.scope);
+    let denylisted = is_operation_preapproved(&operation_key, &policy.denied_calls);
+
+    let (risk_level, matched_keywords, risk_score) =
+        match operation_risk_profile(&spec.operation, &policy) {
+            (ApprovalRiskLevel::High, matched, score) => (ApprovalRiskLevel::High, matched, score),
+            (_, _, score) => (ApprovalRiskLevel::Low, Vec::new(), score),
+        };
+
+    if denylisted {
+        return ApprovalDecisionReport {
+            mode: policy.mode,
+            strategy: policy.strategy,
+            scope: policy.scope,
+            now_epoch_s,
+            operation_key,
+            operation_kind,
+            risk_level,
+            risk_score,
+            denylisted: true,
+            requires_human_approval: true,
+            approved: false,
+            reason: "operation is denylisted by human approval policy".to_owned(),
+            matched_keywords,
+        };
+    }
+
+    let one_time_full_access_active = policy.one_time_full_access_granted
+        && policy
+            .one_time_full_access_expires_at_epoch_s
+            .map(|deadline| now_epoch_s <= deadline)
+            .unwrap_or(true)
+        && policy
+            .one_time_full_access_remaining_uses
+            .map(|remaining| remaining > 0)
+            .unwrap_or(true);
+
+    let one_time_full_access_rejected_reason = if policy.one_time_full_access_granted {
+        if let Some(deadline) = policy.one_time_full_access_expires_at_epoch_s {
+            if now_epoch_s > deadline {
+                Some(format!(
+                    "one-time full access grant expired at {deadline}, now is {now_epoch_s}"
+                ))
+            } else {
+                None
+            }
+        } else if matches!(policy.one_time_full_access_remaining_uses, Some(0)) {
+            Some("one-time full access grant has no remaining uses".to_owned())
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let requires_human_approval = if !target_in_scope {
+        false
+    } else {
+        match policy.mode {
+            HumanApprovalMode::Disabled => false,
+            HumanApprovalMode::MediumBalanced => matches!(risk_level, ApprovalRiskLevel::High),
+            HumanApprovalMode::Strict => true,
+        }
+    };
+
+    let (approved, reason) = if !requires_human_approval {
+        (
+            true,
+            "operation is allowed by default medium-balanced approval policy".to_owned(),
+        )
+    } else {
+        match policy.strategy {
+            HumanApprovalStrategy::OneTimeFullAccess if one_time_full_access_active => (
+                true,
+                "human granted one-time full access for this execution".to_owned(),
+            ),
+            HumanApprovalStrategy::PerCall
+                if is_operation_preapproved(&operation_key, &policy.approved_calls) =>
+            {
+                (
+                    true,
+                    format!("operation {operation_key} is pre-approved by human policy"),
+                )
+            }
+            HumanApprovalStrategy::PerCall => (
+                false,
+                format!(
+                    "human approval required for high-risk operation {operation_key}; \
+                     add to approval.approved_calls or switch to one_time_full_access"
+                ),
+            ),
+            HumanApprovalStrategy::OneTimeFullAccess => (false, one_time_full_access_rejected_reason
+                .unwrap_or_else(|| {
+                    format!(
+                        "human one-time full access is not granted for high-risk operation {operation_key}"
+                    )
+                })),
+        }
+    };
+
+    ApprovalDecisionReport {
+        mode: policy.mode,
+        strategy: policy.strategy,
+        scope: policy.scope,
+        now_epoch_s,
+        operation_key,
+        operation_kind,
+        risk_level,
+        risk_score,
+        denylisted: false,
+        requires_human_approval,
+        approved,
+        reason,
+        matched_keywords,
+    }
+}
+
+fn operation_approval_key(operation: &OperationSpec) -> String {
+    match operation {
+        OperationSpec::Task { task_id, .. } => format!("task:{task_id}"),
+        OperationSpec::ConnectorLegacy {
+            connector_name,
+            operation,
+            ..
+        } => {
+            format!("connector_legacy:{connector_name}:{operation}")
+        }
+        OperationSpec::ConnectorCore {
+            connector_name,
+            operation,
+            ..
+        } => {
+            format!("connector_core:{connector_name}:{operation}")
+        }
+        OperationSpec::ConnectorExtension {
+            connector_name,
+            operation,
+            extension,
+            ..
+        } => {
+            format!("connector_extension:{extension}:{connector_name}:{operation}")
+        }
+        OperationSpec::RuntimeCore { action, .. } => format!("runtime_core:{action}"),
+        OperationSpec::RuntimeExtension {
+            extension, action, ..
+        } => {
+            format!("runtime_extension:{extension}:{action}")
+        }
+        OperationSpec::ToolCore { tool_name, .. } => format!("tool_core:{tool_name}"),
+        OperationSpec::ToolExtension {
+            extension,
+            extension_action,
+            ..
+        } => {
+            format!("tool_extension:{extension}:{extension_action}")
+        }
+        OperationSpec::MemoryCore { operation, .. } => format!("memory_core:{operation}"),
+        OperationSpec::MemoryExtension {
+            extension,
+            operation,
+            ..
+        } => {
+            format!("memory_extension:{extension}:{operation}")
+        }
+        OperationSpec::ToolSearch { query, .. } => format!("tool_search:{query}"),
+        OperationSpec::ProgrammaticToolCall { caller, .. } => {
+            format!("programmatic_tool_call:{caller}")
+        }
+    }
+}
+
+fn operation_approval_kind(operation: &OperationSpec) -> &'static str {
+    match operation {
+        OperationSpec::Task { .. } => "task",
+        OperationSpec::ConnectorLegacy { .. } => "connector_legacy",
+        OperationSpec::ConnectorCore { .. } => "connector_core",
+        OperationSpec::ConnectorExtension { .. } => "connector_extension",
+        OperationSpec::RuntimeCore { .. } => "runtime_core",
+        OperationSpec::RuntimeExtension { .. } => "runtime_extension",
+        OperationSpec::ToolCore { .. } => "tool_core",
+        OperationSpec::ToolExtension { .. } => "tool_extension",
+        OperationSpec::MemoryCore { .. } => "memory_core",
+        OperationSpec::MemoryExtension { .. } => "memory_extension",
+        OperationSpec::ToolSearch { .. } => "tool_search",
+        OperationSpec::ProgrammaticToolCall { .. } => "programmatic_tool_call",
+    }
+}
+
+fn is_operation_in_approval_scope(operation: &OperationSpec, scope: HumanApprovalScope) -> bool {
+    match scope {
+        HumanApprovalScope::ToolCalls => matches!(
+            operation,
+            OperationSpec::ToolCore { .. }
+                | OperationSpec::ToolExtension { .. }
+                | OperationSpec::ProgrammaticToolCall { .. }
+        ),
+        HumanApprovalScope::AllOperations => true,
+    }
+}
+
+pub fn operation_risk_profile(
+    operation: &OperationSpec,
+    policy: &HumanApprovalSpec,
+) -> (ApprovalRiskLevel, Vec<String>, u8) {
+    let profile = resolve_approval_risk_profile(policy);
+    let keywords = normalize_signal_list(profile.high_risk_keywords);
+    let high_risk_tool_names = normalize_signal_list(profile.high_risk_tool_names);
+    let high_risk_payload_keys = normalize_signal_list(profile.high_risk_payload_keys);
+    let scoring = sanitize_risk_scoring(profile.scoring);
+
+    let haystack = operation_risk_haystack(operation);
+    let haystack_lower = haystack.to_ascii_lowercase();
+
+    let matched_keywords: Vec<String> = keywords
+        .iter()
+        .filter(|keyword| haystack_lower.contains(keyword.as_str()))
+        .cloned()
+        .collect();
+
+    let matched_tool_name = operation_tool_name(operation)
+        .map(|name| name.trim().to_ascii_lowercase())
+        .filter(|name| high_risk_tool_names.iter().any(|value| value == name))
+        .map(|name| vec![format!("tool:{name}")])
+        .unwrap_or_default();
+
+    let payload_keys = operation_payload_keys(operation);
+    let matched_payload_keys: Vec<String> = payload_keys
+        .iter()
+        .map(|key| key.trim().to_ascii_lowercase())
+        .filter(|key| high_risk_payload_keys.iter().any(|value| value == key))
+        .map(|key| format!("payload_key:{key}"))
+        .collect();
+
+    let mut matched = Vec::new();
+    matched.extend(matched_keywords.clone());
+    matched.extend(matched_tool_name.clone());
+    matched.extend(matched_payload_keys.clone());
+    matched.sort();
+    matched.dedup();
+
+    let keyword_score = (matched_keywords.len().min(scoring.keyword_hit_cap) as u16)
+        * u16::from(scoring.keyword_weight);
+    let tool_score = if matched_tool_name.is_empty() {
+        0
+    } else {
+        u16::from(scoring.tool_name_weight)
+    };
+    let payload_key_score = (matched_payload_keys.len().min(scoring.payload_key_hit_cap) as u16)
+        * u16::from(scoring.payload_key_weight);
+    let risk_score = keyword_score
+        .saturating_add(tool_score)
+        .saturating_add(payload_key_score)
+        .min(100) as u8;
+
+    if matched.is_empty() || risk_score < scoring.high_risk_threshold {
+        (ApprovalRiskLevel::Low, Vec::new(), 0)
+    } else {
+        (ApprovalRiskLevel::High, matched, risk_score)
+    }
+}
+
+fn resolve_approval_risk_profile(policy: &HumanApprovalSpec) -> ApprovalRiskProfile {
+    let mut profile = policy
+        .risk_profile_path
+        .as_deref()
+        .and_then(load_approval_risk_profile_from_path)
+        .unwrap_or_else(bundled_approval_risk_profile);
+
+    if !policy.high_risk_keywords.is_empty() {
+        profile.high_risk_keywords = policy.high_risk_keywords.clone();
+    }
+    if !policy.high_risk_tool_names.is_empty() {
+        profile.high_risk_tool_names = policy.high_risk_tool_names.clone();
+    }
+    if !policy.high_risk_payload_keys.is_empty() {
+        profile.high_risk_payload_keys = policy.high_risk_payload_keys.clone();
+    }
+
+    profile
+}
+
+fn load_approval_risk_profile_from_path(path: &str) -> Option<ApprovalRiskProfile> {
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str::<ApprovalRiskProfile>(&content).ok()
+}
+
+fn bundled_approval_risk_profile() -> ApprovalRiskProfile {
+    BUNDLED_APPROVAL_RISK_PROFILE
+        .get_or_init(|| {
+            let raw = include_str!("../../config/approval-medium-balanced.json");
+            serde_json::from_str(raw)
+                .or_else(|_| serde_json::from_str::<ApprovalRiskProfile>("{}"))
+                .unwrap_or_else(|_| ApprovalRiskProfile {
+                    high_risk_keywords: Vec::new(),
+                    high_risk_tool_names: Vec::new(),
+                    high_risk_payload_keys: Vec::new(),
+                    scoring: ApprovalRiskScoring::default(),
+                })
+        })
+        .clone()
+}
+
+pub(super) fn normalize_signal_list(list: Vec<String>) -> Vec<String> {
+    let mut normalized: Vec<String> = list
+        .into_iter()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .collect();
+    normalized.sort();
+    normalized.dedup();
+    normalized
+}
+
+fn sanitize_risk_scoring(mut scoring: ApprovalRiskScoring) -> ApprovalRiskScoring {
+    if scoring.keyword_hit_cap == 0 {
+        scoring.keyword_hit_cap = 1;
+    }
+    if scoring.payload_key_hit_cap == 0 {
+        scoring.payload_key_hit_cap = 1;
+    }
+    if scoring.high_risk_threshold == 0 {
+        scoring.high_risk_threshold = 20;
+    }
+    scoring
+}
+
+fn operation_tool_name(operation: &OperationSpec) -> Option<&str> {
+    match operation {
+        OperationSpec::ToolCore { tool_name, .. } => Some(tool_name.as_str()),
+        OperationSpec::ToolExtension {
+            extension_action, ..
+        } => Some(extension_action.as_str()),
+        OperationSpec::ProgrammaticToolCall { caller, .. } => Some(caller.as_str()),
+        _ => None,
+    }
+}
+
+fn operation_payload_keys(operation: &OperationSpec) -> Vec<String> {
+    match operation {
+        OperationSpec::Task { payload, .. }
+        | OperationSpec::ConnectorLegacy { payload, .. }
+        | OperationSpec::ConnectorCore { payload, .. }
+        | OperationSpec::ConnectorExtension { payload, .. }
+        | OperationSpec::RuntimeCore { payload, .. }
+        | OperationSpec::RuntimeExtension { payload, .. }
+        | OperationSpec::ToolCore { payload, .. }
+        | OperationSpec::ToolExtension { payload, .. }
+        | OperationSpec::MemoryCore { payload, .. }
+        | OperationSpec::MemoryExtension { payload, .. } => {
+            let mut keys = Vec::new();
+            collect_json_keys(payload, &mut keys);
+            keys
+        }
+        OperationSpec::ToolSearch { .. } => {
+            let mut keys = Vec::new();
+            keys.extend(
+                ["query", "limit", "include_deferred", "include_examples"]
+                    .iter()
+                    .map(|value| (*value).to_owned()),
+            );
+            keys
+        }
+        OperationSpec::ProgrammaticToolCall {
+            allowed_connectors,
+            connector_rate_limits,
+            connector_circuit_breakers,
+            concurrency,
+            steps,
+            ..
+        } => {
+            let mut keys = Vec::new();
+            keys.extend(
+                [
+                    "caller",
+                    "max_calls",
+                    "include_intermediate",
+                    "connector_rate_limits",
+                    "connector_circuit_breakers",
+                    "concurrency",
+                    "return_step",
+                    "steps",
+                ]
+                .iter()
+                .map(|value| (*value).to_owned()),
+            );
+            keys.push("max_in_flight".to_owned());
+            keys.push(concurrency.max_in_flight.to_string());
+            keys.push("min_in_flight".to_owned());
+            keys.push(concurrency.min_in_flight.to_string());
+            keys.push("fairness".to_owned());
+            keys.push(concurrency.fairness.as_str().to_owned());
+            keys.push("adaptive_budget".to_owned());
+            keys.push(concurrency.adaptive_budget.to_string());
+            keys.push("high_weight".to_owned());
+            keys.push(concurrency.high_weight.to_string());
+            keys.push("normal_weight".to_owned());
+            keys.push(concurrency.normal_weight.to_string());
+            keys.push("low_weight".to_owned());
+            keys.push(concurrency.low_weight.to_string());
+            keys.push("adaptive_recovery_successes".to_owned());
+            keys.push(concurrency.adaptive_recovery_successes.to_string());
+            keys.push("adaptive_upshift_step".to_owned());
+            keys.push(concurrency.adaptive_upshift_step.to_string());
+            keys.push("adaptive_downshift_step".to_owned());
+            keys.push(concurrency.adaptive_downshift_step.to_string());
+            keys.push("adaptive_reduce_on".to_owned());
+            for rule in &concurrency.adaptive_reduce_on {
+                keys.push(rule.as_str().to_owned());
+            }
+            keys.extend(allowed_connectors.iter().cloned());
+            for (connector_name, limit) in connector_rate_limits {
+                keys.push("connector_name".to_owned());
+                keys.push(connector_name.clone());
+                keys.push("min_interval_ms".to_owned());
+                keys.push(limit.min_interval_ms.to_string());
+            }
+            for (connector_name, policy) in connector_circuit_breakers {
+                keys.push("connector_name".to_owned());
+                keys.push(connector_name.clone());
+                keys.push("failure_threshold".to_owned());
+                keys.push(policy.failure_threshold.to_string());
+                keys.push("cooldown_ms".to_owned());
+                keys.push(policy.cooldown_ms.to_string());
+                keys.push("half_open_max_calls".to_owned());
+                keys.push(policy.half_open_max_calls.to_string());
+                keys.push("success_threshold".to_owned());
+                keys.push(policy.success_threshold.to_string());
+            }
+            for step in steps {
+                keys.push("step_id".to_owned());
+                match step {
+                    ProgrammaticStep::SetLiteral { value, .. } => {
+                        collect_json_keys(value, &mut keys);
+                    }
+                    ProgrammaticStep::JsonPointer { .. } => {
+                        keys.push("pointer".to_owned());
+                    }
+                    ProgrammaticStep::ConnectorCall {
+                        connector_name,
+                        operation,
+                        priority_class,
+                        retry,
+                        payload,
+                        ..
+                    } => {
+                        keys.push("connector_name".to_owned());
+                        keys.push("operation".to_owned());
+                        keys.push("priority_class".to_owned());
+                        keys.push(connector_name.clone());
+                        keys.push(operation.clone());
+                        keys.push(priority_class.as_str().to_owned());
+                        if let Some(retry) = retry {
+                            keys.push("retry".to_owned());
+                            keys.push("max_attempts".to_owned());
+                            keys.push("initial_backoff_ms".to_owned());
+                            keys.push("max_backoff_ms".to_owned());
+                            keys.push("jitter_ratio".to_owned());
+                            keys.push("adaptive_jitter".to_owned());
+                            keys.push(retry.max_attempts.to_string());
+                            keys.push(retry.initial_backoff_ms.to_string());
+                            keys.push(retry.max_backoff_ms.to_string());
+                            keys.push(retry.jitter_ratio.to_string());
+                            keys.push(retry.adaptive_jitter.to_string());
+                        }
+                        collect_json_keys(payload, &mut keys);
+                    }
+                    ProgrammaticStep::ConnectorBatch {
+                        parallel,
+                        continue_on_error,
+                        calls,
+                        ..
+                    } => {
+                        keys.push("parallel".to_owned());
+                        keys.push(parallel.to_string());
+                        keys.push("continue_on_error".to_owned());
+                        keys.push(continue_on_error.to_string());
+                        keys.push("calls".to_owned());
+                        for call in calls {
+                            keys.push("call_id".to_owned());
+                            keys.push(call.call_id.clone());
+                            keys.push("connector_name".to_owned());
+                            keys.push("operation".to_owned());
+                            keys.push("priority_class".to_owned());
+                            keys.push(call.connector_name.clone());
+                            keys.push(call.operation.clone());
+                            keys.push(call.priority_class.as_str().to_owned());
+                            if let Some(retry) = &call.retry {
+                                keys.push("retry".to_owned());
+                                keys.push("max_attempts".to_owned());
+                                keys.push("initial_backoff_ms".to_owned());
+                                keys.push("max_backoff_ms".to_owned());
+                                keys.push("jitter_ratio".to_owned());
+                                keys.push("adaptive_jitter".to_owned());
+                                keys.push(retry.max_attempts.to_string());
+                                keys.push(retry.initial_backoff_ms.to_string());
+                                keys.push(retry.max_backoff_ms.to_string());
+                                keys.push(retry.jitter_ratio.to_string());
+                                keys.push(retry.adaptive_jitter.to_string());
+                            }
+                            collect_json_keys(&call.payload, &mut keys);
+                        }
+                    }
+                    ProgrammaticStep::Conditional {
+                        from_step,
+                        pointer,
+                        equals,
+                        exists,
+                        when_true,
+                        when_false,
+                        ..
+                    } => {
+                        keys.push("from_step".to_owned());
+                        keys.push(from_step.clone());
+                        if let Some(pointer) = pointer {
+                            keys.push("pointer".to_owned());
+                            keys.push(pointer.clone());
+                        }
+                        if let Some(equals) = equals {
+                            keys.push("equals".to_owned());
+                            collect_json_keys(equals, &mut keys);
+                        }
+                        if let Some(exists) = exists {
+                            keys.push("exists".to_owned());
+                            keys.push(exists.to_string());
+                        }
+                        keys.push("when_true".to_owned());
+                        collect_json_keys(when_true, &mut keys);
+                        if let Some(when_false) = when_false {
+                            keys.push("when_false".to_owned());
+                            collect_json_keys(when_false, &mut keys);
+                        }
+                    }
+                }
+            }
+            keys
+        }
+    }
+}
+
+fn collect_json_keys(value: &Value, keys: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                keys.push(key.clone());
+                collect_json_keys(child, keys);
+            }
+        }
+        Value::Array(list) => {
+            for child in list {
+                collect_json_keys(child, keys);
+            }
+        }
+        Value::String(_) | Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+fn operation_risk_haystack(operation: &OperationSpec) -> String {
+    let mut text = String::new();
+    text.push_str(operation_approval_kind(operation));
+    text.push(' ');
+    text.push_str(&operation_approval_key(operation));
+    text.push(' ');
+    for value in operation_payload_strings(operation) {
+        text.push_str(&value);
+        text.push(' ');
+    }
+    text
+}
+
+fn operation_payload_strings(operation: &OperationSpec) -> Vec<String> {
+    match operation {
+        OperationSpec::Task { payload, .. }
+        | OperationSpec::ConnectorLegacy { payload, .. }
+        | OperationSpec::ConnectorCore { payload, .. }
+        | OperationSpec::ConnectorExtension { payload, .. }
+        | OperationSpec::RuntimeCore { payload, .. }
+        | OperationSpec::RuntimeExtension { payload, .. }
+        | OperationSpec::ToolCore { payload, .. }
+        | OperationSpec::ToolExtension { payload, .. }
+        | OperationSpec::MemoryCore { payload, .. }
+        | OperationSpec::MemoryExtension { payload, .. } => {
+            let mut values = Vec::new();
+            collect_json_strings(payload, &mut values);
+            values
+        }
+        OperationSpec::ToolSearch {
+            query,
+            limit,
+            include_deferred,
+            include_examples,
+        } => {
+            vec![
+                query.clone(),
+                limit.to_string(),
+                include_deferred.to_string(),
+                include_examples.to_string(),
+            ]
+        }
+        OperationSpec::ProgrammaticToolCall {
+            caller,
+            max_calls,
+            include_intermediate,
+            allowed_connectors,
+            connector_rate_limits,
+            connector_circuit_breakers,
+            concurrency,
+            return_step,
+            steps,
+        } => {
+            let mut values = vec![
+                caller.clone(),
+                max_calls.to_string(),
+                include_intermediate.to_string(),
+                concurrency.max_in_flight.to_string(),
+                concurrency.min_in_flight.to_string(),
+                concurrency.fairness.as_str().to_owned(),
+                concurrency.adaptive_budget.to_string(),
+                concurrency.high_weight.to_string(),
+                concurrency.normal_weight.to_string(),
+                concurrency.low_weight.to_string(),
+                concurrency.adaptive_recovery_successes.to_string(),
+                concurrency.adaptive_upshift_step.to_string(),
+                concurrency.adaptive_downshift_step.to_string(),
+            ];
+            for rule in &concurrency.adaptive_reduce_on {
+                values.push(rule.as_str().to_owned());
+            }
+            values.extend(allowed_connectors.iter().cloned());
+            for (connector_name, limit) in connector_rate_limits {
+                values.push(connector_name.clone());
+                values.push(limit.min_interval_ms.to_string());
+            }
+            for (connector_name, policy) in connector_circuit_breakers {
+                values.push(connector_name.clone());
+                values.push(policy.failure_threshold.to_string());
+                values.push(policy.cooldown_ms.to_string());
+                values.push(policy.half_open_max_calls.to_string());
+                values.push(policy.success_threshold.to_string());
+            }
+            if let Some(return_step) = return_step {
+                values.push(return_step.clone());
+            }
+            for step in steps {
+                match step {
+                    ProgrammaticStep::SetLiteral { step_id, value } => {
+                        values.push(step_id.clone());
+                        collect_json_strings(value, &mut values);
+                    }
+                    ProgrammaticStep::JsonPointer {
+                        step_id,
+                        from_step,
+                        pointer,
+                    } => {
+                        values.push(step_id.clone());
+                        values.push(from_step.clone());
+                        values.push(pointer.clone());
+                    }
+                    ProgrammaticStep::ConnectorCall {
+                        step_id,
+                        connector_name,
+                        operation,
+                        priority_class,
+                        retry,
+                        payload,
+                        ..
+                    } => {
+                        values.push(step_id.clone());
+                        values.push(connector_name.clone());
+                        values.push(operation.clone());
+                        values.push(priority_class.as_str().to_owned());
+                        if let Some(retry) = retry {
+                            values.push(retry.max_attempts.to_string());
+                            values.push(retry.initial_backoff_ms.to_string());
+                            values.push(retry.max_backoff_ms.to_string());
+                            values.push(retry.jitter_ratio.to_string());
+                            values.push(retry.adaptive_jitter.to_string());
+                        }
+                        collect_json_strings(payload, &mut values);
+                    }
+                    ProgrammaticStep::ConnectorBatch {
+                        step_id,
+                        parallel,
+                        continue_on_error,
+                        calls,
+                    } => {
+                        values.push(step_id.clone());
+                        values.push(parallel.to_string());
+                        values.push(continue_on_error.to_string());
+                        for call in calls {
+                            values.push(call.call_id.clone());
+                            values.push(call.connector_name.clone());
+                            values.push(call.operation.clone());
+                            values.push(call.priority_class.as_str().to_owned());
+                            if let Some(retry) = &call.retry {
+                                values.push(retry.max_attempts.to_string());
+                                values.push(retry.initial_backoff_ms.to_string());
+                                values.push(retry.max_backoff_ms.to_string());
+                                values.push(retry.jitter_ratio.to_string());
+                                values.push(retry.adaptive_jitter.to_string());
+                            }
+                            collect_json_strings(&call.payload, &mut values);
+                        }
+                    }
+                    ProgrammaticStep::Conditional {
+                        step_id,
+                        from_step,
+                        pointer,
+                        equals,
+                        exists,
+                        when_true,
+                        when_false,
+                    } => {
+                        values.push(step_id.clone());
+                        values.push(from_step.clone());
+                        if let Some(pointer) = pointer {
+                            values.push(pointer.clone());
+                        }
+                        if let Some(exists) = exists {
+                            values.push(exists.to_string());
+                        }
+                        if let Some(equals) = equals {
+                            collect_json_strings(equals, &mut values);
+                        }
+                        collect_json_strings(when_true, &mut values);
+                        if let Some(when_false) = when_false {
+                            collect_json_strings(when_false, &mut values);
+                        }
+                    }
+                }
+            }
+            values
+        }
+    }
+}
+
+fn collect_json_strings(value: &Value, values: &mut Vec<String>) {
+    match value {
+        Value::String(string) => values.push(string.clone()),
+        Value::Array(array) => {
+            for entry in array {
+                collect_json_strings(entry, values);
+            }
+        }
+        Value::Object(map) => {
+            for (key, entry) in map {
+                values.push(key.clone());
+                collect_json_strings(entry, values);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+fn is_operation_preapproved(operation_key: &str, approvals: &[String]) -> bool {
+    let operation_key_lower = operation_key.to_ascii_lowercase();
+    approvals.iter().any(|raw| {
+        let normalized = raw.trim().to_ascii_lowercase();
+        if normalized.is_empty() {
+            return false;
+        }
+        if normalized == "*" {
+            return true;
+        }
+        if let Some(prefix) = normalized.strip_suffix('*') {
+            return operation_key_lower.starts_with(prefix);
+        }
+        normalized == operation_key_lower
+    })
+}

--- a/crates/spec/src/spec_execution/bridge_support_policy.rs
+++ b/crates/spec/src/spec_execution/bridge_support_policy.rs
@@ -1,0 +1,167 @@
+use std::collections::BTreeMap;
+
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::spec_runtime::*;
+
+pub(super) fn bridge_support_policy_checksum(bridge: &BridgeSupportSpec) -> String {
+    let encoded = bridge_support_policy_canonical_json(bridge);
+    super::fnv1a64_hex(encoded.as_bytes())
+}
+
+pub fn bridge_support_policy_sha256(bridge: &BridgeSupportSpec) -> String {
+    let encoded = bridge_support_policy_canonical_json(bridge);
+    let digest = Sha256::digest(encoded.as_bytes());
+    super::hex_lower(&digest)
+}
+
+fn bridge_support_policy_canonical_json(bridge: &BridgeSupportSpec) -> String {
+    let mut bridges = bridge.supported_bridges.clone();
+    bridges.sort();
+
+    let mut adapter_families = bridge.supported_adapter_families.clone();
+    adapter_families.sort();
+    let mut allowed_commands = bridge.allowed_process_commands.clone();
+    allowed_commands.sort();
+    let security_scan = canonical_security_scan_value(bridge.security_scan.as_ref());
+
+    let canonical = json!({
+        "supported_bridges": bridges,
+        "supported_adapter_families": adapter_families,
+        "enforce_supported": bridge.enforce_supported,
+        "execute_process_stdio": bridge.execute_process_stdio,
+        "execute_http_json": bridge.execute_http_json,
+        "allowed_process_commands": allowed_commands,
+        "enforce_execution_success": bridge.enforce_execution_success,
+        "security_scan": security_scan,
+    });
+
+    serde_json::to_string(&canonical).unwrap_or_default()
+}
+
+fn canonical_security_scan_value(security_scan: Option<&SecurityScanSpec>) -> Value {
+    let Some(scan) = security_scan else {
+        return Value::Null;
+    };
+
+    let mut keywords = scan.high_risk_metadata_keywords.clone();
+    keywords.sort();
+
+    let mut blocked_import_prefixes = scan.wasm.blocked_import_prefixes.clone();
+    blocked_import_prefixes.sort();
+
+    let mut allowed_path_prefixes = scan.wasm.allowed_path_prefixes.clone();
+    allowed_path_prefixes.sort();
+
+    let required_sha256_by_plugin = scan
+        .wasm
+        .required_sha256_by_plugin
+        .iter()
+        .map(|(plugin, digest)| (plugin.clone(), digest.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let profile_signature =
+        canonical_security_scan_profile_signature_value(scan.profile_signature.as_ref());
+    let siem_export = canonical_security_scan_siem_export_value(scan.siem_export.as_ref());
+    let runtime = canonical_security_scan_runtime_value(&scan.runtime);
+
+    json!({
+        "enabled": scan.enabled,
+        "block_on_high": scan.block_on_high,
+        "profile_path": scan.profile_path,
+        "profile_sha256": scan.profile_sha256,
+        "profile_signature": profile_signature,
+        "siem_export": siem_export,
+        "runtime": runtime,
+        "high_risk_metadata_keywords": keywords,
+        "wasm": {
+            "enabled": scan.wasm.enabled,
+            "max_module_bytes": scan.wasm.max_module_bytes,
+            "allow_wasi": scan.wasm.allow_wasi,
+            "blocked_import_prefixes": blocked_import_prefixes,
+            "allowed_path_prefixes": allowed_path_prefixes,
+            "require_hash_pin": scan.wasm.require_hash_pin,
+            "required_sha256_by_plugin": required_sha256_by_plugin,
+        },
+    })
+}
+
+fn canonical_security_scan_profile_signature_value(
+    signature: Option<&SecurityProfileSignatureSpec>,
+) -> Value {
+    let Some(signature) = signature else {
+        return Value::Null;
+    };
+    json!({
+        "algorithm": signature.algorithm.trim().to_ascii_lowercase(),
+        "public_key_base64": signature.public_key_base64,
+        "signature_base64": signature.signature_base64,
+    })
+}
+
+fn canonical_security_scan_siem_export_value(export: Option<&SecuritySiemExportSpec>) -> Value {
+    let Some(export) = export else {
+        return Value::Null;
+    };
+    json!({
+        "enabled": export.enabled,
+        "path": export.path,
+        "include_findings": export.include_findings,
+        "max_findings_per_record": export.max_findings_per_record,
+        "fail_on_error": export.fail_on_error,
+    })
+}
+
+fn canonical_security_scan_runtime_value(runtime: &SecurityRuntimeExecutionSpec) -> Value {
+    let mut allowed_path_prefixes = runtime.allowed_path_prefixes.clone();
+    allowed_path_prefixes.sort();
+
+    json!({
+        "execute_wasm_component": runtime.execute_wasm_component,
+        "allowed_path_prefixes": allowed_path_prefixes,
+        "max_component_bytes": runtime.max_component_bytes,
+        "fuel_limit": runtime.fuel_limit,
+    })
+}
+
+fn canonical_security_scan_profile_value(profile: &SecurityScanProfile) -> Value {
+    let mut keywords = profile.high_risk_metadata_keywords.clone();
+    keywords.sort();
+
+    let mut blocked_import_prefixes = profile.wasm.blocked_import_prefixes.clone();
+    blocked_import_prefixes.sort();
+
+    let mut allowed_path_prefixes = profile.wasm.allowed_path_prefixes.clone();
+    allowed_path_prefixes.sort();
+
+    let required_sha256_by_plugin = profile
+        .wasm
+        .required_sha256_by_plugin
+        .iter()
+        .map(|(plugin, digest)| (plugin.clone(), digest.clone()))
+        .collect::<BTreeMap<_, _>>();
+
+    json!({
+        "high_risk_metadata_keywords": keywords,
+        "wasm": {
+            "enabled": profile.wasm.enabled,
+            "max_module_bytes": profile.wasm.max_module_bytes,
+            "allow_wasi": profile.wasm.allow_wasi,
+            "blocked_import_prefixes": blocked_import_prefixes,
+            "allowed_path_prefixes": allowed_path_prefixes,
+            "require_hash_pin": profile.wasm.require_hash_pin,
+            "required_sha256_by_plugin": required_sha256_by_plugin,
+        }
+    })
+}
+
+pub fn security_scan_profile_sha256(profile: &SecurityScanProfile) -> String {
+    let encoded = security_scan_profile_message(profile);
+    let digest = Sha256::digest(&encoded);
+    super::hex_lower(&digest)
+}
+
+pub fn security_scan_profile_message(profile: &SecurityScanProfile) -> Vec<u8> {
+    let canonical = canonical_security_scan_profile_value(profile);
+    serde_json::to_vec(&canonical).unwrap_or_default()
+}

--- a/crates/spec/src/spec_execution/security_scan_eval.rs
+++ b/crates/spec/src/spec_execution/security_scan_eval.rs
@@ -1,0 +1,583 @@
+use std::{collections::BTreeSet, fs, path::PathBuf};
+
+use kernel::{PluginBridgeKind, PluginDescriptor, PluginScanReport};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use wasmparser::{Parser as WasmParser, Payload as WasmPayload};
+
+use crate::spec_runtime::{
+    is_process_command_allowed, SecurityFinding, SecurityFindingSeverity, SecurityScanSpec,
+    WasmSecurityScanSpec,
+};
+
+use super::SecurityScanDelta;
+
+fn build_security_finding(
+    severity: SecurityFindingSeverity,
+    category: impl Into<String>,
+    plugin_id: impl Into<String>,
+    source_path: impl Into<String>,
+    message: impl Into<String>,
+    evidence: Value,
+) -> SecurityFinding {
+    let category = category.into();
+    let plugin_id = plugin_id.into();
+    let source_path = source_path.into();
+    let message = message.into();
+    let correlation_id = security_finding_correlation_id(
+        &severity,
+        &category,
+        &plugin_id,
+        &source_path,
+        &message,
+        &evidence,
+    );
+
+    SecurityFinding {
+        correlation_id,
+        severity,
+        category,
+        plugin_id,
+        source_path,
+        message,
+        evidence,
+    }
+}
+
+fn security_finding_correlation_id(
+    severity: &SecurityFindingSeverity,
+    category: &str,
+    plugin_id: &str,
+    source_path: &str,
+    message: &str,
+    evidence: &Value,
+) -> String {
+    let canonical = json!({
+        "severity": severity,
+        "category": category,
+        "plugin_id": plugin_id,
+        "source_path": source_path,
+        "message": message,
+        "evidence": evidence,
+    });
+    let Ok(payload) = serde_json::to_vec(&canonical) else {
+        return "sf-0000000000000000".to_owned();
+    };
+    let digest = Sha256::digest(&payload);
+    let full = super::hex_lower(&digest);
+    format!("sf-{}", &full[..16])
+}
+
+pub(super) fn evaluate_plugin_security_scan(
+    report: &PluginScanReport,
+    policy: &SecurityScanSpec,
+    process_allowlist: &BTreeSet<String>,
+) -> SecurityScanDelta {
+    let mut delta = SecurityScanDelta::default();
+    let metadata_keywords =
+        super::approval_policy::normalize_signal_list(policy.high_risk_metadata_keywords.clone());
+    let blocked_import_prefixes =
+        super::approval_policy::normalize_signal_list(policy.wasm.blocked_import_prefixes.clone());
+    let allowed_path_prefixes =
+        super::normalize_allowed_path_prefixes(&policy.wasm.allowed_path_prefixes);
+
+    for descriptor in &report.descriptors {
+        delta.scanned_plugins = delta.scanned_plugins.saturating_add(1);
+        let bridge_kind = super::descriptor_bridge_kind(descriptor);
+        let metadata_finding = scan_descriptor_metadata_keywords(descriptor, &metadata_keywords);
+        accumulate_security_findings(&mut delta, metadata_finding);
+
+        match bridge_kind {
+            PluginBridgeKind::ProcessStdio => {
+                let findings = scan_process_stdio_security(descriptor, process_allowlist);
+                accumulate_security_findings(&mut delta, findings);
+            }
+            PluginBridgeKind::NativeFfi => {
+                let finding = build_security_finding(
+                    SecurityFindingSeverity::Medium,
+                    "native_ffi_review",
+                    descriptor.manifest.plugin_id.clone(),
+                    descriptor.path.clone(),
+                    "native_ffi plugin requires manual review and stronger sandboxing",
+                    json!({
+                        "bridge_kind": bridge_kind.as_str(),
+                        "recommendation": "prefer wasm_component for untrusted community plugins",
+                    }),
+                );
+                accumulate_security_findings(&mut delta, vec![finding]);
+            }
+            PluginBridgeKind::WasmComponent if policy.wasm.enabled => {
+                let findings = scan_wasm_plugin_security(
+                    descriptor,
+                    &policy.wasm,
+                    &blocked_import_prefixes,
+                    &allowed_path_prefixes,
+                );
+                accumulate_security_findings(&mut delta, findings);
+            }
+            PluginBridgeKind::HttpJson
+            | PluginBridgeKind::McpServer
+            | PluginBridgeKind::Unknown
+            | PluginBridgeKind::WasmComponent => {}
+        }
+    }
+
+    if policy.block_on_high && delta.high_findings > 0 {
+        delta.block_reason = Some(format!(
+            "security scan blocked {} high-risk finding(s)",
+            delta.high_findings
+        ));
+    }
+
+    delta
+}
+
+fn accumulate_security_findings(delta: &mut SecurityScanDelta, findings: Vec<SecurityFinding>) {
+    for finding in findings {
+        match finding.severity {
+            SecurityFindingSeverity::High => {
+                delta.high_findings = delta.high_findings.saturating_add(1)
+            }
+            SecurityFindingSeverity::Medium => {
+                delta.medium_findings = delta.medium_findings.saturating_add(1)
+            }
+            SecurityFindingSeverity::Low => {
+                delta.low_findings = delta.low_findings.saturating_add(1)
+            }
+        }
+        delta.findings.push(finding);
+    }
+}
+
+fn scan_descriptor_metadata_keywords(
+    descriptor: &PluginDescriptor,
+    keywords: &[String],
+) -> Vec<SecurityFinding> {
+    if keywords.is_empty() {
+        return Vec::new();
+    }
+
+    let mut haystack_parts = Vec::new();
+    for (key, value) in &descriptor.manifest.metadata {
+        haystack_parts.push(key.to_ascii_lowercase());
+        haystack_parts.push(value.to_ascii_lowercase());
+    }
+    let haystack = haystack_parts.join(" ");
+
+    keywords
+        .iter()
+        .filter(|keyword| haystack.contains(keyword.as_str()))
+        .map(|keyword| {
+            build_security_finding(
+                SecurityFindingSeverity::Medium,
+                "metadata_keyword",
+                descriptor.manifest.plugin_id.clone(),
+                descriptor.path.clone(),
+                format!("metadata contains high-risk keyword: {keyword}"),
+                json!({
+                    "keyword": keyword,
+                    "metadata": descriptor.manifest.metadata.clone(),
+                }),
+            )
+        })
+        .collect()
+}
+
+fn scan_process_stdio_security(
+    descriptor: &PluginDescriptor,
+    process_allowlist: &BTreeSet<String>,
+) -> Vec<SecurityFinding> {
+    let mut findings = Vec::new();
+    let command = descriptor.manifest.metadata.get("command").cloned();
+
+    match command {
+        Some(command) => {
+            if !is_process_command_allowed(&command, process_allowlist) {
+                findings.push(build_security_finding(
+                    SecurityFindingSeverity::High,
+                    "process_command_not_allowlisted",
+                    descriptor.manifest.plugin_id.clone(),
+                    descriptor.path.clone(),
+                    format!("process_stdio command {command} is not in runtime allowlist"),
+                    json!({
+                        "command": command,
+                        "allowlist": process_allowlist,
+                    }),
+                ));
+            }
+        }
+        None => findings.push(build_security_finding(
+            SecurityFindingSeverity::Medium,
+            "process_command_missing",
+            descriptor.manifest.plugin_id.clone(),
+            descriptor.path.clone(),
+            "process_stdio plugin does not declare metadata.command",
+            json!({
+                "recommendation": "declare a fixed command and keep bridge allowlist strict",
+            }),
+        )),
+    }
+
+    findings
+}
+
+fn normalize_wasm_sha256_pin(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("wasm sha256 pin must not be empty".to_owned());
+    }
+
+    let lowered = trimmed.to_ascii_lowercase();
+    let digest = lowered.strip_prefix("sha256:").unwrap_or(&lowered).trim();
+    if digest.len() != 64 || !digest.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return Err(
+            "wasm sha256 pin must be 64 hex characters (optional prefix `sha256:`)".to_owned(),
+        );
+    }
+
+    Ok(digest.to_owned())
+}
+
+fn scan_wasm_plugin_security(
+    descriptor: &PluginDescriptor,
+    policy: &WasmSecurityScanSpec,
+    blocked_import_prefixes: &[String],
+    allowed_path_prefixes: &[PathBuf],
+) -> Vec<SecurityFinding> {
+    let mut findings = Vec::new();
+    let artifact = descriptor_wasm_artifact(descriptor);
+    let Some(raw_artifact) = artifact else {
+        findings.push(build_security_finding(
+            SecurityFindingSeverity::High,
+            "wasm_artifact_missing",
+            descriptor.manifest.plugin_id.clone(),
+            descriptor.path.clone(),
+            "wasm plugin does not declare metadata.component/metadata.wasm_path/endpoint artifact",
+            json!({}),
+        ));
+        return findings;
+    };
+
+    if raw_artifact.starts_with("http://") || raw_artifact.starts_with("https://") {
+        findings.push(build_security_finding(
+            SecurityFindingSeverity::High,
+            "wasm_remote_artifact",
+            descriptor.manifest.plugin_id.clone(),
+            descriptor.path.clone(),
+            "remote wasm artifact cannot be statically verified for local hotplug safety",
+            json!({
+                "artifact": raw_artifact,
+            }),
+        ));
+        return findings;
+    }
+
+    let artifact_path = super::resolve_plugin_relative_path(&descriptor.path, &raw_artifact);
+    let normalized_artifact_path = super::normalize_path_for_policy(&artifact_path);
+    if !allowed_path_prefixes.is_empty()
+        && !allowed_path_prefixes
+            .iter()
+            .any(|prefix| normalized_artifact_path.starts_with(prefix))
+    {
+        findings.push(build_security_finding(
+            SecurityFindingSeverity::High,
+            "wasm_artifact_path_not_allowed",
+            descriptor.manifest.plugin_id.clone(),
+            descriptor.path.clone(),
+            "wasm artifact path is outside allowed_path_prefixes",
+            json!({
+                "artifact_path": normalized_artifact_path.display().to_string(),
+                "allowed_path_prefixes": allowed_path_prefixes
+                    .iter()
+                    .map(|prefix| prefix.display().to_string())
+                    .collect::<Vec<_>>(),
+            }),
+        ));
+        return findings;
+    }
+
+    let bytes = match fs::read(&normalized_artifact_path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            findings.push(build_security_finding(
+                SecurityFindingSeverity::High,
+                "wasm_artifact_unreadable",
+                descriptor.manifest.plugin_id.clone(),
+                descriptor.path.clone(),
+                "wasm artifact cannot be read from filesystem",
+                json!({
+                    "artifact_path": normalized_artifact_path.display().to_string(),
+                    "error": error.to_string(),
+                }),
+            ));
+            return findings;
+        }
+    };
+
+    if bytes.len() > policy.max_module_bytes {
+        findings.push(build_security_finding(
+            SecurityFindingSeverity::High,
+            "wasm_module_too_large",
+            descriptor.manifest.plugin_id.clone(),
+            descriptor.path.clone(),
+            format!(
+                "wasm module size {} exceeds max_module_bytes {}",
+                bytes.len(),
+                policy.max_module_bytes
+            ),
+            json!({
+                "artifact_path": normalized_artifact_path.display().to_string(),
+                "module_size_bytes": bytes.len(),
+                "max_module_bytes": policy.max_module_bytes,
+            }),
+        ));
+    }
+
+    if !bytes.starts_with(&[0x00, 0x61, 0x73, 0x6d]) {
+        findings.push(build_security_finding(
+            SecurityFindingSeverity::High,
+            "wasm_magic_header_invalid",
+            descriptor.manifest.plugin_id.clone(),
+            descriptor.path.clone(),
+            "artifact does not contain valid wasm magic header",
+            json!({
+                "artifact_path": normalized_artifact_path.display().to_string(),
+            }),
+        ));
+        return findings;
+    }
+
+    let digest = Sha256::digest(&bytes);
+    let digest_hex = super::hex_lower(&digest);
+
+    let expected_sha256 = {
+        let mut metadata_pins = Vec::new();
+        for key in [
+            "component_sha256",
+            "component_sha256_pin",
+            "component_sha256_hex",
+        ] {
+            let Some(raw_pin) = descriptor.manifest.metadata.get(key) else {
+                continue;
+            };
+            match normalize_wasm_sha256_pin(raw_pin) {
+                Ok(pin) => metadata_pins.push((format!("metadata.{key}"), pin)),
+                Err(reason) => findings.push(build_security_finding(
+                    SecurityFindingSeverity::High,
+                    "wasm_sha256_pin_invalid",
+                    descriptor.manifest.plugin_id.clone(),
+                    descriptor.path.clone(),
+                    "wasm sha256 pin format is invalid",
+                    json!({
+                        "source": format!("metadata.{key}"),
+                        "pin": raw_pin,
+                        "reason": reason,
+                    }),
+                )),
+            }
+        }
+
+        let metadata_pin = if let Some((source, pin)) = metadata_pins.first() {
+            if let Some((conflict_source, conflict_pin)) =
+                metadata_pins.iter().find(|(_, candidate)| candidate != pin)
+            {
+                findings.push(build_security_finding(
+                    SecurityFindingSeverity::High,
+                    "wasm_sha256_pin_conflict",
+                    descriptor.manifest.plugin_id.clone(),
+                    descriptor.path.clone(),
+                    "multiple metadata wasm sha256 pins conflict with each other",
+                    json!({
+                        "first_source": source,
+                        "first_sha256": pin,
+                        "conflict_source": conflict_source,
+                        "conflict_sha256": conflict_pin,
+                    }),
+                ));
+                None
+            } else {
+                Some(pin.clone())
+            }
+        } else {
+            None
+        };
+
+        let policy_pin = if let Some(raw_pin) = policy
+            .required_sha256_by_plugin
+            .get(&descriptor.manifest.plugin_id)
+        {
+            match normalize_wasm_sha256_pin(raw_pin) {
+                Ok(pin) => Some(pin),
+                Err(reason) => {
+                    findings.push(build_security_finding(
+                        SecurityFindingSeverity::High,
+                        "wasm_sha256_pin_invalid",
+                        descriptor.manifest.plugin_id.clone(),
+                        descriptor.path.clone(),
+                        "wasm sha256 pin format is invalid",
+                        json!({
+                            "source": "security_scan.wasm.required_sha256_by_plugin",
+                            "pin": raw_pin,
+                            "reason": reason,
+                        }),
+                    ));
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        match (metadata_pin, policy_pin) {
+            (Some(metadata_pin), Some(policy_pin)) => {
+                if metadata_pin != policy_pin {
+                    findings.push(build_security_finding(
+                        SecurityFindingSeverity::High,
+                        "wasm_sha256_pin_conflict",
+                        descriptor.manifest.plugin_id.clone(),
+                        descriptor.path.clone(),
+                        "metadata wasm sha256 pin conflicts with required_sha256_by_plugin pin",
+                        json!({
+                            "metadata_sha256": metadata_pin,
+                            "policy_sha256": policy_pin,
+                        }),
+                    ));
+                    None
+                } else {
+                    Some(policy_pin)
+                }
+            }
+            (Some(metadata_pin), None) => Some(metadata_pin),
+            (None, Some(policy_pin)) => Some(policy_pin),
+            (None, None) => {
+                if policy.require_hash_pin {
+                    findings.push(build_security_finding(
+                        SecurityFindingSeverity::High,
+                        "wasm_sha256_pin_missing",
+                        descriptor.manifest.plugin_id.clone(),
+                        descriptor.path.clone(),
+                        "wasm hash pin is required but missing for plugin",
+                        json!({
+                            "required_sha256_by_plugin": policy.required_sha256_by_plugin,
+                        }),
+                    ));
+                }
+                None
+            }
+        }
+    };
+
+    if let Some(expected) = expected_sha256 {
+        if !expected.eq_ignore_ascii_case(&digest_hex) {
+            findings.push(build_security_finding(
+                SecurityFindingSeverity::High,
+                "wasm_sha256_mismatch",
+                descriptor.manifest.plugin_id.clone(),
+                descriptor.path.clone(),
+                "wasm sha256 does not match required pin",
+                json!({
+                    "expected_sha256": expected,
+                    "actual_sha256": digest_hex,
+                }),
+            ));
+        }
+    }
+
+    let imports = match parse_wasm_import_modules(&bytes) {
+        Ok(imports) => imports,
+        Err(error) => {
+            findings.push(build_security_finding(
+                SecurityFindingSeverity::High,
+                "wasm_parse_failed",
+                descriptor.manifest.plugin_id.clone(),
+                descriptor.path.clone(),
+                "wasm parser failed while reading module imports",
+                json!({
+                    "artifact_path": normalized_artifact_path.display().to_string(),
+                    "error": error,
+                }),
+            ));
+            return findings;
+        }
+    };
+
+    for module_name in &imports {
+        let module_name_lower = module_name.to_ascii_lowercase();
+        if !policy.allow_wasi && module_name_lower.starts_with("wasi") {
+            findings.push(build_security_finding(
+                SecurityFindingSeverity::High,
+                "wasm_wasi_import_blocked",
+                descriptor.manifest.plugin_id.clone(),
+                descriptor.path.clone(),
+                "wasi import is blocked by wasm security policy",
+                json!({
+                    "import_module": module_name,
+                }),
+            ));
+        }
+        if blocked_import_prefixes
+            .iter()
+            .any(|prefix| module_name_lower.starts_with(prefix))
+        {
+            findings.push(build_security_finding(
+                SecurityFindingSeverity::High,
+                "wasm_import_prefix_blocked",
+                descriptor.manifest.plugin_id.clone(),
+                descriptor.path.clone(),
+                "wasm import module matched blocked prefix",
+                json!({
+                    "import_module": module_name,
+                    "blocked_import_prefixes": blocked_import_prefixes,
+                }),
+            ));
+        }
+    }
+
+    findings.push(build_security_finding(
+        SecurityFindingSeverity::Low,
+        "wasm_digest_observed",
+        descriptor.manifest.plugin_id.clone(),
+        descriptor.path.clone(),
+        "wasm artifact digest captured for audit",
+        json!({
+            "artifact_path": normalized_artifact_path.display().to_string(),
+            "sha256": digest_hex,
+            "imports": imports,
+        }),
+    ));
+
+    findings
+}
+
+fn parse_wasm_import_modules(bytes: &[u8]) -> Result<Vec<String>, String> {
+    let mut modules = Vec::new();
+    for payload in WasmParser::new(0).parse_all(bytes) {
+        match payload {
+            Ok(WasmPayload::ImportSection(section)) => {
+                for import in section.into_imports() {
+                    let import = import.map_err(|error| error.to_string())?;
+                    modules.push(import.module.to_owned());
+                }
+            }
+            Ok(_) => {}
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+    Ok(modules)
+}
+
+fn descriptor_wasm_artifact(descriptor: &PluginDescriptor) -> Option<String> {
+    descriptor
+        .manifest
+        .metadata
+        .get("component")
+        .cloned()
+        .or_else(|| descriptor.manifest.metadata.get("wasm_path").cloned())
+        .or_else(|| {
+            descriptor
+                .manifest
+                .endpoint
+                .clone()
+                .filter(|value| value.to_ascii_lowercase().ends_with(".wasm"))
+        })
+}

--- a/crates/spec/src/spec_execution/security_scan_policy.rs
+++ b/crates/spec/src/spec_execution/security_scan_policy.rs
@@ -1,0 +1,295 @@
+use std::{collections::BTreeSet, fs, io::Write, path::Path};
+
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use ed25519_dalek::{Signature as Ed25519Signature, Verifier, VerifyingKey};
+use serde_json::json;
+
+use crate::spec_runtime::*;
+use crate::BUNDLED_SECURITY_SCAN_PROFILE;
+
+use super::SecurityScanDelta;
+
+pub fn security_scan_policy(spec: &RunnerSpec) -> Result<Option<SecurityScanSpec>, String> {
+    let Some(mut policy) = spec
+        .bridge_support
+        .as_ref()
+        .filter(|bridge| bridge.enabled)
+        .and_then(|bridge| bridge.security_scan.clone())
+    else {
+        return Ok(None);
+    };
+
+    if !policy.enabled {
+        return Ok(None);
+    }
+
+    validate_security_scan_policy(&policy)?;
+
+    let profile = resolve_security_scan_profile(&policy)?;
+
+    if policy.high_risk_metadata_keywords.is_empty() {
+        policy.high_risk_metadata_keywords = profile.high_risk_metadata_keywords;
+    }
+
+    if policy.wasm.blocked_import_prefixes.is_empty() {
+        policy.wasm.blocked_import_prefixes = profile.wasm.blocked_import_prefixes;
+    }
+
+    if policy.wasm.max_module_bytes == 0 {
+        policy.wasm.max_module_bytes = profile.wasm.max_module_bytes;
+    }
+
+    if policy.wasm.allowed_path_prefixes.is_empty() {
+        policy.wasm.allowed_path_prefixes = profile.wasm.allowed_path_prefixes;
+    }
+
+    if policy.wasm.required_sha256_by_plugin.is_empty() {
+        policy.wasm.required_sha256_by_plugin = profile.wasm.required_sha256_by_plugin;
+    }
+
+    Ok(Some(policy))
+}
+
+fn validate_security_scan_policy(policy: &SecurityScanSpec) -> Result<(), String> {
+    if policy.profile_sha256.is_some() && policy.profile_path.is_none() {
+        return Err(
+            "security scan profile_sha256 requires security_scan.profile_path to be set".to_owned(),
+        );
+    }
+    if policy.profile_signature.is_some() && policy.profile_path.is_none() {
+        return Err(
+            "security scan profile_signature requires security_scan.profile_path to be set"
+                .to_owned(),
+        );
+    }
+    if let Some(signature) = policy.profile_signature.as_ref() {
+        if signature.public_key_base64.trim().is_empty() {
+            return Err(
+                "security scan profile_signature.public_key_base64 cannot be empty".to_owned(),
+            );
+        }
+        if signature.signature_base64.trim().is_empty() {
+            return Err(
+                "security scan profile_signature.signature_base64 cannot be empty".to_owned(),
+            );
+        }
+    }
+    if let Some(export) = policy.siem_export.as_ref().filter(|value| value.enabled) {
+        if export.path.trim().is_empty() {
+            return Err("security scan siem_export.path cannot be empty when enabled".to_owned());
+        }
+    }
+    if policy.runtime.execute_wasm_component && policy.runtime.allowed_path_prefixes.is_empty() {
+        return Err(
+            "security scan runtime.execute_wasm_component requires runtime.allowed_path_prefixes to be configured".to_owned(),
+        );
+    }
+    Ok(())
+}
+
+fn resolve_security_scan_profile(policy: &SecurityScanSpec) -> Result<SecurityScanProfile, String> {
+    if let Some(path) = policy.profile_path.as_deref() {
+        let profile = load_security_scan_profile_from_path(path);
+        match profile {
+            Ok(profile) => {
+                if let Some(expected_sha256) = policy.profile_sha256.as_deref() {
+                    let actual_sha256 = super::security_scan_profile_sha256(&profile);
+                    if !expected_sha256.eq_ignore_ascii_case(&actual_sha256) {
+                        return Err(format!(
+                            "security scan profile sha256 mismatch for {path}: expected {expected_sha256}, actual {actual_sha256}",
+                        ));
+                    }
+                }
+                if let Some(signature) = policy.profile_signature.as_ref() {
+                    verify_security_scan_profile_signature(&profile, signature).map_err(|error| {
+                        format!(
+                            "security scan profile signature verification failed for {path}: {error}"
+                        )
+                    })?;
+                }
+                return Ok(profile);
+            }
+            Err(error) if policy.profile_sha256.is_some() || policy.profile_signature.is_some() => {
+                return Err(format!(
+                    "failed to load security scan profile at {path} while profile integrity is pinned: {error}",
+                ));
+            }
+            Err(_) => {}
+        }
+    }
+
+    Ok(bundled_security_scan_profile())
+}
+
+pub fn load_security_scan_profile_from_path(path: &str) -> Result<SecurityScanProfile, String> {
+    let content =
+        fs::read_to_string(path).map_err(|error| format!("read profile failed: {error}"))?;
+    serde_json::from_str::<SecurityScanProfile>(&content)
+        .map_err(|error| format!("parse profile failed: {error}"))
+}
+
+fn bundled_security_scan_profile() -> SecurityScanProfile {
+    BUNDLED_SECURITY_SCAN_PROFILE
+        .get_or_init(|| {
+            let raw = include_str!("../../config/security-scan-medium-balanced.json");
+            serde_json::from_str(raw)
+                .or_else(|_| serde_json::from_str::<SecurityScanProfile>("{}"))
+                .unwrap_or_else(|_| SecurityScanProfile {
+                    high_risk_metadata_keywords: Vec::new(),
+                    wasm: WasmSecurityScanSpec::default(),
+                })
+        })
+        .clone()
+}
+
+fn verify_security_scan_profile_signature(
+    profile: &SecurityScanProfile,
+    signature: &SecurityProfileSignatureSpec,
+) -> Result<(), String> {
+    let algorithm = signature.algorithm.trim().to_ascii_lowercase();
+    if algorithm != "ed25519" {
+        return Err(format!(
+            "unsupported profile signature algorithm: {algorithm} (expected ed25519)"
+        ));
+    }
+
+    let public_key_bytes = BASE64_STANDARD
+        .decode(signature.public_key_base64.trim())
+        .map_err(|error| format!("invalid public_key_base64: {error}"))?;
+    let public_key_bytes: [u8; 32] = public_key_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_err| "invalid ed25519 public key length (expected 32 bytes)".to_owned())?;
+    let verifying_key = VerifyingKey::from_bytes(&public_key_bytes)
+        .map_err(|error| format!("invalid ed25519 public key bytes: {error}"))?;
+
+    let signature_bytes = BASE64_STANDARD
+        .decode(signature.signature_base64.trim())
+        .map_err(|error| format!("invalid signature_base64: {error}"))?;
+    let signature_bytes: [u8; 64] = signature_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_err| "invalid ed25519 signature length (expected 64 bytes)".to_owned())?;
+    let signature = Ed25519Signature::from_bytes(&signature_bytes);
+
+    let message = super::security_scan_profile_message(profile);
+    verifying_key
+        .verify(&message, &signature)
+        .map_err(|error| format!("ed25519 verification failed: {error}"))
+}
+
+pub(super) fn security_scan_process_allowlist(spec: &RunnerSpec) -> BTreeSet<String> {
+    spec.bridge_support
+        .as_ref()
+        .filter(|bridge| bridge.enabled)
+        .map(|bridge| {
+            bridge
+                .allowed_process_commands
+                .iter()
+                .map(|value| value.trim().to_ascii_lowercase())
+                .filter(|value| !value.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub(super) fn apply_security_scan_delta(report: &mut SecurityScanReport, delta: SecurityScanDelta) {
+    report.scanned_plugins = report.scanned_plugins.saturating_add(delta.scanned_plugins);
+    report.high_findings = report.high_findings.saturating_add(delta.high_findings);
+    report.medium_findings = report.medium_findings.saturating_add(delta.medium_findings);
+    report.low_findings = report.low_findings.saturating_add(delta.low_findings);
+    report.total_findings = report
+        .high_findings
+        .saturating_add(report.medium_findings)
+        .saturating_add(report.low_findings);
+    report.findings.extend(delta.findings);
+    if let Some(reason) = delta.block_reason {
+        report.blocked = true;
+        report.block_reason = Some(reason);
+    }
+}
+
+pub(super) fn emit_security_scan_siem_record(
+    pack_id: &str,
+    agent_id: &str,
+    report: &SecurityScanReport,
+    export: &SecuritySiemExportSpec,
+) -> Result<SecuritySiemExportReport, String> {
+    let mut findings = report.findings.clone();
+    let mut truncated_findings = 0usize;
+
+    if export.include_findings {
+        if let Some(limit) = export.max_findings_per_record {
+            if findings.len() > limit {
+                truncated_findings = findings.len().saturating_sub(limit);
+                findings.truncate(limit);
+            }
+        }
+    } else {
+        truncated_findings = report.findings.len();
+        findings.clear();
+    }
+
+    let categories: Vec<String> = report
+        .findings
+        .iter()
+        .map(|finding| finding.category.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let finding_ids: Vec<String> = report
+        .findings
+        .iter()
+        .map(|finding| finding.correlation_id.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    let record = json!({
+        "event_type": "security_scan_report",
+        "ts_epoch_s": super::current_epoch_s(),
+        "pack_id": pack_id,
+        "agent_id": agent_id,
+        "blocked": report.blocked,
+        "block_reason": report.block_reason.clone(),
+        "counts": {
+            "scanned_plugins": report.scanned_plugins,
+            "total_findings": report.total_findings,
+            "high_findings": report.high_findings,
+            "medium_findings": report.medium_findings,
+            "low_findings": report.low_findings,
+        },
+        "categories": categories,
+        "finding_ids": finding_ids,
+        "truncated_findings": truncated_findings,
+        "findings": findings,
+    });
+
+    let path = Path::new(&export.path);
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("create siem export directory failed: {error}"))?;
+        }
+    }
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| format!("open siem export file failed: {error}"))?;
+    serde_json::to_writer(&mut file, &record)
+        .map_err(|error| format!("serialize siem export record failed: {error}"))?;
+    file.write_all(b"\n")
+        .map_err(|error| format!("flush siem export record failed: {error}"))?;
+
+    Ok(SecuritySiemExportReport {
+        enabled: true,
+        path: export.path.clone(),
+        success: true,
+        exported_records: 1,
+        exported_findings: findings.len(),
+        truncated_findings,
+        error: None,
+    })
+}

--- a/crates/spec/src/spec_execution/tool_search.rs
+++ b/crates/spec/src/spec_execution/tool_search.rs
@@ -1,0 +1,358 @@
+use std::collections::BTreeMap;
+
+use kernel::{IntegrationCatalog, PluginBridgeKind, PluginScanReport, PluginTranslationReport};
+use serde_json::Value;
+
+use super::descriptor_bridge_kind;
+use crate::spec_runtime::{detect_provider_bridge_kind, ToolSearchEntry, ToolSearchResult};
+
+pub(super) fn execute_tool_search(
+    integration_catalog: &IntegrationCatalog,
+    plugin_scan_reports: &[PluginScanReport],
+    plugin_translation_reports: &[PluginTranslationReport],
+    query: &str,
+    limit: usize,
+    include_deferred: bool,
+    include_examples: bool,
+) -> Vec<ToolSearchResult> {
+    let mut entries: BTreeMap<String, ToolSearchEntry> = BTreeMap::new();
+    let mut translation_by_key: BTreeMap<
+        (String, String),
+        (PluginBridgeKind, String, String, String),
+    > = BTreeMap::new();
+
+    for report in plugin_translation_reports {
+        for entry in &report.entries {
+            translation_by_key.insert(
+                (entry.source_path.clone(), entry.plugin_id.clone()),
+                (
+                    entry.runtime.bridge_kind,
+                    entry.runtime.adapter_family.clone(),
+                    entry.runtime.entrypoint_hint.clone(),
+                    entry.runtime.source_language.clone(),
+                ),
+            );
+        }
+    }
+
+    for provider in integration_catalog.providers() {
+        let channel_endpoint = integration_catalog
+            .channels_for_provider(&provider.provider_id)
+            .into_iter()
+            .find(|channel| channel.enabled)
+            .map(|channel| channel.endpoint)
+            .unwrap_or_default();
+        let bridge_kind = detect_provider_bridge_kind(&provider, &channel_endpoint);
+        let tool_id = format!("{}::{}", provider.provider_id, provider.connector_name);
+        let summary = provider.metadata.get("summary").cloned();
+        let tags = metadata_tags(&provider.metadata);
+        let input_examples = metadata_examples(&provider.metadata, "input_examples_json");
+        let output_examples = metadata_examples(&provider.metadata, "output_examples_json");
+        let deferred = metadata_bool(&provider.metadata, "defer_loading").unwrap_or(false);
+        let mut adapter_family = provider.metadata.get("adapter_family").cloned();
+        let mut entrypoint_hint = provider
+            .metadata
+            .get("entrypoint")
+            .or_else(|| provider.metadata.get("entrypoint_hint"))
+            .cloned();
+        let mut source_language = provider.metadata.get("source_language").cloned();
+        let mut resolved_bridge_kind = bridge_kind;
+
+        if let (Some(source_path), Some(plugin_id)) = (
+            provider.metadata.get("plugin_source_path"),
+            provider.metadata.get("plugin_id"),
+        ) {
+            if let Some((bridge, adapter, entrypoint, language)) =
+                translation_by_key.get(&(source_path.clone(), plugin_id.clone()))
+            {
+                resolved_bridge_kind = *bridge;
+                adapter_family = Some(adapter.clone());
+                entrypoint_hint = Some(entrypoint.clone());
+                source_language = Some(language.clone());
+            }
+        }
+
+        entries.insert(
+            tool_id.clone(),
+            ToolSearchEntry {
+                tool_id,
+                plugin_id: provider.metadata.get("plugin_id").cloned(),
+                connector_name: provider.connector_name.clone(),
+                provider_id: provider.provider_id.clone(),
+                source_path: provider.metadata.get("plugin_source_path").cloned(),
+                bridge_kind: resolved_bridge_kind,
+                adapter_family,
+                entrypoint_hint,
+                source_language,
+                summary,
+                tags,
+                input_examples,
+                output_examples,
+                deferred,
+                loaded: true,
+            },
+        );
+    }
+
+    for report in plugin_scan_reports {
+        for descriptor in &report.descriptors {
+            let manifest = &descriptor.manifest;
+            let tool_id = format!("{}::{}", manifest.provider_id, manifest.connector_name);
+            let translation =
+                translation_by_key.get(&(descriptor.path.clone(), manifest.plugin_id.clone()));
+            let bridge_kind = translation
+                .map(|(bridge, _, _, _)| *bridge)
+                .unwrap_or_else(|| descriptor_bridge_kind(descriptor));
+            let adapter_family = translation.map(|(_, adapter, _, _)| adapter.clone());
+            let entrypoint_hint = translation.map(|(_, _, entrypoint, _)| entrypoint.clone());
+            let source_language = translation.map(|(_, _, _, language)| language.clone());
+
+            let entry = entries
+                .entry(tool_id.clone())
+                .or_insert_with(|| ToolSearchEntry {
+                    tool_id: tool_id.clone(),
+                    plugin_id: Some(manifest.plugin_id.clone()),
+                    connector_name: manifest.connector_name.clone(),
+                    provider_id: manifest.provider_id.clone(),
+                    source_path: Some(descriptor.path.clone()),
+                    bridge_kind,
+                    adapter_family: adapter_family.clone(),
+                    entrypoint_hint: entrypoint_hint.clone(),
+                    source_language: source_language.clone(),
+                    summary: manifest.summary.clone(),
+                    tags: manifest.tags.clone(),
+                    input_examples: manifest.input_examples.clone(),
+                    output_examples: manifest.output_examples.clone(),
+                    deferred: manifest.defer_loading,
+                    loaded: false,
+                });
+
+            if entry.plugin_id.is_none() {
+                entry.plugin_id = Some(manifest.plugin_id.clone());
+            }
+            if entry.source_path.is_none() {
+                entry.source_path = Some(descriptor.path.clone());
+            }
+            if entry.summary.is_none() {
+                entry.summary = manifest.summary.clone();
+            }
+            if entry.adapter_family.is_none() {
+                entry.adapter_family = adapter_family.clone();
+            }
+            if entry.entrypoint_hint.is_none() {
+                entry.entrypoint_hint = entrypoint_hint.clone();
+            }
+            if entry.source_language.is_none() {
+                entry.source_language = source_language.clone();
+            }
+            if entry.input_examples.is_empty() {
+                entry.input_examples = manifest.input_examples.clone();
+            }
+            if entry.output_examples.is_empty() {
+                entry.output_examples = manifest.output_examples.clone();
+            }
+            for tag in &manifest.tags {
+                if !entry.tags.iter().any(|existing| existing == tag) {
+                    entry.tags.push(tag.clone());
+                }
+            }
+            if !entry.loaded {
+                entry.deferred = manifest.defer_loading;
+                entry.bridge_kind = bridge_kind;
+            }
+        }
+    }
+
+    let query_normalized = query.trim().to_ascii_lowercase();
+    let tokens: Vec<String> = query_normalized
+        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '-')
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(str::to_owned)
+        .collect();
+
+    let mut ranked: Vec<(u32, ToolSearchEntry)> = entries
+        .into_values()
+        .filter(|entry| include_deferred || !entry.deferred || entry.loaded)
+        .filter_map(|entry| {
+            let score = tool_search_score(&entry, &query_normalized, &tokens);
+            if query_normalized.is_empty() || score > 0 {
+                Some((score, entry))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    ranked.sort_by(|(left_score, left), (right_score, right)| {
+        right_score
+            .cmp(left_score)
+            .then_with(|| right.loaded.cmp(&left.loaded))
+            .then_with(|| left.tool_id.cmp(&right.tool_id))
+    });
+
+    let capped_limit = limit.clamp(1, 50);
+    ranked
+        .into_iter()
+        .take(capped_limit)
+        .map(|(score, entry)| ToolSearchResult {
+            tool_id: entry.tool_id,
+            plugin_id: entry.plugin_id,
+            connector_name: entry.connector_name,
+            provider_id: entry.provider_id,
+            source_path: entry.source_path,
+            bridge_kind: entry.bridge_kind.as_str().to_owned(),
+            adapter_family: entry.adapter_family,
+            entrypoint_hint: entry.entrypoint_hint,
+            source_language: entry.source_language,
+            score,
+            deferred: entry.deferred,
+            loaded: entry.loaded,
+            summary: entry.summary,
+            tags: entry.tags,
+            input_examples: if include_examples {
+                entry.input_examples
+            } else {
+                Vec::new()
+            },
+            output_examples: if include_examples {
+                entry.output_examples
+            } else {
+                Vec::new()
+            },
+        })
+        .collect()
+}
+
+fn metadata_tags(metadata: &BTreeMap<String, String>) -> Vec<String> {
+    if let Some(raw_json) = metadata.get("tags_json") {
+        if let Ok(values) = serde_json::from_str::<Vec<String>>(raw_json) {
+            return values;
+        }
+    }
+
+    metadata
+        .get("tags")
+        .map(|raw| {
+            raw.split([',', ';'])
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn metadata_examples(metadata: &BTreeMap<String, String>, key: &str) -> Vec<Value> {
+    metadata
+        .get(key)
+        .and_then(|raw| serde_json::from_str::<Vec<Value>>(raw).ok())
+        .unwrap_or_default()
+}
+
+fn metadata_bool(metadata: &BTreeMap<String, String>, key: &str) -> Option<bool> {
+    metadata
+        .get(key)
+        .and_then(|raw| match raw.trim().to_ascii_lowercase().as_str() {
+            "true" | "1" | "yes" | "y" | "on" => Some(true),
+            "false" | "0" | "no" | "n" | "off" => Some(false),
+            _ => None,
+        })
+}
+
+fn tool_search_score(entry: &ToolSearchEntry, query: &str, tokens: &[String]) -> u32 {
+    if query.is_empty() {
+        return if entry.loaded { 10 } else { 5 };
+    }
+
+    let connector = entry.connector_name.to_ascii_lowercase();
+    let provider = entry.provider_id.to_ascii_lowercase();
+    let tool_id = entry.tool_id.to_ascii_lowercase();
+    let summary = entry
+        .summary
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let source_path = entry
+        .source_path
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let adapter_family = entry
+        .adapter_family
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let entrypoint_hint = entry
+        .entrypoint_hint
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let source_language = entry
+        .source_language
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let tags: Vec<String> = entry
+        .tags
+        .iter()
+        .map(|tag| tag.to_ascii_lowercase())
+        .collect();
+
+    let mut score = 0_u32;
+    if connector == query {
+        score = score.saturating_add(150);
+    } else if connector.contains(query) {
+        score = score.saturating_add(110);
+    }
+    if provider == query {
+        score = score.saturating_add(120);
+    } else if provider.contains(query) {
+        score = score.saturating_add(80);
+    }
+    if tool_id.contains(query) {
+        score = score.saturating_add(60);
+    }
+    if summary.contains(query) {
+        score = score.saturating_add(55);
+    }
+    if source_path.contains(query) {
+        score = score.saturating_add(35);
+    }
+    if adapter_family.contains(query) {
+        score = score.saturating_add(18);
+    }
+    if entrypoint_hint.contains(query) {
+        score = score.saturating_add(12);
+    }
+    if source_language.contains(query) {
+        score = score.saturating_add(10);
+    }
+    if tags.iter().any(|tag| tag == query) {
+        score = score.saturating_add(45);
+    } else if tags.iter().any(|tag| tag.contains(query)) {
+        score = score.saturating_add(25);
+    }
+
+    let haystack = format!(
+        "{} {} {} {} {} {} {} {}",
+        connector,
+        provider,
+        tool_id,
+        summary,
+        adapter_family,
+        entrypoint_hint,
+        source_language,
+        tags.join(" ")
+    );
+    for token in tokens {
+        if haystack.contains(token) {
+            score = score.saturating_add(8);
+        }
+    }
+
+    if entry.loaded {
+        score = score.saturating_add(4);
+    }
+    score
+}

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -1,11 +1,10 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
+    collections::{BTreeMap, BTreeSet},
     fs,
     io::Read,
     path::{Path, PathBuf},
-    process::Stdio,
-    sync::{Arc, Mutex, OnceLock},
-    time::{Duration, UNIX_EPOCH},
+    sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -21,19 +20,11 @@ use kernel::{
     ToolCoreOutcome, ToolCoreRequest, ToolExtensionAdapter, ToolExtensionOutcome,
     ToolExtensionRequest, VerticalPackManifest,
 };
-use loongclaw_protocol::{
-    JsonLineTransport, OutboundFrame, ProtocolRouter, RouteAuthorizationRequest, Transport,
-    TransportInfo,
-};
-use reqwest::Method;
+use loongclaw_protocol::{OutboundFrame, ProtocolRouter, RouteAuthorizationRequest};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
-use tokio::{
-    io::AsyncReadExt,
-    process::Command as TokioCommand,
-    time::{sleep, timeout, Instant as TokioInstant},
-};
+use tokio::time::{sleep, Instant as TokioInstant};
 use wasmtime::{
     Config as WasmtimeConfig, Engine as WasmtimeEngine, Linker as WasmtimeLinker,
     Module as WasmtimeModule, Store as WasmtimeStore,
@@ -42,178 +33,22 @@ use wasmtime::{
 use crate::spec_execution::{normalize_path_for_policy, resolve_plugin_relative_path};
 use crate::WEBHOOK_TEST_RETRY_STATE;
 
-const DEFAULT_WASM_MODULE_CACHE_CAPACITY: usize = 32;
-const MAX_WASM_MODULE_CACHE_CAPACITY: usize = 4096;
-const DEFAULT_WASM_MODULE_CACHE_MAX_BYTES: usize = 64 * 1024 * 1024;
-const MIN_WASM_MODULE_CACHE_MAX_BYTES: usize = 64 * 1024;
-const MAX_WASM_MODULE_CACHE_MAX_BYTES: usize = 512 * 1024 * 1024;
-static WASM_MODULE_CACHE: OnceLock<Mutex<WasmModuleCache>> = OnceLock::new();
-static WASM_MODULE_CACHE_CAPACITY: OnceLock<usize> = OnceLock::new();
-static WASM_MODULE_CACHE_MAX_BYTES: OnceLock<usize> = OnceLock::new();
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct WasmModuleCacheKey {
-    artifact_path: PathBuf,
-    module_size_bytes: u64,
-    artifact_modified_unix_ns: Option<u128>,
-    artifact_file_identity: Option<WasmArtifactFileIdentity>,
-    expected_sha256: Option<String>,
-    fuel_enabled: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct WasmArtifactFileIdentity {
-    device_id: u64,
-    inode: u64,
-    ctime_seconds: i64,
-    ctime_nanoseconds: i64,
-}
-
-#[derive(Debug, Clone)]
-struct CachedWasmModule {
-    engine: WasmtimeEngine,
-    module: WasmtimeModule,
-    artifact_sha256: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct WasmModuleCacheLookup {
-    hit: bool,
-    inserted: bool,
-    evicted_entries: usize,
-    cache_len: usize,
-    cache_capacity: usize,
-    cache_total_module_bytes: usize,
-    cache_max_bytes: usize,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct WasmModuleCacheInsertOutcome {
-    inserted: bool,
-    evicted_entries: usize,
-}
-
-#[derive(Debug, Clone)]
-struct WasmModuleCacheEntry {
-    module: Arc<CachedWasmModule>,
-    module_size_bytes: usize,
-}
-
-#[derive(Debug, Default)]
-struct WasmModuleCache {
-    order: VecDeque<WasmModuleCacheKey>,
-    entries: HashMap<WasmModuleCacheKey, WasmModuleCacheEntry>,
-    total_module_bytes: usize,
-}
-
-impl WasmModuleCache {
-    fn len(&self) -> usize {
-        self.entries.len()
-    }
-
-    fn total_module_bytes(&self) -> usize {
-        self.total_module_bytes
-    }
-
-    fn touch(&mut self, key: &WasmModuleCacheKey) {
-        if let Some(position) = self.order.iter().position(|candidate| candidate == key) {
-            let _ = self.order.remove(position);
-        }
-        self.order.push_back(key.clone());
-    }
-
-    fn remove_by_key(&mut self, key: &WasmModuleCacheKey) -> bool {
-        self.order.retain(|candidate| candidate != key);
-        let Some(removed) = self.entries.remove(key) else {
-            return false;
-        };
-        self.total_module_bytes = self
-            .total_module_bytes
-            .saturating_sub(removed.module_size_bytes);
-        true
-    }
-
-    fn evict_oldest(&mut self) -> bool {
-        while let Some(oldest) = self.order.pop_front() {
-            if let Some(removed) = self.entries.remove(&oldest) {
-                self.total_module_bytes = self
-                    .total_module_bytes
-                    .saturating_sub(removed.module_size_bytes);
-                return true;
-            }
-        }
-        false
-    }
-
-    fn clear(&mut self) {
-        self.order.clear();
-        self.entries.clear();
-        self.total_module_bytes = 0;
-    }
-
-    fn get(&mut self, key: &WasmModuleCacheKey) -> Option<Arc<CachedWasmModule>> {
-        let entry = self.entries.get(key)?.module.clone();
-        self.touch(key);
-        Some(entry)
-    }
-
-    fn insert(
-        &mut self,
-        key: WasmModuleCacheKey,
-        value: Arc<CachedWasmModule>,
-        module_size_bytes: usize,
-        max_entries: usize,
-        max_total_bytes: usize,
-    ) -> WasmModuleCacheInsertOutcome {
-        if max_entries == 0 || max_total_bytes == 0 {
-            self.clear();
-            return WasmModuleCacheInsertOutcome {
-                inserted: false,
-                evicted_entries: 0,
-            };
-        }
-
-        if module_size_bytes > max_total_bytes {
-            return WasmModuleCacheInsertOutcome {
-                inserted: false,
-                evicted_entries: 0,
-            };
-        }
-
-        let _ = self.remove_by_key(&key);
-        let mut evicted_entries = 0usize;
-        while self.entries.len() >= max_entries
-            || self.total_module_bytes.saturating_add(module_size_bytes) > max_total_bytes
-        {
-            if !self.evict_oldest() {
-                break;
-            }
-            evicted_entries = evicted_entries.saturating_add(1);
-        }
-
-        if self.entries.len() >= max_entries
-            || self.total_module_bytes.saturating_add(module_size_bytes) > max_total_bytes
-        {
-            return WasmModuleCacheInsertOutcome {
-                inserted: false,
-                evicted_entries,
-            };
-        }
-        self.order.push_back(key.clone());
-        self.total_module_bytes = self.total_module_bytes.saturating_add(module_size_bytes);
-        self.entries.insert(
-            key,
-            WasmModuleCacheEntry {
-                module: value,
-                module_size_bytes,
-            },
-        );
-        WasmModuleCacheInsertOutcome {
-            inserted: true,
-            evicted_entries,
-        }
-    }
-}
+mod http_json_bridge;
+mod process_stdio_bridge;
+mod wasm_cache;
+mod wasm_runtime_policy;
+pub use http_json_bridge::execute_http_json_bridge;
+pub use process_stdio_bridge::{
+    execute_process_stdio_bridge, run_process_stdio_json_line_exchange, ProcessStdioExchangeOutcome,
+};
+#[cfg(test)]
+use wasm_cache::WasmModuleCache;
+use wasm_cache::{
+    build_wasm_module_cache_key, insert_cached_wasm_module, lookup_cached_wasm_module,
+    modified_unix_nanos, wasm_artifact_file_identity, wasm_module_cache_capacity,
+    wasm_module_cache_max_bytes, CachedWasmModule, WasmArtifactFileIdentity,
+};
+use wasm_runtime_policy::wasm_signals_based_traps_enabled_from_env;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DefaultCoreSelection {
@@ -1635,518 +1470,6 @@ pub async fn maybe_execute_bridge(
 
 include!("spec_bridge_protocol.inc.rs");
 
-#[allow(clippy::indexing_slicing)] // serde_json::Value string-keyed IndexMut is infallible
-pub fn execute_http_json_bridge(
-    mut execution: Value,
-    provider: &kernel::ProviderConfig,
-    channel: &kernel::ChannelConfig,
-    command: &ConnectorCommand,
-) -> Value {
-    let method_label = provider
-        .metadata
-        .get("http_method")
-        .map(|value| value.trim().to_ascii_uppercase())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "POST".to_owned());
-    let method = match Method::from_bytes(method_label.as_bytes()) {
-        Ok(method) => method,
-        Err(error) => {
-            execution["status"] = Value::String("blocked".to_owned());
-            execution["reason"] =
-                Value::String(format!("invalid http_method {method_label}: {error}"));
-            return execution;
-        }
-    };
-
-    let timeout_ms = parse_http_timeout_ms(provider);
-    let enforce_protocol_contract = parse_http_enforce_protocol_contract(provider);
-    let mut protocol_context =
-        ConnectorProtocolContext::from_connector_command(provider, channel, command);
-    if let Err(reason) = authorize_connector_protocol_context(&mut protocol_context) {
-        execution["status"] = Value::String("blocked".to_owned());
-        execution["reason"] = Value::String(format!("http_json {reason}"));
-        execution["runtime"] = http_json_runtime_evidence(
-            &protocol_context,
-            &method_label,
-            &channel.endpoint,
-            timeout_ms,
-            enforce_protocol_contract,
-            HttpJsonRuntimeEvidenceKind::BaseOnly,
-        );
-        return execution;
-    }
-
-    let request_payload = json!({
-        "provider_id": provider.provider_id,
-        "channel_id": channel.channel_id,
-        "operation": command.operation,
-        "payload": command.payload,
-    });
-    let url = channel.endpoint.clone();
-    let request_payload_for_runtime = request_payload.clone();
-    let request_payload_for_worker = request_payload.clone();
-    let request_method_for_worker = protocol_context.request_method.clone();
-    let request_id_for_worker = protocol_context.request_id.clone();
-
-    type HttpJsonBridgeWorkerResult =
-        Result<(u16, bool, String, Value, Option<String>, Option<String>), String>;
-    let run = std::thread::spawn(move || -> HttpJsonBridgeWorkerResult {
-        let client = reqwest::blocking::Client::builder()
-            .timeout(Duration::from_millis(timeout_ms))
-            .build()
-            .map_err(|error| format!("failed to initialize http_json client: {error}"))?;
-
-        let response = client
-            .request(method, &url)
-            .header("content-type", "application/json")
-            .json(&request_payload_for_worker)
-            .send()
-            .map_err(|error| format!("http_json bridge request failed: {error}"))?;
-
-        let status = response.status();
-        let status_code = status.as_u16();
-        let success = status.is_success();
-        let body = response
-            .text()
-            .map_err(|error| format!("failed to read http_json response body: {error}"))?;
-        let body_json = serde_json::from_str::<Value>(&body).unwrap_or(Value::Null);
-
-        let response_method = body_json
-            .as_object()
-            .and_then(|value| value.get("method"))
-            .and_then(Value::as_str)
-            .map(str::to_owned);
-        let response_id = body_json
-            .as_object()
-            .and_then(|value| value.get("id"))
-            .and_then(Value::as_str)
-            .map(str::to_owned);
-        if enforce_protocol_contract {
-            let method = response_method.as_deref().ok_or_else(|| {
-                "http_json strict protocol contract requires response.method".to_owned()
-            })?;
-            if method != request_method_for_worker {
-                return Err(format!(
-                    "http_json response method mismatch: expected `{}`, got `{method}`",
-                    request_method_for_worker
-                ));
-            }
-            if response_id != request_id_for_worker {
-                return Err(format!(
-                    "http_json response id mismatch: expected `{:?}`, got `{:?}`",
-                    request_id_for_worker, response_id
-                ));
-            }
-        }
-
-        Ok((
-            status_code,
-            success,
-            body,
-            body_json,
-            response_method,
-            response_id,
-        ))
-    })
-    .join();
-
-    match run {
-        Ok(Ok((status_code, success, body, body_json, response_method, response_id))) => {
-            execution["status"] = Value::String(if success {
-                "executed".to_owned()
-            } else {
-                "failed".to_owned()
-            });
-            if !success {
-                execution["reason"] = Value::String(format!(
-                    "http_json bridge request failed with status {status_code}"
-                ));
-            }
-            execution["runtime"] = http_json_runtime_evidence(
-                &protocol_context,
-                &method_label,
-                &channel.endpoint,
-                timeout_ms,
-                enforce_protocol_contract,
-                HttpJsonRuntimeEvidenceKind::Response {
-                    status_code,
-                    request: request_payload_for_runtime,
-                    response_text: body,
-                    response_json: body_json,
-                    response_method,
-                    response_id,
-                },
-            );
-            execution
-        }
-        Ok(Err(reason)) => {
-            execution["status"] = Value::String("failed".to_owned());
-            execution["reason"] = Value::String(reason);
-            execution["runtime"] = http_json_runtime_evidence(
-                &protocol_context,
-                &method_label,
-                &channel.endpoint,
-                timeout_ms,
-                enforce_protocol_contract,
-                HttpJsonRuntimeEvidenceKind::RequestOnly {
-                    request: request_payload_for_runtime,
-                },
-            );
-            execution
-        }
-        Err(_) => {
-            execution["status"] = Value::String("failed".to_owned());
-            execution["reason"] =
-                Value::String("http_json bridge worker thread panicked".to_owned());
-            execution["runtime"] = http_json_runtime_evidence(
-                &protocol_context,
-                &method_label,
-                &channel.endpoint,
-                timeout_ms,
-                enforce_protocol_contract,
-                HttpJsonRuntimeEvidenceKind::RequestOnly {
-                    request: request_payload_for_runtime,
-                },
-            );
-            execution
-        }
-    }
-}
-
-#[allow(clippy::indexing_slicing)] // serde_json::Value string-keyed IndexMut is infallible
-pub async fn execute_process_stdio_bridge(
-    mut execution: Value,
-    provider: &kernel::ProviderConfig,
-    channel: &kernel::ChannelConfig,
-    command: &ConnectorCommand,
-    runtime_policy: &BridgeRuntimePolicy,
-) -> Value {
-    let Some(program) = provider.metadata.get("command").cloned() else {
-        execution["status"] = Value::String("blocked".to_owned());
-        execution["reason"] =
-            Value::String("process_stdio execution requires provider metadata.command".to_owned());
-        return execution;
-    };
-
-    if !is_process_command_allowed(&program, &runtime_policy.allowed_process_commands) {
-        execution["status"] = Value::String("blocked".to_owned());
-        execution["reason"] = Value::String(format!(
-            "process command {program} is not allowed by runtime policy"
-        ));
-        return execution;
-    }
-
-    let args = parse_process_args(provider);
-    let timeout_ms = parse_process_timeout_ms(provider);
-    let envelope = json!({
-        "provider_id": provider.provider_id,
-        "channel_id": channel.channel_id,
-        "operation": command.operation,
-        "payload": command.payload,
-    });
-    let mut protocol_context =
-        ConnectorProtocolContext::from_connector_command(provider, channel, command);
-    if let Err(reason) = authorize_connector_protocol_context(&mut protocol_context) {
-        execution["status"] = Value::String("blocked".to_owned());
-        execution["reason"] = Value::String(format!("process_stdio {reason}"));
-        execution["runtime"] = process_stdio_runtime_evidence(
-            &protocol_context,
-            &program,
-            &args,
-            timeout_ms,
-            ProcessStdioRuntimeEvidenceKind::BaseOnly,
-        );
-        return execution;
-    }
-
-    let exchange_result = run_process_stdio_json_line_exchange(
-        &program,
-        &args,
-        timeout_ms,
-        protocol_context.outbound_frame(envelope),
-    )
-    .await;
-
-    match exchange_result {
-        Ok(outcome) => {
-            execution["status"] = Value::String(if outcome.success {
-                "executed".to_owned()
-            } else {
-                "failed".to_owned()
-            });
-            if !outcome.success {
-                execution["reason"] = Value::String(format!(
-                    "process command exited with code {:?}",
-                    outcome.exit_code
-                ));
-            }
-            execution["runtime"] = process_stdio_runtime_evidence(
-                &protocol_context,
-                &program,
-                &args,
-                timeout_ms,
-                ProcessStdioRuntimeEvidenceKind::Execution {
-                    exit_code: outcome.exit_code,
-                    stdout: outcome.stdout,
-                    stderr: outcome.stderr,
-                    stdout_json: outcome.stdout_json,
-                    response_method: outcome.response_method,
-                    response_id: outcome.response_id,
-                },
-            );
-            execution
-        }
-        Err(reason) => {
-            execution["status"] = Value::String("failed".to_owned());
-            execution["reason"] = Value::String(reason);
-            execution["runtime"] = process_stdio_runtime_evidence(
-                &protocol_context,
-                &program,
-                &args,
-                timeout_ms,
-                ProcessStdioRuntimeEvidenceKind::BaseOnly,
-            );
-            execution
-        }
-    }
-}
-
-pub struct ProcessStdioExchangeOutcome {
-    pub success: bool,
-    pub exit_code: Option<i32>,
-    pub stdout: String,
-    pub stderr: String,
-    pub stdout_json: Value,
-    pub response_method: String,
-    pub response_id: Option<String>,
-}
-
-pub async fn run_process_stdio_json_line_exchange(
-    program: &str,
-    args: &[String],
-    timeout_ms: u64,
-    frame: OutboundFrame,
-) -> Result<ProcessStdioExchangeOutcome, String> {
-    let mut child = TokioCommand::new(program)
-        .args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|error| format!("failed to spawn process command {program}: {error}"))?;
-
-    let stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| format!("process command {program} stdin is not piped"))?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| format!("process command {program} stdout is not piped"))?;
-    let stderr = child.stderr.take();
-    let stderr_task = tokio::spawn(async move {
-        let mut bytes = Vec::new();
-        if let Some(mut stderr_pipe) = stderr {
-            let _ = stderr_pipe.read_to_end(&mut bytes).await;
-        }
-        bytes
-    });
-
-    let transport = JsonLineTransport::new(
-        TransportInfo {
-            name: format!("process_stdio/{program}"),
-            version: "0.1.0".to_owned(),
-            secure: false,
-        },
-        stdout,
-        stdin,
-    );
-
-    let expected_method = frame.method.clone();
-    let expected_id = frame.id.clone();
-
-    if let Err(error) = timeout(Duration::from_millis(timeout_ms), transport.send(frame))
-        .await
-        .map_err(|_err| format!("process_stdio transport send timed out after {timeout_ms}ms"))?
-    {
-        let _ = child.start_kill();
-        let _ = child.wait().await;
-        let _ = stderr_task.await;
-        return Err(format!("process_stdio transport send failed: {error}"));
-    }
-    if let Err(error) = timeout(Duration::from_millis(timeout_ms), transport.close())
-        .await
-        .map_err(|_err| format!("process_stdio transport close timed out after {timeout_ms}ms"))?
-    {
-        let _ = child.start_kill();
-        let _ = child.wait().await;
-        let _ = stderr_task.await;
-        return Err(format!("process_stdio transport close failed: {error}"));
-    }
-
-    let response = match timeout(Duration::from_millis(timeout_ms), transport.recv()).await {
-        Ok(Ok(Some(frame))) => frame,
-        Ok(Ok(None)) => {
-            drop(transport);
-            let _ = child.wait().await;
-            let _ = stderr_task.await;
-            return Err("process_stdio transport closed before response frame".to_owned());
-        }
-        Ok(Err(error)) => {
-            let _ = child.start_kill();
-            let _ = child.wait().await;
-            let _ = stderr_task.await;
-            return Err(format!("process_stdio transport recv failed: {error}"));
-        }
-        Err(_) => {
-            let _ = child.start_kill();
-            let _ = child.wait().await;
-            let _ = stderr_task.await;
-            return Err(format!(
-                "process_stdio transport recv timed out after {timeout_ms}ms"
-            ));
-        }
-    };
-
-    if response.method != expected_method {
-        let _ = child.start_kill();
-        let _ = child.wait().await;
-        let _ = stderr_task.await;
-        return Err(format!(
-            "process_stdio response method mismatch: expected `{expected_method}`, got `{}`",
-            response.method
-        ));
-    }
-    if response.id != expected_id {
-        let _ = child.start_kill();
-        let _ = child.wait().await;
-        let _ = stderr_task.await;
-        return Err(format!(
-            "process_stdio response id mismatch: expected `{:?}`, got `{:?}`",
-            expected_id, response.id
-        ));
-    }
-
-    drop(transport);
-    let status = match timeout(Duration::from_millis(timeout_ms), child.wait()).await {
-        Ok(Ok(status)) => status,
-        Ok(Err(error)) => {
-            let _ = stderr_task.await;
-            return Err(format!("failed to wait process output: {error}"));
-        }
-        Err(_) => {
-            let _ = child.start_kill();
-            let _ = child.wait().await;
-            let _ = stderr_task.await;
-            return Err(format!(
-                "process command timed out after {timeout_ms}ms waiting for exit"
-            ));
-        }
-    };
-    let stderr_bytes = stderr_task
-        .await
-        .map_err(|error| format!("failed to collect process stderr: {error}"))?;
-    let stderr = String::from_utf8_lossy(&stderr_bytes).trim().to_owned();
-    let stdout_json = response.payload;
-    let stdout = serde_json::to_string(&stdout_json).unwrap_or_else(|_| "null".to_owned());
-
-    Ok(ProcessStdioExchangeOutcome {
-        success: status.success(),
-        exit_code: status.code(),
-        stdout,
-        stderr,
-        stdout_json,
-        response_method: response.method,
-        response_id: response.id,
-    })
-}
-
-fn wasm_module_cache() -> &'static Mutex<WasmModuleCache> {
-    WASM_MODULE_CACHE.get_or_init(|| Mutex::new(WasmModuleCache::default()))
-}
-
-fn parse_wasm_module_cache_capacity(raw: Option<&str>) -> usize {
-    raw.and_then(|value| value.trim().parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .map(|value| value.min(MAX_WASM_MODULE_CACHE_CAPACITY))
-        .unwrap_or(DEFAULT_WASM_MODULE_CACHE_CAPACITY)
-}
-
-fn wasm_module_cache_capacity() -> usize {
-    *WASM_MODULE_CACHE_CAPACITY.get_or_init(|| {
-        parse_wasm_module_cache_capacity(
-            std::env::var("LOONGCLAW_WASM_CACHE_CAPACITY")
-                .ok()
-                .as_deref(),
-        )
-    })
-}
-
-fn parse_wasm_module_cache_max_bytes(raw: Option<&str>) -> usize {
-    raw.and_then(|value| value.trim().parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .map(|value| {
-            value.clamp(
-                MIN_WASM_MODULE_CACHE_MAX_BYTES,
-                MAX_WASM_MODULE_CACHE_MAX_BYTES,
-            )
-        })
-        .unwrap_or(DEFAULT_WASM_MODULE_CACHE_MAX_BYTES)
-}
-
-fn wasm_module_cache_max_bytes() -> usize {
-    *WASM_MODULE_CACHE_MAX_BYTES.get_or_init(|| {
-        parse_wasm_module_cache_max_bytes(
-            std::env::var("LOONGCLAW_WASM_CACHE_MAX_BYTES")
-                .ok()
-                .as_deref(),
-        )
-    })
-}
-
-fn modified_unix_nanos(metadata: &fs::Metadata) -> Option<u128> {
-    metadata
-        .modified()
-        .ok()
-        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
-        .map(|duration| duration.as_nanos())
-}
-
-#[cfg(unix)]
-fn wasm_artifact_file_identity(metadata: &fs::Metadata) -> Option<WasmArtifactFileIdentity> {
-    use std::os::unix::fs::MetadataExt;
-
-    Some(WasmArtifactFileIdentity {
-        device_id: metadata.dev(),
-        inode: metadata.ino(),
-        ctime_seconds: metadata.ctime(),
-        ctime_nanoseconds: metadata.ctime_nsec(),
-    })
-}
-
-#[cfg(not(unix))]
-fn wasm_artifact_file_identity(_metadata: &fs::Metadata) -> Option<WasmArtifactFileIdentity> {
-    None
-}
-
-fn build_wasm_module_cache_key(
-    artifact_path: &Path,
-    module_size_bytes: u64,
-    artifact_modified_unix_ns: Option<u128>,
-    artifact_file_identity: Option<WasmArtifactFileIdentity>,
-    expected_sha256: Option<String>,
-    fuel_enabled: bool,
-) -> WasmModuleCacheKey {
-    WasmModuleCacheKey {
-        artifact_path: artifact_path.to_path_buf(),
-        module_size_bytes,
-        artifact_modified_unix_ns,
-        artifact_file_identity,
-        expected_sha256,
-        fuel_enabled,
-    }
-}
-
 fn normalize_allowed_wasm_path_prefixes(prefixes: &[PathBuf]) -> Vec<PathBuf> {
     prefixes
         .iter()
@@ -2281,6 +1604,10 @@ fn compile_wasm_module(
     artifact_sha256: Option<String>,
 ) -> Result<CachedWasmModule, String> {
     let mut config = WasmtimeConfig::new();
+    // On macOS, default to `false` because Wasmtime's signal-based trap path
+    // relies on a global machports handler thread, which has shown intermittent
+    // aborts under highly parallel bridge tests.
+    config.signals_based_traps(wasm_signals_based_traps_enabled_from_env());
     if fuel_enabled {
         config.consume_fuel(true);
     }
@@ -2292,61 +1619,6 @@ fn compile_wasm_module(
         engine,
         module,
         artifact_sha256,
-    })
-}
-
-fn lookup_cached_wasm_module(
-    cache_key: &WasmModuleCacheKey,
-) -> Result<Option<(Arc<CachedWasmModule>, WasmModuleCacheLookup)>, String> {
-    let cache_capacity = wasm_module_cache_capacity();
-    let cache_max_bytes = wasm_module_cache_max_bytes();
-    let cache_lock = wasm_module_cache();
-    let mut cache = cache_lock
-        .lock()
-        .map_err(|error| format!("failed to lock wasm module cache: {error}"))?;
-    let Some(cached) = cache.get(cache_key) else {
-        return Ok(None);
-    };
-    Ok(Some((
-        cached,
-        WasmModuleCacheLookup {
-            hit: true,
-            inserted: false,
-            evicted_entries: 0,
-            cache_len: cache.len(),
-            cache_capacity,
-            cache_total_module_bytes: cache.total_module_bytes(),
-            cache_max_bytes,
-        },
-    )))
-}
-
-fn insert_cached_wasm_module(
-    cache_key: WasmModuleCacheKey,
-    module: Arc<CachedWasmModule>,
-    module_size_bytes: usize,
-) -> Result<WasmModuleCacheLookup, String> {
-    let cache_capacity = wasm_module_cache_capacity();
-    let cache_max_bytes = wasm_module_cache_max_bytes();
-    let cache_lock = wasm_module_cache();
-    let mut cache = cache_lock
-        .lock()
-        .map_err(|error| format!("failed to lock wasm module cache: {error}"))?;
-    let insert_outcome = cache.insert(
-        cache_key,
-        module,
-        module_size_bytes,
-        cache_capacity,
-        cache_max_bytes,
-    );
-    Ok(WasmModuleCacheLookup {
-        hit: false,
-        inserted: insert_outcome.inserted,
-        evicted_entries: insert_outcome.evicted_entries,
-        cache_len: cache.len(),
-        cache_capacity,
-        cache_total_module_bytes: cache.total_module_bytes(),
-        cache_max_bytes,
     })
 }
 
@@ -3223,13 +2495,17 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    use super::{
-        build_wasm_module_cache_key, compile_wasm_module, normalize_sha256_pin,
-        parse_wasm_module_cache_capacity, parse_wasm_module_cache_max_bytes,
-        resolve_expected_wasm_sha256, wasm_artifact_file_identity, BridgeRuntimePolicy,
-        WasmModuleCache, DEFAULT_WASM_MODULE_CACHE_CAPACITY, DEFAULT_WASM_MODULE_CACHE_MAX_BYTES,
+    use super::wasm_runtime_policy::{
+        default_wasm_signals_based_traps, parse_wasm_module_cache_capacity,
+        parse_wasm_module_cache_max_bytes, parse_wasm_signals_based_traps,
+        DEFAULT_WASM_MODULE_CACHE_CAPACITY, DEFAULT_WASM_MODULE_CACHE_MAX_BYTES,
         MAX_WASM_MODULE_CACHE_CAPACITY, MAX_WASM_MODULE_CACHE_MAX_BYTES,
         MIN_WASM_MODULE_CACHE_MAX_BYTES,
+    };
+    use super::{
+        build_wasm_module_cache_key, compile_wasm_module, normalize_sha256_pin,
+        resolve_expected_wasm_sha256, wasm_artifact_file_identity, BridgeRuntimePolicy,
+        WasmModuleCache,
     };
 
     const EMPTY_WASM_MODULE: [u8; 8] = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
@@ -3302,6 +2578,38 @@ mod tests {
             parse_wasm_module_cache_max_bytes(Some(over_limit.as_str())),
             MAX_WASM_MODULE_CACHE_MAX_BYTES
         );
+    }
+
+    #[test]
+    fn parse_wasm_signals_based_traps_defaults_to_platform_policy() {
+        assert_eq!(
+            parse_wasm_signals_based_traps(None),
+            default_wasm_signals_based_traps()
+        );
+        assert_eq!(
+            parse_wasm_signals_based_traps(Some("")),
+            default_wasm_signals_based_traps()
+        );
+        assert_eq!(
+            parse_wasm_signals_based_traps(Some("invalid-value")),
+            default_wasm_signals_based_traps()
+        );
+    }
+
+    #[test]
+    fn parse_wasm_signals_based_traps_accepts_boolean_aliases() {
+        for raw in ["1", "true", "yes", "on", "enabled", "TRUE", " On "] {
+            assert!(
+                parse_wasm_signals_based_traps(Some(raw)),
+                "expected true for {raw}"
+            );
+        }
+        for raw in ["0", "false", "no", "off", "disabled", "FALSE", " Off "] {
+            assert!(
+                !parse_wasm_signals_based_traps(Some(raw)),
+                "expected false for {raw}"
+            );
+        }
     }
 
     #[test]

--- a/crates/spec/src/spec_runtime/http_json_bridge.rs
+++ b/crates/spec/src/spec_runtime/http_json_bridge.rs
@@ -1,0 +1,189 @@
+use std::time::Duration;
+
+use kernel::ConnectorCommand;
+use reqwest::Method;
+use serde_json::{json, Value};
+
+use super::{
+    authorize_connector_protocol_context, http_json_runtime_evidence,
+    parse_http_enforce_protocol_contract, parse_http_timeout_ms, ConnectorProtocolContext,
+    HttpJsonRuntimeEvidenceKind,
+};
+
+#[allow(clippy::indexing_slicing)] // serde_json::Value string-keyed IndexMut is infallible
+pub fn execute_http_json_bridge(
+    mut execution: Value,
+    provider: &kernel::ProviderConfig,
+    channel: &kernel::ChannelConfig,
+    command: &ConnectorCommand,
+) -> Value {
+    let method_label = provider
+        .metadata
+        .get("http_method")
+        .map(|value| value.trim().to_ascii_uppercase())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "POST".to_owned());
+    let method = match Method::from_bytes(method_label.as_bytes()) {
+        Ok(method) => method,
+        Err(error) => {
+            execution["status"] = Value::String("blocked".to_owned());
+            execution["reason"] =
+                Value::String(format!("invalid http_method {method_label}: {error}"));
+            return execution;
+        }
+    };
+
+    let timeout_ms = parse_http_timeout_ms(provider);
+    let enforce_protocol_contract = parse_http_enforce_protocol_contract(provider);
+    let mut protocol_context =
+        ConnectorProtocolContext::from_connector_command(provider, channel, command);
+    if let Err(reason) = authorize_connector_protocol_context(&mut protocol_context) {
+        execution["status"] = Value::String("blocked".to_owned());
+        execution["reason"] = Value::String(format!("http_json {reason}"));
+        execution["runtime"] = http_json_runtime_evidence(
+            &protocol_context,
+            &method_label,
+            &channel.endpoint,
+            timeout_ms,
+            enforce_protocol_contract,
+            HttpJsonRuntimeEvidenceKind::BaseOnly,
+        );
+        return execution;
+    }
+
+    let request_payload = json!({
+        "provider_id": provider.provider_id,
+        "channel_id": channel.channel_id,
+        "operation": command.operation,
+        "payload": command.payload,
+    });
+    let url = channel.endpoint.clone();
+    let request_payload_for_runtime = request_payload.clone();
+    let request_payload_for_worker = request_payload.clone();
+    let request_method_for_worker = protocol_context.request_method.clone();
+    let request_id_for_worker = protocol_context.request_id.clone();
+
+    type HttpJsonBridgeWorkerResult =
+        Result<(u16, bool, String, Value, Option<String>, Option<String>), String>;
+    let run = std::thread::spawn(move || -> HttpJsonBridgeWorkerResult {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_millis(timeout_ms))
+            .build()
+            .map_err(|error| format!("failed to initialize http_json client: {error}"))?;
+
+        let response = client
+            .request(method, &url)
+            .header("content-type", "application/json")
+            .json(&request_payload_for_worker)
+            .send()
+            .map_err(|error| format!("http_json bridge request failed: {error}"))?;
+
+        let status = response.status();
+        let status_code = status.as_u16();
+        let success = status.is_success();
+        let body = response
+            .text()
+            .map_err(|error| format!("failed to read http_json response body: {error}"))?;
+        let body_json = serde_json::from_str::<Value>(&body).unwrap_or(Value::Null);
+
+        let response_method = body_json
+            .as_object()
+            .and_then(|value| value.get("method"))
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let response_id = body_json
+            .as_object()
+            .and_then(|value| value.get("id"))
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        if enforce_protocol_contract {
+            let method = response_method.as_deref().ok_or_else(|| {
+                "http_json strict protocol contract requires response.method".to_owned()
+            })?;
+            if method != request_method_for_worker {
+                return Err(format!(
+                    "http_json response method mismatch: expected `{}`, got `{method}`",
+                    request_method_for_worker
+                ));
+            }
+            if response_id != request_id_for_worker {
+                return Err(format!(
+                    "http_json response id mismatch: expected `{:?}`, got `{:?}`",
+                    request_id_for_worker, response_id
+                ));
+            }
+        }
+
+        Ok((
+            status_code,
+            success,
+            body,
+            body_json,
+            response_method,
+            response_id,
+        ))
+    })
+    .join();
+
+    match run {
+        Ok(Ok((status_code, success, body, body_json, response_method, response_id))) => {
+            execution["status"] = Value::String(if success {
+                "executed".to_owned()
+            } else {
+                "failed".to_owned()
+            });
+            if !success {
+                execution["reason"] = Value::String(format!(
+                    "http_json bridge request failed with status {status_code}"
+                ));
+            }
+            execution["runtime"] = http_json_runtime_evidence(
+                &protocol_context,
+                &method_label,
+                &channel.endpoint,
+                timeout_ms,
+                enforce_protocol_contract,
+                HttpJsonRuntimeEvidenceKind::Response {
+                    status_code,
+                    request: request_payload_for_runtime,
+                    response_text: body,
+                    response_json: body_json,
+                    response_method,
+                    response_id,
+                },
+            );
+            execution
+        }
+        Ok(Err(reason)) => {
+            execution["status"] = Value::String("failed".to_owned());
+            execution["reason"] = Value::String(reason);
+            execution["runtime"] = http_json_runtime_evidence(
+                &protocol_context,
+                &method_label,
+                &channel.endpoint,
+                timeout_ms,
+                enforce_protocol_contract,
+                HttpJsonRuntimeEvidenceKind::RequestOnly {
+                    request: request_payload_for_runtime,
+                },
+            );
+            execution
+        }
+        Err(_) => {
+            execution["status"] = Value::String("failed".to_owned());
+            execution["reason"] =
+                Value::String("http_json bridge worker thread panicked".to_owned());
+            execution["runtime"] = http_json_runtime_evidence(
+                &protocol_context,
+                &method_label,
+                &channel.endpoint,
+                timeout_ms,
+                enforce_protocol_contract,
+                HttpJsonRuntimeEvidenceKind::RequestOnly {
+                    request: request_payload_for_runtime,
+                },
+            );
+            execution
+        }
+    }
+}

--- a/crates/spec/src/spec_runtime/process_stdio_bridge.rs
+++ b/crates/spec/src/spec_runtime/process_stdio_bridge.rs
@@ -1,0 +1,260 @@
+use std::{process::Stdio, time::Duration};
+
+use loongclaw_protocol::{JsonLineTransport, OutboundFrame, Transport, TransportInfo};
+use serde_json::{json, Value};
+use tokio::{io::AsyncReadExt, process::Command as TokioCommand, time::timeout};
+
+use super::{
+    authorize_connector_protocol_context, is_process_command_allowed, parse_process_args,
+    parse_process_timeout_ms, process_stdio_runtime_evidence, BridgeRuntimePolicy,
+    ConnectorProtocolContext, ProcessStdioRuntimeEvidenceKind,
+};
+use kernel::ConnectorCommand;
+
+pub struct ProcessStdioExchangeOutcome {
+    pub success: bool,
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub stdout_json: Value,
+    pub response_method: String,
+    pub response_id: Option<String>,
+}
+
+#[allow(clippy::indexing_slicing)] // serde_json::Value string-keyed IndexMut is infallible
+pub async fn execute_process_stdio_bridge(
+    mut execution: Value,
+    provider: &kernel::ProviderConfig,
+    channel: &kernel::ChannelConfig,
+    command: &ConnectorCommand,
+    runtime_policy: &BridgeRuntimePolicy,
+) -> Value {
+    let Some(program) = provider.metadata.get("command").cloned() else {
+        execution["status"] = Value::String("blocked".to_owned());
+        execution["reason"] =
+            Value::String("process_stdio execution requires provider metadata.command".to_owned());
+        return execution;
+    };
+
+    if !is_process_command_allowed(&program, &runtime_policy.allowed_process_commands) {
+        execution["status"] = Value::String("blocked".to_owned());
+        execution["reason"] = Value::String(format!(
+            "process command {program} is not allowed by runtime policy"
+        ));
+        return execution;
+    }
+
+    let args = parse_process_args(provider);
+    let timeout_ms = parse_process_timeout_ms(provider);
+    let envelope = json!({
+        "provider_id": provider.provider_id,
+        "channel_id": channel.channel_id,
+        "operation": command.operation,
+        "payload": command.payload,
+    });
+    let mut protocol_context =
+        ConnectorProtocolContext::from_connector_command(provider, channel, command);
+    if let Err(reason) = authorize_connector_protocol_context(&mut protocol_context) {
+        execution["status"] = Value::String("blocked".to_owned());
+        execution["reason"] = Value::String(format!("process_stdio {reason}"));
+        execution["runtime"] = process_stdio_runtime_evidence(
+            &protocol_context,
+            &program,
+            &args,
+            timeout_ms,
+            ProcessStdioRuntimeEvidenceKind::BaseOnly,
+        );
+        return execution;
+    }
+
+    let exchange_result = run_process_stdio_json_line_exchange(
+        &program,
+        &args,
+        timeout_ms,
+        protocol_context.outbound_frame(envelope),
+    )
+    .await;
+
+    match exchange_result {
+        Ok(outcome) => {
+            execution["status"] = Value::String(if outcome.success {
+                "executed".to_owned()
+            } else {
+                "failed".to_owned()
+            });
+            if !outcome.success {
+                execution["reason"] = Value::String(format!(
+                    "process command exited with code {:?}",
+                    outcome.exit_code
+                ));
+            }
+            execution["runtime"] = process_stdio_runtime_evidence(
+                &protocol_context,
+                &program,
+                &args,
+                timeout_ms,
+                ProcessStdioRuntimeEvidenceKind::Execution {
+                    exit_code: outcome.exit_code,
+                    stdout: outcome.stdout,
+                    stderr: outcome.stderr,
+                    stdout_json: outcome.stdout_json,
+                    response_method: outcome.response_method,
+                    response_id: outcome.response_id,
+                },
+            );
+            execution
+        }
+        Err(reason) => {
+            execution["status"] = Value::String("failed".to_owned());
+            execution["reason"] = Value::String(reason);
+            execution["runtime"] = process_stdio_runtime_evidence(
+                &protocol_context,
+                &program,
+                &args,
+                timeout_ms,
+                ProcessStdioRuntimeEvidenceKind::BaseOnly,
+            );
+            execution
+        }
+    }
+}
+
+pub async fn run_process_stdio_json_line_exchange(
+    program: &str,
+    args: &[String],
+    timeout_ms: u64,
+    frame: OutboundFrame,
+) -> Result<ProcessStdioExchangeOutcome, String> {
+    let mut child = TokioCommand::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| format!("failed to spawn process command {program}: {error}"))?;
+
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| format!("process command {program} stdin is not piped"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| format!("process command {program} stdout is not piped"))?;
+    let stderr = child.stderr.take();
+    let stderr_task = tokio::spawn(async move {
+        let mut bytes = Vec::new();
+        if let Some(mut stderr_pipe) = stderr {
+            let _ = stderr_pipe.read_to_end(&mut bytes).await;
+        }
+        bytes
+    });
+
+    let transport = JsonLineTransport::new(
+        TransportInfo {
+            name: format!("process_stdio/{program}"),
+            version: "0.1.0".to_owned(),
+            secure: false,
+        },
+        stdout,
+        stdin,
+    );
+
+    let expected_method = frame.method.clone();
+    let expected_id = frame.id.clone();
+
+    if let Err(error) = timeout(Duration::from_millis(timeout_ms), transport.send(frame))
+        .await
+        .map_err(|_err| format!("process_stdio transport send timed out after {timeout_ms}ms"))?
+    {
+        let _ = child.start_kill();
+        let _ = child.wait().await;
+        let _ = stderr_task.await;
+        return Err(format!("process_stdio transport send failed: {error}"));
+    }
+    if let Err(error) = timeout(Duration::from_millis(timeout_ms), transport.close())
+        .await
+        .map_err(|_err| format!("process_stdio transport close timed out after {timeout_ms}ms"))?
+    {
+        let _ = child.start_kill();
+        let _ = child.wait().await;
+        let _ = stderr_task.await;
+        return Err(format!("process_stdio transport close failed: {error}"));
+    }
+
+    let response = match timeout(Duration::from_millis(timeout_ms), transport.recv()).await {
+        Ok(Ok(Some(frame))) => frame,
+        Ok(Ok(None)) => {
+            drop(transport);
+            let _ = child.wait().await;
+            let _ = stderr_task.await;
+            return Err("process_stdio transport closed before response frame".to_owned());
+        }
+        Ok(Err(error)) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            let _ = stderr_task.await;
+            return Err(format!("process_stdio transport recv failed: {error}"));
+        }
+        Err(_) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            let _ = stderr_task.await;
+            return Err(format!(
+                "process_stdio transport recv timed out after {timeout_ms}ms"
+            ));
+        }
+    };
+
+    if response.method != expected_method {
+        let _ = child.start_kill();
+        let _ = child.wait().await;
+        let _ = stderr_task.await;
+        return Err(format!(
+            "process_stdio response method mismatch: expected `{expected_method}`, got `{}`",
+            response.method
+        ));
+    }
+    if response.id != expected_id {
+        let _ = child.start_kill();
+        let _ = child.wait().await;
+        let _ = stderr_task.await;
+        return Err(format!(
+            "process_stdio response id mismatch: expected `{:?}`, got `{:?}`",
+            expected_id, response.id
+        ));
+    }
+
+    drop(transport);
+    let status = match timeout(Duration::from_millis(timeout_ms), child.wait()).await {
+        Ok(Ok(status)) => status,
+        Ok(Err(error)) => {
+            let _ = stderr_task.await;
+            return Err(format!("failed to wait process output: {error}"));
+        }
+        Err(_) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            let _ = stderr_task.await;
+            return Err(format!(
+                "process command timed out after {timeout_ms}ms waiting for exit"
+            ));
+        }
+    };
+    let stderr_bytes = stderr_task
+        .await
+        .map_err(|error| format!("failed to collect process stderr: {error}"))?;
+    let stderr = String::from_utf8_lossy(&stderr_bytes).trim().to_owned();
+    let stdout_json = response.payload;
+    let stdout = serde_json::to_string(&stdout_json).unwrap_or_else(|_| "null".to_owned());
+
+    Ok(ProcessStdioExchangeOutcome {
+        success: status.success(),
+        exit_code: status.code(),
+        stdout,
+        stderr,
+        stdout_json,
+        response_method: response.method,
+        response_id: response.id,
+    })
+}

--- a/crates/spec/src/spec_runtime/wasm_cache.rs
+++ b/crates/spec/src/spec_runtime/wasm_cache.rs
@@ -1,0 +1,295 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    fs,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, OnceLock},
+    time::UNIX_EPOCH,
+};
+
+use wasmtime::{Engine as WasmtimeEngine, Module as WasmtimeModule};
+
+use super::wasm_runtime_policy::{
+    wasm_module_cache_capacity_from_env, wasm_module_cache_max_bytes_from_env,
+};
+
+static WASM_MODULE_CACHE: OnceLock<Mutex<WasmModuleCache>> = OnceLock::new();
+static WASM_MODULE_CACHE_CAPACITY: OnceLock<usize> = OnceLock::new();
+static WASM_MODULE_CACHE_MAX_BYTES: OnceLock<usize> = OnceLock::new();
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) struct WasmModuleCacheKey {
+    artifact_path: PathBuf,
+    module_size_bytes: u64,
+    artifact_modified_unix_ns: Option<u128>,
+    artifact_file_identity: Option<WasmArtifactFileIdentity>,
+    expected_sha256: Option<String>,
+    fuel_enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct WasmArtifactFileIdentity {
+    device_id: u64,
+    inode: u64,
+    ctime_seconds: i64,
+    ctime_nanoseconds: i64,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct CachedWasmModule {
+    pub(super) engine: WasmtimeEngine,
+    pub(super) module: WasmtimeModule,
+    pub(super) artifact_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct WasmModuleCacheLookup {
+    pub(super) hit: bool,
+    pub(super) inserted: bool,
+    pub(super) evicted_entries: usize,
+    pub(super) cache_len: usize,
+    pub(super) cache_capacity: usize,
+    pub(super) cache_total_module_bytes: usize,
+    pub(super) cache_max_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct WasmModuleCacheInsertOutcome {
+    pub(super) inserted: bool,
+    pub(super) evicted_entries: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct WasmModuleCacheEntry {
+    module: Arc<CachedWasmModule>,
+    module_size_bytes: usize,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct WasmModuleCache {
+    order: VecDeque<WasmModuleCacheKey>,
+    entries: HashMap<WasmModuleCacheKey, WasmModuleCacheEntry>,
+    total_module_bytes: usize,
+}
+
+impl WasmModuleCache {
+    pub(super) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(super) fn total_module_bytes(&self) -> usize {
+        self.total_module_bytes
+    }
+
+    fn touch(&mut self, key: &WasmModuleCacheKey) {
+        if let Some(position) = self.order.iter().position(|candidate| candidate == key) {
+            let _ = self.order.remove(position);
+        }
+        self.order.push_back(key.clone());
+    }
+
+    fn remove_by_key(&mut self, key: &WasmModuleCacheKey) -> bool {
+        self.order.retain(|candidate| candidate != key);
+        let Some(removed) = self.entries.remove(key) else {
+            return false;
+        };
+        self.total_module_bytes = self
+            .total_module_bytes
+            .saturating_sub(removed.module_size_bytes);
+        true
+    }
+
+    fn evict_oldest(&mut self) -> bool {
+        while let Some(oldest) = self.order.pop_front() {
+            if let Some(removed) = self.entries.remove(&oldest) {
+                self.total_module_bytes = self
+                    .total_module_bytes
+                    .saturating_sub(removed.module_size_bytes);
+                return true;
+            }
+        }
+        false
+    }
+
+    fn clear(&mut self) {
+        self.order.clear();
+        self.entries.clear();
+        self.total_module_bytes = 0;
+    }
+
+    pub(super) fn get(&mut self, key: &WasmModuleCacheKey) -> Option<Arc<CachedWasmModule>> {
+        let entry = self.entries.get(key)?.module.clone();
+        self.touch(key);
+        Some(entry)
+    }
+
+    pub(super) fn insert(
+        &mut self,
+        key: WasmModuleCacheKey,
+        value: Arc<CachedWasmModule>,
+        module_size_bytes: usize,
+        max_entries: usize,
+        max_total_bytes: usize,
+    ) -> WasmModuleCacheInsertOutcome {
+        if max_entries == 0 || max_total_bytes == 0 {
+            self.clear();
+            return WasmModuleCacheInsertOutcome {
+                inserted: false,
+                evicted_entries: 0,
+            };
+        }
+
+        if module_size_bytes > max_total_bytes {
+            return WasmModuleCacheInsertOutcome {
+                inserted: false,
+                evicted_entries: 0,
+            };
+        }
+
+        let _ = self.remove_by_key(&key);
+        let mut evicted_entries = 0usize;
+        while self.entries.len() >= max_entries
+            || self.total_module_bytes.saturating_add(module_size_bytes) > max_total_bytes
+        {
+            if !self.evict_oldest() {
+                break;
+            }
+            evicted_entries = evicted_entries.saturating_add(1);
+        }
+
+        if self.entries.len() >= max_entries
+            || self.total_module_bytes.saturating_add(module_size_bytes) > max_total_bytes
+        {
+            return WasmModuleCacheInsertOutcome {
+                inserted: false,
+                evicted_entries,
+            };
+        }
+        self.order.push_back(key.clone());
+        self.total_module_bytes = self.total_module_bytes.saturating_add(module_size_bytes);
+        self.entries.insert(
+            key,
+            WasmModuleCacheEntry {
+                module: value,
+                module_size_bytes,
+            },
+        );
+        WasmModuleCacheInsertOutcome {
+            inserted: true,
+            evicted_entries,
+        }
+    }
+}
+
+fn wasm_module_cache() -> &'static Mutex<WasmModuleCache> {
+    WASM_MODULE_CACHE.get_or_init(|| Mutex::new(WasmModuleCache::default()))
+}
+
+pub(super) fn wasm_module_cache_capacity() -> usize {
+    *WASM_MODULE_CACHE_CAPACITY.get_or_init(wasm_module_cache_capacity_from_env)
+}
+
+pub(super) fn wasm_module_cache_max_bytes() -> usize {
+    *WASM_MODULE_CACHE_MAX_BYTES.get_or_init(wasm_module_cache_max_bytes_from_env)
+}
+
+pub(super) fn modified_unix_nanos(metadata: &fs::Metadata) -> Option<u128> {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos())
+}
+
+#[cfg(unix)]
+pub(super) fn wasm_artifact_file_identity(
+    metadata: &fs::Metadata,
+) -> Option<WasmArtifactFileIdentity> {
+    use std::os::unix::fs::MetadataExt;
+
+    Some(WasmArtifactFileIdentity {
+        device_id: metadata.dev(),
+        inode: metadata.ino(),
+        ctime_seconds: metadata.ctime(),
+        ctime_nanoseconds: metadata.ctime_nsec(),
+    })
+}
+
+#[cfg(not(unix))]
+pub(super) fn wasm_artifact_file_identity(
+    _metadata: &fs::Metadata,
+) -> Option<WasmArtifactFileIdentity> {
+    None
+}
+
+pub(super) fn build_wasm_module_cache_key(
+    artifact_path: &Path,
+    module_size_bytes: u64,
+    artifact_modified_unix_ns: Option<u128>,
+    artifact_file_identity: Option<WasmArtifactFileIdentity>,
+    expected_sha256: Option<String>,
+    fuel_enabled: bool,
+) -> WasmModuleCacheKey {
+    WasmModuleCacheKey {
+        artifact_path: artifact_path.to_path_buf(),
+        module_size_bytes,
+        artifact_modified_unix_ns,
+        artifact_file_identity,
+        expected_sha256,
+        fuel_enabled,
+    }
+}
+
+pub(super) fn lookup_cached_wasm_module(
+    cache_key: &WasmModuleCacheKey,
+) -> Result<Option<(Arc<CachedWasmModule>, WasmModuleCacheLookup)>, String> {
+    let cache_capacity = wasm_module_cache_capacity();
+    let cache_max_bytes = wasm_module_cache_max_bytes();
+    let cache_lock = wasm_module_cache();
+    let mut cache = cache_lock
+        .lock()
+        .map_err(|error| format!("failed to lock wasm module cache: {error}"))?;
+    let Some(cached) = cache.get(cache_key) else {
+        return Ok(None);
+    };
+    Ok(Some((
+        cached,
+        WasmModuleCacheLookup {
+            hit: true,
+            inserted: false,
+            evicted_entries: 0,
+            cache_len: cache.len(),
+            cache_capacity,
+            cache_total_module_bytes: cache.total_module_bytes(),
+            cache_max_bytes,
+        },
+    )))
+}
+
+pub(super) fn insert_cached_wasm_module(
+    cache_key: WasmModuleCacheKey,
+    module: Arc<CachedWasmModule>,
+    module_size_bytes: usize,
+) -> Result<WasmModuleCacheLookup, String> {
+    let cache_capacity = wasm_module_cache_capacity();
+    let cache_max_bytes = wasm_module_cache_max_bytes();
+    let cache_lock = wasm_module_cache();
+    let mut cache = cache_lock
+        .lock()
+        .map_err(|error| format!("failed to lock wasm module cache: {error}"))?;
+    let insert_outcome = cache.insert(
+        cache_key,
+        module,
+        module_size_bytes,
+        cache_capacity,
+        cache_max_bytes,
+    );
+    Ok(WasmModuleCacheLookup {
+        hit: false,
+        inserted: insert_outcome.inserted,
+        evicted_entries: insert_outcome.evicted_entries,
+        cache_len: cache.len(),
+        cache_capacity,
+        cache_total_module_bytes: cache.total_module_bytes(),
+        cache_max_bytes,
+    })
+}

--- a/crates/spec/src/spec_runtime/wasm_runtime_policy.rs
+++ b/crates/spec/src/spec_runtime/wasm_runtime_policy.rs
@@ -1,0 +1,56 @@
+pub(super) const DEFAULT_WASM_MODULE_CACHE_CAPACITY: usize = 32;
+pub(super) const MAX_WASM_MODULE_CACHE_CAPACITY: usize = 4096;
+pub(super) const DEFAULT_WASM_MODULE_CACHE_MAX_BYTES: usize = 64 * 1024 * 1024;
+pub(super) const MIN_WASM_MODULE_CACHE_MAX_BYTES: usize = 64 * 1024;
+pub(super) const MAX_WASM_MODULE_CACHE_MAX_BYTES: usize = 512 * 1024 * 1024;
+
+const ENV_WASM_CACHE_CAPACITY: &str = "LOONGCLAW_WASM_CACHE_CAPACITY";
+const ENV_WASM_CACHE_MAX_BYTES: &str = "LOONGCLAW_WASM_CACHE_MAX_BYTES";
+const ENV_WASM_SIGNALS_BASED_TRAPS: &str = "LOONGCLAW_WASM_SIGNALS_BASED_TRAPS";
+
+pub(super) fn parse_wasm_module_cache_capacity(raw: Option<&str>) -> usize {
+    raw.and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .map(|value| value.min(MAX_WASM_MODULE_CACHE_CAPACITY))
+        .unwrap_or(DEFAULT_WASM_MODULE_CACHE_CAPACITY)
+}
+
+pub(super) fn wasm_module_cache_capacity_from_env() -> usize {
+    parse_wasm_module_cache_capacity(std::env::var(ENV_WASM_CACHE_CAPACITY).ok().as_deref())
+}
+
+pub(super) fn parse_wasm_module_cache_max_bytes(raw: Option<&str>) -> usize {
+    raw.and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .map(|value| {
+            value.clamp(
+                MIN_WASM_MODULE_CACHE_MAX_BYTES,
+                MAX_WASM_MODULE_CACHE_MAX_BYTES,
+            )
+        })
+        .unwrap_or(DEFAULT_WASM_MODULE_CACHE_MAX_BYTES)
+}
+
+pub(super) fn wasm_module_cache_max_bytes_from_env() -> usize {
+    parse_wasm_module_cache_max_bytes(std::env::var(ENV_WASM_CACHE_MAX_BYTES).ok().as_deref())
+}
+
+pub(super) fn default_wasm_signals_based_traps() -> bool {
+    !cfg!(target_os = "macos")
+}
+
+pub(super) fn parse_wasm_signals_based_traps(raw: Option<&str>) -> bool {
+    let Some(value) = raw else {
+        return default_wasm_signals_based_traps();
+    };
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "1" | "true" | "yes" | "on" | "enabled" => true,
+        "0" | "false" | "no" | "off" | "disabled" => false,
+        _ => default_wasm_signals_based_traps(),
+    }
+}
+
+pub(super) fn wasm_signals_based_traps_enabled_from_env() -> bool {
+    parse_wasm_signals_based_traps(std::env::var(ENV_WASM_SIGNALS_BASED_TRAPS).ok().as_deref())
+}

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -8,9 +8,22 @@ These must hold at every commit on every branch:
 
 1. `cargo fmt --all -- --check` passes
 2. `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
-3. `cargo test --workspace --all-features` passes (currently 242+ tests)
+3. `cargo test --workspace --all-features` passes (test count evolves with the codebase; CI is the source of truth)
 
 Enforced by: CI (`verify` workflow). The optional `scripts/pre-commit` hook runs a subset of these checks locally.
+
+## Runtime Stability Guardrails
+
+1. **Wasm trap behavior is platform-aware by default** — on macOS, `signals_based_traps` is disabled to avoid trap-handler abort instability under parallel bridge tests.
+2. **Runtime override is explicit** — set `LOONGCLAW_WASM_SIGNALS_BASED_TRAPS=true|false` to force trap behavior for diagnostics/experiments.
+3. **Daemon stress gate is scriptable** — run `./scripts/stress_daemon_tests.sh 10 default,2,1` to execute repeated daemon test rounds across thread modes.
+4. **Trap-mode matrix is available when needed** — set `LOONGCLAW_STRESS_WASM_TRAPS_MODES=auto,false,true` to sweep daemon tests across trap behavior modes.
+
+## Architecture Stability Guardrails
+
+1. **Complexity budgets are machine-checkable** — run `./scripts/check_architecture_boundaries.sh` to inspect module line/function budgets for architecture hotspots (`spec_runtime`, `spec_execution`, `provider/mod`, `memory/mod`).
+2. **Memory operation literals are boundary-guarded** — memory core operation strings (`append_turn`, `window`, `clear_session`) must remain centralized in `crates/app/src/memory/*` and never spread into callsites.
+3. **Strict enforcement is opt-in for local hard gates** — set `LOONGCLAW_ARCH_STRICT=true` to make architecture budget violations fail non-zero.
 
 ## Kernel Invariants
 

--- a/docs/design-docs/alpha-test-architecture-optimization-checklist-2026-03-11.md
+++ b/docs/design-docs/alpha-test-architecture-optimization-checklist-2026-03-11.md
@@ -1,0 +1,158 @@
+# Alpha-Test Engineering Optimization Checklist (2026-03-11)
+
+This checklist tracks architecture hardening and long-term sustainability work for `alpha-test`.
+
+## Baseline Assessment Snapshot
+
+- Crash evidence: macOS daemon abort trace captured at `~/Library/Logs/DiagnosticReports/loongclawd-8971dc537d3d8ba9-2026-03-11-084504.ips` (Wasmtime machports trap handler path).
+- Complexity hotspots (lines/functions):
+  - `crates/spec/src/spec_runtime.rs`: `2771/46`
+  - `crates/spec/src/spec_execution.rs`: `1441/22`
+  - `crates/app/src/provider/mod.rs`: `845/9`
+  - `crates/app/src/memory/mod.rs`: `303/11`
+- Reliability baseline (this branch):
+  - `cargo fmt --all -- --check`
+  - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+  - `cargo test --workspace --all-features --locked`
+  - `./scripts/stress_daemon_tests.sh`
+- Latest verification run (`2026-03-11`): all gates passed, including
+  - `LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh`
+  - `LOONGCLAW_STRESS_WASM_TRAPS_MODES=auto,false ./scripts/stress_daemon_tests.sh 1 default,2`
+
+## Completed in Current Track
+
+- [x] Wasm trap mode made platform-aware by default, with explicit env override (`LOONGCLAW_WASM_SIGNALS_BASED_TRAPS`).
+- [x] Memory plane callsites migrated to abstraction constants/builders (`MEMORY_OP_*`, request builders, payload decoder).
+- [x] Provider orchestration split into dedicated internal modules:
+  - `crates/app/src/provider/model_selection.rs`
+  - `crates/app/src/provider/payload_adaptation.rs`
+- [x] `spec_runtime` Wasm runtime policy parsing moved into dedicated module:
+  - `crates/spec/src/spec_runtime/wasm_runtime_policy.rs`
+- [x] `spec_runtime` process stdio bridge path extracted into dedicated module:
+  - `crates/spec/src/spec_runtime/process_stdio_bridge.rs`
+- [x] `spec_runtime` HTTP JSON bridge path extracted into dedicated module:
+  - `crates/spec/src/spec_runtime/http_json_bridge.rs`
+- [x] `spec_runtime` Wasm cache internals extracted into dedicated module:
+  - `crates/spec/src/spec_runtime/wasm_cache.rs`
+- [x] `spec_execution` tool search logic extracted into dedicated module:
+  - `crates/spec/src/spec_execution/tool_search.rs`
+- [x] `spec_execution` security scan evaluation/runtime checks extracted into dedicated module:
+  - `crates/spec/src/spec_execution/security_scan_eval.rs`
+- [x] `spec_execution` security scan policy/profile loading and SIEM export pipeline extracted into dedicated module:
+  - `crates/spec/src/spec_execution/security_scan_policy.rs`
+- [x] `spec_execution` approval guard and risk-profile pipeline extracted into dedicated module:
+  - `crates/spec/src/spec_execution/approval_policy.rs`
+- [x] `spec_execution` bridge support policy checksum/sha256 and security profile canonicalization extracted into dedicated module:
+  - `crates/spec/src/spec_execution/bridge_support_policy.rs`
+- [x] `spec_execution` blocked-operation report assembly centralized via shared builder to remove duplicated return payload construction.
+- [x] Architecture boundary checker added:
+  - `scripts/check_architecture_boundaries.sh`
+  - Task entries: `check:architecture`, `check:architecture:strict`
+- [x] Daemon stress script supports optional trap-mode matrix (`auto|false|true`) via `LOONGCLAW_STRESS_WASM_TRAPS_MODES`.
+- [x] Provider request gate/error policy extracted into dedicated module:
+  - `crates/app/src/provider/error_policy.rs`
+
+## Detailed Refactor Backlog
+
+### P0 (Immediate, Stabilize Core Maintainability)
+
+- [x] Split provider orchestration module (`crates/app/src/provider/mod.rs`) into bounded submodules.
+  - Delivered slices:
+    - `provider/model_selection.rs` (catalog fetch, ranking, retry)
+    - `provider/payload_adaptation.rs` (payload-mode fallback and body shaping)
+    - `provider/error_policy.rs` (error parsing and retry-next-model policy)
+  - Acceptance:
+    - public API signatures unchanged
+    - `provider` tests remain green
+    - architecture budget script still passes
+
+- [x] Split bridge runtime internals from `crates/spec/src/spec_runtime.rs`.
+  - Proposed slices:
+    - `spec_runtime/wasm_cache.rs` (done)
+    - `spec_runtime/process_stdio_bridge.rs` (done)
+    - `spec_runtime/http_json_bridge.rs` (done)
+  - Acceptance:
+    - zero behavior drift on spec runtime tests
+    - no reduction in audit fields
+    - bridge strict-contract tests unchanged and green
+
+- [x] Split `spec_execution` tool search path into dedicated submodule.
+  - Delivered slice:
+    - `spec_execution/tool_search.rs` (done)
+  - Acceptance:
+    - `OperationSpec::ToolSearch` behavior unchanged
+    - full workspace tests green
+    - architecture budget script still passes
+
+- [x] Split `spec_execution` security finding/evaluation path into dedicated submodule.
+  - Delivered slices:
+    - `spec_execution/security_scan_eval.rs` (done)
+    - `spec_execution/security_scan_policy.rs` (done)
+    - `spec_execution/approval_policy.rs` (done)
+    - `spec_execution/bridge_support_policy.rs` (done)
+  - Acceptance:
+    - security scan behavior unchanged under existing runtime tests
+    - full workspace tests green
+    - architecture budget script still passes
+
+- [ ] Establish CI-visible architecture check stage (without changing workflow logic by default).
+  - Local gate first: `task check:architecture:strict`
+  - Acceptance:
+    - command deterministic on macOS/Linux
+    - no false positives in current codebase
+
+### P1 (Medium-Term, Raise Abstraction Quality)
+
+- [x] Introduce typed provider request context object to replace scattered primitive arguments.
+  - Goal: reduce long argument lists in request functions and prevent argument-order mistakes.
+  - Acceptance:
+    - clippy clean
+    - callsite argument count reduced in `request_*_with_model`
+
+- [ ] Add focused property tests for parser/config boundaries.
+  - Targets:
+    - Wasm env parser aliases and invalid values
+    - memory window payload tolerance and missing fields
+  - Acceptance:
+    - pre-fix regression seeds captured
+    - deterministic and non-flaky tests
+
+- [ ] Build a compact runtime resilience matrix doc.
+  - Cover combinations of:
+    - `LOONGCLAW_WASM_SIGNALS_BASED_TRAPS`
+    - daemon `--test-threads`
+    - retry/backoff policy key values
+  - Acceptance:
+    - matrix maps to executable commands
+    - each row has pass/fail evidence link
+
+### P2 (Long-Term, Sustainable Governance)
+
+- [ ] Define architecture SLOs and monthly drift review.
+  - SLO examples:
+    - no hotspot file grows >10% month-over-month
+    - no new cross-layer literal protocol strings outside adapters
+  - Acceptance:
+    - automated monthly report artifact committed under `docs/releases/`
+
+- [ ] Introduce refactor budget policy per release.
+  - Requirement: each feature release must pay down at least one hotspot metric.
+  - Acceptance:
+    - release checklist includes explicit budget item
+
+## Verification Protocol for Each Refactor PR
+
+1. `cargo fmt --all -- --check`
+2. `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+3. `cargo test --workspace --all-features --locked`
+4. `./scripts/check_architecture_boundaries.sh`
+5. `LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh`
+6. `./scripts/stress_daemon_tests.sh 3 default,2,1`
+7. Optional trap matrix: `LOONGCLAW_STRESS_WASM_TRAPS_MODES=auto,false ./scripts/stress_daemon_tests.sh 3 default,2`
+
+## Stop Conditions
+
+- If any stress run reproduces daemon abort, stop feature work and prioritize runtime stability.
+- If architecture strict gate fails, no further module growth until either:
+  - hotspot is split, or
+  - budget thresholds are explicitly adjusted with rationale.

--- a/docs/design-docs/core-beliefs.md
+++ b/docs/design-docs/core-beliefs.md
@@ -10,7 +10,7 @@ These are the golden principles for anyone — agent or human — working in thi
 
 4. **Audit everything security-critical** — policy denials, token lifecycle events, and plane invocations all emit structured audit events. Silent drops are bugs (see: NoopAuditSink incident).
 
-5. **7-crate DAG, no cycles** — `contracts` (leaf) -> `kernel` -> `protocol` (leaf) -> `app` -> `spec` -> `bench` -> `daemon`. Dependency direction is non-negotiable. See [Layered Kernel Design](layered-kernel-design.md).
+5. **7-crate DAG, no cycles** — keep dependency direction strictly acyclic: `contracts -> kernel`; `app -> {contracts, kernel}`; `protocol` remains a foundation crate used by `spec`; `spec -> {kernel, protocol}`; `bench -> {kernel, spec}`; `daemon -> {kernel, app, spec, bench}`. Dependency direction is non-negotiable. See [Layered Kernel Design](layered-kernel-design.md).
 
 6. **Tests are the contract** — if a behavior isn't tested, it doesn't exist. All tests pass at every commit, enforced by the pre-commit hook.
 
@@ -21,3 +21,5 @@ These are the golden principles for anyone — agent or human — working in thi
 9. **Enforce mechanically, not manually** — prefer linters, CI gates, and pre-commit hooks over code review comments. Encode taste into tooling. See `scripts/pre-commit`.
 
 10. **YAGNI ruthlessly** — don't design for hypothetical future requirements. The minimum complexity for the current task is the right amount. Three similar lines of code is better than a premature abstraction.
+
+11. **Control complexity growth with explicit budgets** — large hotspots must have line/function budget checks and boundary assertions (`scripts/check_architecture_boundaries.sh`) so architecture drift is detected before review time.

--- a/scripts/check_architecture_boundaries.sh
+++ b/scripts/check_architecture_boundaries.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+STRICT="${LOONGCLAW_ARCH_STRICT:-false}"
+if [[ "$STRICT" != "true" && "$STRICT" != "false" ]]; then
+  echo "invalid LOONGCLAW_ARCH_STRICT: $STRICT (expected true|false)" >&2
+  exit 2
+fi
+
+violations=0
+
+check_file_budget() {
+  local key="$1"
+  local file="$2"
+  local max_lines="$3"
+  local max_functions="$4"
+
+  if [[ ! -f "$file" ]]; then
+    echo "[arch] missing file: $file" >&2
+    violations=$((violations + 1))
+    return
+  fi
+
+  local lines
+  lines="$(wc -l <"$file" | tr -d '[:space:]')"
+
+  local functions
+  functions="$(rg -n '^(pub\s+)?(async\s+)?fn\s+' "$file" | wc -l | tr -d '[:space:]')"
+
+  local line_status="ok"
+  local fn_status="ok"
+
+  if (( lines > max_lines )); then
+    line_status="over"
+    violations=$((violations + 1))
+  fi
+  if (( functions > max_functions )); then
+    fn_status="over"
+    violations=$((violations + 1))
+  fi
+
+  printf '[arch] %-16s lines=%4s/%-4s (%s) fns=%3s/%-3s (%s) file=%s\n' \
+    "$key" "$lines" "$max_lines" "$line_status" "$functions" "$max_functions" "$fn_status" "$file"
+}
+
+check_file_budget "spec_runtime" "crates/spec/src/spec_runtime.rs" 3600 65
+check_file_budget "spec_execution" "crates/spec/src/spec_execution.rs" 3700 80
+check_file_budget "provider_mod" "crates/app/src/provider/mod.rs" 1000 20
+check_file_budget "memory_mod" "crates/app/src/memory/mod.rs" 400 16
+
+memory_literal_hits="$(rg -n '"append_turn"|"window"|"clear_session"' crates/app/src --glob '!crates/app/src/memory/**' || true)"
+if [[ -n "$memory_literal_hits" ]]; then
+  echo "[arch] over: memory operation literals found outside memory module boundary" >&2
+  echo "$memory_literal_hits" >&2
+  violations=$((violations + 1))
+else
+  echo "[arch] ok: memory operation literals are centralized in crates/app/src/memory/*"
+fi
+
+if (( violations > 0 )); then
+  if [[ "$STRICT" == "true" ]]; then
+    echo "[arch] failed: detected $violations architectural boundary violation(s)" >&2
+    exit 1
+  fi
+  echo "[arch] warning: detected $violations architectural boundary violation(s) (strict mode disabled)" >&2
+  exit 0
+fi
+
+echo "[arch] passed: architectural boundaries are within configured budgets"

--- a/scripts/stress_daemon_tests.sh
+++ b/scripts/stress_daemon_tests.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+ROUNDS="${1:-10}"
+THREAD_MODES="${2:-default,2,1}"
+LOG_DIR="${3:-target/test-stress/daemon}"
+TRAP_MODES="${4:-${LOONGCLAW_STRESS_WASM_TRAPS_MODES:-auto}}"
+LOCKED="${LOONGCLAW_STRESS_LOCKED:-true}"
+
+if ! [[ "$ROUNDS" =~ ^[0-9]+$ ]] || [[ "$ROUNDS" -le 0 ]]; then
+  echo "invalid ROUNDS: $ROUNDS (expected positive integer)" >&2
+  exit 2
+fi
+
+if [[ "$LOCKED" != "true" && "$LOCKED" != "false" ]]; then
+  echo "invalid LOONGCLAW_STRESS_LOCKED: $LOCKED (expected true|false)" >&2
+  exit 2
+fi
+
+mkdir -p "$LOG_DIR"
+
+start_ts="$(date +%s)"
+
+run_mode() {
+  local trap_mode="$1"
+  local mode="$2"
+  local run_index
+  for run_index in $(seq 1 "$ROUNDS"); do
+    local log_file="$LOG_DIR/traps-${trap_mode}-mode-${mode}-run-${run_index}.log"
+    local cmd=(
+      cargo test
+      -p loongclaw-daemon
+      --bin loongclawd
+      --all-features
+    )
+    if [[ "$LOCKED" == "true" ]]; then
+      cmd+=(--locked)
+    fi
+    if [[ "$mode" != "default" ]]; then
+      cmd+=(-- "--test-threads=${mode}")
+    fi
+
+    echo "[stress] traps=${trap_mode} mode=${mode} run=${run_index}/${ROUNDS}"
+    if [[ "$trap_mode" == "auto" ]]; then
+      if ! env -u LOONGCLAW_WASM_SIGNALS_BASED_TRAPS "${cmd[@]}" >"$log_file" 2>&1; then
+        echo "[stress] failed: traps=${trap_mode} mode=${mode} run=${run_index}" >&2
+        echo "[stress] log: $log_file" >&2
+        tail -n 80 "$log_file" >&2 || true
+        exit 1
+      fi
+      continue
+    fi
+
+    if ! LOONGCLAW_WASM_SIGNALS_BASED_TRAPS="$trap_mode" "${cmd[@]}" >"$log_file" 2>&1; then
+      echo "[stress] failed: traps=${trap_mode} mode=${mode} run=${run_index}" >&2
+      echo "[stress] log: $log_file" >&2
+      tail -n 80 "$log_file" >&2 || true
+      exit 1
+    fi
+  done
+}
+
+IFS=',' read -r -a modes <<<"$THREAD_MODES"
+IFS=',' read -r -a trap_modes <<<"$TRAP_MODES"
+for trap_mode_raw in "${trap_modes[@]}"; do
+  trap_mode="${trap_mode_raw//[[:space:]]/}"
+  if [[ -z "$trap_mode" ]]; then
+    continue
+  fi
+  if [[ "$trap_mode" != "auto" && "$trap_mode" != "true" && "$trap_mode" != "false" ]]; then
+    echo "invalid trap mode: $trap_mode (expected auto|true|false)" >&2
+    exit 2
+  fi
+
+  for mode_raw in "${modes[@]}"; do
+    mode="${mode_raw//[[:space:]]/}"
+    if [[ -z "$mode" ]]; then
+      continue
+    fi
+    if [[ "$mode" != "default" && ! "$mode" =~ ^[0-9]+$ ]]; then
+      echo "invalid thread mode: $mode (expected default or positive integer)" >&2
+      exit 2
+    fi
+    run_mode "$trap_mode" "$mode"
+  done
+done
+
+end_ts="$(date +%s)"
+echo "[stress] completed in $((end_ts - start_ts))s"
+echo "[stress] modes=${THREAD_MODES} traps=${TRAP_MODES} rounds=${ROUNDS} (logs: ${LOG_DIR})"


### PR DESCRIPTION
## Summary

This PR performs a deep architecture hardening pass for `alpha-test` by decomposing high-churn hotspots into focused internal modules while preserving existing runtime behavior.

Closes #10.

### Main changes

- `spec_runtime` internals split into dedicated modules:
  - `wasm_runtime_policy.rs`
  - `process_stdio_bridge.rs`
  - `http_json_bridge.rs`
  - `wasm_cache.rs`
- `spec_execution` internals split into dedicated modules:
  - `tool_search.rs`
  - `security_scan_eval.rs`
  - `security_scan_policy.rs`
  - `approval_policy.rs`
  - `bridge_support_policy.rs`
- centralized repeated blocked-result assembly in `execute_spec`
- `provider/mod.rs` decomposition:
  - `model_selection.rs`
  - `payload_adaptation.rs`
  - `error_policy.rs`
- architecture and stress helper scripts added
- docs/checklist updated with metrics and validation protocol

## Metrics

- `crates/spec/src/spec_execution.rs`: `2655/56 -> 1441/22` (lines/functions)
- `crates/app/src/provider/mod.rs`: `905/14 -> 845/9`

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh`
- `LOONGCLAW_STRESS_WASM_TRAPS_MODES=auto,false ./scripts/stress_daemon_tests.sh 1 default,2`
