### PR TITLE
refactor(alpha-test): rename cli command to loongclaw

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         required: true
 
 env:
-  BIN_NAME: loongclawd
+  BIN_NAME: loongclaw
   PACKAGE_NAME: loongclaw
 
 jobs:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -27,7 +27,7 @@ No dependency cycles. This is non-negotiable.
 | `app` | Providers, tools, channels, memory backends, configuration, and conversation engine. Houses all feature-flagged modules. |
 | `spec` | Execution specification runner for deterministic test scenarios. |
 | `bench` | Performance benchmark harness and gate enforcement. |
-| `daemon` | CLI binary (`loongclawd`). Wires all crates into runnable commands: `setup`, `onboard`, `doctor`, `chat`, `run-spec`, benchmarks. |
+| `daemon` | CLI binary (`loongclaw`). Wires all crates into runnable commands: `setup`, `onboard`, `doctor`, `chat`, `run-spec`, benchmarks. |
 
 ## Layered Execution Model
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cargo install --path crates/daemon
 1. Generate config and bootstrap local state:
 
    ```bash
-   loongclawd setup
+   loongclaw setup
    ```
 
 2. Set your provider API key:
@@ -109,10 +109,10 @@ cargo install --path crates/daemon
 3. Start chatting:
 
    ```bash
-   loongclawd chat
+   loongclaw chat
    ```
 
-Run `loongclawd doctor --fix` if anything goes wrong.
+Run `loongclaw doctor --fix` if anything goes wrong.
 
 ### Run Tests
 
@@ -182,7 +182,7 @@ contracts (leaf -- zero internal deps)
 | `app` | Providers, tools, channels, memory, configuration, conversation engine. |
 | `spec` | Execution spec runner for deterministic test scenarios. |
 | `bench` | Benchmark harness and gate enforcement. |
-| `daemon` | CLI binary (`loongclawd`). Wires everything into runnable commands. |
+| `daemon` | CLI binary (`loongclaw`). Wires everything into runnable commands. |
 
 For the full layered execution model (L0-L9), see [ARCHITECTURE.md](ARCHITECTURE.md).
 
@@ -237,7 +237,7 @@ cargo build -p loongclaw-daemon --no-default-features --features "channel-cli,pr
 
 ## Configuration
 
-`loongclawd setup` defaults to referencing secrets via environment variables (not storing them directly):
+`loongclaw setup` defaults to referencing secrets via environment variables (not storing them directly):
 
 ```toml
 [provider]
@@ -250,7 +250,7 @@ For direct values, use the non-`_env` fields instead (`api_key = "sk-..."`).
 Validate your config:
 
 ```bash
-loongclawd validate-config --config ~/.loongclaw/config.toml --json
+loongclaw validate-config --config ~/.loongclaw/config.toml --json
 ```
 
 ## Contributing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,7 +97,7 @@ cargo install --path crates/daemon
 1. 生成配置并引导本地状态：
 
    ```bash
-   loongclawd setup
+   loongclaw setup
    ```
 
 2. 设置 provider API 密钥：
@@ -109,10 +109,10 @@ cargo install --path crates/daemon
 3. 开始聊天：
 
    ```bash
-   loongclawd chat
+   loongclaw chat
    ```
 
-遇到问题请运行 `loongclawd doctor --fix`。
+遇到问题请运行 `loongclaw doctor --fix`。
 
 ### 运行测试
 
@@ -182,7 +182,7 @@ contracts (leaf -- 零内部依赖)
 | `app` | Provider、工具、通道、内存、配置、对话引擎。 |
 | `spec` | 确定性测试场景执行器。 |
 | `bench` | 基准测试框架和验收执行。 |
-| `daemon` | CLI 二进制 (`loongclawd`)。将所有 crate 连接为可运行的命令。 |
+| `daemon` | CLI 二进制 (`loongclaw`)。将所有 crate 连接为可运行的命令。 |
 
 完整的分层执行模型（L0-L9），请参见 [ARCHITECTURE.md](ARCHITECTURE.md)。
 
@@ -236,7 +236,7 @@ cargo build -p loongclaw-daemon --no-default-features --features "channel-cli,pr
 
 ## 配置
 
-`loongclawd setup` 默认使用环境变量引用密钥（不直接存储）：
+`loongclaw setup` 默认使用环境变量引用密钥（不直接存储）：
 
 ```toml
 [provider]
