### PR TITLE
fix(alpha-test): repair architecture strict follow-up

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,7 +61,7 @@ tasks:
   check:architecture:strict:
     desc: Fail on any architecture boundary budget violations
     cmds:
-      - LOONGCLAW_ARCH_STRICT=1 scripts/check_architecture_boundaries.sh
+      - LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
 
   check:deny:
     desc: Run cargo-deny (advisories, bans, sources)
@@ -82,8 +82,9 @@ tasks:
       - task: check:deny
 
   verify:full:
-    desc: Extended verification including smoke and benchmark gates
+    desc: Extended verification including architecture, smoke, and benchmark gates
     cmds:
       - task: verify
+      - task: check:architecture:strict
       - task: smoke
       - task: benchmark:pressure

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -16,14 +16,14 @@ Enforced by: CI (`verify` workflow). The optional `scripts/pre-commit` hook runs
 
 1. **Wasm trap behavior is platform-aware by default** — on macOS, `signals_based_traps` is disabled to avoid trap-handler abort instability under parallel bridge tests.
 2. **Runtime override is explicit** — set `LOONGCLAW_WASM_SIGNALS_BASED_TRAPS=true|false` to force trap behavior for diagnostics/experiments.
-3. **Daemon stress gate is scriptable** — run `./scripts/stress_daemon_tests.sh 10 default,2,1` to execute repeated daemon test rounds across thread modes.
-4. **Trap-mode matrix is available when needed** — set `LOONGCLAW_STRESS_WASM_TRAPS_MODES=auto,false,true` to sweep daemon tests across trap behavior modes.
+3. **Daemon stress helper is scriptable** — run `./scripts/stress_daemon_tests.sh 10 default,2,1` for manual repeated daemon test validation across thread modes.
+4. **Trap-mode matrix is available when needed** — set `LOONGCLAW_STRESS_WASM_TRAPS_MODES=auto,false,true` to sweep daemon tests across trap behavior modes during targeted investigation.
 
 ## Architecture Stability Guardrails
 
-1. **Complexity budgets are machine-checkable** — run `./scripts/check_architecture_boundaries.sh` to inspect module line/function budgets for architecture hotspots (`spec_runtime`, `spec_execution`, `provider/mod`, `memory/mod`).
+1. **Complexity budgets are locally machine-checkable** — run `./scripts/check_architecture_boundaries.sh` or `task check:architecture` to inspect module line/function budgets for architecture hotspots (`spec_runtime`, `spec_execution`, `provider/mod`, `memory/mod`).
 2. **Memory operation literals are boundary-guarded** — memory core operation strings (`append_turn`, `window`, `clear_session`) must remain centralized in `crates/app/src/memory/*` and never spread into callsites.
-3. **Strict enforcement is opt-in for local hard gates** — set `LOONGCLAW_ARCH_STRICT=true` to make architecture budget violations fail non-zero.
+3. **Strict enforcement is an extended local gate** — use `task check:architecture:strict` (or set `LOONGCLAW_ARCH_STRICT=true`) to make architecture budget violations fail non-zero. This check is part of `task verify:full`, not the canonical CI-parity gate.
 
 ## Kernel Invariants
 

--- a/docs/design-docs/alpha-test-architecture-optimization-checklist-2026-03-11.md
+++ b/docs/design-docs/alpha-test-architecture-optimization-checklist-2026-03-11.md
@@ -47,7 +47,7 @@ This checklist tracks architecture hardening and long-term sustainability work f
 - [x] `spec_execution` blocked-operation report assembly centralized via shared builder to remove duplicated return payload construction.
 - [x] Architecture boundary checker added:
   - `scripts/check_architecture_boundaries.sh`
-  - Task entries: `check:architecture`, `check:architecture:strict`
+  - Task entries: `check:architecture`, `check:architecture:strict` (local / extended verification)
 - [x] Daemon stress script supports optional trap-mode matrix (`auto|false|true`) via `LOONGCLAW_STRESS_WASM_TRAPS_MODES`.
 - [x] Provider request gate/error policy extracted into dedicated module:
   - `crates/app/src/provider/error_policy.rs`
@@ -96,7 +96,7 @@ This checklist tracks architecture hardening and long-term sustainability work f
     - architecture budget script still passes
 
 - [ ] Establish CI-visible architecture check stage (without changing workflow logic by default).
-  - Local gate first: `task check:architecture:strict`
+  - Local gate first: `task check:architecture:strict` (now wired into `task verify:full`)
   - Acceptance:
     - command deterministic on macOS/Linux
     - no false positives in current codebase

--- a/docs/design-docs/core-beliefs.md
+++ b/docs/design-docs/core-beliefs.md
@@ -22,4 +22,4 @@ These are the golden principles for anyone — agent or human — working in thi
 
 10. **YAGNI ruthlessly** — don't design for hypothetical future requirements. The minimum complexity for the current task is the right amount. Three similar lines of code is better than a premature abstraction.
 
-11. **Control complexity growth with explicit budgets** — large hotspots must have line/function budget checks and boundary assertions (`scripts/check_architecture_boundaries.sh`) so architecture drift is detected before review time.
+11. **Control complexity growth with explicit budgets** — large hotspots should have line/function budget checks and boundary assertions (`scripts/check_architecture_boundaries.sh`) so architecture drift is surfaced early in local verification and can be promoted into CI once the checks are stable.


### PR DESCRIPTION
## Summary

Follow-up to merged PR #12.

This PR fixes the broken `check:architecture:strict` task and aligns the architecture/stress guardrail docs with the checks that are actually enforced today.

### Changes

- fix `Taskfile.yml` so `task check:architecture:strict` uses `LOONGCLAW_ARCH_STRICT=true`
- wire `check:architecture:strict` into `task verify:full`
- soften docs that previously implied the new guardrails were already canonical CI gates
- keep the alpha-test checklist explicit that CI-visible architecture enforcement is still pending

## Why

PR #12 introduced a broken local strict gate:

- `task check:architecture:strict` failed immediately because the Taskfile passed `LOONGCLAW_ARCH_STRICT=1`
- `scripts/check_architecture_boundaries.sh` only accepts `true|false`

The same merge also made the docs read stronger than the actual enforcement level. This PR brings the wording back in line with reality without changing canonical CI behavior.

## Validation

- `task check:architecture:strict`
- `task check:docs`
- `task --dry verify:full`
- pre-commit hook (`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`)
