### PR TITLE
feat(external-skills): enforce approval-gated fetch with domain policy controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,38 @@ loongclaw import-claw --mode apply_selected --input ~/legacy-claws \
 loongclaw import-claw --mode rollback_last_apply --output ~/.loongclaw/config.toml
 ```
 
+## External Skills Runtime Guardrails
+
+External skills runtime is now safety-first by default and explicitly opt-in:
+
+- `external_skills.enabled = false` by default (downloads/runtime disabled).
+- `external_skills.require_download_approval = true` by default.
+- Domain blocklist has priority over every other rule.
+- If `allowed_domains` is non-empty, only allowlisted domains can be downloaded.
+- `external_skills.fetch` blocks redirects to avoid silent cross-domain hops.
+
+Recommended config baseline:
+
+```toml
+[external_skills]
+enabled = true
+require_download_approval = true
+allowed_domains = ["skills.sh", "clawhub.io"]
+blocked_domains = ["*.evil.example"]
+```
+
+Agent-facing tools:
+
+- `external_skills_policy`
+  - `action=get` reads effective runtime policy.
+  - `action=set` updates enable/approval/domain policy at runtime (requires `policy_update_approved=true`).
+  - `action=reset` clears runtime overrides back to config defaults (requires `policy_update_approved=true`).
+- `external_skills_fetch`
+  - Requires `url`.
+  - Requires `approval_granted=true` when approval guard is enabled.
+  - Saves artifact under `<tools.file_root>/external-skills-downloads/`.
+  - Enforces allowlist/blocklist before network download.
+
 ## Key Features
 
 **Kernel and Security**
@@ -211,7 +243,7 @@ loongclaw import-claw --mode rollback_last_apply --output ~/.loongclaw/config.to
 - `onboard` -- guided first-run with preflight diagnostics
 - `doctor` -- diagnostics with optional safe fixes (`--fix`) and machine-readable output (`--json`)
 - `chat` -- interactive CLI with sliding-window conversation memory
-- Core tools: `shell.exec`, `file.read`, `file.write`
+- Core tools: `shell.exec`, `file.read`, `file.write`, `external_skills.policy`, `external_skills.fetch`
 - Providers: OpenAI-compatible, Volcengine custom endpoint
 - Channels: CLI, Telegram polling, Feishu encrypted webhook
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,38 @@ before the rest of first-run setup continues.
 - Advanced path: plan multiple sources, merge only the profile lane, and keep prompt/system identity single-source.
 - Safety defaults: secrets are not migrated, imported runtime identity is normalized to `LoongClaw`, and every apply creates a backup manifest with rollback support.
 
+CLI migration workflow:
+
+- Default mode is now `plan` (safe preview, no file write) when `--mode` is omitted.
+- `apply_selected` accepts both `--source-id` and alias `--selection-id`.
+- Safe merge accepts both `--primary-source-id` and alias `--primary-selection-id`.
+- `map_external_skills` builds a deterministic external-skills mapping plan.
+- `--apply-external-skills-plan` can attach that mapping into `profile_note` during `apply_selected`.
+- applying external-skills plan also writes `.loongclaw-migration/<config>.external-skills.json` for audit and replay.
+
+```bash
+# Discover and score import candidates under a root
+loongclaw import-claw --mode discover --input ~/legacy-claws
+
+# Plan all candidates and print recommendation
+loongclaw import-claw --mode plan_many --input ~/legacy-claws
+
+# Preview external skills mapping artifacts and generated profile addendum
+loongclaw import-claw --mode map_external_skills --input ~/legacy-claws
+
+# Apply one selected source to a target config
+loongclaw import-claw --mode apply_selected --input ~/legacy-claws \
+  --source-id openclaw --output ~/.loongclaw/config.toml --force
+
+# Apply selected source and also attach external-skills mapping addendum
+loongclaw import-claw --mode apply_selected --input ~/legacy-claws \
+  --source-id openclaw --output ~/.loongclaw/config.toml \
+  --apply-external-skills-plan --force
+
+# Roll back the last apply_selected/import apply for this output config
+loongclaw import-claw --mode rollback_last_apply --output ~/.loongclaw/config.toml
+```
+
 ## Key Features
 
 **Kernel and Security**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,6 +154,38 @@ loongclaw import-claw --mode apply_selected --input ~/legacy-claws \
 loongclaw import-claw --mode rollback_last_apply --output ~/.loongclaw/config.toml
 ```
 
+## External Skills 运行时安全护栏
+
+external skills 运行时采用默认安全关闭策略，必须显式开启：
+
+- `external_skills.enabled = false`（默认禁用下载/挂载）。
+- `external_skills.require_download_approval = true`（默认每次下载都需授权）。
+- 域名黑名单优先级最高，命中即拒绝。
+- 当 `allowed_domains` 非空时，仅允许白名单域名下载。
+- `external_skills.fetch` 默认拒绝 HTTP 重定向，避免静默跨域跳转。
+
+推荐配置基线：
+
+```toml
+[external_skills]
+enabled = true
+require_download_approval = true
+allowed_domains = ["skills.sh", "clawhub.io"]
+blocked_domains = ["*.evil.example"]
+```
+
+面向 agent 的工具：
+
+- `external_skills_policy`
+  - `action=get`：读取当前生效策略。
+  - `action=set`：在运行时更新开关、授权门禁、域名白/黑名单（必须带 `policy_update_approved=true`）。
+  - `action=reset`：清除运行时覆盖，回到配置文件默认值（必须带 `policy_update_approved=true`）。
+- `external_skills_fetch`
+  - 必填 `url`。
+  - 当授权门禁开启时必须传 `approval_granted=true`。
+  - 下载文件落在 `<tools.file_root>/external-skills-downloads/`。
+  - 下载前强制执行白/黑名单校验。
+
 ## 核心功能
 
 **内核与安全**
@@ -177,7 +209,7 @@ loongclaw import-claw --mode rollback_last_apply --output ~/.loongclaw/config.to
 - `onboard` -- 引导式首次运行，带预检诊断
 - `doctor` -- 诊断工具，可选安全修复 (`--fix`) 和机器可读输出 (`--json`)
 - `chat` -- 交互式 CLI，滑动窗口对话记忆