@@ -249,7 +249,7 @@ api_key_env = "PROVIDER_API_KEY"   # 环境变量名称，不是密钥本身
 验证配置：
 
 ```bash
-loongclawd validate-config --config ~/.loongclaw/config.toml --json
+loongclaw validate-config --config ~/.loongclaw/config.toml --json
 ```
 
 ## 贡献

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,9 +34,9 @@ tasks:
   smoke:
     desc: Run representative spec-runner smoke scenarios
     cmds:
-      - cargo run -p loongclaw-daemon --bin loongclawd -- run-spec --spec examples/spec/runtime-extension.json --print-audit
-      - cargo run -p loongclaw-daemon --bin loongclawd -- run-spec --spec examples/spec/tool-search.json --print-audit
-      - cargo run -p loongclaw-daemon --bin loongclawd -- run-spec --spec examples/spec/programmatic-tool-call.json --print-audit
+      - cargo run -p loongclaw-daemon --bin loongclaw -- run-spec --spec examples/spec/runtime-extension.json --print-audit
+      - cargo run -p loongclaw-daemon --bin loongclaw -- run-spec --spec examples/spec/tool-search.json --print-audit
+      - cargo run -p loongclaw-daemon --bin loongclaw -- run-spec --spec examples/spec/programmatic-tool-call.json --print-audit
 
   benchmark:pressure:
     desc: Run programmatic pressure benchmark with gate enforcement

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -106,7 +106,7 @@ pub fn load(path: Option<&str>) -> CliResult<(PathBuf, LoongClawConfig)> {
     let config_path = path.map(expand_path).unwrap_or_else(default_config_path);
     let raw = fs::read_to_string(&config_path).map_err(|error| {
         format!(
-            "failed to read config {}: {error}. run `loongclawd setup` first",
+            "failed to read config {}: {error}. run `loongclaw setup` first",
             config_path.display()
         )
     })?;
@@ -134,7 +134,7 @@ pub fn validate_file_with_locale(
     let config_path = path.map(expand_path).unwrap_or_else(default_config_path);
     let raw = fs::read_to_string(&config_path).map_err(|error| {
         format!(
-            "failed to read config {}: {error}. run `loongclawd setup` first",
+            "failed to read config {}: {error}. run `loongclaw setup` first",
             config_path.display()
         )
     })?;
@@ -443,6 +443,15 @@ api_key_env = "$OPENAI_API_KEY"
     #[test]
     fn supported_validation_locales_stays_stable() {
         assert_eq!(supported_validation_locales(), vec!["en"]);
+    }
+
+    #[test]
+    fn load_missing_config_guides_user_to_loongclaw_setup() {
+        let missing = unique_config_path("loongclaw-config-missing");
+        let path_string = missing.display().to_string();
+
+        let error = load(Some(&path_string)).expect_err("missing config should fail");
+        assert!(error.contains("run `loongclaw setup` first"));
     }
 
     #[test]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -30,7 +30,7 @@ tokio.workspace = true
 chrono.workspace = true
 
 [[bin]]
-name = "loongclawd"
+name = "loongclaw"
 path = "src/main.rs"
 
 [dev-dependencies]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -38,7 +38,7 @@ const PUBLIC_GITHUB_REPO: &str = "loongclaw-ai/loongclaw";
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "loongclawd",
+    name = "loongclaw",
     about = "LoongClaw low-level runtime daemon",
     version
 )]
@@ -625,7 +625,7 @@ fn run_setup_cli(output: Option<&str>, force: bool) -> CliResult<()> {
     {
         println!("setup complete\n- config: {}", path.display());
     }
-    println!("next step: loongclawd chat --config {}", path.display());
+    println!("next step: loongclaw chat --config {}", path.display());
     Ok(())
 }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -145,7 +145,7 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
     }
     #[cfg(feature = "memory-sqlite")]
     println!("- sqlite memory: {}", memory_path.display());
