### PR TITLE
docs: add Volcengine Coding Plan README demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,19 @@ api_key = "${PROVIDER_API_KEY}"    # preferred explicit env reference
 `provider.api_key` also accepts `$PROVIDER_API_KEY`, `env:PROVIDER_API_KEY`, `%PROVIDER_API_KEY%`, or a direct literal like `api_key = "sk-..."`.
 Legacy `api_key_env = "PROVIDER_API_KEY"` remains supported for compatibility, but new configs should prefer `provider.api_key`.
 
+Volcengine Coding Plan / ARK demo:
+
+```toml
+[provider]
+kind = "volcengine"
+model = "your-coding-plan-model-id"
+api_key = "${ARK_API_KEY}"
+base_url = "https://ark.cn-beijing.volces.com"
+chat_completions_path = "/api/v3/chat/completions"
+```
+
+`kind = "volcengine"` already applies the Volcengine defaults above, so `base_url` and `chat_completions_path` are only needed when you want the config to spell them out explicitly.
+
 Validate your config:
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -247,6 +247,19 @@ api_key = "${PROVIDER_API_KEY}"    # 推荐的显式环境变量引用写法
 `provider.api_key` 也兼容 `$PROVIDER_API_KEY`、`env:PROVIDER_API_KEY`、`%PROVIDER_API_KEY%`，以及直接字面量写法 `api_key = "sk-..."`。
 旧格式 `api_key_env = "PROVIDER_API_KEY"` 仍然兼容，但新配置建议优先使用 `provider.api_key`。
 
+火山 Coding Plan / ARK 示例：
+
+```toml
+[provider]
+kind = "volcengine"
+model = "your-coding-plan-model-id"
+api_key = "${ARK_API_KEY}"
+base_url = "https://ark.cn-beijing.volces.com"
+chat_completions_path = "/api/v3/chat/completions"
+```
+
+`kind = "volcengine"` 已经内置了上面的火山默认 endpoint，所以只有在你希望把这些值明确写进配置时，才需要额外保留 `base_url` 和 `chat_completions_path`。
+
 验证配置：
 
 ```bash


### PR DESCRIPTION
## Summary
- add a concrete Volcengine Coding Plan / ARK config example to README.md
- add the matching example to README.zh-CN.md
- clarify that `kind = "volcengine"` already carries the built-in endpoint defaults

## Verification
- git diff --check