-- 核心工具：`shell.exec`、`file.read`、`file.write`
+- 核心工具：`shell.exec`、`file.read`、`file.write`、`external_skills.policy`、`external_skills.fetch`
 - Provider：OpenAI 兼容、火山引擎自定义端点
 - 通道：CLI、Telegram 轮询、飞书加密 webhook
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -120,6 +120,40 @@ cargo install --path crates/daemon
 cargo test --workspace --all-features
 ```
 
+## 迁移与导入
+
+LoongClaw 支持从旧 claw 工作区进行发现、规划、应用与回滚：
+
+- 不传 `--mode` 时默认使用 `plan`（仅预览，不落盘）。
+- `apply_selected` 同时兼容 `--source-id` 与别名 `--selection-id`。
+- 安全合并同样兼容 `--primary-source-id` 与别名 `--primary-selection-id`。
+- `map_external_skills` 可生成可审计、可复现的外部 skills 映射计划。
+- `apply_selected` 配合 `--apply-external-skills-plan` 可把映射结果附加到 `profile_note`。
+- 应用 external-skills 计划时，会额外写入 `.loongclaw-migration/<config>.external-skills.json` 便于审计与回放。
+
+```bash
+# 扫描并评分导入候选源
+loongclaw import-claw --mode discover --input ~/legacy-claws
+
+# 规划所有候选并给出推荐主源
+loongclaw import-claw --mode plan_many --input ~/legacy-claws
+
+# 预览外部 skills 映射工件与生成的 profile addendum
+loongclaw import-claw --mode map_external_skills --input ~/legacy-claws
+
+# 选择单一来源应用到目标配置
+loongclaw import-claw --mode apply_selected --input ~/legacy-claws \
+  --source-id openclaw --output ~/.loongclaw/config.toml --force
+
+# 选择来源并附加外部 skills 映射结果
+loongclaw import-claw --mode apply_selected --input ~/legacy-claws \
+  --source-id openclaw --output ~/.loongclaw/config.toml \
+  --apply-external-skills-plan --force
+
+# 回滚最近一次 apply/import
+loongclaw import-claw --mode rollback_last_apply --output ~/.loongclaw/config.toml
+```
+
 ## 核心功能
 
 **内核与安全**

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -716,6 +716,28 @@ fn apply_runtime_env(config: &LoongClawConfig) {
         "LOONGCLAW_FILE_ROOT",
         config.tools.resolved_file_root().display().to_string(),
     );
+    crate::process_env::set_var(
+        "LOONGCLAW_EXTERNAL_SKILLS_ENABLED",
+        config.external_skills.enabled.to_string(),
+    );
+    crate::process_env::set_var(
+        "LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL",
+        config.external_skills.require_download_approval.to_string(),
+    );
+    crate::process_env::set_var(
+        "LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS",
+        config
+            .external_skills
+            .normalized_allowed_domains()
+            .join(","),
+    );
+    crate::process_env::set_var(
+        "LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS",
+        config
+            .external_skills
+            .normalized_blocked_domains()
+            .join(","),
+    );
     // Populate the typed tool runtime config so executors never hit env vars
     // on the hot path.  Ignore the error if already initialised.
     let tool_rt = crate::tools::runtime_config::ToolRuntimeConfig {
@@ -726,6 +748,20 @@ fn apply_runtime_env(config: &LoongClawConfig) {
             .map(|s| s.to_ascii_lowercase())
             .collect(),
         file_root: Some(config.tools.resolved_file_root()),
+        external_skills: crate::tools::runtime_config::ExternalSkillsRuntimePolicy {
+            enabled: config.external_skills.enabled,
+            require_download_approval: config.external_skills.require_download_approval,
+            allowed_domains: config
+                .external_skills
+                .normalized_allowed_domains()
+                .into_iter()
+                .collect(),
+            blocked_domains: config
+                .external_skills
+                .normalized_blocked_domains()
+                .into_iter()
+                .collect(),
+        },
     };
     let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -399,6 +399,28 @@ fn export_runtime_env(config: &LoongClawConfig) {
         "LOONGCLAW_FILE_ROOT",
         config.tools.resolved_file_root().display().to_string(),
     );
+    crate::process_env::set_var(
+        "LOONGCLAW_EXTERNAL_SKILLS_ENABLED",
+        config.external_skills.enabled.to_string(),
+    );
+    crate::process_env::set_var(
+        "LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL",
+        config.external_skills.require_download_approval.to_string(),
+    );
+    crate::process_env::set_var(
+        "LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS",
+        config
+            .external_skills
+            .normalized_allowed_domains()
+            .join(","),
+    );
+    crate::process_env::set_var(
+        "LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS",
+        config
+            .external_skills
+            .normalized_blocked_domains()
+            .join(","),
+    );
     // Populate the typed tool runtime config so executors never hit env vars
     // on the hot path.  Ignore the error if already initialised (e.g. tests).
     let tool_rt = crate::tools::runtime_config::ToolRuntimeConfig {
@@ -409,6 +431,20 @@ fn export_runtime_env(config: &LoongClawConfig) {
             .map(|s| s.to_ascii_lowercase())
             .collect(),
         file_root: Some(config.tools.resolved_file_root()),
+        external_skills: crate::tools::runtime_config::ExternalSkillsRuntimePolicy {
+            enabled: config.external_skills.enabled,
+            require_download_approval: config.external_skills.require_download_approval,
+            allowed_domains: config
+                .external_skills
+                .normalized_allowed_domains()
+                .into_iter()
+                .collect(),
+            blocked_domains: config
+                .external_skills
+                .normalized_blocked_domains()
+                .into_iter()
+                .collect(),
+        },
     };
     let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);
 

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -25,7 +25,9 @@ pub use runtime::{
 #[allow(unused_imports)]
 pub use shared::expand_path;
 #[allow(unused_imports)]
-pub use tools_memory::{MemoryBackendKind, MemoryConfig, MemoryMode, MemoryProfile, ToolConfig};
+pub use tools_memory::{
+    ExternalSkillsConfig, MemoryBackendKind, MemoryConfig, MemoryMode, MemoryProfile, ToolConfig,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -13,7 +13,7 @@ use super::{
         default_loongclaw_home as shared_default_loongclaw_home, expand_path,
         format_config_validation_issues,
     },
-    tools_memory::{MemoryConfig, ToolConfig},
+    tools_memory::{ExternalSkillsConfig, MemoryConfig, ToolConfig},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -66,6 +66,8 @@ pub struct LoongClawConfig {
     pub conversation: ConversationConfig,
     #[serde(default)]
     pub tools: ToolConfig,
+    #[serde(default)]
+    pub external_skills: ExternalSkillsConfig,
     #[serde(default)]
     pub memory: MemoryConfig,
 }
@@ -622,6 +624,29 @@ api_key_env = "{secret}"
 
         let raw = fs::read_to_string(&path).expect("read written config");
         assert!(!raw.contains("api_key_env = \"OPENAI_API_KEY\""));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn write_default_config_keeps_external_skills_guardrails() {
+        let path = unique_config_path("loongclaw-config-runtime-external-skills");
+        let path_string = path.display().to_string();
+
+        write(Some(&path_string), &LoongClawConfig::default(), true)
+            .expect("default config write should pass");
+
+        let raw = fs::read_to_string(&path).expect("read written config");
+        assert!(raw.contains("[external_skills]"));
+        assert!(raw.contains("enabled = false"));
+        assert!(raw.contains("require_download_approval = true"));
+
+        let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
+        assert!(!loaded.external_skills.enabled);
+        assert!(loaded.external_skills.require_download_approval);
+        assert!(loaded.external_skills.allowed_domains.is_empty());
+        assert!(loaded.external_skills.blocked_domains.is_empty());
 
         let _ = fs::remove_file(path);
     }

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::BTreeSet, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -16,6 +16,18 @@ pub struct ToolConfig {
     pub shell_allowlist: Vec<String>,
     #[serde(default)]
     pub file_root: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalSkillsConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_require_download_approval")]
+    pub require_download_approval: bool,
+    #[serde(default)]
+    pub allowed_domains: Vec<String>,
+    #[serde(default)]
+    pub blocked_domains: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -109,12 +121,33 @@ impl Default for ToolConfig {
     }
 }
 
+impl Default for ExternalSkillsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            require_download_approval: default_require_download_approval(),
+            allowed_domains: Vec::new(),
+            blocked_domains: Vec::new(),
+        }
+    }
+}
+
 impl ToolConfig {
     pub fn resolved_file_root(&self) -> PathBuf {
         if let Some(path) = self.file_root.as_deref() {
             return expand_path(path);
         }
         std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    }
+}
+
+impl ExternalSkillsConfig {
+    pub fn normalized_allowed_domains(&self) -> Vec<String> {
+        normalize_domain_entries(&self.allowed_domains)
+    }
+
+    pub fn normalized_blocked_domains(&self) -> Vec<String> {
+        normalize_domain_entries(&self.blocked_domains)
     }
 }
 
@@ -190,6 +223,21 @@ fn default_shell_allowlist() -> Vec<String> {
     ]
 }
 
+const fn default_require_download_approval() -> bool {
+    true
+}
+
+fn normalize_domain_entries(entries: &[String]) -> Vec<String> {
+    let mut normalized = BTreeSet::new();
+    for entry in entries {
+        let value = entry.trim().to_ascii_lowercase();
+        if !value.is_empty() {
+            normalized.insert(value);
+        }
+    }
+    normalized.into_iter().collect()
+}
+
 const fn default_sliding_window() -> usize {
     12
 }
@@ -221,6 +269,41 @@ mod tests {
         assert_eq!(
             config.trimmed_profile_note().as_deref(),
             Some("imported preferences")
+        );
+    }
+
+    #[test]
+    fn external_skills_defaults_to_safe_off_mode() {
+        let config = ExternalSkillsConfig::default();
+        assert!(!config.enabled);
+        assert!(config.require_download_approval);
+        assert!(config.allowed_domains.is_empty());
+        assert!(config.blocked_domains.is_empty());
+    }
+
+    #[test]
+    fn external_skills_normalized_domains_are_lowercase_and_deduped() {
+        let config = ExternalSkillsConfig {
+            enabled: true,
+            require_download_approval: true,
+            allowed_domains: vec![
+                "Skills.SH".to_owned(),
+                "skills.sh".to_owned(),
+                "  CLAWHUB.IO ".to_owned(),
+            ],
+            blocked_domains: vec![
+                "Bad.Example".to_owned(),
+                "bad.example".to_owned(),
+                " ".to_owned(),
+            ],
+        };
+        assert_eq!(
+            config.normalized_allowed_domains(),
+            vec!["clawhub.io".to_owned(), "skills.sh".to_owned()]
+        );
+        assert_eq!(
+            config.normalized_blocked_domains(),
+            vec!["bad.example".to_owned()]
         );
     }
 }

--- a/crates/app/src/conversation/integration_tests.rs
+++ b/crates/app/src/conversation/integration_tests.rs
@@ -93,6 +93,7 @@ impl TurnTestHarness {
         let tool_config = ToolRuntimeConfig {
             shell_allowlist: BTreeSet::from(["echo".to_owned(), "cat".to_owned(), "ls".to_owned()]),
             file_root: Some(temp_dir.clone()),
+            external_skills: Default::default(),
         };
 
         let audit = Arc::new(InMemoryAuditSink::default());

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10,8 +10,8 @@ use loongclaw_kernel::{
 use serde_json::{Value, json};
 
 use super::super::config::{
-    CliChannelConfig, ConversationConfig, FeishuChannelConfig, LoongClawConfig, MemoryConfig,
-    ProviderConfig, TelegramChannelConfig, ToolConfig,
+    CliChannelConfig, ConversationConfig, ExternalSkillsConfig, FeishuChannelConfig,
+    LoongClawConfig, MemoryConfig, ProviderConfig, TelegramChannelConfig, ToolConfig,
 };
 use super::persistence::format_provider_error_reply;
 use super::runtime::DefaultConversationRuntime;
@@ -151,6 +151,7 @@ fn test_config() -> LoongClawConfig {
         feishu: FeishuChannelConfig::default(),
         conversation: ConversationConfig::default(),
         tools: ToolConfig::default(),
+        external_skills: ExternalSkillsConfig::default(),
         memory: MemoryConfig::default(),
     }
 }

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -1,7 +1,11 @@
 mod merge;
 mod orchestrator;
 
-use std::{collections::BTreeSet, fs, path::Path};
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use crate::{
     CliResult,
@@ -64,6 +68,86 @@ pub struct ImportPlan {
     pub warnings: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExternalSkillArtifactKind {
+    SkillsCatalog,
+    SkillsLock,
+    CodexSkillsDir,
+    ClaudeSkillsDir,
+    SkillsDir,
+}
+
+impl ExternalSkillArtifactKind {
+    pub fn as_id(self) -> &'static str {
+        match self {
+            Self::SkillsCatalog => "skills_catalog",
+            Self::SkillsLock => "skills_lock",
+            Self::CodexSkillsDir => "codex_skills_dir",
+            Self::ClaudeSkillsDir => "claude_skills_dir",
+            Self::SkillsDir => "skills_dir",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalSkillArtifact {
+    pub kind: ExternalSkillArtifactKind,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ExternalSkillMappingPlan {
+    pub input_path: PathBuf,
+    pub artifacts: Vec<ExternalSkillArtifact>,
+    pub declared_skills: Vec<String>,
+    pub locked_skills: Vec<String>,
+    pub resolved_skills: Vec<String>,
+    pub profile_note_addendum: Option<String>,
+    pub warnings: Vec<String>,
+}
+
+pub fn plan_external_skill_mapping(input_path: &Path) -> ExternalSkillMappingPlan {
+    let artifacts = detect_external_skill_artifacts(input_path);
+    let mut warnings = artifacts
+        .iter()
+        .map(external_skill_warning)
+        .collect::<Vec<_>>();
+    let declared_skills = collect_declared_skills(&artifacts, &mut warnings);
+    let locked_skills = collect_locked_skills(&artifacts, &mut warnings);
+    let resolved_skills = merge_resolved_skills(&declared_skills, &locked_skills);
+    ExternalSkillMappingPlan {
+        input_path: input_path.to_path_buf(),
+        profile_note_addendum: render_external_skill_profile_note_addendum(
+            &artifacts,
+            &declared_skills,
+            &locked_skills,
+            &resolved_skills,
+        ),
+        artifacts,
+        declared_skills,
+        locked_skills,
+        resolved_skills,
+        warnings,
+    }
+}
+
+pub fn apply_external_skill_mapping(
+    config: &mut LoongClawConfig,
+    plan: &ExternalSkillMappingPlan,
+) -> usize {
+    let Some(addendum) = plan.profile_note_addendum.as_deref() else {
+        return 0;
+    };
+    let Some(merged) = merge_profile_note_addendum(config.memory.profile_note.as_deref(), addendum)
+    else {
+        return 0;
+    };
+
+    config.memory.profile = MemoryProfile::ProfilePlusWindow;
+    config.memory.profile_note = Some(merged);
+    trimmed_bullet_line_count(addendum)
+}
+
 pub fn plan_import_from_path(
     input_path: &Path,
     hint: Option<LegacyClawSource>,
@@ -112,6 +196,10 @@ pub fn plan_import_from_path(
         }
     }
 
+    for warning in build_external_skill_warnings(input_path) {
+        warnings.push(warning);
+    }
+
     if prompt_blocks.is_empty()
         && profile_blocks.is_empty()
         && warnings.is_empty()
@@ -152,8 +240,9 @@ pub(crate) fn inspect_import_path(
     input_path: &Path,
     hint: Option<LegacyClawSource>,
 ) -> CliResult<Option<ImportPathInspection>> {
+    let external_skill_artifacts = detect_external_skill_artifacts(input_path);
     let files = collect_import_files(input_path)?;
-    if files.is_empty() {
+    if files.is_empty() && external_skill_artifacts.is_empty() {
         return Ok(None);
     }
 
@@ -162,6 +251,17 @@ pub(crate) fn inspect_import_path(
     let mut custom_prompt_files = 0usize;
     let mut custom_profile_files = 0usize;
     let mut warning_count = 0usize;
+
+    if !external_skill_artifacts.is_empty() {
+        found_files.extend(external_skill_artifacts.iter().map(|artifact| {
+            format!(
+                "external_skill:{}:{}",
+                artifact.kind.as_id(),
+                artifact.path.display()
+            )
+        }));
+        warning_count = warning_count.saturating_add(external_skill_artifacts.len());
+    }
 
     for file in files {
         found_files.push(file.label.clone());
@@ -467,6 +567,372 @@ fn heartbeat_has_active_tasks(content: &str) -> bool {
         .any(|line| line.starts_with("- ") && line.len() > 2)
 }
 
+fn build_external_skill_warnings(input_path: &Path) -> Vec<String> {
+    plan_external_skill_mapping(input_path).warnings
+}
+
+fn detect_external_skill_artifacts(input_path: &Path) -> Vec<ExternalSkillArtifact> {
+    let mut artifacts = Vec::new();
+    let mut seen = BTreeSet::new();
+    for root in external_skill_probe_roots(input_path) {
+        for (relative, kind) in [
+            ("SKILLS.md", ExternalSkillArtifactKind::SkillsCatalog),
+            ("skills-lock.json", ExternalSkillArtifactKind::SkillsLock),
+            (".codex/skills", ExternalSkillArtifactKind::CodexSkillsDir),
+            (".claude/skills", ExternalSkillArtifactKind::ClaudeSkillsDir),
+            ("skills", ExternalSkillArtifactKind::SkillsDir),
+        ] {
+            let path = root.join(relative);
+            if path.is_file() || path.is_dir() {
+                let canonical = path.canonicalize().unwrap_or(path);
+                let key = canonical.display().to_string();
+                if seen.insert(key) {
+                    artifacts.push(ExternalSkillArtifact {
+                        kind,
+                        path: canonical,
+                    });
+                }
+            }
+        }
+    }
+    artifacts.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then_with(|| left.kind.as_id().cmp(right.kind.as_id()))
+    });
+    artifacts
+}
+
+fn external_skill_probe_roots(input_path: &Path) -> Vec<PathBuf> {
+    let mut roots = BTreeSet::new();
+    if input_path.is_file() {
+        if let Some(parent) = input_path.parent() {
+            roots.insert(parent.to_path_buf());
+        }
+    } else {
+        roots.insert(input_path.to_path_buf());
+        let workspace_root = input_path.join("workspace");
+        if workspace_root.is_dir() {
+            roots.insert(workspace_root);
+        }
+    }
+    roots.into_iter().collect()
+}
+
+fn external_skill_warning(artifact: &ExternalSkillArtifact) -> String {
+    format!(
+        "detected external skills artifact `{}` ({}); LoongClaw imports prompt/profile content but does not auto-wire external skill runtimes",
+        artifact.path.display(),
+        artifact.kind.as_id()
+    )
+}
+
+fn collect_declared_skills(
+    artifacts: &[ExternalSkillArtifact],
+    warnings: &mut Vec<String>,
+) -> Vec<String> {
+    let mut collected = BTreeSet::new();
+    for artifact in artifacts {
+        match artifact.kind {
+            ExternalSkillArtifactKind::SkillsCatalog => {
+                let content = match fs::read_to_string(&artifact.path) {
+                    Ok(content) => content,
+                    Err(error) => {
+                        warnings.push(format!(
+                            "failed to read declared skills catalog {}: {error}",
+                            artifact.path.display()
+                        ));
+                        continue;
+                    }
+                };
+                for skill in parse_skills_markdown_entries(&content) {
+                    collected.insert(skill);
+                }
+            }
+            ExternalSkillArtifactKind::CodexSkillsDir
+            | ExternalSkillArtifactKind::ClaudeSkillsDir
+            | ExternalSkillArtifactKind::SkillsDir => {
+                for skill in list_directory_skill_entries(&artifact.path, warnings) {
+                    collected.insert(skill);
+                }
+            }
+            ExternalSkillArtifactKind::SkillsLock => {}
+        }
+    }
+    collected.into_iter().collect()
+}
+
+fn collect_locked_skills(
+    artifacts: &[ExternalSkillArtifact],
+    warnings: &mut Vec<String>,
+) -> Vec<String> {
+    let mut collected = BTreeSet::new();
+    for artifact in artifacts {
+        if artifact.kind != ExternalSkillArtifactKind::SkillsLock {
+            continue;
+        }
+
+        let content = match fs::read_to_string(&artifact.path) {
+            Ok(content) => content,
+            Err(error) => {
+                warnings.push(format!(
+                    "failed to read skills lock {}: {error}",
+                    artifact.path.display()
+                ));
+                continue;
+            }
+        };
+        let value = match serde_json::from_str::<Value>(&content) {
+            Ok(value) => value,
+            Err(error) => {
+                warnings.push(format!(
+                    "failed to parse skills lock {}: {error}",
+                    artifact.path.display()
+                ));
+                continue;
+            }
+        };
+        for skill in parse_skills_lock_entries(&value) {
+            collected.insert(skill);
+        }
+    }
+    collected.into_iter().collect()
+}
+
+fn merge_resolved_skills(declared: &[String], locked: &[String]) -> Vec<String> {
+    let mut resolved = BTreeSet::new();
+    for skill in declared.iter().chain(locked.iter()) {
+        resolved.insert(skill.clone());
+    }
+    resolved.into_iter().collect()
+}
+
+fn parse_skills_markdown_entries(content: &str) -> Vec<String> {
+    let mut skills = BTreeSet::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        let candidate = trimmed
+            .strip_prefix("- ")
+            .or_else(|| trimmed.strip_prefix("* "))
+            .map(str::trim);
+        let Some(raw_entry) = candidate else {
+            continue;
+        };
+        if let Some(skill) = normalize_skill_reference(raw_entry) {
+            skills.insert(skill);
+        }
+    }
+    skills.into_iter().collect()
+}
+
+fn list_directory_skill_entries(path: &Path, warnings: &mut Vec<String>) -> Vec<String> {
+    if !path.is_dir() {
+        return Vec::new();
+    }
+    let entries = match fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(error) => {
+            warnings.push(format!(
+                "failed to enumerate skills directory {}: {error}",
+                path.display()
+            ));
+            return Vec::new();
+        }
+    };
+
+    let mut skills = BTreeSet::new();
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                warnings.push(format!(
+                    "failed to read skills directory entry under {}: {error}",
+                    path.display()
+                ));
+                continue;
+            }
+        };
+        let entry_path = entry.path();
+        if !entry_path.is_dir() {
+            continue;
+        }
+        if let Some(skill) = entry_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(normalize_skill_reference)
+        {
+            skills.insert(skill);
+        }
+    }
+    skills.into_iter().collect()
+}
+
+fn parse_skills_lock_entries(value: &Value) -> Vec<String> {
+    let mut skills = BTreeSet::new();
+    extract_skill_refs_from_lock_value(value, &mut skills);
+    skills.into_iter().collect()
+}
+
+fn extract_skill_refs_from_lock_value(value: &Value, skills: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(object) => {
+            for (key, nested) in object {
+                match key.as_str() {
+                    "skills" | "skill" | "skill_id" | "skillId" | "id" | "name" | "slug" => {
+                        collect_skill_refs_from_value(nested, skills);
+                    }
+                    _ => extract_skill_refs_from_lock_value(nested, skills),
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                extract_skill_refs_from_lock_value(item, skills);
+            }
+        }
+        Value::String(raw) => {
+            if let Some(skill) = normalize_skill_reference(raw) {
+                skills.insert(skill);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_skill_refs_from_value(value: &Value, skills: &mut BTreeSet<String>) {
+    match value {
+        Value::String(raw) => {
+            if let Some(skill) = normalize_skill_reference(raw) {
+                skills.insert(skill);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_skill_refs_from_value(item, skills);
+            }
+        }
+        Value::Object(object) => {
+            for nested in object.values() {
+                collect_skill_refs_from_value(nested, skills);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn normalize_skill_reference(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let unwrapped = trimmed.trim_matches('`').trim();
+    let mut candidate = if unwrapped.starts_with('[') {
+        unwrapped
+            .strip_prefix('[')
+            .and_then(|rest| rest.split_once(']'))
+            .map(|(label, _)| label)
+            .unwrap_or(unwrapped)
+    } else {
+        unwrapped
+    };
+
+    if let Some((head, _)) = candidate.split_once("](") {
+        candidate = head;
+    }
+    if let Some((head, _)) = candidate.split_once(char::is_whitespace) {
+        candidate = head;
+    }
+    let normalized = candidate
+        .trim_matches(|ch: char| matches!(ch, ',' | ';' | '.' | '"' | '\'' | ')' | '('))
+        .trim();
+    if normalized.is_empty() {
+        return None;
+    }
+    if normalized.starts_with('#') {
+        return None;
+    }
+    if normalized.len() > 120 {
+        return None;
+    }
+
+    let canonical = normalized.to_ascii_lowercase();
+    if canonical
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '/' | '.'))
+    {
+        return Some(canonical);
+    }
+    None
+}
+
+fn render_external_skill_profile_note_addendum(
+    artifacts: &[ExternalSkillArtifact],
+    declared_skills: &[String],
+    locked_skills: &[String],
+    resolved_skills: &[String],
+) -> Option<String> {
+    if artifacts.is_empty() {
+        return None;
+    }
+
+    let mut lines = vec!["## Imported External Skills Artifacts".to_owned()];
+    for artifact in artifacts {
+        lines.push(format!(
+            "- kind={} path={}",
+            artifact.kind.as_id(),
+            artifact.path.display()
+        ));
+    }
+    if !declared_skills.is_empty() {
+        lines.push("## Imported External Skills Declared".to_owned());
+        for skill in declared_skills {
+            lines.push(format!("- skill={skill} source=declared"));
+        }
+    }
+    if !locked_skills.is_empty() {
+        lines.push("## Imported External Skills Locked".to_owned());
+        for skill in locked_skills {
+            lines.push(format!("- skill={skill} source=lock"));
+        }
+    }
+    if !resolved_skills.is_empty() {
+        lines.push("## Imported External Skills Resolved".to_owned());
+        for skill in resolved_skills {
+            lines.push(format!("- skill={skill} source=resolved"));
+        }
+    }
+    Some(lines.join("\n"))
+}
+
+fn merge_profile_note_addendum(existing: Option<&str>, addendum: &str) -> Option<String> {
+    let trimmed_addendum = addendum.trim();
+    if trimmed_addendum.is_empty() {
+        return None;
+    }
+
+    match existing {
+        None => Some(trimmed_addendum.to_owned()),
+        Some(current) => {
+            if current.contains(trimmed_addendum) {
+                return None;
+            }
+            if current.trim().is_empty() {
+                return Some(trimmed_addendum.to_owned());
+            }
+            Some(format!("{}\n\n{trimmed_addendum}", current.trim_end()))
+        }
+    }
+}
+
+fn trimmed_bullet_line_count(content: &str) -> usize {
+    content
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("- "))
+        .count()
+}
+
 fn render_aieos_profile_note(content: &str) -> CliResult<Option<String>> {
     let value = serde_json::from_str::<Value>(content)
         .map_err(|error| format!("failed to parse imported identity.json: {error}"))?;
@@ -749,6 +1215,91 @@ mod tests {
         assert!(note.contains("Nova"));
         assert!(note.contains("LoongClaw Labs"));
         assert!(note.contains("privacy first"));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn external_skill_artifacts_emit_warnings_in_import_plan() {
+        let root = unique_temp_dir("loongclaw-import-external-skill-warning");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "SOUL.md",
+            "# Soul\n\nPrefer concise shell output with clear reasoning.\n",
+        );
+        write_file(&root, "SKILLS.md", "# Skills\n\n- custom/skill-a\n");
+        fs::create_dir_all(root.join(".codex/skills")).expect("create skills dir");
+
+        let plan = plan_import_from_path(&root, Some(LegacyClawSource::Unknown))
+            .expect("plan should succeed");
+        assert!(
+            plan.warnings
+                .iter()
+                .any(|warning| warning.contains("external skills artifact")),
+            "expected at least one external skills warning"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn plan_external_skill_mapping_builds_profile_note_addendum() {
+        let root = unique_temp_dir("loongclaw-import-external-skill-map");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(&root, "SKILLS.md", "# Skills\n\n- custom/skill-a\n");
+        fs::create_dir_all(root.join(".codex/skills")).expect("create codex skills dir");
+        write_file(
+            &root,
+            "skills-lock.json",
+            "{ \"version\": 1, \"skills\": [\"custom/skill-a\"] }\n",
+        );
+
+        let mapping = plan_external_skill_mapping(&root);
+        assert_eq!(mapping.input_path, root);
+        assert_eq!(mapping.artifacts.len(), 3);
+        assert_eq!(mapping.warnings.len(), 3);
+        assert_eq!(mapping.declared_skills, vec!["custom/skill-a".to_owned()]);
+        assert_eq!(mapping.locked_skills, vec!["custom/skill-a".to_owned()]);
+        assert_eq!(mapping.resolved_skills, vec!["custom/skill-a".to_owned()]);
+        let addendum = mapping
+            .profile_note_addendum
+            .as_deref()
+            .expect("profile note addendum should exist");
+        assert!(addendum.contains("Imported External Skills Artifacts"));
+        assert!(addendum.contains("kind=skills_catalog"));
+        assert!(addendum.contains("kind=skills_lock"));
+        assert!(addendum.contains("kind=codex_skills_dir"));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn apply_external_skill_mapping_appends_profile_note_once() {
+        let root = unique_temp_dir("loongclaw-import-external-skill-apply");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(&root, "SKILLS.md", "# Skills\n\n- custom/skill-a\n");
+
+        let plan = plan_external_skill_mapping(&root);
+        let mut config = LoongClawConfig::default();
+        config.memory.profile_note = Some("## Imported IDENTITY.md\n- tone steady".to_owned());
+
+        let first_applied = apply_external_skill_mapping(&mut config, &plan);
+        assert_eq!(first_applied, 3);
+        let first_note = config
+            .memory
+            .profile_note
+            .clone()
+            .expect("profile note should exist");
+        assert!(first_note.contains("Imported External Skills Artifacts"));
+
+        let second_applied = apply_external_skill_mapping(&mut config, &plan);
+        assert_eq!(second_applied, 0, "duplicate addendum should not re-append");
+        assert_eq!(
+            config.memory.profile_note.as_deref(),
+            Some(first_note.as_str()),
+            "profile note should remain stable after duplicate apply"
+        );
 
         fs::remove_dir_all(&root).ok();
     }

--- a/crates/app/src/migration/orchestrator.rs
+++ b/crates/app/src/migration/orchestrator.rs
@@ -10,8 +10,9 @@ use serde::{Deserialize, Serialize};
 use crate::CliResult;
 
 use super::{
-    LegacyClawSource, MergedProfilePlan, ProfileEntryLane, ProfileMergeEntry, apply_import_plan,
-    inspect_import_path, merge_profile_entries, plan_import_from_path,
+    LegacyClawSource, MergedProfilePlan, ProfileEntryLane, ProfileMergeEntry,
+    apply_external_skill_mapping, apply_import_plan, inspect_import_path, merge_profile_entries,
+    plan_external_skill_mapping, plan_import_from_path,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -77,6 +78,8 @@ pub struct ApplyImportSelection {
     pub discovery: DiscoveryReport,
     pub output_path: PathBuf,
     pub mode: ImportSelectionMode,
+    pub apply_external_skills_plan: bool,
+    pub external_skills_input_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,11 +87,14 @@ pub struct ApplyImportSelectionResult {
     pub output_path: PathBuf,
     pub backup_path: PathBuf,
     pub manifest_path: PathBuf,
+    pub external_skills_manifest_path: Option<PathBuf>,
     pub selected_primary_source_id: String,
     pub merged_source_ids: Vec<String>,
     pub prompt_owner_source_id: Option<String>,
     pub unresolved_conflicts: usize,
     pub warnings: Vec<String>,
+    pub external_skill_artifact_count: usize,
+    pub external_skill_entries_applied: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -102,6 +108,30 @@ struct ImportApplyManifest {
     output_preexisted: bool,
     warnings: Vec<String>,
     unresolved_conflicts: usize,
+    #[serde(default)]
+    external_skill_artifact_count: usize,
+    #[serde(default)]
+    external_skill_entries_applied: usize,
+    #[serde(default)]
+    external_skills_manifest_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ExternalSkillsApplyManifest {
+    output_path: String,
+    input_path: String,
+    artifact_count: usize,
+    artifacts: Vec<ExternalSkillsApplyArtifact>,
+    declared_skills: Vec<String>,
+    locked_skills: Vec<String>,
+    resolved_skills: Vec<String>,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ExternalSkillsApplyArtifact {
+    kind: String,
+    path: String,
 }
 
 pub fn discover_import_sources(
@@ -239,6 +269,9 @@ pub fn apply_import_selection(
 
     let mut config = load_or_default_config(Some(&request.output_path))?;
     let mut warnings = Vec::new();
+    let mut external_skill_artifact_count = 0usize;
+    let mut external_skill_entries_applied = 0usize;
+    let mut external_skill_mapping = None;
     let (merged_source_ids, prompt_owner_source_id, unresolved_conflicts) = match &request.mode {
         ImportSelectionMode::RecommendedSingleSource { .. }
         | ImportSelectionMode::SelectedSingleSource { .. } => {
@@ -291,6 +324,21 @@ pub fn apply_import_selection(
         }
     };
 
+    if request.apply_external_skills_plan {
+        let input_path = request
+            .external_skills_input_path
+            .as_deref()
+            .ok_or_else(|| {
+                "apply_external_skills_plan requires external_skills_input_path".to_owned()
+            })?;
+        let mapping = plan_external_skill_mapping(input_path);
+        external_skill_artifact_count = mapping.artifacts.len();
+        external_skill_entries_applied = apply_external_skill_mapping(&mut config, &mapping);
+        warnings.extend(mapping.warnings.clone());
+        external_skill_mapping = Some(mapping);
+    }
+    dedup_strings_in_place(&mut warnings);
+
     let state_dir = migration_state_dir(&request.output_path);
     fs::create_dir_all(&state_dir).map_err(|error| {
         format!(
@@ -320,6 +368,22 @@ pub fn apply_import_selection(
 
     let output_string = request.output_path.display().to_string();
     let written_output_path = crate::config::write(Some(&output_string), &config, true)?;
+    let external_skills_manifest_path = if let Some(mapping) = external_skill_mapping.as_ref() {
+        let external_path =
+            external_skills_manifest_path_for_output(&request.output_path, &state_dir);
+        let external_manifest = build_external_skills_apply_manifest(&written_output_path, mapping);
+        let body = serde_json::to_vec_pretty(&external_manifest)
+            .map_err(|error| format!("failed to encode external skills manifest: {error}"))?;
+        fs::write(&external_path, body).map_err(|error| {
+            format!(
+                "failed to write external skills manifest {}: {error}",
+                external_path.display()
+            )
+        })?;
+        Some(external_path)
+    } else {
+        None
+    };
 
     let manifest = ImportApplyManifest {
         session_id,
@@ -331,6 +395,11 @@ pub fn apply_import_selection(
         output_preexisted,
         warnings: warnings.clone(),
         unresolved_conflicts,
+        external_skill_artifact_count,
+        external_skill_entries_applied,
+        external_skills_manifest_path: external_skills_manifest_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
     };
     let manifest_body = serde_json::to_vec_pretty(&manifest)
         .map_err(|error| format!("failed to encode import manifest: {error}"))?;
@@ -345,12 +414,43 @@ pub fn apply_import_selection(
         output_path: written_output_path,
         backup_path,
         manifest_path,
+        external_skills_manifest_path,
         selected_primary_source_id,
         merged_source_ids,
         prompt_owner_source_id,
         unresolved_conflicts,
         warnings,
+        external_skill_artifact_count,
+        external_skill_entries_applied,
     })
+}
+
+fn dedup_strings_in_place(values: &mut Vec<String>) {
+    let mut seen = BTreeSet::new();
+    values.retain(|value| seen.insert(value.clone()));
+}
+
+fn build_external_skills_apply_manifest(
+    output_path: &Path,
+    mapping: &super::ExternalSkillMappingPlan,
+) -> ExternalSkillsApplyManifest {
+    ExternalSkillsApplyManifest {
+        output_path: output_path.display().to_string(),
+        input_path: mapping.input_path.display().to_string(),
+        artifact_count: mapping.artifacts.len(),
+        artifacts: mapping
+            .artifacts
+            .iter()
+            .map(|artifact| ExternalSkillsApplyArtifact {
+                kind: artifact.kind.as_id().to_owned(),
+                path: artifact.path.display().to_string(),
+            })
+            .collect(),
+        declared_skills: mapping.declared_skills.clone(),
+        locked_skills: mapping.locked_skills.clone(),
+        resolved_skills: mapping.resolved_skills.clone(),
+        warnings: mapping.warnings.clone(),
+    }
 }
 
 pub fn rollback_last_import(output_path: &Path) -> CliResult<PathBuf> {
@@ -612,6 +712,14 @@ fn manifest_path_for_output(output_path: &Path, state_dir: &Path) -> PathBuf {
     state_dir.join(format!("{file_tag}.last-import.json"))
 }
 
+fn external_skills_manifest_path_for_output(output_path: &Path, state_dir: &Path) -> PathBuf {
+    let file_tag = output_path
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|| "loongclaw-config".to_owned());
+    state_dir.join(format!("{file_tag}.external-skills.json"))
+}
+
 fn backup_path_for_output(output_path: &Path, state_dir: &Path, session_id: &str) -> PathBuf {
     let file_tag = output_path
         .file_name()
@@ -845,6 +953,8 @@ mod tests {
             mode: ImportSelectionMode::RecommendedSingleSource {
                 source_id: "openclaw".to_owned(),
             },
+            apply_external_skills_plan: false,
+            external_skills_input_path: None,
         })
         .expect("apply should succeed");
 
@@ -899,6 +1009,8 @@ mod tests {
             mode: ImportSelectionMode::SafeProfileMerge {
                 primary_source_id: recommendation.source_id,
             },
+            apply_external_skills_plan: false,
+            external_skills_input_path: None,
         })
         .expect("safe profile merge should succeed");
 
@@ -960,6 +1072,8 @@ mod tests {
             mode: ImportSelectionMode::SelectedSingleSource {
                 source_id: selected_source_id.clone(),
             },
+            apply_external_skills_plan: false,
+            external_skills_input_path: None,
         })
         .expect("apply should succeed");
 
@@ -982,6 +1096,68 @@ mod tests {
                 .as_deref()
                 .is_some_and(|value| value.contains("region: west")),
             "expected selected source profile note to be imported"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn apply_import_selection_can_attach_external_skill_mapping() {
+        let root = unique_temp_dir("loongclaw-import-apply-external-skills");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n",
+        );
+        write_file(&root, "SKILLS.md", "# Skills\n\n- custom/skill-a\n");
+
+        let discovery = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        let output_path = root.join("loongclaw.toml");
+
+        let result = apply_import_selection(&ApplyImportSelection {
+            discovery,
+            output_path: output_path.clone(),
+            mode: ImportSelectionMode::SelectedSingleSource {
+                source_id: "openclaw".to_owned(),
+            },
+            apply_external_skills_plan: true,
+            external_skills_input_path: Some(root.clone()),
+        })
+        .expect("apply should succeed");
+
+        assert_eq!(result.external_skill_artifact_count, 1);
+        assert_eq!(result.external_skill_entries_applied, 3);
+        assert!(
+            result.external_skills_manifest_path.is_some(),
+            "expected external skills manifest path"
+        );
+        let output_string = output_path.display().to_string();
+        let (_, merged_config) =
+            crate::config::load(Some(&output_string)).expect("load merged config");
+        let profile_note = merged_config
+            .memory
+            .profile_note
+            .as_deref()
+            .expect("profile note should be present");
+        assert!(profile_note.contains("Imported External Skills Artifacts"));
+        assert!(profile_note.contains("kind=skills_catalog"));
+        let external_manifest = result
+            .external_skills_manifest_path
+            .as_ref()
+            .expect("external skills manifest should be present");
+        assert!(
+            external_manifest.exists(),
+            "external skills manifest should be written"
         );
 
         fs::remove_dir_all(&root).ok();
@@ -1018,6 +1194,8 @@ mod tests {
             mode: ImportSelectionMode::RecommendedSingleSource {
                 source_id: "openclaw".to_owned(),
             },
+            apply_external_skills_plan: false,
+            external_skills_input_path: None,
         })
         .expect("apply should succeed");
 

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -483,8 +483,8 @@ mod tests {
     use super::payload_adaptation::{ReasoningField, TemperatureField, TokenLimitField};
     use super::*;
     use crate::config::{
-        ConversationConfig, FeishuChannelConfig, MemoryConfig, ProviderConfig, ProviderKind,
-        ReasoningEffort, ToolConfig,
+        ConversationConfig, ExternalSkillsConfig, FeishuChannelConfig, MemoryConfig,
+        ProviderConfig, ProviderKind, ReasoningEffort, ToolConfig,
     };
     use serde_json::json;
 
@@ -497,6 +497,7 @@ mod tests {
             feishu: FeishuChannelConfig::default(),
             conversation: ConversationConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
         };
 
@@ -515,6 +516,7 @@ mod tests {
             feishu: FeishuChannelConfig::default(),
             conversation: ConversationConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
         };
 
@@ -550,6 +552,7 @@ mod tests {
             feishu: FeishuChannelConfig::default(),
             conversation: ConversationConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
         };
 
@@ -630,6 +633,7 @@ mod tests {
             feishu: FeishuChannelConfig::default(),
             conversation: ConversationConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
         };
 
@@ -700,6 +704,7 @@ mod tests {
             telegram: crate::config::TelegramChannelConfig::default(),
             feishu: FeishuChannelConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
             conversation: crate::config::ConversationConfig::default(),
         };
@@ -722,6 +727,7 @@ mod tests {
             telegram: crate::config::TelegramChannelConfig::default(),
             feishu: FeishuChannelConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
             conversation: crate::config::ConversationConfig::default(),
         };
@@ -752,6 +758,7 @@ mod tests {
             telegram: crate::config::TelegramChannelConfig::default(),
             feishu: FeishuChannelConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
             conversation: crate::config::ConversationConfig::default(),
         };
@@ -796,6 +803,7 @@ mod tests {
             feishu: FeishuChannelConfig::default(),
             conversation: ConversationConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
         };
         config.provider.reasoning_effort = Some(ReasoningEffort::High);
@@ -820,6 +828,7 @@ mod tests {
             telegram: crate::config::TelegramChannelConfig::default(),
             feishu: FeishuChannelConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
             conversation: crate::config::ConversationConfig::default(),
         };
@@ -859,6 +868,7 @@ mod tests {
             feishu: FeishuChannelConfig::default(),
             conversation: ConversationConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
         };
 
@@ -917,6 +927,7 @@ mod tests {
             feishu: FeishuChannelConfig::default(),
             conversation: ConversationConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
         };
 
@@ -942,6 +953,8 @@ mod tests {
 
         let mut expected = Vec::new();
         expected.push("claw_import");
+        expected.push("external_skills_fetch");
+        expected.push("external_skills_policy");
         #[cfg(feature = "tool-file")]
         {
             expected.push("file_read");
@@ -1115,6 +1128,7 @@ mod tests {
             telegram: crate::config::TelegramChannelConfig::default(),
             feishu: FeishuChannelConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
             conversation: crate::config::ConversationConfig::default(),
         };
@@ -1136,6 +1150,7 @@ mod tests {
             telegram: crate::config::TelegramChannelConfig::default(),
             feishu: FeishuChannelConfig::default(),
             tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
             conversation: crate::config::ConversationConfig::default(),
         };

--- a/crates/app/src/tools/claw_import.rs
+++ b/crates/app/src/tools/claw_import.rs
@@ -38,10 +38,11 @@ pub(super) fn execute_claw_import_tool_with_config(
             | "plan_many"
             | "recommend_primary"
             | "merge_profiles"
+            | "map_external_skills"
             | "rollback_last_apply"
     ) {
         return Err(format!(
-            "claw.import payload.mode must be `plan`, `apply`, `apply_selected`, `discover`, `plan_many`, `recommend_primary`, `merge_profiles`, or `rollback_last_apply`, got `{mode}`"
+            "claw.import payload.mode must be `plan`, `apply`, `apply_selected`, `discover`, `plan_many`, `recommend_primary`, `merge_profiles`, `map_external_skills`, or `rollback_last_apply`, got `{mode}`"
         ));
     }
 
@@ -168,11 +169,29 @@ pub(super) fn execute_claw_import_tool_with_config(
         });
     }
 
+    if mode == "map_external_skills" {
+        let mapping = migration::plan_external_skill_mapping(input_path.as_path());
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "core-tools",
+                "tool_name": request.tool_name,
+                "mode": "map_external_skills",
+                "input_path": input_path.display().to_string(),
+                "result": external_skill_mapping_plan_payload(&mapping),
+            }),
+        });
+    }
+
     if mode == "apply_selected" {
         let report =
             migration::discover_import_sources(input_path, migration::DiscoveryOptions::default())?;
         let summary = migration::plan_import_sources(&report)?;
         let selection = parse_apply_selection_mode(payload, &summary)?;
+        let apply_external_skills_plan = payload
+            .get("apply_external_skills_plan")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
         let selected_output_path = output_path.clone().ok_or_else(|| {
             "claw.import apply_selected mode requires payload.output_path".to_owned()
         })?;
@@ -180,6 +199,12 @@ pub(super) fn execute_claw_import_tool_with_config(
             discovery: report,
             output_path: selected_output_path,
             mode: selection,
+            apply_external_skills_plan,
+            external_skills_input_path: if apply_external_skills_plan {
+                Some(input_path.to_path_buf())
+            } else {
+                None
+            },
         })?;
         return Ok(ToolCoreOutcome {
             status: "ok".to_owned(),
@@ -189,6 +214,7 @@ pub(super) fn execute_claw_import_tool_with_config(
                 "mode": "apply_selected",
                 "input_path": input_path.display().to_string(),
                 "output_path": result.output_path.display().to_string(),
+                "apply_external_skills_plan": apply_external_skills_plan,
                 "result": apply_selection_result_payload(&result),
             }),
         });
@@ -229,7 +255,7 @@ pub(super) fn execute_claw_import_tool_with_config(
             "config_toml": config_toml,
             "next_step": written_output_path
                 .as_ref()
-                .map(|path| format!("loongclawd chat --config {}", path.display())),
+                .map(|path| format!("loongclaw chat --config {}", path.display())),
         }),
     })
 }
@@ -318,15 +344,43 @@ fn merged_profile_plan_payload(plan: &migration::MergedProfilePlan) -> Value {
     })
 }
 
+fn external_skill_mapping_plan_payload(plan: &migration::ExternalSkillMappingPlan) -> Value {
+    json!({
+        "input_path": plan.input_path.display().to_string(),
+        "artifact_count": plan.artifacts.len(),
+        "artifacts": plan
+            .artifacts
+            .iter()
+            .map(|artifact| {
+                json!({
+                    "kind": artifact.kind.as_id(),
+                    "path": artifact.path.display().to_string(),
+                })
+            })
+            .collect::<Vec<_>>(),
+        "declared_skills": plan.declared_skills,
+        "locked_skills": plan.locked_skills,
+        "resolved_skills": plan.resolved_skills,
+        "profile_note_addendum": plan.profile_note_addendum,
+        "warnings": plan.warnings,
+    })
+}
+
 fn apply_selection_result_payload(result: &migration::ApplyImportSelectionResult) -> Value {
     json!({
         "output_path": result.output_path.display().to_string(),
         "backup_path": result.backup_path.display().to_string(),
         "manifest_path": result.manifest_path.display().to_string(),
+        "external_skills_manifest_path": result
+            .external_skills_manifest_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
         "selected_primary_source_id": result.selected_primary_source_id,
         "merged_source_ids": result.merged_source_ids,
         "prompt_owner_source_id": result.prompt_owner_source_id,
         "unresolved_conflicts": result.unresolved_conflicts,
+        "external_skill_artifact_count": result.external_skill_artifact_count,
+        "external_skill_entries_applied": result.external_skill_entries_applied,
         "warnings": result.warnings,
     })
 }

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -1,0 +1,809 @@
+use std::{
+    collections::BTreeSet,
+    fs,
+    io::Read,
+    path::{Path, PathBuf},
+    sync::{OnceLock, RwLock},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+
+const DEFAULT_DOWNLOAD_DIR_NAME: &str = "external-skills-downloads";
+const DEFAULT_MAX_DOWNLOAD_BYTES: usize = 5 * 1024 * 1024;
+const HARD_MAX_DOWNLOAD_BYTES: usize = 20 * 1024 * 1024;
+
+#[derive(Debug, Clone, Default)]
+struct ExternalSkillsPolicyOverride {
+    enabled: Option<bool>,
+    require_download_approval: Option<bool>,
+    allowed_domains: Option<BTreeSet<String>>,
+    blocked_domains: Option<BTreeSet<String>>,
+}
+
+static EXTERNAL_SKILLS_POLICY_OVERRIDE: OnceLock<RwLock<ExternalSkillsPolicyOverride>> =
+    OnceLock::new();
+
+pub(super) fn execute_external_skills_policy_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "external_skills.policy payload must be an object".to_owned())?;
+    let action = payload
+        .get("action")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("get")
+        .to_ascii_lowercase();
+
+    if !matches!(action.as_str(), "get" | "set" | "reset") {
+        return Err(format!(
+            "external_skills.policy payload.action must be `get`, `set`, or `reset`, got `{action}`"
+        ));
+    }
+
+    match action.as_str() {
+        "get" => {
+            let effective_policy = resolve_effective_policy(config)?;
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "adapter": "core-tools",
+                    "tool_name": request.tool_name,
+                    "action": "get",
+                    "policy": policy_payload(&effective_policy),
+                    "override_active": policy_override_is_active()?,
+                }),
+            })
+        }
+        "set" => {
+            let policy_update_approved = payload
+                .get("policy_update_approved")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            if !policy_update_approved {
+                return Err(
+                    "external skills policy update requires explicit authorization; set payload.policy_update_approved=true after user approval"
+                        .to_owned(),
+                );
+            }
+
+            let enabled = parse_optional_bool(payload, "enabled")?;
+            let require_download_approval =
+                parse_optional_bool(payload, "require_download_approval")?;
+            let allowed_domains = parse_optional_domain_list(payload, "allowed_domains")?;
+            let blocked_domains = parse_optional_domain_list(payload, "blocked_domains")?;
+
+            let override_store = policy_override_store();
+            let mut override_state = override_store
+                .write()
+                .map_err(|error| format!("external skills policy lock poisoned: {error}"))?;
+
+            if let Some(value) = enabled {
+                override_state.enabled = Some(value);
+            }
+            if let Some(value) = require_download_approval {
+                override_state.require_download_approval = Some(value);
+            }
+            if let Some(value) = allowed_domains {
+                override_state.allowed_domains = Some(value);
+            }
+            if let Some(value) = blocked_domains {
+                override_state.blocked_domains = Some(value);
+            }
+
+            let effective_policy = build_effective_policy(config, &override_state);
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "adapter": "core-tools",
+                    "tool_name": request.tool_name,
+                    "action": "set",
+                    "policy_update_approved": policy_update_approved,
+                    "policy": policy_payload(&effective_policy),
+                    "override_active": override_state.has_values(),
+                }),
+            })
+        }
+        "reset" => {
+            let policy_update_approved = payload
+                .get("policy_update_approved")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            if !policy_update_approved {
+                return Err(
+                    "external skills policy update requires explicit authorization; set payload.policy_update_approved=true after user approval"
+                        .to_owned(),
+                );
+            }
+
+            let override_store = policy_override_store();
+            let mut override_state = override_store
+                .write()
+                .map_err(|error| format!("external skills policy lock poisoned: {error}"))?;
+            *override_state = ExternalSkillsPolicyOverride::default();
+
+            let effective_policy = build_effective_policy(config, &override_state);
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "adapter": "core-tools",
+                    "tool_name": request.tool_name,
+                    "action": "reset",
+                    "policy_update_approved": policy_update_approved,
+                    "policy": policy_payload(&effective_policy),
+                    "override_active": false,
+                }),
+            })
+        }
+        _ => Err("unreachable external skills policy action".to_owned()),
+    }
+}
+
+pub(super) fn execute_external_skills_fetch_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "external_skills.fetch payload must be an object".to_owned())?;
+
+    let url = payload
+        .get("url")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "external_skills.fetch requires payload.url".to_owned())?;
+
+    let parsed_url = reqwest::Url::parse(url)
+        .map_err(|error| format!("invalid external skills url `{url}`: {error}"))?;
+    let host = parsed_url
+        .host_str()
+        .map(str::to_ascii_lowercase)
+        .ok_or_else(|| format!("external skills url `{url}` has no host"))?;
+    if parsed_url.scheme() != "https" {
+        return Err(format!(
+            "external skills download requires https url, got scheme `{}`",
+            parsed_url.scheme()
+        ));
+    }
+
+    let policy = resolve_effective_policy(config)?;
+    if !policy.enabled {
+        return Err(
+            "external skills runtime is disabled; enable `external_skills.enabled = true` first"
+                .to_owned(),
+        );
+    }
+
+    if let Some(rule) = first_matching_domain_rule(&host, &policy.blocked_domains) {
+        return Err(format!(
+            "external skills download blocked: host `{host}` matches blocked domain rule `{rule}`"
+        ));
+    }
+
+    if !policy.allowed_domains.is_empty()
+        && first_matching_domain_rule(&host, &policy.allowed_domains).is_none()
+    {
+        return Err(format!(
+            "external skills download denied: host `{host}` is not in allowed_domains"
+        ));
+    }
+
+    let approval_granted = payload
+        .get("approval_granted")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    if policy.require_download_approval && !approval_granted {
+        return Err(
+            "external skills download requires explicit authorization; set payload.approval_granted=true after user approval"
+                .to_owned(),
+        );
+    }
+
+    let max_bytes = parse_max_download_bytes(payload)?;
+    let save_as = parse_optional_string(payload, "save_as")?;
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|error| {
+            format!("failed to build HTTP client for external skills download: {error}")
+        })?;
+
+    let response = client
+        .get(parsed_url.clone())
+        .send()
+        .map_err(|error| format!("external skills download request failed: {error}"))?;
+
+    if response.status().is_redirection() {
+        return Err(format!(
+            "external skills download rejected redirect response {} for `{url}`",
+            response.status()
+        ));
+    }
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "external skills download returned non-success status {} for `{url}`",
+            response.status()
+        ));
+    }
+
+    let mut body = Vec::new();
+    let mut limited_reader = response.take((max_bytes as u64).saturating_add(1));
+    limited_reader
+        .read_to_end(&mut body)
+        .map_err(|error| format!("failed to read external skills download body: {error}"))?;
+
+    if body.len() > max_bytes {
+        return Err(format!(
+            "external skills download exceeded max_bytes limit ({max_bytes} bytes)"
+        ));
+    }
+
+    let output_dir = resolve_download_dir(config);
+    fs::create_dir_all(&output_dir).map_err(|error| {
+        format!(
+            "failed to create external skills download directory {}: {error}",
+            output_dir.display()
+        )
+    })?;
+
+    let requested_name = save_as
+        .as_deref()
+        .map(sanitize_filename)
+        .filter(|value| !value.is_empty());
+    let derived_name = requested_name.unwrap_or_else(|| derive_filename_from_url(&parsed_url));
+    let output_path = unique_output_path(&output_dir, &derived_name);
+
+    fs::write(&output_path, &body).map_err(|error| {
+        format!(
+            "failed to write downloaded external skill artifact {}: {error}",
+            output_path.display()
+        )
+    })?;
+
+    let sha256 = format!("{:x}", Sha256::digest(&body));
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": request.tool_name,
+            "url": url,
+            "host": host,
+            "saved_path": output_path.display().to_string(),
+            "bytes_downloaded": body.len(),
+            "sha256": sha256,
+            "approval_required": policy.require_download_approval,
+            "approval_granted": approval_granted,
+            "max_bytes": max_bytes,
+            "policy": policy_payload(&policy),
+        }),
+    })
+}
+
+fn policy_override_store() -> &'static RwLock<ExternalSkillsPolicyOverride> {
+    EXTERNAL_SKILLS_POLICY_OVERRIDE
+        .get_or_init(|| RwLock::new(ExternalSkillsPolicyOverride::default()))
+}
+
+fn policy_override_is_active() -> Result<bool, String> {
+    let guard = policy_override_store()
+        .read()
+        .map_err(|error| format!("external skills policy lock poisoned: {error}"))?;
+    Ok(guard.has_values())
+}
+
+fn resolve_effective_policy(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<super::runtime_config::ExternalSkillsRuntimePolicy, String> {
+    let override_state = policy_override_store()
+        .read()
+        .map_err(|error| format!("external skills policy lock poisoned: {error}"))?;
+    Ok(build_effective_policy(config, &override_state))
+}
+
+fn build_effective_policy(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    override_state: &ExternalSkillsPolicyOverride,
+) -> super::runtime_config::ExternalSkillsRuntimePolicy {
+    let mut effective = config.external_skills.clone();
+    if let Some(value) = override_state.enabled {
+        effective.enabled = value;
+    }
+    if let Some(value) = override_state.require_download_approval {
+        effective.require_download_approval = value;
+    }
+    if let Some(value) = override_state.allowed_domains.as_ref() {
+        effective.allowed_domains = value.clone();
+    }
+    if let Some(value) = override_state.blocked_domains.as_ref() {
+        effective.blocked_domains = value.clone();
+    }
+    effective
+}
+
+impl ExternalSkillsPolicyOverride {
+    fn has_values(&self) -> bool {
+        self.enabled.is_some()
+            || self.require_download_approval.is_some()
+            || self.allowed_domains.is_some()
+            || self.blocked_domains.is_some()
+    }
+}
+
+fn parse_optional_bool(payload: &Map<String, Value>, key: &str) -> Result<Option<bool>, String> {
+    let Some(value) = payload.get(key) else {
+        return Ok(None);
+    };
+    let parsed = value
+        .as_bool()
+        .ok_or_else(|| format!("external_skills.policy payload.{key} must be a boolean"))?;
+    Ok(Some(parsed))
+}
+
+fn parse_optional_string(
+    payload: &Map<String, Value>,
+    key: &str,
+) -> Result<Option<String>, String> {
+    let Some(value) = payload.get(key) else {
+        return Ok(None);
+    };
+    let parsed = value
+        .as_str()
+        .map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
+        .ok_or_else(|| format!("external_skills.fetch payload.{key} must be a non-empty string"))?;
+    Ok(Some(parsed.to_owned()))
+}
+
+fn parse_optional_domain_list(
+    payload: &Map<String, Value>,
+    key: &str,
+) -> Result<Option<BTreeSet<String>>, String> {
+    let Some(value) = payload.get(key) else {
+        return Ok(None);
+    };
+
+    let items = value.as_array().ok_or_else(|| {
+        format!("external_skills.policy payload.{key} must be an array of strings")
+    })?;
+
+    let mut normalized = BTreeSet::new();
+    for item in items {
+        let raw = item.as_str().ok_or_else(|| {
+            format!("external_skills.policy payload.{key} must contain only strings")
+        })?;
+        let rule = normalize_domain_rule(raw)
+            .map_err(|error| format!("invalid domain rule in payload.{key}: {error}"))?;
+        normalized.insert(rule);
+    }
+
+    Ok(Some(normalized))
+}
+
+fn normalize_domain_rule(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("domain rule cannot be empty".to_owned());
+    }
+
+    let mut wildcard = false;
+    let lowered = trimmed.to_ascii_lowercase();
+    let mut candidate = if let Some(rest) = lowered.strip_prefix("*.") {
+        wildcard = true;
+        rest.to_owned()
+    } else {
+        lowered
+    };
+
+    if candidate.contains("://") {
+        let parsed = reqwest::Url::parse(trimmed)
+            .map_err(|error| format!("invalid domain/url `{trimmed}`: {error}"))?;
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| format!("domain/url `{trimmed}` has no host"))?;
+        candidate = host.to_ascii_lowercase();
+        wildcard = false;
+    }
+
+    let candidate = candidate.trim_end_matches('.').to_owned();
+    if candidate.is_empty() {
+        return Err("domain rule cannot be empty".to_owned());
+    }
+
+    if candidate.starts_with('.') || candidate.ends_with('.') || candidate.contains("..") {
+        return Err(format!("invalid domain `{candidate}`"));
+    }
+
+    let valid_chars = candidate
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '.'));
+    if !valid_chars {
+        return Err(format!("invalid domain `{candidate}`"));
+    }
+
+    if candidate != "localhost" && !candidate.contains('.') {
+        return Err(format!(
+            "domain `{candidate}` must contain a dot or be localhost"
+        ));
+    }
+
+    if wildcard {
+        Ok(format!("*.{candidate}"))
+    } else {
+        Ok(candidate)
+    }
+}
+
+fn first_matching_domain_rule<'a>(host: &str, rules: &'a BTreeSet<String>) -> Option<&'a str> {
+    for rule in rules {
+        if domain_rule_matches(host, rule) {
+            return Some(rule.as_str());
+        }
+    }
+    None
+}
+
+fn domain_rule_matches(host: &str, rule: &str) -> bool {
+    if let Some(suffix) = rule.strip_prefix("*.") {
+        return host == suffix || host.ends_with(&format!(".{suffix}"));
+    }
+    host == rule
+}
+
+fn parse_max_download_bytes(payload: &Map<String, Value>) -> Result<usize, String> {
+    let Some(value) = payload.get("max_bytes") else {
+        return Ok(DEFAULT_MAX_DOWNLOAD_BYTES);
+    };
+    let parsed = value
+        .as_u64()
+        .ok_or_else(|| "external_skills.fetch payload.max_bytes must be an integer".to_owned())?;
+    if parsed == 0 {
+        return Err("external_skills.fetch payload.max_bytes must be >= 1".to_owned());
+    }
+    let capped = parsed.min(HARD_MAX_DOWNLOAD_BYTES as u64);
+    usize::try_from(capped).map_err(|error| format!("invalid max_bytes `{parsed}`: {error}"))
+}
+
+fn resolve_download_dir(config: &super::runtime_config::ToolRuntimeConfig) -> PathBuf {
+    let root = config
+        .file_root
+        .clone()
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    root.join(DEFAULT_DOWNLOAD_DIR_NAME)
+}
+
+fn derive_filename_from_url(url: &reqwest::Url) -> String {
+    let from_path = url
+        .path_segments()
+        .and_then(|mut segments| segments.next_back())
+        .unwrap_or("skill-package.bin");
+    let sanitized = sanitize_filename(from_path);
+    if sanitized.is_empty() {
+        "skill-package.bin".to_owned()
+    } else {
+        sanitized
+    }
+}
+
+fn sanitize_filename(raw: &str) -> String {
+    let mut normalized = String::new();
+    for ch in raw.trim().chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+            normalized.push(ch);
+        } else {
+            normalized.push('_');
+        }
+    }
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "skill-package.bin".to_owned()
+    } else {
+        normalized.to_owned()
+    }
+}
+
+fn unique_output_path(dir: &Path, filename: &str) -> PathBuf {
+    let candidate = dir.join(filename);
+    if !candidate.exists() {
+        return candidate;
+    }
+
+    let (stem, ext) = split_stem_and_ext(filename);
+    for index in 1..=9_999usize {
+        let name = if ext.is_empty() {
+            format!("{stem}-{index}")
+        } else {
+            format!("{stem}-{index}.{ext}")
+        };
+        let next = dir.join(name);
+        if !next.exists() {
+            return next;
+        }
+    }
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    if ext.is_empty() {
+        dir.join(format!("{stem}-{suffix}"))
+    } else {
+        dir.join(format!("{stem}-{suffix}.{ext}"))
+    }
+}
+
+fn split_stem_and_ext(filename: &str) -> (&str, &str) {
+    if let Some((stem, ext)) = filename.rsplit_once('.')
+        && !stem.is_empty()
+        && !ext.is_empty()
+    {
+        return (stem, ext);
+    }
+    (filename, "")
+}
+
+fn policy_payload(policy: &super::runtime_config::ExternalSkillsRuntimePolicy) -> Value {
+    json!({
+        "enabled": policy.enabled,
+        "require_download_approval": policy.require_download_approval,
+        "allowed_domains": policy.allowed_domains.iter().cloned().collect::<Vec<_>>(),
+        "blocked_domains": policy.blocked_domains.iter().cloned().collect::<Vec<_>>(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::tools::runtime_config::{ExternalSkillsRuntimePolicy, ToolRuntimeConfig};
+
+    static POLICY_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn with_policy_test_lock<T>(f: impl FnOnce() -> T) -> T {
+        let lock = POLICY_TEST_LOCK.get_or_init(|| Mutex::new(()));
+        let _guard = lock.lock().expect("policy test lock");
+        f()
+    }
+
+    fn reset_policy_override_for_test() {
+        if let Some(store) = EXTERNAL_SKILLS_POLICY_OVERRIDE.get()
+            && let Ok(mut guard) = store.write()
+        {
+            *guard = ExternalSkillsPolicyOverride::default();
+        }
+    }
+
+    fn base_runtime_config() -> ToolRuntimeConfig {
+        ToolRuntimeConfig {
+            shell_allowlist: BTreeSet::new(),
+            file_root: Some(std::env::temp_dir().join("loongclaw-ext-skills-tests")),
+            external_skills: ExternalSkillsRuntimePolicy {
+                enabled: false,
+                require_download_approval: true,
+                allowed_domains: BTreeSet::new(),
+                blocked_domains: BTreeSet::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn normalize_domain_rule_accepts_exact_and_wildcard_domains() {
+        assert_eq!(
+            normalize_domain_rule("skills.sh").expect("normalize"),
+            "skills.sh"
+        );
+        assert_eq!(
+            normalize_domain_rule("*.clawhub.io").expect("normalize wildcard"),
+            "*.clawhub.io"
+        );
+        assert!(normalize_domain_rule("not-a-domain").is_err());
+    }
+
+    #[test]
+    fn domain_rule_matching_supports_subdomains() {
+        assert!(domain_rule_matches("api.skills.sh", "*.skills.sh"));
+        assert!(domain_rule_matches("skills.sh", "*.skills.sh"));
+        assert!(!domain_rule_matches("skills.sh", "*.clawhub.io"));
+        assert!(domain_rule_matches("skills.sh", "skills.sh"));
+    }
+
+    #[test]
+    fn policy_tool_set_and_reset_override_runtime_policy() {
+        with_policy_test_lock(|| {
+            reset_policy_override_for_test();
+            let config = base_runtime_config();
+
+            let set_outcome = execute_external_skills_policy_tool_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.policy".to_owned(),
+                    payload: json!({
+                        "action": "set",
+                        "policy_update_approved": true,
+                        "enabled": true,
+                        "allowed_domains": ["skills.sh"],
+                        "blocked_domains": ["*.evil.example"]
+                    }),
+                },
+                &config,
+            )
+            .expect("set policy should succeed");
+
+            assert_eq!(set_outcome.status, "ok");
+            assert_eq!(set_outcome.payload["policy"]["enabled"], json!(true));
+            assert_eq!(
+                set_outcome.payload["policy"]["allowed_domains"],
+                json!(["skills.sh"])
+            );
+            assert_eq!(set_outcome.payload["override_active"], json!(true));
+
+            let reset_outcome = execute_external_skills_policy_tool_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.policy".to_owned(),
+                    payload: json!({
+                        "action": "reset",
+                        "policy_update_approved": true
+                    }),
+                },
+                &config,
+            )
+            .expect("reset policy should succeed");
+            assert_eq!(reset_outcome.status, "ok");
+            assert_eq!(reset_outcome.payload["policy"]["enabled"], json!(false));
+            assert_eq!(reset_outcome.payload["override_active"], json!(false));
+        });
+    }
+
+    #[test]
+    fn policy_tool_set_requires_explicit_authorization() {
+        with_policy_test_lock(|| {
+            reset_policy_override_for_test();
+            let config = base_runtime_config();
+
+            let error = execute_external_skills_policy_tool_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.policy".to_owned(),
+                    payload: json!({
+                        "action": "set",
+                        "enabled": true
+                    }),
+                },
+                &config,
+            )
+            .expect_err("policy update should require explicit authorization");
+
+            assert!(error.contains("policy update requires explicit authorization"));
+        });
+    }
+
+    #[test]
+    fn fetch_requires_enabled_runtime() {
+        with_policy_test_lock(|| {
+            reset_policy_override_for_test();
+            let config = base_runtime_config();
+
+            let error = execute_external_skills_fetch_tool_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.fetch".to_owned(),
+                    payload: json!({
+                        "url": "https://skills.sh/demo.tgz",
+                        "approval_granted": true
+                    }),
+                },
+                &config,
+            )
+            .expect_err("disabled runtime must fail");
+
+            assert!(error.contains("external skills runtime is disabled"));
+        });
+    }
+
+    #[test]
+    fn fetch_rejects_non_https_urls() {
+        with_policy_test_lock(|| {
+            reset_policy_override_for_test();
+            let config = base_runtime_config();
+
+            let error = execute_external_skills_fetch_tool_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.fetch".to_owned(),
+                    payload: json!({
+                        "url": "http://skills.sh/demo.tgz",
+                        "approval_granted": true
+                    }),
+                },
+                &config,
+            )
+            .expect_err("non-https url must fail");
+
+            assert!(error.contains("requires https url"));
+        });
+    }
+
+    #[test]
+    fn fetch_checks_domain_policy_and_approval_before_network() {
+        with_policy_test_lock(|| {
+            reset_policy_override_for_test();
+            let config = base_runtime_config();
+
+            execute_external_skills_policy_tool_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.policy".to_owned(),
+                    payload: json!({
+                        "action": "set",
+                        "policy_update_approved": true,
+                        "enabled": true,
+                        "require_download_approval": true,
+                        "allowed_domains": ["skills.sh"],
+                        "blocked_domains": ["*.evil.example"]
+                    }),
+                },
+                &config,
+            )
+            .expect("set policy should succeed");
+
+            let approval_error = execute_external_skills_fetch_tool_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.fetch".to_owned(),
+                    payload: json!({
+                        "url": "https://skills.sh/demo.tgz"
+                    }),
+                },
+                &config,
+            )
+            .expect_err("approval should be required");
+            assert!(approval_error.contains("requires explicit authorization"));
+
+            let deny_error = execute_external_skills_fetch_tool_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.fetch".to_owned(),
+                    payload: json!({
+                        "url": "https://cdn.evil.example/demo.tgz",
+                        "approval_granted": true
+                    }),
+                },
+                &config,
+            )
+            .expect_err("blocked domains should be denied");
+            assert!(deny_error.contains("matches blocked domain rule"));
+
+            let allowlist_error = execute_external_skills_fetch_tool_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.fetch".to_owned(),
+                    payload: json!({
+                        "url": "https://clawhub.io/demo.tgz",
+                        "approval_granted": true
+                    }),
+                },
+                &config,
+            )
+            .expect_err("non-allowlisted domain should be rejected");
+            assert!(allowlist_error.contains("not in allowed_domains"));
+
+            execute_external_skills_policy_tool_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.policy".to_owned(),
+                    payload: json!({
+                        "action": "reset",
+                        "policy_update_approved": true
+                    }),
+                },
+                &config,
+            )
+            .expect("reset policy should succeed");
+        });
+    }
+}

