### PR TITLE
test(app): add scoped env harness for config tests

### DIFF
--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -619,6 +619,8 @@ mod tests {
     /// 3. Neither HOME nor USERPROFILE set → should return "."
     #[test]
     fn get_user_home_deterministic_fallback_scenarios() {
+        use crate::test_support::ScopedEnv;
+
         // Scenario 1: real OS should have at least one var set
         let home_on_real_os = get_user_home();
         assert_ne!(
@@ -627,33 +629,22 @@ mod tests {
             "get_user_home() should resolve to a real directory, not \".\""
         );
 
-        let original_home = env::var_os("HOME");
-        let original_userprofile = env::var_os("USERPROFILE");
-
         let synthetic = PathBuf::from(if cfg!(windows) {
             r"C:\Users\loongclaw-test-synthetic"
         } else {
             "/tmp/loongclaw-test-synthetic"
         });
 
+        let mut env_guard = ScopedEnv::new();
+
         // Scenario 2: HOME absent, USERPROFILE present → returns USERPROFILE
-        env::remove_var("HOME");
-        env::set_var("USERPROFILE", &synthetic);
+        env_guard.remove("HOME");
+        env_guard.set("USERPROFILE", &synthetic);
         let result_userprofile = get_user_home();
 
         // Scenario 3: both absent → returns "."
-        env::remove_var("USERPROFILE");
+        env_guard.remove("USERPROFILE");
         let result_dot = get_user_home();
-
-        // Restore original env before assertions (panic-safe ordering)
-        match original_home {
-            Some(v) => env::set_var("HOME", v),
-            None => env::remove_var("HOME"),
-        }
-        match original_userprofile {
-            Some(v) => env::set_var("USERPROFILE", v),
-            None => env::remove_var("USERPROFILE"),
-        }
 
         assert_eq!(
             result_userprofile, synthetic,

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -9,5 +9,8 @@ pub mod tools;
 
 pub use context::KernelContext;
 
+#[cfg(test)]
+pub(crate) mod test_support;
+
 /// Result type for MVP CLI operations.
 pub type CliResult<T> = Result<T, String>;

--- a/crates/app/src/test_support.rs
+++ b/crates/app/src/test_support.rs
@@ -1,0 +1,50 @@
+use std::ffi::{OsStr, OsString};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+fn env_lock() -> &'static Mutex<()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+pub(crate) struct ScopedEnv {
+    originals: Vec<(&'static str, Option<OsString>)>,
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl ScopedEnv {
+    pub(crate) fn new() -> Self {
+        let guard = env_lock().lock().expect("env lock should not be poisoned");
+        Self {
+            originals: Vec::new(),
+            _guard: guard,
+        }
+    }
+
+    pub(crate) fn set(&mut self, key: &'static str, value: impl AsRef<OsStr>) {
+        self.capture_original(key);
+        std::env::set_var(key, value);
+    }
+
+    pub(crate) fn remove(&mut self, key: &'static str) {
+        self.capture_original(key);
+        std::env::remove_var(key);
+    }
+
+    fn capture_original(&mut self, key: &'static str) {
+        if self.originals.iter().any(|(saved, _)| *saved == key) {
+            return;
+        }
+        self.originals.push((key, std::env::var_os(key)));
+    }
+}
+
+impl Drop for ScopedEnv {
+    fn drop(&mut self) {
+        for (key, original) in self.originals.iter().rev() {
+            match original {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}

--- a/crates/app/src/test_support.rs
+++ b/crates/app/src/test_support.rs
@@ -13,7 +13,9 @@ pub(crate) struct ScopedEnv {
 
 impl ScopedEnv {
     pub(crate) fn new() -> Self {
-        let guard = env_lock().lock().expect("env lock should not be poisoned");
+        let guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         Self {
             originals: Vec::new(),
             _guard: guard,
@@ -46,5 +48,27 @@ impl Drop for ScopedEnv {
                 None => std::env::remove_var(key),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ScopedEnv;
+
+    #[test]
+    fn scoped_env_recovers_after_mutex_poison() {
+        let panic_result = std::thread::spawn(|| {
+            let _env = ScopedEnv::new();
+            panic!("poison env lock for test");
+        })
+        .join();
+
+        assert!(panic_result.is_err(), "setup thread should poison the lock");
+
+        let recovery = std::panic::catch_unwind(ScopedEnv::new);
+        assert!(
+            recovery.is_ok(),
+            "ScopedEnv::new should recover from a poisoned env lock"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add a shared `ScopedEnv` helper for app tests
- migrate `config/shared.rs` home-dir fallback coverage to the shared helper
- keep this PR limited to deterministic env restoration and test harness reuse

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [ ] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Env-mutating test coverage now uses `ScopedEnv`, which takes a shared mutex, snapshots the original values once per key, and restores them on drop.

## Linked Issues

No linked issue. Split from PR #4 review follow-up.
