### PR TITLE
Prefer generic provider.api_key credential references

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,15 +273,16 @@ cargo build -p loongclaw-daemon --no-default-features --features "channel-cli,pr
 
 ## Configuration
 
-`loongclaw setup` defaults to referencing secrets via environment variables (not storing them directly):
+`loongclaw setup` defaults to referencing provider credentials through `provider.api_key`, so secrets stay outside the config file:
 
 ```toml
 [provider]
 kind = "openai"
-api_key_env = "PROVIDER_API_KEY"   # env var name, not the key itself
+api_key = "${PROVIDER_API_KEY}"    # preferred explicit env reference
 ```
 
-For direct values, use the non-`_env` fields instead (`api_key = "sk-..."`).
+`provider.api_key` also accepts `$PROVIDER_API_KEY`, `env:PROVIDER_API_KEY`, `%PROVIDER_API_KEY%`, or a direct literal like `api_key = "sk-..."`.
+Legacy `api_key_env = "PROVIDER_API_KEY"` remains supported for compatibility, but new configs should prefer `provider.api_key`.
 
 Validate your config:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -236,15 +236,16 @@ cargo build -p loongclaw-daemon --no-default-features --features "channel-cli,pr
 
 ## 配置
 
-`loongclaw setup` 默认使用环境变量引用密钥（不直接存储）：
+`loongclaw setup` 默认通过 `provider.api_key` 引用 provider 凭据，这样密钥不会直接落在配置文件里：
 
 ```toml
 [provider]
 kind = "openai"
-api_key_env = "PROVIDER_API_KEY"   # 环境变量名称，不是密钥本身
+api_key = "${PROVIDER_API_KEY}"    # 推荐的显式环境变量引用写法
 ```
 
-如需直接写入值，使用非 `_env` 字段（`api_key = "sk-..."`）。
+`provider.api_key` 也兼容 `$PROVIDER_API_KEY`、`env:PROVIDER_API_KEY`、`%PROVIDER_API_KEY%`，以及直接字面量写法 `api_key = "sk-..."`。
+旧格式 `api_key_env = "PROVIDER_API_KEY"` 仍然兼容，但新配置建议优先使用 `provider.api_key`。
 
 验证配置：
 

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -306,6 +306,19 @@ mod tests {
     }
 
     #[test]