--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -281,6 +281,7 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: Default::default(),
             file_root: Some(root.clone()),
+            external_skills: Default::default(),
         };
         let error =
             resolve_safe_file_path_with_config("secret-link", &config).expect_err("escape denied");
@@ -304,6 +305,7 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: Default::default(),
             file_root: Some(root.clone()),
+            external_skills: Default::default(),
         };
         let request = ToolCoreRequest {
             tool_name: "file.write".to_owned(),
@@ -329,6 +331,7 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: Default::default(),
             file_root: Some(root.clone()),
+            external_skills: Default::default(),
         };
         let request = ToolCoreRequest {
             tool_name: "file.write".to_owned(),

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -6,6 +6,7 @@ use serde_json::{Value, json};
 use crate::KernelContext;
 
 mod claw_import;
+mod external_skills;
 mod file;
 mod kernel_adapter;
 pub mod runtime_config;
@@ -43,6 +44,8 @@ pub fn execute_tool_core(request: ToolCoreRequest) -> Result<ToolCoreOutcome, St
 pub fn canonical_tool_name(raw: &str) -> &str {
     match raw {
         "claw_import" | "import_claw" => "claw.import",
+        "external_skills_policy" => "external_skills.policy",
+        "external_skills_fetch" => "external_skills.fetch",
         "file_read" => "file.read",
         "file_write" => "file.write",
         "shell_exec" | "shell" => "shell.exec",
@@ -53,7 +56,12 @@ pub fn canonical_tool_name(raw: &str) -> &str {
 pub fn is_known_tool_name(raw: &str) -> bool {
     matches!(
         canonical_tool_name(raw),
-        "claw.import" | "shell.exec" | "file.read" | "file.write"
+        "claw.import"
+            | "external_skills.policy"
+            | "external_skills.fetch"
+            | "shell.exec"
+            | "file.read"
+            | "file.write"
     )
 }
 
@@ -68,6 +76,12 @@ pub fn execute_tool_core_with_config(
     };
     match canonical_name {
         "claw.import" => claw_import::execute_claw_import_tool_with_config(request, config),
+        "external_skills.policy" => {
+            external_skills::execute_external_skills_policy_tool_with_config(request, config)
+        }
+        "external_skills.fetch" => {
+            external_skills::execute_external_skills_fetch_tool_with_config(request, config)
+        }
         "shell.exec" => shell::execute_shell_tool_with_config(request, config),
         "file.read" => file::execute_file_read_tool_with_config(request, config),
         "file.write" => file::execute_file_write_tool_with_config(request, config),
@@ -91,6 +105,14 @@ pub fn tool_registry() -> Vec<ToolRegistryEntry> {
     entries.push(ToolRegistryEntry {
         name: "claw.import",
         description: "Import legacy Claw configs into native LoongClaw settings",
+    });
+    entries.push(ToolRegistryEntry {
+        name: "external_skills.fetch",
+        description: "Download external skills artifacts with domain policy and approval guards",
+    });
+    entries.push(ToolRegistryEntry {
+        name: "external_skills.policy",
+        description: "Read/update external skills domain allow/block policy at runtime",
     });
     #[cfg(feature = "tool-file")]
     {
@@ -198,6 +220,81 @@ pub fn provider_tool_definitions() -> Vec<Value> {
                     }
                 },
                 "required": [],
+                "additionalProperties": false
+            }
+        }
+    }));
+
+    tools.push(json!({
+        "type": "function",
+        "function": {
+            "name": "external_skills_policy",
+            "description": "Get, set, or reset runtime policy for external skills downloads (enabled flag, approval gate, domain allowlist/blocklist).",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["get", "set", "reset"],
+                        "description": "Policy action. Defaults to `get`."
+                    },
+                    "policy_update_approved": {
+                        "type": "boolean",
+                        "description": "Explicit user authorization for policy updates. Required for `set` and `reset`."
+                    },
+                    "enabled": {
+                        "type": "boolean",
+                        "description": "Whether external skills runtime/download is enabled."
+                    },
+                    "require_download_approval": {
+                        "type": "boolean",
+                        "description": "When true, every external skills download requires explicit approval_granted=true."
+                    },
+                    "allowed_domains": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional domain allowlist (supports exact domains and wildcard forms like *.example.com). Empty list means allow all domains unless blocked."
+                    },
+                    "blocked_domains": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional domain blocklist (supports exact domains and wildcard forms like *.example.com). Blocklist always takes precedence."
+                    }
+                },
+                "required": [],
+                "additionalProperties": false
+            }
+        }
+    }));
+
+    tools.push(json!({
+        "type": "function",
+        "function": {
+            "name": "external_skills_fetch",
+            "description": "Download an external skill artifact with strict domain policy checks and explicit approval gating.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "HTTPS URL to download."
+                    },
+                    "approval_granted": {
+                        "type": "boolean",
+                        "description": "Explicit user authorization for this download. Required when require_download_approval=true."
+                    },
+                    "save_as": {
+                        "type": "string",
+                        "description": "Optional output filename (stored under configured file root / external-skills-downloads)."
+                    },
+                    "max_bytes": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 20971520,
+                        "description": "Maximum download size in bytes. Defaults to 5242880 and is capped at 20971520."
+                    }
+                },
+                "required": ["url"],
                 "additionalProperties": false
             }
         }
