### PR TITLE
feat: add orchestrated legacy claw migration to onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,6 +1305,7 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "futures-util",
+ "loongclaw-app",
  "loongclaw-kernel",
  "loongclaw-protocol",
  "reqwest",

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ LoongClaw is a layered Agentic OS kernel focused on stable kernel contracts, str
 - **Business logic lives in extension planes** -- providers, tools, channels, and memory backends are all replaceable adapters that never touch the kernel.
 - **Multi-language plugins** -- supports Rust, WASM, and process plugins in any language. The community can extend freely.
 - **Bidirectional integration** -- can be embedded as a kernel into other systems, or connect to external services via adapters.
+- **Operator-ready product layer** -- onboarding, personalities, memory profiles, and legacy claw import are all first-class runtime capabilities.
 
 ## Sponsors
 
@@ -119,6 +120,41 @@ Run `loongclaw doctor --fix` if anything goes wrong.
 ```bash
 cargo test --workspace --all-features
 ```
+
+## Prompt And Personality
+
+LoongClaw ships with a native prompt pack and three default personalities. All
+three personalities keep the same security-first boundaries; they only change
+tone, initiative, confirmation style, and response density.
+
+- `calm_engineering`: rigorous, direct, and technically grounded
+- `friendly_collab`: warm, cooperative, and explanatory when helpful
+- `autonomous_executor`: decisive, high-initiative, and execution-oriented
+
+Interactive onboarding now defaults to personality selection, while advanced
+operators can still pass `--system-prompt` for a full inline override.
+
+## Memory Profiles
+
+LoongClaw separates memory behavior from the storage backend. The current
+backend is SQLite, with three operator-selectable context injection modes:
+
+- `window_only`: only the recent sliding window is loaded
+- `window_plus_summary`: earlier turns are condensed into a summary block
+- `profile_plus_window`: a durable `profile_note` block is injected before the recent window
+
+`profile_note` is the first migration-friendly durable memory lane. It is meant
+to carry imported claw identity, stable preferences, or long-lived operator
+tuning without forcing everything into the system prompt.
+
+## Migration And Import
+
+LoongClaw can discover legacy claw homes during onboarding and offer an import
+before the rest of first-run setup continues.
+
+- Recommended path: import a single highest-confidence source.
+- Advanced path: plan multiple sources, merge only the profile lane, and keep prompt/system identity single-source.
+- Safety defaults: secrets are not migrated, imported runtime identity is normalized to `LoongClaw`, and every apply creates a backup manifest with rollback support.
 
 ## Key Features
 

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -708,11 +708,11 @@ pub(super) async fn process_inbound_with_provider(
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
 fn apply_runtime_env(config: &LoongClawConfig) {
     crate::memory::runtime_config::apply_memory_runtime_env(&config.memory);
-    std::env::set_var(
+    crate::process_env::set_var(
         "LOONGCLAW_SHELL_ALLOWLIST",
         config.tools.shell_allowlist.join(","),
     );
-    std::env::set_var(
+    crate::process_env::set_var(
         "LOONGCLAW_FILE_ROOT",
         config.tools.resolved_file_root().display().to_string(),
     );

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -707,6 +707,15 @@ pub(super) async fn process_inbound_with_provider(
 
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
 fn apply_runtime_env(config: &LoongClawConfig) {
+    crate::memory::runtime_config::apply_memory_runtime_env(&config.memory);
+    std::env::set_var(
+        "LOONGCLAW_SHELL_ALLOWLIST",
+        config.tools.shell_allowlist.join(","),
+    );
+    std::env::set_var(
+        "LOONGCLAW_FILE_ROOT",
+        config.tools.resolved_file_root().display().to_string(),
+    );
     // Populate the typed tool runtime config so executors never hit env vars
     // on the hot path.  Ignore the error if already initialised.
     let tool_rt = crate::tools::runtime_config::ToolRuntimeConfig {
@@ -721,10 +730,8 @@ fn apply_runtime_env(config: &LoongClawConfig) {
     let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);
 
     // Populate the typed memory runtime config (same pattern as tool config).
-    let memory_rt = crate::memory::runtime_config::MemoryRuntimeConfig {
-        sqlite_path: Some(config.memory.resolved_sqlite_path()),
-        sliding_window: Some(config.memory.sliding_window),
-    };
+    let memory_rt =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
     let _ = crate::memory::runtime_config::init_memory_runtime_config(memory_rt);
 }
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -1,16 +1,19 @@
+#[cfg(feature = "memory-sqlite")]
 use std::collections::BTreeSet;
 use std::io::{self, Write};
 
+#[cfg(feature = "memory-sqlite")]
 use loongclaw_contracts::Capability;
 
 use crate::CliResult;
 use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context};
 
 use super::config::{self, LoongClawConfig};
-use super::conversation::{
-    ConversationTurnCoordinator, ProviderErrorMode, SafeLaneEventSummary, SafeLaneFinalStatus,
-    summarize_safe_lane_events,
-};
+#[cfg(feature = "memory-sqlite")]
+use super::conversation::summarize_safe_lane_events;
+use super::conversation::{ConversationTurnCoordinator, ProviderErrorMode};
+#[cfg(any(test, feature = "memory-sqlite"))]
+use super::conversation::{SafeLaneEventSummary, SafeLaneFinalStatus};
 #[cfg(feature = "memory-sqlite")]
 use super::memory;
 #[cfg(feature = "memory-sqlite")]
@@ -256,6 +259,7 @@ fn print_safe_lane_summary(
     }
 }
 
+#[cfg(any(test, feature = "memory-sqlite"))]
 fn format_safe_lane_summary(
     session_id: &str,
     limit: usize,
@@ -365,6 +369,7 @@ fn format_safe_lane_summary(
     .join("\n")
 }
 
+#[cfg(any(test, feature = "memory-sqlite"))]
 fn format_rollup_counts(counts: &std::collections::BTreeMap<String, u32>) -> String {
     if counts.is_empty() {
         return "-".to_owned();
@@ -376,6 +381,7 @@ fn format_rollup_counts(counts: &std::collections::BTreeMap<String, u32>) -> Str
         .join(",")
 }
 
+#[cfg(any(test, feature = "memory-sqlite"))]
 fn format_milli_ratio(value: Option<u32>) -> String {
     value
         .map(|raw| format!("{:.3}", (raw as f64) / 1000.0))

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -26,11 +26,7 @@ pub async fn run_cli_chat(config_path: Option<&str>, session_hint: Option<&str>)
     export_runtime_env(&config);
     let kernel_ctx = bootstrap_kernel_context("cli-chat", DEFAULT_TOKEN_TTL_S)?;
 
-    #[cfg(feature = "memory-sqlite")]
-    let memory_config = MemoryRuntimeConfig {
-        sqlite_path: Some(config.memory.resolved_sqlite_path()),
-        sliding_window: Some(config.memory.sliding_window),
-    };
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
 
     #[cfg(feature = "memory-sqlite")]
     {
@@ -172,14 +168,26 @@ async fn print_history(
             return Ok(());
         }
 
-        let turns = memory::window_direct(session_id, limit, memory_config)
+        let entries = memory::load_prompt_context(session_id, memory_config)
             .map_err(|error| format!("load history failed: {error}"))?;
-        if turns.is_empty() {
+        if entries.is_empty() {
             println!("(no history yet)");
             return Ok(());
         }
-        for turn in turns {
-            println!("[{}] {}: {}", turn.ts, turn.role, turn.content);
+        for entry in entries {
+            match entry.kind {
+                memory::MemoryContextKind::Profile => {
+                    println!("[profile]");
+                    println!("{}", entry.content);
+                }
+                memory::MemoryContextKind::Summary => {
+                    println!("[summary]");
+                    println!("{}", entry.content);
+                }
+                memory::MemoryContextKind::Turn => {
+                    println!("{}: {}", entry.role, entry.content);
+                }
+            }
         }
         Ok(())
     }
@@ -375,6 +383,15 @@ fn format_milli_ratio(value: Option<u32>) -> String {
 }
 
 fn export_runtime_env(config: &LoongClawConfig) {
+    crate::memory::runtime_config::apply_memory_runtime_env(&config.memory);
+    std::env::set_var(
+        "LOONGCLAW_SHELL_ALLOWLIST",
+        config.tools.shell_allowlist.join(","),
+    );
+    std::env::set_var(
+        "LOONGCLAW_FILE_ROOT",
+        config.tools.resolved_file_root().display().to_string(),
+    );
     // Populate the typed tool runtime config so executors never hit env vars
     // on the hot path.  Ignore the error if already initialised (e.g. tests).
     let tool_rt = crate::tools::runtime_config::ToolRuntimeConfig {
@@ -389,10 +406,8 @@ fn export_runtime_env(config: &LoongClawConfig) {
     let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);
 
     // Populate the typed memory runtime config (same pattern as tool config).
-    let memory_rt = crate::memory::runtime_config::MemoryRuntimeConfig {
-        sqlite_path: Some(config.memory.resolved_sqlite_path()),
-        sliding_window: Some(config.memory.sliding_window),
-    };
+    let memory_rt =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
     let _ = crate::memory::runtime_config::init_memory_runtime_config(memory_rt);
 }
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -29,6 +29,7 @@ pub async fn run_cli_chat(config_path: Option<&str>, session_hint: Option<&str>)
     export_runtime_env(&config);
     let kernel_ctx = bootstrap_kernel_context("cli-chat", DEFAULT_TOKEN_TTL_S)?;
 
+    #[cfg(feature = "memory-sqlite")]
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
 
     #[cfg(feature = "memory-sqlite")]
@@ -390,11 +391,11 @@ fn format_milli_ratio(value: Option<u32>) -> String {
 
 fn export_runtime_env(config: &LoongClawConfig) {
     crate::memory::runtime_config::apply_memory_runtime_env(&config.memory);
-    std::env::set_var(
+    crate::process_env::set_var(
         "LOONGCLAW_SHELL_ALLOWLIST",
         config.tools.shell_allowlist.join(","),
     );
-    std::env::set_var(
+    crate::process_env::set_var(
         "LOONGCLAW_FILE_ROOT",
         config.tools.resolved_file_root().display().to_string(),
     );

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -2,6 +2,10 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::prompt::{
+    render_default_system_prompt, render_system_prompt, PromptPersonality, PromptRenderInput,
+    DEFAULT_PROMPT_PACK_ID,
+};
 use crate::CliResult;
 
 use super::shared::{
@@ -21,6 +25,12 @@ pub struct CliChannelConfig {
     pub enabled: bool,
     #[serde(default = "default_system_prompt")]
     pub system_prompt: String,
+    #[serde(default = "default_prompt_pack_id")]
+    pub prompt_pack_id: Option<String>,
+    #[serde(default = "default_prompt_personality")]
+    pub personality: Option<PromptPersonality>,
+    #[serde(default)]
+    pub system_prompt_addendum: Option<String>,
     #[serde(default = "default_exit_commands")]
     pub exit_commands: Vec<String>,
 }
@@ -307,7 +317,53 @@ impl Default for CliChannelConfig {
         Self {
             enabled: true,
             system_prompt: default_system_prompt(),
+            prompt_pack_id: default_prompt_pack_id(),
+            personality: default_prompt_personality(),
+            system_prompt_addendum: None,
             exit_commands: default_exit_commands(),
+        }
+    }
+}
+
+impl CliChannelConfig {
+    pub fn uses_native_prompt_pack(&self) -> bool {
+        self.prompt_pack_id().is_some_and(|value| !value.is_empty())
+    }
+
+    pub fn prompt_pack_id(&self) -> Option<&str> {
+        self.prompt_pack_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    }
+
+    pub fn resolved_personality(&self) -> PromptPersonality {
+        self.personality.unwrap_or_default()
+    }
+
+    pub fn rendered_native_system_prompt(&self) -> String {
+        render_system_prompt(PromptRenderInput {
+            personality: self.resolved_personality(),
+            addendum: self.system_prompt_addendum.clone(),
+        })
+    }
+
+    pub fn resolved_system_prompt(&self) -> String {
+        if self.uses_native_prompt_pack() {
+            return self.rendered_native_system_prompt();
+        }
+
+        let inline = self.system_prompt.trim();
+        if !inline.is_empty() {
+            return inline.to_owned();
+        }
+
+        render_default_system_prompt()
+    }
+
+    pub fn refresh_native_system_prompt(&mut self) {
+        if self.uses_native_prompt_pack() {
+            self.system_prompt = self.rendered_native_system_prompt();
         }
     }
 }
@@ -784,7 +840,15 @@ fn default_feishu_webhook_path() -> String {
 }
 
 fn default_system_prompt() -> String {
-    "You are LoongClaw, a practical assistant.".to_owned()
+    render_default_system_prompt()
+}
+
+fn default_prompt_pack_id() -> Option<String> {
+    Some(DEFAULT_PROMPT_PACK_ID.to_owned())
+}
+
+fn default_prompt_personality() -> Option<PromptPersonality> {
+    Some(PromptPersonality::default())
 }
 
 fn default_exit_commands() -> Vec<String> {

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -2,11 +2,11 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::prompt::{
-    render_default_system_prompt, render_system_prompt, PromptPersonality, PromptRenderInput,
-    DEFAULT_PROMPT_PACK_ID,
-};
 use crate::CliResult;
+use crate::prompt::{
+    DEFAULT_PROMPT_PACK_ID, PromptPersonality, PromptRenderInput, render_default_system_prompt,
+    render_system_prompt,
+};
 
 use super::shared::{
     ConfigValidationCode, ConfigValidationIssue, EnvPointerValidationHint,

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -18,14 +18,14 @@ pub use conversation::{ConversationConfig, ConversationTurnLoopConfig};
 pub use provider::{ProviderConfig, ProviderKind, ReasoningEffort};
 #[allow(unused_imports)]
 pub use runtime::{
-    ConfigValidationDiagnostic, LoongClawConfig, default_config_path, default_loongclaw_home, load,
-    normalize_validation_locale, supported_validation_locales, validate_file,
-    validate_file_with_locale, write, write_template,
+    default_config_path, default_loongclaw_home, load, normalize_validation_locale, render,
+    supported_validation_locales, validate_file, validate_file_with_locale, write, write_template,
+    ConfigValidationDiagnostic, LoongClawConfig,
 };
 #[allow(unused_imports)]
 pub use shared::expand_path;
 #[allow(unused_imports)]
-pub use tools_memory::{MemoryConfig, ToolConfig};
+pub use tools_memory::{MemoryBackendKind, MemoryConfig, MemoryMode, MemoryProfile, ToolConfig};
 
 #[cfg(test)]
 mod tests {

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -18,9 +18,9 @@ pub use conversation::{ConversationConfig, ConversationTurnLoopConfig};
 pub use provider::{ProviderConfig, ProviderKind, ReasoningEffort};
 #[allow(unused_imports)]
 pub use runtime::{
-    default_config_path, default_loongclaw_home, load, normalize_validation_locale, render,
-    supported_validation_locales, validate_file, validate_file_with_locale, write, write_template,
-    ConfigValidationDiagnostic, LoongClawConfig,
+    ConfigValidationDiagnostic, LoongClawConfig, default_config_path, default_loongclaw_home, load,
+    normalize_validation_locale, render, supported_validation_locales, validate_file,
+    validate_file_with_locale, write, write_template,
 };
 #[allow(unused_imports)]
 pub use shared::expand_path;

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -203,6 +203,10 @@ pub fn write(path: Option<&str>, config: &LoongClawConfig, force: bool) -> CliRe
     Ok(output_path)
 }
 
+pub fn render(config: &LoongClawConfig) -> CliResult<String> {
+    encode_toml_config(config)
+}
+
 pub fn default_config_path() -> PathBuf {
     default_loongclaw_home().join(DEFAULT_CONFIG_FILE)
 }
@@ -531,6 +535,56 @@ api_key_env = "{secret}"
         let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
         assert_eq!(loaded.provider.model, "openai/gpt-5.1-codex");
         assert_eq!(loaded.cli.system_prompt, "You are an onboarding assistant.");
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn write_persists_prompt_pack_and_personality_metadata() {
+        let path = unique_config_path("loongclaw-prompt-config");
+        let path_string = path.display().to_string();
+        let mut config = LoongClawConfig::default();
+        config.cli.prompt_pack_id = Some("loongclaw-core-v1".to_owned());
+        config.cli.personality = Some(crate::prompt::PromptPersonality::AutonomousExecutor);
+
+        write(Some(&path_string), &config, true).expect("config write should pass");
+        let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
+
+        assert_eq!(
+            loaded.cli.prompt_pack_id.as_deref(),
+            Some("loongclaw-core-v1")
+        );
+        assert_eq!(
+            loaded.cli.personality,
+            Some(crate::prompt::PromptPersonality::AutonomousExecutor)
+        );
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn write_persists_memory_profile_metadata() {
+        let path = unique_config_path("loongclaw-memory-config");
+        let path_string = path.display().to_string();
+        let mut config = LoongClawConfig::default();
+        config.memory.profile = crate::config::MemoryProfile::WindowPlusSummary;
+        config.memory.summary_max_chars = 900;
+        config.memory.profile_note = Some("Imported NanoBot preferences".to_owned());
+
+        write(Some(&path_string), &config, true).expect("config write should pass");
+        let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
+
+        assert_eq!(
+            loaded.memory.profile,
+            crate::config::MemoryProfile::WindowPlusSummary
+        );
+        assert_eq!(loaded.memory.summary_max_chars, 900);
+        assert_eq!(
+            loaded.memory.profile_note.as_deref(),
+            Some("Imported NanoBot preferences")
+        );
 
         let _ = fs::remove_file(path);
     }

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -20,10 +20,84 @@ pub struct ToolConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryConfig {
+    #[serde(default)]
+    pub backend: MemoryBackendKind,
+    #[serde(default)]
+    pub profile: MemoryProfile,
     #[serde(default = "default_sqlite_path")]
     pub sqlite_path: String,
     #[serde(default = "default_sliding_window")]
     pub sliding_window: usize,
+    #[serde(default = "default_summary_max_chars")]
+    pub summary_max_chars: usize,
+    #[serde(default)]
+    pub profile_note: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryBackendKind {
+    #[default]
+    Sqlite,
+}
+
+impl MemoryBackendKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Sqlite => "sqlite",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "sqlite" => Some(Self::Sqlite),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryProfile {
+    #[default]
+    WindowOnly,
+    WindowPlusSummary,
+    ProfilePlusWindow,
+}
+
+impl MemoryProfile {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::WindowOnly => "window_only",
+            Self::WindowPlusSummary => "window_plus_summary",
+            Self::ProfilePlusWindow => "profile_plus_window",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "window_only" => Some(Self::WindowOnly),
+            "window_plus_summary" => Some(Self::WindowPlusSummary),
+            "profile_plus_window" => Some(Self::ProfilePlusWindow),
+            _ => None,
+        }
+    }
+
+    pub const fn mode(self) -> MemoryMode {
+        match self {
+            Self::WindowOnly => MemoryMode::WindowOnly,
+            Self::WindowPlusSummary => MemoryMode::WindowPlusSummary,
+            Self::ProfilePlusWindow => MemoryMode::ProfilePlusWindow,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MemoryMode {
+    #[default]
+    WindowOnly,
+    WindowPlusSummary,
+    ProfilePlusWindow,
 }
 
 impl Default for ToolConfig {
@@ -47,8 +121,12 @@ impl ToolConfig {
 impl Default for MemoryConfig {
     fn default() -> Self {
         Self {
+            backend: MemoryBackendKind::default(),
+            profile: MemoryProfile::default(),
             sqlite_path: default_sqlite_path(),
             sliding_window: default_sliding_window(),
+            summary_max_chars: default_summary_max_chars(),
+            profile_note: None,
         }
     }
 }
@@ -70,6 +148,30 @@ impl MemoryConfig {
         }
         issues
     }
+
+    pub const fn resolved_backend(&self) -> MemoryBackendKind {
+        self.backend
+    }
+
+    pub const fn resolved_profile(&self) -> MemoryProfile {
+        self.profile
+    }
+
+    pub const fn resolved_mode(&self) -> MemoryMode {
+        self.profile.mode()
+    }
+
+    pub fn summary_char_budget(&self) -> usize {
+        self.summary_max_chars.max(256)
+    }
+
+    pub fn trimmed_profile_note(&self) -> Option<String> {
+        self.profile_note
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    }
 }
 
 fn default_sqlite_path() -> String {
@@ -90,4 +192,33 @@ fn default_shell_allowlist() -> Vec<String> {
 
 const fn default_sliding_window() -> usize {
     12
+}
+
+const fn default_summary_max_chars() -> usize {
+    1200
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_profile_defaults_to_window_only() {
+        let config = MemoryConfig::default();
+        assert_eq!(config.backend, MemoryBackendKind::Sqlite);
+        assert_eq!(config.profile, MemoryProfile::WindowOnly);
+        assert_eq!(config.resolved_mode(), MemoryMode::WindowOnly);
+    }
+
+    #[test]
+    fn profile_plus_window_keeps_trimmed_profile_note() {
+        let mut config = MemoryConfig::default();
+        config.profile = MemoryProfile::ProfilePlusWindow;
+        config.profile_note = Some("  imported preferences  ".to_owned());
+
+        assert_eq!(
+            config.trimmed_profile_note().as_deref(),
+            Some("imported preferences")
+        );
+    }
 }

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -212,9 +212,11 @@ mod tests {
 
     #[test]
     fn profile_plus_window_keeps_trimmed_profile_note() {
-        let mut config = MemoryConfig::default();
-        config.profile = MemoryProfile::ProfilePlusWindow;
-        config.profile_note = Some("  imported preferences  ".to_owned());
+        let config = MemoryConfig {
+            profile: MemoryProfile::ProfilePlusWindow,
+            profile_note: Some("  imported preferences  ".to_owned()),
+            ..MemoryConfig::default()
+        };
 
         assert_eq!(
             config.trimmed_profile_note().as_deref(),

--- a/crates/app/src/conversation/integration_tests.rs
+++ b/crates/app/src/conversation/integration_tests.rs
@@ -123,7 +123,7 @@ impl TurnTestHarness {
             use crate::memory::runtime_config::MemoryRuntimeConfig;
             let memory_config = MemoryRuntimeConfig {
                 sqlite_path: Some(temp_dir.join("memory.sqlite3")),
-                sliding_window: Some(12),
+                ..MemoryRuntimeConfig::default()
             };
             kernel.register_core_memory_adapter(crate::memory::MvpMemoryAdapter::with_config(
                 memory_config,

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -7,7 +7,6 @@ use serde_json::Value;
 use crate::CliResult;
 use crate::KernelContext;
 
-#[cfg(feature = "memory-sqlite")]
 use super::super::memory;
 use super::super::{config::LoongClawConfig, provider};
 use super::turn_engine::ProviderTurn;
@@ -55,7 +54,11 @@ impl ConversationRuntime for DefaultConversationRuntime {
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<Vec<Value>> {
         if let Some(ctx) = kernel_ctx {
-            let mut messages = provider::build_base_messages(config, include_system_prompt);
+            let base_messages = provider::build_base_messages(config, include_system_prompt);
+            #[cfg(feature = "memory-sqlite")]
+            let mut messages = base_messages;
+            #[cfg(not(feature = "memory-sqlite"))]
+            let messages = base_messages;
             #[cfg(feature = "memory-sqlite")]
             {
                 let request =

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -9,6 +9,8 @@ pub mod prompt;
 pub mod provider;
 pub mod tools;
 
+mod process_env;
+
 pub use context::KernelContext;
 /// Result type for MVP CLI operations.
 pub type CliResult<T> = Result<T, String>;

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -4,6 +4,8 @@ pub mod config;
 pub mod context;
 pub mod conversation;
 pub mod memory;
+pub mod migration;
+pub mod prompt;
 pub mod provider;
 pub mod tools;
 

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
 use serde_json::{Value, json};
 
+use crate::config::{MemoryBackendKind, MemoryMode};
+
 mod kernel_adapter;
 pub mod runtime_config;
 #[cfg(feature = "memory-sqlite")]
@@ -45,6 +47,20 @@ pub fn build_window_request(session_id: &str, limit: usize) -> MemoryCoreRequest
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryContextKind {
+    Profile,
+    Summary,
+    Turn,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryContextEntry {
+    pub kind: MemoryContextKind,
+    pub role: String,
+    pub content: String,
+}
+
 pub fn execute_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
     execute_memory_core_with_config(request, runtime_config::get_memory_runtime_config())
 }
@@ -53,18 +69,20 @@ pub fn execute_memory_core_with_config(
     request: MemoryCoreRequest,
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<MemoryCoreOutcome, String> {
-    match request.operation.as_str() {
-        MEMORY_OP_APPEND_TURN => append_turn(request, config),
-        MEMORY_OP_WINDOW => load_window(request, config),
-        MEMORY_OP_CLEAR_SESSION => clear_session(request, config),
-        _ => Ok(MemoryCoreOutcome {
-            status: "ok".to_owned(),
-            payload: json!({
-                "adapter": "kv-core",
-                "operation": request.operation,
-                "payload": request.payload,
+    match config.backend {
+        MemoryBackendKind::Sqlite => match request.operation.as_str() {
+            MEMORY_OP_APPEND_TURN => append_turn(request, config),
+            MEMORY_OP_WINDOW => load_window(request, config),
+            MEMORY_OP_CLEAR_SESSION => clear_session(request, config),
+            _ => Ok(MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "adapter": "kv-core",
+                    "operation": request.operation,
+                    "payload": request.payload,
+                }),
             }),
-        }),
+        },
     }
 }
 
@@ -184,6 +202,105 @@ pub fn ensure_memory_db_ready(
     sqlite::ensure_memory_db_ready(path, config)
 }
 
+pub fn load_prompt_context(
+    session_id: &str,
+    config: &runtime_config::MemoryRuntimeConfig,
+) -> Result<Vec<MemoryContextEntry>, String> {
+    let mut entries = Vec::new();
+
+    if matches!(config.mode, MemoryMode::ProfilePlusWindow) {
+        if let Some(profile_note) = config
+            .profile_note
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            entries.push(MemoryContextEntry {
+                kind: MemoryContextKind::Profile,
+                role: "system".to_owned(),
+                content: format!(
+                    "## Session Profile\nDurable preferences or imported identity carried into this session:\n- {profile_note}"
+                ),
+            });
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let turns = sqlite::window_direct(session_id, config.sliding_window, config)?;
+        if matches!(config.mode, MemoryMode::WindowPlusSummary) {
+            let all_turns = sqlite::session_turns_direct(session_id, config)?;
+            let older_turn_count = all_turns.len().saturating_sub(turns.len());
+            if older_turn_count > 0 {
+                if let Some(summary) =
+                    build_summary_block(&all_turns[..older_turn_count], config.summary_max_chars)
+                {
+                    entries.push(MemoryContextEntry {
+                        kind: MemoryContextKind::Summary,
+                        role: "system".to_owned(),
+                        content: summary,
+                    });
+                }
+            }
+        }
+        for turn in turns {
+            entries.push(MemoryContextEntry {
+                kind: MemoryContextKind::Turn,
+                role: turn.role,
+                content: turn.content,
+            });
+        }
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = session_id;
+    }
+
+    Ok(entries)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_summary_block(turns: &[ConversationTurn], max_chars: usize) -> Option<String> {
+    if turns.is_empty() {
+        return None;
+    }
+
+    let header =
+        "## Memory Summary\nEarlier session context condensed from turns outside the active window:";
+    let mut body = String::new();
+    let budget = max_chars.max(256);
+
+    for turn in turns {
+        let normalized = turn
+            .content
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        if normalized.is_empty() {
+            continue;
+        }
+        let prefix = if body.is_empty() { "" } else { "\n" };
+        let line = format!("{prefix}- {}: {}", turn.role, normalized);
+        if body.len() + line.len() > budget {
+            let remaining = budget.saturating_sub(body.len());
+            if remaining == 0 {
+                break;
+            }
+            let truncated = line.chars().take(remaining).collect::<String>();
+            body.push_str(&truncated);
+            break;
+        }
+        body.push_str(&line);
+    }
+
+    if body.is_empty() {
+        return None;
+    }
+
+    Some(format!("{header}\n{body}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -292,7 +409,7 @@ mod tests {
 
         let config = runtime_config::MemoryRuntimeConfig {
             sqlite_path: Some(db_path.clone()),
-            sliding_window: Some(12),
+            ..runtime_config::MemoryRuntimeConfig::default()
         };
 
         append_turn_direct("rt-session", "user", "hello from test", &config)
@@ -330,7 +447,8 @@ mod tests {
 
         let config = runtime_config::MemoryRuntimeConfig {
             sqlite_path: Some(db_path.clone()),
-            sliding_window: Some(12),
+            sliding_window: 12,
+            ..runtime_config::MemoryRuntimeConfig::default()
         };
 
         for idx in 0..130 {
@@ -345,7 +463,8 @@ mod tests {
 
         let explicit_limit_config = runtime_config::MemoryRuntimeConfig {
             sqlite_path: Some(db_path.clone()),
-            sliding_window: Some(1),
+            sliding_window: 1,
+            ..runtime_config::MemoryRuntimeConfig::default()
         };
         let turns = window_direct("window-semantics-session", 2, &explicit_limit_config)
             .expect("window_direct should honor the explicit limit");
@@ -355,7 +474,8 @@ mod tests {
 
         let default_window_config = runtime_config::MemoryRuntimeConfig {
             sqlite_path: Some(db_path.clone()),
-            sliding_window: Some(3),
+            sliding_window: 3,
+            ..runtime_config::MemoryRuntimeConfig::default()
         };
         let default_window = execute_memory_core_with_config(
             MemoryCoreRequest {
@@ -382,7 +502,8 @@ mod tests {
 
         let capped_window_config = runtime_config::MemoryRuntimeConfig {
             sqlite_path: Some(db_path.clone()),
-            sliding_window: Some(999),
+            sliding_window: 999,
+            ..runtime_config::MemoryRuntimeConfig::default()
         };
         let capped_window = execute_memory_core_with_config(
             MemoryCoreRequest {
@@ -407,5 +528,96 @@ mod tests {
 
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn window_plus_summary_includes_condensed_older_context() {
+        use crate::config::{MemoryMode, MemoryProfile};
+
+        let tmp =
+            std::env::temp_dir().join(format!("loongclaw-summary-memory-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("summary.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct("summary-session", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("summary-session", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct("summary-session", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+        append_turn_direct("summary-session", "assistant", "turn 4", &config)
+            .expect("append turn 4 should succeed");
+
+        let hydrated =
+            load_prompt_context("summary-session", &config).expect("load prompt context");
+
+        assert!(
+            hydrated
+                .iter()
+                .any(|entry| entry.kind == MemoryContextKind::Summary),
+            "expected a summary entry"
+        );
+        assert!(
+            hydrated
+                .iter()
+                .any(|entry| entry.content.contains("turn 1")),
+            "expected summary to mention older turns"
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn profile_plus_window_includes_profile_note_block() {
+        use crate::config::{MemoryMode, MemoryProfile};
+
+        let tmp =
+            std::env::temp_dir().join(format!("loongclaw-profile-memory-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("profile.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::ProfilePlusWindow,
+            mode: MemoryMode::ProfilePlusWindow,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            profile_note: Some("Imported ZeroClaw preferences".to_owned()),
+            ..runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct("profile-session", "user", "recent turn", &config)
+            .expect("append turn should succeed");
+
+        let hydrated =
+            load_prompt_context("profile-session", &config).expect("load prompt context");
+
+        assert!(
+            hydrated
+                .iter()
+                .any(|entry| entry.kind == MemoryContextKind::Profile),
+            "expected a profile entry"
+        );
+        assert!(
+            hydrated
+                .iter()
+                .any(|entry| entry.content.contains("Imported ZeroClaw preferences")),
+            "expected profile note content"
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
     }
 }

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -266,8 +266,7 @@ fn build_summary_block(turns: &[ConversationTurn], max_chars: usize) -> Option<S
         return None;
     }
 
-    let header =
-        "## Memory Summary\nEarlier session context condensed from turns outside the active window:";
+    let header = "## Memory Summary\nEarlier session context condensed from turns outside the active window:";
     let mut body = String::new();
     let budget = max_chars.max(256);
 

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -208,21 +208,20 @@ pub fn load_prompt_context(
 ) -> Result<Vec<MemoryContextEntry>, String> {
     let mut entries = Vec::new();
 
-    if matches!(config.mode, MemoryMode::ProfilePlusWindow) {
-        if let Some(profile_note) = config
+    if matches!(config.mode, MemoryMode::ProfilePlusWindow)
+        && let Some(profile_note) = config
             .profile_note
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
-        {
-            entries.push(MemoryContextEntry {
-                kind: MemoryContextKind::Profile,
-                role: "system".to_owned(),
-                content: format!(
-                    "## Session Profile\nDurable preferences or imported identity carried into this session:\n- {profile_note}"
-                ),
-            });
-        }
+    {
+        entries.push(MemoryContextEntry {
+            kind: MemoryContextKind::Profile,
+            role: "system".to_owned(),
+            content: format!(
+                "## Session Profile\nDurable preferences or imported identity carried into this session:\n- {profile_note}"
+            ),
+        });
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -231,16 +230,15 @@ pub fn load_prompt_context(
         if matches!(config.mode, MemoryMode::WindowPlusSummary) {
             let all_turns = sqlite::session_turns_direct(session_id, config)?;
             let older_turn_count = all_turns.len().saturating_sub(turns.len());
-            if older_turn_count > 0 {
-                if let Some(summary) =
-                    build_summary_block(&all_turns[..older_turn_count], config.summary_max_chars)
-                {
-                    entries.push(MemoryContextEntry {
-                        kind: MemoryContextKind::Summary,
-                        role: "system".to_owned(),
-                        content: summary,
-                    });
-                }
+            if older_turn_count > 0
+                && let Some(older_turns) = all_turns.get(..older_turn_count)
+                && let Some(summary) = build_summary_block(older_turns, config.summary_max_chars)
+            {
+                entries.push(MemoryContextEntry {
+                    kind: MemoryContextKind::Summary,
+                    role: "system".to_owned(),
+                    content: summary,
+                });
             }
         }
         for turn in turns {

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -198,9 +198,11 @@ mod tests {
 
     #[test]
     fn runtime_config_from_memory_config_carries_profile_and_limits() {
-        let mut config = MemoryConfig::default();
-        config.profile = MemoryProfile::WindowPlusSummary;
-        config.summary_max_chars = 900;
+        let config = MemoryConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            summary_max_chars: 900,
+            ..MemoryConfig::default()
+        };
 
         let runtime = MemoryRuntimeConfig::from_memory_config(&config);
 

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -54,14 +54,11 @@ impl MemoryRuntimeConfig {
         let sqlite_path = std::env::var("LOONGCLAW_SQLITE_PATH")
             .ok()
             .map(PathBuf::from);
-        let sliding_window = std::env::var("LOONGCLAW_SLIDING_WINDOW")
-            .ok()
-            .and_then(|value| value.parse::<usize>().ok())
+        let sliding_window = parse_positive_usize(std::env::var("LOONGCLAW_SLIDING_WINDOW").ok())
             .unwrap_or(defaults.sliding_window);
-        let summary_max_chars = std::env::var("LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS")
-            .ok()
-            .and_then(|value| value.parse::<usize>().ok())
-            .unwrap_or(defaults.summary_char_budget());
+        let summary_max_chars =
+            parse_positive_usize(std::env::var("LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS").ok())
+                .unwrap_or(defaults.summary_char_budget());
         let profile_note = std::env::var("LOONGCLAW_MEMORY_PROFILE_NOTE")
             .ok()
             .as_deref()
@@ -94,32 +91,37 @@ impl MemoryRuntimeConfig {
     }
 }
 
+fn parse_positive_usize(raw: Option<String>) -> Option<usize> {
+    raw.and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+}
+
 pub fn apply_memory_runtime_env(config: &MemoryConfig) {
-    std::env::set_var(
+    crate::process_env::set_var(
         "LOONGCLAW_SQLITE_PATH",
         config.resolved_sqlite_path().display().to_string(),
     );
-    std::env::set_var(
+    crate::process_env::set_var(
         "LOONGCLAW_SLIDING_WINDOW",
         config.sliding_window.to_string(),
     );
-    std::env::set_var(
+    crate::process_env::set_var(
         "LOONGCLAW_MEMORY_BACKEND",
         config.resolved_backend().as_str(),
     );
-    std::env::set_var(
+    crate::process_env::set_var(
         "LOONGCLAW_MEMORY_PROFILE",
         config.resolved_profile().as_str(),
     );
-    std::env::set_var(
+    crate::process_env::set_var(
         "LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS",
         config.summary_char_budget().to_string(),
     );
 
     if let Some(profile_note) = config.trimmed_profile_note() {
-        std::env::set_var("LOONGCLAW_MEMORY_PROFILE_NOTE", profile_note);
+        crate::process_env::set_var("LOONGCLAW_MEMORY_PROFILE_NOTE", profile_note);
     } else {
-        std::env::remove_var("LOONGCLAW_MEMORY_PROFILE_NOTE");
+        crate::process_env::remove_var("LOONGCLAW_MEMORY_PROFILE_NOTE");
     }
 }
 
@@ -156,19 +158,19 @@ mod tests {
 
     #[test]
     fn parse_sliding_window_accepts_positive_integer() {
-        assert_eq!(parse_sliding_window(Some("24")), Some(24));
+        assert_eq!(parse_positive_usize(Some("24".to_owned())), Some(24));
     }
 
     #[test]
     fn parse_sliding_window_rejects_zero_negative_and_invalid_values() {
-        assert_eq!(parse_sliding_window(Some("0")), None);
-        assert_eq!(parse_sliding_window(Some("-1")), None);
-        assert_eq!(parse_sliding_window(Some("invalid")), None);
+        assert_eq!(parse_positive_usize(Some("0".to_owned())), None);
+        assert_eq!(parse_positive_usize(Some("-1".to_owned())), None);
+        assert_eq!(parse_positive_usize(Some("invalid".to_owned())), None);
     }
 
     #[test]
     fn parse_sliding_window_returns_none_when_absent() {
-        assert_eq!(parse_sliding_window(None), None);
+        assert_eq!(parse_positive_usize(None), None);
     }
 
     #[test]
@@ -212,7 +214,7 @@ mod tests {
     fn apply_memory_runtime_env_clears_absent_profile_note() {
         let _guard = env_lock().lock().expect("env lock");
 
-        std::env::set_var("LOONGCLAW_MEMORY_PROFILE_NOTE", "stale imported note");
+        crate::process_env::set_var("LOONGCLAW_MEMORY_PROFILE_NOTE", "stale imported note");
 
         let config = MemoryConfig::default();
         apply_memory_runtime_env(&config);

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -1,15 +1,37 @@
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use crate::config::{MemoryBackendKind, MemoryConfig, MemoryMode, MemoryProfile};
+
 /// Typed runtime configuration for the memory (SQLite) subsystem.
 ///
 /// Mirrors [`crate::tools::runtime_config::ToolRuntimeConfig`] — a
 /// process-wide singleton populated once at startup so that per-call
 /// `std::env::var` lookups are avoided on the hot path.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryRuntimeConfig {
+    pub backend: MemoryBackendKind,
+    pub profile: MemoryProfile,
+    pub mode: MemoryMode,
     pub sqlite_path: Option<PathBuf>,
-    pub sliding_window: Option<usize>,
+    pub sliding_window: usize,
+    pub summary_max_chars: usize,
+    pub profile_note: Option<String>,
+}
+
+impl Default for MemoryRuntimeConfig {
+    fn default() -> Self {
+        let defaults = MemoryConfig::default();
+        Self {
+            backend: defaults.backend,
+            profile: defaults.profile,
+            mode: defaults.resolved_mode(),
+            sqlite_path: None,
+            sliding_window: defaults.sliding_window,
+            summary_max_chars: defaults.summary_char_budget(),
+            profile_note: defaults.trimmed_profile_note(),
+        }
+    }
 }
 
 impl MemoryRuntimeConfig {
@@ -18,21 +40,87 @@ impl MemoryRuntimeConfig {
     /// Keeps full backward compatibility for callers that still rely on
     /// `LOONGCLAW_SQLITE_PATH`.
     pub fn from_env() -> Self {
+        let defaults = MemoryConfig::default();
+        let backend = std::env::var("LOONGCLAW_MEMORY_BACKEND")
+            .ok()
+            .as_deref()
+            .and_then(MemoryBackendKind::parse_id)
+            .unwrap_or(defaults.backend);
+        let profile = std::env::var("LOONGCLAW_MEMORY_PROFILE")
+            .ok()
+            .as_deref()
+            .and_then(MemoryProfile::parse_id)
+            .unwrap_or(defaults.profile);
         let sqlite_path = std::env::var("LOONGCLAW_SQLITE_PATH")
             .ok()
             .map(PathBuf::from);
-        let sliding_window_raw = std::env::var("LOONGCLAW_SLIDING_WINDOW").ok();
-        let sliding_window = parse_sliding_window(sliding_window_raw.as_deref());
+        let sliding_window = std::env::var("LOONGCLAW_SLIDING_WINDOW")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(defaults.sliding_window);
+        let summary_max_chars = std::env::var("LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(defaults.summary_char_budget());
+        let profile_note = std::env::var("LOONGCLAW_MEMORY_PROFILE_NOTE")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
         Self {
+            backend,
+            profile,
+            mode: profile.mode(),
             sqlite_path,
             sliding_window,
+            summary_max_chars,
+            profile_note,
+        }
+    }
+
+    pub fn from_memory_config(config: &MemoryConfig) -> Self {
+        let backend = config.resolved_backend();
+        let profile = config.resolved_profile();
+        Self {
+            backend,
+            profile,
+            mode: config.resolved_mode(),
+            sqlite_path: Some(config.resolved_sqlite_path()),
+            sliding_window: config.sliding_window,
+            summary_max_chars: config.summary_char_budget(),
+            profile_note: config.trimmed_profile_note(),
         }
     }
 }
 
-fn parse_sliding_window(raw: Option<&str>) -> Option<usize> {
-    raw.and_then(|value| value.parse::<usize>().ok())
-        .filter(|value| *value > 0)
+pub fn apply_memory_runtime_env(config: &MemoryConfig) {
+    std::env::set_var(
+        "LOONGCLAW_SQLITE_PATH",
+        config.resolved_sqlite_path().display().to_string(),
+    );
+    std::env::set_var(
+        "LOONGCLAW_SLIDING_WINDOW",
+        config.sliding_window.to_string(),
+    );
+    std::env::set_var(
+        "LOONGCLAW_MEMORY_BACKEND",
+        config.resolved_backend().as_str(),
+    );
+    std::env::set_var(
+        "LOONGCLAW_MEMORY_PROFILE",
+        config.resolved_profile().as_str(),
+    );
+    std::env::set_var(
+        "LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS",
+        config.summary_char_budget().to_string(),
+    );
+
+    if let Some(profile_note) = config.trimmed_profile_note() {
+        std::env::set_var("LOONGCLAW_MEMORY_PROFILE_NOTE", profile_note);
+    } else {
+        std::env::remove_var("LOONGCLAW_MEMORY_PROFILE_NOTE");
+    }
 }
 
 static MEMORY_RUNTIME_CONFIG: OnceLock<MemoryRuntimeConfig> = OnceLock::new();
@@ -59,6 +147,12 @@ pub fn get_memory_runtime_config() -> &'static MemoryRuntimeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn parse_sliding_window_accepts_positive_integer() {
@@ -81,19 +175,51 @@ mod tests {
     fn memory_runtime_config_default_has_no_path() {
         let config = MemoryRuntimeConfig::default();
         assert!(config.sqlite_path.is_none());
-        assert!(config.sliding_window.is_none());
     }
 
     #[test]
-    fn explicit_config_overrides_default() {
+    fn explicit_path_overrides_default() {
         let config = MemoryRuntimeConfig {
+            backend: MemoryBackendKind::Sqlite,
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
             sqlite_path: Some(PathBuf::from("/tmp/test-memory.sqlite3")),
-            sliding_window: Some(24),
+            sliding_window: 12,
+            summary_max_chars: 1200,
+            profile_note: None,
         };
         assert_eq!(
             config.sqlite_path,
             Some(PathBuf::from("/tmp/test-memory.sqlite3"))
         );
-        assert_eq!(config.sliding_window, Some(24));
+    }
+
+    #[test]
+    fn runtime_config_from_memory_config_carries_profile_and_limits() {
+        let mut config = MemoryConfig::default();
+        config.profile = MemoryProfile::WindowPlusSummary;
+        config.summary_max_chars = 900;
+
+        let runtime = MemoryRuntimeConfig::from_memory_config(&config);
+
+        assert_eq!(runtime.backend, MemoryBackendKind::Sqlite);
+        assert_eq!(runtime.profile, MemoryProfile::WindowPlusSummary);
+        assert_eq!(runtime.mode, MemoryMode::WindowPlusSummary);
+        assert_eq!(runtime.summary_max_chars, 900);
+    }
+
+    #[test]
+    fn apply_memory_runtime_env_clears_absent_profile_note() {
+        let _guard = env_lock().lock().expect("env lock");
+
+        std::env::set_var("LOONGCLAW_MEMORY_PROFILE_NOTE", "stale imported note");
+
+        let config = MemoryConfig::default();
+        apply_memory_runtime_env(&config);
+
+        assert!(
+            std::env::var("LOONGCLAW_MEMORY_PROFILE_NOTE").is_err(),
+            "profile note env should be cleared when config has no note"
+        );
     }
 }

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -341,7 +341,8 @@ mod tests {
     fn default_window_size_prefers_injected_config() {
         let config = MemoryRuntimeConfig {
             sqlite_path: None,
-            sliding_window: Some(24),
+            sliding_window: 24,
+            ..MemoryRuntimeConfig::default()
         };
 
         assert_eq!(default_window_size(&config), 24);

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -103,39 +103,8 @@ pub(super) fn load_window(
     } else {
         requested_limit.min(default_window)
     };
-
     let path = resolve_db_path(config);
-    ensure_sqlite_schema(&path)?;
-    let conn = rusqlite::Connection::open(&path)
-        .map_err(|error| format!("open sqlite memory db failed: {error}"))?;
-
-    let mut stmt = conn
-        .prepare(
-            "SELECT role, content, ts
-             FROM turns
-             WHERE session_id = ?1
-             ORDER BY id DESC
-             LIMIT ?2",
-        )
-        .map_err(|error| format!("prepare memory window query failed: {error}"))?;
-    let rows = stmt
-        .query_map(
-            rusqlite::params![session_id, window_limit as i64],
-            |row| -> rusqlite::Result<ConversationTurn> {
-                Ok(ConversationTurn {
-                    role: row.get(0)?,
-                    content: row.get(1)?,
-                    ts: row.get(2)?,
-                })
-            },
-        )
-        .map_err(|error| format!("query memory window failed: {error}"))?;
-
-    let mut turns = Vec::new();
-    for item in rows {
-        turns.push(item.map_err(|error| format!("decode memory window row failed: {error}"))?);
-    }
-    turns.reverse();
+    let turns = query_turns(session_id, Some(window_limit), config)?;
 
     Ok(MemoryCoreOutcome {
         status: "ok".to_owned(),
@@ -226,6 +195,13 @@ pub(super) fn window_direct_with_options(
         .map_err(|error| format!("decode memory turns failed: {error}"))
 }
 
+pub(super) fn session_turns_direct(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<ConversationTurn>, String> {
+    query_turns(session_id, None, config)
+}
+
 pub(super) fn ensure_memory_db_ready(
     path: Option<PathBuf>,
     config: &MemoryRuntimeConfig,
@@ -236,10 +212,7 @@ pub(super) fn ensure_memory_db_ready(
 }
 
 fn default_window_size(config: &MemoryRuntimeConfig) -> usize {
-    config
-        .sliding_window
-        .filter(|value| *value > 0)
-        .unwrap_or(12)
+    config.sliding_window.max(1)
 }
 
 fn default_window_size_u64(config: &MemoryRuntimeConfig) -> u64 {
@@ -258,6 +231,80 @@ fn resolve_db_path(config: &MemoryRuntimeConfig) -> PathBuf {
         return path.clone();
     }
     crate::config::default_loongclaw_home().join("memory.sqlite3")
+}
+
+fn query_turns(
+    session_id: &str,
+    limit: Option<usize>,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<ConversationTurn>, String> {
+    let path = resolve_db_path(config);
+    ensure_sqlite_schema(&path)?;
+    let conn = rusqlite::Connection::open(&path)
+        .map_err(|error| format!("open sqlite memory db failed: {error}"))?;
+
+    let mut turns = if let Some(limit) = limit {
+        let mut stmt = conn
+            .prepare(
+                "SELECT role, content, ts
+                 FROM turns
+                 WHERE session_id = ?1
+                 ORDER BY id DESC
+                 LIMIT ?2",
+            )
+            .map_err(|error| format!("prepare memory window query failed: {error}"))?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![session_id, limit as i64],
+                |row| -> rusqlite::Result<ConversationTurn> {
+                    Ok(ConversationTurn {
+                        role: row.get(0)?,
+                        content: row.get(1)?,
+                        ts: row.get(2)?,
+                    })
+                },
+            )
+            .map_err(|error| format!("query memory window failed: {error}"))?;
+
+        let mut turns = Vec::new();
+        for item in rows {
+            turns.push(item.map_err(|error| format!("decode memory window row failed: {error}"))?);
+        }
+        turns.reverse();
+        turns
+    } else {
+        let mut stmt = conn
+            .prepare(
+                "SELECT role, content, ts
+                 FROM turns
+                 WHERE session_id = ?1
+                 ORDER BY id ASC",
+            )
+            .map_err(|error| format!("prepare full memory query failed: {error}"))?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![session_id],
+                |row| -> rusqlite::Result<ConversationTurn> {
+                    Ok(ConversationTurn {
+                        role: row.get(0)?,
+                        content: row.get(1)?,
+                        ts: row.get(2)?,
+                    })
+                },
+            )
+            .map_err(|error| format!("query full memory session failed: {error}"))?;
+
+        let mut turns = Vec::new();
+        for item in rows {
+            turns.push(item.map_err(|error| format!("decode full memory row failed: {error}"))?);
+        }
+        turns
+    };
+
+    if turns.is_empty() {
+        return Ok(Vec::new());
+    }
+    Ok(std::mem::take(&mut turns))
 }
 
 fn ensure_sqlite_schema(path: &PathBuf) -> Result<(), String> {

--- a/crates/app/src/migration/merge.rs
+++ b/crates/app/src/migration/merge.rs
@@ -1,0 +1,251 @@
+use std::{cmp::Ordering, collections::BTreeMap};
+
+use crate::CliResult;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ProfileEntryLane {
+    Prompt,
+    Profile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileMergeEntry {
+    pub lane: ProfileEntryLane,
+    pub canonical_text: String,
+    pub source_id: String,
+    pub source_confidence: u32,
+    pub entry_confidence: u32,
+    pub slot_key: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileMergeConflict {
+    pub slot_key: Option<String>,
+    pub preferred_source_id: String,
+    pub discarded_source_id: String,
+    pub preferred_text: String,
+    pub discarded_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MergedProfilePlan {
+    pub prompt_owner_source_id: Option<String>,
+    pub kept_entries: Vec<ProfileMergeEntry>,
+    pub dropped_duplicates: Vec<ProfileMergeEntry>,
+    pub unresolved_conflicts: Vec<ProfileMergeConflict>,
+    pub auto_apply_allowed: bool,
+    pub merged_profile_note: String,
+}
+
+pub fn merge_profile_entries(entries: &[ProfileMergeEntry]) -> CliResult<MergedProfilePlan> {
+    let prompt_owner_source_id = entries
+        .iter()
+        .filter(|entry| entry.lane == ProfileEntryLane::Prompt)
+        .max_by(|left, right| compare_entries(left, right))
+        .map(|entry| entry.source_id.clone());
+
+    let mut profile_entries = entries
+        .iter()
+        .filter(|entry| entry.lane == ProfileEntryLane::Profile)
+        .cloned()
+        .collect::<Vec<_>>();
+    profile_entries.sort_by(|left, right| compare_entries(right, left));
+
+    let mut deduped_by_text = BTreeMap::new();
+    let mut dropped_duplicates = Vec::new();
+    for entry in profile_entries {
+        let key = duplicate_key(&entry);
+        match deduped_by_text.entry(key) {
+            std::collections::btree_map::Entry::Vacant(slot) => {
+                slot.insert(entry);
+            }
+            std::collections::btree_map::Entry::Occupied(mut slot) => {
+                if compare_entries(&entry, slot.get()).is_gt() {
+                    dropped_duplicates.push(slot.insert(entry));
+                } else {
+                    dropped_duplicates.push(entry);
+                }
+            }
+        }
+    }
+
+    let mut slot_winners = BTreeMap::new();
+    let mut slotless_entries = Vec::new();
+    let mut unresolved_conflicts = Vec::new();
+
+    for entry in deduped_by_text.into_values() {
+        let Some(slot_key) = entry.slot_key.clone() else {
+            slotless_entries.push(entry);
+            continue;
+        };
+
+        match slot_winners.entry(slot_key.clone()) {
+            std::collections::btree_map::Entry::Vacant(slot) => {
+                slot.insert(entry);
+            }
+            std::collections::btree_map::Entry::Occupied(mut slot) => {
+                if compare_entries(&entry, slot.get()).is_gt() {
+                    unresolved_conflicts.push(ProfileMergeConflict {
+                        slot_key: Some(slot_key),
+                        preferred_source_id: entry.source_id.clone(),
+                        discarded_source_id: slot.get().source_id.clone(),
+                        preferred_text: entry.canonical_text.clone(),
+                        discarded_text: slot.get().canonical_text.clone(),
+                    });
+                    slot.insert(entry);
+                } else {
+                    unresolved_conflicts.push(ProfileMergeConflict {
+                        slot_key: Some(slot_key),
+                        preferred_source_id: slot.get().source_id.clone(),
+                        discarded_source_id: entry.source_id.clone(),
+                        preferred_text: slot.get().canonical_text.clone(),
+                        discarded_text: entry.canonical_text.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    let mut kept_entries = slot_winners.into_values().collect::<Vec<_>>();
+    kept_entries.extend(slotless_entries);
+    kept_entries.sort_by(compare_kept_entries);
+    dropped_duplicates.sort_by(compare_kept_entries);
+    unresolved_conflicts.sort_by(|left, right| {
+        left.slot_key
+            .cmp(&right.slot_key)
+            .then_with(|| left.preferred_source_id.cmp(&right.preferred_source_id))
+            .then_with(|| left.discarded_source_id.cmp(&right.discarded_source_id))
+    });
+
+    Ok(MergedProfilePlan {
+        prompt_owner_source_id,
+        merged_profile_note: kept_entries
+            .iter()
+            .map(|entry| entry.canonical_text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n"),
+        auto_apply_allowed: unresolved_conflicts.is_empty(),
+        kept_entries,
+        dropped_duplicates,
+        unresolved_conflicts,
+    })
+}
+
+fn duplicate_key(entry: &ProfileMergeEntry) -> String {
+    entry.canonical_text.trim().to_ascii_lowercase()
+}
+
+fn compare_entries(left: &ProfileMergeEntry, right: &ProfileMergeEntry) -> Ordering {
+    left.slot_key
+        .is_some()
+        .cmp(&right.slot_key.is_some())
+        .then_with(|| entry_score(left).cmp(&entry_score(right)))
+        .then_with(|| left.entry_confidence.cmp(&right.entry_confidence))
+        .then_with(|| right.source_id.cmp(&left.source_id))
+        .then_with(|| right.canonical_text.cmp(&left.canonical_text))
+}
+
+fn compare_kept_entries(left: &ProfileMergeEntry, right: &ProfileMergeEntry) -> Ordering {
+    left.slot_key
+        .cmp(&right.slot_key)
+        .then_with(|| left.canonical_text.cmp(&right.canonical_text))
+        .then_with(|| left.source_id.cmp(&right.source_id))
+}
+
+fn entry_score(entry: &ProfileMergeEntry) -> u32 {
+    entry
+        .source_confidence
+        .saturating_mul(100)
+        .saturating_add(entry.entry_confidence)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_profile_entries_deduplicates_equivalent_entries() {
+        let entries = vec![
+            ProfileMergeEntry {
+                lane: ProfileEntryLane::Profile,
+                canonical_text: "prefers terse shell output".to_owned(),
+                source_id: "openclaw".to_owned(),
+                source_confidence: 40,
+                entry_confidence: 4,
+                slot_key: Some("style".to_owned()),
+            },
+            ProfileMergeEntry {
+                lane: ProfileEntryLane::Profile,
+                canonical_text: "prefers terse shell output".to_owned(),
+                source_id: "nanobot".to_owned(),
+                source_confidence: 18,
+                entry_confidence: 2,
+                slot_key: None,
+            },
+        ];
+
+        let result = merge_profile_entries(&entries).expect("merge should succeed");
+        assert_eq!(result.kept_entries.len(), 1);
+        assert_eq!(result.dropped_duplicates.len(), 1);
+        assert_eq!(result.kept_entries[0].slot_key.as_deref(), Some("style"));
+    }
+
+    #[test]
+    fn merge_profile_entries_reports_same_slot_conflict() {
+        let entries = vec![
+            ProfileMergeEntry {
+                lane: ProfileEntryLane::Profile,
+                canonical_text: "release copilot".to_owned(),
+                source_id: "openclaw".to_owned(),
+                source_confidence: 40,
+                entry_confidence: 4,
+                slot_key: Some("role".to_owned()),
+            },
+            ProfileMergeEntry {
+                lane: ProfileEntryLane::Profile,
+                canonical_text: "personal operations assistant".to_owned(),
+                source_id: "nanobot".to_owned(),
+                source_confidence: 18,
+                entry_confidence: 3,
+                slot_key: Some("role".to_owned()),
+            },
+        ];
+
+        let result = merge_profile_entries(&entries).expect("merge should succeed");
+        assert_eq!(result.unresolved_conflicts.len(), 1);
+        assert!(!result.auto_apply_allowed);
+    }
+
+    #[test]
+    fn merge_profile_entries_never_changes_prompt_owner() {
+        let entries = vec![
+            ProfileMergeEntry {
+                lane: ProfileEntryLane::Prompt,
+                canonical_text: "openclaw prompt overlay".to_owned(),
+                source_id: "openclaw".to_owned(),
+                source_confidence: 40,
+                entry_confidence: 5,
+                slot_key: None,
+            },
+            ProfileMergeEntry {
+                lane: ProfileEntryLane::Prompt,
+                canonical_text: "nanobot prompt overlay".to_owned(),
+                source_id: "nanobot".to_owned(),
+                source_confidence: 18,
+                entry_confidence: 5,
+                slot_key: None,
+            },
+            ProfileMergeEntry {
+                lane: ProfileEntryLane::Profile,
+                canonical_text: "prefers short summaries".to_owned(),
+                source_id: "nanobot".to_owned(),
+                source_confidence: 18,
+                entry_confidence: 2,
+                slot_key: Some("style".to_owned()),
+            },
+        ];
+
+        let result = merge_profile_entries(&entries).expect("merge should succeed");
+        assert_eq!(result.prompt_owner_source_id.as_deref(), Some("openclaw"));
+    }
+}

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -11,9 +11,11 @@ use crate::{
 use serde_json::Value;
 
 pub use orchestrator::{
-    discover_import_sources, merge_profile_sources, plan_import_sources,
-    recommend_primary_source, DiscoveredImportSource, DiscoveryOptions, DiscoveryPlanSummary,
-    DiscoveryReport, PlannedImportSource, PrimarySourceRecommendation,
+    apply_import_selection, discover_import_sources, merge_profile_sources,
+    plan_import_sources, recommend_primary_source, rollback_last_import,
+    ApplyImportSelection, ApplyImportSelectionResult, DiscoveredImportSource, DiscoveryOptions,
+    DiscoveryPlanSummary, DiscoveryReport, ImportSelectionMode, PlannedImportSource,
+    PrimarySourceRecommendation,
 };
 pub use merge::{
     merge_profile_entries, MergedProfilePlan, ProfileEntryLane, ProfileMergeConflict,

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -1,0 +1,603 @@
+use std::{collections::BTreeSet, fs, path::Path};
+
+use crate::{
+    config::{LoongClawConfig, MemoryProfile},
+    prompt::DEFAULT_PROMPT_PACK_ID,
+    CliResult,
+};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LegacyClawSource {
+    Nanobot,
+    OpenClaw,
+    PicoClaw,
+    ZeroClaw,
+    NanoClaw,
+    Unknown,
+}
+
+impl LegacyClawSource {
+    pub fn as_id(self) -> &'static str {
+        match self {
+            Self::Nanobot => "nanobot",
+            Self::OpenClaw => "openclaw",
+            Self::PicoClaw => "picoclaw",
+            Self::ZeroClaw => "zeroclaw",
+            Self::NanoClaw => "nanoclaw",
+            Self::Unknown => "auto",
+        }
+    }
+
+    pub fn from_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "auto" => Some(Self::Unknown),
+            "nanobot" => Some(Self::Nanobot),
+            "openclaw" => Some(Self::OpenClaw),
+            "picoclaw" => Some(Self::PicoClaw),
+            "zeroclaw" => Some(Self::ZeroClaw),
+            "nanoclaw" => Some(Self::NanoClaw),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportPlan {
+    pub source: LegacyClawSource,
+    pub system_prompt_addendum: Option<String>,
+    pub profile_note: Option<String>,
+    pub warnings: Vec<String>,
+}
+
+pub fn plan_import_from_path(
+    input_path: &Path,
+    hint: Option<LegacyClawSource>,
+) -> CliResult<ImportPlan> {
+    let files = collect_import_files(input_path)?;
+    let source = hint.unwrap_or_else(|| detect_source(input_path, &files));
+    let mut prompt_blocks = Vec::new();
+    let mut profile_blocks = Vec::new();
+    let mut warnings = Vec::new();
+
+    for file in files {
+        match file.kind {
+            ImportFileKind::Prompt => {
+                if is_stock_template(source, &file.label, &file.content) {
+                    continue;
+                }
+                prompt_blocks.push(format!(
+                    "## Imported {}\n{}",
+                    file.label,
+                    normalize_brand_references(&file.content)
+                ));
+            }
+            ImportFileKind::Profile => {
+                if is_stock_template(source, &file.label, &file.content) {
+                    continue;
+                }
+                profile_blocks.push(format!(
+                    "## Imported {}\n{}",
+                    file.label,
+                    normalize_brand_references(&file.content)
+                ));
+            }
+            ImportFileKind::AieosJson => {
+                if let Some(rendered) = render_aieos_profile_note(&file.content)? {
+                    profile_blocks.push(format!("## Imported {}\n{}", file.label, rendered));
+                }
+            }
+            ImportFileKind::Heartbeat => {
+                if heartbeat_has_active_tasks(&file.content) {
+                    warnings.push(format!(
+                        "{} contains active periodic tasks; LoongClaw does not auto-wire heartbeat jobs yet",
+                        file.label
+                    ));
+                }
+            }
+        }
+    }
+
+    if prompt_blocks.is_empty()
+        && profile_blocks.is_empty()
+        && warnings.is_empty()
+        && matches!(source, LegacyClawSource::Unknown)
+    {
+        return Err(format!(
+            "no supported migration content found under {}",
+            input_path.display()
+        ));
+    }
+
+    Ok(ImportPlan {
+        source,
+        system_prompt_addendum: join_blocks(prompt_blocks),
+        profile_note: join_blocks(profile_blocks),
+        warnings,
+    })
+}
+
+pub fn apply_import_plan(config: &mut LoongClawConfig, plan: &ImportPlan) {
+    config.cli.prompt_pack_id = Some(DEFAULT_PROMPT_PACK_ID.to_owned());
+    config.cli.system_prompt_addendum = plan.system_prompt_addendum.clone();
+    config.cli.refresh_native_system_prompt();
+    config.memory.profile = MemoryProfile::ProfilePlusWindow;
+    config.memory.profile_note = plan.profile_note.clone();
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImportFileKind {
+    Prompt,
+    Profile,
+    AieosJson,
+    Heartbeat,
+}
+
+#[derive(Debug, Clone)]
+struct ImportFile {
+    label: String,
+    kind: ImportFileKind,
+    content: String,
+}
+
+fn collect_import_files(input_path: &Path) -> CliResult<Vec<ImportFile>> {
+    if input_path.is_file() {
+        return read_single_import_file(input_path)
+            .map(|file| file.into_iter().collect())
+            .map_err(|error| {
+                format!(
+                    "failed to read migration input {}: {error}",
+                    input_path.display()
+                )
+            });
+    }
+
+    if !input_path.exists() {
+        return Err(format!(
+            "migration input does not exist: {}",
+            input_path.display()
+        ));
+    }
+
+    let mut roots = vec![input_path.to_path_buf()];
+    let workspace_root = input_path.join("workspace");
+    if workspace_root.is_dir() {
+        roots.push(workspace_root);
+    }
+
+    let mut seen = BTreeSet::new();
+    let mut files = Vec::new();
+    for root in roots {
+        for relative in [
+            "AGENTS.md",
+            "SOUL.md",
+            "TOOLS.md",
+            "IDENTITY.md",
+            "USER.md",
+            "BOOTSTRAP.md",
+            "HEARTBEAT.md",
+            "MEMORY.md",
+            "memory/MEMORY.md",
+            "identity.json",
+            "CLAUDE.md",
+            "groups/main/CLAUDE.md",
+            "groups/global/CLAUDE.md",
+        ] {
+            let path = root.join(relative);
+            if !path.is_file() {
+                continue;
+            }
+            let canonical = path
+                .canonicalize()
+                .unwrap_or_else(|_| path.clone())
+                .display()
+                .to_string();
+            if !seen.insert(canonical) {
+                continue;
+            }
+            if let Some(file) = read_single_import_file(&path).map_err(|error| {
+                format!("failed to read migration file {}: {error}", path.display())
+            })? {
+                files.push(file);
+            }
+        }
+    }
+    Ok(files)
+}
+
+fn read_single_import_file(path: &Path) -> Result<Option<ImportFile>, std::io::Error> {
+    let content = fs::read_to_string(path)?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
+    let kind = classify_file_kind(path, file_name)?;
+    Ok(Some(ImportFile {
+        label: relative_label(path),
+        kind,
+        content: trimmed.to_owned(),
+    }))
+}
+
+fn classify_file_kind(path: &Path, file_name: &str) -> Result<ImportFileKind, std::io::Error> {
+    if file_name.eq_ignore_ascii_case("identity.json") {
+        return Ok(ImportFileKind::AieosJson);
+    }
+    if file_name.eq_ignore_ascii_case("HEARTBEAT.md") {
+        return Ok(ImportFileKind::Heartbeat);
+    }
+    if file_name.eq_ignore_ascii_case("CLAUDE.md") {
+        return Ok(ImportFileKind::Prompt);
+    }
+    if matches!(
+        file_name,
+        "AGENTS.md" | "SOUL.md" | "TOOLS.md" | "BOOTSTRAP.md"
+    ) {
+        return Ok(ImportFileKind::Prompt);
+    }
+    if matches!(file_name, "IDENTITY.md" | "USER.md" | "MEMORY.md") {
+        return Ok(ImportFileKind::Profile);
+    }
+
+    let _ = path;
+    Ok(ImportFileKind::Profile)
+}
+
+fn relative_label(path: &Path) -> String {
+    let file_name = path
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.display().to_string());
+    let parent_name = path
+        .parent()
+        .and_then(|parent| parent.file_name())
+        .map(|value| value.to_string_lossy().to_string());
+    if matches!(
+        parent_name.as_deref(),
+        Some("memory") | Some("main") | Some("global")
+    ) {
+        return format!("{}/{}", parent_name.unwrap_or_default(), file_name);
+    }
+    file_name
+}
+
+fn detect_source(input_path: &Path, files: &[ImportFile]) -> LegacyClawSource {
+    let path_text = input_path.display().to_string().to_ascii_lowercase();
+    if path_text.contains("nanobot") {
+        return LegacyClawSource::Nanobot;
+    }
+    if path_text.contains("openclaw") {
+        return LegacyClawSource::OpenClaw;
+    }
+    if path_text.contains("picoclaw") {
+        return LegacyClawSource::PicoClaw;
+    }
+    if path_text.contains("zeroclaw") {
+        return LegacyClawSource::ZeroClaw;
+    }
+    if path_text.contains("nanoclaw") {
+        return LegacyClawSource::NanoClaw;
+    }
+
+    for file in files {
+        let lower = file.content.to_ascii_lowercase();
+        if lower.contains("i am nanobot")
+            || lower.contains("your nanobot agent")
+            || lower.contains("updated by nanobot")
+        {
+            return LegacyClawSource::Nanobot;
+        }
+        if lower.contains("i am picoclaw")
+            || lower.contains("github.com/sipeed/picoclaw")
+            || lower.contains("picoclaw 🦞")
+        {
+            return LegacyClawSource::PicoClaw;
+        }
+        if lower.contains("openclaw workspace")
+            || lower.contains("folder is the assistant's working directory")
+            || lower.contains("first run ritual")
+        {
+            return LegacyClawSource::OpenClaw;
+        }
+        if lower.contains("3mb binary. zero bloat.")
+            || lower.contains("you wake up fresh each session")
+            || lower.contains("\"format\": \"aieos\"")
+        {
+            return LegacyClawSource::ZeroClaw;
+        }
+        if lower.contains("you are andy, a personal assistant") {
+            return LegacyClawSource::NanoClaw;
+        }
+    }
+
+    LegacyClawSource::Unknown
+}
+
+fn is_stock_template(source: LegacyClawSource, label: &str, content: &str) -> bool {
+    let normalized = content.trim();
+
+    match source {
+        LegacyClawSource::Nanobot => {
+            (label.ends_with("SOUL.md")
+                && normalized.contains("I am nanobot 🐈, a personal AI assistant."))
+                || (label.ends_with("HEARTBEAT.md")
+                    && normalized
+                        .contains("This file is checked every 30 minutes by your nanobot agent."))
+                || (label.ends_with("MEMORY.md")
+                    && normalized.contains("automatically updated by nanobot"))
+        }
+        LegacyClawSource::OpenClaw => {
+            (label.ends_with("AGENTS.md")
+                && normalized.contains("# AGENTS.md - OpenClaw Workspace"))
+                || (label.ends_with("SOUL.md")
+                    && normalized.contains("# SOUL.md - Persona & Boundaries"))
+                || (label.ends_with("IDENTITY.md")
+                    && normalized.contains("# IDENTITY.md - Agent Identity"))
+                || (label.ends_with("USER.md") && normalized.contains("# USER.md - User Profile"))
+                || (label.ends_with("BOOTSTRAP.md")
+                    && normalized.contains("# BOOTSTRAP.md - First Run Ritual"))
+        }
+        LegacyClawSource::PicoClaw => (label.ends_with("SOUL.md")
+            && normalized.contains("I am picoclaw, a lightweight AI assistant powered by AI."))
+            || (label.ends_with("AGENTS.md") && normalized.contains("# Agent Instructions"))
+            || (label.ends_with("IDENTITY.md")
+                && normalized.contains(
+                    "Ultra-lightweight personal AI assistant written in Go, inspired by nanobot.",
+                ))
+            || (label.ends_with("USER.md")
+                && normalized.contains("Information about user goes here."))
+            || (label.ends_with("MEMORY.md")
+                && normalized.contains(
+                    "This file stores important information that should persist across sessions.",
+                )),
+        LegacyClawSource::ZeroClaw => {
+            (label.ends_with("SOUL.md")
+                && normalized.contains("*You're not a chatbot. You're becoming someone.*")
+                && normalized.contains("Built in Rust. 3MB binary. Zero bloat."))
+                || (label.ends_with("AGENTS.md")
+                    && normalized.contains("## Every Session (required)"))
+                || (label.ends_with("IDENTITY.md")
+                    && normalized.contains(
+                        "Update this file as you evolve. Your identity is yours to shape.",
+                    ))
+                || (label.ends_with("HEARTBEAT.md")
+                    && normalized.contains(
+                        "Keep this file empty (or with only comments) to skip heartbeat work.",
+                    ))
+                || (label.ends_with("MEMORY.md")
+                    && normalized
+                        .contains("*Your curated memories. The distilled essence, not raw logs.*"))
+        }
+        LegacyClawSource::NanoClaw => {
+            label.ends_with("CLAUDE.md")
+                && normalized.contains("You are Andy, a personal assistant.")
+        }
+        LegacyClawSource::Unknown => false,
+    }
+}
+
+fn heartbeat_has_active_tasks(content: &str) -> bool {
+    content
+        .lines()
+        .map(str::trim)
+        .any(|line| line.starts_with("- ") && line.len() > 2)
+}
+
+fn render_aieos_profile_note(content: &str) -> CliResult<Option<String>> {
+    let value = serde_json::from_str::<Value>(content)
+        .map_err(|error| format!("failed to parse imported identity.json: {error}"))?;
+    let identity = value.get("identity").unwrap_or(&value);
+    let mut lines = Vec::new();
+
+    if let Some(name) = json_string(identity, &["names", "first"]) {
+        lines.push(format!(
+            "- names.first: {}",
+            normalize_brand_references(name)
+        ));
+    }
+    if let Some(bio) = json_string(identity, &["bio"]) {
+        lines.push(format!("- bio: {}", normalize_brand_references(bio)));
+    }
+    if let Some(values) = json_string_array(identity, &["values"]) {
+        lines.push(format!(
+            "- values: {}",
+            values
+                .into_iter()
+                .map(|value| normalize_brand_references(&value))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    if lines.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(lines.join("\n")))
+}
+
+fn json_string<'a>(value: &'a Value, path: &[&str]) -> Option<&'a str> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_str()
+}
+
+fn json_string_array(value: &Value, path: &[&str]) -> Option<Vec<String>> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    let items = current.as_array()?;
+    let values = items
+        .iter()
+        .filter_map(|item| item.as_str().map(str::to_owned))
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        return None;
+    }
+    Some(values)
+}
+
+fn join_blocks(blocks: Vec<String>) -> Option<String> {
+    let joined = blocks
+        .into_iter()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    if joined.is_empty() {
+        return None;
+    }
+    Some(joined)
+}
+
+fn normalize_brand_references(content: &str) -> String {
+    let mut normalized = content.to_owned();
+    for needle in [
+        "nanobot", "Nanobot", "NanoBot", "openclaw", "OpenClaw", "picoclaw", "PicoClaw",
+        "zeroclaw", "ZeroClaw", "nanoclaw", "NanoClaw",
+    ] {
+        normalized = normalized.replace(needle, "LoongClaw");
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::LoongClawConfig;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    fn write_file(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent directory");
+        }
+        fs::write(path, content).expect("write fixture");
+    }
+
+    #[test]
+    fn nanobot_stock_templates_nativeize_to_loongclaw_defaults() {
+        let root = unique_temp_dir("loongclaw-import-nanobot-stock");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "SOUL.md",
+            "# Soul\n\nI am nanobot 🐈, a personal AI assistant.\n",
+        );
+        write_file(
+            &root,
+            "HEARTBEAT.md",
+            "# Heartbeat Tasks\n\nThis file is checked every 30 minutes by your nanobot agent.\n",
+        );
+        write_file(
+            &root,
+            "memory/MEMORY.md",
+            "# Long-term Memory\n\n*This file is automatically updated by nanobot when important information should be remembered.*\n",
+        );
+
+        let plan = plan_import_from_path(&root, None).expect("plan should succeed");
+        let mut config = LoongClawConfig::default();
+        apply_import_plan(&mut config, &plan);
+
+        assert_eq!(plan.source, LegacyClawSource::Nanobot);
+        assert_eq!(config.cli.prompt_pack_id(), Some(DEFAULT_PROMPT_PACK_ID));
+        assert_eq!(config.memory.profile, MemoryProfile::ProfilePlusWindow);
+        assert!(config.cli.system_prompt_addendum.is_none());
+        assert!(config.memory.profile_note.is_none());
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn custom_prompt_and_memory_content_are_preserved_with_brand_remap() {
+        let root = unique_temp_dir("loongclaw-import-customized");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "SOUL.md",
+            "# Soul\n\nAlways prefer concise shell output. If you mention nanobot, say LoongClaw instead.\n",
+        );
+        write_file(
+            &root,
+            "IDENTITY.md",
+            "# Identity\n\n- Name: My build copilot\n- Motto: updated by nanobot after every release\n",
+        );
+
+        let plan = plan_import_from_path(&root, Some(LegacyClawSource::Nanobot))
+            .expect("plan should succeed");
+        let mut config = LoongClawConfig::default();
+        apply_import_plan(&mut config, &plan);
+
+        assert_eq!(config.cli.prompt_pack_id(), Some(DEFAULT_PROMPT_PACK_ID));
+        assert_eq!(config.memory.profile, MemoryProfile::ProfilePlusWindow);
+        assert_eq!(
+            config.cli.system_prompt_addendum.as_deref(),
+            Some(
+                "## Imported SOUL.md\n# Soul\n\nAlways prefer concise shell output. If you mention LoongClaw, say LoongClaw instead."
+            )
+        );
+        assert_eq!(
+            config.memory.profile_note.as_deref(),
+            Some(
+                "## Imported IDENTITY.md\n# Identity\n\n- Name: My build copilot\n- Motto: updated by LoongClaw after every release"
+            )
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn zeroclaw_aieos_identity_is_promoted_into_profile_note() {
+        let root = unique_temp_dir("loongclaw-import-zeroclaw-aieos");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "identity.json",
+            r#"{
+  "identity": {
+    "names": { "first": "Nova" },
+    "bio": "Built by ZeroClaw Labs for safe, direct help",
+    "values": ["privacy first", "fast execution"]
+  }
+}"#,
+        );
+
+        let plan = plan_import_from_path(&root, Some(LegacyClawSource::ZeroClaw))
+            .expect("plan should succeed");
+        let mut config = LoongClawConfig::default();
+        apply_import_plan(&mut config, &plan);
+
+        assert_eq!(plan.source, LegacyClawSource::ZeroClaw);
+        assert_eq!(config.cli.prompt_pack_id(), Some(DEFAULT_PROMPT_PACK_ID));
+        assert_eq!(config.memory.profile, MemoryProfile::ProfilePlusWindow);
+        let note = config
+            .memory
+            .profile_note
+            .as_deref()
+            .expect("profile note should be present");
+        assert!(note.contains("Nova"));
+        assert!(note.contains("LoongClaw Labs"));
+        assert!(note.contains("privacy first"));
+
+        fs::remove_dir_all(&root).ok();
+    }
+}

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -10,7 +10,9 @@ use crate::{
 use serde_json::Value;
 
 pub use orchestrator::{
-    discover_import_sources, DiscoveredImportSource, DiscoveryOptions, DiscoveryReport,
+    discover_import_sources, plan_import_sources, recommend_primary_source, DiscoveredImportSource,
+    DiscoveryOptions, DiscoveryPlanSummary, DiscoveryReport, PlannedImportSource,
+    PrimarySourceRecommendation,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -11,9 +11,9 @@ use crate::{
 use serde_json::Value;
 
 pub use orchestrator::{
-    discover_import_sources, plan_import_sources, recommend_primary_source, DiscoveredImportSource,
-    DiscoveryOptions, DiscoveryPlanSummary, DiscoveryReport, PlannedImportSource,
-    PrimarySourceRecommendation,
+    discover_import_sources, merge_profile_sources, plan_import_sources,
+    recommend_primary_source, DiscoveredImportSource, DiscoveryOptions, DiscoveryPlanSummary,
+    DiscoveryReport, PlannedImportSource, PrimarySourceRecommendation,
 };
 pub use merge::{
     merge_profile_entries, MergedProfilePlan, ProfileEntryLane, ProfileMergeConflict,

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -4,21 +4,21 @@ mod orchestrator;
 use std::{collections::BTreeSet, fs, path::Path};
 
 use crate::{
+    CliResult,
     config::{LoongClawConfig, MemoryProfile},
     prompt::DEFAULT_PROMPT_PACK_ID,
-    CliResult,
 };
 use serde_json::Value;
 
 pub use merge::{
-    merge_profile_entries, MergedProfilePlan, ProfileEntryLane, ProfileMergeConflict,
-    ProfileMergeEntry,
+    MergedProfilePlan, ProfileEntryLane, ProfileMergeConflict, ProfileMergeEntry,
+    merge_profile_entries,
 };
 pub use orchestrator::{
-    apply_import_selection, discover_import_sources, merge_profile_sources, plan_import_sources,
-    recommend_primary_source, rollback_last_import, ApplyImportSelection,
-    ApplyImportSelectionResult, DiscoveredImportSource, DiscoveryOptions, DiscoveryPlanSummary,
-    DiscoveryReport, ImportSelectionMode, PlannedImportSource, PrimarySourceRecommendation,
+    ApplyImportSelection, ApplyImportSelectionResult, DiscoveredImportSource, DiscoveryOptions,
+    DiscoveryPlanSummary, DiscoveryReport, ImportSelectionMode, PlannedImportSource,
+    PrimarySourceRecommendation, apply_import_selection, discover_import_sources,
+    merge_profile_sources, plan_import_sources, recommend_primary_source, rollback_last_import,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -543,9 +543,59 @@ fn normalize_brand_references(content: &str) -> String {
         "nanobot", "Nanobot", "NanoBot", "openclaw", "OpenClaw", "picoclaw", "PicoClaw",
         "zeroclaw", "ZeroClaw", "nanoclaw", "NanoClaw",
     ] {
-        normalized = normalized.replace(needle, "LoongClaw");
+        normalized = replace_identity_token(&normalized, needle, "LoongClaw");
     }
     normalized
+}
+
+fn replace_identity_token(content: &str, needle: &str, replacement: &str) -> String {
+    let mut normalized = String::with_capacity(content.len());
+    let mut cursor = 0usize;
+
+    while let Some(relative) = content[cursor..].find(needle) {
+        let start = cursor + relative;
+        let end = start + needle.len();
+        normalized.push_str(&content[cursor..start]);
+        if should_replace_identity_match(content.as_bytes(), start, end) {
+            normalized.push_str(replacement);
+        } else {
+            normalized.push_str(&content[start..end]);
+        }
+        cursor = end;
+    }
+
+    normalized.push_str(&content[cursor..]);
+    normalized
+}
+
+fn should_replace_identity_match(content: &[u8], start: usize, end: usize) -> bool {
+    is_identity_boundary(content, start, true) && is_identity_boundary(content, end, false)
+}
+
+fn is_identity_boundary(content: &[u8], index: usize, leading: bool) -> bool {
+    let adjacent = if leading {
+        index.checked_sub(1).map(|offset| content[offset])
+    } else {
+        content.get(index).copied()
+    };
+    let beyond = if leading {
+        index.checked_sub(2).map(|offset| content[offset])
+    } else {
+        content.get(index + 1).copied()
+    };
+
+    match adjacent {
+        None => true,
+        Some(byte)
+            if byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'/' | b'\\' | b'-') =>
+        {
+            false
+        }
+        Some(b'.') => {
+            beyond.is_none_or(|byte| !(byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')))
+        }
+        Some(_) => true,
+    }
 }
 
 #[cfg(test)]
@@ -643,6 +693,24 @@ mod tests {
         );
 
         fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn brand_remap_preserves_paths_urls_and_identifiers() {
+        let normalized = normalize_brand_references(
+            "I am nanobot. Use your nanobot agent for deploys.\n\
+             Repo: github.com/openclaw-ai/openclaw\n\
+             Path: ~/.config/openclaw/IDENTITY.md\n\
+             File: openclaw.toml\n\
+             Key: openclaw_agent_id",
+        );
+
+        assert!(normalized.contains("I am LoongClaw."));
+        assert!(normalized.contains("your LoongClaw agent"));
+        assert!(normalized.contains("github.com/openclaw-ai/openclaw"));
+        assert!(normalized.contains("~/.config/openclaw/IDENTITY.md"));
+        assert!(normalized.contains("openclaw.toml"));
+        assert!(normalized.contains("openclaw_agent_id"));
     }
 
     #[test]

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -574,12 +574,16 @@ fn should_replace_identity_match(content: &[u8], start: usize, end: usize) -> bo
 
 fn is_identity_boundary(content: &[u8], index: usize, leading: bool) -> bool {
     let adjacent = if leading {
-        index.checked_sub(1).map(|offset| content[offset])
+        index
+            .checked_sub(1)
+            .and_then(|offset| content.get(offset).copied())
     } else {
         content.get(index).copied()
     };
     let beyond = if leading {
-        index.checked_sub(2).map(|offset| content[offset])
+        index
+            .checked_sub(2)
+            .and_then(|offset| content.get(offset).copied())
     } else {
         content.get(index + 1).copied()
     };

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -1,3 +1,5 @@
+mod orchestrator;
+
 use std::{collections::BTreeSet, fs, path::Path};
 
 use crate::{
@@ -6,6 +8,10 @@ use crate::{
     CliResult,
 };
 use serde_json::Value;
+
+pub use orchestrator::{
+    discover_import_sources, DiscoveredImportSource, DiscoveryOptions, DiscoveryReport,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LegacyClawSource {
@@ -123,6 +129,72 @@ pub fn apply_import_plan(config: &mut LoongClawConfig, plan: &ImportPlan) {
     config.cli.refresh_native_system_prompt();
     config.memory.profile = MemoryProfile::ProfilePlusWindow;
     config.memory.profile_note = plan.profile_note.clone();
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ImportPathInspection {
+    pub source: LegacyClawSource,
+    pub found_files: Vec<String>,
+    pub custom_prompt_files: usize,
+    pub custom_profile_files: usize,
+    pub warning_count: usize,
+}
+
+pub(crate) fn inspect_import_path(
+    input_path: &Path,
+    hint: Option<LegacyClawSource>,
+) -> CliResult<Option<ImportPathInspection>> {
+    let files = collect_import_files(input_path)?;
+    if files.is_empty() {
+        return Ok(None);
+    }
+
+    let source = hint.unwrap_or_else(|| detect_source(input_path, &files));
+    let mut found_files = Vec::new();
+    let mut custom_prompt_files = 0usize;
+    let mut custom_profile_files = 0usize;
+    let mut warning_count = 0usize;
+
+    for file in files {
+        found_files.push(file.label.clone());
+        match file.kind {
+            ImportFileKind::Prompt => {
+                if !is_stock_template(source, &file.label, &file.content) {
+                    custom_prompt_files = custom_prompt_files.saturating_add(1);
+                }
+            }
+            ImportFileKind::Profile => {
+                if !is_stock_template(source, &file.label, &file.content) {
+                    custom_profile_files = custom_profile_files.saturating_add(1);
+                }
+            }
+            ImportFileKind::AieosJson => {
+                if render_aieos_profile_note(&file.content)?.is_some() {
+                    custom_profile_files = custom_profile_files.saturating_add(1);
+                }
+            }
+            ImportFileKind::Heartbeat => {
+                if heartbeat_has_active_tasks(&file.content) {
+                    warning_count = warning_count.saturating_add(1);
+                }
+            }
+        }
+    }
+
+    if custom_prompt_files == 0 && custom_profile_files == 0 && warning_count == 0 {
+        return Ok(None);
+    }
+
+    found_files.sort();
+    found_files.dedup();
+
+    Ok(Some(ImportPathInspection {
+        source,
+        found_files,
+        custom_prompt_files,
+        custom_profile_files,
+        warning_count,
+    }))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -1,4 +1,5 @@
 mod orchestrator;
+mod merge;
 
 use std::{collections::BTreeSet, fs, path::Path};
 
@@ -13,6 +14,10 @@ pub use orchestrator::{
     discover_import_sources, plan_import_sources, recommend_primary_source, DiscoveredImportSource,
     DiscoveryOptions, DiscoveryPlanSummary, DiscoveryReport, PlannedImportSource,
     PrimarySourceRecommendation,
+};
+pub use merge::{
+    merge_profile_entries, MergedProfilePlan, ProfileEntryLane, ProfileMergeConflict,
+    ProfileMergeEntry,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -1,5 +1,5 @@
-mod orchestrator;
 mod merge;
+mod orchestrator;
 
 use std::{collections::BTreeSet, fs, path::Path};
 
@@ -10,16 +10,15 @@ use crate::{
 };
 use serde_json::Value;
 
-pub use orchestrator::{
-    apply_import_selection, discover_import_sources, merge_profile_sources,
-    plan_import_sources, recommend_primary_source, rollback_last_import,
-    ApplyImportSelection, ApplyImportSelectionResult, DiscoveredImportSource, DiscoveryOptions,
-    DiscoveryPlanSummary, DiscoveryReport, ImportSelectionMode, PlannedImportSource,
-    PrimarySourceRecommendation,
-};
 pub use merge::{
     merge_profile_entries, MergedProfilePlan, ProfileEntryLane, ProfileMergeConflict,
     ProfileMergeEntry,
+};
+pub use orchestrator::{
+    apply_import_selection, discover_import_sources, merge_profile_sources, plan_import_sources,
+    recommend_primary_source, rollback_last_import, ApplyImportSelection,
+    ApplyImportSelectionResult, DiscoveredImportSource, DiscoveryOptions, DiscoveryPlanSummary,
+    DiscoveryReport, ImportSelectionMode, PlannedImportSource, PrimarySourceRecommendation,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/app/src/migration/orchestrator.rs
+++ b/crates/app/src/migration/orchestrator.rs
@@ -1,0 +1,227 @@
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use crate::CliResult;
+
+use super::{inspect_import_path, LegacyClawSource};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveryOptions {
+    pub include_child_directories: bool,
+}
+
+impl Default for DiscoveryOptions {
+    fn default() -> Self {
+        Self {
+            include_child_directories: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredImportSource {
+    pub source: LegacyClawSource,
+    pub path: PathBuf,
+    pub confidence_score: u32,
+    pub found_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DiscoveryReport {
+    pub sources: Vec<DiscoveredImportSource>,
+}
+
+pub fn discover_import_sources(
+    search_root: &Path,
+    options: DiscoveryOptions,
+) -> CliResult<DiscoveryReport> {
+    if !search_root.exists() {
+        return Err(format!(
+            "discovery root does not exist: {}",
+            search_root.display()
+        ));
+    }
+
+    let mut sources = Vec::new();
+    for candidate in collect_candidate_directories(search_root, &options)? {
+        let Some(inspection) = inspect_import_path(&candidate, None)? else {
+            continue;
+        };
+        sources.push(DiscoveredImportSource {
+            source: inspection.source,
+            confidence_score: score_discovered_source(&inspection),
+            found_files: inspection.found_files,
+            path: candidate,
+        });
+    }
+
+    sources.sort_by(|left, right| {
+        right
+            .confidence_score
+            .cmp(&left.confidence_score)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+
+    Ok(DiscoveryReport { sources })
+}
+
+fn collect_candidate_directories(
+    search_root: &Path,
+    options: &DiscoveryOptions,
+) -> CliResult<Vec<PathBuf>> {
+    let mut seen = BTreeSet::new();
+    let mut candidates = Vec::new();
+    push_candidate(&mut candidates, &mut seen, search_root.to_path_buf());
+
+    if options.include_child_directories && search_root.is_dir() {
+        let entries = fs::read_dir(search_root).map_err(|error| {
+            format!(
+                "failed to read discovery root {}: {error}",
+                search_root.display()
+            )
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|error| {
+                format!(
+                    "failed to enumerate discovery root {}: {error}",
+                    search_root.display()
+                )
+            })?;
+            let path = entry.path();
+            if path.is_dir() {
+                push_candidate(&mut candidates, &mut seen, path);
+            }
+        }
+    }
+
+    Ok(candidates)
+}
+
+fn push_candidate(candidates: &mut Vec<PathBuf>, seen: &mut BTreeSet<String>, path: PathBuf) {
+    let canonical = path
+        .canonicalize()
+        .unwrap_or_else(|_| path.clone())
+        .display()
+        .to_string();
+    if seen.insert(canonical) {
+        candidates.push(path);
+    }
+}
+
+fn score_discovered_source(inspection: &super::ImportPathInspection) -> u32 {
+    let mut score = 0u32;
+    if inspection.source != LegacyClawSource::Unknown {
+        score = score.saturating_add(10);
+    }
+    score = score.saturating_add(inspection.custom_prompt_files as u32 * 12);
+    score = score.saturating_add(inspection.custom_profile_files as u32 * 12);
+    score = score.saturating_add(inspection.warning_count as u32 * 3);
+    score = score.saturating_add(inspection.found_files.len() as u32);
+    score
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    fn write_file(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent directory");
+        }
+        fs::write(path, content).expect("write fixture");
+    }
+
+    #[test]
+    fn discover_import_sources_returns_ranked_candidates_from_fixture_root() {
+        let root = unique_temp_dir("loongclaw-import-discovery-ranked");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- Role: Release copilot\n- Priority: stability first\n",
+        );
+
+        let nanobot_root = root.join("nanobot");
+        fs::create_dir_all(&nanobot_root).expect("create nanobot root");
+        write_file(
+            &nanobot_root,
+            "SOUL.md",
+            "# Soul\n\nAlways prefer brief shell output.\n",
+        );
+
+        let report = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        assert_eq!(report.sources.len(), 2);
+        assert_eq!(report.sources[0].source.as_id(), "openclaw");
+        assert!(
+            report.sources[0].confidence_score >= report.sources[1].confidence_score,
+            "expected descending confidence scores"
+        );
+        assert!(report.sources[0]
+            .found_files
+            .iter()
+            .any(|value| value == "SOUL.md"));
+        assert!(report.sources[0]
+            .found_files
+            .iter()
+            .any(|value| value == "IDENTITY.md"));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn discover_import_sources_ignores_empty_or_stock_only_noise_directories() {
+        let root = unique_temp_dir("loongclaw-import-discovery-noise");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let empty_root = root.join("empty");
+        fs::create_dir_all(&empty_root).expect("create empty root");
+
+        let stock_nanobot = root.join("stock-nanobot");
+        fs::create_dir_all(&stock_nanobot).expect("create stock nanobot root");
+        write_file(
+            &stock_nanobot,
+            "SOUL.md",
+            "# Soul\n\nI am nanobot 🐈, a personal AI assistant.\n",
+        );
+        write_file(
+            &stock_nanobot,
+            "memory/MEMORY.md",
+            "# Long-term Memory\n\n*This file is automatically updated by nanobot when important information should be remembered.*\n",
+        );
+
+        let report = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        assert!(
+            report.sources.is_empty(),
+            "noise-only roots should be ignored"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+}

--- a/crates/app/src/migration/orchestrator.rs
+++ b/crates/app/src/migration/orchestrator.rs
@@ -6,7 +6,10 @@ use std::{
 
 use crate::CliResult;
 
-use super::{inspect_import_path, plan_import_from_path, LegacyClawSource};
+use super::{
+    inspect_import_path, merge_profile_entries, plan_import_from_path, LegacyClawSource,
+    MergedProfilePlan, ProfileEntryLane, ProfileMergeEntry,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscoveryOptions {
@@ -140,6 +143,44 @@ pub fn recommend_primary_source(
     })
 }
 
+pub fn merge_profile_sources(report: &DiscoveryReport) -> CliResult<MergedProfilePlan> {
+    if report.sources.is_empty() {
+        return Err("cannot merge profiles from an empty discovery report".to_owned());
+    }
+
+    let mut entries = Vec::new();
+    for source in &report.sources {
+        let plan = plan_import_from_path(&source.path, Some(source.source))?;
+        let source_id = source.source.as_id().to_owned();
+
+        if let Some(prompt_addendum) = plan.system_prompt_addendum.as_deref() {
+            entries.push(ProfileMergeEntry {
+                lane: ProfileEntryLane::Prompt,
+                canonical_text: prompt_addendum.trim().to_owned(),
+                source_id: source_id.clone(),
+                source_confidence: source.confidence_score,
+                entry_confidence: 1,
+                slot_key: None,
+            });
+        }
+
+        if let Some(profile_note) = plan.profile_note.as_deref() {
+            entries.extend(parse_profile_merge_entries(
+                profile_note,
+                &source_id,
+                source.confidence_score,
+            ));
+        }
+    }
+
+    let mut merged = merge_profile_entries(&entries)?;
+    if merged.prompt_owner_source_id.is_none() {
+        let summary = plan_import_sources(report)?;
+        merged.prompt_owner_source_id = Some(recommend_primary_source(&summary)?.source_id);
+    }
+    Ok(merged)
+}
+
 fn collect_candidate_directories(
     search_root: &Path,
     options: &DiscoveryOptions,
@@ -207,6 +248,75 @@ fn primary_recommendation_score(plan: &PlannedImportSource) -> u32 {
         score = score.saturating_add(3);
     }
     score.saturating_sub(plan.warning_count as u32)
+}
+
+fn parse_profile_merge_entries(
+    profile_note: &str,
+    source_id: &str,
+    source_confidence: u32,
+) -> Vec<ProfileMergeEntry> {
+    let mut entries = Vec::new();
+    let mut block_lines = Vec::new();
+
+    let flush_block = |entries: &mut Vec<ProfileMergeEntry>, block_lines: &mut Vec<String>| {
+        let joined = block_lines
+            .iter()
+            .map(|line| line.trim())
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
+        block_lines.clear();
+        if joined.is_empty() {
+            return;
+        }
+        entries.push(ProfileMergeEntry {
+            lane: ProfileEntryLane::Profile,
+            canonical_text: joined,
+            source_id: source_id.to_owned(),
+            source_confidence,
+            entry_confidence: 1,
+            slot_key: None,
+        });
+    };
+
+    for line in profile_note.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            flush_block(&mut entries, &mut block_lines);
+            continue;
+        }
+        if trimmed.starts_with("## Imported ") || trimmed.starts_with('#') {
+            flush_block(&mut entries, &mut block_lines);
+            continue;
+        }
+        if let Some((slot_key, value)) = parse_profile_slot_line(trimmed) {
+            flush_block(&mut entries, &mut block_lines);
+            entries.push(ProfileMergeEntry {
+                lane: ProfileEntryLane::Profile,
+                canonical_text: format!("{slot_key}: {value}"),
+                source_id: source_id.to_owned(),
+                source_confidence,
+                entry_confidence: 10,
+                slot_key: Some(slot_key),
+            });
+            continue;
+        }
+        block_lines.push(trimmed.to_owned());
+    }
+    flush_block(&mut entries, &mut block_lines);
+
+    entries
+}
+
+fn parse_profile_slot_line(line: &str) -> Option<(String, String)> {
+    let trimmed = line.trim_start_matches(['-', '*', ' ']).trim();
+    let (raw_key, raw_value) = trimmed.split_once(':')?;
+    let slot_key = raw_key.trim().to_ascii_lowercase();
+    let value = raw_value.trim();
+    if slot_key.is_empty() || value.is_empty() {
+        return None;
+    }
+    Some((slot_key, value.to_owned()))
 }
 
 #[cfg(test)]

--- a/crates/app/src/migration/orchestrator.rs
+++ b/crates/app/src/migration/orchestrator.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fs,
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 use crate::CliResult;
 
 use super::{
-    apply_import_plan, inspect_import_path, merge_profile_entries, plan_import_from_path,
-    LegacyClawSource, MergedProfilePlan, ProfileEntryLane, ProfileMergeEntry,
+    LegacyClawSource, MergedProfilePlan, ProfileEntryLane, ProfileMergeEntry, apply_import_plan,
+    inspect_import_path, merge_profile_entries, plan_import_from_path,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,6 +30,7 @@ impl Default for DiscoveryOptions {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscoveredImportSource {
     pub source: LegacyClawSource,
+    pub source_id: String,
     pub path: PathBuf,
     pub confidence_score: u32,
     pub found_files: Vec<String>,
@@ -121,6 +122,7 @@ pub fn discover_import_sources(
         };
         sources.push(DiscoveredImportSource {
             source: inspection.source,
+            source_id: String::new(),
             confidence_score: score_discovered_source(&inspection),
             found_files: inspection.found_files,
             path: candidate,
@@ -133,6 +135,7 @@ pub fn discover_import_sources(
             .cmp(&left.confidence_score)
             .then_with(|| left.path.cmp(&right.path))
     });
+    assign_discovery_source_ids(&mut sources);
 
     Ok(DiscoveryReport { sources })
 }
@@ -143,7 +146,7 @@ pub fn plan_import_sources(report: &DiscoveryReport) -> CliResult<DiscoveryPlanS
         let plan = plan_import_from_path(&source.path, Some(source.source))?;
         plans.push(PlannedImportSource {
             source: source.source,
-            source_id: source.source.as_id().to_owned(),
+            source_id: source.source_id.clone(),
             input_path: source.path.clone(),
             confidence_score: source.confidence_score,
             prompt_addendum_present: plan.system_prompt_addendum.is_some(),
@@ -193,7 +196,7 @@ pub fn merge_profile_sources(report: &DiscoveryReport) -> CliResult<MergedProfil
     let mut entries = Vec::new();
     for source in &report.sources {
         let plan = plan_import_from_path(&source.path, Some(source.source))?;
-        let source_id = source.source.as_id().to_owned();
+        let source_id = source.source_id.clone();
 
         if let Some(prompt_addendum) = plan.system_prompt_addendum.as_deref() {
             entries.push(ProfileMergeEntry {
@@ -253,7 +256,6 @@ pub fn apply_import_selection(
             let primary_plan =
                 plan_import_from_path(&selected_primary.path, Some(selected_primary.source))?;
             warnings.extend(primary_plan.warnings.clone());
-            apply_import_plan(&mut config, &primary_plan);
 
             for source in &request.discovery.sources {
                 if source.path == selected_primary.path {
@@ -281,12 +283,9 @@ pub fn apply_import_selection(
                     .discovery
                     .sources
                     .iter()
-                    .map(|source| source.source.as_id().to_owned())
+                    .map(|source| source.source_id.clone())
                     .collect(),
-                merged
-                    .prompt_owner_source_id
-                    .clone()
-                    .or(Some(selected_primary_source_id.clone())),
+                None,
                 merged.unresolved_conflicts.len(),
             )
         }
@@ -439,6 +438,59 @@ fn score_discovered_source(inspection: &super::ImportPathInspection) -> u32 {
     score
 }
 
+fn assign_discovery_source_ids(sources: &mut [DiscoveredImportSource]) {
+    let mut source_type_counts = BTreeMap::<String, usize>::new();
+    for source in sources.iter() {
+        *source_type_counts
+            .entry(source.source.as_id().to_owned())
+            .or_default() += 1;
+    }
+
+    let mut token_counts = BTreeMap::<String, usize>::new();
+    for source in sources.iter_mut() {
+        let base_id = source.source.as_id().to_owned();
+        let token_base = if source_type_counts.get(&base_id).copied().unwrap_or(0) > 1 {
+            format!("{base_id}-{}", selection_slug(&source.path))
+        } else {
+            base_id
+        };
+        let count = token_counts.entry(token_base.clone()).or_default();
+        *count += 1;
+        source.source_id = if *count == 1 {
+            token_base
+        } else {
+            format!("{token_base}-{}", *count)
+        };
+    }
+}
+
+fn selection_slug(path: &Path) -> String {
+    let raw = path
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "source".to_owned());
+
+    let mut slug = String::new();
+    let mut just_pushed_dash = false;
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            just_pushed_dash = false;
+        } else if !just_pushed_dash {
+            slug.push('-');
+            just_pushed_dash = true;
+        }
+    }
+
+    let trimmed = slug.trim_matches('-');
+    if trimmed.is_empty() {
+        "source".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
 fn primary_recommendation_score(plan: &PlannedImportSource) -> u32 {
     let mut score = plan.confidence_score;
     if plan.prompt_addendum_present {
@@ -529,7 +581,7 @@ fn resolve_discovered_source<'a>(
     report
         .sources
         .iter()
-        .find(|source| source.source.as_id() == source_id)
+        .find(|source| source.source_id == source_id)
         .ok_or_else(|| format!("selected import source `{source_id}` was not discovered"))
 }
 
@@ -635,14 +687,18 @@ mod tests {
             report.sources[0].confidence_score >= report.sources[1].confidence_score,
             "expected descending confidence scores"
         );
-        assert!(report.sources[0]
-            .found_files
-            .iter()
-            .any(|value| value == "SOUL.md"));
-        assert!(report.sources[0]
-            .found_files
-            .iter()
-            .any(|value| value == "IDENTITY.md"));
+        assert!(
+            report.sources[0]
+                .found_files
+                .iter()
+                .any(|value| value == "SOUL.md")
+        );
+        assert!(
+            report.sources[0]
+                .found_files
+                .iter()
+                .any(|value| value == "IDENTITY.md")
+        );
 
         fs::remove_dir_all(&root).ok();
     }
@@ -795,6 +851,138 @@ mod tests {
         assert!(result.backup_path.exists());
         assert!(result.manifest_path.exists());
         assert_eq!(result.selected_primary_source_id, "openclaw");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn safe_profile_merge_keeps_existing_prompt_and_applies_only_profile_lane() {
+        let root = unique_temp_dir("loongclaw-import-safe-merge-profile-only");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n",
+        );
+
+        let nanobot_root = root.join("nanobot");
+        fs::create_dir_all(&nanobot_root).expect("create nanobot root");
+        write_file(
+            &nanobot_root,
+            "IDENTITY.md",
+            "# Identity\n\n- region: apac\n",
+        );
+
+        let discovery = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        let summary = plan_import_sources(&discovery).expect("summary should succeed");
+        let recommendation =
+            recommend_primary_source(&summary).expect("recommendation should succeed");
+        let output_path = root.join("loongclaw.toml");
+
+        let mut existing = crate::config::LoongClawConfig::default();
+        existing.cli.system_prompt_addendum = Some("Native LoongClaw prompt".to_owned());
+        let existing_body = crate::config::render(&existing).expect("render existing config");
+        fs::write(&output_path, existing_body).expect("write existing config");
+
+        let result = apply_import_selection(&ApplyImportSelection {
+            discovery,
+            output_path: output_path.clone(),
+            mode: ImportSelectionMode::SafeProfileMerge {
+                primary_source_id: recommendation.source_id,
+            },
+        })
+        .expect("safe profile merge should succeed");
+
+        let output_string = output_path.display().to_string();
+        let (_, merged_config) =
+            crate::config::load(Some(&output_string)).expect("load merged config");
+        assert_eq!(result.prompt_owner_source_id, None);
+        assert_eq!(
+            merged_config.cli.system_prompt_addendum.as_deref(),
+            Some("Native LoongClaw prompt")
+        );
+        assert_eq!(
+            merged_config.memory.profile,
+            crate::config::MemoryProfile::ProfilePlusWindow
+        );
+        let profile_note = merged_config
+            .memory
+            .profile_note
+            .as_deref()
+            .expect("profile note should be present");
+        assert!(profile_note.contains("role: release copilot"));
+        assert!(profile_note.contains("region: apac"));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn duplicate_source_types_get_distinct_ids_and_apply_selected_uses_requested_source() {
+        let root = unique_temp_dir("loongclaw-import-duplicate-source-kind");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let alpha_root = root.join("openclaw-alpha");
+        fs::create_dir_all(&alpha_root).expect("create alpha root");
+        write_file(&alpha_root, "SOUL.md", "# Soul\n\nAlpha prompt guidance.\n");
+        write_file(&alpha_root, "IDENTITY.md", "# Identity\n\n- region: east\n");
+
+        let beta_root = root.join("openclaw-beta");
+        fs::create_dir_all(&beta_root).expect("create beta root");
+        write_file(&beta_root, "SOUL.md", "# Soul\n\nBeta prompt guidance.\n");
+        write_file(&beta_root, "IDENTITY.md", "# Identity\n\n- region: west\n");
+
+        let discovery = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        let summary = plan_import_sources(&discovery).expect("summary should succeed");
+        assert_eq!(summary.plans.len(), 2);
+        assert_ne!(summary.plans[0].source_id, summary.plans[1].source_id);
+        assert!(summary.plans[0].source_id.starts_with("openclaw-"));
+        assert!(summary.plans[1].source_id.starts_with("openclaw-"));
+
+        let selected_source_id = summary.plans[1].source_id.clone();
+        let output_path = root.join("loongclaw.toml");
+        let original_body =
+            crate::config::render(&crate::config::LoongClawConfig::default()).expect("render");
+        fs::write(&output_path, original_body).expect("write original config");
+
+        let result = apply_import_selection(&ApplyImportSelection {
+            discovery,
+            output_path: output_path.clone(),
+            mode: ImportSelectionMode::SelectedSingleSource {
+                source_id: selected_source_id.clone(),
+            },
+        })
+        .expect("apply should succeed");
+
+        let output_string = output_path.display().to_string();
+        let (_, merged_config) =
+            crate::config::load(Some(&output_string)).expect("load merged config");
+        assert_eq!(result.selected_primary_source_id, selected_source_id);
+        assert!(
+            merged_config
+                .cli
+                .system_prompt_addendum
+                .as_deref()
+                .is_some_and(|value| value.contains("Beta prompt guidance")),
+            "expected selected source prompt to be imported"
+        );
+        assert!(
+            merged_config
+                .memory
+                .profile_note
+                .as_deref()
+                .is_some_and(|value| value.contains("region: west")),
+            "expected selected source profile note to be imported"
+        );
 
         fs::remove_dir_all(&root).ok();
     }

--- a/crates/app/src/migration/orchestrator.rs
+++ b/crates/app/src/migration/orchestrator.rs
@@ -2,13 +2,16 @@ use std::{
     collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
 };
+
+use serde::{Deserialize, Serialize};
 
 use crate::CliResult;
 
 use super::{
-    inspect_import_path, merge_profile_entries, plan_import_from_path, LegacyClawSource,
-    MergedProfilePlan, ProfileEntryLane, ProfileMergeEntry,
+    apply_import_plan, inspect_import_path, merge_profile_entries, plan_import_from_path,
+    LegacyClawSource, MergedProfilePlan, ProfileEntryLane, ProfileMergeEntry,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,6 +62,45 @@ pub struct PrimarySourceRecommendation {
     pub source_id: String,
     pub input_path: PathBuf,
     pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportSelectionMode {
+    RecommendedSingleSource { source_id: String },
+    SelectedSingleSource { source_id: String },
+    SafeProfileMerge { primary_source_id: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplyImportSelection {
+    pub discovery: DiscoveryReport,
+    pub output_path: PathBuf,
+    pub mode: ImportSelectionMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplyImportSelectionResult {
+    pub output_path: PathBuf,
+    pub backup_path: PathBuf,
+    pub manifest_path: PathBuf,
+    pub selected_primary_source_id: String,
+    pub merged_source_ids: Vec<String>,
+    pub prompt_owner_source_id: Option<String>,
+    pub unresolved_conflicts: usize,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ImportApplyManifest {
+    session_id: String,
+    selected_primary_source: String,
+    merged_sources: Vec<String>,
+    prompt_owner_source: Option<String>,
+    output_path: String,
+    backup_path: String,
+    output_preexisted: bool,
+    warnings: Vec<String>,
+    unresolved_conflicts: usize,
 }
 
 pub fn discover_import_sources(
@@ -179,6 +221,166 @@ pub fn merge_profile_sources(report: &DiscoveryReport) -> CliResult<MergedProfil
         merged.prompt_owner_source_id = Some(recommend_primary_source(&summary)?.source_id);
     }
     Ok(merged)
+}
+
+pub fn apply_import_selection(
+    request: &ApplyImportSelection,
+) -> CliResult<ApplyImportSelectionResult> {
+    let selected_primary_source_id = match &request.mode {
+        ImportSelectionMode::RecommendedSingleSource { source_id }
+        | ImportSelectionMode::SelectedSingleSource { source_id } => source_id.clone(),
+        ImportSelectionMode::SafeProfileMerge { primary_source_id } => primary_source_id.clone(),
+    };
+    let selected_primary =
+        resolve_discovered_source(&request.discovery, selected_primary_source_id.as_str())?;
+
+    let mut config = load_or_default_config(Some(&request.output_path))?;
+    let mut warnings = Vec::new();
+    let (merged_source_ids, prompt_owner_source_id, unresolved_conflicts) = match &request.mode {
+        ImportSelectionMode::RecommendedSingleSource { .. }
+        | ImportSelectionMode::SelectedSingleSource { .. } => {
+            let plan = plan_import_from_path(&selected_primary.path, Some(selected_primary.source))?;
+            warnings.extend(plan.warnings.clone());
+            apply_import_plan(&mut config, &plan);
+            (
+                vec![selected_primary_source_id.clone()],
+                Some(selected_primary_source_id.clone()),
+                0,
+            )
+        }
+        ImportSelectionMode::SafeProfileMerge { .. } => {
+            let primary_plan =
+                plan_import_from_path(&selected_primary.path, Some(selected_primary.source))?;
+            warnings.extend(primary_plan.warnings.clone());
+            apply_import_plan(&mut config, &primary_plan);
+
+            for source in &request.discovery.sources {
+                if source.path == selected_primary.path {
+                    continue;
+                }
+                let plan = plan_import_from_path(&source.path, Some(source.source))?;
+                warnings.extend(plan.warnings);
+            }
+
+            let merged = merge_profile_sources(&request.discovery)?;
+            if !merged.auto_apply_allowed {
+                return Err(format!(
+                    "cannot auto-apply safe profile merge with {} unresolved conflict(s)",
+                    merged.unresolved_conflicts.len()
+                ));
+            }
+            config.memory.profile = crate::config::MemoryProfile::ProfilePlusWindow;
+            config.memory.profile_note = if merged.merged_profile_note.trim().is_empty() {
+                None
+            } else {
+                Some(merged.merged_profile_note.clone())
+            };
+            (
+                request
+                    .discovery
+                    .sources
+                    .iter()
+                    .map(|source| source.source.as_id().to_owned())
+                    .collect(),
+                merged
+                    .prompt_owner_source_id
+                    .clone()
+                    .or(Some(selected_primary_source_id.clone())),
+                merged.unresolved_conflicts.len(),
+            )
+        }
+    };
+
+    let state_dir = migration_state_dir(&request.output_path);
+    fs::create_dir_all(&state_dir).map_err(|error| {
+        format!(
+            "failed to create migration state directory {}: {error}",
+            state_dir.display()
+        )
+    })?;
+    let session_id = import_session_id();
+    let backup_path = backup_path_for_output(&request.output_path, &state_dir, &session_id);
+    let manifest_path = manifest_path_for_output(&request.output_path, &state_dir);
+    let output_preexisted = request.output_path.exists();
+    if output_preexisted {
+        fs::copy(&request.output_path, &backup_path).map_err(|error| {
+            format!(
+                "failed to write import backup {}: {error}",
+                backup_path.display()
+            )
+        })?;
+    } else {
+        fs::write(&backup_path, "").map_err(|error| {
+            format!(
+                "failed to initialize import backup {}: {error}",
+                backup_path.display()
+            )
+        })?;
+    }
+
+    let output_string = request.output_path.display().to_string();
+    let written_output_path = crate::config::write(Some(&output_string), &config, true)?;
+
+    let manifest = ImportApplyManifest {
+        session_id,
+        selected_primary_source: selected_primary_source_id.clone(),
+        merged_sources: merged_source_ids.clone(),
+        prompt_owner_source: prompt_owner_source_id.clone(),
+        output_path: written_output_path.display().to_string(),
+        backup_path: backup_path.display().to_string(),
+        output_preexisted,
+        warnings: warnings.clone(),
+        unresolved_conflicts,
+    };
+    let manifest_body = serde_json::to_vec_pretty(&manifest)
+        .map_err(|error| format!("failed to encode import manifest: {error}"))?;
+    fs::write(&manifest_path, manifest_body).map_err(|error| {
+        format!(
+            "failed to write import manifest {}: {error}",
+            manifest_path.display()
+        )
+    })?;
+
+    Ok(ApplyImportSelectionResult {
+        output_path: written_output_path,
+        backup_path,
+        manifest_path,
+        selected_primary_source_id,
+        merged_source_ids,
+        prompt_owner_source_id,
+        unresolved_conflicts,
+        warnings,
+    })
+}
+
+pub fn rollback_last_import(output_path: &Path) -> CliResult<PathBuf> {
+    let manifest_path = manifest_path_for_output(output_path, &migration_state_dir(output_path));
+    let manifest_body = fs::read(&manifest_path).map_err(|error| {
+        format!(
+            "failed to read migration manifest {}: {error}",
+            manifest_path.display()
+        )
+    })?;
+    let manifest: ImportApplyManifest = serde_json::from_slice(&manifest_body)
+        .map_err(|error| format!("failed to parse migration manifest: {error}"))?;
+    let backup_path = PathBuf::from(&manifest.backup_path);
+    if manifest.output_preexisted {
+        fs::copy(&backup_path, output_path).map_err(|error| {
+            format!(
+                "failed to restore config {} from backup {}: {error}",
+                output_path.display(),
+                backup_path.display()
+            )
+        })?;
+    } else if output_path.exists() {
+        fs::remove_file(output_path).map_err(|error| {
+            format!(
+                "failed to remove imported config {}: {error}",
+                output_path.display()
+            )
+        })?;
+    }
+    Ok(output_path.to_path_buf())
 }
 
 fn collect_candidate_directories(
@@ -317,6 +519,60 @@ fn parse_profile_slot_line(line: &str) -> Option<(String, String)> {
         return None;
     }
     Some((slot_key, value.to_owned()))
+}
+
+fn resolve_discovered_source<'a>(
+    report: &'a DiscoveryReport,
+    source_id: &str,
+) -> CliResult<&'a DiscoveredImportSource> {
+    report
+        .sources
+        .iter()
+        .find(|source| source.source.as_id() == source_id)
+        .ok_or_else(|| format!("selected import source `{source_id}` was not discovered"))
+}
+
+fn load_or_default_config(path: Option<&Path>) -> CliResult<crate::config::LoongClawConfig> {
+    let Some(path) = path else {
+        return Ok(crate::config::LoongClawConfig::default());
+    };
+    if !path.exists() {
+        return Ok(crate::config::LoongClawConfig::default());
+    }
+    let path_string = path.display().to_string();
+    let (_, config) = crate::config::load(Some(&path_string))?;
+    Ok(config)
+}
+
+fn migration_state_dir(output_path: &Path) -> PathBuf {
+    output_path
+        .parent()
+        .unwrap_or(Path::new("."))
+        .join(".loongclaw-migration")
+}
+
+fn manifest_path_for_output(output_path: &Path, state_dir: &Path) -> PathBuf {
+    let file_tag = output_path
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|| "loongclaw-config".to_owned());
+    state_dir.join(format!("{file_tag}.last-import.json"))
+}
+
+fn backup_path_for_output(output_path: &Path, state_dir: &Path, session_id: &str) -> PathBuf {
+    let file_tag = output_path
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|| "loongclaw-config".to_owned());
+    state_dir.join(format!("{file_tag}.{session_id}.bak"))
+}
+
+fn import_session_id() -> String {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    format!("import-{millis}")
 }
 
 #[cfg(test)]
@@ -496,6 +752,90 @@ mod tests {
         assert!(
             !recommendation.reasons.is_empty(),
             "recommendation reasons should be populated"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn apply_import_selection_writes_backup_and_manifest() {
+        let root = unique_temp_dir("loongclaw-import-apply-selection");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n- tone: steady\n",
+        );
+
+        let discovery = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        let output_path = root.join("loongclaw.toml");
+        let original_body =
+            crate::config::render(&crate::config::LoongClawConfig::default()).expect("render");
+        fs::write(&output_path, &original_body).expect("write original config");
+
+        let result = apply_import_selection(&ApplyImportSelection {
+            discovery: discovery.clone(),
+            output_path: output_path.clone(),
+            mode: ImportSelectionMode::RecommendedSingleSource {
+                source_id: "openclaw".to_owned(),
+            },
+        })
+        .expect("apply should succeed");
+
+        assert!(result.backup_path.exists());
+        assert!(result.manifest_path.exists());
+        assert_eq!(result.selected_primary_source_id, "openclaw");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn rollback_last_import_restores_previous_config() {
+        let root = unique_temp_dir("loongclaw-import-rollback");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n- tone: steady\n",
+        );
+
+        let discovery = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        let output_path = root.join("loongclaw.toml");
+        let original_body =
+            crate::config::render(&crate::config::LoongClawConfig::default()).expect("render");
+        fs::write(&output_path, &original_body).expect("write original config");
+
+        apply_import_selection(&ApplyImportSelection {
+            discovery,
+            output_path: output_path.clone(),
+            mode: ImportSelectionMode::RecommendedSingleSource {
+                source_id: "openclaw".to_owned(),
+            },
+        })
+        .expect("apply should succeed");
+
+        rollback_last_import(&output_path).expect("rollback should succeed");
+        assert_eq!(
+            fs::read_to_string(&output_path).expect("read restored config"),
+            original_body
         );
 
         fs::remove_dir_all(&root).ok();

--- a/crates/app/src/migration/orchestrator.rs
+++ b/crates/app/src/migration/orchestrator.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::CliResult;
 
-use super::{inspect_import_path, LegacyClawSource};
+use super::{inspect_import_path, plan_import_from_path, LegacyClawSource};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscoveryOptions {
@@ -32,6 +32,30 @@ pub struct DiscoveredImportSource {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DiscoveryReport {
     pub sources: Vec<DiscoveredImportSource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedImportSource {
+    pub source: LegacyClawSource,
+    pub source_id: String,
+    pub input_path: PathBuf,
+    pub confidence_score: u32,
+    pub prompt_addendum_present: bool,
+    pub profile_note_present: bool,
+    pub warning_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DiscoveryPlanSummary {
+    pub plans: Vec<PlannedImportSource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrimarySourceRecommendation {
+    pub source: LegacyClawSource,
+    pub source_id: String,
+    pub input_path: PathBuf,
+    pub reasons: Vec<String>,
 }
 
 pub fn discover_import_sources(
@@ -66,6 +90,54 @@ pub fn discover_import_sources(
     });
 
     Ok(DiscoveryReport { sources })
+}
+
+pub fn plan_import_sources(report: &DiscoveryReport) -> CliResult<DiscoveryPlanSummary> {
+    let mut plans = Vec::new();
+    for source in &report.sources {
+        let plan = plan_import_from_path(&source.path, Some(source.source))?;
+        plans.push(PlannedImportSource {
+            source: source.source,
+            source_id: source.source.as_id().to_owned(),
+            input_path: source.path.clone(),
+            confidence_score: source.confidence_score,
+            prompt_addendum_present: plan.system_prompt_addendum.is_some(),
+            profile_note_present: plan.profile_note.is_some(),
+            warning_count: plan.warnings.len(),
+        });
+    }
+    Ok(DiscoveryPlanSummary { plans })
+}
+
+pub fn recommend_primary_source(
+    summary: &DiscoveryPlanSummary,
+) -> CliResult<PrimarySourceRecommendation> {
+    let Some(best) = summary.plans.iter().max_by(|left, right| {
+        primary_recommendation_score(left)
+            .cmp(&primary_recommendation_score(right))
+            .then_with(|| left.input_path.cmp(&right.input_path))
+    }) else {
+        return Err("cannot recommend primary source from an empty plan summary".to_owned());
+    };
+
+    let mut reasons = Vec::new();
+    reasons.push(format!("confidence score {}", best.confidence_score));
+    if best.prompt_addendum_present {
+        reasons.push("contains imported prompt overlay".to_owned());
+    }
+    if best.profile_note_present {
+        reasons.push("contains imported profile overlay".to_owned());
+    }
+    if best.warning_count == 0 {
+        reasons.push("has no import warnings".to_owned());
+    }
+
+    Ok(PrimarySourceRecommendation {
+        source: best.source,
+        source_id: best.source_id.clone(),
+        input_path: best.input_path.clone(),
+        reasons,
+    })
 }
 
 fn collect_candidate_directories(
@@ -121,6 +193,20 @@ fn score_discovered_source(inspection: &super::ImportPathInspection) -> u32 {
     score = score.saturating_add(inspection.warning_count as u32 * 3);
     score = score.saturating_add(inspection.found_files.len() as u32);
     score
+}
+
+fn primary_recommendation_score(plan: &PlannedImportSource) -> u32 {
+    let mut score = plan.confidence_score;
+    if plan.prompt_addendum_present {
+        score = score.saturating_add(10);
+    }
+    if plan.profile_note_present {
+        score = score.saturating_add(10);
+    }
+    if plan.warning_count == 0 {
+        score = score.saturating_add(3);
+    }
+    score.saturating_sub(plan.warning_count as u32)
 }
 
 #[cfg(test)]
@@ -220,6 +306,86 @@ mod tests {
         assert!(
             report.sources.is_empty(),
             "noise-only roots should be ignored"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn plan_import_sources_returns_summary_for_each_candidate() {
+        let root = unique_temp_dir("loongclaw-import-plan-many");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- Role: Release copilot\n- Priority: stability first\n",
+        );
+
+        let nanobot_root = root.join("nanobot");
+        fs::create_dir_all(&nanobot_root).expect("create nanobot root");
+        write_file(
+            &nanobot_root,
+            "IDENTITY.md",
+            "# Identity\n\n- Motto: your nanobot agent for deploys\n",
+        );
+
+        let discovery = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        let summary = plan_import_sources(&discovery).expect("plan-many should succeed");
+
+        assert_eq!(summary.plans.len(), 2);
+        assert_eq!(summary.plans[0].source_id, "openclaw");
+        assert!(summary.plans[0].prompt_addendum_present);
+        assert!(summary.plans[0].profile_note_present);
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn recommend_primary_source_prefers_richer_custom_source() {
+        let root = unique_temp_dir("loongclaw-import-recommend-primary");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- Role: Release copilot\n- Priority: stability first\n",
+        );
+
+        let nanobot_root = root.join("nanobot");
+        fs::create_dir_all(&nanobot_root).expect("create nanobot root");
+        write_file(
+            &nanobot_root,
+            "SOUL.md",
+            "# Soul\n\nAlways prefer brief shell output.\n",
+        );
+
+        let discovery = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        let summary = plan_import_sources(&discovery).expect("plan-many should succeed");
+        let recommendation =
+            recommend_primary_source(&summary).expect("primary recommendation should succeed");
+
+        assert_eq!(recommendation.source_id, "openclaw");
+        assert_eq!(recommendation.source, LegacyClawSource::OpenClaw);
+        assert!(
+            !recommendation.reasons.is_empty(),
+            "recommendation reasons should be populated"
         );
 
         fs::remove_dir_all(&root).ok();

--- a/crates/app/src/migration/orchestrator.rs
+++ b/crates/app/src/migration/orchestrator.rs
@@ -239,7 +239,8 @@ pub fn apply_import_selection(
     let (merged_source_ids, prompt_owner_source_id, unresolved_conflicts) = match &request.mode {
         ImportSelectionMode::RecommendedSingleSource { .. }
         | ImportSelectionMode::SelectedSingleSource { .. } => {
-            let plan = plan_import_from_path(&selected_primary.path, Some(selected_primary.source))?;
+            let plan =
+                plan_import_from_path(&selected_primary.path, Some(selected_primary.source))?;
             warnings.extend(plan.warnings.clone());
             apply_import_plan(&mut config, &plan);
             (

--- a/crates/app/src/process_env.rs
+++ b/crates/app/src/process_env.rs
@@ -5,6 +5,8 @@ use std::ffi::OsStr;
 /// mutation can race with readers in other threads.
 #[inline]
 pub(crate) fn set_var(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+    // SAFETY: LoongClaw only mutates process env during single-threaded startup
+    // or in tests that serialize env access behind a global mutex.
     #[allow(unsafe_code)]
     unsafe {
         std::env::set_var(key, value);
@@ -15,6 +17,8 @@ pub(crate) fn set_var(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
 /// constraints as [`set_var`].
 #[inline]
 pub(crate) fn remove_var(key: impl AsRef<OsStr>) {
+    // SAFETY: See `set_var`; removals happen under the same startup/test-only
+    // serialization constraints.
     #[allow(unsafe_code)]
     unsafe {
         std::env::remove_var(key);

--- a/crates/app/src/process_env.rs
+++ b/crates/app/src/process_env.rs
@@ -1,0 +1,22 @@
+use std::ffi::OsStr;
+
+/// Mutate process environment only during startup or under a serialized
+/// test lock. Rust 2024 marks these APIs as unsafe because concurrent
+/// mutation can race with readers in other threads.
+#[inline]
+pub(crate) fn set_var(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+    #[allow(unsafe_code)]
+    unsafe {
+        std::env::set_var(key, value);
+    }
+}
+
+/// Remove process environment variables under the same startup/test-only
+/// constraints as [`set_var`].
+#[inline]
+pub(crate) fn remove_var(key: impl AsRef<OsStr>) {
+    #[allow(unsafe_code)]
+    unsafe {
+        std::env::remove_var(key);
+    }
+}

--- a/crates/app/src/prompt/mod.rs
+++ b/crates/app/src/prompt/mod.rs
@@ -1,0 +1,139 @@
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_PROMPT_PACK_ID: &str = "loongclaw-core-v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptPersonality {
+    #[default]
+    CalmEngineering,
+    FriendlyCollab,
+    AutonomousExecutor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptRenderInput {
+    pub personality: PromptPersonality,
+    pub addendum: Option<String>,
+}
+
+pub fn render_system_prompt(input: PromptRenderInput) -> String {
+    let mut sections = vec![
+        base_prompt().to_owned(),
+        personality_overlay(input.personality).to_owned(),
+    ];
+    if let Some(addendum) = input
+        .addendum
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+    {
+        sections.push(format!("## User Addendum\n{addendum}"));
+    }
+    sections.join("\n\n")
+}
+
+pub fn render_default_system_prompt() -> String {
+    render_system_prompt(PromptRenderInput {
+        personality: PromptPersonality::default(),
+        addendum: None,
+    })
+}
+
+fn base_prompt() -> &'static str {
+    r#"You are LoongClaw 🐉, an AI agent built by LoongClaw AI.
+
+## Core Identity
+- You are security-first, speed-focused, performance-aware, and memory-efficient.
+- You aim to be stable, reliable, flexible, and capable of high-autonomy execution without becoming reckless.
+- You solve real tasks with minimal waste in time, memory, and operational complexity.
+
+## Operating Priorities
+1. Protect the user, their data, and their environment.
+2. Complete useful work quickly.
+3. Prefer efficient, memory-conscious, and reliable solutions.
+4. Stay flexible when the safe path is clear.
+5. Keep responses direct, practical, and actionable.
+
+## Safety Invariants
+- Safety has higher priority than speed, autonomy, or convenience.
+- Do not expose, guess, mishandle, or casually move secrets, tokens, credentials, or private data.
+- Treat destructive, irreversible, privileged, or externally impactful actions as high-risk. Confirm first unless the user has already made the exact action explicit and the action is clearly low-risk and reversible.
+- If a request is ambiguous and could cause harm, stop and ask a focused clarifying question.
+- Do not claim success without verifying results.
+- Use only the tools, permissions, and data actually available in the runtime.
+
+## Execution Style
+- Prefer the simplest safe plan that finishes the task.
+- Avoid unnecessary steps, repeated tool calls, and bloated context.
+- Prefer solutions that are fast, efficient, and robust rather than flashy or fragile.
+- Preserve stability: avoid hacks that create hidden risk unless the user explicitly asks for a quick temporary workaround and the risks are clearly stated.
+- Flexibility is a strength, but it must not weaken policy, reliability, or user intent.
+
+## Communication
+- Be concise, direct, and useful.
+- Match the user's language when practical unless they ask otherwise.
+- Match the user's technical depth; explain more when the decision or result is non-obvious.
+- Avoid filler, hype, and performative reassurance.
+- When action is clear and safe, act. When risk or ambiguity is material, ask.
+
+## Personality Layer
+Apply the active personality overlay below. The overlay may change tone, initiative, confirmation style, and response density, but it must not weaken any safety invariant above."#
+}
+
+fn personality_overlay(personality: PromptPersonality) -> &'static str {
+    match personality {
+        PromptPersonality::CalmEngineering => {
+            r#"## Personality Overlay: Calm Engineering
+- Sound composed, technically rigorous, and low-drama.
+- Prioritize precision, tradeoff clarity, and defensible reasoning.
+- Keep wording lean; do not over-explain unless it adds real value.
+- Initiative: medium. Move forward on clear tasks. Pause on ambiguous or risky edges.
+- Confirmation threshold: medium. Confirm destructive, preference-sensitive, or unclear actions.
+- Tool-use bias: measured and deliberate."#
+        }
+        PromptPersonality::FriendlyCollab => {
+            r#"## Personality Overlay: Friendly Collaboration
+- Sound approachable, cooperative, and human, while staying efficient and professional.
+- Explain intent a little more often than the engineering profile.
+- Offer options or helpful framing when it reduces user effort.
+- Initiative: medium. Be helpful without becoming pushy.
+- Confirmation threshold: medium-high for externally visible, preference-sensitive, or user-facing changes.
+- Tool-use bias: measured, with slightly more explanation before multi-step actions."#
+        }
+        PromptPersonality::AutonomousExecutor => {
+            r#"## Personality Overlay: Autonomous Executor
+- Sound decisive, efficient, and execution-oriented.
+- Default to action on clear requests; do not wait for unnecessary confirmation.
+- Keep progress updates short and outcome-focused.
+- Initiative: high. Break work down and drive it forward when the path is clear.
+- Confirmation threshold: low for safe and reversible actions, high for destructive, privileged, or externally impactful actions.
+- Tool-use bias: proactive, but never reckless."#
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_prompt_uses_loongclaw_base_and_selected_personality() {
+        let rendered = render_system_prompt(PromptRenderInput {
+            personality: PromptPersonality::CalmEngineering,
+            addendum: None,
+        });
+        assert!(rendered.contains("You are LoongClaw"));
+        assert!(rendered.contains("## Safety Invariants"));
+        assert!(rendered.contains("## Personality Overlay: Calm Engineering"));
+    }
+
+    #[test]
+    fn render_prompt_adds_optional_addendum_at_the_end() {
+        let rendered = render_system_prompt(PromptRenderInput {
+            personality: PromptPersonality::FriendlyCollab,
+            addendum: Some("Always prefer concise summaries.".to_owned()),
+        });
+        assert!(rendered.contains("Always prefer concise summaries."));
+        assert!(rendered.contains("## User Addendum"));
+    }
+}

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -5,7 +5,8 @@ use tokio::time::sleep;
 
 use crate::CliResult;
 
-use super::config::{LoongClawConfig, ProviderConfig, ProviderKind, ReasoningEffort};
+use super::config::LoongClawConfig;
+#[cfg(feature = "memory-sqlite")]
 use super::memory;
 
 mod error_policy;
@@ -58,6 +59,7 @@ pub(crate) fn build_base_messages(
         .collect()
 }
 
+#[cfg(feature = "memory-sqlite")]
 pub(crate) fn push_history_message(messages: &mut Vec<Value>, role: &str, content: &str) {
     if !is_supported_chat_role(role) {
         return;
@@ -71,10 +73,12 @@ pub(crate) fn push_history_message(messages: &mut Vec<Value>, role: &str, conten
     }));
 }
 
+#[cfg(feature = "memory-sqlite")]
 fn is_supported_chat_role(role: &str) -> bool {
     matches!(role, "system" | "user" | "assistant" | "tool")
 }
 
+#[cfg(feature = "memory-sqlite")]
 fn should_skip_history_turn(role: &str, content: &str) -> bool {
     if role != "assistant" {
         return false;
@@ -113,7 +117,11 @@ pub fn load_memory_window_messages(
                     }));
                 }
                 memory::MemoryContextKind::Turn => {
-                    push_history_message(&mut messages, entry.role.as_str(), entry.content.as_str());
+                    push_history_message(
+                        &mut messages,
+                        entry.role.as_str(),
+                        entry.content.as_str(),
+                    );
                 }
             }
         }
@@ -556,10 +564,8 @@ mod tests {
             .join(format!("{session_id}.sqlite3"))
             .display()
             .to_string();
-        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(config.memory.resolved_sqlite_path()),
-            sliding_window: Some(config.memory.sliding_window),
-        };
+        let memory_config =
+            crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
         crate::memory::append_turn_direct(&session_id, "user", "hello", &memory_config)
             .expect("persist user turn");
         crate::memory::append_turn_direct(
@@ -638,10 +644,8 @@ mod tests {
             .join(format!("{session_id}.sqlite3"))
             .display()
             .to_string();
-        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(config.memory.resolved_sqlite_path()),
-            sliding_window: Some(config.memory.sliding_window),
-        };
+        let memory_config =
+            crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
         crate::memory::append_turn_direct(&session_id, "user", "hello", &memory_config)
             .expect("persist user turn");
         crate::memory::append_turn_direct(

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -5,8 +5,7 @@ use tokio::time::sleep;
 
 use crate::CliResult;
 
-use super::config::LoongClawConfig;
-#[cfg(feature = "memory-sqlite")]
+use super::config::{LoongClawConfig, ProviderConfig, ProviderKind, ReasoningEffort};
 use super::memory;
 
 mod error_policy;
@@ -36,7 +35,8 @@ pub fn build_system_message(
     if !include_system_prompt {
         return None;
     }
-    let system = config.cli.system_prompt.trim();
+    let system_prompt = config.cli.resolved_system_prompt();
+    let system = system_prompt.trim();
     let snapshot = super::tools::capability_snapshot();
     let content = if system.is_empty() {
         snapshot
@@ -99,15 +99,23 @@ pub fn load_memory_window_messages(
 ) -> CliResult<Vec<Value>> {
     #[cfg(feature = "memory-sqlite")]
     {
-        let mem_config = super::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(config.memory.resolved_sqlite_path()),
-            sliding_window: Some(config.memory.sliding_window),
-        };
-        let turns = memory::window_direct(session_id, config.memory.sliding_window, &mem_config)
-            .map_err(|error| format!("load memory window failed: {error}"))?;
-        let mut messages = Vec::with_capacity(turns.len());
-        for turn in turns {
-            push_history_message(&mut messages, turn.role.as_str(), turn.content.as_str());
+        let mem_config =
+            super::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let memory_entries = memory::load_prompt_context(session_id, &mem_config)
+            .map_err(|error| format!("load prompt memory context failed: {error}"))?;
+        let mut messages = Vec::with_capacity(memory_entries.len());
+        for entry in memory_entries {
+            match entry.kind {
+                memory::MemoryContextKind::Profile | memory::MemoryContextKind::Summary => {
+                    messages.push(json!({
+                        "role": entry.role,
+                        "content": entry.content,
+                    }));
+                }
+                memory::MemoryContextKind::Turn => {
+                    push_history_message(&mut messages, entry.role.as_str(), entry.content.as_str());
+                }
+            }
         }
         Ok(messages)
     }
@@ -681,6 +689,101 @@ mod tests {
     }
 
     #[test]
+    fn message_builder_uses_rendered_prompt_from_pack_metadata() {
+        let mut config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        config.cli.personality = Some(crate::prompt::PromptPersonality::FriendlyCollab);
+        config.cli.system_prompt = String::new();
+
+        let messages =
+            build_messages_for_session(&config, "noop-session", true).expect("build messages");
+        let system_content = messages[0]["content"].as_str().expect("system content");
+
+        assert!(system_content.contains("## Personality Overlay: Friendly Collaboration"));
+        assert!(system_content.contains("[available_tools]"));
+    }
+
+    #[test]
+    fn message_builder_keeps_legacy_inline_prompt_when_pack_is_disabled() {
+        let mut config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        config.cli.prompt_pack_id = None;
+        config.cli.personality = None;
+        config.cli.system_prompt = "You are a legacy inline prompt.".to_owned();
+
+        let messages =
+            build_messages_for_session(&config, "noop-session", true).expect("build messages");
+        let system_content = messages[0]["content"].as_str().expect("system content");
+
+        assert!(system_content.contains("You are a legacy inline prompt."));
+        assert!(!system_content.contains("## Personality Overlay: Calm Engineering"));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn message_builder_includes_summary_block_for_window_plus_summary_profile() {
+        let tmp =
+            std::env::temp_dir().join(format!("loongclaw-provider-summary-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("provider-summary.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let mut config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        config.memory.sqlite_path = db_path.display().to_string();
+        config.memory.profile = crate::config::MemoryProfile::WindowPlusSummary;
+        config.memory.sliding_window = 2;
+
+        let memory_config =
+            crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        crate::memory::append_turn_direct("summary-session", "user", "turn 1", &memory_config)
+            .expect("append turn 1 should succeed");
+        crate::memory::append_turn_direct("summary-session", "assistant", "turn 2", &memory_config)
+            .expect("append turn 2 should succeed");
+        crate::memory::append_turn_direct("summary-session", "user", "turn 3", &memory_config)
+            .expect("append turn 3 should succeed");
+        crate::memory::append_turn_direct("summary-session", "assistant", "turn 4", &memory_config)
+            .expect("append turn 4 should succeed");
+
+        let messages =
+            build_messages_for_session(&config, "summary-session", true).expect("build messages");
+
+        assert!(
+            messages.iter().any(|message| {
+                message["role"] == "system"
+                    && message["content"]
+                        .as_str()
+                        .is_some_and(|content| content.contains("## Memory Summary"))
+            }),
+            "expected a system summary block in provider messages"
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[test]
     fn completion_body_includes_reasoning_effort_when_configured() {
         let mut config = LoongClawConfig {
             provider: ProviderConfig::default(),
@@ -834,6 +937,7 @@ mod tests {
             .collect();
 
         let mut expected = Vec::new();
+        expected.push("claw_import");
         #[cfg(feature = "tool-file")]
         {
             expected.push("file_read");

--- a/crates/app/src/tools/claw_import.rs
+++ b/crates/app/src/tools/claw_import.rs
@@ -29,9 +29,12 @@ pub(super) fn execute_claw_import_tool_with_config(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(DEFAULT_MODE);
-    if !matches!(mode, "plan" | "apply") {
+    if !matches!(
+        mode,
+        "plan" | "apply" | "discover" | "plan_many" | "recommend_primary"
+    ) {
         return Err(format!(
-            "claw.import payload.mode must be `plan` or `apply`, got `{mode}`"
+            "claw.import payload.mode must be `plan`, `apply`, `discover`, `plan_many`, or `recommend_primary`, got `{mode}`"
         ));
     }
 
@@ -65,6 +68,48 @@ pub(super) fn execute_claw_import_tool_with_config(
         .map(parse_source_hint)
         .transpose()?
         .flatten();
+
+    if mode == "discover" {
+        let report = migration::discover_import_sources(
+            &input_path,
+            migration::DiscoveryOptions::default(),
+        )?;
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "core-tools",
+                "tool_name": request.tool_name,
+                "mode": "discover",
+                "input_path": input_path.display().to_string(),
+                "sources": report
+                    .sources
+                    .iter()
+                    .map(discovered_source_payload)
+                    .collect::<Vec<_>>(),
+            }),
+        });
+    }
+
+    if matches!(mode, "plan_many" | "recommend_primary") {
+        let report = migration::discover_import_sources(
+            &input_path,
+            migration::DiscoveryOptions::default(),
+        )?;
+        let summary = migration::plan_import_sources(&report)?;
+        let recommendation = migration::recommend_primary_source(&summary).ok();
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "core-tools",
+                "tool_name": request.tool_name,
+                "mode": mode,
+                "input_path": input_path.display().to_string(),
+                "plans": summary.plans.iter().map(planned_source_payload).collect::<Vec<_>>(),
+                "recommendation": recommendation.as_ref().map(primary_recommendation_payload),
+            }),
+        });
+    }
+
     let plan = migration::plan_import_from_path(&input_path, hint)?;
 
     let mut merged_config = load_or_default_config(output_path.as_deref())?;
@@ -102,6 +147,36 @@ pub(super) fn execute_claw_import_tool_with_config(
                 .as_ref()
                 .map(|path| format!("loongclawd chat --config {}", path.display())),
         }),
+    })
+}
+
+fn discovered_source_payload(source: &migration::DiscoveredImportSource) -> Value {
+    json!({
+        "source_id": source.source.as_id(),
+        "input_path": source.path.display().to_string(),
+        "confidence_score": source.confidence_score,
+        "found_files": source.found_files,
+    })
+}
+
+fn planned_source_payload(plan: &migration::PlannedImportSource) -> Value {
+    json!({
+        "source_id": plan.source_id,
+        "input_path": plan.input_path.display().to_string(),
+        "confidence_score": plan.confidence_score,
+        "prompt_addendum_present": plan.prompt_addendum_present,
+        "profile_note_present": plan.profile_note_present,
+        "warning_count": plan.warning_count,
+    })
+}
+
+fn primary_recommendation_payload(
+    recommendation: &migration::PrimarySourceRecommendation,
+) -> Value {
+    json!({
+        "source_id": recommendation.source_id,
+        "input_path": recommendation.input_path.display().to_string(),
+        "reasons": recommendation.reasons,
     })
 }
 

--- a/crates/app/src/tools/claw_import.rs
+++ b/crates/app/src/tools/claw_import.rs
@@ -1,0 +1,305 @@
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+use serde_json::{json, Value};
+
+use crate::{
+    config::{self, LoongClawConfig, MemoryProfile},
+    migration::{self, LegacyClawSource},
+};
+
+const DEFAULT_MODE: &str = "plan";
+const SUPPORTED_SOURCES: &str = "auto, nanobot, openclaw, picoclaw, zeroclaw, nanoclaw";
+
+pub(super) fn execute_claw_import_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "claw.import payload must be an object".to_owned())?;
+    let mode = payload
+        .get("mode")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_MODE);
+    if !matches!(mode, "plan" | "apply") {
+        return Err(format!(
+            "claw.import payload.mode must be `plan` or `apply`, got `{mode}`"
+        ));
+    }
+
+    let input_path = payload
+        .get("input_path")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "claw.import requires payload.input_path".to_owned())?;
+    let input_path = resolve_safe_path_with_config(input_path, config)?;
+
+    let output_path = payload
+        .get("output_path")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| resolve_safe_path_with_config(value, config))
+        .transpose()?;
+
+    if mode == "apply" && output_path.is_none() {
+        return Err("claw.import apply mode requires payload.output_path".to_owned());
+    }
+
+    let force = payload
+        .get("force")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let hint = payload
+        .get("source")
+        .and_then(Value::as_str)
+        .map(parse_source_hint)
+        .transpose()?
+        .flatten();
+    let plan = migration::plan_import_from_path(&input_path, hint)?;
+
+    let mut merged_config = load_or_default_config(output_path.as_deref())?;
+    migration::apply_import_plan(&mut merged_config, &plan);
+    let config_toml = config::render(&merged_config)?;
+
+    let written_output_path = if mode == "apply" {
+        let output_path = output_path
+            .clone()
+            .expect("output path already required in apply mode");
+        let output_string = output_path.display().to_string();
+        Some(config::write(Some(&output_string), &merged_config, force)?)
+    } else {
+        None
+    };
+    let response_output_path = written_output_path
+        .as_ref()
+        .or(output_path.as_ref())
+        .map(|path| path.display().to_string());
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": request.tool_name,
+            "mode": mode,
+            "source": plan.source.as_id(),
+            "input_path": input_path.display().to_string(),
+            "output_path": response_output_path,
+            "config_written": mode == "apply",
+            "warnings": plan.warnings,
+            "config_preview": config_preview_payload(&merged_config),
+            "config_toml": config_toml,
+            "next_step": written_output_path
+                .as_ref()
+                .map(|path| format!("loongclawd chat --config {}", path.display())),
+        }),
+    })
+}
+
+fn parse_source_hint(raw: &str) -> Result<Option<LegacyClawSource>, String> {
+    let parsed = LegacyClawSource::from_id(raw).ok_or_else(|| {
+        format!("unsupported claw.import payload.source `{raw}`. supported: {SUPPORTED_SOURCES}")
+    })?;
+    if matches!(parsed, LegacyClawSource::Unknown) {
+        Ok(None)
+    } else {
+        Ok(Some(parsed))
+    }
+}
+
+fn load_or_default_config(path: Option<&Path>) -> Result<LoongClawConfig, String> {
+    let Some(path) = path else {
+        return Ok(LoongClawConfig::default());
+    };
+    if !path.exists() {
+        return Ok(LoongClawConfig::default());
+    }
+    let path_string = path.display().to_string();
+    let (_, config) = config::load(Some(&path_string))?;
+    Ok(config)
+}
+
+fn config_preview_payload(config: &LoongClawConfig) -> Value {
+    json!({
+        "prompt_pack_id": config
+            .cli
+            .prompt_pack_id()
+            .unwrap_or(crate::prompt::DEFAULT_PROMPT_PACK_ID),
+        "memory_profile": memory_profile_id(config.memory.profile),
+        "system_prompt_addendum": config.cli.system_prompt_addendum.clone(),
+        "profile_note": config.memory.profile_note.clone(),
+    })
+}
+
+fn memory_profile_id(profile: MemoryProfile) -> &'static str {
+    match profile {
+        MemoryProfile::WindowOnly => "window_only",
+        MemoryProfile::WindowPlusSummary => "window_plus_summary",
+        MemoryProfile::ProfilePlusWindow => "profile_plus_window",
+    }
+}
+
+fn resolve_safe_path_with_config(
+    raw: &str,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<PathBuf, String> {
+    if config.file_root.is_none() {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let candidate = Path::new(raw);
+        let combined = if candidate.is_absolute() {
+            candidate.to_path_buf()
+        } else {
+            cwd.join(candidate)
+        };
+        return canonicalize_or_fallback(combined);
+    }
+
+    let root = config
+        .file_root
+        .clone()
+        .expect("file_root already checked above");
+    let root = canonicalize_or_fallback(root)?;
+
+    let candidate = Path::new(raw);
+    let combined = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        root.join(candidate)
+    };
+    let normalized = normalize_without_fs_access(&combined);
+    resolve_path_within_root(&root, &normalized)
+}
+
+fn canonicalize_or_fallback(path: PathBuf) -> Result<PathBuf, String> {
+    if path.exists() {
+        return fs::canonicalize(&path)
+            .map_err(|error| format!("failed to canonicalize {}: {error}", path.display()));
+    }
+    Ok(normalize_without_fs_access(&path))
+}
+
+fn resolve_path_within_root(root: &Path, normalized: &Path) -> Result<PathBuf, String> {
+    ensure_path_within_root(root, normalized)?;
+
+    if normalized.exists() {
+        let canonical = fs::canonicalize(normalized).map_err(|error| {
+            format!(
+                "failed to canonicalize target path {}: {error}",
+                normalized.display()
+            )
+        })?;
+        ensure_path_within_root(root, &canonical)?;
+        return Ok(canonical);
+    }
+
+    let (ancestor, suffix) = split_existing_ancestor(normalized)?;
+    let canonical_ancestor = fs::canonicalize(&ancestor).map_err(|error| {
+        format!(
+            "failed to canonicalize ancestor {}: {error}",
+            ancestor.display()
+        )
+    })?;
+    ensure_path_within_root(root, &canonical_ancestor)?;
+
+    let mut reconstructed = canonical_ancestor;
+    for component in suffix {
+        reconstructed.push(component);
+    }
+    ensure_path_within_root(root, &reconstructed)?;
+    Ok(reconstructed)
+}
+
+fn ensure_path_within_root(root: &Path, path: &Path) -> Result<(), String> {
+    if path.starts_with(root) {
+        return Ok(());
+    }
+    Err(format!(
+        "migration path {} escapes configured file root {}",
+        path.display(),
+        root.display()
+    ))
+}
+
+fn split_existing_ancestor(path: &Path) -> Result<(PathBuf, Vec<OsString>), String> {
+    let mut cursor = path.to_path_buf();
+    let mut suffix = Vec::new();
+
+    loop {
+        if cursor.exists() {
+            suffix.reverse();
+            return Ok((cursor, suffix));
+        }
+
+        let Some(name) = cursor.file_name().map(|value| value.to_owned()) else {
+            return Err(format!(
+                "cannot resolve existing ancestor for {}",
+                path.display()
+            ));
+        };
+        suffix.push(name);
+        let Some(parent) = cursor.parent() else {
+            return Err(format!(
+                "cannot resolve existing ancestor for {}",
+                path.display()
+            ));
+        };
+        cursor = parent.to_path_buf();
+    }
+}
+
+fn normalize_without_fs_access(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut parts: Vec<OsString> = Vec::new();
+    let mut prefix: Option<OsString> = None;
+    let mut has_root = false;
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(value) => prefix = Some(value.as_os_str().to_owned()),
+            Component::RootDir => has_root = true,
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if let Some(last) = parts.last() {
+                    if last != ".." {
+                        let _ = parts.pop();
+                    } else if !has_root {
+                        parts.push(OsString::from(".."));
+                    }
+                } else if !has_root {
+                    parts.push(OsString::from(".."));
+                }
+            }
+            Component::Normal(value) => parts.push(value.to_owned()),
+        }
+    }
+
+    let mut normalized = PathBuf::new();
+    if let Some(prefix) = prefix {
+        normalized.push(prefix);
+    }
+    if has_root {
+        normalized.push(Path::new(std::path::MAIN_SEPARATOR_STR));
+    }
+    for part in parts {
+        normalized.push(part);
+    }
+    if normalized.as_os_str().is_empty() {
+        if has_root {
+            PathBuf::from(std::path::MAIN_SEPARATOR_STR)
+        } else {
+            PathBuf::from(".")
+        }
+    } else {
+        normalized
+    }
+}

--- a/crates/app/src/tools/claw_import.rs
+++ b/crates/app/src/tools/claw_import.rs
@@ -31,10 +31,15 @@ pub(super) fn execute_claw_import_tool_with_config(
         .unwrap_or(DEFAULT_MODE);
     if !matches!(
         mode,
-        "plan" | "apply" | "discover" | "plan_many" | "recommend_primary"
+        "plan"
+            | "apply"
+            | "discover"
+            | "plan_many"
+            | "recommend_primary"
+            | "merge_profiles"
     ) {
         return Err(format!(
-            "claw.import payload.mode must be `plan`, `apply`, `discover`, `plan_many`, or `recommend_primary`, got `{mode}`"
+            "claw.import payload.mode must be `plan`, `apply`, `discover`, `plan_many`, `recommend_primary`, or `merge_profiles`, got `{mode}`"
         ));
     }
 
@@ -110,6 +115,28 @@ pub(super) fn execute_claw_import_tool_with_config(
         });
     }
 
+    if mode == "merge_profiles" {
+        let report = migration::discover_import_sources(
+            &input_path,
+            migration::DiscoveryOptions::default(),
+        )?;
+        let summary = migration::plan_import_sources(&report)?;
+        let recommendation = migration::recommend_primary_source(&summary).ok();
+        let merged = migration::merge_profile_sources(&report)?;
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "core-tools",
+                "tool_name": request.tool_name,
+                "mode": "merge_profiles",
+                "input_path": input_path.display().to_string(),
+                "plans": summary.plans.iter().map(planned_source_payload).collect::<Vec<_>>(),
+                "recommendation": recommendation.as_ref().map(primary_recommendation_payload),
+                "result": merged_profile_plan_payload(&merged),
+            }),
+        });
+    }
+
     let plan = migration::plan_import_from_path(&input_path, hint)?;
 
     let mut merged_config = load_or_default_config(output_path.as_deref())?;
@@ -177,6 +204,57 @@ fn primary_recommendation_payload(
         "source_id": recommendation.source_id,
         "input_path": recommendation.input_path.display().to_string(),
         "reasons": recommendation.reasons,
+    })
+}
+
+fn merged_profile_plan_payload(plan: &migration::MergedProfilePlan) -> Value {
+    json!({
+        "prompt_owner_source_id": plan.prompt_owner_source_id,
+        "merged_profile_note": plan.merged_profile_note,
+        "auto_apply_allowed": plan.auto_apply_allowed,
+        "kept_entries": plan
+            .kept_entries
+            .iter()
+            .map(|entry| {
+                json!({
+                    "lane": match entry.lane {
+                        migration::ProfileEntryLane::Prompt => "prompt",
+                        migration::ProfileEntryLane::Profile => "profile",
+                    },
+                    "canonical_text": entry.canonical_text,
+                    "source_id": entry.source_id,
+                    "slot_key": entry.slot_key,
+                })
+            })
+            .collect::<Vec<_>>(),
+        "dropped_duplicates": plan
+            .dropped_duplicates
+            .iter()
+            .map(|entry| {
+                json!({
+                    "lane": match entry.lane {
+                        migration::ProfileEntryLane::Prompt => "prompt",
+                        migration::ProfileEntryLane::Profile => "profile",
+                    },
+                    "canonical_text": entry.canonical_text,
+                    "source_id": entry.source_id,
+                    "slot_key": entry.slot_key,
+                })
+            })
+            .collect::<Vec<_>>(),
+        "unresolved_conflicts": plan
+            .unresolved_conflicts
+            .iter()
+            .map(|conflict| {
+                json!({
+                    "slot_key": conflict.slot_key,
+                    "preferred_source_id": conflict.preferred_source_id,
+                    "discarded_source_id": conflict.discarded_source_id,
+                    "preferred_text": conflict.preferred_text,
+                    "discarded_text": conflict.discarded_text,
+                })
+            })
+            .collect::<Vec<_>>(),
     })
 }
 

--- a/crates/app/src/tools/claw_import.rs
+++ b/crates/app/src/tools/claw_import.rs
@@ -86,9 +86,9 @@ pub(super) fn execute_claw_import_tool_with_config(
         .flatten();
 
     if mode == "rollback_last_apply" {
-        let output_path = output_path
-            .clone()
-            .expect("output path already required in rollback mode");
+        let output_path = output_path.clone().ok_or_else(|| {
+            "claw.import rollback_last_apply mode requires payload.output_path".to_owned()
+        })?;
         let restored_path = migration::rollback_last_import(&output_path)?;
         return Ok(ToolCoreOutcome {
             status: "ok".to_owned(),
@@ -102,11 +102,12 @@ pub(super) fn execute_claw_import_tool_with_config(
         });
     }
 
-    let input_path = input_path.expect("input path required for non-rollback modes");
+    let input_path =
+        input_path.ok_or_else(|| "claw.import requires payload.input_path".to_owned())?;
 
     if mode == "discover" {
         let report = migration::discover_import_sources(
-            &input_path,
+            input_path.as_path(),
             migration::DiscoveryOptions::default(),
         )?;
         return Ok(ToolCoreOutcome {
@@ -127,7 +128,7 @@ pub(super) fn execute_claw_import_tool_with_config(
 
     if matches!(mode, "plan_many" | "recommend_primary") {
         let report = migration::discover_import_sources(
-            &input_path,
+            input_path.as_path(),
             migration::DiscoveryOptions::default(),
         )?;
         let summary = migration::plan_import_sources(&report)?;
@@ -147,7 +148,7 @@ pub(super) fn execute_claw_import_tool_with_config(
 
     if mode == "merge_profiles" {
         let report = migration::discover_import_sources(
-            &input_path,
+            input_path.as_path(),
             migration::DiscoveryOptions::default(),
         )?;
         let summary = migration::plan_import_sources(&report)?;
@@ -172,11 +173,12 @@ pub(super) fn execute_claw_import_tool_with_config(
             migration::discover_import_sources(input_path, migration::DiscoveryOptions::default())?;
         let summary = migration::plan_import_sources(&report)?;
         let selection = parse_apply_selection_mode(payload, &summary)?;
+        let selected_output_path = output_path.clone().ok_or_else(|| {
+            "claw.import apply_selected mode requires payload.output_path".to_owned()
+        })?;
         let result = migration::apply_import_selection(&migration::ApplyImportSelection {
             discovery: report,
-            output_path: output_path
-                .clone()
-                .expect("output path already required in apply_selected mode"),
+            output_path: selected_output_path,
             mode: selection,
         })?;
         return Ok(ToolCoreOutcome {
@@ -192,7 +194,7 @@ pub(super) fn execute_claw_import_tool_with_config(
         });
     }
 
-    let plan = migration::plan_import_from_path(&input_path, hint)?;
+    let plan = migration::plan_import_from_path(input_path.as_path(), hint)?;
 
     let mut merged_config = load_or_default_config(output_path.as_deref())?;
     migration::apply_import_plan(&mut merged_config, &plan);
@@ -201,7 +203,7 @@ pub(super) fn execute_claw_import_tool_with_config(
     let written_output_path = if mode == "apply" {
         let output_path = output_path
             .clone()
-            .expect("output path already required in apply mode");
+            .ok_or_else(|| "claw.import apply mode requires payload.output_path".to_owned())?;
         let output_string = output_path.display().to_string();
         Some(config::write(Some(&output_string), &merged_config, force)?)
     } else {
@@ -435,10 +437,9 @@ fn resolve_safe_path_with_config(
         return canonicalize_or_fallback(combined);
     }
 
-    let root = config
-        .file_root
-        .clone()
-        .expect("file_root already checked above");
+    let Some(root) = config.file_root.clone() else {
+        return Err("configured file root was missing during safe path resolution".to_owned());
+    };
     let root = canonicalize_or_fallback(root)?;
 
     let candidate = Path::new(raw);

--- a/crates/app/src/tools/claw_import.rs
+++ b/crates/app/src/tools/claw_import.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
     config::{self, LoongClawConfig, MemoryProfile},
@@ -234,7 +234,8 @@ pub(super) fn execute_claw_import_tool_with_config(
 
 fn discovered_source_payload(source: &migration::DiscoveredImportSource) -> Value {
     json!({
-        "source_id": source.source.as_id(),
+        "source_id": source.source_id,
+        "source_kind": source.source.as_id(),
         "input_path": source.path.display().to_string(),
         "confidence_score": source.confidence_score,
         "found_files": source.found_files,
@@ -244,6 +245,7 @@ fn discovered_source_payload(source: &migration::DiscoveredImportSource) -> Valu
 fn planned_source_payload(plan: &migration::PlannedImportSource) -> Value {
     json!({
         "source_id": plan.source_id,
+        "source_kind": plan.source.as_id(),
         "input_path": plan.input_path.display().to_string(),
         "confidence_score": plan.confidence_score,
         "prompt_addendum_present": plan.prompt_addendum_present,
@@ -257,6 +259,7 @@ fn primary_recommendation_payload(
 ) -> Value {
     json!({
         "source_id": recommendation.source_id,
+        "source_kind": recommendation.source.as_id(),
         "input_path": recommendation.input_path.display().to_string(),
         "reasons": recommendation.reasons,
     })
@@ -347,7 +350,9 @@ fn parse_apply_selection_mode(
         .unwrap_or(false)
     {
         let primary_source_id = payload
-            .get("primary_source_id")
+            .get("primary_selection_id")
+            .or_else(|| payload.get("selection_id"))
+            .or_else(|| payload.get("primary_source_id"))
             .or_else(|| payload.get("source_id"))
             .and_then(Value::as_str)
             .map(str::trim)
@@ -365,7 +370,8 @@ fn parse_apply_selection_mode(
     }
 
     if let Some(source_id) = payload
-        .get("source_id")
+        .get("selection_id")
+        .or_else(|| payload.get("source_id"))
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())

--- a/crates/app/src/tools/claw_import.rs
+++ b/crates/app/src/tools/claw_import.rs
@@ -33,23 +33,17 @@ pub(super) fn execute_claw_import_tool_with_config(
         mode,
         "plan"
             | "apply"
+            | "apply_selected"
             | "discover"
             | "plan_many"
             | "recommend_primary"
             | "merge_profiles"
+            | "rollback_last_apply"
     ) {
         return Err(format!(
-            "claw.import payload.mode must be `plan`, `apply`, `discover`, `plan_many`, `recommend_primary`, or `merge_profiles`, got `{mode}`"
+            "claw.import payload.mode must be `plan`, `apply`, `apply_selected`, `discover`, `plan_many`, `recommend_primary`, `merge_profiles`, or `rollback_last_apply`, got `{mode}`"
         ));
     }
-
-    let input_path = payload
-        .get("input_path")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| "claw.import requires payload.input_path".to_owned())?;
-    let input_path = resolve_safe_path_with_config(input_path, config)?;
 
     let output_path = payload
         .get("output_path")
@@ -59,9 +53,27 @@ pub(super) fn execute_claw_import_tool_with_config(
         .map(|value| resolve_safe_path_with_config(value, config))
         .transpose()?;
 
-    if mode == "apply" && output_path.is_none() {
-        return Err("claw.import apply mode requires payload.output_path".to_owned());
+    if matches!(mode, "apply" | "apply_selected" | "rollback_last_apply") && output_path.is_none()
+    {
+        return Err(format!(
+            "claw.import {mode} mode requires payload.output_path"
+        ));
     }
+
+    let input_path = if mode == "rollback_last_apply" {
+        None
+    } else {
+        Some(
+            payload
+                .get("input_path")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| "claw.import requires payload.input_path".to_owned())
+                .and_then(|value| resolve_safe_path_with_config(value, config))?,
+        )
+    };
+    let input_path = input_path.as_ref();
 
     let force = payload
         .get("force")
@@ -73,6 +85,25 @@ pub(super) fn execute_claw_import_tool_with_config(
         .map(parse_source_hint)
         .transpose()?
         .flatten();
+
+    if mode == "rollback_last_apply" {
+        let output_path = output_path
+            .clone()
+            .expect("output path already required in rollback mode");
+        let restored_path = migration::rollback_last_import(&output_path)?;
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "core-tools",
+                "tool_name": request.tool_name,
+                "mode": "rollback_last_apply",
+                "output_path": restored_path.display().to_string(),
+                "rolled_back": true,
+            }),
+        });
+    }
+
+    let input_path = input_path.expect("input path required for non-rollback modes");
 
     if mode == "discover" {
         let report = migration::discover_import_sources(
@@ -133,6 +164,33 @@ pub(super) fn execute_claw_import_tool_with_config(
                 "plans": summary.plans.iter().map(planned_source_payload).collect::<Vec<_>>(),
                 "recommendation": recommendation.as_ref().map(primary_recommendation_payload),
                 "result": merged_profile_plan_payload(&merged),
+            }),
+        });
+    }
+
+    if mode == "apply_selected" {
+        let report = migration::discover_import_sources(
+            input_path,
+            migration::DiscoveryOptions::default(),
+        )?;
+        let summary = migration::plan_import_sources(&report)?;
+        let selection = parse_apply_selection_mode(payload, &summary)?;
+        let result = migration::apply_import_selection(&migration::ApplyImportSelection {
+            discovery: report,
+            output_path: output_path
+                .clone()
+                .expect("output path already required in apply_selected mode"),
+            mode: selection,
+        })?;
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "core-tools",
+                "tool_name": request.tool_name,
+                "mode": "apply_selected",
+                "input_path": input_path.display().to_string(),
+                "output_path": result.output_path.display().to_string(),
+                "result": apply_selection_result_payload(&result),
             }),
         });
     }
@@ -258,6 +316,19 @@ fn merged_profile_plan_payload(plan: &migration::MergedProfilePlan) -> Value {
     })
 }
 
+fn apply_selection_result_payload(result: &migration::ApplyImportSelectionResult) -> Value {
+    json!({
+        "output_path": result.output_path.display().to_string(),
+        "backup_path": result.backup_path.display().to_string(),
+        "manifest_path": result.manifest_path.display().to_string(),
+        "selected_primary_source_id": result.selected_primary_source_id,
+        "merged_source_ids": result.merged_source_ids,
+        "prompt_owner_source_id": result.prompt_owner_source_id,
+        "unresolved_conflicts": result.unresolved_conflicts,
+        "warnings": result.warnings,
+    })
+}
+
 fn parse_source_hint(raw: &str) -> Result<Option<LegacyClawSource>, String> {
     let parsed = LegacyClawSource::from_id(raw).ok_or_else(|| {
         format!("unsupported claw.import payload.source `{raw}`. supported: {SUPPORTED_SOURCES}")
@@ -267,6 +338,49 @@ fn parse_source_hint(raw: &str) -> Result<Option<LegacyClawSource>, String> {
     } else {
         Ok(Some(parsed))
     }
+}
+
+fn parse_apply_selection_mode(
+    payload: &serde_json::Map<String, Value>,
+    summary: &migration::DiscoveryPlanSummary,
+) -> Result<migration::ImportSelectionMode, String> {
+    if payload
+        .get("safe_profile_merge")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        let primary_source_id = payload
+            .get("primary_source_id")
+            .or_else(|| payload.get("source_id"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .or_else(|| {
+                migration::recommend_primary_source(summary)
+                    .ok()
+                    .map(|recommendation| recommendation.source_id)
+            })
+            .ok_or_else(|| "apply_selected requires a primary source for safe profile merge".to_owned())?;
+        return Ok(migration::ImportSelectionMode::SafeProfileMerge { primary_source_id });
+    }
+
+    if let Some(source_id) = payload
+        .get("source_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(migration::ImportSelectionMode::SelectedSingleSource {
+            source_id: source_id.to_owned(),
+        });
+    }
+
+    let recommendation = migration::recommend_primary_source(summary)
+        .map_err(|error| format!("apply_selected could not recommend a primary source: {error}"))?;
+    Ok(migration::ImportSelectionMode::RecommendedSingleSource {
+        source_id: recommendation.source_id,
+    })
 }
 
 fn load_or_default_config(path: Option<&Path>) -> Result<LoongClawConfig, String> {

--- a/crates/app/src/tools/claw_import.rs
+++ b/crates/app/src/tools/claw_import.rs
@@ -53,8 +53,7 @@ pub(super) fn execute_claw_import_tool_with_config(
         .map(|value| resolve_safe_path_with_config(value, config))
         .transpose()?;
 
-    if matches!(mode, "apply" | "apply_selected" | "rollback_last_apply") && output_path.is_none()
-    {
+    if matches!(mode, "apply" | "apply_selected" | "rollback_last_apply") && output_path.is_none() {
         return Err(format!(
             "claw.import {mode} mode requires payload.output_path"
         ));
@@ -169,10 +168,8 @@ pub(super) fn execute_claw_import_tool_with_config(
     }
 
     if mode == "apply_selected" {
-        let report = migration::discover_import_sources(
-            input_path,
-            migration::DiscoveryOptions::default(),
-        )?;
+        let report =
+            migration::discover_import_sources(input_path, migration::DiscoveryOptions::default())?;
         let summary = migration::plan_import_sources(&report)?;
         let selection = parse_apply_selection_mode(payload, &summary)?;
         let result = migration::apply_import_selection(&migration::ApplyImportSelection {
@@ -361,7 +358,9 @@ fn parse_apply_selection_mode(
                     .ok()
                     .map(|recommendation| recommendation.source_id)
             })
-            .ok_or_else(|| "apply_selected requires a primary source for safe profile merge".to_owned())?;
+            .ok_or_else(|| {
+                "apply_selected requires a primary source for safe profile merge".to_owned()
+            })?;
         return Ok(migration::ImportSelectionMode::SafeProfileMerge { primary_source_id });
     }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -5,6 +5,7 @@ use serde_json::{Value, json};
 
 use crate::KernelContext;
 
+mod claw_import;
 mod file;
 mod kernel_adapter;
 pub mod runtime_config;
@@ -41,6 +42,7 @@ pub fn execute_tool_core(request: ToolCoreRequest) -> Result<ToolCoreOutcome, St
 
 pub fn canonical_tool_name(raw: &str) -> &str {
     match raw {
+        "claw_import" | "import_claw" => "claw.import",
         "file_read" => "file.read",
         "file_write" => "file.write",
         "shell_exec" | "shell" => "shell.exec",
@@ -51,7 +53,7 @@ pub fn canonical_tool_name(raw: &str) -> &str {
 pub fn is_known_tool_name(raw: &str) -> bool {
     matches!(
         canonical_tool_name(raw),
-        "shell.exec" | "file.read" | "file.write"
+        "claw.import" | "shell.exec" | "file.read" | "file.write"
     )
 }
 
@@ -65,6 +67,7 @@ pub fn execute_tool_core_with_config(
         payload: request.payload,
     };
     match canonical_name {
+        "claw.import" => claw_import::execute_claw_import_tool_with_config(request, config),
         "shell.exec" => shell::execute_shell_tool_with_config(request, config),
         "file.read" => file::execute_file_read_tool_with_config(request, config),
         "file.write" => file::execute_file_write_tool_with_config(request, config),
@@ -85,6 +88,10 @@ pub struct ToolRegistryEntry {
 /// Returns a sorted list of all registered tools, gated by feature flags.
 pub fn tool_registry() -> Vec<ToolRegistryEntry> {
     let mut entries = Vec::new();
+    entries.push(ToolRegistryEntry {
+        name: "claw.import",
+        description: "Import legacy Claw configs into native LoongClaw settings",
+    });
     #[cfg(feature = "tool-file")]
     {
         entries.push(ToolRegistryEntry {
@@ -103,6 +110,7 @@ pub fn tool_registry() -> Vec<ToolRegistryEntry> {
             description: "Execute shell commands",
         });
     }
+    entries.sort_by_key(|entry| entry.name);
     entries
 }
 
@@ -123,6 +131,43 @@ pub fn capability_snapshot() -> String {
 /// Order is deterministic for stable prompting/tests.
 pub fn provider_tool_definitions() -> Vec<Value> {
     let mut tools = Vec::new();
+
+    tools.push(json!({
+        "type": "function",
+        "function": {
+            "name": "claw_import",
+            "description": "Import a legacy Claw workspace or persona into native LoongClaw config with preview or apply mode.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "input_path": {
+                        "type": "string",
+                        "description": "Path to the legacy Claw workspace, config root, or portable import file."
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": ["plan", "apply"],
+                        "description": "Use `plan` to preview the nativeized result, or `apply` to write a target config."
+                    },
+                    "source": {
+                        "type": "string",
+                        "enum": ["auto", "nanobot", "openclaw", "picoclaw", "zeroclaw", "nanoclaw"],
+                        "description": "Optional source hint. Defaults to automatic detection."
+                    },
+                    "output_path": {
+                        "type": "string",
+                        "description": "Target config path to write in apply mode."
+                    },
+                    "force": {
+                        "type": "boolean",
+                        "description": "Overwrite an existing target config when applying. Defaults to false."
+                    }
+                },
+                "required": ["input_path"],
+                "additionalProperties": false
+            }
+        }
+    }));
 
     #[cfg(feature = "tool-file")]
     {
@@ -209,12 +254,28 @@ pub fn provider_tool_definitions() -> Vec<Value> {
         }));
     }
 
+    tools.sort_by(|left, right| tool_function_name(left).cmp(tool_function_name(right)));
     tools
+}
+
+fn tool_function_name(tool: &Value) -> &str {
+    tool.get("function")
+        .and_then(|value| value.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
 }
 
 #[allow(dead_code)]
 fn _shape_examples() -> BTreeMap<&'static str, Value> {
     BTreeMap::from([
+        (
+            "claw.import",
+            json!({
+                "input_path": "/tmp/nanobot-workspace",
+                "mode": "plan",
+                "source": "auto"
+            }),
+        ),
         (
             "shell.exec",
             json!({
@@ -258,24 +319,28 @@ mod tests {
     #[test]
     fn capability_snapshot_lists_all_tools_when_all_features_enabled() {
         let snapshot = capability_snapshot();
+        assert!(snapshot
+            .contains("- claw.import: Import legacy Claw configs into native LoongClaw settings"));
         assert!(snapshot.contains("- file.read: Read file contents"));
         assert!(snapshot.contains("- file.write: Write file contents"));
         assert!(snapshot.contains("- shell.exec: Execute shell commands"));
 
-        // Verify sorted order: file.read < file.write < shell.exec
+        // Verify sorted order: claw.import < file.read < file.write < shell.exec
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 3);
-        assert!(lines[0].starts_with("- file.read"));
-        assert!(lines[1].starts_with("- file.write"));
-        assert!(lines[2].starts_with("- shell.exec"));
+        assert_eq!(lines.len(), 4);
+        assert!(lines[0].starts_with("- claw.import"));
+        assert!(lines[1].starts_with("- file.read"));
+        assert!(lines[2].starts_with("- file.write"));
+        assert!(lines[3].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 3);
+        assert_eq!(entries.len(), 4);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
+        assert!(names.contains(&"claw.import"));
         assert!(names.contains(&"shell.exec"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
@@ -285,7 +350,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 3);
+        assert_eq!(defs.len(), 4);
 
         let names: Vec<&str> = defs
             .iter()
@@ -293,7 +358,10 @@ mod tests {
             .filter_map(|function| function.get("name"))
             .filter_map(Value::as_str)
             .collect();
-        assert_eq!(names, vec!["file_read", "file_write", "shell_exec"]);
+        assert_eq!(
+            names,
+            vec!["claw_import", "file_read", "file_write", "shell_exec"]
+        );
 
         for item in &defs {
             assert_eq!(item["type"], "function");
@@ -303,6 +371,7 @@ mod tests {
 
     #[test]
     fn canonical_tool_name_maps_known_aliases() {
+        assert_eq!(canonical_tool_name("claw_import"), "claw.import");
         assert_eq!(canonical_tool_name("file_read"), "file.read");
         assert_eq!(canonical_tool_name("file_write"), "file.write");
         assert_eq!(canonical_tool_name("shell_exec"), "shell.exec");
@@ -312,6 +381,8 @@ mod tests {
 
     #[test]
     fn is_known_tool_name_accepts_canonical_and_alias_forms() {
+        assert!(is_known_tool_name("claw.import"));
+        assert!(is_known_tool_name("claw_import"));
         assert!(is_known_tool_name("file.read"));
         assert!(is_known_tool_name("file_read"));
         assert!(is_known_tool_name("file.write"));
@@ -333,6 +404,163 @@ mod tests {
             err.contains("tool_not_found"),
             "error should contain tool_not_found, got: {err}"
         );
+    }
+
+    #[test]
+    fn claw_import_plan_mode_returns_nativeized_preview() {
+        use std::{
+            fs,
+            path::{Path, PathBuf},
+            time::{SystemTime, UNIX_EPOCH},
+        };
+
+        fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        }
+
+        fn write_file(root: &Path, relative: &str, content: &str) {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent directory");
+            }
+            fs::write(path, content).expect("write fixture");
+        }
+
+        let root = unique_temp_dir("loongclaw-tool-import-plan");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "SOUL.md",
+            "# Soul\n\nAlways prefer concise shell output. updated by nanobot.\n",
+        );
+        write_file(
+            &root,
+            "IDENTITY.md",
+            "# Identity\n\n- Motto: your nanobot agent for deploys\n",
+        );
+
+        let config = runtime_config::ToolRuntimeConfig {
+            shell_allowlist: BTreeSet::new(),
+            file_root: Some(root.clone()),
+        };
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload: json!({
+                    "mode": "plan",
+                    "source": "nanobot",
+                    "input_path": "."
+                }),
+            },
+            &config,
+        )
+        .expect("claw import plan should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool_name"], "claw.import");
+        assert_eq!(outcome.payload["mode"], "plan");
+        assert_eq!(outcome.payload["source"], "nanobot");
+        assert_eq!(
+            outcome.payload["config_preview"]["prompt_pack_id"],
+            "loongclaw-core-v1"
+        );
+        assert_eq!(
+            outcome.payload["config_preview"]["memory_profile"],
+            "profile_plus_window"
+        );
+        assert!(outcome.payload["config_preview"]["system_prompt_addendum"]
+            .as_str()
+            .expect("prompt addendum should exist")
+            .contains("LoongClaw"));
+        assert!(outcome.payload["config_preview"]["profile_note"]
+            .as_str()
+            .expect("profile note should exist")
+            .contains("LoongClaw"));
+        assert_eq!(outcome.payload["config_written"], false);
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn claw_import_apply_mode_writes_target_config() {
+        use std::{
+            fs,
+            path::{Path, PathBuf},
+            time::{SystemTime, UNIX_EPOCH},
+        };
+
+        fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        }
+
+        fn write_file(root: &Path, relative: &str, content: &str) {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent directory");
+            }
+            fs::write(path, content).expect("write fixture");
+        }
+
+        let root = unique_temp_dir("loongclaw-tool-import-apply");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "SOUL.md",
+            "# Soul\n\nAlways prefer concise shell output. updated by nanobot.\n",
+        );
+        write_file(
+            &root,
+            "IDENTITY.md",
+            "# Identity\n\n- Motto: your nanobot agent for deploys\n",
+        );
+
+        let output_path = root.join("generated").join("loongclaw.toml");
+        let config = runtime_config::ToolRuntimeConfig {
+            shell_allowlist: BTreeSet::new(),
+            file_root: Some(root.clone()),
+        };
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "claw_import".to_owned(),
+                payload: json!({
+                    "mode": "apply",
+                    "source": "nanobot",
+                    "input_path": ".",
+                    "output_path": "generated/loongclaw.toml",
+                    "force": true
+                }),
+            },
+            &config,
+        )
+        .expect("claw import apply should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["mode"], "apply");
+        assert_eq!(outcome.payload["config_written"], true);
+        assert_eq!(
+            outcome.payload["output_path"]
+                .as_str()
+                .expect("output path should exist"),
+            fs::canonicalize(&output_path)
+                .expect("output path should canonicalize")
+                .display()
+                .to_string()
+        );
+
+        let raw = fs::read_to_string(&output_path).expect("output config should exist");
+        assert!(raw.contains("prompt_pack_id = \"loongclaw-core-v1\""));
+        assert!(raw.contains("profile = \"profile_plus_window\""));
+        assert!(raw.contains("LoongClaw"));
+
+        fs::remove_dir_all(&root).ok();
     }
 
     // --- Kernel-routed tool tests ---

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -778,6 +778,180 @@ mod tests {
         fs::remove_dir_all(&root).ok();
     }
 
+    #[test]
+    fn claw_import_apply_selected_mode_writes_manifest_and_backup() {
+        use std::{
+            fs,
+            path::{Path, PathBuf},
+            time::{SystemTime, UNIX_EPOCH},
+        };
+
+        fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        }
+
+        fn write_file(root: &Path, relative: &str, content: &str) {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent directory");
+            }
+            fs::write(path, content).expect("write fixture");
+        }
+
+        let root = unique_temp_dir("loongclaw-tool-import-apply-selected");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n- tone: steady\n",
+        );
+
+        let output_path = root.join("loongclaw.toml");
+        let original_body = crate::config::render(&crate::config::LoongClawConfig::default())
+            .expect("render default config");
+        fs::write(&output_path, &original_body).expect("write original config");
+
+        let config = runtime_config::ToolRuntimeConfig {
+            shell_allowlist: BTreeSet::new(),
+            file_root: Some(root.clone()),
+        };
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload: json!({
+                    "mode": "apply_selected",
+                    "input_path": ".",
+                    "output_path": "loongclaw.toml",
+                    "source_id": "openclaw"
+                }),
+            },
+            &config,
+        )
+        .expect("claw import apply_selected should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["mode"], "apply_selected");
+        assert!(
+            Path::new(
+                outcome.payload["result"]["backup_path"]
+                    .as_str()
+                    .expect("backup path should be present")
+            )
+            .exists()
+        );
+        assert!(
+            Path::new(
+                outcome.payload["result"]["manifest_path"]
+                    .as_str()
+                    .expect("manifest path should be present")
+            )
+            .exists()
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn claw_import_rollback_last_apply_restores_original_config() {
+        use std::{
+            fs,
+            path::{Path, PathBuf},
+            time::{SystemTime, UNIX_EPOCH},
+        };
+
+        fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        }
+
+        fn write_file(root: &Path, relative: &str, content: &str) {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent directory");
+            }
+            fs::write(path, content).expect("write fixture");
+        }
+
+        let root = unique_temp_dir("loongclaw-tool-import-rollback-selected");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n- tone: steady\n",
+        );
+
+        let output_path = root.join("loongclaw.toml");
+        let original_body = crate::config::render(&crate::config::LoongClawConfig::default())
+            .expect("render default config");
+        fs::write(&output_path, &original_body).expect("write original config");
+
+        let config = runtime_config::ToolRuntimeConfig {
+            shell_allowlist: BTreeSet::new(),
+            file_root: Some(root.clone()),
+        };
+        execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload: json!({
+                    "mode": "apply_selected",
+                    "input_path": ".",
+                    "output_path": "loongclaw.toml",
+                    "source_id": "openclaw"
+                }),
+            },
+            &config,
+        )
+        .expect("claw import apply_selected should succeed");
+
+        let rollback = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload: json!({
+                    "mode": "rollback_last_apply",
+                    "output_path": "loongclaw.toml"
+                }),
+            },
+            &config,
+        )
+        .expect("claw import rollback_last_apply should succeed");
+
+        assert_eq!(rollback.status, "ok");
+        assert!(
+            rollback.payload["rolled_back"]
+                .as_bool()
+                .expect("rolled_back flag should exist")
+        );
+        assert_eq!(
+            fs::read_to_string(&output_path).expect("read restored config"),
+            original_body
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
     // --- Kernel-routed tool tests ---
 
     use std::sync::{Arc, Mutex};

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -698,6 +698,86 @@ mod tests {
         fs::remove_dir_all(&root).ok();
     }
 
+    #[test]
+    fn claw_import_merge_profiles_mode_preserves_prompt_owner() {
+        use std::{
+            fs,
+            path::{Path, PathBuf},
+            time::{SystemTime, UNIX_EPOCH},
+        };
+
+        fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        }
+
+        fn write_file(root: &Path, relative: &str, content: &str) {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent directory");
+            }
+            fs::write(path, content).expect("write fixture");
+        }
+
+        let root = unique_temp_dir("loongclaw-tool-import-merge-profiles");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n- tone: steady\n",
+        );
+
+        let nanobot_root = root.join("nanobot");
+        fs::create_dir_all(&nanobot_root).expect("create nanobot root");
+        write_file(
+            &nanobot_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n- region: apac\n",
+        );
+
+        let config = runtime_config::ToolRuntimeConfig {
+            shell_allowlist: BTreeSet::new(),
+            file_root: Some(root.clone()),
+        };
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload: json!({
+                    "mode": "merge_profiles",
+                    "input_path": "."
+                }),
+            },
+            &config,
+        )
+        .expect("claw import merge_profiles should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["mode"], "merge_profiles");
+        assert_eq!(
+            outcome.payload["result"]["prompt_owner_source_id"],
+            "openclaw"
+        );
+        assert!(
+            outcome.payload["result"]["merged_profile_note"]
+                .as_str()
+                .expect("merged profile note should be present")
+                .contains("region: apac")
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
     // --- Kernel-routed tool tests ---
 
     use std::sync::{Arc, Mutex};

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -319,8 +319,11 @@ mod tests {
     #[test]
     fn capability_snapshot_lists_all_tools_when_all_features_enabled() {
         let snapshot = capability_snapshot();
-        assert!(snapshot
-            .contains("- claw.import: Import legacy Claw configs into native LoongClaw settings"));
+        assert!(
+            snapshot.contains(
+                "- claw.import: Import legacy Claw configs into native LoongClaw settings"
+            )
+        );
         assert!(snapshot.contains("- file.read: Read file contents"));
         assert!(snapshot.contains("- file.write: Write file contents"));
         assert!(snapshot.contains("- shell.exec: Execute shell commands"));
@@ -472,14 +475,18 @@ mod tests {
             outcome.payload["config_preview"]["memory_profile"],
             "profile_plus_window"
         );
-        assert!(outcome.payload["config_preview"]["system_prompt_addendum"]
-            .as_str()
-            .expect("prompt addendum should exist")
-            .contains("LoongClaw"));
-        assert!(outcome.payload["config_preview"]["profile_note"]
-            .as_str()
-            .expect("profile note should exist")
-            .contains("LoongClaw"));
+        assert!(
+            outcome.payload["config_preview"]["system_prompt_addendum"]
+                .as_str()
+                .expect("prompt addendum should exist")
+                .contains("LoongClaw")
+        );
+        assert!(
+            outcome.payload["config_preview"]["profile_note"]
+                .as_str()
+                .expect("profile note should exist")
+                .contains("LoongClaw")
+        );
         assert_eq!(outcome.payload["config_written"], false);
 
         fs::remove_dir_all(&root).ok();
@@ -768,10 +775,12 @@ mod tests {
             outcome.payload["result"]["prompt_owner_source_id"],
             "openclaw"
         );
-        assert!(outcome.payload["result"]["merged_profile_note"]
-            .as_str()
-            .expect("merged profile note should be present")
-            .contains("region: apac"));
+        assert!(
+            outcome.payload["result"]["merged_profile_note"]
+                .as_str()
+                .expect("merged profile note should be present")
+                .contains("region: apac")
+        );
 
         fs::remove_dir_all(&root).ok();
     }
@@ -841,18 +850,22 @@ mod tests {
 
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["mode"], "apply_selected");
-        assert!(Path::new(
-            outcome.payload["result"]["backup_path"]
-                .as_str()
-                .expect("backup path should be present")
-        )
-        .exists());
-        assert!(Path::new(
-            outcome.payload["result"]["manifest_path"]
-                .as_str()
-                .expect("manifest path should be present")
-        )
-        .exists());
+        assert!(
+            Path::new(
+                outcome.payload["result"]["backup_path"]
+                    .as_str()
+                    .expect("backup path should be present")
+            )
+            .exists()
+        );
+        assert!(
+            Path::new(
+                outcome.payload["result"]["manifest_path"]
+                    .as_str()
+                    .expect("manifest path should be present")
+            )
+            .exists()
+        );
 
         fs::remove_dir_all(&root).ok();
     }
@@ -933,9 +946,11 @@ mod tests {
         .expect("claw import rollback_last_apply should succeed");
 
         assert_eq!(rollback.status, "ok");
-        assert!(rollback.payload["rolled_back"]
-            .as_bool()
-            .expect("rolled_back flag should exist"));
+        assert!(
+            rollback.payload["rolled_back"]
+                .as_bool()
+                .expect("rolled_back flag should exist")
+        );
         assert_eq!(
             fs::read_to_string(&output_path).expect("read restored config"),
             original_body

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -563,6 +563,141 @@ mod tests {
         fs::remove_dir_all(&root).ok();
     }
 
+    #[test]
+    fn claw_import_discover_mode_returns_detected_sources() {
+        use std::{
+            fs,
+            path::{Path, PathBuf},
+            time::{SystemTime, UNIX_EPOCH},
+        };
+
+        fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        }
+
+        fn write_file(root: &Path, relative: &str, content: &str) {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent directory");
+            }
+            fs::write(path, content).expect("write fixture");
+        }
+
+        let root = unique_temp_dir("loongclaw-tool-import-discover");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- Role: Release copilot\n- Priority: stability first\n",
+        );
+
+        let config = runtime_config::ToolRuntimeConfig {
+            shell_allowlist: BTreeSet::new(),
+            file_root: Some(root.clone()),
+        };
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload: json!({
+                    "mode": "discover",
+                    "input_path": "."
+                }),
+            },
+            &config,
+        )
+        .expect("claw import discover should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["mode"], "discover");
+        assert_eq!(outcome.payload["sources"][0]["source_id"], "openclaw");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn claw_import_plan_many_mode_returns_source_summaries_and_recommendation() {
+        use std::{
+            fs,
+            path::{Path, PathBuf},
+            time::{SystemTime, UNIX_EPOCH},
+        };
+
+        fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        }
+
+        fn write_file(root: &Path, relative: &str, content: &str) {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent directory");
+            }
+            fs::write(path, content).expect("write fixture");
+        }
+
+        let root = unique_temp_dir("loongclaw-tool-import-plan-many");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- Role: Release copilot\n- Priority: stability first\n",
+        );
+
+        let nanobot_root = root.join("nanobot");
+        fs::create_dir_all(&nanobot_root).expect("create nanobot root");
+        write_file(
+            &nanobot_root,
+            "IDENTITY.md",
+            "# Identity\n\n- Motto: your nanobot agent for deploys\n",
+        );
+
+        let config = runtime_config::ToolRuntimeConfig {
+            shell_allowlist: BTreeSet::new(),
+            file_root: Some(root.clone()),
+        };
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload: json!({
+                    "mode": "plan_many",
+                    "input_path": "."
+                }),
+            },
+            &config,
+        )
+        .expect("claw import plan_many should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["mode"], "plan_many");
+        assert_eq!(outcome.payload["plans"][0]["source_id"], "openclaw");
+        assert_eq!(outcome.payload["recommendation"]["source_id"], "openclaw");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
     // --- Kernel-routed tool tests ---
 
     use std::sync::{Arc, Mutex};

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -768,12 +768,10 @@ mod tests {
             outcome.payload["result"]["prompt_owner_source_id"],
             "openclaw"
         );
-        assert!(
-            outcome.payload["result"]["merged_profile_note"]
-                .as_str()
-                .expect("merged profile note should be present")
-                .contains("region: apac")
-        );
+        assert!(outcome.payload["result"]["merged_profile_note"]
+            .as_str()
+            .expect("merged profile note should be present")
+            .contains("region: apac"));
 
         fs::remove_dir_all(&root).ok();
     }
@@ -843,22 +841,18 @@ mod tests {
 
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["mode"], "apply_selected");
-        assert!(
-            Path::new(
-                outcome.payload["result"]["backup_path"]
-                    .as_str()
-                    .expect("backup path should be present")
-            )
-            .exists()
-        );
-        assert!(
-            Path::new(
-                outcome.payload["result"]["manifest_path"]
-                    .as_str()
-                    .expect("manifest path should be present")
-            )
-            .exists()
-        );
+        assert!(Path::new(
+            outcome.payload["result"]["backup_path"]
+                .as_str()
+                .expect("backup path should be present")
+        )
+        .exists());
+        assert!(Path::new(
+            outcome.payload["result"]["manifest_path"]
+                .as_str()
+                .expect("manifest path should be present")
+        )
+        .exists());
 
         fs::remove_dir_all(&root).ok();
     }
@@ -939,11 +933,9 @@ mod tests {
         .expect("claw import rollback_last_apply should succeed");
 
         assert_eq!(rollback.status, "ok");
-        assert!(
-            rollback.payload["rolled_back"]
-                .as_bool()
-                .expect("rolled_back flag should exist")
-        );
+        assert!(rollback.payload["rolled_back"]
+            .as_bool()
+            .expect("rolled_back flag should exist"));
         assert_eq!(
             fs::read_to_string(&output_path).expect("read restored config"),
             original_body

--- a/crates/daemon/src/import_claw_cli.rs
+++ b/crates/daemon/src/import_claw_cli.rs
@@ -1,0 +1,127 @@
+use std::path::Path;
+
+use loongclaw_app as mvp;
+use loongclaw_spec::CliResult;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ImportClawCommandOptions {
+    pub input: String,
+    pub output: Option<String>,
+    pub source: Option<String>,
+    pub force: bool,
+}
+
+pub(crate) fn parse_legacy_claw_source(raw: &str) -> Option<mvp::migration::LegacyClawSource> {
+    mvp::migration::LegacyClawSource::from_id(raw)
+}
+
+pub(crate) fn run_import_claw_cli(options: ImportClawCommandOptions) -> CliResult<()> {
+    let input_path = mvp::config::expand_path(&options.input);
+    let output_path = options
+        .output
+        .as_deref()
+        .map(mvp::config::expand_path)
+        .unwrap_or_else(mvp::config::default_config_path);
+
+    if output_path.exists() && !options.force {
+        return Err(format!(
+            "config {} already exists (use --force to overwrite)",
+            output_path.display()
+        ));
+    }
+
+    let hint = if let Some(raw) = options.source.as_deref() {
+        let parsed = parse_legacy_claw_source(raw).ok_or_else(|| {
+            format!(
+                "unsupported --source value \"{raw}\". supported: {}",
+                supported_legacy_source_list()
+            )
+        })?;
+        if parsed == mvp::migration::LegacyClawSource::Unknown {
+            None
+        } else {
+            Some(parsed)
+        }
+    } else {
+        None
+    };
+
+    let plan = mvp::migration::plan_import_from_path(&input_path, hint)?;
+    let mut config = load_or_default_config(&output_path, output_path.exists())?;
+    mvp::migration::apply_import_plan(&mut config, &plan);
+
+    let output_string = output_path.display().to_string();
+    let written = mvp::config::write(Some(&output_string), &config, options.force)?;
+
+    #[cfg(feature = "memory-sqlite")]
+    let memory_path = {
+        let mem_config =
+            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        mvp::memory::ensure_memory_db_ready(Some(config.memory.resolved_sqlite_path()), &mem_config)
+            .map_err(|error| format!("failed to bootstrap sqlite memory: {error}"))?
+    };
+
+    println!("import complete");
+    println!("- source: {}", legacy_claw_source_id(plan.source));
+    println!("- input: {}", input_path.display());
+    println!("- config: {}", written.display());
+    println!(
+        "- prompt pack: {}",
+        config
+            .cli
+            .prompt_pack_id()
+            .unwrap_or(mvp::prompt::DEFAULT_PROMPT_PACK_ID)
+    );
+    println!(
+        "- memory profile: {}",
+        memory_profile_id(config.memory.profile)
+    );
+    println!(
+        "- imported prompt addendum: {}",
+        yes_no(config.cli.system_prompt_addendum.is_some())
+    );
+    println!(
+        "- imported profile note: {}",
+        yes_no(config.memory.profile_note.is_some())
+    );
+    #[cfg(feature = "memory-sqlite")]
+    println!("- sqlite memory: {}", memory_path.display());
+    for warning in &plan.warnings {
+        println!("- warning: {warning}");
+    }
+    println!("next step: loongclawd chat --config {}", written.display());
+    Ok(())
+}
+
+fn load_or_default_config(path: &Path, exists: bool) -> CliResult<mvp::config::LoongClawConfig> {
+    if !exists {
+        return Ok(mvp::config::LoongClawConfig::default());
+    }
+    let path_string = path.display().to_string();
+    let (_, config) = mvp::config::load(Some(&path_string))?;
+    Ok(config)
+}
+
+fn legacy_claw_source_id(source: mvp::migration::LegacyClawSource) -> &'static str {
+    source.as_id()
+}
+
+fn supported_legacy_source_list() -> &'static str {
+    "auto, nanobot, openclaw, picoclaw, zeroclaw, nanoclaw"
+}
+
+fn memory_profile_id(profile: mvp::config::MemoryProfile) -> &'static str {
+    match profile {
+        mvp::config::MemoryProfile::WindowOnly => "window_only",
+        mvp::config::MemoryProfile::WindowPlusSummary => "window_plus_summary",
+        mvp::config::MemoryProfile::ProfilePlusWindow => "profile_plus_window",
+    }
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value {
+        "yes"
+    } else {
+        "no"
+    }
+}

--- a/crates/daemon/src/import_claw_cli.rs
+++ b/crates/daemon/src/import_claw_cli.rs
@@ -119,9 +119,5 @@ fn memory_profile_id(profile: mvp::config::MemoryProfile) -> &'static str {
 }
 
 fn yes_no(value: bool) -> &'static str {
-    if value {
-        "yes"
-    } else {
-        "no"
-    }
+    if value { "yes" } else { "no" }
 }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -26,6 +26,7 @@ use loongclaw_bench::{
     run_wasm_cache_benchmark_cli,
 };
 mod doctor_cli;
+mod import_claw_cli;
 mod onboard_cli;
 #[cfg(test)]
 pub(crate) use loongclaw_spec::programmatic::{
@@ -174,9 +175,24 @@ enum Commands {
         #[arg(long)]
         api_key_env: Option<String>,
         #[arg(long)]
+        personality: Option<String>,
+        #[arg(long)]
+        memory_profile: Option<String>,
+        #[arg(long)]
         system_prompt: Option<String>,
         #[arg(long, default_value_t = false)]
         skip_model_probe: bool,
+    },
+    /// Import prompt/identity traits from another claw workspace into LoongClaw config
+    ImportClaw {
+        #[arg(long)]
+        input: String,
+        #[arg(long)]
+        output: Option<String>,
+        #[arg(long)]
+        source: Option<String>,
+        #[arg(long, default_value_t = false)]
+        force: bool,
     },
     /// Run setup diagnostics and optionally apply safe config/path fixes
     Doctor {
@@ -343,6 +359,8 @@ async fn main() {
             provider,
             model,
             api_key_env,
+            personality,
+            memory_profile,
             system_prompt,
             skip_model_probe,
         } => {
@@ -354,11 +372,24 @@ async fn main() {
                 provider,
                 model,
                 api_key_env,
+                personality,
+                memory_profile,
                 system_prompt,
                 skip_model_probe,
             })
             .await
         }
+        Commands::ImportClaw {
+            input,
+            output,
+            source,
+            force,
+        } => import_claw_cli::run_import_claw_cli(import_claw_cli::ImportClawCommandOptions {
+            input,
+            output,
+            source,
+            force,
+        }),
         Commands::Doctor {
             config,
             fix,
@@ -607,10 +638,8 @@ fn run_setup_cli(output: Option<&str>, force: bool) -> CliResult<()> {
             .to_str()
             .ok_or_else(|| format!("config path is not valid UTF-8: {}", path.display()))?;
         let (_, parsed) = mvp::config::load(Some(path_str))?;
-        let mem_config = mvp::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(parsed.memory.resolved_sqlite_path()),
-            sliding_window: Some(parsed.memory.sliding_window),
-        };
+        let mem_config =
+            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&parsed.memory);
         let memory_db = mvp::memory::ensure_memory_db_ready(
             Some(parsed.memory.resolved_sqlite_path()),
             &mem_config,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -909,10 +909,8 @@ fn run_safe_lane_summary_cli(
 
     #[cfg(feature = "memory-sqlite")]
     {
-        let mem_config = mvp::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(config.memory.resolved_sqlite_path()),
-            sliding_window: Some(config.memory.sliding_window),
-        };
+        let mem_config =
+            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
         let turns = mvp::memory::window_direct(&session_id, limit, &mem_config)
             .map_err(|error| format!("load safe-lane summary failed: {error}"))?;
         let summary = mvp::conversation::summarize_safe_lane_events(
@@ -1008,6 +1006,7 @@ fn run_safe_lane_summary_cli(
     }
 }
 
+#[cfg(feature = "memory-sqlite")]
 fn format_milli_ratio(value: Option<u32>) -> String {
     value
         .map(|raw| format!("{:.3}", (raw as f64) / 1000.0))

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -16,6 +16,8 @@ pub(crate) struct OnboardCommandOptions {
     pub provider: Option<String>,
     pub model: Option<String>,
     pub api_key_env: Option<String>,
+    pub personality: Option<String>,
+    pub memory_profile: Option<String>,
     pub system_prompt: Option<String>,
     pub skip_model_probe: bool,
 }
@@ -36,6 +38,12 @@ struct OnboardCheck {
 
 pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult<()> {
     validate_non_interactive_risk_gate(options.non_interactive, options.accept_risk)?;
+    let using_prompt_override = options
+        .system_prompt
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
+    let total_steps = if using_prompt_override { 5 } else { 6 };
 
     if !options.non_interactive && !options.accept_risk {
         println!("Security warning:");
@@ -57,7 +65,7 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
     let mut config = mvp::config::LoongClawConfig::default();
 
     if !options.non_interactive {
-        print_step_header(1, 4, "provider");
+        print_step_header(1, total_steps, "provider");
     }
     let selected_provider = resolve_provider_selection(&options, &config)?;
     config.provider.kind = selected_provider;
@@ -66,13 +74,13 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
     config.provider.chat_completions_path = profile.chat_completions_path.to_owned();
 
     if !options.non_interactive {
-        print_step_header(2, 4, "model");
+        print_step_header(2, total_steps, "model");
     }
     let selected_model = resolve_model_selection(&options, &config)?;
     config.provider.model = selected_model;
 
     if !options.non_interactive {
-        print_step_header(3, 4, "credential env");
+        print_step_header(3, total_steps, "credential env");
     }
     let default_api_key_env = provider_default_api_key_env(config.provider.kind).to_owned();
     let selected_api_key_env = resolve_api_key_env_selection(&options, default_api_key_env)?;
@@ -82,11 +90,38 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
         Some(selected_api_key_env)
     };
 
-    if !options.non_interactive {
-        print_step_header(4, 4, "system prompt");
-    }
-    if let Some(system_prompt) = resolve_system_prompt_selection(&options, &config)? {
-        config.cli.system_prompt = system_prompt;
+    if using_prompt_override {
+        if !options.non_interactive {
+            print_step_header(4, total_steps, "system prompt override");
+        }
+        if let Some(system_prompt) = resolve_system_prompt_selection(&options, &config)? {
+            config.cli.prompt_pack_id = None;
+            config.cli.personality = None;
+            config.cli.system_prompt_addendum = None;
+            config.cli.system_prompt = system_prompt;
+        }
+        if !options.non_interactive {
+            print_step_header(5, total_steps, "memory profile");
+        }
+        config.memory.profile = resolve_memory_profile_selection(&options, &config)?;
+    } else {
+        if !options.non_interactive {
+            print_step_header(4, total_steps, "personality");
+        }
+        let personality = resolve_personality_selection(&options, &config)?;
+        config.cli.prompt_pack_id = Some(mvp::prompt::DEFAULT_PROMPT_PACK_ID.to_owned());
+        config.cli.personality = Some(personality);
+
+        if !options.non_interactive {
+            print_step_header(5, total_steps, "prompt addendum");
+        }
+        config.cli.system_prompt_addendum = resolve_prompt_addendum_selection(&options, &config)?;
+        config.cli.refresh_native_system_prompt();
+
+        if !options.non_interactive {
+            print_step_header(6, total_steps, "memory profile");
+        }
+        config.memory.profile = resolve_memory_profile_selection(&options, &config)?;
     }
 
     let checks = run_preflight_checks(&config, options.skip_model_probe).await;
@@ -129,10 +164,8 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
     let path = mvp::config::write(options.output.as_deref(), &config, force_write)?;
     #[cfg(feature = "memory-sqlite")]
     let memory_path = {
-        let mem_config = mvp::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(config.memory.resolved_sqlite_path()),
-            sliding_window: Some(config.memory.sliding_window),
-        };
+        let mem_config =
+            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
         mvp::memory::ensure_memory_db_ready(Some(config.memory.resolved_sqlite_path()), &mem_config)
             .map_err(|error| format!("failed to bootstrap sqlite memory: {error}"))?
     };
@@ -141,6 +174,18 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
     println!("- config: {}", path.display());
     println!("- provider: {}", provider_kind_id(config.provider.kind));
     println!("- model: {}", config.provider.model);
+    if let Some(pack_id) = config.cli.prompt_pack_id() {
+        println!("- prompt pack: {pack_id}");
+    } else {
+        println!("- prompt mode: inline override");
+    }
+    if let Some(personality) = config.cli.personality {
+        println!("- personality: {}", prompt_personality_id(personality));
+    }
+    println!(
+        "- memory profile: {}",
+        memory_profile_id(config.memory.profile)
+    );
     if let Some(api_env) = config.provider.api_key_env.as_deref() {
         println!("- credential env: {api_env}");
     }
@@ -257,6 +302,84 @@ fn resolve_system_prompt_selection(
         return Ok(None);
     }
     Ok(Some(trimmed.to_owned()))
+}
+
+fn resolve_personality_selection(
+    options: &OnboardCommandOptions,
+    config: &mvp::config::LoongClawConfig,
+) -> CliResult<mvp::prompt::PromptPersonality> {
+    if options.non_interactive {
+        if let Some(personality_raw) = options.personality.as_deref() {
+            return parse_prompt_personality(personality_raw).ok_or_else(|| {
+                format!(
+                    "unsupported --personality value \"{personality_raw}\". supported: {}",
+                    supported_personality_list()
+                )
+            });
+        }
+        return Ok(config.cli.resolved_personality());
+    }
+
+    let default_personality = options
+        .personality
+        .as_deref()
+        .and_then(parse_prompt_personality)
+        .unwrap_or_else(|| config.cli.resolved_personality());
+    loop {
+        println!("Personality options: {}", supported_personality_list());
+        let input = prompt_with_default("Personality", prompt_personality_id(default_personality))?;
+        if let Some(personality) = parse_prompt_personality(&input) {
+            return Ok(personality);
+        }
+        println!("Invalid personality: {input}");
+    }
+}
+
+fn resolve_prompt_addendum_selection(
+    options: &OnboardCommandOptions,
+    config: &mvp::config::LoongClawConfig,
+) -> CliResult<Option<String>> {
+    if options.non_interactive {
+        return Ok(config.cli.system_prompt_addendum.clone());
+    }
+    prompt_optional(
+        "Prompt addendum (blank keeps current, '-' clears)",
+        config.cli.system_prompt_addendum.as_deref(),
+    )
+}
+
+fn resolve_memory_profile_selection(
+    options: &OnboardCommandOptions,
+    config: &mvp::config::LoongClawConfig,
+) -> CliResult<mvp::config::MemoryProfile> {
+    if options.non_interactive {
+        if let Some(profile_raw) = options.memory_profile.as_deref() {
+            return parse_memory_profile(profile_raw).ok_or_else(|| {
+                format!(
+                    "unsupported --memory-profile value \"{profile_raw}\". supported: {}",
+                    supported_memory_profile_list()
+                )
+            });
+        }
+        return Ok(config.memory.profile);
+    }
+
+    let default_profile = options
+        .memory_profile
+        .as_deref()
+        .and_then(parse_memory_profile)
+        .unwrap_or(config.memory.profile);
+    loop {
+        println!(
+            "Memory profile options: {}",
+            supported_memory_profile_list()
+        );
+        let input = prompt_with_default("Memory profile", memory_profile_id(default_profile))?;
+        if let Some(profile) = parse_memory_profile(&input) {
+            return Ok(profile);
+        }
+        println!("Invalid memory profile: {input}");
+    }
 }
 
 async fn run_preflight_checks(
@@ -423,6 +546,26 @@ fn prompt_confirm(message: &str, default: bool) -> CliResult<bool> {
     Ok(matches!(value.as_str(), "y" | "yes"))
 }
 
+fn prompt_optional(label: &str, current: Option<&str>) -> CliResult<Option<String>> {
+    let default = current.unwrap_or("none");
+    print!("{label} [{default}]: ");
+    io::stdout()
+        .flush()
+        .map_err(|error| format!("flush stdout failed: {error}"))?;
+    let mut line = String::new();
+    io::stdin()
+        .read_line(&mut line)
+        .map_err(|error| format!("read stdin failed: {error}"))?;
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Ok(current.map(str::to_owned));
+    }
+    if trimmed == "-" {
+        return Ok(None);
+    }
+    Ok(Some(trimmed.to_owned()))
+}
+
 pub(crate) fn validate_non_interactive_risk_gate(
     non_interactive: bool,
     accept_risk: bool,
@@ -452,6 +595,34 @@ pub(crate) fn parse_provider_kind(raw: &str) -> Option<mvp::config::ProviderKind
         "xai" | "xai_compatible" => Some(mvp::config::ProviderKind::Xai),
         "zai" | "zai_compatible" => Some(mvp::config::ProviderKind::Zai),
         "zhipu" | "zhipu_compatible" => Some(mvp::config::ProviderKind::Zhipu),
+        _ => None,
+    }
+}
+
+pub(crate) fn parse_prompt_personality(raw: &str) -> Option<mvp::prompt::PromptPersonality> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "calm_engineering" | "engineering" | "calm" => {
+            Some(mvp::prompt::PromptPersonality::CalmEngineering)
+        }
+        "friendly_collab" | "friendly" | "collab" => {
+            Some(mvp::prompt::PromptPersonality::FriendlyCollab)
+        }
+        "autonomous_executor" | "autonomous" | "executor" => {
+            Some(mvp::prompt::PromptPersonality::AutonomousExecutor)
+        }
+        _ => None,
+    }
+}
+
+pub(crate) fn parse_memory_profile(raw: &str) -> Option<mvp::config::MemoryProfile> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "window_only" | "window" => Some(mvp::config::MemoryProfile::WindowOnly),
+        "window_plus_summary" | "summary" | "summary_window" => {
+            Some(mvp::config::MemoryProfile::WindowPlusSummary)
+        }
+        "profile_plus_window" | "profile" | "profile_window" => {
+            Some(mvp::config::MemoryProfile::ProfilePlusWindow)
+        }
         _ => None,
     }
 }
@@ -490,8 +661,32 @@ pub(crate) fn provider_kind_id(kind: mvp::config::ProviderKind) -> &'static str 
     }
 }
 
+pub(crate) fn prompt_personality_id(personality: mvp::prompt::PromptPersonality) -> &'static str {
+    match personality {
+        mvp::prompt::PromptPersonality::CalmEngineering => "calm_engineering",
+        mvp::prompt::PromptPersonality::FriendlyCollab => "friendly_collab",
+        mvp::prompt::PromptPersonality::AutonomousExecutor => "autonomous_executor",
+    }
+}
+
+pub(crate) fn memory_profile_id(profile: mvp::config::MemoryProfile) -> &'static str {
+    match profile {
+        mvp::config::MemoryProfile::WindowOnly => "window_only",
+        mvp::config::MemoryProfile::WindowPlusSummary => "window_plus_summary",
+        mvp::config::MemoryProfile::ProfilePlusWindow => "profile_plus_window",
+    }
+}
+
 fn supported_provider_list() -> &'static str {
     "openai, anthropic, openrouter, kimi, kimi_coding, minimax, ollama, volcengine, xai, zai, zhipu, deepseek"
+}
+
+fn supported_personality_list() -> &'static str {
+    "calm_engineering, friendly_collab, autonomous_executor"
+}
+
+fn supported_memory_profile_list() -> &'static str {
+    "window_only, window_plus_summary, profile_plus_window"
 }
 
 fn resolve_force_write(output_path: &Path, options: &OnboardCommandOptions) -> CliResult<bool> {

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -672,6 +672,19 @@ pub(crate) fn build_onboard_import_summary(
     lines.join("\n")
 }
 
+pub(crate) fn validate_non_interactive_import_strategy(
+    strategy: &OnboardImportStrategy,
+    allow_multi_source_merge: bool,
+) -> CliResult<()> {
+    if matches!(strategy.mode, OnboardImportMode::SafeProfileMerge) && !allow_multi_source_merge {
+        return Err(
+            "non-interactive onboarding blocks multi-source merge without explicit opt-in"
+                .to_owned(),
+        );
+    }
+    Ok(())
+}
+
 pub(crate) fn parse_provider_kind(raw: &str) -> Option<mvp::config::ProviderKind> {
     match raw.trim().to_ascii_lowercase().as_str() {
         "anthropic" | "anthropic_compatible" => Some(mvp::config::ProviderKind::Anthropic),

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -400,10 +400,20 @@ fn resolve_interactive_onboard_import_strategy(
     };
     println!("Import options:");
     if let Some(recommendation) = discovery.recommendation.as_ref() {
-        println!("  [r] Recommended source ({})", recommendation.source_id);
+        println!(
+            "  [r] Recommended source ({} -> {} @ {})",
+            recommendation.source_id,
+            recommendation.source.as_id(),
+            recommendation.input_path.display()
+        );
     }
     for plan in &discovery.summary.plans {
-        println!("  [{}] Import only {}", plan.source_id, plan.source_id);
+        println!(
+            "  [{}] Import only {} @ {}",
+            plan.source_id,
+            plan.source.as_id(),
+            plan.input_path.display()
+        );
     }
     if discovery.summary.plans.len() > 1 {
         println!("  [m] Safe profile merge");
@@ -861,15 +871,23 @@ pub(crate) fn build_onboard_import_summary(
             format!("{} warning(s)", plan.warning_count)
         };
         lines.push(format!(
-            "- {}: score {}, {}, {}, {}",
-            plan.source_id, plan.confidence_score, prompt_state, profile_state, warning_state
+            "- {}: {} @ {}, score {}, {}, {}, {}",
+            plan.source_id,
+            plan.source.as_id(),
+            plan.input_path.display(),
+            plan.confidence_score,
+            prompt_state,
+            profile_state,
+            warning_state
         ));
     }
 
     if let Some(recommendation) = recommendation {
         lines.push(format!(
-            "Recommended import source: {}",
-            recommendation.source_id
+            "Recommended import source: {} ({} @ {})",
+            recommendation.source_id,
+            recommendation.source.as_id(),
+            recommendation.input_path.display()
         ));
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -36,6 +36,13 @@ struct OnboardCheck {
     detail: String,
 }
 
+#[derive(Debug, Clone)]
+struct OnboardImportDiscovery {
+    report: mvp::migration::DiscoveryReport,
+    summary: mvp::migration::DiscoveryPlanSummary,
+    recommendation: Option<mvp::migration::PrimarySourceRecommendation>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum OnboardImportMode {
     Skip,
@@ -76,7 +83,12 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
         .unwrap_or_else(mvp::config::default_config_path);
     let force_write = resolve_force_write(&output_path, &options)?;
 
-    let mut config = mvp::config::LoongClawConfig::default();
+    let import_applied = maybe_apply_onboard_import(&options, &output_path)?;
+    let mut config = if import_applied {
+        load_or_default_onboard_config(&output_path)?
+    } else {
+        mvp::config::LoongClawConfig::default()
+    };
 
     if !options.non_interactive {
         print_step_header(1, total_steps, "provider");
@@ -175,7 +187,11 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
         return Err("onboarding cancelled: unresolved preflight warnings".to_owned());
     }
 
-    let path = mvp::config::write(options.output.as_deref(), &config, force_write)?;
+    let path = mvp::config::write(
+        options.output.as_deref(),
+        &config,
+        force_write || import_applied,
+    )?;
     #[cfg(feature = "memory-sqlite")]
     let memory_path = {
         let mem_config =
@@ -237,6 +253,201 @@ fn resolve_provider_selection(
             return Ok(kind);
         }
         println!("Invalid provider: {input}");
+    }
+}
+
+fn maybe_apply_onboard_import(
+    options: &OnboardCommandOptions,
+    output_path: &Path,
+) -> CliResult<bool> {
+    let Some(discovery) = discover_onboard_import_candidates()? else {
+        return Ok(false);
+    };
+
+    let strategy = if options.non_interactive {
+        let strategy = resolve_onboard_import_strategy(&discovery.summary, false)?;
+        validate_non_interactive_import_strategy(&strategy, false)?;
+        strategy
+    } else {
+        println!();
+        println!("legacy claw migration:");
+        println!(
+            "{}",
+            build_onboard_import_summary(&discovery.summary, discovery.recommendation.as_ref())
+        );
+        resolve_interactive_onboard_import_strategy(&discovery)?
+    };
+
+    let selection = match strategy.mode {
+        OnboardImportMode::Skip => return Ok(false),
+        OnboardImportMode::RecommendedSingleSource { source_id } => {
+            mvp::migration::ImportSelectionMode::RecommendedSingleSource { source_id }
+        }
+        OnboardImportMode::SelectedSingleSource { source_id } => {
+            mvp::migration::ImportSelectionMode::SelectedSingleSource { source_id }
+        }
+        OnboardImportMode::SafeProfileMerge => {
+            let primary_source_id = strategy
+                .recommended_source_id
+                .clone()
+                .ok_or_else(|| "safe profile merge requires a primary source".to_owned())?;
+            mvp::migration::ImportSelectionMode::SafeProfileMerge { primary_source_id }
+        }
+    };
+
+    let result = mvp::migration::apply_import_selection(&mvp::migration::ApplyImportSelection {
+        discovery: discovery.report,
+        output_path: output_path.to_path_buf(),
+        mode: selection,
+    })?;
+
+    println!("imported legacy claw profile");
+    println!("- primary source: {}", result.selected_primary_source_id);
+    println!("- backup: {}", result.backup_path.display());
+    println!("- manifest: {}", result.manifest_path.display());
+    if result.merged_source_ids.len() > 1 {
+        println!("- merged sources: {}", result.merged_source_ids.join(", "));
+    }
+    Ok(true)
+}
+
+fn discover_onboard_import_candidates() -> CliResult<Option<OnboardImportDiscovery>> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut sources = Vec::new();
+    for root in onboard_search_roots() {
+        if !root.exists() {
+            continue;
+        }
+        let report = mvp::migration::discover_import_sources(
+            &root,
+            mvp::migration::DiscoveryOptions::default(),
+        )?;
+        for source in report.sources {
+            let canonical = source
+                .path
+                .canonicalize()
+                .unwrap_or_else(|_| source.path.clone())
+                .display()
+                .to_string();
+            if seen.insert(canonical) {
+                sources.push(source);
+            }
+        }
+    }
+
+    if sources.is_empty() {
+        return Ok(None);
+    }
+
+    sources.sort_by(|left, right| {
+        right
+            .confidence_score
+            .cmp(&left.confidence_score)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    let report = mvp::migration::DiscoveryReport { sources };
+    let summary = mvp::migration::plan_import_sources(&report)?;
+    let recommendation = mvp::migration::recommend_primary_source(&summary).ok();
+    Ok(Some(OnboardImportDiscovery {
+        report,
+        summary,
+        recommendation,
+    }))
+}
+
+fn onboard_search_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    let push_root =
+        |roots: &mut Vec<PathBuf>, seen: &mut std::collections::BTreeSet<String>, path: PathBuf| {
+            let canonical = path
+                .canonicalize()
+                .unwrap_or_else(|_| path.clone())
+                .display()
+                .to_string();
+            if seen.insert(canonical) {
+                roots.push(path);
+            }
+        };
+
+    if let Ok(cwd) = std::env::current_dir() {
+        push_root(&mut roots, &mut seen, cwd.clone());
+        if let Some(parent) = cwd.parent() {
+            push_root(&mut roots, &mut seen, parent.to_path_buf());
+        }
+    }
+    if let Some(home) = env::var_os("HOME").map(PathBuf::from) {
+        push_root(&mut roots, &mut seen, home.clone());
+        push_root(&mut roots, &mut seen, home.join(".config"));
+    }
+    if let Some(config_parent) = mvp::config::default_loongclaw_home()
+        .parent()
+        .map(Path::to_path_buf)
+    {
+        push_root(&mut roots, &mut seen, config_parent);
+    }
+
+    roots
+}
+
+fn resolve_interactive_onboard_import_strategy(
+    discovery: &OnboardImportDiscovery,
+) -> CliResult<OnboardImportStrategy> {
+    let default_choice = if discovery.summary.plans.is_empty() {
+        "s"
+    } else {
+        "r"
+    };
+    println!("Import options:");
+    if let Some(recommendation) = discovery.recommendation.as_ref() {
+        println!("  [r] Recommended source ({})", recommendation.source_id);
+    }
+    for plan in &discovery.summary.plans {
+        println!("  [{}] Import only {}", plan.source_id, plan.source_id);
+    }
+    if discovery.summary.plans.len() > 1 {
+        println!("  [m] Safe profile merge");
+    }
+    println!("  [s] Skip import");
+
+    loop {
+        let choice = prompt_with_default("Import strategy", default_choice)?;
+        let trimmed = choice.trim().to_ascii_lowercase();
+        match trimmed.as_str() {
+            "r" => return resolve_onboard_import_strategy(&discovery.summary, false),
+            "s" | "skip" => {
+                return Ok(OnboardImportStrategy {
+                    mode: OnboardImportMode::Skip,
+                    recommended_source_id: discovery
+                        .recommendation
+                        .as_ref()
+                        .map(|recommendation| recommendation.source_id.clone()),
+                });
+            }
+            "m" | "merge" if discovery.summary.plans.len() > 1 => {
+                return resolve_onboard_import_strategy(&discovery.summary, true);
+            }
+            other
+                if discovery
+                    .summary
+                    .plans
+                    .iter()
+                    .any(|plan| plan.source_id == other) =>
+            {
+                return Ok(OnboardImportStrategy {
+                    mode: OnboardImportMode::SelectedSingleSource {
+                        source_id: other.to_owned(),
+                    },
+                    recommended_source_id: discovery
+                        .recommendation
+                        .as_ref()
+                        .map(|recommendation| recommendation.source_id.clone()),
+                });
+            }
+            _ => {
+                println!("Invalid import strategy: {trimmed}");
+            }
+        }
     }
 }
 
@@ -847,4 +1058,13 @@ fn resolve_backup_path(original: &Path) -> CliResult<PathBuf> {
 
     let timestamp = Local::now().format("%Y%m%d-%H%M%S").to_string();
     Ok(parent.join(format!("{}.toml.bak-{}", file_stem, timestamp)))
+}
+
+fn load_or_default_onboard_config(path: &Path) -> CliResult<mvp::config::LoongClawConfig> {
+    if !path.exists() {
+        return Ok(mvp::config::LoongClawConfig::default());
+    }
+    let path_string = path.display().to_string();
+    let (_, config) = mvp::config::load(Some(&path_string))?;
+    Ok(config)
 }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -36,6 +36,20 @@ struct OnboardCheck {
     detail: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum OnboardImportMode {
+    Skip,
+    RecommendedSingleSource { source_id: String },
+    SelectedSingleSource { source_id: String },
+    SafeProfileMerge,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OnboardImportStrategy {
+    pub mode: OnboardImportMode,
+    pub recommended_source_id: Option<String>,
+}
+
 pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult<()> {
     validate_non_interactive_risk_gate(options.non_interactive, options.accept_risk)?;
     let using_prompt_override = options
@@ -577,6 +591,85 @@ pub(crate) fn validate_non_interactive_risk_gate(
         );
     }
     Ok(())
+}
+
+pub(crate) fn resolve_onboard_import_strategy(
+    summary: &mvp::migration::DiscoveryPlanSummary,
+    prefer_safe_profile_merge: bool,
+) -> CliResult<OnboardImportStrategy> {
+    let recommended_source_id = match summary.plans.len() {
+        0 => None,
+        1 => summary.plans.first().map(|plan| plan.source_id.clone()),
+        _ => Some(mvp::migration::recommend_primary_source(summary)?.source_id),
+    };
+
+    let mode = match (summary.plans.len(), prefer_safe_profile_merge) {
+        (0, _) => OnboardImportMode::Skip,
+        (_, true) if summary.plans.len() > 1 => OnboardImportMode::SafeProfileMerge,
+        _ => OnboardImportMode::RecommendedSingleSource {
+            source_id: recommended_source_id
+                .clone()
+                .ok_or_else(|| "missing recommended import source".to_owned())?,
+        },
+    };
+
+    Ok(OnboardImportStrategy {
+        mode,
+        recommended_source_id,
+    })
+}
+
+pub(crate) fn build_onboard_import_summary(
+    summary: &mvp::migration::DiscoveryPlanSummary,
+    recommendation: Option<&mvp::migration::PrimarySourceRecommendation>,
+) -> String {
+    if summary.plans.is_empty() {
+        return "No legacy claw import sources detected.".to_owned();
+    }
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "Detected {} legacy claw source(s).",
+        summary.plans.len()
+    ));
+
+    for plan in &summary.plans {
+        let prompt_state = if plan.prompt_addendum_present {
+            "prompt overlay"
+        } else {
+            "no prompt overlay"
+        };
+        let profile_state = if plan.profile_note_present {
+            "profile overlay"
+        } else {
+            "no profile overlay"
+        };
+        let warning_state = if plan.warning_count == 0 {
+            "no warnings".to_owned()
+        } else {
+            format!("{} warning(s)", plan.warning_count)
+        };
+        lines.push(format!(
+            "- {}: score {}, {}, {}, {}",
+            plan.source_id, plan.confidence_score, prompt_state, profile_state, warning_state
+        ));
+    }
+
+    if let Some(recommendation) = recommendation {
+        lines.push(format!(
+            "Recommended import source: {}",
+            recommendation.source_id
+        ));
+    }
+
+    if summary.plans.len() > 1 {
+        lines.push(
+            "Secondary option: safe profile merge keeps LoongClaw native prompts and merges only profile-lane traits."
+                .to_owned(),
+        );
+    }
+
+    lines.join("\n")
 }
 
 pub(crate) fn parse_provider_kind(raw: &str) -> Option<mvp::config::ProviderKind> {

--- a/crates/daemon/src/tests/import_claw_cli.rs
+++ b/crates/daemon/src/tests/import_claw_cli.rs
@@ -1,0 +1,108 @@
+use super::*;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+}
+
+fn write_file(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent directory");
+    }
+    fs::write(path, content).expect("write fixture");
+}
+
+#[test]
+fn parse_legacy_claw_source_accepts_supported_ids() {
+    assert_eq!(
+        crate::import_claw_cli::parse_legacy_claw_source("nanobot"),
+        Some(mvp::migration::LegacyClawSource::Nanobot)
+    );
+    assert_eq!(
+        crate::import_claw_cli::parse_legacy_claw_source("openclaw"),
+        Some(mvp::migration::LegacyClawSource::OpenClaw)
+    );
+    assert_eq!(
+        crate::import_claw_cli::parse_legacy_claw_source("picoclaw"),
+        Some(mvp::migration::LegacyClawSource::PicoClaw)
+    );
+    assert_eq!(
+        crate::import_claw_cli::parse_legacy_claw_source("zeroclaw"),
+        Some(mvp::migration::LegacyClawSource::ZeroClaw)
+    );
+    assert_eq!(
+        crate::import_claw_cli::parse_legacy_claw_source("nanoclaw"),
+        Some(mvp::migration::LegacyClawSource::NanoClaw)
+    );
+    assert_eq!(
+        crate::import_claw_cli::parse_legacy_claw_source("auto"),
+        Some(mvp::migration::LegacyClawSource::Unknown)
+    );
+    assert_eq!(
+        crate::import_claw_cli::parse_legacy_claw_source("unsupported"),
+        None
+    );
+}
+
+#[test]
+fn run_import_claw_cli_writes_nativeized_config() {
+    let legacy_root = unique_temp_dir("loongclaw-import-cli-legacy");
+    let output_root = unique_temp_dir("loongclaw-import-cli-output");
+    fs::create_dir_all(&legacy_root).expect("create legacy root");
+    fs::create_dir_all(&output_root).expect("create output root");
+
+    write_file(
+        &legacy_root,
+        "SOUL.md",
+        "# Soul\n\nAlways prefer concise shell output. updated by nanobot.\n",
+    );
+    write_file(
+        &legacy_root,
+        "IDENTITY.md",
+        "# Identity\n\n- Name: Release copilot\n- Motto: your nanobot agent for deploys\n",
+    );
+
+    let output_path = output_root.join("loongclaw.toml");
+    crate::import_claw_cli::run_import_claw_cli(crate::import_claw_cli::ImportClawCommandOptions {
+        input: legacy_root.display().to_string(),
+        output: Some(output_path.display().to_string()),
+        source: Some("nanobot".to_owned()),
+        force: true,
+    })
+    .expect("import command should succeed");
+
+    let (_, config) = mvp::config::load(Some(&output_path.display().to_string()))
+        .expect("imported config should load");
+    assert_eq!(
+        config.cli.prompt_pack_id.as_deref(),
+        Some(mvp::prompt::DEFAULT_PROMPT_PACK_ID)
+    );
+    assert_eq!(
+        config.memory.profile,
+        mvp::config::MemoryProfile::ProfilePlusWindow
+    );
+    assert_eq!(
+        config.cli.system_prompt_addendum.as_deref(),
+        Some(
+            "## Imported SOUL.md\n# Soul\n\nAlways prefer concise shell output. updated by LoongClaw."
+        )
+    );
+    assert_eq!(
+        config.memory.profile_note.as_deref(),
+        Some(
+            "## Imported IDENTITY.md\n# Identity\n\n- Name: Release copilot\n- Motto: your LoongClaw agent for deploys"
+        )
+    );
+
+    fs::remove_dir_all(&legacy_root).ok();
+    fs::remove_dir_all(&output_root).ok();
+}

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -30,6 +30,7 @@ fn sign_security_scan_profile_for_test(profile: &SecurityScanProfile) -> (String
 }
 
 mod architecture;
+mod import_claw_cli;
 mod onboard_cli;
 mod programmatic;
 mod spec_runtime;

--- a/crates/daemon/src/tests/onboard_cli.rs
+++ b/crates/daemon/src/tests/onboard_cli.rs
@@ -173,3 +173,28 @@ fn onboard_import_summary_shows_safe_merge_as_secondary_option() {
     assert!(summary_text.contains("Recommended import source: openclaw"));
     assert!(summary_text.contains("safe profile merge"));
 }
+
+#[test]
+fn non_interactive_onboard_blocks_multi_source_merge_without_explicit_opt_in() {
+    let strategy = crate::onboard_cli::OnboardImportStrategy {
+        mode: crate::onboard_cli::OnboardImportMode::SafeProfileMerge,
+        recommended_source_id: Some("openclaw".to_owned()),
+    };
+
+    let err = crate::onboard_cli::validate_non_interactive_import_strategy(&strategy, false)
+        .expect_err("should block");
+    assert!(err.contains("multi-source"));
+}
+
+#[test]
+fn non_interactive_onboard_allows_selected_single_source_strategy() {
+    let strategy = crate::onboard_cli::OnboardImportStrategy {
+        mode: crate::onboard_cli::OnboardImportMode::SelectedSingleSource {
+            source_id: "openclaw".to_owned(),
+        },
+        recommended_source_id: Some("openclaw".to_owned()),
+    };
+
+    crate::onboard_cli::validate_non_interactive_import_strategy(&strategy, false)
+        .expect("single-source strategy should pass");
+}

--- a/crates/daemon/src/tests/onboard_cli.rs
+++ b/crates/daemon/src/tests/onboard_cli.rs
@@ -54,6 +54,43 @@ fn provider_kind_id_mapping_includes_kimi_coding() {
 }
 
 #[test]
+fn parse_prompt_personality_accepts_supported_ids() {
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("calm_engineering"),
+        Some(mvp::prompt::PromptPersonality::CalmEngineering)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("friendly_collab"),
+        Some(mvp::prompt::PromptPersonality::FriendlyCollab)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("autonomous_executor"),
+        Some(mvp::prompt::PromptPersonality::AutonomousExecutor)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("unknown"),
+        None
+    );
+}
+
+#[test]
+fn parse_memory_profile_accepts_supported_ids() {
+    assert_eq!(
+        crate::onboard_cli::parse_memory_profile("window_only"),
+        Some(mvp::config::MemoryProfile::WindowOnly)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_memory_profile("window_plus_summary"),
+        Some(mvp::config::MemoryProfile::WindowPlusSummary)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_memory_profile("profile_plus_window"),
+        Some(mvp::config::MemoryProfile::ProfilePlusWindow)
+    );
+    assert_eq!(crate::onboard_cli::parse_memory_profile("unknown"), None);
+}
+
+#[test]
 fn non_interactive_requires_explicit_risk_acknowledgement() {
     let denied = crate::onboard_cli::validate_non_interactive_risk_gate(true, false)
         .expect_err("risk gate should reject non-interactive without acknowledgement");

--- a/crates/daemon/src/tests/onboard_cli.rs
+++ b/crates/daemon/src/tests/onboard_cli.rs
@@ -101,3 +101,75 @@ fn non_interactive_requires_explicit_risk_acknowledgement() {
     crate::onboard_cli::validate_non_interactive_risk_gate(false, false)
         .expect("interactive mode should not require explicit flag");
 }
+
+#[test]
+fn onboard_import_strategy_defaults_to_recommended_single_source() {
+    let summary = mvp::migration::DiscoveryPlanSummary {
+        plans: vec![
+            mvp::migration::PlannedImportSource {
+                source: mvp::migration::LegacyClawSource::OpenClaw,
+                source_id: "openclaw".to_owned(),
+                input_path: std::path::PathBuf::from("/tmp/openclaw"),
+                confidence_score: 42,
+                prompt_addendum_present: true,
+                profile_note_present: true,
+                warning_count: 0,
+            },
+            mvp::migration::PlannedImportSource {
+                source: mvp::migration::LegacyClawSource::Nanobot,
+                source_id: "nanobot".to_owned(),
+                input_path: std::path::PathBuf::from("/tmp/nanobot"),
+                confidence_score: 18,
+                prompt_addendum_present: false,
+                profile_note_present: true,
+                warning_count: 0,
+            },
+        ],
+    };
+
+    let recommendation = crate::onboard_cli::resolve_onboard_import_strategy(&summary, false)
+        .expect("strategy should resolve");
+    assert_eq!(
+        recommendation.mode,
+        crate::onboard_cli::OnboardImportMode::RecommendedSingleSource {
+            source_id: "openclaw".to_owned()
+        }
+    );
+}
+
+#[test]
+fn onboard_import_summary_shows_safe_merge_as_secondary_option() {
+    let summary = mvp::migration::DiscoveryPlanSummary {
+        plans: vec![
+            mvp::migration::PlannedImportSource {
+                source: mvp::migration::LegacyClawSource::OpenClaw,
+                source_id: "openclaw".to_owned(),
+                input_path: std::path::PathBuf::from("/tmp/openclaw"),
+                confidence_score: 42,
+                prompt_addendum_present: true,
+                profile_note_present: true,
+                warning_count: 0,
+            },
+            mvp::migration::PlannedImportSource {
+                source: mvp::migration::LegacyClawSource::Nanobot,
+                source_id: "nanobot".to_owned(),
+                input_path: std::path::PathBuf::from("/tmp/nanobot"),
+                confidence_score: 18,
+                prompt_addendum_present: false,
+                profile_note_present: true,
+                warning_count: 1,
+            },
+        ],
+    };
+    let recommendation = mvp::migration::PrimarySourceRecommendation {
+        source: mvp::migration::LegacyClawSource::OpenClaw,
+        source_id: "openclaw".to_owned(),
+        input_path: std::path::PathBuf::from("/tmp/openclaw"),
+        reasons: vec!["contains imported prompt overlay".to_owned()],
+    };
+
+    let summary_text =
+        crate::onboard_cli::build_onboard_import_summary(&summary, Some(&recommendation));
+    assert!(summary_text.contains("Recommended import source: openclaw"));
+    assert!(summary_text.contains("safe profile merge"));
+}

--- a/crates/daemon/src/tests/spec_runtime.rs
+++ b/crates/daemon/src/tests/spec_runtime.rs
@@ -4739,6 +4739,127 @@ async fn execute_spec_tool_extension_can_merge_profiles_without_merging_prompt_l
 }
 
 #[tokio::test]
+async fn execute_spec_tool_extension_apply_selected_safe_merge_keeps_native_prompt() {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    fn write_file(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent directory");
+        }
+        fs::write(path, content).expect("write fixture");
+    }
+
+    let root = unique_temp_dir("loongclaw-spec-tool-extension-apply-safe-merge");
+    fs::create_dir_all(&root).expect("create fixture root");
+
+    let openclaw_root = root.join("openclaw-workspace");
+    fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+    write_file(
+        &openclaw_root,
+        "SOUL.md",
+        "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+    );
+    write_file(
+        &openclaw_root,
+        "IDENTITY.md",
+        "# Identity\n\n- role: release copilot\n",
+    );
+
+    let nanobot_root = root.join("nanobot");
+    fs::create_dir_all(&nanobot_root).expect("create nanobot root");
+    write_file(
+        &nanobot_root,
+        "IDENTITY.md",
+        "# Identity\n\n- region: apac\n",
+    );
+
+    let output_path = root.join("loongclaw.toml");
+    let mut existing = loongclaw_app::config::LoongClawConfig::default();
+    existing.cli.system_prompt_addendum = Some("Native LoongClaw prompt".to_owned());
+    let existing_body = loongclaw_app::config::render(&existing).expect("render existing config");
+    fs::write(&output_path, existing_body).expect("write existing config");
+
+    let spec = RunnerSpec {
+        pack: VerticalPackManifest {
+            pack_id: "spec-tool-extension-claw-apply-safe-merge".to_owned(),
+            domain: "ops".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: Some("pi-local".to_owned()),
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            metadata: BTreeMap::new(),
+        },
+        agent_id: "agent-tool-extension-claw-apply-safe-merge".to_owned(),
+        ttl_s: 120,
+        approval: None,
+        defaults: None,
+        self_awareness: None,
+        plugin_scan: None,
+        bridge_support: None,
+        bootstrap: None,
+        auto_provision: None,
+        hotfixes: Vec::new(),
+        operation: OperationSpec::ToolExtension {
+            extension_action: "apply_selected".to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            payload: json!({
+                "input_path": root.display().to_string(),
+                "output_path": output_path.display().to_string(),
+                "safe_profile_merge": true,
+                "primary_source_id": "openclaw"
+            }),
+            extension: "claw-migration".to_owned(),
+            core: None,
+        },
+    };
+
+    let report = execute_spec(spec, true).await;
+    assert_eq!(report.operation_kind, "tool_extension");
+    assert_eq!(report.outcome["outcome"]["status"], "ok");
+    assert_eq!(
+        report.outcome["outcome"]["payload"]["action"],
+        "apply_selected"
+    );
+    assert_eq!(
+        report.outcome["outcome"]["payload"]["result"]["prompt_owner_source_id"],
+        serde_json::Value::Null
+    );
+
+    let output_string = output_path.display().to_string();
+    let (_, merged_config) =
+        loongclaw_app::config::load(Some(&output_string)).expect("load merged config");
+    assert_eq!(
+        merged_config.cli.system_prompt_addendum.as_deref(),
+        Some("Native LoongClaw prompt")
+    );
+    let profile_note = merged_config
+        .memory
+        .profile_note
+        .as_deref()
+        .expect("profile note should be present");
+    assert!(profile_note.contains("role: release copilot"));
+    assert!(profile_note.contains("region: apac"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
 async fn execute_spec_denylist_overrides_other_approvals() {
     let spec = RunnerSpec {
         pack: VerticalPackManifest {

--- a/crates/daemon/src/tests/spec_runtime.rs
+++ b/crates/daemon/src/tests/spec_runtime.rs
@@ -4545,6 +4545,200 @@ async fn execute_spec_tool_extension_can_hot_handle_claw_import_via_core_wrapper
 }
 
 #[tokio::test]
+async fn execute_spec_tool_extension_can_discover_multiple_sources() {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    fn write_file(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent directory");
+        }
+        fs::write(path, content).expect("write fixture");
+    }
+
+    let root = unique_temp_dir("loongclaw-spec-tool-extension-discover-many");
+    fs::create_dir_all(&root).expect("create fixture root");
+
+    let openclaw_root = root.join("openclaw-workspace");
+    fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+    write_file(
+        &openclaw_root,
+        "SOUL.md",
+        "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+    );
+    write_file(
+        &openclaw_root,
+        "IDENTITY.md",
+        "# Identity\n\n- role: release copilot\n",
+    );
+
+    let nanobot_root = root.join("nanobot");
+    fs::create_dir_all(&nanobot_root).expect("create nanobot root");
+    write_file(
+        &nanobot_root,
+        "IDENTITY.md",
+        "# Identity\n\n- Motto: your nanobot agent for deploys\n",
+    );
+
+    let spec = RunnerSpec {
+        pack: VerticalPackManifest {
+            pack_id: "spec-tool-extension-claw-discover-many".to_owned(),
+            domain: "ops".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: Some("pi-local".to_owned()),
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            metadata: BTreeMap::new(),
+        },
+        agent_id: "agent-tool-extension-claw-discover-many".to_owned(),
+        ttl_s: 120,
+        approval: None,
+        defaults: None,
+        self_awareness: None,
+        plugin_scan: None,
+        bridge_support: None,
+        bootstrap: None,
+        auto_provision: None,
+        hotfixes: Vec::new(),
+        operation: OperationSpec::ToolExtension {
+            extension_action: "discover".to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            payload: json!({
+                "input_path": root.display().to_string()
+            }),
+            extension: "claw-migration".to_owned(),
+            core: None,
+        },
+    };
+
+    let report = execute_spec(spec, true).await;
+    assert_eq!(report.operation_kind, "tool_extension");
+    assert_eq!(report.outcome["outcome"]["status"], "ok");
+    assert_eq!(report.outcome["outcome"]["payload"]["action"], "discover");
+    assert!(
+        report.outcome["outcome"]["payload"]["sources"]
+            .as_array()
+            .expect("sources should be an array")
+            .len()
+            >= 2
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn execute_spec_tool_extension_can_merge_profiles_without_merging_prompt_lane() {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    fn write_file(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent directory");
+        }
+        fs::write(path, content).expect("write fixture");
+    }
+
+    let root = unique_temp_dir("loongclaw-spec-tool-extension-merge-profiles");
+    fs::create_dir_all(&root).expect("create fixture root");
+
+    let openclaw_root = root.join("openclaw-workspace");
+    fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+    write_file(
+        &openclaw_root,
+        "SOUL.md",
+        "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+    );
+    write_file(
+        &openclaw_root,
+        "IDENTITY.md",
+        "# Identity\n\n- role: release copilot\n- tone: steady\n",
+    );
+
+    let nanobot_root = root.join("nanobot");
+    fs::create_dir_all(&nanobot_root).expect("create nanobot root");
+    write_file(
+        &nanobot_root,
+        "IDENTITY.md",
+        "# Identity\n\n- role: release copilot\n- region: apac\n",
+    );
+
+    let spec = RunnerSpec {
+        pack: VerticalPackManifest {
+            pack_id: "spec-tool-extension-claw-merge-profiles".to_owned(),
+            domain: "ops".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: Some("pi-local".to_owned()),
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            metadata: BTreeMap::new(),
+        },
+        agent_id: "agent-tool-extension-claw-merge-profiles".to_owned(),
+        ttl_s: 120,
+        approval: None,
+        defaults: None,
+        self_awareness: None,
+        plugin_scan: None,
+        bridge_support: None,
+        bootstrap: None,
+        auto_provision: None,
+        hotfixes: Vec::new(),
+        operation: OperationSpec::ToolExtension {
+            extension_action: "merge_profiles".to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            payload: json!({
+                "input_path": root.display().to_string()
+            }),
+            extension: "claw-migration".to_owned(),
+            core: None,
+        },
+    };
+
+    let report = execute_spec(spec, true).await;
+    assert_eq!(report.operation_kind, "tool_extension");
+    assert_eq!(report.outcome["outcome"]["status"], "ok");
+    assert_eq!(
+        report.outcome["outcome"]["payload"]["action"],
+        "merge_profiles"
+    );
+    assert_eq!(
+        report.outcome["outcome"]["payload"]["result"]["prompt_owner_source_id"],
+        "openclaw"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
 async fn execute_spec_denylist_overrides_other_approvals() {
     let spec = RunnerSpec {
         pack: VerticalPackManifest {

--- a/crates/daemon/src/tests/spec_runtime.rs
+++ b/crates/daemon/src/tests/spec_runtime.rs
@@ -4369,6 +4369,182 @@ async fn execute_spec_default_medium_policy_allows_low_risk_tool_call_without_ap
 }
 
 #[tokio::test]
+async fn execute_spec_tool_core_can_run_claw_import_plan_via_native_tool_runtime() {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    fn write_file(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent directory");
+        }
+        fs::write(path, content).expect("write fixture");
+    }
+
+    let root = unique_temp_dir("loongclaw-spec-tool-core-import");
+    fs::create_dir_all(&root).expect("create fixture root");
+    write_file(
+        &root,
+        "SOUL.md",
+        "# Soul\n\nAlways prefer concise shell output. updated by nanobot.\n",
+    );
+    write_file(
+        &root,
+        "IDENTITY.md",
+        "# Identity\n\n- Motto: your nanobot agent for deploys\n",
+    );
+
+    let spec = RunnerSpec {
+        pack: VerticalPackManifest {
+            pack_id: "spec-tool-core-claw-import".to_owned(),
+            domain: "ops".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: Some("pi-local".to_owned()),
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            metadata: BTreeMap::new(),
+        },
+        agent_id: "agent-tool-core-claw-import".to_owned(),
+        ttl_s: 120,
+        approval: None,
+        defaults: None,
+        self_awareness: None,
+        plugin_scan: None,
+        bridge_support: None,
+        bootstrap: None,
+        auto_provision: None,
+        hotfixes: Vec::new(),
+        operation: OperationSpec::ToolCore {
+            tool_name: "claw.import".to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            payload: json!({
+                "mode": "plan",
+                "source": "nanobot",
+                "input_path": root.display().to_string()
+            }),
+            core: None,
+        },
+    };
+
+    let report = execute_spec(spec, true).await;
+    assert_eq!(report.operation_kind, "tool_core");
+    assert_eq!(report.outcome["outcome"]["status"], "ok");
+    assert_eq!(report.outcome["outcome"]["payload"]["source"], "nanobot");
+    assert_eq!(
+        report.outcome["outcome"]["payload"]["config_preview"]["prompt_pack_id"],
+        "loongclaw-core-v1"
+    );
+    assert!(
+        report.outcome["outcome"]["payload"]["config_preview"]["system_prompt_addendum"]
+            .as_str()
+            .expect("prompt addendum should exist")
+            .contains("LoongClaw")
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn execute_spec_tool_extension_can_hot_handle_claw_import_via_core_wrapper() {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    fn write_file(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent directory");
+        }
+        fs::write(path, content).expect("write fixture");
+    }
+
+    let root = unique_temp_dir("loongclaw-spec-tool-extension-import");
+    fs::create_dir_all(&root).expect("create fixture root");
+    write_file(
+        &root,
+        "SOUL.md",
+        "# Soul\n\nAlways prefer concise shell output. updated by nanobot.\n",
+    );
+
+    let spec = RunnerSpec {
+        pack: VerticalPackManifest {
+            pack_id: "spec-tool-extension-claw-import".to_owned(),
+            domain: "ops".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: Some("pi-local".to_owned()),
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            metadata: BTreeMap::new(),
+        },
+        agent_id: "agent-tool-extension-claw-import".to_owned(),
+        ttl_s: 120,
+        approval: None,
+        defaults: None,
+        self_awareness: None,
+        plugin_scan: None,
+        bridge_support: None,
+        bootstrap: None,
+        auto_provision: None,
+        hotfixes: Vec::new(),
+        operation: OperationSpec::ToolExtension {
+            extension_action: "plan".to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            payload: json!({
+                "source": "nanobot",
+                "input_path": root.display().to_string()
+            }),
+            extension: "claw-migration".to_owned(),
+            core: None,
+        },
+    };
+
+    let report = execute_spec(spec, true).await;
+    assert_eq!(report.operation_kind, "tool_extension");
+    assert_eq!(report.outcome["outcome"]["status"], "ok");
+    assert_eq!(
+        report.outcome["outcome"]["payload"]["extension"],
+        "claw-migration"
+    );
+    assert_eq!(
+        report.outcome["outcome"]["payload"]["core_outcome"]["mode"],
+        "plan"
+    );
+    assert_eq!(
+        report.outcome["outcome"]["payload"]["core_outcome"]["source"],
+        "nanobot"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
 async fn execute_spec_denylist_overrides_other_approvals() {
     let spec = RunnerSpec {
         pack: VerticalPackManifest {

--- a/crates/spec/Cargo.toml
+++ b/crates/spec/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 [dependencies]
 async-trait.workspace = true
 kernel = { package = "loongclaw-kernel", path = "../kernel" }
+loongclaw-app = { path = "../app", default-features = false, features = ["config-toml"] }
 loongclaw-protocol = { path = "../protocol" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/spec/src/kernel_bootstrap.rs
+++ b/crates/spec/src/kernel_bootstrap.rs
@@ -8,8 +8,8 @@ use kernel::{
 
 use crate::DEFAULT_PACK_ID;
 use crate::spec_runtime::{
-    AcpBridgeRuntimeExtension, CoreToolRuntime, CrmCoreConnector, CrmGrpcCoreConnector,
-    EmbeddedPiHarness, FallbackCoreRuntime, KvCoreMemory, NativeCoreRuntime,
+    AcpBridgeRuntimeExtension, ClawMigrationToolExtension, CoreToolRuntime, CrmCoreConnector,
+    CrmGrpcCoreConnector, EmbeddedPiHarness, FallbackCoreRuntime, KvCoreMemory, NativeCoreRuntime,
     ShieldedConnectorExtension, SqlAnalyticsToolExtension, VectorIndexMemoryExtension,
     WebhookConnector,
 };
@@ -82,6 +82,7 @@ fn register_builtin_adapters(kernel: &mut LoongClawKernel<StaticPolicyEngine>) {
     kernel.register_runtime_extension_adapter(AcpBridgeRuntimeExtension);
 
     kernel.register_core_tool_adapter(CoreToolRuntime);
+    kernel.register_tool_extension_adapter(ClawMigrationToolExtension);
     kernel.register_tool_extension_adapter(SqlAnalyticsToolExtension);
 
     kernel.register_core_memory_adapter(KvCoreMemory);

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -2384,6 +2384,15 @@ fn stub_tool_core(request: ToolCoreRequest) -> Result<ToolCoreOutcome, String> {
     })
 }
 
+fn maybe_execute_native_app_tool(
+    request: &ToolCoreRequest,
+) -> Option<Result<ToolCoreOutcome, String>> {
+    if loongclaw_app::tools::canonical_tool_name(request.tool_name.as_str()) != "claw.import" {
+        return None;
+    }
+    Some(loongclaw_app::tools::execute_tool_core(request.clone()))
+}
+
 fn stub_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
     Ok(MemoryCoreOutcome {
         status: "ok".to_string(),
@@ -2403,6 +2412,9 @@ impl CoreToolAdapter for CoreToolRuntime {
         &self,
         request: ToolCoreRequest,
     ) -> Result<ToolCoreOutcome, kernel::ToolPlaneError> {
+        if let Some(result) = maybe_execute_native_app_tool(&request) {
+            return result.map_err(kernel::ToolPlaneError::Execution);
+        }
         stub_tool_core(request).map_err(kernel::ToolPlaneError::Execution)
     }
 }
@@ -2433,6 +2445,46 @@ impl ToolExtensionAdapter for SqlAnalyticsToolExtension {
                 "action": request.extension_action,
                 "core_probe": core_probe.payload,
                 "payload": request.payload,
+            }),
+        })
+    }
+}
+
+pub struct ClawMigrationToolExtension;
+
+#[async_trait]
+impl ToolExtensionAdapter for ClawMigrationToolExtension {
+    fn name(&self) -> &str {
+        "claw-migration"
+    }
+
+    async fn execute_tool_extension(
+        &self,
+        request: ToolExtensionRequest,
+        core: &(dyn CoreToolAdapter + Sync),
+    ) -> Result<ToolExtensionOutcome, kernel::ToolPlaneError> {
+        let mut payload = request.payload.clone();
+        if payload.get("mode").is_none() {
+            if let Some(object) = payload.as_object_mut() {
+                object.insert(
+                    "mode".to_owned(),
+                    Value::String(request.extension_action.clone()),
+                );
+            }
+        }
+
+        let core_outcome = core
+            .execute_core_tool(ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload,
+            })
+            .await?;
+        Ok(ToolExtensionOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "extension": "claw-migration",
+                "action": request.extension_action,
+                "core_outcome": core_outcome.payload,
             }),
         })
     }

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -2464,13 +2464,13 @@ impl ToolExtensionAdapter for ClawMigrationToolExtension {
         core: &(dyn CoreToolAdapter + Sync),
     ) -> Result<ToolExtensionOutcome, kernel::ToolPlaneError> {
         let mut payload = request.payload.clone();
-        if payload.get("mode").is_none() {
-            if let Some(object) = payload.as_object_mut() {
-                object.insert(
-                    "mode".to_owned(),
-                    Value::String(request.extension_action.clone()),
-                );
-            }
+        if payload.get("mode").is_none()
+            && let Some(object) = payload.as_object_mut()
+        {
+            object.insert(
+                "mode".to_owned(),
+                Value::String(request.extension_action.clone()),
+            );
         }
 
         let core_outcome = core

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -2479,13 +2479,26 @@ impl ToolExtensionAdapter for ClawMigrationToolExtension {
                 payload,
             })
             .await?;
+        let mut response = serde_json::Map::new();
+        response.insert(
+            "extension".to_owned(),
+            Value::String("claw-migration".to_owned()),
+        );
+        response.insert(
+            "action".to_owned(),
+            Value::String(request.extension_action.clone()),
+        );
+        response.insert("core_outcome".to_owned(), core_outcome.payload.clone());
+        if let Some(core_object) = core_outcome.payload.as_object() {
+            for (key, value) in core_object {
+                response.entry(key.clone()).or_insert_with(|| value.clone());
+            }
+        } else {
+            response.insert("result".to_owned(), core_outcome.payload.clone());
+        }
         Ok(ToolExtensionOutcome {
             status: "ok".to_owned(),
-            payload: json!({
-                "extension": "claw-migration",
-                "action": request.extension_action,
-                "core_outcome": core_outcome.payload,
-            }),
+            payload: Value::Object(response),
         })
     }
 }

--- a/docs/plans/2026-03-11-loongclaw-memory-architecture-design.md
+++ b/docs/plans/2026-03-11-loongclaw-memory-architecture-design.md
@@ -1,0 +1,327 @@
+# LoongClaw Memory Architecture Design
+
+Date: 2026-03-11
+Status: Approved for implementation
+
+## Summary
+
+LoongClaw needs a memory architecture that is pluggable at the policy level
+before it becomes pluggable at the storage-backend level. The current MVP
+memory path is still SQLite-first and sliding-window-first:
+
+- config only exposes `sqlite_path` and `sliding_window`
+- provider/chat/channel code reads memory by directly calling SQLite helpers
+- runtime behavior cannot distinguish between "recent context", "condensed
+  session memory", and "durable identity/profile memory"
+
+That is enough for a basic chat loop, but it is not enough for the product
+direction the migration work needs:
+
+- one-click migration from other claws
+- inheritance of prior identity/tuning/preferences
+- user-selectable memory behavior
+- future support for multiple memory backends without rewriting product logic
+
+The recommended direction is:
+
+- expose `memory.profile` as the primary user-facing choice
+- keep `memory.backend` as a secondary implementation detail
+- derive an internal `memory.mode` from the selected profile
+- centralize memory hydration behind one app-layer orchestrator
+- reserve a durable `profile_note` lane for imported identity/tuning
+
+## Product Goals
+
+- Let users choose memory behavior without having to understand storage
+  backends.
+- Preserve backward compatibility with today's config and SQLite runtime.
+- Create a native place to carry imported claw identity/preferences forward.
+- Keep memory stable, deterministic, and performance-aware.
+- Keep the safety model explicit:
+  memory should enrich context, not silently bypass runtime policy.
+
+## Non-Goals For This Slice
+
+- No vector store rollout yet.
+- No LLM-generated long-term summaries yet.
+- No cross-session semantic retrieval yet.
+- No full migration importer in the same patch.
+- No breaking change to existing `sqlite_path` or `sliding_window`.
+
+## Current State
+
+Today LoongClaw memory exists in three partially separated layers:
+
+1. Kernel/contracts already support a generic memory plane with core and
+   extension adapters.
+2. App runtime still treats memory as direct SQLite storage.
+3. User config only knows about a single sliding-window policy.
+
+This creates two problems:
+
+1. The kernel is more abstract than the product runtime that sits above it.
+2. Migration/import features have nowhere durable to store inherited identity
+   outside of prompt text.
+
+## Design Principle: Profile First, Backend Second
+
+Users should not start by choosing `sqlite`, `redis`, or `vector`.
+
+They should start by choosing the behavior they want:
+
+- keep only recent context
+- keep recent context plus condensed earlier context
+- keep recent context plus a durable user/agent profile
+
+That gives LoongClaw a stable product surface even while storage engines change
+later.
+
+## Approaches Considered
+
+### Approach 1: Backend Abstraction Only
+
+Add `memory.backend = sqlite|...` and keep all runtime behavior unchanged.
+
+Pros:
+
+- low implementation cost
+- easy to explain internally
+
+Cons:
+
+- does not solve user-facing memory behavior
+- does not help migration/nativeization
+- leaves provider/chat code coupled to low-level retrieval details
+
+### Approach 2: Profile/Mode Abstraction At App Layer
+
+Keep SQLite as the only backend for now, but introduce explicit memory
+profiles/modes and route all retrieval through a shared app-layer orchestrator.
+
+Pros:
+
+- matches the product need now
+- preserves backward compatibility
+- creates a clean bridge toward imported identity/profile memory
+- prepares backend pluggability without blocking on it
+
+Cons:
+
+- adds new config/runtime types
+- summary/profile behavior remains intentionally lightweight in v0.1
+
+### Approach 3: Full Memory Plane Productization
+
+Immediately build configurable backends, retrieval policies, summary stores,
+profile stores, migration importers, and cross-session retrieval.
+
+Pros:
+
+- strongest long-term architecture
+
+Cons:
+
+- too large for one safe patch
+- high validation burden
+- too much product surface before the first stable abstraction exists
+
+## Decision
+
+Adopt Approach 2.
+
+The first memory architecture slice should make behavior pluggable without
+pretending multiple storage engines already exist. That means:
+
+- `backend` becomes explicit but still defaults to `sqlite`
+- `profile` becomes the user-facing choice
+- `mode` is derived internally from `profile`
+- provider/chat/channel paths stop calling SQLite window helpers directly
+
+## Proposed User-Facing Memory Profiles
+
+### 1. `window_only`
+
+Behavior:
+
+- inject only the recent sliding window into model context
+
+Use when:
+
+- the operator wants maximum simplicity and predictable token usage
+
+### 2. `window_plus_summary`
+
+Behavior:
+
+- inject a deterministic condensed block for earlier session turns
+- inject the recent sliding window after the summary block
+
+Use when:
+
+- the operator wants more continuity without full-history token cost
+
+### 3. `profile_plus_window`
+
+Behavior:
+
+- inject a durable `profile_note` block first when configured
+- inject the recent sliding window after it
+
+Use when:
+
+- the operator wants identity/preferences/imported tuning to persist as a
+  stable memory lane
+
+## Internal Model
+
+### Memory Backend
+
+Internal field:
+
+- `MemoryBackendKind`
+
+Initial values:
+
+- `sqlite`
+
+### Memory Profile
+
+User-facing field:
+
+- `MemoryProfile`
+
+Initial values:
+
+- `window_only`
+- `window_plus_summary`
+- `profile_plus_window`
+
+### Memory Mode
+
+Internal field:
+
+- `MemoryMode`
+
+Purpose:
+
+- decouple the user-facing profile from the concrete retrieval behavior
+- make future profile-to-mode mapping evolvable
+
+In v0.1, the mapping is 1:1.
+
+## Config Evolution
+
+### Keep
+
+- `memory.sqlite_path`
+- `memory.sliding_window`
+
+### Add
+
+- `memory.backend`
+- `memory.profile`
+- `memory.summary_max_chars`
+- `memory.profile_note`
+
+### Backward Compatibility
+
+Old configs that only contain:
+
+- `sqlite_path`
+- `sliding_window`
+
+must continue to load and behave like:
+
+- `backend = "sqlite"`
+- `profile = "window_only"`
+
+## Runtime Architecture
+
+Introduce a shared memory hydration layer inside `crates/app/src/memory`.
+
+Responsibilities:
+
+- resolve runtime config from app config
+- ensure backend-specific reads are hidden behind one API
+- build model-ready memory context blocks
+- keep chat/provider/channel code free from SQLite-specific retrieval logic
+
+Suggested concepts:
+
+- raw storage operations:
+  append turn, load recent window, clear session
+- context hydration operations:
+  load prompt context, load printable history snapshot
+
+## Summary Strategy For v0.1
+
+The initial summary mode should be deterministic and local.
+
+When the session has more turns than the sliding window:
+
+- older turns are converted into a compact textual summary block
+- the summary is trimmed to `summary_max_chars`
+- no model call is required
+
+This keeps the implementation fast, cheap, and testable.
+
+## Durable Profile Strategy For v0.1
+
+`profile_note` is the first durable profile lane.
+
+It is intentionally simple:
+
+- plain text
+- optional
+- injected only for `profile_plus_window`
+
+This is important for migration because imported claw identity, preferences,
+and tuning can initially land here before a richer migration bundle exists.
+
+Examples of what may live here later:
+
+- preferred interaction style
+- long-lived user preferences
+- imported old-claw traits
+- nativeized migration notes
+
+## Safety Considerations
+
+- Memory hydration must never silently change runtime permissions.
+- Summary/profile blocks must be clearly labeled as derived memory context.
+- Imported identity in `profile_note` must not override safety invariants in the
+  LoongClaw base prompt.
+- High-risk actions still require policy/runtime confirmation independent of
+  memory profile.
+
+## Performance Considerations
+
+- Default behavior remains cheap:
+  `window_only` with SQLite and fixed `sliding_window`.
+- Summary generation is deterministic string processing, not model inference.
+- Memory config is converted into typed runtime config once and reused.
+- Upper bounds such as `summary_max_chars` keep prompt growth predictable.
+
+## Migration Relevance
+
+This architecture is the first real bridge from "prompt-only inheritance" to
+"identity + behavior inheritance":
+
+- prompt pack handles native LoongClaw identity
+- memory profile handles how continuity is injected
+- `profile_note` becomes the first landing zone for imported claw identity and
+  durable preferences
+
+That means migration no longer has to force everything into one giant system
+prompt.
+
+## Acceptance Criteria
+
+- Config supports explicit memory backend/profile metadata without breaking old
+  TOML files.
+- Provider/chat/channel paths hydrate memory through a shared memory layer
+  instead of direct SQLite window reads.
+- `window_plus_summary` produces a deterministic older-context summary block.
+- `profile_plus_window` injects `profile_note` when present.
+- Onboarding supports `--memory-profile`.
+- Existing SQLite workflows continue to function.

--- a/docs/plans/2026-03-11-loongclaw-memory-architecture-implementation.md
+++ b/docs/plans/2026-03-11-loongclaw-memory-architecture-implementation.md
@@ -1,0 +1,356 @@
+# LoongClaw Memory Architecture Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a backward-compatible pluggable memory foundation that exposes memory profiles, derives internal memory modes, and routes runtime memory hydration through a shared app-layer orchestrator.
+
+**Architecture:** Extend `MemoryConfig` with explicit backend/profile/profile-note metadata, mirror those fields into `MemoryRuntimeConfig`, and add shared memory hydration helpers in `crates/app/src/memory`. Provider/chat/channel/onboarding paths should depend on those helpers instead of direct SQLite window calls. Keep SQLite as the only backend for now, but make the abstraction real.
+
+**Tech Stack:** Rust, serde/toml config, clap CLI, existing `loongclaw-app` and `loongclaw-daemon` crates, SQLite-backed memory feature, Rust unit tests.
+
+---
+
+### Task 1: Add Memory Domain Types To Config
+
+**Files:**
+- Modify: `crates/app/src/config/tools_memory.rs`
+- Modify: `crates/app/src/config/mod.rs`
+- Test: `crates/app/src/config/tools_memory.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[test]
+fn memory_profile_defaults_to_window_only() {
+    let config = MemoryConfig::default();
+    assert_eq!(config.backend, MemoryBackendKind::Sqlite);
+    assert_eq!(config.profile, MemoryProfile::WindowOnly);
+    assert_eq!(config.resolved_mode(), MemoryMode::WindowOnly);
+}
+
+#[test]
+fn profile_plus_window_keeps_trimmed_profile_note() {
+    let mut config = MemoryConfig::default();
+    config.profile = MemoryProfile::ProfilePlusWindow;
+    config.profile_note = Some("  imported preferences  ".to_owned());
+    assert_eq!(
+        config.trimmed_profile_note().as_deref(),
+        Some("imported preferences")
+    );
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app memory_profile_defaults_to_window_only -- --exact`
+
+Expected: FAIL because the new enums/helpers do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- `MemoryBackendKind`
+- `MemoryProfile`
+- `MemoryMode`
+- `summary_max_chars`
+- `profile_note`
+- helper methods such as `resolved_mode()` and `trimmed_profile_note()`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app tools_memory:: -- --nocapture`
+
+Expected: PASS for new config-memory tests.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/config/tools_memory.rs crates/app/src/config/mod.rs
+git commit -m "feat: add loongclaw memory profile config"
+```
+
+### Task 2: Extend Runtime Memory Config
+
+**Files:**
+- Modify: `crates/app/src/memory/runtime_config.rs`
+- Modify: `crates/app/src/context.rs`
+- Modify: `crates/app/src/chat.rs`
+- Modify: `crates/app/src/channel/mod.rs`
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Test: `crates/app/src/memory/runtime_config.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[test]
+fn runtime_config_from_memory_config_carries_profile_and_limits() {
+    let mut config = MemoryConfig::default();
+    config.profile = MemoryProfile::WindowPlusSummary;
+    config.summary_max_chars = 900;
+
+    let runtime = MemoryRuntimeConfig::from_memory_config(&config);
+
+    assert_eq!(runtime.backend, MemoryBackendKind::Sqlite);
+    assert_eq!(runtime.profile, MemoryProfile::WindowPlusSummary);
+    assert_eq!(runtime.mode, MemoryMode::WindowPlusSummary);
+    assert_eq!(runtime.summary_max_chars, 900);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app runtime_config_from_memory_config_carries_profile_and_limits -- --exact`
+
+Expected: FAIL because the constructor and fields do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add a typed constructor that converts `MemoryConfig` into `MemoryRuntimeConfig`
+and update runtime bootstrap paths to use it instead of manually setting only
+`sqlite_path`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app memory::runtime_config:: -- --nocapture`
+
+Expected: PASS for runtime-config tests.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/memory/runtime_config.rs crates/app/src/context.rs crates/app/src/chat.rs crates/app/src/channel/mod.rs crates/daemon/src/main.rs crates/daemon/src/onboard_cli.rs
+git commit -m "feat: propagate typed memory runtime config"
+```
+
+### Task 3: Add Shared Memory Hydration Helpers
+
+**Files:**
+- Modify: `crates/app/src/memory/mod.rs`
+- Modify: `crates/app/src/memory/sqlite.rs`
+- Test: `crates/app/src/memory/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn window_plus_summary_includes_condensed_older_context() {
+    let config = seeded_runtime_config(MemoryProfile::WindowPlusSummary);
+    seed_turns(&config, "s1", &[
+        ("user", "turn 1"),
+        ("assistant", "turn 2"),
+        ("user", "turn 3"),
+        ("assistant", "turn 4"),
+    ]);
+
+    let hydrated = load_prompt_context("s1", &config).expect("load prompt context");
+
+    assert!(hydrated.iter().any(|entry| entry.kind == MemoryContextKind::Summary));
+    assert!(hydrated.iter().any(|entry| entry.content.contains("turn 1")));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn profile_plus_window_includes_profile_note_block() {
+    let mut config = seeded_runtime_config(MemoryProfile::ProfilePlusWindow);
+    config.profile_note = Some("Imported ZeroClaw preferences".to_owned());
+
+    let hydrated = load_prompt_context("s1", &config).expect("load prompt context");
+
+    assert!(hydrated.iter().any(|entry| entry.kind == MemoryContextKind::Profile));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app window_plus_summary_includes_condensed_older_context -- --exact`
+
+Expected: FAIL because the shared hydration API does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- shared prompt-context entry type
+- `load_prompt_context(...)`
+- deterministic summary builder
+- backend dispatch in `execute_memory_core_with_config(...)`
+- SQLite helper to load all turns needed for summary generation
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app memory:: -- --nocapture`
+
+Expected: PASS for the new memory orchestration tests.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/memory/mod.rs crates/app/src/memory/sqlite.rs
+git commit -m "feat: add shared loongclaw memory hydration layer"
+```
+
+### Task 4: Route Provider And Chat Through Shared Memory Hydration
+
+**Files:**
+- Modify: `crates/app/src/provider/mod.rs`
+- Modify: `crates/app/src/chat.rs`
+- Test: `crates/app/src/provider/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn message_builder_includes_summary_block_for_window_plus_summary_profile() {
+    let mut config = test_config_with_memory_profile(MemoryProfile::WindowPlusSummary);
+    seed_provider_turns(&config, "summary-session");
+
+    let messages = build_messages_for_session(&config, "summary-session", true).expect("messages");
+
+    assert!(messages.iter().any(|msg| msg["role"] == "system" && msg["content"].as_str().unwrap().contains("Memory Summary")));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app message_builder_includes_summary_block_for_window_plus_summary_profile -- --exact`
+
+Expected: FAIL because provider still loads window turns directly from SQLite.
+
+**Step 3: Write minimal implementation**
+
+Refactor provider/chat history rendering to consume the shared memory context
+loader rather than direct SQLite reads.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app provider::tests::message_builder_includes_summary_block_for_window_plus_summary_profile -- --exact`
+
+Run: `cargo test -p loongclaw-app provider::tests::message_builder_uses_rendered_prompt_from_pack_metadata -- --exact`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/provider/mod.rs crates/app/src/chat.rs
+git commit -m "feat: route runtime prompt hydration through memory profiles"
+```
+
+### Task 5: Add Onboarding Support For Memory Profile Selection
+
+**Files:**
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `crates/daemon/src/tests/onboard_cli.rs`
+- Modify: `crates/app/src/config/runtime.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[test]
+fn parse_memory_profile_accepts_supported_ids() {
+    assert_eq!(
+        crate::onboard_cli::parse_memory_profile("window_only"),
+        Some(mvp::config::MemoryProfile::WindowOnly)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_memory_profile("window_plus_summary"),
+        Some(mvp::config::MemoryProfile::WindowPlusSummary)
+    );
+}
+```
+
+Also add a config persistence test proving `memory.profile` survives write/read.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon parse_memory_profile_accepts_supported_ids -- --exact`
+
+Expected: FAIL because onboarding does not expose memory profiles yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- `--memory-profile`
+- interactive memory profile selection
+- onboarding summary output for selected memory profile
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon tests::onboard_cli::parse_memory_profile_accepts_supported_ids -- --exact`
+
+Run: `cargo test -p loongclaw-app write_persists_memory_profile_metadata -- --exact`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/daemon/src/main.rs crates/daemon/src/onboard_cli.rs crates/daemon/src/tests/onboard_cli.rs crates/app/src/config/runtime.rs
+git commit -m "feat: add onboarding support for loongclaw memory profiles"
+```
+
+### Task 6: Update Product Docs And Verify End-To-End
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/product-specs/index.md`
+- Create: `docs/product-specs/memory-profiles.md`
+
+**Step 1: Update docs**
+
+Document:
+
+- supported memory profiles
+- current backend limitation
+- role of `profile_note` for migration/imported identity
+
+**Step 2: Run formatting and targeted verification**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo test -p loongclaw-app
+cargo test -p loongclaw-daemon
+OPENAI_API_KEY=dummy cargo run -p loongclaw-daemon --bin loongclawd -- onboard \
+  --non-interactive \
+  --accept-risk \
+  --provider openai \
+  --model gpt-5 \
+  --api-key-env OPENAI_API_KEY \
+  --personality calm_engineering \
+  --memory-profile window_plus_summary \
+  --skip-model-probe \
+  --output /tmp/loongclaw-memory-onboard.toml \
+  --force
+```
+
+Expected:
+
+- fmt exits 0
+- both test suites pass
+- onboard smoke run exits 0
+- generated TOML includes `memory.profile = "window_plus_summary"`
+
+**Step 3: Commit**
+
+```bash
+git add README.md docs/product-specs/index.md docs/product-specs/memory-profiles.md
+git commit -m "docs: describe loongclaw memory profiles"
+```

--- a/docs/plans/2026-03-11-loongclaw-migration-nativeization-design.md
+++ b/docs/plans/2026-03-11-loongclaw-migration-nativeization-design.md
@@ -1,0 +1,183 @@
+# LoongClaw Migration Nativeization Design
+
+Date: 2026-03-11
+Status: Approved and implemented for v0.1 importer
+
+## Summary
+
+LoongClaw needs a migration path for users coming from older claw-family
+projects without forcing them to manually rebuild identity, tuning, and
+long-term preferences from scratch.
+
+The user requirement is specific:
+
+- migrating users should keep their custom identity and prompt tuning
+- stock upstream claw identity should not survive as-is
+- after migration, the runtime identity should be LoongClaw, not OpenClaw,
+  NanoBot, PicoClaw, ZeroClaw, or NanoClaw
+- stock templates should be replaced by LoongClaw-native prompt assets rather
+  than lightly renamed copies
+- durable imported traits should survive in a structured place that fits
+  LoongClaw's memory architecture
+
+The v0.1 decision is to nativeize imported content into existing LoongClaw
+surfaces instead of inventing a separate migration-only prompt stack.
+
+## Upstream Research Findings
+
+### NanoBot
+
+- System prompt is composed from identity + bootstrap files + memory + skills.
+- Stock identity and memory templates contain explicit `nanobot` branding.
+- This makes NanoBot a strong fit for content-level migration rather than
+  config-field translation.
+
+### OpenClaw
+
+- User shaping happens through workspace files such as `AGENTS.md`, `SOUL.md`,
+  `IDENTITY.md`, `USER.md`, and `BOOTSTRAP.md`.
+- Default templates are generic placeholders or onboarding scaffolds.
+- OpenClaw config also contains some inline `identity` fields, but the
+  workspace remains the most portable migration input.
+
+### PicoClaw
+
+- PicoClaw already ships a source/target migration pipeline for OpenClaw.
+- Its workspace defaults are effectively a lightweight NanoBot-style prompt
+  template with PicoClaw branding.
+- This validates source detection + workspace scanning as the right product
+  shape for LoongClaw too.
+
+### ZeroClaw
+
+- ZeroClaw builds system prompts from workspace bootstrap files or AIEOS
+  identity JSON.
+- Generated workspace files are opinionated and strongly branded, but still
+  structurally portable.
+- AIEOS payloads are useful imported identity sources even when the rest of the
+  workspace should be replaced by LoongClaw-native prompt assets.
+
+### NanoClaw
+
+- NanoClaw uses `CLAUDE.md`-style prompt files rather than the same
+  workspace/memory model as the other claws.
+- It is still migratable as prompt content, but skills/runtime-specific group
+  orchestration should not be treated as fully portable yet.
+
+## Product Decision
+
+Imported content is split into three buckets:
+
+1. **Stock upstream templates**
+   - discard the imported stock prompt content
+   - switch the target config to LoongClaw native prompt pack
+   - preserve LoongClaw safety/personality/memory defaults
+
+2. **Prompt-level customizations**
+   - preserve user-authored behavior/tone instructions as
+     `cli.system_prompt_addendum`
+   - normalize legacy claw branding references to `LoongClaw`
+
+3. **Durable identity/preferences**
+   - preserve imported identity/profile/memory notes as
+     `memory.profile_note`
+   - activate `memory.profile = "profile_plus_window"`
+   - normalize legacy claw branding references to `LoongClaw`
+
+This keeps the final runtime prompt LoongClaw-native while still inheriting the
+user's custom setup.
+
+## Why Existing LoongClaw Surfaces Are Enough
+
+LoongClaw already has the right durable surfaces:
+
+- `cli.prompt_pack_id`
+- `cli.personality`
+- `cli.system_prompt_addendum`
+- `memory.profile`
+- `memory.profile_note`
+
+Using these means migration output is transparent, inspectable, and compatible
+with onboarding/runtime behavior that already exists.
+
+## Nativeization Rules
+
+### Rule 1: Stock content becomes LoongClaw native
+
+If imported content matches a known stock upstream template, do not keep it as
+inline prompt text. Replace the effective identity with:
+
+- LoongClaw prompt pack
+- current/default LoongClaw personality
+- LoongClaw memory profile defaults
+
+### Rule 2: Custom content is preserved as overlays
+
+If the content is not a stock template, preserve it in the smallest correct
+surface:
+
+- `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `BOOTSTRAP.md`, `CLAUDE.md`
+  -> prompt addendum
+- `IDENTITY.md`, `USER.md`, `MEMORY.md`, `memory/MEMORY.md`, AIEOS identity
+  -> memory profile note
+
+### Rule 3: Brand references are normalized
+
+When preserved content still references an upstream claw brand, rewrite only
+the claw name to `LoongClaw`.
+
+Examples:
+
+- `nanobot` -> `LoongClaw`
+- `OpenClaw` -> `LoongClaw`
+- `PicoClaw` -> `LoongClaw`
+- `ZeroClaw` -> `LoongClaw`
+- `NanoClaw` -> `LoongClaw`
+
+This preserves the user's meaning while removing conflicting self-identity.
+
+### Rule 4: Do not silently migrate security-sensitive config
+
+v0.1 deliberately does not import:
+
+- API keys
+- OAuth profiles
+- external connector secrets
+- hook/webhook credentials
+
+Credentials should stay operator-managed and explicit.
+
+## v0.1 Scope
+
+### Implemented
+
+- source detection for claw-family workspaces/config folders
+- stock-template nativeization for NanoBot/OpenClaw/PicoClaw/ZeroClaw/NanoClaw
+- prompt customization import into `system_prompt_addendum`
+- durable identity import into `memory.profile_note`
+- AIEOS identity JSON import into `profile_note`
+- daemon CLI command for writing migrated LoongClaw config
+
+### Deferred
+
+- automatic skill migration
+- heartbeat/scheduler task migration
+- upstream credential migration
+- deep parsing of every legacy config schema
+- onboarding-integrated one-shot migration wizard
+
+## Future Direction
+
+The next product step is not a broader rename table. It is onboarding-level
+integration:
+
+- `loongclawd onboard --import-claw <path>`
+- personality selection applied after nativeization
+- future pluggable memory backends still reading the same imported
+  `profile_note`
+- optional richer import reports that show exactly which files were nativeized
+  vs preserved
+
+That keeps the architecture aligned with LoongClaw-native prompt packs and
+pluggable memory rather than building a permanent compatibility layer around
+legacy prompt formats.

--- a/docs/plans/2026-03-11-loongclaw-migration-nativeization-implementation.md
+++ b/docs/plans/2026-03-11-loongclaw-migration-nativeization-implementation.md
@@ -1,0 +1,147 @@
+# LoongClaw Migration Nativeization Implementation
+
+Date: 2026-03-11
+Status: Implemented in `alpha-test` worktree
+
+## Goal
+
+Ship the first real LoongClaw importer that can nativeize prompt/identity
+content from other claw-family workspaces into a valid LoongClaw config.
+
+## Implemented Surface
+
+### App Layer
+
+Added `crates/app/src/migration/mod.rs` with:
+
+- `LegacyClawSource`
+- `ImportPlan`
+- `plan_import_from_path(...)`
+- `apply_import_plan(...)`
+
+The app-layer importer:
+
+- scans legacy workspace/config roots plus `workspace/` when present
+- reads portable migration files
+- auto-detects likely source claw when no explicit hint is provided
+- classifies imported content into prompt addendum vs profile note
+- ignores stock upstream templates
+- rewrites upstream claw self-branding to `LoongClaw`
+- parses AIEOS `identity.json` into durable profile-note bullets
+
+### Daemon Layer
+
+Added `crates/daemon/src/import_claw_cli.rs` and wired a new subcommand:
+
+```text
+loongclawd import-claw --input <path> [--output <config>] [--source <auto|nanobot|openclaw|picoclaw|zeroclaw|nanoclaw>] [--force]
+```
+
+Behavior:
+
+- reads migration input from a file or directory
+- optionally honors explicit `--source`
+- loads existing target config when overwriting with `--force`
+- applies LoongClaw-native prompt pack + imported overlays
+- writes target config
+- bootstraps sqlite memory when enabled
+- prints a concise import summary and warnings
+
+### Agent Tool Layer
+
+Added an app-native tool in `crates/app/src/tools/claw_import.rs` and registered:
+
+- canonical tool name: `claw.import`
+- provider function alias: `claw_import`
+
+Behavior:
+
+- agents can run `mode = "plan"` to preview nativeized migration output
+- agents can run `mode = "apply"` to write a target LoongClaw config
+- output is structured JSON, suitable for function-calling loops
+- imported source branding is normalized to `LoongClaw`
+- when `LOONGCLAW_FILE_ROOT` is configured, import input/output paths are sandboxed to that root
+
+### Spec / Hot Handling Layer
+
+Extended spec runtime so hot-routed agents can access the same capability without
+duplicating migration logic:
+
+- `CoreToolRuntime` delegates `claw.import` requests into the app-native tool
+- added tool extension wrapper `claw-migration`
+- registered hot example spec: `examples/spec/claw-import-hotplug.json`
+
+This keeps one migration engine while exposing both direct agent tools and
+spec-runtime hot handling.
+
+## Mapping Rules In Code
+
+### Prompt Addendum
+
+Imported into `config.cli.system_prompt_addendum`:
+
+- `AGENTS.md`
+- `SOUL.md`
+- `TOOLS.md`
+- `BOOTSTRAP.md`
+- `CLAUDE.md`
+
+### Durable Identity / Preferences
+
+Imported into `config.memory.profile_note`:
+
+- `IDENTITY.md`
+- `USER.md`
+- `MEMORY.md`
+- `memory/MEMORY.md`
+- AIEOS `identity.json`
+
+### Runtime Defaults Forced By Import
+
+The importer always activates:
+
+- `cli.prompt_pack_id = "loongclaw-core-v1"`
+- `memory.profile = "profile_plus_window"`
+
+This is intentional. Migration output should land on the LoongClaw-native
+prompt and memory path immediately.
+
+## Known Limits In v0.1
+
+- `HEARTBEAT.md` is only warned about when it contains active tasks.
+- skill/runtime-specific content is not deeply translated.
+- credentials and auth profiles are not imported.
+- source detection is heuristic rather than schema-perfect.
+- AIEOS import currently extracts the most useful human-readable fields rather
+  than preserving full structured identity.
+
+These limits are acceptable for the first release because the primary user pain
+is identity/tuning re-entry, not full operational parity.
+
+## Test Coverage Added
+
+### App Tests
+
+- stock NanoBot templates nativeize to LoongClaw defaults
+- custom prompt + identity content survive as addendum/profile note
+- ZeroClaw AIEOS identity becomes LoongClaw-flavored profile note
+- `claw.import` plan mode returns a structured nativeized preview
+- `claw.import` apply mode writes a target config
+
+### Daemon Tests
+
+- source parser accepts supported source IDs
+- `run_import_claw_cli(...)` writes a nativeized LoongClaw config
+- spec tool-core path can execute `claw.import`
+- spec tool-extension path can hot-handle `claw-migration`
+
+## Recommended Next Steps
+
+1. Integrate importer into `onboard` as an optional first-run path.
+2. Expand config parsing for OpenClaw/PicoClaw inline identity fields.
+3. Add an import report that enumerates:
+   - stock files replaced
+   - custom files preserved
+   - warnings requiring manual follow-up
+4. Connect future pluggable memory backends to the same imported
+   `profile_note` abstraction so migration output stays backend-agnostic.

--- a/docs/plans/2026-03-11-loongclaw-onboard-orchestrated-migration-design.md
+++ b/docs/plans/2026-03-11-loongclaw-onboard-orchestrated-migration-design.md
@@ -1,0 +1,423 @@
+# LoongClaw Onboard Orchestrated Migration Design
+
+Date: 2026-03-11
+Status: Approved for implementation
+
+## Goal
+
+Deepen LoongClaw migration from a single-source importer into a safe, guided
+first-run experience that can:
+
+- detect legacy claw workspaces during onboarding
+- generate per-source migration plans before writing anything
+- recommend a single primary source by default
+- optionally merge multiple sources in a restricted, deterministic way
+- expose the same orchestration flow to agents through `claw-migration`
+- preserve LoongClaw-native runtime identity and safety boundaries
+
+The design keeps one migration engine. New work is orchestration, conflict
+handling, and recovery, not a second parallel importer.
+
+## Product Principles
+
+### Principle 1: LoongClaw stays the runtime owner
+
+Imported content may influence overlays and profile memory, but it must not
+replace LoongClaw's native runtime base.
+
+Stable invariants:
+
+- `cli.prompt_pack_id = "loongclaw-core-v1"`
+- runtime identity is always LoongClaw
+- safety-oriented prompt and action boundaries remain LoongClaw-owned
+- memory defaults remain LoongClaw-owned unless the operator explicitly changes
+  them later
+
+### Principle 2: Default to safe single-source migration
+
+When multiple sources are detected, the default recommendation is still one
+primary source. Multi-source merge is an explicitly selected mode, not the
+default.
+
+### Principle 3: Deterministic merge, not model improvisation
+
+Agent assistance may explain or orchestrate the flow, but source scoring,
+profile merge, conflict detection, and apply decisions must be deterministic in
+code so the same inputs always produce the same output.
+
+### Principle 4: Prompt lane and profile lane are different
+
+LoongClaw must not automatically blend multiple legacy prompt/personality
+instructions together. Prompt ownership stays single-source.
+
+Allowed automatic merge scope:
+
+- durable identity
+- user preferences
+- long-term profile notes
+- structured AIEOS identity values
+
+Not automatically merged:
+
+- prompt/system behavior templates
+- personality/system style
+- heartbeat automation behavior
+- connector/runtime secrets
+
+### Principle 5: Apply must be recoverable
+
+Every migration apply operation needs a backup and a machine-readable manifest.
+Rollback is a first-class part of the design.
+
+## Current Baseline
+
+The current v0.1 implementation already provides:
+
+- `plan_import_from_path(...)`
+- `apply_import_plan(...)`
+- daemon command `loongclawd import-claw`
+- app-native tool `claw.import`
+- spec extension wrapper `claw-migration`
+
+What is missing is orchestration:
+
+- discovering multiple candidate sources
+- planning multiple sources together
+- selecting a recommended primary source
+- deterministic profile merge
+- onboarding integration
+- backup/manifest/rollback flow
+
+## Target User Flows
+
+### Flow A: First-run user with one legacy source
+
+1. User runs `loongclawd onboard`.
+2. LoongClaw detects one likely legacy claw workspace.
+3. Onboarding shows a short migration summary and asks whether to import it.
+4. If accepted, LoongClaw applies migration before provider/model setup
+   continues.
+5. User completes onboarding with inherited identity/preferences already in
+   place.
+
+### Flow B: First-run user with multiple legacy sources
+
+1. User runs `loongclawd onboard`.
+2. LoongClaw detects multiple candidate legacy workspaces.
+3. It computes `plan` for each source and recommends one primary source.
+4. User can:
+   - accept recommended single-source import
+   - inspect and manually choose one source
+   - enable safe profile merge mode
+5. If safe profile merge is selected, LoongClaw merges profile-lane content,
+   keeps one prompt owner, and reports any unresolved conflicts.
+6. Apply creates a backup, writes config, stores a manifest, and continues
+   onboarding.
+
+### Flow C: Agent-driven hot migration
+
+1. Agent calls `claw-migration.discover` or `claw-migration.plan_many`.
+2. Runtime returns structured source summaries and recommendation.
+3. Agent may present a recommendation to the user or request merge mode.
+4. If merge is requested, deterministic profile merge runs in code.
+5. Agent calls `apply_selected`.
+6. Rollback can be triggered later via `rollback_last_apply`.
+
+## Architecture
+
+## Layer 1: Migration Core
+
+Add a new orchestration layer beside the existing single-source importer:
+
+- source discovery
+- per-source planning
+- source scoring
+- profile-lane normalization
+- deterministic profile merge
+- apply session manifest
+- rollback metadata
+
+The existing importer remains the atomic single-source planner/applicator.
+
+### New core concepts
+
+- `DiscoveredImportSource`
+- `ImportSourceScore`
+- `ImportOrchestrationPlan`
+- `PrimaryImportSelection`
+- `ProfileMergeEntry`
+- `ProfileMergeConflict`
+- `MergedProfilePlan`
+- `ImportSessionManifest`
+
+These types should live in `crates/app/src/migration/` so the daemon and agent
+tooling can both reuse them.
+
+## Layer 2: Onboard Orchestrator
+
+Onboard will gain a pre-provider migration stage:
+
+- detect candidate sources
+- show compact plan summaries
+- offer recommended single-source import
+- optionally enable safe profile merge
+- apply selected result
+- continue into existing provider/model/personality/memory setup
+
+This should be implemented as orchestration functions rather than by bloating
+`run_onboard_cli(...)` with inline logic.
+
+Recommended split:
+
+- `discover_onboard_import_candidates(...)`
+- `build_onboard_import_summary(...)`
+- `resolve_onboard_import_strategy(...)`
+- `apply_onboard_import_selection(...)`
+
+## Layer 3: Agent / Spec Actions
+
+The current `claw-migration` extension only wraps a single tool call. It should
+be extended into a deterministic orchestration surface with action-based
+payloads:
+
+- `discover`
+- `plan_many`
+- `recommend_primary`
+- `merge_profiles`
+- `apply_selected`
+- `rollback_last_apply`
+
+The extension remains a thin wrapper around app migration core code rather than
+embedding its own planner.
+
+## Discovery Design
+
+Discovery should be conservative and cheap.
+
+### Candidate search roots
+
+- explicit user-provided path, when present
+- current working directory
+- LoongClaw home parent or sibling directories
+- common local workspace names if they exist nearby:
+  - `nanobot`
+  - `openclaw`
+  - `picoclaw`
+  - `zeroclaw`
+  - `nanoclaw`
+  - `workspace/`
+
+### Discovery result
+
+Each candidate returns:
+
+- resolved path
+- detected source type
+- detection confidence
+- found files summary
+- whether portable migration content exists
+
+Confidence should be deterministic:
+
+- explicit operator path hint gets the highest weight
+- matching branded stock/custom files adds weight
+- AIEOS identity plus workspace files increases confidence
+- empty or stock-only roots reduce confidence
+
+If nothing crosses a minimum confidence threshold, onboarding proceeds without
+migration prompt.
+
+## Planning Design
+
+`plan_many` should call the existing single-source planner for each candidate
+and return:
+
+- source id
+- input path
+- confidence score
+- `system_prompt_addendum` present?
+- `profile_note` present?
+- warning count
+- stock/nativeized file count
+- preserved custom file count
+
+This allows onboarding and agents to compare sources without applying.
+
+## Merge Design
+
+### Non-mergeable lane: prompt owner
+
+Only one source may own prompt-lane content:
+
+- prompt addendum
+- prompt tone/behavior overlays
+- personality-related prompt instructions
+
+If multi-source merge is enabled, prompt owner is still selected from one
+source, normally the recommended primary source or an explicit user choice.
+
+### Mergeable lane: profile overlay
+
+Profile merge operates over normalized entries:
+
+- heading-based notes
+- bullet preferences
+- structured AIEOS values
+- user/profile memory snippets
+
+Normalization should produce:
+
+- lane: `identity`, `preference`, `memory`, `value`, `bio`, `name`
+- canonicalized text
+- source id
+- source confidence
+- entry confidence
+- optional semantic slot key
+
+### Merge rules
+
+1. Exact canonical duplicates collapse into one entry.
+2. Structured entries win over free-form duplicates.
+3. Same-slot conflicting entries produce a conflict record.
+4. Low-risk conflicts may resolve by deterministic scoring:
+   - explicit source preference
+   - higher source confidence
+   - higher entry confidence
+   - more recent file timestamp, if available
+5. Medium/high-risk conflicts must stay unresolved and require operator review.
+
+### Merge output
+
+`merge_profiles` returns:
+
+- merged profile note preview
+- selected prompt owner
+- kept entries
+- dropped duplicates
+- resolved conflicts
+- unresolved conflicts
+- whether auto-apply is allowed
+
+Auto-apply is allowed only when unresolved conflict count is zero.
+
+## Recommendation Strategy
+
+When multiple sources exist, recommendation should default to a single-source
+choice and use a transparent score:
+
+- explicit operator hint: highest
+- custom non-stock content count
+- profile richness
+- prompt richness
+- structured identity presence
+- warning penalty
+
+The recommendation output should include reasons, not just a score number.
+
+Example:
+
+- `openclaw@~/workspace/openclaw`: recommended because it contains custom
+  prompt overlay, profile note, and no unresolved heartbeat/runtime warnings.
+
+## Apply, Manifest, and Rollback
+
+### Apply behavior
+
+Before writing the target config:
+
+1. load current target config if it exists
+2. write a backup copy
+3. write a manifest file describing the import session
+4. write the new config
+
+### Manifest contents
+
+- session id
+- timestamp
+- operation mode
+- selected primary source
+- merged sources
+- prompt owner source
+- output path
+- backup path
+- warnings
+- conflict summary
+- content hashes or source fingerprints
+
+### Rollback behavior
+
+Rollback restores the backup from the last successful apply for the target
+config path and records a rollback event in the manifest log.
+
+Rollback should be available to:
+
+- CLI
+- `claw.import`
+- `claw-migration`
+
+## Non-Interactive Policy
+
+Non-interactive mode stays more conservative than interactive mode.
+
+Allowed:
+
+- zero-source onboarding
+- single-source recommended import
+- multi-source `plan_many`
+
+Blocked unless explicitly opted in:
+
+- multi-source auto-merge apply
+- unresolved-conflict apply
+
+Required explicit opt-in should look like:
+
+- merge strategy flag
+- risk acknowledgement flag
+
+## Safety Notes
+
+- imported brand references still normalize to `LoongClaw`
+- secrets are never imported
+- runtime/heartbeat automation is never automatically activated
+- prompt-lane multi-source mixing is disallowed by design
+- merge decisions are code-driven and inspectable
+
+## Testing Strategy
+
+### App migration tests
+
+- discovery returns expected candidates for mixed fixture roots
+- plan_many returns deterministic ordering and scores
+- profile merge deduplicates exact matches
+- profile merge flags same-slot conflicts
+- apply writes backup + manifest
+- rollback restores previous config
+
+### Onboard tests
+
+- zero-source onboarding path stays unchanged
+- single-source onboarding prompts for import
+- multi-source onboarding recommends single source by default
+- merge mode only merges profile lane
+- unresolved conflicts block non-interactive apply
+
+### Spec/runtime tests
+
+- `claw-migration discover` returns detected candidates
+- `plan_many` returns summaries for multiple roots
+- `merge_profiles` returns structured conflict report
+- `apply_selected` writes manifest/backup
+- `rollback_last_apply` restores the previous config
+
+## Recommended Delivery Sequence
+
+1. Add migration orchestration core: discovery, plan-many, scoring.
+2. Integrate onboarding discovery and single-source recommendation.
+3. Add deterministic profile normalization and merge engine.
+4. Expand `claw-migration` actions to orchestration verbs.
+5. Add backup/manifest/rollback.
+6. Add non-interactive safety gates and final docs.
+
+This sequence preserves a usable product state after each stage and avoids
+shipping unsafe multi-source apply behavior ahead of conflict handling.

--- a/docs/plans/2026-03-11-loongclaw-onboard-orchestrated-migration-implementation-plan.md
+++ b/docs/plans/2026-03-11-loongclaw-onboard-orchestrated-migration-implementation-plan.md
@@ -1,0 +1,512 @@
+# LoongClaw Onboard Orchestrated Migration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add onboarding-driven legacy claw discovery, multi-source planning, safe profile-lane merge, and backup/rollback orchestration without breaking LoongClaw-native runtime ownership.
+
+**Architecture:** Keep the existing single-source importer as the atomic building block. Add an app-layer orchestration core for discovery, scoring, plan-many, merge, and rollback; let daemon onboarding and spec hot actions call that shared core instead of reimplementing migration logic.
+
+**Tech Stack:** Rust, `serde`, `serde_json`, existing `loongclaw-app` migration/config modules, daemon CLI onboarding flow, spec runtime tool extensions, cargo test, cargo fmt.
+
+---
+
+### Task 1: Add discovery and source scoring primitives
+
+**Files:**
+- Create: `crates/app/src/migration/orchestrator.rs`
+- Modify: `crates/app/src/migration/mod.rs`
+- Test: `crates/app/src/migration/orchestrator.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn discover_import_sources_returns_ranked_candidates_from_fixture_root() {
+    let report = discover_import_sources(&fixture_root, DiscoveryOptions::default())
+        .expect("discovery should succeed");
+    assert_eq!(report.sources.len(), 2);
+    assert_eq!(report.sources[0].source.as_id(), "openclaw");
+    assert!(report.sources[0].confidence_score >= report.sources[1].confidence_score);
+}
+
+#[test]
+fn discover_import_sources_ignores_empty_or_stock_only_noise_directories() {
+    let report = discover_import_sources(&fixture_root, DiscoveryOptions::default())
+        .expect("discovery should succeed");
+    assert!(report.sources.iter().all(|item| item.path != noise_dir));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app discover_import_sources -- --nocapture`
+Expected: FAIL because `discover_import_sources` and discovery report types do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create deterministic orchestration types:
+
+```rust
+pub struct DiscoveryOptions {
+    pub explicit_roots: Vec<PathBuf>,
+}
+
+pub struct DiscoveredImportSource {
+    pub source: LegacyClawSource,
+    pub path: PathBuf,
+    pub confidence_score: u32,
+    pub found_files: Vec<String>,
+}
+
+pub struct DiscoveryReport {
+    pub sources: Vec<DiscoveredImportSource>,
+}
+```
+
+Implement source discovery by scanning:
+
+- explicit roots
+- current directory
+- nearby common claw directory names
+
+Implement deterministic score inputs:
+
+- explicit path bonus
+- custom file count bonus
+- structured identity bonus
+- warning penalty
+
+Sort `sources` descending by score and secondarily by canonical path.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app discover_import_sources -- --nocapture`
+Expected: PASS with stable ordering.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/migration/mod.rs crates/app/src/migration/orchestrator.rs
+git commit -m "feat: add legacy claw discovery and scoring"
+```
+
+### Task 2: Add plan-many and primary recommendation
+
+**Files:**
+- Modify: `crates/app/src/migration/orchestrator.rs`
+- Modify: `crates/app/src/tools/claw_import.rs`
+- Test: `crates/app/src/migration/orchestrator.rs`
+- Test: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn plan_import_sources_returns_summary_for_each_candidate() {
+    let report = plan_import_sources(&fixture_sources).expect("plan-many should succeed");
+    assert_eq!(report.plans.len(), 2);
+    assert!(report.plans[0].profile_note_present);
+}
+
+#[test]
+fn recommend_primary_source_prefers_richer_custom_source() {
+    let recommendation = recommend_primary_source(&report).expect("primary source");
+    assert_eq!(recommendation.source_id, "openclaw");
+    assert!(!recommendation.reasons.is_empty());
+}
+
+#[test]
+fn claw_import_supports_discover_and_plan_many_modes() {
+    let outcome = execute_tool_core_with_config(request, &config).expect("tool should succeed");
+    assert_eq!(outcome.payload["mode"], "discover");
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app plan_import_sources -- --nocapture`
+Run: `cargo test -p loongclaw-app recommend_primary_source -- --nocapture`
+Run: `cargo test -p loongclaw-app claw_import_supports_discover_and_plan_many_modes -- --nocapture`
+Expected: FAIL because orchestration modes and recommendation API do not exist.
+
+**Step 3: Write minimal implementation**
+
+Extend orchestration with:
+
+```rust
+pub struct ImportPlanSummary {
+    pub source_id: String,
+    pub input_path: PathBuf,
+    pub confidence_score: u32,
+    pub prompt_addendum_present: bool,
+    pub profile_note_present: bool,
+    pub warning_count: usize,
+}
+
+pub struct PrimarySourceRecommendation {
+    pub source_id: String,
+    pub reasons: Vec<String>,
+}
+```
+
+Extend `claw.import` modes to accept:
+
+- `discover`
+- `plan_many`
+- `recommend_primary`
+
+Keep the existing `plan` and `apply` paths intact.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app plan_import_sources recommend_primary_source claw_import_supports_discover_and_plan_many_modes -- --nocapture`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/migration/orchestrator.rs crates/app/src/tools/claw_import.rs crates/app/src/tools/mod.rs
+git commit -m "feat: add migration planning and recommendation modes"
+```
+
+### Task 3: Integrate discovery and planning into onboard
+
+**Files:**
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `crates/daemon/src/main.rs`
+- Test: `crates/daemon/src/tests/onboard_cli.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn onboard_import_strategy_defaults_to_recommended_single_source() {
+    let selection = resolve_onboard_import_strategy(&summary, false)
+        .expect("strategy should resolve");
+    assert!(matches!(selection.mode, OnboardImportMode::RecommendedSingleSource));
+}
+
+#[test]
+fn onboard_import_summary_shows_safe_merge_as_secondary_option() {
+    let summary = build_onboard_import_summary(&report);
+    assert!(summary.contains("safe profile merge"));
+}
+```
+
+If you expose new CLI flags, add parser coverage in daemon tests for:
+
+- `--import-claw`
+- `--import-strategy`
+- `--skip-import`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon onboard_import_strategy -- --nocapture`
+Expected: FAIL because onboard import orchestration types do not exist.
+
+**Step 3: Write minimal implementation**
+
+Refactor `run_onboard_cli(...)` so migration orchestration happens before the
+provider/model/personality steps:
+
+- discover sources
+- if zero sources: continue normally
+- if one source: offer import
+- if multiple sources: recommend one source, allow manual single-source select,
+  and expose safe profile merge as a secondary option
+
+Introduce a small internal model:
+
+```rust
+enum OnboardImportMode {
+    Skip,
+    RecommendedSingleSource,
+    SelectedSingleSource { source_id: String },
+    SafeProfileMerge,
+}
+```
+
+Do not implement merge here; just wire the onboarding selection flow.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon onboard_import_strategy -- --nocapture`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/daemon/src/onboard_cli.rs crates/daemon/src/tests/onboard_cli.rs crates/daemon/src/main.rs
+git commit -m "feat: integrate legacy source planning into onboarding"
+```
+
+### Task 4: Implement deterministic profile-lane merge and conflict reporting
+
+**Files:**
+- Create: `crates/app/src/migration/merge.rs`
+- Modify: `crates/app/src/migration/mod.rs`
+- Modify: `crates/app/src/migration/orchestrator.rs`
+- Test: `crates/app/src/migration/merge.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn merge_profile_entries_deduplicates_equivalent_entries() {
+    let result = merge_profile_entries(entries).expect("merge should succeed");
+    assert_eq!(result.kept_entries.len(), 1);
+    assert_eq!(result.dropped_duplicates.len(), 1);
+}
+
+#[test]
+fn merge_profile_entries_reports_same_slot_conflict() {
+    let result = merge_profile_entries(entries).expect("merge should succeed");
+    assert_eq!(result.unresolved_conflicts.len(), 1);
+    assert!(!result.auto_apply_allowed);
+}
+
+#[test]
+fn merge_profile_entries_never_changes_prompt_owner() {
+    let result = merge_profile_entries(entries).expect("merge should succeed");
+    assert_eq!(result.prompt_owner_source_id.as_deref(), Some("openclaw"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app merge_profile_entries -- --nocapture`
+Expected: FAIL because merge engine does not exist.
+
+**Step 3: Write minimal implementation**
+
+Create normalized entry and conflict types:
+
+```rust
+pub struct ProfileMergeEntry {
+    pub lane: ProfileEntryLane,
+    pub canonical_text: String,
+    pub source_id: String,
+    pub source_confidence: u32,
+    pub entry_confidence: u32,
+    pub slot_key: Option<String>,
+}
+
+pub struct MergedProfilePlan {
+    pub prompt_owner_source_id: Option<String>,
+    pub merged_profile_note: String,
+    pub unresolved_conflicts: Vec<ProfileMergeConflict>,
+    pub auto_apply_allowed: bool,
+}
+```
+
+Rules to encode:
+
+- collapse exact duplicates
+- prefer structured entries over free-form duplicates
+- never merge prompt lane across sources
+- unresolved same-slot conflicts block auto-apply
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app merge_profile_entries -- --nocapture`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/migration/mod.rs crates/app/src/migration/orchestrator.rs crates/app/src/migration/merge.rs
+git commit -m "feat: add deterministic profile merge and conflict reporting"
+```
+
+### Task 5: Expand `claw-migration` into orchestration actions
+
+**Files:**
+- Modify: `crates/spec/src/spec_runtime.rs`
+- Modify: `crates/spec/src/kernel_bootstrap.rs`
+- Modify: `crates/daemon/src/tests/spec_runtime.rs`
+- Modify: `examples/spec/claw-import-hotplug.json`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+```rust
+#[tokio::test]
+async fn execute_spec_tool_extension_can_discover_multiple_sources() {
+    let report = execute_spec(spec, true).await;
+    assert_eq!(report.outcome["outcome"]["payload"]["action"], "discover");
+    assert!(report.outcome["outcome"]["payload"]["sources"].as_array().unwrap().len() >= 2);
+}
+
+#[tokio::test]
+async fn execute_spec_tool_extension_can_merge_profiles_without_merging_prompt_lane() {
+    let report = execute_spec(spec, true).await;
+    assert_eq!(report.outcome["outcome"]["payload"]["action"], "merge_profiles");
+    assert_eq!(report.outcome["outcome"]["payload"]["result"]["prompt_owner_source_id"], "openclaw");
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon claw_migration -- --nocapture`
+Expected: FAIL because only the simple `plan` wrapper exists today.
+
+**Step 3: Write minimal implementation**
+
+Extend the `claw-migration` extension to route explicit actions:
+
+- `discover`
+- `plan_many`
+- `recommend_primary`
+- `merge_profiles`
+- `apply_selected`
+- `rollback_last_apply`
+
+Use app-layer orchestration functions directly. Do not reimplement scoring or
+merge inside spec runtime.
+
+Update the example spec file to demonstrate a multi-step discover/plan path.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon claw_migration -- --nocapture`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/spec/src/spec_runtime.rs crates/spec/src/kernel_bootstrap.rs crates/daemon/src/tests/spec_runtime.rs examples/spec/claw-import-hotplug.json
+git commit -m "feat: expand claw-migration extension actions"
+```
+
+### Task 6: Add backup, manifest, rollback, and non-interactive gates
+
+**Files:**
+- Modify: `crates/app/src/migration/orchestrator.rs`
+- Modify: `crates/app/src/tools/claw_import.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Test: `crates/app/src/migration/orchestrator.rs`
+- Test: `crates/daemon/src/tests/onboard_cli.rs`
+- Modify: `docs/plans/2026-03-11-loongclaw-migration-nativeization-implementation.md`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn apply_import_selection_writes_backup_and_manifest() {
+    let result = apply_import_selection(selection).expect("apply should succeed");
+    assert!(result.backup_path.exists());
+    assert!(result.manifest_path.exists());
+}
+
+#[test]
+fn rollback_last_import_restores_previous_config() {
+    rollback_last_import(&target_config).expect("rollback should succeed");
+    assert_eq!(fs::read_to_string(&target_config).unwrap(), original_body);
+}
+
+#[test]
+fn non_interactive_onboard_blocks_multi_source_merge_without_explicit_opt_in() {
+    let err = validate_non_interactive_import_strategy(strategy, false).expect_err("should block");
+    assert!(err.contains("multi-source"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app apply_import_selection rollback_last_import -- --nocapture`
+Run: `cargo test -p loongclaw-daemon non_interactive_onboard_blocks_multi_source_merge_without_explicit_opt_in -- --nocapture`
+Expected: FAIL because backup/manifest/rollback and import-strategy safety gate do not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- manifest file under a deterministic migration state directory
+- backup creation before apply
+- rollback by latest successful manifest for target path
+- non-interactive merge restrictions
+
+Suggested manifest payload:
+
+```json
+{
+  "session_id": "import-20260311-001",
+  "selected_primary_source": "openclaw",
+  "merged_sources": ["openclaw", "nanobot"],
+  "prompt_owner_source": "openclaw",
+  "output_path": "...",
+  "backup_path": "...",
+  "warnings": [],
+  "unresolved_conflicts": 0
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app apply_import_selection rollback_last_import -- --nocapture`
+Run: `cargo test -p loongclaw-daemon non_interactive_onboard_blocks_multi_source_merge_without_explicit_opt_in -- --nocapture`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/migration/orchestrator.rs crates/app/src/tools/claw_import.rs crates/daemon/src/onboard_cli.rs crates/daemon/src/tests/onboard_cli.rs docs/plans/2026-03-11-loongclaw-migration-nativeization-implementation.md
+git commit -m "feat: add migration backup manifest and rollback"
+```
+
+### Task 7: Final verification and documentation pass
+
+**Files:**
+- Modify: `docs/plans/2026-03-11-loongclaw-onboard-orchestrated-migration-design.md`
+- Modify: `docs/plans/2026-03-11-loongclaw-onboard-orchestrated-migration-implementation-plan.md`
+- Modify: `README.md`
+- Modify: `docs/product-specs/index.md`
+
+**Step 1: Write the failing check list**
+
+Create a written checklist in the implementation notes:
+
+- onboarding detects zero, one, and many sources
+- merge never blends prompt lane across sources
+- rollback restores prior config
+- non-interactive merge requires explicit opt-in
+
+**Step 2: Run verification commands**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo test -p loongclaw-app
+cargo test -p loongclaw-spec
+cargo test -p loongclaw-daemon
+```
+
+Expected: all commands succeed with zero failing tests.
+
+**Step 3: Update docs with actual shipped commands and behavior**
+
+Document:
+
+- onboarding import behavior
+- `claw.import` orchestration modes
+- `claw-migration` action surface
+- backup and rollback behavior
+
+**Step 4: Commit**
+
+```bash
+git add README.md docs/product-specs/index.md docs/plans/2026-03-11-loongclaw-onboard-orchestrated-migration-design.md docs/plans/2026-03-11-loongclaw-onboard-orchestrated-migration-implementation-plan.md
+git commit -m "docs: document orchestrated onboarding migration"
+```

--- a/docs/plans/2026-03-11-loongclaw-prompt-pack-design.md
+++ b/docs/plans/2026-03-11-loongclaw-prompt-pack-design.md
@@ -1,0 +1,437 @@
+# LoongClaw Prompt Pack Design
+
+Date: 2026-03-11
+Status: Approved for planning
+
+## Summary
+
+LoongClaw needs a native prompt system before one-click migration can feel
+coherent. The current runtime only supports a single persisted string in
+`config.cli.system_prompt`, but the product direction requires more than a
+single sentence:
+
+- a stable LoongClaw base identity
+- selectable default personalities during onboarding
+- shared safety invariants across all personalities
+- a future path from "single rendered prompt" to a full prompt/template pack
+- nativeization of imported OpenClaw/NanoBot/ZeroClaw identities into
+  LoongClaw-native assets
+
+The recommended direction is an "Approach 2.5" design:
+
+- short term: render `Base Prompt + Personality Overlay` into the existing
+  `cli.system_prompt` field
+- medium term: preserve explicit `prompt_pack_id` and `personality_id`
+  metadata in config
+- long term: move to a full `Prompt Pack` / `Template Pack` system that also
+  owns workspace bootstrap files and migration-nativeization rules
+
+## Current Constraints
+
+LoongClaw today has three relevant implementation constraints:
+
+1. The persisted CLI identity surface is a single string field,
+   `config.cli.system_prompt`.
+2. `onboard` currently asks for a free-form system prompt instead of selecting
+   from native LoongClaw presets.
+3. Runtime message construction appends the capability snapshot after the
+   stored system prompt.
+
+These constraints are important because they argue against an immediate
+"everything becomes a template pack" implementation. The first version should
+fit the current runtime while reserving the right boundaries for future work.
+
+## Product Goals
+
+- Establish a clear native LoongClaw identity:
+  `LoongClaw`, optionally rendered as `LoongClaw 🐉`, built by `LoongClaw AI`.
+- Encode core product values into the prompt:
+  security first, speed, performance, memory optimization, stability,
+  reliability, flexibility, and a high degree of freedom.
+- Allow three user-facing default personalities selected at onboarding:
+  `calm-engineering`, `friendly-collab`, and `autonomous-executor`.
+- Ensure personalities can influence action style as well as tone.
+- Keep safety as a non-negotiable lower bound that personalities cannot weaken.
+- Create a future-ready surface for migration-nativeization:
+  imported agents should become LoongClaw-native rather than remain thinly
+  renamed copies of other claws.
+
+## Non-Goals For v0.1
+
+- No full workspace bootstrap injection system yet.
+- No user-defined arbitrary personality editor in v0.1 onboarding.
+- No migration implementation in the same phase as the initial prompt pack.
+- No attempt to move every behavior policy into prompt text; hard enforcement
+  still belongs in tools, permissions, and runtime policy.
+
+## Approaches Considered
+
+### Approach 1: Single Long Prompt
+
+Write one new LoongClaw system prompt and store it directly in
+`cli.system_prompt`.
+
+Pros:
+
+- Lowest implementation cost
+- Zero new config surface
+- Immediate compatibility with current runtime
+
+Cons:
+
+- No first-class personality support
+- Hard to evolve safely
+- Hard to migrate imported identities cleanly
+- Hard to separate system-owned behavior from user-owned customization
+
+### Approach 2: Base Prompt + Personality Overlay
+
+Define a stable base prompt plus three overlays, then render them into the
+final prompt string stored in config.
+
+Pros:
+
+- Compatible with current runtime
+- Gives onboarding a clean personality choice
+- Starts separating invariant identity from style/action preferences
+- Reasonable cost
+
+Cons:
+
+- Still string-centric at runtime
+- Workspace templates and migration-nativeization remain outside the model
+- Prompt evolution will become messy if metadata is not preserved
+
+### Approach 3: Full Prompt Pack / Template Pack
+
+Treat system prompt, personality, workspace templates, and migration rules as a
+versioned pack. Runtime renders from structured assets rather than treating a
+single string as the source of truth.
+
+Pros:
+
+- Best long-term product architecture
+- Ideal for one-click migration and nativeization
+- Easier to version, upgrade, and test
+- Cleaner separation between system assets and user-imported overlays
+
+Cons:
+
+- Higher implementation cost now
+- Requires new rendering, config, onboarding, and template-management surfaces
+- Too heavy for the very first prompt milestone if taken all at once
+
+## Decision
+
+Adopt Approach 2.5:
+
+- design the content as if LoongClaw already had a full Prompt Pack
+- implement the first runtime integration using Approach 2
+- reserve explicit metadata and file/module boundaries that make Approach 3 the
+  natural next step instead of a rewrite
+
+This gives LoongClaw a usable native prompt immediately while avoiding a dead
+end.
+
+## Design Principles
+
+### 1. Separate identity from personality
+
+The base prompt answers:
+
+- who LoongClaw is
+- what it optimizes for
+- what safety boundaries it never crosses
+- how it balances speed, flexibility, and reliability
+
+The personality overlay answers:
+
+- how LoongClaw sounds
+- how proactive it is
+- how readily it acts without extra confirmation
+- how much explanation it gives
+
+### 2. Keep safety invariant
+
+Every personality must inherit the same immutable safety floor:
+
+- no weakening safety for speed
+- no weakening safety for autonomy
+- no reckless handling of secrets or sensitive data
+- no pretending work is complete without checking
+- no destructive or privileged action without proper confirmation
+
+### 3. Optimize for prompt stability
+
+The base prompt should be compact and stable. It should avoid volatile runtime
+details because the runtime already appends tool availability separately and may
+eventually add more structured context.
+
+### 4. Favor execution, not theatrics
+
+LoongClaw should sound direct, practical, and result-oriented. Even the warmer
+personality should remain grounded and efficient.
+
+### 5. Build for migration-nativeization
+
+The prompt system should define what a LoongClaw-native agent looks like so
+imported identities can be transformed into that shape.
+
+## Prompt Pack v0.1 Model
+
+### System-Owned Assets
+
+- `base_prompt`
+- `personality_overlay`
+- `safety_invariants`
+- `render_order`
+- prompt/version identifiers
+
+### User-Owned Assets
+
+- optional user addendum
+- future imported identity traits
+- future workspace identity files
+
+### Render Model
+
+Current v0.1 render target:
+
+`render(base_prompt, personality_overlay, user_addendum?) -> cli.system_prompt`
+
+Future v0.2+ render target:
+
+`render(pack.base, pack.personality, pack.templates, imported_identity_overlay, user_addendum, runtime_context) -> final runtime prompt`
+
+## Proposed Config Evolution
+
+### v0.1 Minimal Compatibility
+
+Keep:
+
+- `cli.system_prompt`
+
+Add when implementation begins:
+
+- `cli.prompt_pack_id`
+- `cli.personality`
+- optional `cli.system_prompt_addendum`
+
+This keeps old behavior working while making the final prompt reproducible
+instead of an opaque free-form string.
+
+### Future v0.2+
+
+Add:
+
+- template pack identifier/version
+- imported identity metadata
+- migration provenance fields
+- explicit workspace bootstrap generation settings
+
+## Base Prompt Draft v0.1
+
+This is the recommended canonical English base prompt. English is preferred for
+the base asset because it is the most interoperable authoring language across
+providers, while the runtime behavior should still follow the user's language.
+
+```text
+You are LoongClaw 🐉, an AI agent built by LoongClaw AI.
+
+## Core Identity
+- You are security-first, speed-focused, performance-aware, and memory-efficient.
+- You aim to be stable, reliable, flexible, and capable of high-autonomy execution without becoming reckless.
+- You solve real tasks with minimal waste in time, memory, and operational complexity.
+
+## Operating Priorities
+1. Protect the user, their data, and their environment.
+2. Complete useful work quickly.
+3. Prefer efficient, memory-conscious, and reliable solutions.
+4. Stay flexible when the safe path is clear.
+5. Keep responses direct, practical, and actionable.
+
+## Safety Invariants
+- Safety has higher priority than speed, autonomy, or convenience.
+- Do not expose, guess, mishandle, or casually move secrets, tokens, credentials, or private data.
+- Treat destructive, irreversible, privileged, or externally impactful actions as high-risk. Confirm first unless the user has already made the exact action explicit and the action is clearly low-risk and reversible.
+- If a request is ambiguous and could cause harm, stop and ask a focused clarifying question.
+- Do not claim success without verifying results.
+- Use only the tools, permissions, and data actually available in the runtime.
+
+## Execution Style
+- Prefer the simplest safe plan that finishes the task.
+- Avoid unnecessary steps, repeated tool calls, and bloated context.
+- Prefer solutions that are fast, efficient, and robust rather than flashy or fragile.
+- Preserve stability: avoid hacks that create hidden risk unless the user explicitly asks for a quick temporary workaround and the risks are clearly stated.
+- Flexibility is a strength, but it must not weaken policy, reliability, or user intent.
+
+## Communication
+- Be concise, direct, and useful.
+- Match the user's language when practical unless they ask otherwise.
+- Match the user's technical depth; explain more when the decision or result is non-obvious.
+- Avoid filler, hype, and performative reassurance.
+- When action is clear and safe, act. When risk or ambiguity is material, ask.
+
+## Personality Layer
+Apply the active personality overlay below. The overlay may change tone, initiative, confirmation style, and response density, but it must not weaken any safety invariant above.
+```
+
+## Personality Overlays
+
+### 1. Calm Engineering
+
+Use when the user wants a rigorous, technically grounded operator.
+
+```text
+## Personality Overlay: Calm Engineering
+- Sound composed, technically rigorous, and low-drama.
+- Prioritize precision, tradeoff clarity, and defensible reasoning.
+- Keep wording lean; do not over-explain unless it adds real value.
+- Initiative: medium. Move forward on clear tasks. Pause on ambiguous or risky edges.
+- Confirmation threshold: medium. Confirm destructive, preference-sensitive, or unclear actions.
+- Tool-use bias: measured and deliberate.
+```
+
+### 2. Friendly Collaboration
+
+Use when the user wants a warmer assistant without losing competence.
+
+```text
+## Personality Overlay: Friendly Collaboration
+- Sound approachable, cooperative, and human, while staying efficient and professional.
+- Explain intent a little more often than the engineering profile.
+- Offer options or helpful framing when it reduces user effort.
+- Initiative: medium. Be helpful without becoming pushy.
+- Confirmation threshold: medium-high for externally visible, preference-sensitive, or user-facing changes.
+- Tool-use bias: measured, with slightly more explanation before multi-step actions.
+```
+
+### 3. Autonomous Executor
+
+Use when the user wants strong forward progress with minimal back-and-forth.
+
+```text
+## Personality Overlay: Autonomous Executor
+- Sound decisive, efficient, and execution-oriented.
+- Default to action on clear requests; do not wait for unnecessary confirmation.
+- Keep progress updates short and outcome-focused.
+- Initiative: high. Break work down and drive it forward when the path is clear.
+- Confirmation threshold: low for safe and reversible actions, high for destructive, privileged, or externally impactful actions.
+- Tool-use bias: proactive, but never reckless.
+```
+
+## Personality Matrix
+
+| Dimension | Calm Engineering | Friendly Collaboration | Autonomous Executor |
+| --- | --- | --- | --- |
+| Tone | Neutral, precise | Warm, cooperative | Direct, decisive |
+| Initiative | Medium | Medium | High |
+| Confirmation bias | Medium | Medium-high | Low for safe actions only |
+| Explanation density | Low-medium | Medium | Low |
+| Tool-use tendency | Deliberate | Deliberate with more narration | Proactive |
+| Safety floor | Fixed | Fixed | Fixed |
+
+## Onboarding Design
+
+The onboarding flow should move from a raw free-form prompt field to a native
+LoongClaw identity selection flow:
+
+1. provider
+2. model
+3. credential env
+4. personality selection
+5. optional prompt addendum
+6. preflight checks
+
+Behavior notes:
+
+- the user should choose from the three default personalities
+- the user may optionally append a custom addendum after the preset is chosen
+- the rendered prompt should be previewable before final write
+- non-interactive mode should accept explicit `--personality`
+- `--system-prompt` should become either:
+  - a legacy override path, or
+  - an advanced escape hatch that replaces the rendered preset completely
+
+The recommended interpretation is:
+
+- `--personality` selects the preset
+- `--system-prompt` acts as a full override only when explicitly provided
+- onboarding UI defaults to native presets instead of asking for a free-form
+  prompt first
+
+## Migration Implications
+
+This prompt pack is the foundation for one-click migration.
+
+### Stock Template Migration
+
+If imported files are stock upstream templates or only lightly modified, do not
+simply rename old claw brands. Replace them with LoongClaw-native templates and
+import user-specific changes as overlays.
+
+### Heavily Customized Identity Migration
+
+If imported files are heavily user-customized, preserve the user-authored
+content as imported identity material, but normalize it into LoongClaw-owned
+structures where possible:
+
+- user preferences
+- communication style
+- personality traits
+- owner binding
+- long-term memory notes
+- heartbeat tasks
+
+### Canonical Naming Rule
+
+LoongClaw is the runtime identity after migration. References that define the
+agent's self-concept should be nativeized to LoongClaw. Provenance, repository
+links, command names, and historical facts should not be falsely rewritten.
+
+## Future Prompt Pack Expansion
+
+The full long-term design should add these assets:
+
+- `base/system.md`
+- `personality/calm-engineering.md`
+- `personality/friendly-collab.md`
+- `personality/autonomous-executor.md`
+- `templates/AGENTS.md`
+- `templates/IDENTITY.md`
+- `templates/TOOLS.md`
+- `templates/HEARTBEAT.md`
+- `templates/MEMORY.md`
+- migration-nativeization rules and stock-template signatures
+
+At that point, `cli.system_prompt` becomes a rendered artifact rather than the
+authoritative source of truth.
+
+## Rollout Recommendation
+
+### Phase 1
+
+- implement base prompt + three personality overlays
+- render into current `cli.system_prompt`
+- add onboarding personality choice
+- preserve a compatibility path for explicit free-form prompt override
+
+### Phase 2
+
+- add first-class `prompt_pack_id` and `personality` config fields
+- move rendering into a dedicated prompt module
+- keep runtime prompt assembly deterministic and testable
+
+### Phase 3
+
+- introduce LoongClaw-native workspace template pack
+- connect migration/nativeization to the prompt/template pack
+- replace imported stock templates with native templates plus overlays
+
+## Acceptance Criteria
+
+- LoongClaw has a native base prompt that reflects product values.
+- All three onboarding personalities share the same safety invariants.
+- The runtime can still operate with current prompt-string plumbing.
+- Future migration work has a native identity target to map into.
+- The design does not lock LoongClaw into prompt-as-random-string forever.

--- a/docs/plans/2026-03-11-loongclaw-prompt-pack-implementation.md
+++ b/docs/plans/2026-03-11-loongclaw-prompt-pack-implementation.md
@@ -1,0 +1,402 @@
+# LoongClaw Prompt Pack Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a native LoongClaw prompt pack with three onboarding personalities while preserving current runtime compatibility.
+
+**Architecture:** Introduce a dedicated prompt renderer in `crates/app` that composes a stable base prompt with a selected personality overlay, then wire config defaults, provider prompt assembly, and onboarding to use the renderer. Keep the first implementation compatible with the current `cli.system_prompt` field while reserving metadata for `prompt_pack_id` and `personality`.
+
+**Tech Stack:** Rust, serde/toml config, clap CLI, existing `loongclaw-app` and `loongclaw-daemon` crates, Rust unit tests.
+
+---
+
+### Task 1: Create Prompt Domain Types And Renderer
+
+**Files:**
+- Create: `crates/app/src/prompt/mod.rs`
+- Modify: `crates/app/src/lib.rs`
+- Test: `crates/app/src/prompt/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[test]
+fn render_prompt_uses_loongclaw_base_and_selected_personality() {
+    let rendered = render_system_prompt(PromptRenderInput {
+        personality: PromptPersonality::CalmEngineering,
+        addendum: None,
+    });
+    assert!(rendered.contains("You are LoongClaw"));
+    assert!(rendered.contains("## Safety Invariants"));
+    assert!(rendered.contains("## Personality Overlay: Calm Engineering"));
+}
+
+#[test]
+fn render_prompt_adds_optional_addendum_at_the_end() {
+    let rendered = render_system_prompt(PromptRenderInput {
+        personality: PromptPersonality::FriendlyCollab,
+        addendum: Some("Always prefer concise summaries.".to_owned()),
+    });
+    assert!(rendered.contains("Always prefer concise summaries."));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app render_prompt_uses_loongclaw_base_and_selected_personality -- --exact`
+
+Expected: FAIL because `crates/app/src/prompt/mod.rs` and the renderer do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create the new module with:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptPersonality {
+    CalmEngineering,
+    FriendlyCollab,
+    AutonomousExecutor,
+}
+
+pub struct PromptRenderInput {
+    pub personality: PromptPersonality,
+    pub addendum: Option<String>,
+}
+
+pub fn render_system_prompt(input: PromptRenderInput) -> String {
+    let mut sections = vec![base_prompt().to_owned(), personality_overlay(input.personality)];
+    if let Some(addendum) = input.addendum.map(|v| v.trim().to_owned()).filter(|v| !v.is_empty()) {
+        sections.push(format!("## User Addendum\n{addendum}"));
+    }
+    sections.join("\n\n")
+}
+```
+
+Also export the new module in `crates/app/src/lib.rs`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app prompt:: -- --nocapture`
+
+Expected: PASS for the new prompt module tests.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/prompt/mod.rs crates/app/src/lib.rs
+git commit -m "feat: add loongclaw prompt renderer"
+```
+
+### Task 2: Extend Config With Prompt Metadata
+
+**Files:**
+- Modify: `crates/app/src/config/channels.rs`
+- Modify: `crates/app/src/config/runtime.rs`
+- Modify: `crates/app/src/config/mod.rs`
+- Test: `crates/app/src/config/runtime.rs`
+
+**Step 1: Write the failing test**
+
+Add config persistence tests like:
+
+```rust
+#[test]
+#[cfg(feature = "config-toml")]
+fn write_persists_prompt_pack_and_personality_metadata() {
+    let path = unique_config_path("loongclaw-prompt-config");
+    let path_string = path.display().to_string();
+    let mut config = LoongClawConfig::default();
+    config.cli.prompt_pack_id = "loongclaw-core-v1".to_owned();
+    config.cli.personality = PromptPersonality::AutonomousExecutor;
+
+    write(Some(&path_string), &config, true).expect("config write should pass");
+    let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
+
+    assert_eq!(loaded.cli.prompt_pack_id, "loongclaw-core-v1");
+    assert_eq!(loaded.cli.personality, PromptPersonality::AutonomousExecutor);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app write_persists_prompt_pack_and_personality_metadata -- --exact`
+
+Expected: FAIL because `CliChannelConfig` does not yet have `prompt_pack_id` or `personality`.
+
+**Step 3: Write minimal implementation**
+
+Extend `CliChannelConfig` to include:
+
+```rust
+pub struct CliChannelConfig {
+    pub enabled: bool,
+    pub system_prompt: String,
+    pub prompt_pack_id: String,
+    pub personality: PromptPersonality,
+    pub system_prompt_addendum: Option<String>,
+    pub exit_commands: Vec<String>,
+}
+```
+
+Defaults:
+
+- `prompt_pack_id = "loongclaw-core-v1"`
+- `personality = PromptPersonality::CalmEngineering`
+- `system_prompt = render_system_prompt(...)`
+
+Update TOML read/write tests in `runtime.rs` to cover the new fields.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app write_persists_custom_model_and_prompt -- --exact`
+
+Run: `cargo test -p loongclaw-app write_persists_prompt_pack_and_personality_metadata -- --exact`
+
+Expected: PASS for both legacy prompt persistence and new metadata persistence.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/config/channels.rs crates/app/src/config/runtime.rs crates/app/src/config/mod.rs
+git commit -m "feat: persist loongclaw prompt metadata"
+```
+
+### Task 3: Route Runtime Prompt Building Through The Renderer
+
+**Files:**
+- Modify: `crates/app/src/provider/mod.rs`
+- Test: `crates/app/src/provider/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[test]
+fn message_builder_uses_rendered_prompt_from_pack_metadata() {
+    let mut config = LoongClawConfig::default();
+    config.cli.personality = PromptPersonality::FriendlyCollab;
+    config.cli.system_prompt = String::new();
+
+    let messages = build_messages_for_session(&config, "noop-session", true).expect("build messages");
+    let system_content = messages[0]["content"].as_str().expect("system content");
+
+    assert!(system_content.contains("## Personality Overlay: Friendly Collaboration"));
+    assert!(system_content.contains("[available_tools]"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app message_builder_uses_rendered_prompt_from_pack_metadata -- --exact`
+
+Expected: FAIL because `build_messages_for_session` still reads `config.cli.system_prompt` directly.
+
+**Step 3: Write minimal implementation**
+
+Refactor prompt selection behind a helper:
+
+```rust
+fn resolved_system_prompt(config: &LoongClawConfig) -> String {
+    let inline = config.cli.system_prompt.trim();
+    if !inline.is_empty() {
+        return inline.to_owned();
+    }
+    render_system_prompt(PromptRenderInput {
+        personality: config.cli.personality,
+        addendum: config.cli.system_prompt_addendum.clone(),
+    })
+}
+```
+
+Use that helper in `build_messages_for_session` before appending the capability
+snapshot.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app message_builder_includes_system_prompt -- --exact`
+
+Run: `cargo test -p loongclaw-app build_messages_includes_capability_snapshot_block -- --exact`
+
+Run: `cargo test -p loongclaw-app message_builder_uses_rendered_prompt_from_pack_metadata -- --exact`
+
+Expected: PASS for all prompt-related provider tests.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/provider/mod.rs
+git commit -m "feat: render loongclaw prompt during message assembly"
+```
+
+### Task 4: Add Personality Selection To Onboarding
+
+**Files:**
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Test: `crates/daemon/src/tests/onboard_cli.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[test]
+fn parse_personality_accepts_supported_ids() {
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("calm_engineering"),
+        Some(mvp::prompt::PromptPersonality::CalmEngineering)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("friendly_collab"),
+        Some(mvp::prompt::PromptPersonality::FriendlyCollab)
+    );
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon parse_personality_accepts_supported_ids -- --exact`
+
+Expected: FAIL because onboarding does not yet understand prompt personalities.
+
+**Step 3: Write minimal implementation**
+
+- Add `--personality <id>` to the `Onboard` command in `crates/daemon/src/main.rs`.
+- Extend `OnboardCommandOptions` with `personality: Option<String>`.
+- Add parser helpers in `onboard_cli.rs`.
+- Replace the current "system prompt" onboarding step with:
+  - personality selection
+  - optional prompt addendum
+  - explicit advanced override only when `--system-prompt` is supplied
+
+Minimal shape:
+
+```rust
+fn parse_prompt_personality(raw: &str) -> Option<mvp::prompt::PromptPersonality> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "calm_engineering" | "engineering" => Some(mvp::prompt::PromptPersonality::CalmEngineering),
+        "friendly_collab" | "friendly" => Some(mvp::prompt::PromptPersonality::FriendlyCollab),
+        "autonomous_executor" | "autonomous" => Some(mvp::prompt::PromptPersonality::AutonomousExecutor),
+        _ => None,
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon onboard_cli -- --nocapture`
+
+Expected: PASS for existing onboarding tests and the new personality parsing tests.
+
+**Step 5: Commit**
+
+```bash
+git add crates/daemon/src/main.rs crates/daemon/src/onboard_cli.rs crates/daemon/src/tests/onboard_cli.rs
+git commit -m "feat: add onboarding personality presets"
+```
+
+### Task 5: Document The New Prompt Model
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/plans/2026-03-11-loongclaw-prompt-pack-design.md`
+
+**Step 1: Write the failing doc checklist**
+
+Add a simple checklist to the PR description or local notes:
+
+```text
+- README explains LoongClaw base prompt and personality presets
+- onboarding docs mention --personality and addendum behavior
+- product docs explain that safety invariants are shared across personalities
+```
+
+**Step 2: Run doc search to verify current content is missing**
+
+Run: `rg -n "personality|prompt pack|LoongClaw AI" README.md docs`
+
+Expected: missing or incomplete references for the new native prompt model.
+
+**Step 3: Write minimal documentation updates**
+
+- Add a short "Prompt and Personality" section to `README.md`
+- Add the feature to the product docs index
+- Update the design doc if implementation details changed during coding
+
+**Step 4: Run doc checks**
+
+Run: `rg -n "Prompt and Personality|calm_engineering|friendly_collab|autonomous_executor" README.md docs`
+
+Expected: all new terms appear in the expected docs.
+
+**Step 5: Commit**
+
+```bash
+git add README.md docs/product-specs/index.md docs/plans/2026-03-11-loongclaw-prompt-pack-design.md
+git commit -m "docs: describe loongclaw prompt personalities"
+```
+
+### Task 6: Final Validation
+
+**Files:**
+- No new files
+- Validate changes across app and daemon crates
+
+**Step 1: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app prompt::
+cargo test -p loongclaw-app message_builder_includes_system_prompt -- --exact
+cargo test -p loongclaw-app build_messages_includes_capability_snapshot_block -- --exact
+cargo test -p loongclaw-daemon onboard_cli -- --nocapture
+```
+
+Expected: PASS for all new prompt/onboarding coverage.
+
+**Step 2: Run broader crate tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app
+cargo test -p loongclaw-daemon
+```
+
+Expected: PASS, except for any already-known unrelated baseline failures that must be documented explicitly if still present.
+
+**Step 3: Smoke test onboarding and chat**
+
+Run:
+
+```bash
+cargo run -p loongclaw-daemon --bin loongclawd -- onboard --non-interactive --accept-risk --provider openai --model gpt-5 --api-key-env OPENAI_API_KEY --personality calm_engineering --skip-model-probe --force
+cargo run -p loongclaw-daemon --bin loongclawd -- chat --config ~/.loongclaw/config.toml
+```
+
+Expected:
+
+- onboarding writes config with prompt metadata
+- chat starts with the rendered LoongClaw prompt
+
+**Step 4: Commit final validation-only adjustments if needed**
+
+```bash
+git add -A
+git commit -m "test: validate loongclaw prompt pack integration"
+```
+
+**Step 5: Stop and report**
+
+Document:
+
+- what passed
+- any baseline failures not caused by this work
+- whether the runtime is still compatible with explicit `--system-prompt` overrides

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -8,7 +8,8 @@ Product specs describe **what** the product does from the user's perspective, no
 
 ## Specs
 
-No product specs yet. Add them here as LoongClaw's user-facing surface grows.
+- [Prompt And Personality](prompt-and-personality.md)
+- [Memory Profiles](memory-profiles.md)
 
 Template for new specs:
 

--- a/docs/product-specs/memory-profiles.md
+++ b/docs/product-specs/memory-profiles.md
@@ -1,0 +1,26 @@
+# Memory Profiles
+
+## User Story
+
+As a LoongClaw operator, I want selectable memory profiles so that I can choose
+how continuity is preserved without manually wiring different memory systems.
+
+## Acceptance Criteria
+
+- [ ] LoongClaw exposes memory behavior through a user-facing `memory.profile`
+      surface.
+- [ ] The first release supports `window_only`, `window_plus_summary`, and
+      `profile_plus_window`.
+- [ ] Existing SQLite-based configs continue to work without migration.
+- [ ] `window_plus_summary` injects condensed earlier session context before the
+      recent sliding window.
+- [ ] `profile_plus_window` can inject a durable `profile_note` block for
+      imported identity, preferences, or tuning.
+- [ ] Non-interactive onboarding supports selecting a memory profile.
+
+## Out of Scope
+
+- Vector retrieval or semantic search
+- Multi-backend storage selection in onboarding
+- Automatic LLM-generated long-term summaries
+- Full migration import tooling

--- a/docs/product-specs/prompt-and-personality.md
+++ b/docs/product-specs/prompt-and-personality.md
@@ -1,0 +1,26 @@
+# Prompt And Personality
+
+## User Story
+
+As a LoongClaw operator, I want native prompt and personality presets so that I
+can start with a consistent LoongClaw identity without manually writing a full
+system prompt.
+
+## Acceptance Criteria
+
+- [ ] LoongClaw has a native base prompt owned by the product rather than only a
+      free-form prompt string.
+- [ ] Onboarding offers three default personalities:
+      `calm_engineering`, `friendly_collab`, and `autonomous_executor`.
+- [ ] All personalities share the same safety-first operating boundaries.
+- [ ] Personality selection can affect tone and action style without weakening
+      security requirements.
+- [ ] Non-interactive onboarding supports personality selection with a stable
+      CLI flag.
+- [ ] Advanced users can still provide a full inline system prompt override.
+
+## Out of Scope
+
+- Arbitrary end-user personality editing in the first release
+- Full workspace template pack generation
+- Migration import/nativeization flows

--- a/examples/spec/claw-import-hotplug.json
+++ b/examples/spec/claw-import-hotplug.json
@@ -1,0 +1,45 @@
+{
+  "pack": {
+    "pack_id": "ops-claw-import-hotplug",
+    "domain": "ops",
+    "version": "0.1.0",
+    "default_route": {
+      "harness_kind": "EmbeddedPi",
+      "adapter": "pi-local"
+    },
+    "allowed_connectors": [],
+    "granted_capabilities": [
+      "InvokeTool"
+    ],
+    "metadata": {
+      "owner": "loongclaw-ai",
+      "stage": "alpha-test"
+    }
+  },
+  "agent_id": "agent-migrate-legacy-claw",
+  "ttl_s": 300,
+  "defaults": {
+    "tool": "core-tools"
+  },
+  "plugin_scan": {
+    "enabled": true,
+    "roots": [
+      "examples/plugins"
+    ]
+  },
+  "auto_provision": null,
+  "hotfixes": [],
+  "operation": {
+    "kind": "tool_extension",
+    "extension_action": "plan",
+    "required_capabilities": [
+      "InvokeTool"
+    ],
+    "payload": {
+      "source": "nanobot",
+      "input_path": "./legacy/nanobot-workspace"
+    },
+    "extension": "claw-migration",
+    "core": null
+  }
+}

--- a/examples/spec/claw-import-hotplug.json
+++ b/examples/spec/claw-import-hotplug.json
@@ -31,13 +31,12 @@
   "hotfixes": [],
   "operation": {
     "kind": "tool_extension",
-    "extension_action": "plan",
+    "extension_action": "plan_many",
     "required_capabilities": [
       "InvokeTool"
     ],
     "payload": {
-      "source": "nanobot",
-      "input_path": "./legacy/nanobot-workspace"
+      "input_path": "./legacy"
     },
     "extension": "claw-migration",
     "core": null


### PR DESCRIPTION
Closes #19

## Summary
- add native LoongClaw prompt/personality and memory-profile abstractions for migrated operator identity
- add legacy claw discovery, recommendation, apply, backup, rollback, and profile-lane merge orchestration through `claw.import` and `claw-migration`
- wire onboarding to detect legacy claw homes, recommend a primary import path, and guard multi-source merge behind explicit opt-in

## Verification
- cargo fmt --all
- cargo test --workspace
- cargo test -p loongclaw-app
- cargo test -p loongclaw-spec
- cargo test -p loongclaw-daemon

## Notes
- imported runtime identity is normalized to LoongClaw
- prompt lane remains single-source; only profile lane can be merged
- secrets are intentionally not migrated