+    fn provider_api_key_missing_explicit_env_reference_does_not_fall_back_to_legacy_env() {
+        let config = ProviderConfig {
+            kind: ProviderKind::Openai,
+            api_key: Some("${LOONGCLAW_TEST_MISSING_API_KEY}".to_owned()),
+            api_key_env: Some("PATH".to_owned()),
+            ..ProviderConfig::default()
+        };
+
+        assert_eq!(config.api_key(), None);
+        assert_eq!(config.authorization_header(), None);
+    }
+
+    #[test]
     fn provider_api_key_env_legacy_fallback_still_works() {
         let expected = required_env_value("PATH");
         let config = ProviderConfig {

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -30,7 +30,15 @@ pub use tools_memory::{MemoryBackendKind, MemoryConfig, MemoryMode, MemoryProfil
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeSet;
+    use std::{collections::BTreeSet, env};
+
+    fn required_env_value(key: &str) -> String {
+        env::var(key)
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| panic!("required env var {key} must be available for test"))
+    }
 
     #[test]
     fn endpoint_resolution_for_openai_compatible_is_stable() {
@@ -157,6 +165,12 @@ mod tests {
     }
 
     #[test]
+    fn provider_default_config_does_not_prepopulate_legacy_api_key_env_pointer() {
+        let config = ProviderConfig::default();
+        assert_eq!(config.api_key_env, None);
+    }
+
+    #[test]
     fn switching_provider_kind_uses_profile_defaults() {
         let config = ProviderConfig {
             kind: ProviderKind::Openrouter,
@@ -251,6 +265,57 @@ mod tests {
             config.authorization_header(),
             Some("Bearer vc-oauth-token".to_owned())
         );
+    }
+
+    #[test]
+    fn provider_api_key_supports_common_explicit_env_reference_formats() {
+        let expected = required_env_value("PATH");
+        let cases = vec!["${PATH}", "$PATH", "env:PATH", "%PATH%"];
+
+        for raw_api_key in cases {
+            let config = ProviderConfig {
+                kind: ProviderKind::Ollama,
+                api_key: Some(raw_api_key.to_owned()),
+                api_key_env: None,
+                ..ProviderConfig::default()
+            };
+            assert_eq!(
+                config.api_key().as_deref(),
+                Some(expected.as_str()),
+                "api_key={raw_api_key}"
+            );
+            assert_eq!(
+                config.authorization_header().as_deref(),
+                Some(format!("Bearer {expected}").as_str()),
+                "authorization_header should resolve env ref for {raw_api_key}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_api_key_missing_explicit_env_reference_is_not_treated_as_literal() {
+        let config = ProviderConfig {
+            kind: ProviderKind::Ollama,
+            api_key: Some("${LOONGCLAW_TEST_MISSING_API_KEY}".to_owned()),
+            api_key_env: None,
+            ..ProviderConfig::default()
+        };
+
+        assert_eq!(config.api_key(), None);
+        assert_eq!(config.authorization_header(), None);
+    }
+
+    #[test]
+    fn provider_api_key_env_legacy_fallback_still_works() {
+        let expected = required_env_value("PATH");
+        let config = ProviderConfig {
+            kind: ProviderKind::Ollama,
+            api_key: None,
+            api_key_env: Some("PATH".to_owned()),
+            ..ProviderConfig::default()
+        };
+
+        assert_eq!(config.api_key().as_deref(), Some(expected.as_str()));
     }
 
     #[test]

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -3,7 +3,8 @@ use std::{collections::BTreeMap, env};
 use serde::{Deserialize, Serialize};
 
 use super::shared::{
-    ConfigValidationIssue, EnvPointerValidationHint, read_secret_prefer_inline,
+    ConfigValidationIssue, EnvPointerValidationHint, parse_explicit_env_reference,
+    read_secret_prefer_inline,
     validate_env_pointer_field,
 };
 
@@ -513,6 +514,9 @@ fn resolve_secret_with_env_fallbacks(inline: Option<&str>, env_keys: &[String]) 
     let primary_env_key = env_keys.first().map(String::as_str);
     if let Some(value) = read_secret_prefer_inline(inline, primary_env_key) {
         return Some(value);
+    }
+    if inline.and_then(parse_explicit_env_reference).is_some() {
+        return None;
     }
     env_keys.get(1..).and_then(first_non_empty_env_value)
 }

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -514,10 +514,7 @@ fn resolve_secret_with_env_fallbacks(inline: Option<&str>, env_keys: &[String]) 
     if let Some(value) = read_secret_prefer_inline(inline, primary_env_key) {
         return Some(value);
     }
-    if env_keys.len() <= 1 {
-        return None;
-    }
-    first_non_empty_env_value(&env_keys[1..])
+    env_keys.get(1..).and_then(first_non_empty_env_value)
 }
 
 fn push_unique_env_key(keys: &mut Vec<String>, maybe_key: Option<&str>) {

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -2,7 +2,10 @@ use std::{collections::BTreeMap, env};
 
 use serde::{Deserialize, Serialize};
 
-use super::shared::{ConfigValidationIssue, EnvPointerValidationHint, validate_env_pointer_field};
+use super::shared::{
+    ConfigValidationIssue, EnvPointerValidationHint, read_secret_prefer_inline,
+    validate_env_pointer_field,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProviderProfile {
@@ -117,7 +120,7 @@ impl Default for ProviderConfig {
             endpoint: None,
             models_endpoint: None,
             api_key: None,
-            api_key_env: Some(default_provider_api_key_env().to_owned()),
+            api_key_env: None,
             oauth_access_token: None,
             oauth_access_token_env: None,
             preferred_models: Vec::new(),
@@ -238,13 +241,6 @@ impl ProviderConfig {
     }
 
     pub fn oauth_access_token(&self) -> Option<String> {
-        if let Some(raw) = self.oauth_access_token.as_deref() {
-            let value = raw.trim();
-            if !value.is_empty() {
-                return Some(value.to_owned());
-            }
-        }
-
         let mut env_keys = Vec::new();
         push_unique_env_key(&mut env_keys, self.oauth_access_token_env.as_deref());
         push_unique_env_key(&mut env_keys, self.kind.default_oauth_access_token_env());
@@ -252,7 +248,7 @@ impl ProviderConfig {
             push_unique_env_key(&mut env_keys, Some(alias));
         }
 
-        first_non_empty_env_value(&env_keys)
+        resolve_secret_with_env_fallbacks(self.oauth_access_token.as_deref(), &env_keys)
     }
 
     fn resolve_base_url(&self, profile_default: &str, openai_default: &str) -> String {
@@ -294,13 +290,6 @@ impl ProviderConfig {
     }
 
     pub fn api_key(&self) -> Option<String> {
-        if let Some(raw) = self.api_key.as_deref() {
-            let value = raw.trim();
-            if !value.is_empty() {
-                return Some(value.to_owned());
-            }
-        }
-
         let mut env_keys = Vec::new();
         push_unique_env_key(&mut env_keys, self.api_key_env.as_deref());
         push_unique_env_key(&mut env_keys, self.kind.default_api_key_env());
@@ -308,7 +297,7 @@ impl ProviderConfig {
             push_unique_env_key(&mut env_keys, Some(alias));
         }
 
-        first_non_empty_env_value(&env_keys)
+        resolve_secret_with_env_fallbacks(self.api_key.as_deref(), &env_keys)
     }
 
     pub fn header_value(&self, name: &str) -> Option<&str> {
@@ -484,10 +473,6 @@ fn default_provider_base_url() -> String {
     "https://api.openai.com".to_owned()
 }
 
-const fn default_provider_api_key_env() -> &'static str {
-    "OPENAI_API_KEY"
-}
-
 fn default_openai_chat_path() -> String {
     "/v1/chat/completions".to_owned()
 }
@@ -522,6 +507,17 @@ fn first_non_empty_env_value(keys: &[String]) -> Option<String> {
         }
     }
     None
+}
+
+fn resolve_secret_with_env_fallbacks(inline: Option<&str>, env_keys: &[String]) -> Option<String> {
+    let primary_env_key = env_keys.first().map(String::as_str);
+    if let Some(value) = read_secret_prefer_inline(inline, primary_env_key) {
+        return Some(value);
+    }
+    if env_keys.len() <= 1 {
+        return None;
+    }
+    first_non_empty_env_value(&env_keys[1..])
 }
 
 fn push_unique_env_key(keys: &mut Vec<String>, maybe_key: Option<&str>) {

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -4,8 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::shared::{
     ConfigValidationIssue, EnvPointerValidationHint, parse_explicit_env_reference,
-    read_secret_prefer_inline,
-    validate_env_pointer_field,
+    read_secret_prefer_inline, validate_env_pointer_field,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -250,9 +250,9 @@ fn encode_toml_config(_config: &LoongClawConfig) -> CliResult<String> {
 
 fn template_secret_usage_comment() -> &'static str {
     "# Secret configuration notes:\n\
-# - `*_env` fields store environment variable names, not secret values.\n\
-# - Example: `provider.api_key_env = \"PROVIDER_API_KEY\"`.\n\
-# - To write direct literals in config, use fields without `_env` (for example `provider.api_key`).\n\
+# - Preferred provider credential form: `provider.api_key = \"${PROVIDER_API_KEY}\"`.\n\
+# - `provider.api_key` also accepts direct literals and explicit env refs like `$VAR`, `env:VAR`, and `%VAR%`.\n\
+# - Legacy `*_env` fields stay supported for compatibility, but new configs should prefer the non-`_env` fields.\n\
 \n"
 }
 
@@ -313,7 +313,29 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
 
         let raw = std::fs::read_to_string(&config_path).expect("read template");
         assert!(raw.contains("# Secret configuration notes:"));
-        assert!(raw.contains("`*_env` fields store environment variable names"));
+        assert!(raw.contains("Preferred provider credential form"));
+
+        std::fs::remove_file(&config_path).ok();
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn write_template_prefers_generic_provider_api_key_reference_example() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let temp_dir = std::env::temp_dir().join(format!("loongclaw-template-api-key-{unique}"));
+        std::fs::create_dir_all(&temp_dir).expect("create temp directory");
+        let config_path = temp_dir.join("config.toml");
+
+        write_template(Some(config_path.to_string_lossy().as_ref()), true)
+            .expect("write template should succeed");
+
+        let raw = std::fs::read_to_string(&config_path).expect("read template");
+        assert!(raw.contains("provider.api_key = \"${PROVIDER_API_KEY}\""));
+        assert!(!raw.contains("provider.api_key_env = \"PROVIDER_API_KEY\""));
 
         std::fs::remove_file(&config_path).ok();
         std::fs::remove_dir_all(&temp_dir).ok();
@@ -585,6 +607,21 @@ api_key_env = "{secret}"
             loaded.memory.profile_note.as_deref(),
             Some("Imported NanoBot preferences")
         );
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn write_default_config_omits_legacy_provider_api_key_env_field() {
+        let path = unique_config_path("loongclaw-config-runtime-default");
+        let path_string = path.display().to_string();
+
+        write(Some(&path_string), &LoongClawConfig::default(), true)
+            .expect("default config write should pass");
+
+        let raw = fs::read_to_string(&path).expect("read written config");
+        assert!(!raw.contains("api_key_env = \"OPENAI_API_KEY\""));
 
         let _ = fs::remove_file(path);
     }

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -583,24 +583,83 @@ fn normalize_dollar_prefixed_env_name(raw: &str, fallback: &str) -> String {
     trimmed.to_owned()
 }
 
+enum InlineSecretInput<'a> {
+    Literal(&'a str),
+    EnvReference(&'a str),
+}
+
+fn classify_inline_secret_input(raw: &str) -> Option<InlineSecretInput<'_>> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(env_key) = parse_explicit_env_reference(trimmed) {
+        return Some(InlineSecretInput::EnvReference(env_key));
+    }
+    Some(InlineSecretInput::Literal(trimmed))
+}
+
+fn parse_explicit_env_reference(raw: &str) -> Option<&str> {
+    parse_dollar_env_reference(raw)
+        .or_else(|| parse_env_prefix_reference(raw))
+        .or_else(|| parse_percent_env_reference(raw))
+}
+
+fn parse_dollar_env_reference(raw: &str) -> Option<&str> {
+    let stripped = raw.trim().strip_prefix('$')?.trim();
+    if stripped.is_empty() {
+        return None;
+    }
+    let candidate = stripped
+        .strip_prefix('{')
+        .and_then(|rest| rest.strip_suffix('}'))
+        .map(str::trim)
+        .unwrap_or(stripped);
+    looks_like_compatible_env_name(candidate).then_some(candidate)
+}
+
+fn parse_env_prefix_reference(raw: &str) -> Option<&str> {
+    if raw.len() < 4 || !raw[..4].eq_ignore_ascii_case("env:") {
+        return None;
+    }
+    let candidate = raw[4..].trim();
+    looks_like_compatible_env_name(candidate).then_some(candidate)
+}
+
+fn parse_percent_env_reference(raw: &str) -> Option<&str> {
+    let candidate = parse_percent_wrapped_env_name(raw)?;
+    looks_like_compatible_env_name(candidate).then_some(candidate)
+}
+
+fn read_non_empty_env_value(key: &str) -> Option<String> {
+    let trimmed_key = key.trim();
+    if trimmed_key.is_empty() {
+        return None;
+    }
+    let value = env::var(trimmed_key).ok()?;
+    let trimmed_value = value.trim();
+    if trimmed_value.is_empty() {
+        return None;
+    }
+    Some(trimmed_value.to_owned())
+}
+
 pub(super) fn read_secret_prefer_inline(
     inline: Option<&str>,
     env_key: Option<&str>,
 ) -> Option<String> {
     if let Some(raw) = inline {
-        let value = raw.trim();
-        if !value.is_empty() {
-            return Some(value.to_owned());
+        match classify_inline_secret_input(raw) {
+            Some(InlineSecretInput::Literal(value)) => return Some(value.to_owned()),
+            Some(InlineSecretInput::EnvReference(key)) => {
+                if let Some(value) = read_non_empty_env_value(key) {
+                    return Some(value);
+                }
+            }
+            None => {}
         }
     }
-    if let Some(key) = env_key {
-        let value = env::var(key).ok()?;
-        let trimmed = value.trim();
-        if !trimmed.is_empty() {
-            return Some(trimmed.to_owned());
-        }
-    }
-    None
+    env_key.and_then(read_non_empty_env_value)
 }
 
 #[cfg(test)]

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -599,7 +599,7 @@ fn classify_inline_secret_input(raw: &str) -> Option<InlineSecretInput<'_>> {
     Some(InlineSecretInput::Literal(trimmed))
 }
 
-fn parse_explicit_env_reference(raw: &str) -> Option<&str> {
+pub(super) fn parse_explicit_env_reference(raw: &str) -> Option<&str> {
     parse_dollar_env_reference(raw)
         .or_else(|| parse_env_prefix_reference(raw))
         .or_else(|| parse_percent_env_reference(raw))
@@ -651,11 +651,7 @@ pub(super) fn read_secret_prefer_inline(
     if let Some(raw) = inline {
         match classify_inline_secret_input(raw) {
             Some(InlineSecretInput::Literal(value)) => return Some(value.to_owned()),
-            Some(InlineSecretInput::EnvReference(key)) => {
-                if let Some(value) = read_non_empty_env_value(key) {
-                    return Some(value);
-                }
-            }
+            Some(InlineSecretInput::EnvReference(key)) => return read_non_empty_env_value(key),
             None => {}
         }
     }

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -59,8 +59,18 @@ pub(crate) async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<(
         });
     } else {
         let mut hints = Vec::new();
+        if let Some(key) = config
+            .provider
+            .api_key
+            .as_deref()
+            .and_then(parse_provider_api_key_env_hint)
+            && !hints.iter().any(|existing| existing == key)
+        {
+            hints.push(key.to_owned());
+        }
         if let Some(key) = config.provider.api_key_env.as_deref().map(str::trim)
             && !key.is_empty()
+            && !hints.iter().any(|existing| existing == key)
         {
             hints.push(key.to_owned());
         }
@@ -429,22 +439,40 @@ fn maybe_apply_provider_env_fix(
     fix: bool,
     fixes: &mut Vec<String>,
 ) -> bool {
-    let mut changed = false;
-    if config
+    if !fix
+        || config
+            .provider
+            .api_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_some()
+    {
+        return false;
+    }
+
+    if let Some(existing_key) = config
         .provider
         .api_key_env
         .as_deref()
         .map(str::trim)
-        .unwrap_or("")
-        .is_empty()
-        && let Some(default_key) = config.provider.kind.default_api_key_env()
-        && fix
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
     {
-        config.provider.api_key_env = Some(default_key.to_owned());
-        fixes.push(format!("set provider.api_key_env={default_key}"));
-        changed = true;
+        config.provider.api_key = Some(format!("${{{existing_key}}}"));
+        config.provider.api_key_env = None;
+        fixes.push(format!("migrate provider.api_key=${{{existing_key}}}"));
+        return true;
     }
-    changed
+
+    if let Some(default_key) = config.provider.kind.default_api_key_env() {
+        config.provider.api_key = Some(format!("${{{default_key}}}"));
+        config.provider.api_key_env = None;
+        fixes.push(format!("set provider.api_key=${{{default_key}}}"));
+        return true;
+    }
+
+    false
 }
 
 fn maybe_apply_channel_env_fix(
@@ -508,6 +536,50 @@ fn ensure_env_binding(
     *slot = Some(default_key.to_owned());
     fixes.push(format!("{label}={default_key}"));
     true
+}
+
+fn parse_provider_api_key_env_hint(raw: &str) -> Option<&str> {
+    let trimmed = raw.trim();
+    if trimmed.len() >= 4 && trimmed[..4].eq_ignore_ascii_case("env:") {
+        let candidate = trimmed[4..].trim();
+        return looks_like_env_name(candidate).then_some(candidate);
+    }
+    if let Some(candidate) = parse_dollar_env_name(trimmed) {
+        return Some(candidate);
+    }
+    if let Some(candidate) = trimmed
+        .strip_prefix('%')
+        .and_then(|rest| rest.strip_suffix('%'))
+        .map(str::trim)
+        .filter(|value| looks_like_env_name(value))
+    {
+        return Some(candidate);
+    }
+    None
+}
+
+fn parse_dollar_env_name(raw: &str) -> Option<&str> {
+    let stripped = raw.strip_prefix('$')?.trim();
+    if stripped.is_empty() {
+        return None;
+    }
+    let candidate = stripped
+        .strip_prefix('{')
+        .and_then(|rest| rest.strip_suffix('}'))
+        .map(str::trim)
+        .unwrap_or(stripped);
+    looks_like_env_name(candidate).then_some(candidate)
+}
+
+fn looks_like_env_name(raw: &str) -> bool {
+    let mut chars = raw.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphanumeric() || first == '_') {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.')
 }
 
 #[cfg(test)]
@@ -602,6 +674,27 @@ mod tests {
         assert!(changed);
         assert_eq!(slot.as_deref(), Some("OPENAI_API_KEY"));
         assert_eq!(fixes.len(), 1);
+    }
+
+    #[test]
+    fn maybe_apply_provider_env_fix_prefers_generic_api_key_reference() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.api_key = None;
+        config.provider.api_key_env = None;
+        let mut fixes = Vec::new();
+
+        let changed = maybe_apply_provider_env_fix(&mut config, true, &mut fixes);
+
+        assert!(changed);
+        assert_eq!(
+            config.provider.api_key.as_deref(),
+            Some("${OPENAI_API_KEY}")
+        );
+        assert_eq!(config.provider.api_key_env, None);
+        assert_eq!(
+            fixes,
+            vec!["set provider.api_key=${OPENAI_API_KEY}".to_owned()]
+        );
     }
 
     #[test]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -172,8 +172,8 @@ enum Commands {
         provider: Option<String>,
         #[arg(long)]
         model: Option<String>,
-        #[arg(long)]
-        api_key_env: Option<String>,
+        #[arg(long, alias = "api-key-env")]
+        api_key: Option<String>,
         #[arg(long)]
         personality: Option<String>,
         #[arg(long)]
@@ -358,7 +358,7 @@ async fn main() {
             accept_risk,
             provider,
             model,
-            api_key_env,
+            api_key,
             personality,
             memory_profile,
             system_prompt,
@@ -371,7 +371,7 @@ async fn main() {
                 accept_risk,
                 provider,
                 model,
-                api_key_env,
+                api_key,
                 personality,
                 memory_profile,
                 system_prompt,
@@ -1073,5 +1073,45 @@ mod cli_tests {
         let error = run_safe_lane_summary_cli(None, Some("session-a"), 0, false)
             .expect_err("zero limit must be rejected");
         assert!(error.contains(">= 1"));
+    }
+
+    #[test]
+    fn onboard_cli_accepts_generic_api_key_flag() {
+        let cli = Cli::try_parse_from([
+            "loongclaw",
+            "onboard",
+            "--non-interactive",
+            "--accept-risk",
+            "--api-key",
+            "${OPENAI_API_KEY}",
+        ])
+        .expect("`--api-key` should parse");
+
+        match cli.command {
+            Some(Commands::Onboard { api_key, .. }) => {
+                assert_eq!(api_key.as_deref(), Some("${OPENAI_API_KEY}"));
+            }
+            other => panic!("unexpected command parsed: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn onboard_cli_keeps_legacy_api_key_env_alias() {
+        let cli = Cli::try_parse_from([
+            "loongclaw",
+            "onboard",
+            "--non-interactive",
+            "--accept-risk",
+            "--api-key-env",
+            "OPENAI_API_KEY",
+        ])
+        .expect("legacy `--api-key-env` alias should still parse");
+
+        match cli.command {
+            Some(Commands::Onboard { api_key, .. }) => {
+                assert_eq!(api_key.as_deref(), Some("OPENAI_API_KEY"));
+            }
+            other => panic!("unexpected command parsed: {other:?}"),
+        }
     }
 }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -15,7 +15,7 @@ pub(crate) struct OnboardCommandOptions {
     pub accept_risk: bool,
     pub provider: Option<String>,
     pub model: Option<String>,
-    pub api_key_env: Option<String>,
+    pub api_key: Option<String>,
     pub personality: Option<String>,
     pub memory_profile: Option<String>,
     pub system_prompt: Option<String>,
@@ -106,15 +106,12 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
     config.provider.model = selected_model;
 
     if !options.non_interactive {
-        print_step_header(3, total_steps, "credential env");
+        print_step_header(3, total_steps, "credential source");
     }
     let default_api_key_env = provider_default_api_key_env(config.provider.kind).to_owned();
-    let selected_api_key_env = resolve_api_key_env_selection(&options, default_api_key_env)?;
-    config.provider.api_key_env = if selected_api_key_env.trim().is_empty() {
-        None
-    } else {
-        Some(selected_api_key_env)
-    };
+    let selected_api_key = resolve_api_key_selection(&options, default_api_key_env)?;
+    config.provider.api_key = normalize_provider_api_key_source(&selected_api_key);
+    config.provider.api_key_env = None;
 
     if using_prompt_override {
         if !options.non_interactive {
@@ -167,11 +164,8 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
     if options.non_interactive {
         if !credential_ok {
             return Err(format!(
-                "onboard preflight failed: provider credentials missing. set {} in env or pass --api-key-env with a populated variable",
-                config
-                    .provider
-                    .api_key_env
-                    .clone()
+                "onboard preflight failed: provider credentials missing. set {} in env or pass --api-key with a populated value",
+                provider_credential_env_hint(&config)
                     .unwrap_or_else(|| "OPENAI_API_KEY".to_owned())
             ));
         }
@@ -216,9 +210,10 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
         "- memory profile: {}",
         memory_profile_id(config.memory.profile)
     );
-    if let Some(api_env) = config.provider.api_key_env.as_deref() {
-        println!("- credential env: {api_env}");
-    }
+    println!(
+        "- credential source: {}",
+        describe_provider_credential_source(&config)
+    );
     #[cfg(feature = "memory-sqlite")]
     println!("- sqlite memory: {}", memory_path.display());
     println!("next step: loongclaw chat --config {}", path.display());
@@ -490,13 +485,13 @@ fn resolve_model_selection(
     Ok(trimmed.to_owned())
 }
 
-fn resolve_api_key_env_selection(
+fn resolve_api_key_selection(
     options: &OnboardCommandOptions,
     default_api_key_env: String,
 ) -> CliResult<String> {
     if options.non_interactive {
         return Ok(options
-            .api_key_env
+            .api_key
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
@@ -504,12 +499,12 @@ fn resolve_api_key_env_selection(
             .to_owned());
     }
     let initial = options
-        .api_key_env
+        .api_key
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(default_api_key_env.as_str());
-    let value = prompt_with_default("API key env var", initial)?;
+    let value = prompt_with_default("API key or env var", initial)?;
     Ok(value.trim().to_owned())
 }
 
@@ -623,40 +618,17 @@ async fn run_preflight_checks(
 ) -> Vec<OnboardCheck> {
     let mut checks = Vec::new();
 
-    let api_key_env = config
-        .provider
-        .api_key_env
-        .as_deref()
-        .map(str::trim)
-        .unwrap_or("");
-    let has_credentials = if api_key_env.is_empty() {
-        false
-    } else {
-        env::var(api_key_env)
-            .ok()
-            .map(|value| !value.trim().is_empty())
-            .unwrap_or(false)
-    };
-
-    if api_key_env.is_empty() {
-        checks.push(OnboardCheck {
-            name: "provider credentials",
-            level: OnboardCheckLevel::Warn,
-            detail: "provider.api_key_env is empty".to_owned(),
-        });
-    } else if has_credentials {
-        checks.push(OnboardCheck {
-            name: "provider credentials",
-            level: OnboardCheckLevel::Pass,
-            detail: format!("{api_key_env} is available"),
-        });
-    } else {
-        checks.push(OnboardCheck {
-            name: "provider credentials",
-            level: OnboardCheckLevel::Warn,
-            detail: format!("{api_key_env} is not set"),
-        });
-    }
+    let credential_source = provider_credential_source(config);
+    let has_credentials = credential_source.is_available();
+    checks.push(OnboardCheck {
+        name: "provider credentials",
+        level: if has_credentials {
+            OnboardCheckLevel::Pass
+        } else {
+            OnboardCheckLevel::Warn
+        },
+        detail: credential_source.detail(),
+    });
 
     if skip_model_probe {
         checks.push(OnboardCheck {
@@ -738,6 +710,176 @@ fn print_preflight_checks(checks: &[OnboardCheck]) {
 fn print_step_header(step: usize, total: usize, title: &str) {
     println!();
     println!("[{step}/{total}] {title}");
+}
+
+#[derive(Debug, Clone)]
+enum ProviderCredentialSource {
+    InlineLiteral,
+    ApiKeyEnvRef(String),
+    LegacyApiKeyEnv(String),
+    DefaultApiKeyEnv(String),
+    Missing,
+}
+
+impl ProviderCredentialSource {
+    fn is_available(&self) -> bool {
+        match self {
+            Self::InlineLiteral => true,
+            Self::ApiKeyEnvRef(key) | Self::LegacyApiKeyEnv(key) | Self::DefaultApiKeyEnv(key) => {
+                env::var(key)
+                    .ok()
+                    .map(|value| !value.trim().is_empty())
+                    .unwrap_or(false)
+            }
+            Self::Missing => false,
+        }
+    }
+
+    fn detail(&self) -> String {
+        match self {
+            Self::InlineLiteral => "provider.api_key literal is configured".to_owned(),
+            Self::ApiKeyEnvRef(key) => {
+                if self.is_available() {
+                    format!("env {key} is available")
+                } else {
+                    format!("env {key} is not set")
+                }
+            }
+            Self::LegacyApiKeyEnv(key) => {
+                if self.is_available() {
+                    format!("legacy env {key} is available")
+                } else {
+                    format!("legacy env {key} is not set")
+                }
+            }
+            Self::DefaultApiKeyEnv(key) => {
+                if self.is_available() {
+                    format!("default env {key} is available")
+                } else {
+                    format!("default env {key} is not set")
+                }
+            }
+            Self::Missing => "provider.api_key is empty".to_owned(),
+        }
+    }
+
+    fn summary(&self) -> String {
+        match self {
+            Self::InlineLiteral => "direct provider.api_key".to_owned(),
+            Self::ApiKeyEnvRef(key) => format!("env {key}"),
+            Self::LegacyApiKeyEnv(key) => format!("legacy env {key}"),
+            Self::DefaultApiKeyEnv(key) => format!("default env {key}"),
+            Self::Missing => "not configured".to_owned(),
+        }
+    }
+
+    fn env_hint(&self) -> Option<String> {
+        match self {
+            Self::ApiKeyEnvRef(key) | Self::LegacyApiKeyEnv(key) | Self::DefaultApiKeyEnv(key) => {
+                Some(key.clone())
+            }
+            Self::InlineLiteral | Self::Missing => None,
+        }
+    }
+}
+
+fn provider_credential_source(config: &mvp::config::LoongClawConfig) -> ProviderCredentialSource {
+    if let Some(raw) = config
+        .provider
+        .api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if let Some(env_name) = normalize_api_key_env_name(raw) {
+            return ProviderCredentialSource::ApiKeyEnvRef(env_name);
+        }
+        return ProviderCredentialSource::InlineLiteral;
+    }
+    if let Some(key) = config
+        .provider
+        .api_key_env
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return ProviderCredentialSource::LegacyApiKeyEnv(key.to_owned());
+    }
+    if let Some(default_key) = config.provider.kind.default_api_key_env() {
+        return ProviderCredentialSource::DefaultApiKeyEnv(default_key.to_owned());
+    }
+    ProviderCredentialSource::Missing
+}
+
+fn provider_credential_env_hint(config: &mvp::config::LoongClawConfig) -> Option<String> {
+    provider_credential_source(config).env_hint()
+}
+
+fn describe_provider_credential_source(config: &mvp::config::LoongClawConfig) -> String {
+    provider_credential_source(config).summary()
+}
+
+fn normalize_provider_api_key_source(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(env_name) = normalize_api_key_env_name(trimmed) {
+        return Some(format!("${{{env_name}}}"));
+    }
+    Some(trimmed.to_owned())
+}
+
+fn normalize_api_key_env_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if looks_like_env_name(trimmed) {
+        return Some(trimmed.to_owned());
+    }
+    if let Some(env_name) = parse_dollar_env_name(trimmed) {
+        return Some(env_name.to_owned());
+    }
+    if trimmed.len() >= 4 && trimmed[..4].eq_ignore_ascii_case("env:") {
+        let env_name = trimmed[4..].trim();
+        if looks_like_env_name(env_name) {
+            return Some(env_name.to_owned());
+        }
+    }
+    if let Some(env_name) = trimmed
+        .strip_prefix('%')
+        .and_then(|rest| rest.strip_suffix('%'))
+        .map(str::trim)
+        .filter(|value| looks_like_env_name(value))
+    {
+        return Some(env_name.to_owned());
+    }
+    None
+}
+
+fn parse_dollar_env_name(raw: &str) -> Option<&str> {
+    let stripped = raw.strip_prefix('$')?.trim();
+    if stripped.is_empty() {
+        return None;
+    }
+    let candidate = stripped
+        .strip_prefix('{')
+        .and_then(|rest| rest.strip_suffix('}'))
+        .map(str::trim)
+        .unwrap_or(stripped);
+    looks_like_env_name(candidate).then_some(candidate)
+}
+
+fn looks_like_env_name(raw: &str) -> bool {
+    let mut chars = raw.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphanumeric() || first == '_') {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.')
 }
 
 fn check_level_marker(level: OnboardCheckLevel) -> &'static str {

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -791,7 +791,7 @@ fn provider_credential_source(config: &mvp::config::LoongClawConfig) -> Provider
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
-        if let Some(env_name) = normalize_api_key_env_name(raw) {
+        if let Some(env_name) = parse_explicit_api_key_env_name(raw) {
             return ProviderCredentialSource::ApiKeyEnvRef(env_name);
         }
         return ProviderCredentialSource::InlineLiteral;
@@ -824,19 +824,30 @@ fn normalize_provider_api_key_source(raw: &str) -> Option<String> {
     if trimmed.is_empty() {
         return None;
     }
-    if let Some(env_name) = normalize_api_key_env_name(trimmed) {
+    if let Some(env_name) = normalize_onboard_api_key_env_name(trimmed) {
         return Some(format!("${{{env_name}}}"));
     }
     Some(trimmed.to_owned())
 }
 
-fn normalize_api_key_env_name(raw: &str) -> Option<String> {
+fn normalize_onboard_api_key_env_name(raw: &str) -> Option<String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return None;
     }
-    if looks_like_env_name(trimmed) {
+    if let Some(env_name) = parse_explicit_api_key_env_name(trimmed) {
+        return Some(env_name);
+    }
+    if looks_like_bare_onboard_env_name(trimmed) {
         return Some(trimmed.to_owned());
+    }
+    None
+}
+
+fn parse_explicit_api_key_env_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
     }
     if let Some(env_name) = parse_dollar_env_name(trimmed) {
         return Some(env_name.to_owned());
@@ -856,6 +867,17 @@ fn normalize_api_key_env_name(raw: &str) -> Option<String> {
         return Some(env_name.to_owned());
     }
     None
+}
+
+fn looks_like_bare_onboard_env_name(raw: &str) -> bool {
+    let mut chars = raw.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_uppercase() || first == '_') {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '_')
 }
 
 fn parse_dollar_env_name(raw: &str) -> Option<&str> {

--- a/crates/daemon/src/tests/onboard_cli.rs
+++ b/crates/daemon/src/tests/onboard_cli.rs
@@ -1,4 +1,8 @@
 use super::*;
+use std::{
+    fs,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 #[test]
 fn parse_provider_kind_accepts_primary_and_legacy_aliases() {
@@ -197,4 +201,39 @@ fn non_interactive_onboard_allows_selected_single_source_strategy() {
 
     crate::onboard_cli::validate_non_interactive_import_strategy(&strategy, false)
         .expect("single-source strategy should pass");
+}
+
+#[tokio::test]
+async fn non_interactive_onboard_persists_generic_provider_api_key_reference() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_nanos();
+    let temp_dir = std::env::temp_dir().join(format!("loongclaw-onboard-api-key-{unique}"));
+    fs::create_dir_all(&temp_dir).expect("create temp directory");
+    let config_path = temp_dir.join("config.toml");
+    let path_string = config_path.display().to_string();
+
+    crate::onboard_cli::run_onboard_cli(crate::onboard_cli::OnboardCommandOptions {
+        output: Some(path_string.clone()),
+        force: true,
+        non_interactive: true,
+        accept_risk: true,
+        provider: Some("openai".to_owned()),
+        model: Some("auto".to_owned()),
+        api_key: Some("PATH".to_owned()),
+        personality: None,
+        memory_profile: None,
+        system_prompt: None,
+        skip_model_probe: true,
+    })
+    .await
+    .expect("non-interactive onboarding should succeed with populated env");
+
+    let (_, config) = mvp::config::load(Some(&path_string)).expect("load written config");
+    assert_eq!(config.provider.api_key.as_deref(), Some("${PATH}"));
+    assert_eq!(config.provider.api_key_env, None);
+
+    fs::remove_file(&config_path).ok();
+    fs::remove_dir_all(&temp_dir).ok();
 }

--- a/crates/daemon/src/tests/onboard_cli.rs
+++ b/crates/daemon/src/tests/onboard_cli.rs
@@ -237,3 +237,39 @@ async fn non_interactive_onboard_persists_generic_provider_api_key_reference() {
     fs::remove_file(&config_path).ok();
     fs::remove_dir_all(&temp_dir).ok();
 }
+
+#[tokio::test]
+async fn non_interactive_onboard_preserves_inline_api_key_literals() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_nanos();
+    let temp_dir = std::env::temp_dir().join(format!("loongclaw-onboard-api-key-inline-{unique}"));
+    fs::create_dir_all(&temp_dir).expect("create temp directory");
+    let config_path = temp_dir.join("config.toml");
+    let path_string = config_path.display().to_string();
+    let literal_api_key = "sk-proj-demo-token";
+
+    crate::onboard_cli::run_onboard_cli(crate::onboard_cli::OnboardCommandOptions {
+        output: Some(path_string.clone()),
+        force: true,
+        non_interactive: true,
+        accept_risk: true,
+        provider: Some("openai".to_owned()),
+        model: Some("auto".to_owned()),
+        api_key: Some(literal_api_key.to_owned()),
+        personality: None,
+        memory_profile: None,
+        system_prompt: None,
+        skip_model_probe: true,
+    })
+    .await
+    .expect("non-interactive onboarding should accept inline api key literals");
+
+    let (_, config) = mvp::config::load(Some(&path_string)).expect("load written config");
+    assert_eq!(config.provider.api_key.as_deref(), Some(literal_api_key));
+    assert_eq!(config.provider.api_key_env, None);
+
+    fs::remove_file(&config_path).ok();
+    fs::remove_dir_all(&temp_dir).ok();
+}


### PR DESCRIPTION
Closes #22

## Summary
- make `provider.api_key` the primary provider credential field and accept direct literals plus explicit env reference formats like `${VAR}`, `$VAR`, `env:VAR`, and `%VAR%`
- keep `provider.api_key_env` as a legacy compatibility fallback while removing it from default config output, onboarding defaults, and doctor fix recommendations
- update config templates, CLI onboarding flow, doctor hints, and README docs to prefer the generic `provider.api_key` style

## Validation
- cargo fmt --all --manifest-path Cargo.toml
- cargo test -p loongclaw-app --manifest-path Cargo.toml
- cargo test -p loongclaw-daemon --manifest-path Cargo.toml