@@ -318,6 +415,24 @@ fn _shape_examples() -> BTreeMap<&'static str, Value> {
             }),
         ),
         (
+            "external_skills.policy",
+            json!({
+                "action": "set",
+                "policy_update_approved": true,
+                "enabled": true,
+                "require_download_approval": true,
+                "allowed_domains": ["skills.sh"],
+                "blocked_domains": ["*.evil.example"]
+            }),
+        ),
+        (
+            "external_skills.fetch",
+            json!({
+                "url": "https://skills.sh/packages/demo-skill.tar.gz",
+                "approval_granted": true
+            }),
+        ),
+        (
             "file.read",
             json!({
                 "path": "README.md",
@@ -358,26 +473,32 @@ mod tests {
                 "- claw.import: Import legacy Claw configs into native LoongClaw settings"
             )
         );
+        assert!(snapshot.contains("- external_skills.fetch: Download external skills artifacts with domain policy and approval guards"));
+        assert!(snapshot.contains("- external_skills.policy: Read/update external skills domain allow/block policy at runtime"));
         assert!(snapshot.contains("- file.read: Read file contents"));
         assert!(snapshot.contains("- file.write: Write file contents"));
         assert!(snapshot.contains("- shell.exec: Execute shell commands"));
 
-        // Verify sorted order: claw.import < file.read < file.write < shell.exec
+        // Verify sorted order: claw.import < external_skills.* < file.* < shell.exec
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 4);
+        assert_eq!(lines.len(), 6);
         assert!(lines[0].starts_with("- claw.import"));
-        assert!(lines[1].starts_with("- file.read"));
-        assert!(lines[2].starts_with("- file.write"));
-        assert!(lines[3].starts_with("- shell.exec"));
+        assert!(lines[1].starts_with("- external_skills.fetch"));
+        assert!(lines[2].starts_with("- external_skills.policy"));
+        assert!(lines[3].starts_with("- file.read"));
+        assert!(lines[4].starts_with("- file.write"));
+        assert!(lines[5].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 4);
+        assert_eq!(entries.len(), 6);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"claw.import"));
+        assert!(names.contains(&"external_skills.fetch"));
+        assert!(names.contains(&"external_skills.policy"));
         assert!(names.contains(&"shell.exec"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
@@ -387,7 +508,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 4);
+        assert_eq!(defs.len(), 6);
 
         let names: Vec<&str> = defs
             .iter()
@@ -397,7 +518,14 @@ mod tests {
             .collect();
         assert_eq!(
             names,
-            vec!["claw_import", "file_read", "file_write", "shell_exec"]
+            vec![
+                "claw_import",
+                "external_skills_fetch",
+                "external_skills_policy",
+                "file_read",
+                "file_write",
+                "shell_exec"
+            ]
         );
 
         for item in &defs {
@@ -446,6 +574,14 @@ mod tests {
     #[test]
     fn canonical_tool_name_maps_known_aliases() {
         assert_eq!(canonical_tool_name("claw_import"), "claw.import");
+        assert_eq!(
+            canonical_tool_name("external_skills_policy"),
+            "external_skills.policy"
+        );
+        assert_eq!(
+            canonical_tool_name("external_skills_fetch"),
+            "external_skills.fetch"
+        );
         assert_eq!(canonical_tool_name("file_read"), "file.read");
         assert_eq!(canonical_tool_name("file_write"), "file.write");
         assert_eq!(canonical_tool_name("shell_exec"), "shell.exec");
@@ -457,6 +593,10 @@ mod tests {
     fn is_known_tool_name_accepts_canonical_and_alias_forms() {
         assert!(is_known_tool_name("claw.import"));
         assert!(is_known_tool_name("claw_import"));
+        assert!(is_known_tool_name("external_skills.policy"));
+        assert!(is_known_tool_name("external_skills_policy"));
+        assert!(is_known_tool_name("external_skills.fetch"));
+        assert!(is_known_tool_name("external_skills_fetch"));
         assert!(is_known_tool_name("file.read"));
         assert!(is_known_tool_name("file_read"));
         assert!(is_known_tool_name("file.write"));
@@ -520,6 +660,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            external_skills: Default::default(),
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -604,6 +745,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            external_skills: Default::default(),
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -692,6 +834,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            external_skills: Default::default(),
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -763,6 +906,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            external_skills: Default::default(),
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -835,6 +979,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            external_skills: Default::default(),
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -896,6 +1041,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            external_skills: Default::default(),
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -978,6 +1124,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            external_skills: Default::default(),
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -1061,6 +1208,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            external_skills: Default::default(),
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -1146,6 +1294,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            external_skills: Default::default(),
         };
         execute_tool_core_with_config(
             ToolCoreRequest {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -136,34 +136,68 @@ pub fn provider_tool_definitions() -> Vec<Value> {
         "type": "function",
         "function": {
             "name": "claw_import",
-            "description": "Import a legacy Claw workspace or persona into native LoongClaw config with preview or apply mode.",
+            "description": "Import, discover, plan, merge, apply, and rollback legacy Claw workspace migration into native LoongClaw config.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "input_path": {
                         "type": "string",
-                        "description": "Path to the legacy Claw workspace, config root, or portable import file."
+                        "description": "Path to the legacy Claw workspace, config root, or portable import file. Required for all modes except rollback_last_apply."
                     },
                     "mode": {
                         "type": "string",
-                        "enum": ["plan", "apply"],
-                        "description": "Use `plan` to preview the nativeized result, or `apply` to write a target config."
+                        "enum": [
+                            "plan",
+                            "apply",
+                            "discover",
+                            "plan_many",
+                            "recommend_primary",
+                            "merge_profiles",
+                            "map_external_skills",
+                            "apply_selected",
+                            "rollback_last_apply"
+                        ],
+                        "description": "Migration mode. Defaults to `plan` when omitted."
                     },
                     "source": {
                         "type": "string",
                         "enum": ["auto", "nanobot", "openclaw", "picoclaw", "zeroclaw", "nanoclaw"],
-                        "description": "Optional source hint. Defaults to automatic detection."
+                        "description": "Optional source hint for plan/apply modes. Defaults to automatic detection."
+                    },
+                    "source_id": {
+                        "type": "string",
+                        "description": "Selected source identifier for apply_selected mode."
+                    },
+                    "selection_id": {
+                        "type": "string",
+                        "description": "Alias of source_id for apply_selected mode."
+                    },
+                    "primary_source_id": {
+                        "type": "string",
+                        "description": "Primary source identifier for safe profile merge in apply_selected mode."
+                    },
+                    "primary_selection_id": {
+                        "type": "string",
+                        "description": "Alias of primary_source_id for safe profile merge in apply_selected mode."
+                    },
+                    "safe_profile_merge": {
+                        "type": "boolean",
+                        "description": "Enable safe multi-source profile merge in apply_selected mode."
+                    },
+                    "apply_external_skills_plan": {
+                        "type": "boolean",
+                        "description": "When true, apply a generated external-skills mapping addendum into profile_note during apply_selected."
                     },
                     "output_path": {
                         "type": "string",
-                        "description": "Target config path to write in apply mode."
+                        "description": "Target config path. Required in apply/apply_selected/rollback_last_apply modes."
                     },
                     "force": {
                         "type": "boolean",
                         "description": "Overwrite an existing target config when applying. Defaults to false."
                     }
                 },
-                "required": ["input_path"],
+                "required": [],
                 "additionalProperties": false
             }
         }
@@ -370,6 +404,43 @@ mod tests {
             assert_eq!(item["type"], "function");
             assert_eq!(item["function"]["parameters"]["type"], "object");
         }
+
+        let claw_import = defs
+            .iter()
+            .find(|item| {
+                item.get("function")
+                    .and_then(|function| function.get("name"))
+                    .and_then(Value::as_str)
+                    == Some("claw_import")
+            })
+            .expect("claw_import definition should exist");
+        let mode_enum: Vec<&str> =
+            claw_import["function"]["parameters"]["properties"]["mode"]["enum"]
+                .as_array()
+                .expect("mode enum should be an array")
+                .iter()
+                .filter_map(Value::as_str)
+                .collect();
+        assert_eq!(
+            mode_enum,
+            vec![
+                "plan",
+                "apply",
+                "discover",
+                "plan_many",
+                "recommend_primary",
+                "merge_profiles",
+                "map_external_skills",
+                "apply_selected",
+                "rollback_last_apply"
+            ]
+        );
+        assert!(
+            claw_import["function"]["parameters"]["required"]
+                .as_array()
+                .expect("required should be an array")
+                .is_empty()
+        );
     }
 
     #[test]
@@ -552,6 +623,14 @@ mod tests {
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["mode"], "apply");
         assert_eq!(outcome.payload["config_written"], true);
+        assert_eq!(
+            outcome.payload["next_step"]
+                .as_str()
+                .expect("next_step should be present")
+                .split_whitespace()
+                .next(),
+            Some("loongclaw")
+        );
         assert_eq!(
             outcome.payload["output_path"]
                 .as_str()
@@ -786,6 +865,72 @@ mod tests {
     }
 
     #[test]
+    fn claw_import_map_external_skills_mode_returns_mapping_plan() {
+        use std::{
+            fs,
+            path::{Path, PathBuf},
+            time::{SystemTime, UNIX_EPOCH},
+        };
+
+        fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        }
+
+        fn write_file(root: &Path, relative: &str, content: &str) {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent directory");
+            }
+            fs::write(path, content).expect("write fixture");
+        }
+
+        let root = unique_temp_dir("loongclaw-tool-import-map-external-skills");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(&root, "SKILLS.md", "# Skills\n\n- custom/skill-a\n");
+        fs::create_dir_all(root.join(".codex/skills")).expect("create codex skills dir");
+
+        let config = runtime_config::ToolRuntimeConfig {
+            shell_allowlist: BTreeSet::new(),
+            file_root: Some(root.clone()),
+        };
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload: json!({
+                    "mode": "map_external_skills",
+                    "input_path": "."
+                }),
+            },
+            &config,
+        )
+        .expect("claw import map_external_skills should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["mode"], "map_external_skills");
+        assert_eq!(outcome.payload["result"]["artifact_count"], 2);
+        assert_eq!(
+            outcome.payload["result"]["declared_skills"][0],
+            "custom/skill-a"
+        );
+        assert_eq!(
+            outcome.payload["result"]["resolved_skills"][0],
+            "custom/skill-a"
+        );
+        assert!(
+            outcome.payload["result"]["profile_note_addendum"]
+                .as_str()
+                .expect("profile note addendum should exist")
+                .contains("Imported External Skills Artifacts")
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
     fn claw_import_apply_selected_mode_writes_manifest_and_backup() {
         use std::{
             fs,
@@ -866,6 +1011,89 @@ mod tests {
             )
             .exists()
         );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn claw_import_apply_selected_mode_can_apply_external_skills_plan() {
+        use std::{
+            fs,
+            path::{Path, PathBuf},
+            time::{SystemTime, UNIX_EPOCH},
+        };
+
+        fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        }
+
+        fn write_file(root: &Path, relative: &str, content: &str) {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent directory");
+            }
+            fs::write(path, content).expect("write fixture");
+        }
+
+        let root = unique_temp_dir("loongclaw-tool-import-apply-selected-external");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n- tone: steady\n",
+        );
+        write_file(&root, "SKILLS.md", "# Skills\n\n- custom/skill-a\n");
+
+        let output_path = root.join("loongclaw.toml");
+
+        let config = runtime_config::ToolRuntimeConfig {
+            shell_allowlist: BTreeSet::new(),
+            file_root: Some(root.clone()),
+        };
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload: json!({
+                    "mode": "apply_selected",
+                    "input_path": ".",
+                    "output_path": "loongclaw.toml",
+                    "source_id": "openclaw",
+                    "apply_external_skills_plan": true
+                }),
+            },
+            &config,
+        )
+        .expect("claw import apply_selected with external skills should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(
+            outcome.payload["result"]["external_skill_artifact_count"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["result"]["external_skill_entries_applied"],
+            3
+        );
+        assert!(
+            outcome.payload["result"]["external_skills_manifest_path"]
+                .as_str()
+                .is_some(),
+            "external skills manifest path should exist"
+        );
+        let raw = fs::read_to_string(&output_path).expect("read output config");
+        assert!(raw.contains("Imported External Skills Artifacts"));
 
         fs::remove_dir_all(&root).ok();
     }

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -2,6 +2,25 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalSkillsRuntimePolicy {
+    pub enabled: bool,
+    pub require_download_approval: bool,
+    pub allowed_domains: BTreeSet<String>,
+    pub blocked_domains: BTreeSet<String>,
+}
+
+impl Default for ExternalSkillsRuntimePolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            require_download_approval: true,
+            allowed_domains: BTreeSet::new(),
+            blocked_domains: BTreeSet::new(),
+        }
+    }
+}
+
 /// Typed runtime configuration for tool executors.
 ///
 /// Replaces per-call `std::env::var` lookups with a single read from a