-    println!("next step: loongclawd chat --config {}", path.display());
+    println!("next step: loongclaw chat --config {}", path.display());
     Ok(())
 }
 

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use clap::CommandFactory;
 
 fn approval_test_operation(tool_name: &str, payload: Value) -> OperationSpec {
     OperationSpec::ToolCore {
@@ -33,6 +34,12 @@ mod onboard_cli;
 mod programmatic;
 mod spec_runtime;
 mod spec_runtime_bridge;
+
+#[test]
+fn clap_command_name_is_loongclaw() {
+    let command = Cli::command();
+    assert_eq!(command.get_name(), "loongclaw");
+}
 
 #[test]
 fn resolve_validate_output_defaults_to_text() {

--- a/docs/design-docs/alpha-test-architecture-optimization-checklist-2026-03-11.md
+++ b/docs/design-docs/alpha-test-architecture-optimization-checklist-2026-03-11.md
@@ -4,7 +4,7 @@ This checklist tracks architecture hardening and long-term sustainability work f
 
 ## Baseline Assessment Snapshot
 
-- Crash evidence: macOS daemon abort trace captured at `~/Library/Logs/DiagnosticReports/loongclawd-8971dc537d3d8ba9-2026-03-11-084504.ips` (Wasmtime machports trap handler path).
+- Crash evidence: macOS daemon abort trace captured in `~/Library/Logs/DiagnosticReports/` for the CLI binary (Wasmtime machports trap handler path).
 - Complexity hotspots (lines/functions):
   - `crates/spec/src/spec_runtime.rs`: `2771/46`
   - `crates/spec/src/spec_execution.rs`: `1441/22`

--- a/docs/plans/2026-03-11-channel-account-hardening-phase-9-design.md
+++ b/docs/plans/2026-03-11-channel-account-hardening-phase-9-design.md
@@ -75,8 +75,8 @@ For both `telegram` and `feishu`:
 `ChannelStatusSnapshot` should grow a boolean marker for default-account
 selection. That marker should appear in:
 
-- JSON output from `loongclawd channels --json`
-- text output from `loongclawd channels`
+- JSON output from `loongclaw channels --json`
+- text output from `loongclaw channels`
 - snapshot notes used by `doctor` and other diagnostics
 
 The goal is not cosmetic labeling. The goal is to make it obvious which

--- a/docs/plans/2026-03-11-channel-doctor-runtime-phase-5-design.md
+++ b/docs/plans/2026-03-11-channel-doctor-runtime-phase-5-design.md
@@ -2,7 +2,7 @@
 
 **Scope**
 
-Phase 5 upgrades `loongclawd doctor` from configuration-only channel checks to
+Phase 5 upgrades `loongclaw doctor` from configuration-only channel checks to
 runtime-aware diagnostics for tracked serve operations.
 
 It does not add new channel transports. It closes the operator feedback loop
@@ -11,7 +11,7 @@ opened by Phase 4 runtime persistence.
 **Problem Statement**
 
 After Phase 4, LoongClaw could persist serve runtime state and expose it through
-`loongclawd channels`, but `doctor` still treated channels as a pure readiness
+`loongclaw channels`, but `doctor` still treated channels as a pure readiness
 problem. That left two operator workflows misaligned:
 
 - `channels` could say a serve loop was stale or not running

--- a/docs/plans/2026-03-11-channel-doctor-runtime-phase-5.md
+++ b/docs/plans/2026-03-11-channel-doctor-runtime-phase-5.md
@@ -1,7 +1,7 @@
 # Channel Doctor Runtime Phase 5 Implementation Plan
 
-**Goal:** Make `loongclawd doctor` consume the same runtime-aware channel
-snapshots as `loongclawd channels`, so operator diagnostics reflect both config
+**Goal:** Make `loongclaw doctor` consume the same runtime-aware channel
+snapshots as `loongclaw channels`, so operator diagnostics reflect both config
 readiness and serve-loop liveness.
 
 **Architecture:** Reuse shared channel snapshots from `loongclaw-app::channel`,

--- a/docs/plans/2026-03-11-channel-runtime-state-phase-4-design.md
+++ b/docs/plans/2026-03-11-channel-runtime-state-phase-4-design.md
@@ -116,7 +116,7 @@ premature coordinator or lock server.
 - `process_channel_batch(...)` updates runtime for Telegram serve work
 - `feishu_webhook_handler(...)` updates runtime around provider processing
 - channel registry merges persisted runtime into serve operation snapshots
-- `loongclawd channels` renders runtime lines for tracked operations
+- `loongclaw channels` renders runtime lines for tracked operations
 
 **Why This Is The Right Next Step**
 

--- a/docs/plans/2026-03-11-channel-runtime-state-phase-4.md
+++ b/docs/plans/2026-03-11-channel-runtime-state-phase-4.md
@@ -57,7 +57,7 @@ Required behavior:
 
 ### Task 4: Expose runtime in operator surfaces
 
-Update `loongclawd channels` text output to include:
+Update `loongclaw channels` text output to include:
 
 - `running`
 - `stale`

--- a/docs/plans/2026-03-11-cli-name-unification-design.md
+++ b/docs/plans/2026-03-11-cli-name-unification-design.md
@@ -1,0 +1,73 @@
+# CLI Name Unification Design
+
+**Scope**
+
+Unify the canonical command name on `alpha-test` to `loongclaw` everywhere that
+the repository exposes or documents a runnable CLI.
+
+This includes:
+
+- the compiled binary name
+- clap help / command identity
+- install scripts
+- source-level operator guidance strings
+- README and examples
+- release workflow packaging inputs
+
+This change explicitly does **not** keep a legacy compatibility alias.
+
+**Problem Statement**
+
+The repository already presents itself as `LoongClaw` at the project level, and
+release archives are already named `loongclaw-*`. The mismatch is that the
+actual executable and most command examples still use a daemon-suffixed command
+name.
+
+That split creates three operator problems:
+
+- users have to remember a daemon-suffixed command that does not match the
+  product name
+- install, help, and follow-up guidance are inconsistent with release artifact
+  naming
+- future docs and automation will keep leaking mixed terminology unless the
+  binary identity itself changes
+
+**Chosen Design**
+
+Make `loongclaw` the only canonical CLI name by changing the binary definition
+and every user-facing reference that currently points to the daemon-suffixed
+legacy command.
+
+Implementation follows four layers:
+
+1. rename the binary target in `crates/daemon/Cargo.toml`
+2. rename the clap command identity in `crates/daemon/src/main.rs`
+3. update all source strings that instruct operators which command to run
+4. update scripts, docs, examples, and release workflow inputs so build,
+   install, and published artifacts all speak the same name
+
+**Behavior**
+
+After this change:
+
+- `cargo build -p loongclaw-daemon --bin loongclaw` is the intended build path
+- help output identifies the CLI as `loongclaw`
+- generated operator guidance says `loongclaw setup`, `loongclaw chat`, and
+  `loongclaw doctor --fix`
+- install scripts place `loongclaw` in the destination prefix
+- release workflow packages the `loongclaw` executable inside
+  `loongclaw-vX.Y.Z-*` archives
+
+There is no fallback daemon-style binary name, alias, or compatibility wording
+left behind.
+
+**Risks And Mitigations**
+
+- Existing scripts outside the repository that call the old daemon-suffixed
+  command will break.
+  This is an intentional compatibility break requested for the branch.
+- CI / release workflow can silently drift if only docs are changed. Mitigation:
+  update workflow variables and build invocations together with source.
+- User guidance strings are easy to miss. Mitigation: add focused tests around
+  the canonical command name and run a repository-wide search before
+  completion.

--- a/docs/plans/2026-03-11-cli-name-unification.md
+++ b/docs/plans/2026-03-11-cli-name-unification.md
@@ -1,0 +1,64 @@
+# CLI Name Unification Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `loongclaw` the only CLI command name on `alpha-test`, with no
+legacy daemon-suffixed compatibility path.
+
+**Architecture:** Rename the binary target and clap identity first, then sweep
+all operator-facing references in source, scripts, docs, examples, and release
+workflow configuration so the repository exposes one command name end-to-end.
+
+**Tech Stack:** Rust, clap, shell, PowerShell, GitHub Actions, Markdown
+
+---
+
+### Task 1: Add failing tests for the canonical CLI name
+
+**Files:**
+- Modify: `crates/daemon/src/tests/mod.rs`
+- Modify: `crates/app/src/config/runtime.rs`
+
+Add tests that prove:
+
+- the clap command name is `loongclaw`
+- the config-load guidance tells users to run `loongclaw setup`
+
+### Task 2: Rename the binary and source-level command guidance
+
+**Files:**
+- Modify: `crates/daemon/Cargo.toml`
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `crates/app/src/config/runtime.rs`
+
+Rename the compiled binary and every built-in operator hint from the old
+daemon-suffixed command name to `loongclaw`.
+
+### Task 3: Update install, documentation, examples, and release workflow
+
+**Files:**
+- Modify: `scripts/install.sh`
+- Modify: `scripts/install.ps1`
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+- Modify: `examples/README.md`
+- Modify: `ARCHITECTURE.md`
+- Modify: `Taskfile.yml`
+- Modify: `.github/workflows/release.yml`
+- Modify: `docs/plans/*.md` entries that still show the old command name where
+  the current branch should describe the new canonical CLI
+
+Remove the old daemon-suffixed command name from repository-owned operator
+instructions and build automation.
+
+### Task 4: Verify the rename
+
+Run:
+
+```bash
+cargo test -p loongclaw-app config::
+cargo test -p loongclaw-daemon tests::
+rg -n '\bloongclawd\b' .
+cargo test --workspace --all-features
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,7 +35,7 @@ Each spec file is a self-contained execution scenario. No external services requ
 ## Running Spec Files
 
 ```bash
-loongclawd run-spec --spec examples/spec/runtime-extension.json --print-audit
+loongclaw run-spec --spec examples/spec/runtime-extension.json --print-audit
 ```
 
 `--print-audit` shows the full audit trail for the execution.
@@ -45,7 +45,7 @@ Run all spec files:
 ```bash
 for spec in examples/spec/*.json; do
   echo "--- Running: $spec ---"
-  loongclawd run-spec --spec "$spec" --print-audit
+  loongclaw run-spec --spec "$spec" --print-audit
 done
 ```
 
@@ -54,7 +54,7 @@ done
 Programmatic pressure benchmark:
 
 ```bash
-loongclawd benchmark-programmatic-pressure \
+loongclaw benchmark-programmatic-pressure \
   --matrix examples/benchmarks/programmatic-pressure-matrix.json \
   --enforce-gate
 ```
@@ -62,7 +62,7 @@ loongclawd benchmark-programmatic-pressure \
 WASM cache benchmark:
 
 ```bash
-loongclawd benchmark-wasm-cache \
+loongclaw benchmark-wasm-cache \
   --wasm examples/plugins-wasm/secure_echo.wasm \
   --enforce-gate
 ```
@@ -71,7 +71,7 @@ Optional runtime tuning:
 
 ```bash
 # default = 32, max = 4096
-LOONGCLAW_WASM_CACHE_CAPACITY=64 loongclawd benchmark-wasm-cache \
+LOONGCLAW_WASM_CACHE_CAPACITY=64 loongclaw benchmark-wasm-cache \
   --wasm examples/plugins-wasm/secure_echo.wasm \
   --enforce-gate
 ```

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -10,8 +10,8 @@ function Write-Usage {
 Usage: pwsh ./scripts/install.ps1 [-Prefix <dir>] [-Setup]
 
 Options:
-  -Prefix <dir>   Install directory for loongclawd (default: $HOME/.local/bin)
-  -Setup          Run 'loongclawd setup --force' after install
+  -Prefix <dir>   Install directory for loongclaw (default: $HOME/.local/bin)
+  -Setup          Run 'loongclaw setup --force' after install
 "@
 }
 
@@ -27,23 +27,23 @@ if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Resolve-Path (Join-Path $scriptDir "..")
 
-Write-Host "==> Building loongclawd (release)"
+Write-Host "==> Building loongclaw (release)"
 Push-Location $repoRoot
 try {
-    cargo build -p loongclaw-daemon --bin loongclawd --release | Out-Host
+    cargo build -p loongclaw-daemon --bin loongclaw --release | Out-Host
 } finally {
     Pop-Location
 }
 
 New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
-$sourceBinary = Join-Path $repoRoot "target/release/loongclawd"
+$sourceBinary = Join-Path $repoRoot "target/release/loongclaw"
 if (-not (Test-Path $sourceBinary)) {
-    $sourceBinary = Join-Path $repoRoot "target/release/loongclawd.exe"
+    $sourceBinary = Join-Path $repoRoot "target/release/loongclaw.exe"
 }
 $destBinary = Join-Path $Prefix (Split-Path -Leaf $sourceBinary)
 Copy-Item -Force $sourceBinary $destBinary
 
-Write-Host "==> Installed loongclawd to $destBinary"
+Write-Host "==> Installed loongclaw to $destBinary"
 
 if ($Setup) {
     Write-Host "==> Running initial setup"
@@ -59,4 +59,4 @@ if (-not ($pathItems -contains $Prefix)) {
 
 Write-Host ""
 Write-Host "Done. Try:"
-Write-Host "  loongclawd --help"
+Write-Host "  loongclaw --help"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,8 +6,8 @@ usage() {
 Usage: ./scripts/install.sh [--prefix <dir>] [--setup]
 
 Options:
-  --prefix <dir>   Install directory for loongclawd (default: $HOME/.local/bin)
-  --setup          Run `loongclawd setup --force` after install
+  --prefix <dir>   Install directory for loongclaw (default: $HOME/.local/bin)
+  --setup          Run `loongclaw setup --force` after install
   -h, --help       Show this help
 USAGE
 }
@@ -49,20 +49,20 @@ fi
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/.." && pwd)"
 
-printf '==> Building loongclawd (release)\n'
+printf '==> Building loongclaw (release)\n'
 (
   cd "${repo_root}"
-  cargo build -p loongclaw-daemon --bin loongclawd --release
+  cargo build -p loongclaw-daemon --bin loongclaw --release
 )
 
 mkdir -p "${prefix}"
-install -m 755 "${repo_root}/target/release/loongclawd" "${prefix}/loongclawd"
+install -m 755 "${repo_root}/target/release/loongclaw" "${prefix}/loongclaw"
 
-printf '==> Installed loongclawd to %s\n' "${prefix}/loongclawd"
+printf '==> Installed loongclaw to %s\n' "${prefix}/loongclaw"
 
 if [[ "${run_setup}" -eq 1 ]]; then
   printf '==> Running initial setup\n'
-  "${prefix}/loongclawd" setup --force
+  "${prefix}/loongclaw" setup --force
 fi
 
 case ":${PATH}:" in
@@ -73,4 +73,4 @@ case ":${PATH}:" in
     ;;
 esac
 
-printf '\nDone. Try:\n  loongclawd --help\n'
+printf '\nDone. Try:\n  loongclaw --help\n'

--- a/scripts/stress_daemon_tests.sh
+++ b/scripts/stress_daemon_tests.sh
@@ -33,7 +33,7 @@ run_mode() {
     local cmd=(
       cargo test
       -p loongclaw-daemon
-      --bin loongclawd
+      --bin loongclaw
       --all-features
     )
     if [[ "$LOCKED" == "true" ]]; then


### PR DESCRIPTION
## Summary
- rename the daemon binary and clap command identity from `loongclawd` to `loongclaw`
- update install scripts, release workflow, smoke/stress scripts, and user-facing guidance to use `loongclaw`
- add regression coverage for the canonical CLI name and `loongclaw setup` guidance, plus planning docs for the rename

## Test Plan
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `./scripts/check-docs.sh`
- `cargo deny check advisories bans sources`