@@ -10,6 +29,7 @@ use std::sync::OnceLock;
 pub struct ToolRuntimeConfig {
     pub shell_allowlist: BTreeSet<String>,
     pub file_root: Option<PathBuf>,
+    pub external_skills: ExternalSkillsRuntimePolicy,
 }
 
 impl ToolRuntimeConfig {
@@ -28,12 +48,45 @@ impl ToolRuntimeConfig {
             .collect();
 
         let file_root = std::env::var("LOONGCLAW_FILE_ROOT").ok().map(PathBuf::from);
+        let enabled = parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_ENABLED").unwrap_or(false);
+        let require_download_approval =
+            parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL").unwrap_or(true);
+        let allowed_domains = parse_env_domain_list("LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS");
+        let blocked_domains = parse_env_domain_list("LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS");
 
         Self {
             shell_allowlist,
             file_root,
+            external_skills: ExternalSkillsRuntimePolicy {
+                enabled,
+                require_download_approval,
+                allowed_domains,
+                blocked_domains,
+            },
         }
     }
+}
+
+fn parse_env_bool(key: &str) -> Option<bool> {
+    std::env::var(key).ok().and_then(|raw| {
+        let value = raw.trim().to_ascii_lowercase();
+        match value.as_str() {
+            "1" | "true" | "yes" | "on" => Some(true),
+            "0" | "false" | "no" | "off" => Some(false),
+            _ => None,
+        }
+    })
+}
+
+fn parse_env_domain_list(key: &str) -> BTreeSet<String> {
+    std::env::var(key)
+        .ok()
+        .unwrap_or_default()
+        .split([',', ';', ' '])
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect()
 }
 
 static TOOL_RUNTIME_CONFIG: OnceLock<ToolRuntimeConfig> = OnceLock::new();
@@ -66,6 +119,10 @@ mod tests {
         let config = ToolRuntimeConfig::default();
         assert!(config.shell_allowlist.is_empty());
         assert!(config.file_root.is_none());
+        assert!(!config.external_skills.enabled);
+        assert!(config.external_skills.require_download_approval);
+        assert!(config.external_skills.allowed_domains.is_empty());
+        assert!(config.external_skills.blocked_domains.is_empty());
     }
 
     #[test]
@@ -75,11 +132,20 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: BTreeSet::from(["git".to_owned(), "cargo".to_owned()]),
             file_root: Some(PathBuf::from("/tmp/test-root")),
+            external_skills: ExternalSkillsRuntimePolicy {
+                enabled: true,
+                require_download_approval: false,
+                allowed_domains: BTreeSet::from(["skills.sh".to_owned()]),
+                blocked_domains: BTreeSet::new(),
+            },
         };
         assert!(config.shell_allowlist.contains("git"));
         assert!(config.shell_allowlist.contains("cargo"));
         assert!(!config.shell_allowlist.contains("echo"));
         assert_eq!(config.file_root, Some(PathBuf::from("/tmp/test-root")));
+        assert!(config.external_skills.enabled);
+        assert!(!config.external_skills.require_download_approval);
+        assert!(config.external_skills.allowed_domains.contains("skills.sh"));
     }
 
     #[test]
@@ -98,6 +164,7 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: BTreeSet::from(["echo".to_owned()]),
             file_root: Some(PathBuf::from("/tmp/injected-root")),
+            external_skills: ExternalSkillsRuntimePolicy::default(),
         };
         let result = crate::tools::execute_tool_core_with_config(
             loongclaw_contracts::ToolCoreRequest {
@@ -114,5 +181,44 @@ mod tests {
                 .unwrap()
                 .contains("injected")
         );
+    }
+
+    #[test]
+    fn from_env_parses_external_skills_policy() {
+        crate::process_env::set_var("LOONGCLAW_EXTERNAL_SKILLS_ENABLED", "true");
+        crate::process_env::set_var(
+            "LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL",
+            "false",
+        );
+        crate::process_env::set_var(
+            "LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS",
+            "skills.sh,clawhub.io",
+        );
+        crate::process_env::set_var(
+            "LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS",
+            "malicious.example",
+        );
+
+        let config = ToolRuntimeConfig::from_env();
+        assert!(config.external_skills.enabled);
+        assert!(!config.external_skills.require_download_approval);
+        assert!(config.external_skills.allowed_domains.contains("skills.sh"));
+        assert!(
+            config
+                .external_skills
+                .allowed_domains
+                .contains("clawhub.io")
+        );
+        assert!(
+            config
+                .external_skills
+                .blocked_domains
+                .contains("malicious.example")
+        );
+
+        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_ENABLED");
+        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL");
+        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS");
+        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS");
     }
 }

--- a/crates/daemon/src/import_claw_cli.rs
+++ b/crates/daemon/src/import_claw_cli.rs
@@ -1,13 +1,59 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use clap::ValueEnum;
 use loongclaw_app as mvp;
 use loongclaw_spec::CliResult;
+use serde_json::{Value, json};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "snake_case")]
+pub(crate) enum ImportClawMode {
+    Apply,
+    Plan,
+    Discover,
+    PlanMany,
+    RecommendPrimary,
+    MergeProfiles,
+    MapExternalSkills,
+    ApplySelected,
+    RollbackLastApply,
+}
+
+impl ImportClawMode {
+    fn requires_input(self) -> bool {
+        !matches!(self, Self::RollbackLastApply)
+    }
+
+    fn writes_output(self) -> bool {
+        matches!(self, Self::Apply | Self::ApplySelected)
+    }
+
+    fn as_id(self) -> &'static str {
+        match self {
+            Self::Apply => "apply",
+            Self::Plan => "plan",
+            Self::Discover => "discover",
+            Self::PlanMany => "plan_many",
+            Self::RecommendPrimary => "recommend_primary",
+            Self::MergeProfiles => "merge_profiles",
+            Self::MapExternalSkills => "map_external_skills",
+            Self::ApplySelected => "apply_selected",
+            Self::RollbackLastApply => "rollback_last_apply",
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct ImportClawCommandOptions {
-    pub input: String,
+    pub input: Option<String>,
     pub output: Option<String>,
     pub source: Option<String>,
+    pub mode: ImportClawMode,
+    pub json: bool,
+    pub source_id: Option<String>,
+    pub safe_profile_merge: bool,
+    pub primary_source_id: Option<String>,
+    pub apply_external_skills_plan: bool,
     pub force: bool,
 }
 
@@ -16,81 +62,378 @@ pub(crate) fn parse_legacy_claw_source(raw: &str) -> Option<mvp::migration::Lega
 }
 
 pub(crate) fn run_import_claw_cli(options: ImportClawCommandOptions) -> CliResult<()> {
-    let input_path = mvp::config::expand_path(&options.input);
-    let output_path = options
-        .output
-        .as_deref()
-        .map(mvp::config::expand_path)
-        .unwrap_or_else(mvp::config::default_config_path);
+    let output_path = resolve_output_path(options.output.as_deref());
+    let input_path = options.input.as_deref().map(mvp::config::expand_path);
 
-    if output_path.exists() && !options.force {
+    if options.mode.writes_output() && output_path.exists() && !options.force {
         return Err(format!(
             "config {} already exists (use --force to overwrite)",
             output_path.display()
         ));
     }
 
-    let hint = if let Some(raw) = options.source.as_deref() {
-        let parsed = parse_legacy_claw_source(raw).ok_or_else(|| {
-            format!(
-                "unsupported --source value \"{raw}\". supported: {}",
-                supported_legacy_source_list()
-            )
-        })?;
-        if parsed == mvp::migration::LegacyClawSource::Unknown {
-            None
-        } else {
-            Some(parsed)
+    match options.mode {
+        ImportClawMode::RollbackLastApply => run_rollback_mode(&output_path, options.json),
+        ImportClawMode::Discover => {
+            let input = require_input_path(input_path, options.mode)?;
+            let report = mvp::migration::discover_import_sources(
+                &input,
+                mvp::migration::DiscoveryOptions::default(),
+            )?;
+            if options.json {
+                return print_json_payload(json!({
+                    "mode": options.mode.as_id(),
+                    "input_path": input.display().to_string(),
+                    "sources": report
+                        .sources
+                        .iter()
+                        .map(discovered_source_payload)
+                        .collect::<Vec<_>>(),
+                }));
+            }
+
+            println!("import discovery complete");
+            println!("- input: {}", input.display());
+            println!("- discovered sources: {}", report.sources.len());
+            for source in &report.sources {
+                println!(
+                    "- [{}] kind={} confidence={} path={}",
+                    source.source_id,
+                    source.source.as_id(),
+                    source.confidence_score,
+                    source.path.display()
+                );
+            }
+            Ok(())
         }
-    } else {
-        None
-    };
+        ImportClawMode::PlanMany | ImportClawMode::RecommendPrimary => {
+            let input = require_input_path(input_path, options.mode)?;
+            let report = mvp::migration::discover_import_sources(
+                &input,
+                mvp::migration::DiscoveryOptions::default(),
+            )?;
+            let summary = mvp::migration::plan_import_sources(&report)?;
+            let recommendation = mvp::migration::recommend_primary_source(&summary).ok();
 
-    let plan = mvp::migration::plan_import_from_path(&input_path, hint)?;
-    let mut config = load_or_default_config(&output_path, output_path.exists())?;
-    mvp::migration::apply_import_plan(&mut config, &plan);
+            if matches!(options.mode, ImportClawMode::RecommendPrimary) && recommendation.is_none()
+            {
+                return Err(
+                    "no import sources discovered; cannot recommend primary source".to_owned(),
+                );
+            }
 
-    let output_string = output_path.display().to_string();
-    let written = mvp::config::write(Some(&output_string), &config, options.force)?;
+            if options.json {
+                return print_json_payload(json!({
+                    "mode": options.mode.as_id(),
+                    "input_path": input.display().to_string(),
+                    "plans": summary.plans.iter().map(planned_source_payload).collect::<Vec<_>>(),
+                    "recommendation": recommendation.as_ref().map(primary_recommendation_payload),
+                }));
+            }
 
-    #[cfg(feature = "memory-sqlite")]
-    let memory_path = {
-        let mem_config =
-            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-        mvp::memory::ensure_memory_db_ready(Some(config.memory.resolved_sqlite_path()), &mem_config)
-            .map_err(|error| format!("failed to bootstrap sqlite memory: {error}"))?
-    };
+            println!("import planning complete");
+            println!("- mode: {}", options.mode.as_id());
+            println!("- input: {}", input.display());
+            println!("- planned sources: {}", summary.plans.len());
+            if let Some(recommended) = recommendation.as_ref() {
+                println!(
+                    "- recommended source: {} ({})",
+                    recommended.source_id,
+                    recommended.source.as_id()
+                );
+            }
+            for plan in &summary.plans {
+                println!(
+                    "- [{}] kind={} confidence={} prompt={} profile={} warnings={} path={}",
+                    plan.source_id,
+                    plan.source.as_id(),
+                    plan.confidence_score,
+                    yes_no(plan.prompt_addendum_present),
+                    yes_no(plan.profile_note_present),
+                    plan.warning_count,
+                    plan.input_path.display()
+                );
+            }
+            Ok(())
+        }
+        ImportClawMode::MergeProfiles => {
+            let input = require_input_path(input_path, options.mode)?;
+            let report = mvp::migration::discover_import_sources(
+                &input,
+                mvp::migration::DiscoveryOptions::default(),
+            )?;
+            let summary = mvp::migration::plan_import_sources(&report)?;
+            let recommendation = mvp::migration::recommend_primary_source(&summary).ok();
+            let merged = mvp::migration::merge_profile_sources(&report)?;
 
-    println!("import complete");
-    println!("- source: {}", legacy_claw_source_id(plan.source));
-    println!("- input: {}", input_path.display());
-    println!("- config: {}", written.display());
-    println!(
-        "- prompt pack: {}",
-        config
-            .cli
-            .prompt_pack_id()
-            .unwrap_or(mvp::prompt::DEFAULT_PROMPT_PACK_ID)
-    );
-    println!(
-        "- memory profile: {}",
-        memory_profile_id(config.memory.profile)
-    );
-    println!(
-        "- imported prompt addendum: {}",
-        yes_no(config.cli.system_prompt_addendum.is_some())
-    );
-    println!(
-        "- imported profile note: {}",
-        yes_no(config.memory.profile_note.is_some())
-    );
-    #[cfg(feature = "memory-sqlite")]
-    println!("- sqlite memory: {}", memory_path.display());
-    for warning in &plan.warnings {
-        println!("- warning: {warning}");
+            if options.json {
+                return print_json_payload(json!({
+                    "mode": options.mode.as_id(),
+                    "input_path": input.display().to_string(),
+                    "plans": summary.plans.iter().map(planned_source_payload).collect::<Vec<_>>(),
+                    "recommendation": recommendation.as_ref().map(primary_recommendation_payload),
+                    "result": merged_profile_plan_payload(&merged),
+                }));
+            }
+
+            println!("profile merge preview complete");
+            println!("- input: {}", input.display());
+            println!("- source count: {}", summary.plans.len());
+            if let Some(recommended) = recommendation.as_ref() {
+                println!("- recommended prompt owner: {}", recommended.source_id);
+            }
+            println!(
+                "- auto apply allowed: {}",
+                yes_no(merged.auto_apply_allowed)
+            );
+            println!(
+                "- unresolved conflicts: {}",
+                merged.unresolved_conflicts.len()
+            );
+            println!("- kept entries: {}", merged.kept_entries.len());
+            println!("- dropped duplicates: {}", merged.dropped_duplicates.len());
+            Ok(())
+        }
+        ImportClawMode::MapExternalSkills => {
+            let input = require_input_path(input_path, options.mode)?;
+            let mapping = mvp::migration::plan_external_skill_mapping(&input);
+
+            if options.json {
+                return print_json_payload(json!({
+                    "mode": options.mode.as_id(),
+                    "input_path": input.display().to_string(),
+                    "result": external_skill_mapping_plan_payload(&mapping),
+                }));
+            }
+
+            println!("external skills mapping plan ready");
+            println!("- input: {}", input.display());
+            println!("- detected artifacts: {}", mapping.artifacts.len());
+            println!("- declared skills: {}", mapping.declared_skills.len());
+            println!("- locked skills: {}", mapping.locked_skills.len());
+            println!("- resolved skills: {}", mapping.resolved_skills.len());
+            println!(
+                "- profile addendum generated: {}",
+                yes_no(mapping.profile_note_addendum.is_some())
+            );
+            for artifact in &mapping.artifacts {
+                println!(
+                    "- artifact: kind={} path={}",
+                    artifact.kind.as_id(),
+                    artifact.path.display()
+                );
+            }
+            for warning in &mapping.warnings {
+                println!("- warning: {warning}");
+            }
+            println!(
+                "next step: loongclaw import-claw --mode apply_selected --input {} --output {} --apply-external-skills-plan --force",
+                input.display(),
+                output_path.display()
+            );
+            Ok(())
+        }
+        ImportClawMode::ApplySelected => {
+            let input = require_input_path(input_path, options.mode)?;
+            let report = mvp::migration::discover_import_sources(
+                &input,
+                mvp::migration::DiscoveryOptions::default(),
+            )?;
+            let summary = mvp::migration::plan_import_sources(&report)?;
+            let selection = resolve_apply_selection_mode(&options, &summary)?;
+            let result =
+                mvp::migration::apply_import_selection(&mvp::migration::ApplyImportSelection {
+                    discovery: report,
+                    output_path: output_path.clone(),
+                    mode: selection.clone(),
+                    apply_external_skills_plan: options.apply_external_skills_plan,
+                    external_skills_input_path: if options.apply_external_skills_plan {
+                        Some(input.clone())
+                    } else {
+                        None
+                    },
+                })?;
+
+            #[cfg(feature = "memory-sqlite")]
+            let memory_path = ensure_memory_ready_from_path(&result.output_path)?;
+
+            if options.json {
+                return print_json_payload(json!({
+                    "mode": options.mode.as_id(),
+                    "input_path": input.display().to_string(),
+                    "output_path": result.output_path.display().to_string(),
+                    "selection_mode": selection_mode_id(&selection),
+                    "apply_external_skills_plan": options.apply_external_skills_plan,
+                    "result": apply_selection_result_payload(&result),
+                }));
+            }
+
+            println!("import selection applied");
+            println!("- mode: {}", options.mode.as_id());
+            println!("- input: {}", input.display());
+            println!("- output: {}", result.output_path.display());
+            println!("- selection mode: {}", selection_mode_id(&selection));
+            println!(
+                "- selected primary source: {}",
+                result.selected_primary_source_id
+            );
+            println!(
+                "- merged source ids: {}",
+                result.merged_source_ids.join(", ")
+            );
+            println!("- unresolved conflicts: {}", result.unresolved_conflicts);
+            println!(
+                "- external skill artifacts: {}",
+                result.external_skill_artifact_count
+            );
+            println!(
+                "- external skill entries applied: {}",
+                result.external_skill_entries_applied
+            );
+            if let Some(path) = result.external_skills_manifest_path.as_ref() {
+                println!("- external skills manifest: {}", path.display());
+            }
+            #[cfg(feature = "memory-sqlite")]
+            println!("- sqlite memory: {}", memory_path.display());
+            for warning in &result.warnings {
+                println!("- warning: {warning}");
+            }
+            println!(
+                "next step: loongclaw chat --config {}",
+                result.output_path.display()
+            );
+            Ok(())
+        }
+        ImportClawMode::Plan | ImportClawMode::Apply => {
+            let input = require_input_path(input_path, options.mode)?;
+            let hint = if let Some(raw) = options.source.as_deref() {
+                let parsed = parse_legacy_claw_source(raw).ok_or_else(|| {
+                    format!(
+                        "unsupported --source value \"{raw}\". supported: {}",
+                        supported_legacy_source_list()
+                    )
+                })?;
+                if parsed == mvp::migration::LegacyClawSource::Unknown {
+                    None
+                } else {
+                    Some(parsed)
+                }
+            } else {
+                None
+            };
+
+            let plan = mvp::migration::plan_import_from_path(&input, hint)?;
+            let mut config = load_or_default_config(&output_path, output_path.exists())?;
+            mvp::migration::apply_import_plan(&mut config, &plan);
+
+            if matches!(options.mode, ImportClawMode::Plan) {
+                if options.json {
+                    let rendered = mvp::config::render(&config)
+                        .map_err(|error| format!("render preview failed: {error}"))?;
+                    return print_json_payload(json!({
+                        "mode": options.mode.as_id(),
+                        "source": legacy_claw_source_id(plan.source),
+                        "input_path": input.display().to_string(),
+                        "output_path": output_path.display().to_string(),
+                        "warnings": plan.warnings,
+                        "config_preview": config_preview_payload(&config),
+                        "config_toml": rendered,
+                    }));
+                }
+
+                println!("import plan ready");
+                println!("- source: {}", legacy_claw_source_id(plan.source));
+                println!("- input: {}", input.display());
+                println!("- output target: {}", output_path.display());
+                println!(
+                    "- prompt pack: {}",
+                    config
+                        .cli
+                        .prompt_pack_id()
+                        .unwrap_or(mvp::prompt::DEFAULT_PROMPT_PACK_ID)
+                );
+                println!(
+                    "- memory profile: {}",
+                    memory_profile_id(config.memory.profile)
+                );
+                println!(
+                    "- imported prompt addendum: {}",
+                    yes_no(config.cli.system_prompt_addendum.is_some())
+                );
+                println!(
+                    "- imported profile note: {}",
+                    yes_no(config.memory.profile_note.is_some())
+                );
+                for warning in &plan.warnings {
+                    println!("- warning: {warning}");
+                }
+                println!(
+                    "next step: loongclaw import-claw --mode apply --input {} --output {} --force",
+                    input.display(),
+                    output_path.display()
+                );
+                return Ok(());
+            }
+
+            let output_string = output_path.display().to_string();
+            let written = mvp::config::write(Some(&output_string), &config, options.force)?;
+
+            #[cfg(feature = "memory-sqlite")]
+            let memory_path = {
+                let mem_config =
+                    mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
+                        &config.memory,
+                    );
+                mvp::memory::ensure_memory_db_ready(
+                    Some(config.memory.resolved_sqlite_path()),
+                    &mem_config,
+                )
+                .map_err(|error| format!("failed to bootstrap sqlite memory: {error}"))?
+            };
+
+            if options.json {
+                return print_json_payload(json!({
+                    "mode": options.mode.as_id(),
+                    "source": legacy_claw_source_id(plan.source),
+                    "input_path": input.display().to_string(),
+                    "output_path": written.display().to_string(),
+                    "warnings": plan.warnings,
+                    "config_preview": config_preview_payload(&config),
+                }));
+            }
+
+            println!("import complete");
+            println!("- source: {}", legacy_claw_source_id(plan.source));
+            println!("- input: {}", input.display());
+            println!("- config: {}", written.display());
+            println!(
+                "- prompt pack: {}",
+                config
+                    .cli
+                    .prompt_pack_id()
+                    .unwrap_or(mvp::prompt::DEFAULT_PROMPT_PACK_ID)
+            );
+            println!(
+                "- memory profile: {}",
+                memory_profile_id(config.memory.profile)
+            );
+            println!(
+                "- imported prompt addendum: {}",
+                yes_no(config.cli.system_prompt_addendum.is_some())
+            );
+            println!(
+                "- imported profile note: {}",
+                yes_no(config.memory.profile_note.is_some())
+            );
+            #[cfg(feature = "memory-sqlite")]
+            println!("- sqlite memory: {}", memory_path.display());
+            for warning in &plan.warnings {
+                println!("- warning: {warning}");
+            }
+            println!("next step: loongclaw chat --config {}", written.display());
+            Ok(())
+        }
     }
-    println!("next step: loongclawd chat --config {}", written.display());
-    Ok(())
 }
 
 fn load_or_default_config(path: &Path, exists: bool) -> CliResult<mvp::config::LoongClawConfig> {
@@ -108,6 +451,239 @@ fn legacy_claw_source_id(source: mvp::migration::LegacyClawSource) -> &'static s
 
 fn supported_legacy_source_list() -> &'static str {
     "auto, nanobot, openclaw, picoclaw, zeroclaw, nanoclaw"
+}
+
+fn resolve_output_path(output: Option<&str>) -> PathBuf {
+    output
+        .map(mvp::config::expand_path)
+        .unwrap_or_else(mvp::config::default_config_path)
+}
+
+fn require_input_path(input: Option<PathBuf>, mode: ImportClawMode) -> CliResult<PathBuf> {
+    if mode.requires_input() {
+        return input
+            .ok_or_else(|| format!("import-claw mode `{}` requires --input", mode.as_id()));
+    }
+    Ok(PathBuf::new())
+}
+
+fn print_json_payload(payload: Value) -> CliResult<()> {
+    let encoded = serde_json::to_string_pretty(&payload)
+        .map_err(|error| format!("json serialization failed: {error}"))?;
+    println!("{encoded}");
+    Ok(())
+}
+
+fn resolve_apply_selection_mode(
+    options: &ImportClawCommandOptions,
+    summary: &mvp::migration::DiscoveryPlanSummary,
+) -> CliResult<mvp::migration::ImportSelectionMode> {
+    let source_id = options
+        .source_id
+        .as_deref()
+        .or(options.primary_source_id.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+
+    if options.safe_profile_merge {
+        let primary_source_id = source_id
+            .or_else(|| {
+                mvp::migration::recommend_primary_source(summary)
+                    .ok()
+                    .map(|recommendation| recommendation.source_id)
+            })
+            .ok_or_else(|| {
+                "apply_selected requires --source-id or --primary-source-id when --safe-profile-merge is enabled".to_owned()
+            })?;
+        return Ok(mvp::migration::ImportSelectionMode::SafeProfileMerge { primary_source_id });
+    }
+
+    if let Some(source_id) = source_id {
+        return Ok(mvp::migration::ImportSelectionMode::SelectedSingleSource { source_id });
+    }
+
+    let recommendation = mvp::migration::recommend_primary_source(summary)
+        .map_err(|error| format!("cannot recommend primary source: {error}"))?;
+    Ok(
+        mvp::migration::ImportSelectionMode::RecommendedSingleSource {
+            source_id: recommendation.source_id,
+        },
+    )
+}
+
+fn discovered_source_payload(source: &mvp::migration::DiscoveredImportSource) -> Value {
+    json!({
+        "source_id": source.source_id,
+        "source_kind": source.source.as_id(),
+        "input_path": source.path.display().to_string(),
+        "confidence_score": source.confidence_score,
+        "found_files": source.found_files,
+    })
+}
+
+fn planned_source_payload(plan: &mvp::migration::PlannedImportSource) -> Value {
+    json!({
+        "source_id": plan.source_id,
+        "source_kind": plan.source.as_id(),
+        "input_path": plan.input_path.display().to_string(),
+        "confidence_score": plan.confidence_score,
+        "prompt_addendum_present": plan.prompt_addendum_present,
+        "profile_note_present": plan.profile_note_present,
+        "warning_count": plan.warning_count,
+    })
+}
+
+fn primary_recommendation_payload(
+    recommendation: &mvp::migration::PrimarySourceRecommendation,
+) -> Value {
+    json!({
+        "source_id": recommendation.source_id,
+        "source_kind": recommendation.source.as_id(),
+        "input_path": recommendation.input_path.display().to_string(),
+        "reasons": recommendation.reasons,
+    })
+}
+
+fn merged_profile_plan_payload(plan: &mvp::migration::MergedProfilePlan) -> Value {
+    json!({
+        "prompt_owner_source_id": plan.prompt_owner_source_id,
+        "merged_profile_note": plan.merged_profile_note,
+        "auto_apply_allowed": plan.auto_apply_allowed,
+        "kept_entries": plan
+            .kept_entries
+            .iter()
+            .map(|entry| {
+                json!({
+                    "lane": match entry.lane {
+                        mvp::migration::ProfileEntryLane::Prompt => "prompt",
+                        mvp::migration::ProfileEntryLane::Profile => "profile",
+                    },
+                    "canonical_text": entry.canonical_text,
+                    "source_id": entry.source_id,
+                    "slot_key": entry.slot_key,
+                })
+            })
+            .collect::<Vec<_>>(),
+        "dropped_duplicates": plan
+            .dropped_duplicates
+            .iter()
+            .map(|entry| {
+                json!({
+                    "lane": match entry.lane {
+                        mvp::migration::ProfileEntryLane::Prompt => "prompt",
+                        mvp::migration::ProfileEntryLane::Profile => "profile",
+                    },
+                    "canonical_text": entry.canonical_text,
+                    "source_id": entry.source_id,
+                    "slot_key": entry.slot_key,
+                })
+            })
+            .collect::<Vec<_>>(),
+        "unresolved_conflicts": plan
+            .unresolved_conflicts
+            .iter()
+            .map(|conflict| {
+                json!({
+                    "slot_key": conflict.slot_key,
+                    "preferred_source_id": conflict.preferred_source_id,
+                    "discarded_source_id": conflict.discarded_source_id,
+                    "preferred_text": conflict.preferred_text,
+                    "discarded_text": conflict.discarded_text,
+                })
+            })
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn external_skill_mapping_plan_payload(plan: &mvp::migration::ExternalSkillMappingPlan) -> Value {
+    json!({
+        "input_path": plan.input_path.display().to_string(),
+        "artifact_count": plan.artifacts.len(),
+        "artifacts": plan
+            .artifacts
+            .iter()
+            .map(|artifact| {
+                json!({
+                    "kind": artifact.kind.as_id(),
+                    "path": artifact.path.display().to_string(),
+                })
+            })
+            .collect::<Vec<_>>(),
+        "declared_skills": plan.declared_skills,
+        "locked_skills": plan.locked_skills,
+        "resolved_skills": plan.resolved_skills,
+        "profile_note_addendum": plan.profile_note_addendum,
+        "warnings": plan.warnings,
+    })
+}
+
+fn apply_selection_result_payload(result: &mvp::migration::ApplyImportSelectionResult) -> Value {
+    json!({
+        "output_path": result.output_path.display().to_string(),
+        "backup_path": result.backup_path.display().to_string(),
+        "manifest_path": result.manifest_path.display().to_string(),
+        "external_skills_manifest_path": result
+            .external_skills_manifest_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        "selected_primary_source_id": result.selected_primary_source_id,
+        "merged_source_ids": result.merged_source_ids,
+        "prompt_owner_source_id": result.prompt_owner_source_id,
+        "unresolved_conflicts": result.unresolved_conflicts,
+        "external_skill_artifact_count": result.external_skill_artifact_count,
+        "external_skill_entries_applied": result.external_skill_entries_applied,
+        "warnings": result.warnings,
+    })
+}
+
+fn config_preview_payload(config: &mvp::config::LoongClawConfig) -> Value {
+    json!({
+        "prompt_pack_id": config
+            .cli
+            .prompt_pack_id()
+            .unwrap_or(mvp::prompt::DEFAULT_PROMPT_PACK_ID),
+        "memory_profile": memory_profile_id(config.memory.profile),
+        "system_prompt_addendum": config.cli.system_prompt_addendum.clone(),
+        "profile_note": config.memory.profile_note.clone(),
+    })
+}
+
+fn selection_mode_id(selection: &mvp::migration::ImportSelectionMode) -> &'static str {
+    match selection {
+        mvp::migration::ImportSelectionMode::RecommendedSingleSource { .. } => {
+            "recommended_single_source"
+        }
+        mvp::migration::ImportSelectionMode::SelectedSingleSource { .. } => {
+            "selected_single_source"
+        }
+        mvp::migration::ImportSelectionMode::SafeProfileMerge { .. } => "safe_profile_merge",
+    }
+}
+
+fn run_rollback_mode(output_path: &Path, as_json: bool) -> CliResult<()> {
+    let restored = mvp::migration::rollback_last_import(output_path)?;
+    if as_json {
+        return print_json_payload(json!({
+            "mode": "rollback_last_apply",
+            "output_path": restored.display().to_string(),
+            "rolled_back": true,
+        }));
+    }
+
+    println!("rollback complete");
+    println!("- restored config: {}", restored.display());
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn ensure_memory_ready_from_path(path: &Path) -> CliResult<PathBuf> {
+    let output = path.display().to_string();
+    let (_, config) = mvp::config::load(Some(&output))?;
+    let runtime =
+        mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    mvp::memory::ensure_memory_db_ready(Some(config.memory.resolved_sqlite_path()), &runtime)
+        .map_err(|error| format!("failed to bootstrap sqlite memory: {error}"))
 }
 
 fn memory_profile_id(profile: mvp::config::MemoryProfile) -> &'static str {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -186,11 +186,23 @@ enum Commands {
     /// Import prompt/identity traits from another claw workspace into LoongClaw config
     ImportClaw {
         #[arg(long)]
-        input: String,
+        input: Option<String>,
         #[arg(long)]
         output: Option<String>,
         #[arg(long)]
         source: Option<String>,
+        #[arg(long, value_enum, default_value = "plan")]
+        mode: import_claw_cli::ImportClawMode,
+        #[arg(long, default_value_t = false)]
+        json: bool,
+        #[arg(long, visible_alias = "selection-id")]
+        source_id: Option<String>,
+        #[arg(long, default_value_t = false)]
+        safe_profile_merge: bool,
+        #[arg(long, visible_alias = "primary-selection-id")]
+        primary_source_id: Option<String>,
+        #[arg(long, default_value_t = false)]
+        apply_external_skills_plan: bool,
         #[arg(long, default_value_t = false)]
         force: bool,
     },
@@ -383,11 +395,23 @@ async fn main() {
             input,
             output,
             source,
+            mode,
+            json,
+            source_id,
+            safe_profile_merge,
+            primary_source_id,
+            apply_external_skills_plan,
             force,
         } => import_claw_cli::run_import_claw_cli(import_claw_cli::ImportClawCommandOptions {
             input,
             output,
             source,
+            mode,
+            json,
+            source_id,
+            safe_profile_merge,
+            primary_source_id,
+            apply_external_skills_plan,
             force,
         }),
         Commands::Doctor {

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -294,6 +294,8 @@ fn maybe_apply_onboard_import(
         discovery: discovery.report,
         output_path: output_path.to_path_buf(),
         mode: selection,
+        apply_external_skills_plan: false,
+        external_skills_input_path: None,
     })?;
 
     println!("imported legacy claw profile");

--- a/crates/daemon/src/tests/import_claw_cli.rs
+++ b/crates/daemon/src/tests/import_claw_cli.rs
@@ -1,4 +1,5 @@
 use super::*;
+use clap::Parser;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -73,9 +74,15 @@ fn run_import_claw_cli_writes_nativeized_config() {
 
     let output_path = output_root.join("loongclaw.toml");
     crate::import_claw_cli::run_import_claw_cli(crate::import_claw_cli::ImportClawCommandOptions {
-        input: legacy_root.display().to_string(),
+        input: Some(legacy_root.display().to_string()),
         output: Some(output_path.display().to_string()),
         source: Some("nanobot".to_owned()),
+        mode: crate::import_claw_cli::ImportClawMode::Apply,
+        json: false,
+        source_id: None,
+        safe_profile_merge: false,
+        primary_source_id: None,
+        apply_external_skills_plan: false,
         force: true,
     })
     .expect("import command should succeed");
@@ -105,4 +112,187 @@ fn run_import_claw_cli_writes_nativeized_config() {
 
     fs::remove_dir_all(&legacy_root).ok();
     fs::remove_dir_all(&output_root).ok();
+}
+
+#[test]
+fn run_import_claw_cli_plan_mode_returns_preview_without_writing() {
+    let legacy_root = unique_temp_dir("loongclaw-import-cli-plan-legacy");
+    let output_root = unique_temp_dir("loongclaw-import-cli-plan-output");
+    fs::create_dir_all(&legacy_root).expect("create legacy root");
+    fs::create_dir_all(&output_root).expect("create output root");
+
+    write_file(
+        &legacy_root,
+        "SOUL.md",
+        "# Soul\n\nAlways prefer concise shell output. updated by nanobot.\n",
+    );
+    let output_path = output_root.join("preview-only.toml");
+    crate::import_claw_cli::run_import_claw_cli(crate::import_claw_cli::ImportClawCommandOptions {
+        input: Some(legacy_root.display().to_string()),
+        output: Some(output_path.display().to_string()),
+        source: Some("nanobot".to_owned()),
+        mode: crate::import_claw_cli::ImportClawMode::Plan,
+        json: false,
+        source_id: None,
+        safe_profile_merge: false,
+        primary_source_id: None,
+        apply_external_skills_plan: false,
+        force: true,
+    })
+    .expect("plan mode should succeed");
+
+    assert!(
+        !output_path.exists(),
+        "plan mode should not write output config"
+    );
+
+    fs::remove_dir_all(&legacy_root).ok();
+    fs::remove_dir_all(&output_root).ok();
+}
+
+#[test]
+fn run_import_claw_cli_apply_selected_mode_writes_manifest_and_config() {
+    let discovery_root = unique_temp_dir("loongclaw-import-cli-selected-discovery");
+    let output_root = unique_temp_dir("loongclaw-import-cli-selected-output");
+    fs::create_dir_all(&discovery_root).expect("create discovery root");
+    fs::create_dir_all(&output_root).expect("create output root");
+
+    let openclaw_root = discovery_root.join("openclaw-workspace");
+    fs::create_dir_all(&openclaw_root).expect("create openclaw source root");
+    write_file(
+        &openclaw_root,
+        "SOUL.md",
+        "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+    );
+    write_file(
+        &openclaw_root,
+        "IDENTITY.md",
+        "# Identity\n\n- role: release copilot\n- tone: steady\n",
+    );
+
+    let output_path = output_root.join("selected.toml");
+    crate::import_claw_cli::run_import_claw_cli(crate::import_claw_cli::ImportClawCommandOptions {
+        input: Some(discovery_root.display().to_string()),
+        output: Some(output_path.display().to_string()),
+        source: None,
+        mode: crate::import_claw_cli::ImportClawMode::ApplySelected,
+        json: false,
+        source_id: Some("openclaw".to_owned()),
+        safe_profile_merge: false,
+        primary_source_id: None,
+        apply_external_skills_plan: false,
+        force: true,
+    })
+    .expect("apply_selected mode should succeed");
+
+    assert!(output_path.exists(), "selected import should write config");
+    let manifest_path = output_root
+        .join(".loongclaw-migration")
+        .join("selected.toml.last-import.json");
+    assert!(
+        manifest_path.exists(),
+        "apply_selected mode should write migration manifest"
+    );
+
+    fs::remove_dir_all(&discovery_root).ok();
+    fs::remove_dir_all(&output_root).ok();
+}
+
+#[test]
+fn run_import_claw_cli_apply_selected_mode_can_apply_external_skill_plan() {
+    let discovery_root = unique_temp_dir("loongclaw-import-cli-external-skills-discovery");
+    let output_root = unique_temp_dir("loongclaw-import-cli-external-skills-output");
+    fs::create_dir_all(&discovery_root).expect("create discovery root");
+    fs::create_dir_all(&output_root).expect("create output root");
+
+    let openclaw_root = discovery_root.join("openclaw-workspace");
+    fs::create_dir_all(&openclaw_root).expect("create openclaw source root");
+    write_file(
+        &openclaw_root,
+        "SOUL.md",
+        "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+    );
+    write_file(
+        &openclaw_root,
+        "IDENTITY.md",
+        "# Identity\n\n- role: release copilot\n- tone: steady\n",
+    );
+    write_file(
+        &discovery_root,
+        "SKILLS.md",
+        "# Skills\n\n- custom/skill-a\n",
+    );
+
+    let output_path = output_root.join("selected-external.toml");
+    crate::import_claw_cli::run_import_claw_cli(crate::import_claw_cli::ImportClawCommandOptions {
+        input: Some(discovery_root.display().to_string()),
+        output: Some(output_path.display().to_string()),
+        source: None,
+        mode: crate::import_claw_cli::ImportClawMode::ApplySelected,
+        json: false,
+        source_id: Some("openclaw".to_owned()),
+        safe_profile_merge: false,
+        primary_source_id: None,
+        apply_external_skills_plan: true,
+        force: true,
+    })
+    .expect("apply_selected mode with external skills should succeed");
+
+    let raw = fs::read_to_string(&output_path).expect("read generated config");
+    assert!(raw.contains("Imported External Skills Artifacts"));
+    assert!(raw.contains("kind=skills_catalog"));
+    let external_manifest_path = output_root
+        .join(".loongclaw-migration")
+        .join("selected-external.toml.external-skills.json");
+    assert!(
+        external_manifest_path.exists(),
+        "apply_selected mode should write external skills manifest"
+    );
+
+    fs::remove_dir_all(&discovery_root).ok();
+    fs::remove_dir_all(&output_root).ok();
+}
+
+#[test]
+fn import_claw_cli_defaults_to_plan_mode() {
+    let cli = Cli::try_parse_from(["loongclaw", "import-claw", "--input", "/tmp/legacy"])
+        .expect("import-claw args should parse");
+    match cli.command.expect("subcommand should exist") {
+        Commands::ImportClaw { mode, .. } => {
+            assert_eq!(mode, crate::import_claw_cli::ImportClawMode::Plan);
+        }
+        other => panic!("expected import-claw command, got {other:?}"),
+    }
+}
+
+#[test]
+fn import_claw_cli_accepts_selection_alias_flags() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "import-claw",
+        "--mode",
+        "apply_selected",
+        "--input",
+        "/tmp/legacy",
+        "--selection-id",
+        "openclaw",
+        "--primary-selection-id",
+        "nanobot",
+        "--apply-external-skills-plan",
+    ])
+    .expect("selection alias flags should parse");
+
+    match cli.command.expect("subcommand should exist") {
+        Commands::ImportClaw {
+            source_id,
+            primary_source_id,
+            apply_external_skills_plan,
+            ..
+        } => {
+            assert_eq!(source_id.as_deref(), Some("openclaw"));
+            assert_eq!(primary_source_id.as_deref(), Some("nanobot"));
+            assert!(apply_external_skills_plan);
+        }
+        other => panic!("expected import-claw command, got {other:?}"),
+    }
 }


### PR DESCRIPTION
## Summary
- add a new `external_skills` config section with safety-first defaults (`enabled=false`, `require_download_approval=true`)
- wire external-skills runtime policy into typed tool runtime config and startup env propagation paths
- add two core tools:
  - `external_skills.policy` for runtime policy get/set/reset (set/reset require explicit `policy_update_approved=true`)
  - `external_skills.fetch` for guarded downloads (HTTPS-only, no redirects, domain allow/block enforcement, explicit approval gate)
- keep migration artifacts/audit path intact while adding runtime-level enforcement
- document the new policy model and operational usage in README (EN/ZH)

## Validation
- `cargo test -p loongclaw-app`
- `cargo test -p loongclaw-daemon import_claw_cli`
- `cargo clippy -p loongclaw-app -p loongclaw-daemon --all-targets --all-features -- -D warnings`

Closes #26
