### PR TITLE
feat: deep harden safe-lane health observability and truncation governance

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -8,7 +8,7 @@ use loongclaw_contracts::Capability;
 use crate::CliResult;
 use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context};
 
-use super::config::{self, LoongClawConfig};
+use super::config::{self, ConversationConfig, LoongClawConfig};
 #[cfg(feature = "memory-sqlite")]
 use super::conversation::summarize_safe_lane_events;
 use super::conversation::{ConversationTurnCoordinator, ProviderErrorMode};
@@ -98,9 +98,9 @@ pub async fn run_cli_chat(config_path: Option<&str>, session_hint: Option<&str>)
         }
         if let Some(limit) = parse_safe_lane_summary_limit(input, config.memory.sliding_window)? {
             #[cfg(feature = "memory-sqlite")]
-            print_safe_lane_summary(&session_id, limit, &memory_config)?;
+            print_safe_lane_summary(&session_id, limit, &config.conversation, &memory_config)?;
             #[cfg(not(feature = "memory-sqlite"))]
-            print_safe_lane_summary(&session_id, limit)?;
+            print_safe_lane_summary(&session_id, limit, &config.conversation)?;
             continue;
         }
 
@@ -237,6 +237,7 @@ fn parse_safe_lane_summary_limit(input: &str, default_window: usize) -> CliResul
 fn print_safe_lane_summary(
     session_id: &str,
     limit: usize,
+    conversation_config: &ConversationConfig,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
@@ -248,13 +249,16 @@ fn print_safe_lane_summary(
                 .iter()
                 .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.as_str())),
         );
-        println!("{}", format_safe_lane_summary(session_id, limit, &summary));
+        println!(
+            "{}",
+            format_safe_lane_summary(session_id, limit, conversation_config, &summary)
+        );
         Ok(())
     }
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = (session_id, limit);
+        let _ = (session_id, limit, conversation_config);
         println!("safe-lane summary unavailable: memory-sqlite feature disabled");
         Ok(())
     }
@@ -264,6 +268,7 @@ fn print_safe_lane_summary(
 fn format_safe_lane_summary(
     session_id: &str,
     limit: usize,
+    conversation_config: &ConversationConfig,
     summary: &SafeLaneEventSummary,
 ) -> String {
     let final_status = match summary.final_status {
@@ -295,6 +300,65 @@ fn format_safe_lane_summary(
         format_milli_ratio(summary.session_governor_latest_trend_failure_ewma_milli);
     let governor_trend_backpressure_ewma =
         format_milli_ratio(summary.session_governor_latest_trend_backpressure_ewma_milli);
+    let latest_tool_truncation_ratio = format_milli_ratio(
+        summary
+            .latest_tool_output
+            .as_ref()
+            .map(|snapshot| snapshot.truncation_ratio_milli),
+    );
+    let aggregate_tool_truncation_ratio_milli = summary
+        .tool_output_aggregate_truncation_ratio_milli
+        .or_else(|| {
+            if summary.tool_output_result_lines_total == 0 {
+                None
+            } else {
+                Some(
+                    summary
+                        .tool_output_truncated_result_lines_total
+                        .saturating_mul(1000)
+                        .saturating_div(summary.tool_output_result_lines_total)
+                        .min(u32::MAX as u64) as u32,
+                )
+            }
+        });
+    let aggregate_tool_truncation_ratio =
+        aggregate_tool_truncation_ratio_milli.map(|milli| (milli as f64) / 1000.0);
+    let aggregate_tool_truncation_ratio_text = aggregate_tool_truncation_ratio
+        .map(|value| format!("{value:.3}"))
+        .unwrap_or_else(|| "-".to_owned());
+    let health_signal = derive_safe_lane_health_signal(
+        conversation_config,
+        summary,
+        replan_rate,
+        verify_failure_rate,
+        aggregate_tool_truncation_ratio,
+    );
+    let health_flags = if health_signal.flags.is_empty() {
+        "-".to_owned()
+    } else {
+        health_signal.flags.join(",")
+    };
+    let health_payload = serde_json::json!({
+        "severity": health_signal.severity,
+        "flags": health_signal.flags.clone(),
+    })
+    .to_string();
+    let latest_health_event_severity = summary
+        .latest_health_signal
+        .as_ref()
+        .map(|snapshot| snapshot.severity.as_str())
+        .unwrap_or("-");
+    let latest_health_event_flags = summary
+        .latest_health_signal
+        .as_ref()
+        .map(|snapshot| {
+            if snapshot.flags.is_empty() {
+                "-".to_owned()
+            } else {
+                snapshot.flags.join(",")
+            }
+        })
+        .unwrap_or_else(|| "-".to_owned());
 
     let metrics_line = if let Some(metrics) = metrics {
         format!(
@@ -362,12 +426,107 @@ fn format_safe_lane_summary(
             "rates replan_per_round={:.3} verify_fail_per_round={:.3}",
             replan_rate, verify_failure_rate
         ),
+        format!(
+            "tool_output snapshots={} truncated_events={} result_lines_total={} truncated_result_lines_total={} latest_truncation_ratio={} aggregate_truncation_ratio={} aggregate_truncation_ratio_milli={} truncation_verify_failed_events={} truncation_replan_events={} truncation_final_failure_events={}",
+            summary.tool_output_snapshots_seen,
+            summary.tool_output_truncated_events,
+            summary.tool_output_result_lines_total,
+            summary.tool_output_truncated_result_lines_total,
+            latest_tool_truncation_ratio,
+            aggregate_tool_truncation_ratio_text
+            ,
+            aggregate_tool_truncation_ratio_milli
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_owned()),
+            summary.tool_output_truncation_verify_failed_events,
+            summary.tool_output_truncation_replan_events,
+            summary.tool_output_truncation_final_failure_events
+        ),
+        format!(
+            "health severity={} flags={health_flags}",
+            health_signal.severity
+        ),
+        format!("health_payload {health_payload}"),
+        format!(
+            "health_events snapshots={} warn={} critical={} latest_severity={} latest_flags={}",
+            summary.health_signal_snapshots_seen,
+            summary.health_signal_warn_events,
+            summary.health_signal_critical_events,
+            latest_health_event_severity,
+            latest_health_event_flags
+        ),
         metrics_line,
         format!("rollup route_decisions={route_rollup}"),
         format!("rollup route_reasons={route_reason_rollup}"),
         format!("rollup failure_codes={failure_rollup}"),
     ]
     .join("\n")
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn derive_safe_lane_health_signal(
+    conversation_config: &ConversationConfig,
+    summary: &SafeLaneEventSummary,
+    replan_rate: f64,
+    verify_failure_rate: f64,
+    aggregate_truncation_ratio: Option<f64>,
+) -> SafeLaneHealthSignal {
+    let mut flags = Vec::new();
+    let mut has_critical = false;
+    let truncation_warn_threshold =
+        conversation_config.safe_lane_health_truncation_warn_threshold();
+    let truncation_critical_threshold =
+        conversation_config.safe_lane_health_truncation_critical_threshold();
+    let verify_failure_warn_threshold =
+        conversation_config.safe_lane_health_verify_failure_warn_threshold();
+    let replan_warn_threshold = conversation_config.safe_lane_health_replan_warn_threshold();
+
+    if let Some(ratio) = aggregate_truncation_ratio {
+        if ratio >= truncation_critical_threshold {
+            flags.push(format!("truncation_severe({ratio:.3})"));
+            has_critical = true;
+        } else if ratio >= truncation_warn_threshold {
+            flags.push(format!("truncation_pressure({ratio:.3})"));
+        }
+    }
+    if verify_failure_rate >= verify_failure_warn_threshold {
+        flags.push(format!("verify_failure_pressure({verify_failure_rate:.3})"));
+    }
+    if replan_rate >= replan_warn_threshold {
+        flags.push(format!("replan_pressure({replan_rate:.3})"));
+    }
+    let terminal_instability = matches!(summary.final_status, Some(SafeLaneFinalStatus::Failed))
+        && summary
+            .final_failure_code
+            .as_deref()
+            .map(|code| {
+                code.contains("verify_failed")
+                    || code.contains("backpressure")
+                    || code.contains("session_governor")
+            })
+            .unwrap_or(false);
+    if terminal_instability {
+        flags.push("terminal_instability".to_owned());
+        has_critical = true;
+    }
+
+    SafeLaneHealthSignal {
+        severity: if has_critical {
+            "critical"
+        } else if flags.is_empty() {
+            "ok"
+        } else {
+            "warn"
+        },
+        flags,
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SafeLaneHealthSignal {
+    severity: &'static str,
+    flags: Vec<String>,
 }
 
 #[cfg(any(test, feature = "memory-sqlite"))]
@@ -483,6 +642,7 @@ mod tests {
 
     #[test]
     fn format_safe_lane_summary_includes_rollups_and_rates() {
+        let config = ConversationConfig::default();
         let mut summary = SafeLaneEventSummary {
             lane_selected_events: 1,
             round_started_events: 2,
@@ -516,6 +676,28 @@ mod tests {
                 replans_triggered: 1,
                 total_attempts_used: 3,
             }),
+            latest_tool_output: Some(crate::conversation::SafeLaneToolOutputSnapshot {
+                output_lines: 2,
+                result_lines: 2,
+                truncated_result_lines: 1,
+                any_truncated: true,
+                truncation_ratio_milli: 500,
+            }),
+            tool_output_snapshots_seen: 2,
+            tool_output_truncated_events: 1,
+            tool_output_result_lines_total: 3,
+            tool_output_truncated_result_lines_total: 1,
+            tool_output_aggregate_truncation_ratio_milli: Some(333),
+            tool_output_truncation_verify_failed_events: 1,
+            tool_output_truncation_replan_events: 1,
+            tool_output_truncation_final_failure_events: 1,
+            latest_health_signal: Some(crate::conversation::SafeLaneHealthSignalSnapshot {
+                severity: "critical".to_owned(),
+                flags: vec!["terminal_instability".to_owned()],
+            }),
+            health_signal_snapshots_seen: 2,
+            health_signal_warn_events: 1,
+            health_signal_critical_events: 1,
             ..SafeLaneEventSummary::default()
         };
         summary
@@ -527,7 +709,7 @@ mod tests {
         summary
             .failure_code_counts
             .insert("safe_lane_plan_verify_failed".to_owned(), 1);
-        let formatted = format_safe_lane_summary("session-a", 128, &summary);
+        let formatted = format_safe_lane_summary("session-a", 128, &config, &summary);
 
         assert!(formatted.contains("safe_lane_summary session=session-a limit=128"));
         assert!(formatted.contains("status=failed"));
@@ -540,8 +722,97 @@ mod tests {
         assert!(formatted.contains("trigger_trend_threshold=1"));
         assert!(formatted.contains("governor_latest snapshots=2"));
         assert!(formatted.contains("trend_failure_ewma=0.250"));
+        assert!(formatted.contains(
+            "tool_output snapshots=2 truncated_events=1 result_lines_total=3 truncated_result_lines_total=1"
+        ));
+        assert!(formatted.contains("latest_truncation_ratio=0.500"));
+        assert!(formatted.contains("aggregate_truncation_ratio=0.333"));
+        assert!(formatted.contains("aggregate_truncation_ratio_milli=333"));
+        assert!(formatted.contains("truncation_verify_failed_events=1"));
+        assert!(formatted.contains("truncation_replan_events=1"));
+        assert!(formatted.contains("truncation_final_failure_events=1"));
+        assert!(formatted.contains("health severity=critical"));
+        assert!(formatted.contains("health_payload {\"flags\":"));
+        assert!(formatted.contains("\"severity\":\"critical\""));
+        assert!(formatted.contains(
+            "health_events snapshots=2 warn=1 critical=1 latest_severity=critical latest_flags=terminal_instability"
+        ));
+        assert!(formatted.contains("truncation_pressure(0.333)"));
+        assert!(formatted.contains("verify_failure_pressure(0.500)"));
+        assert!(formatted.contains("replan_pressure(0.500)"));
+        assert!(formatted.contains("terminal_instability"));
         assert!(formatted.contains("rollup route_decisions=terminal:1"));
         assert!(formatted.contains("rollup route_reasons=session_governor_no_replan:1"));
         assert!(formatted.contains("rollup failure_codes=safe_lane_plan_verify_failed:1"));
+    }
+
+    #[test]
+    fn format_safe_lane_summary_health_is_ok_when_no_risk_signals() {
+        let config = ConversationConfig::default();
+        let summary = SafeLaneEventSummary {
+            lane_selected_events: 1,
+            round_started_events: 3,
+            final_status_events: 1,
+            final_status: Some(SafeLaneFinalStatus::Succeeded),
+            latest_metrics: Some(crate::conversation::SafeLaneMetricsSnapshot {
+                rounds_started: 3,
+                rounds_succeeded: 3,
+                rounds_failed: 0,
+                verify_failures: 0,
+                replans_triggered: 0,
+                total_attempts_used: 3,
+            }),
+            tool_output_snapshots_seen: 1,
+            tool_output_result_lines_total: 2,
+            tool_output_truncated_result_lines_total: 0,
+            latest_tool_output: Some(crate::conversation::SafeLaneToolOutputSnapshot {
+                output_lines: 2,
+                result_lines: 2,
+                truncated_result_lines: 0,
+                any_truncated: false,
+                truncation_ratio_milli: 0,
+            }),
+            ..SafeLaneEventSummary::default()
+        };
+        let formatted = format_safe_lane_summary("session-ok", 64, &config, &summary);
+        assert!(formatted.contains("health severity=ok flags=-"));
+        assert!(formatted.contains("health_payload {\"flags\":[],\"severity\":\"ok\"}"));
+        assert!(formatted.contains(
+            "health_events snapshots=0 warn=0 critical=0 latest_severity=- latest_flags=-"
+        ));
+    }
+
+    #[test]
+    fn format_safe_lane_summary_respects_configurable_health_thresholds() {
+        let config = ConversationConfig {
+            safe_lane_health_truncation_warn_threshold: 0.20,
+            safe_lane_health_truncation_critical_threshold: 0.50,
+            safe_lane_health_verify_failure_warn_threshold: 0.70,
+            safe_lane_health_replan_warn_threshold: 0.70,
+            ..ConversationConfig::default()
+        };
+        let summary = SafeLaneEventSummary {
+            round_started_events: 4,
+            verify_failed_events: 1,
+            replan_triggered_events: 1,
+            tool_output_snapshots_seen: 1,
+            tool_output_result_lines_total: 4,
+            tool_output_truncated_result_lines_total: 1,
+            tool_output_aggregate_truncation_ratio_milli: Some(250),
+            latest_tool_output: Some(crate::conversation::SafeLaneToolOutputSnapshot {
+                output_lines: 4,
+                result_lines: 4,
+                truncated_result_lines: 1,
+                any_truncated: true,
+                truncation_ratio_milli: 250,
+            }),
+            ..SafeLaneEventSummary::default()
+        };
+
+        let formatted = format_safe_lane_summary("session-threshold", 32, &config, &summary);
+        assert!(formatted.contains("health severity=warn"));
+        assert!(formatted.contains("truncation_pressure(0.250)"));
+        assert!(!formatted.contains("verify_failure_pressure"));
+        assert!(!formatted.contains("replan_pressure"));
     }
 }

--- a/crates/app/src/config/conversation.rs
+++ b/crates/app/src/config/conversation.rs
@@ -82,6 +82,16 @@ pub struct ConversationConfig {
     pub safe_lane_complexity_threshold: u32,
     #[serde(default = "default_fast_lane_max_input_chars")]
     pub fast_lane_max_input_chars: usize,
+    #[serde(default = "default_tool_result_payload_summary_limit_chars")]
+    pub tool_result_payload_summary_limit_chars: usize,
+    #[serde(default = "default_safe_lane_health_truncation_warn_threshold")]
+    pub safe_lane_health_truncation_warn_threshold: f64,
+    #[serde(default = "default_safe_lane_health_truncation_critical_threshold")]
+    pub safe_lane_health_truncation_critical_threshold: f64,
+    #[serde(default = "default_safe_lane_health_verify_failure_warn_threshold")]
+    pub safe_lane_health_verify_failure_warn_threshold: f64,
+    #[serde(default = "default_safe_lane_health_replan_warn_threshold")]
+    pub safe_lane_health_replan_warn_threshold: f64,
     #[serde(default = "default_high_risk_keywords")]
     pub high_risk_keywords: Vec<String>,
 }
@@ -144,6 +154,16 @@ impl Default for ConversationConfig {
             safe_lane_risk_threshold: default_safe_lane_risk_threshold(),
             safe_lane_complexity_threshold: default_safe_lane_complexity_threshold(),
             fast_lane_max_input_chars: default_fast_lane_max_input_chars(),
+            tool_result_payload_summary_limit_chars:
+                default_tool_result_payload_summary_limit_chars(),
+            safe_lane_health_truncation_warn_threshold:
+                default_safe_lane_health_truncation_warn_threshold(),
+            safe_lane_health_truncation_critical_threshold:
+                default_safe_lane_health_truncation_critical_threshold(),
+            safe_lane_health_verify_failure_warn_threshold:
+                default_safe_lane_health_verify_failure_warn_threshold(),
+            safe_lane_health_replan_warn_threshold: default_safe_lane_health_replan_warn_threshold(
+            ),
             high_risk_keywords: default_high_risk_keywords(),
         }
     }
@@ -285,6 +305,40 @@ impl ConversationConfig {
     pub fn safe_lane_session_governor_force_node_max_attempts(&self) -> u8 {
         self.safe_lane_session_governor_force_node_max_attempts
             .max(1)
+    }
+
+    pub fn tool_result_payload_summary_limit_chars(&self) -> usize {
+        self.tool_result_payload_summary_limit_chars
+            .clamp(256, 64_000)
+    }
+
+    pub fn safe_lane_health_truncation_warn_threshold(&self) -> f64 {
+        clamp_unit_interval(
+            self.safe_lane_health_truncation_warn_threshold,
+            default_safe_lane_health_truncation_warn_threshold(),
+        )
+    }
+
+    pub fn safe_lane_health_truncation_critical_threshold(&self) -> f64 {
+        clamp_unit_interval(
+            self.safe_lane_health_truncation_critical_threshold,
+            default_safe_lane_health_truncation_critical_threshold(),
+        )
+        .max(self.safe_lane_health_truncation_warn_threshold())
+    }
+
+    pub fn safe_lane_health_verify_failure_warn_threshold(&self) -> f64 {
+        clamp_unit_interval(
+            self.safe_lane_health_verify_failure_warn_threshold,
+            default_safe_lane_health_verify_failure_warn_threshold(),
+        )
+    }
+
+    pub fn safe_lane_health_replan_warn_threshold(&self) -> f64 {
+        clamp_unit_interval(
+            self.safe_lane_health_replan_warn_threshold,
+            default_safe_lane_health_replan_warn_threshold(),
+        )
     }
 }
 
@@ -428,6 +482,26 @@ const fn default_fast_lane_max_input_chars() -> usize {
     400
 }
 
+const fn default_tool_result_payload_summary_limit_chars() -> usize {
+    2_048
+}
+
+const fn default_safe_lane_health_truncation_warn_threshold() -> f64 {
+    0.30
+}
+
+const fn default_safe_lane_health_truncation_critical_threshold() -> f64 {
+    0.60
+}
+
+const fn default_safe_lane_health_verify_failure_warn_threshold() -> f64 {
+    0.40
+}
+
+const fn default_safe_lane_health_replan_warn_threshold() -> f64 {
+    0.50
+}
+
 fn default_high_risk_keywords() -> Vec<String> {
     [
         "rm -rf",
@@ -520,5 +594,52 @@ mod tests {
         };
 
         assert_eq!(config.safe_lane_session_governor_trend_ewma_alpha(), 0.01);
+    }
+
+    #[test]
+    fn tool_result_payload_summary_limit_is_clamped() {
+        let too_small = ConversationConfig {
+            tool_result_payload_summary_limit_chars: 0,
+            ..ConversationConfig::default()
+        };
+        assert_eq!(too_small.tool_result_payload_summary_limit_chars(), 256);
+
+        let too_large = ConversationConfig {
+            tool_result_payload_summary_limit_chars: 1_000_000,
+            ..ConversationConfig::default()
+        };
+        assert_eq!(too_large.tool_result_payload_summary_limit_chars(), 64_000);
+    }
+
+    #[test]
+    fn safe_lane_health_thresholds_are_clamped_and_ordered() {
+        let config = ConversationConfig {
+            safe_lane_health_truncation_warn_threshold: 2.0,
+            safe_lane_health_truncation_critical_threshold: -1.0,
+            safe_lane_health_verify_failure_warn_threshold: f64::NAN,
+            safe_lane_health_replan_warn_threshold: -3.0,
+            ..ConversationConfig::default()
+        };
+        assert_eq!(config.safe_lane_health_truncation_warn_threshold(), 1.0);
+        assert_eq!(config.safe_lane_health_truncation_critical_threshold(), 1.0);
+        assert_eq!(
+            config.safe_lane_health_verify_failure_warn_threshold(),
+            default_safe_lane_health_verify_failure_warn_threshold()
+        );
+        assert_eq!(config.safe_lane_health_replan_warn_threshold(), 0.0);
+    }
+
+    #[test]
+    fn safe_lane_health_truncation_critical_threshold_respects_warn_floor() {
+        let config = ConversationConfig {
+            safe_lane_health_truncation_warn_threshold: 0.55,
+            safe_lane_health_truncation_critical_threshold: 0.20,
+            ..ConversationConfig::default()
+        };
+        assert_eq!(config.safe_lane_health_truncation_warn_threshold(), 0.55);
+        assert_eq!(
+            config.safe_lane_health_truncation_critical_threshold(),
+            0.55
+        );
     }
 }

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -865,6 +865,75 @@ max_followup_tool_payload_chars_total = 3200
     }
 
     #[test]
+    #[cfg(feature = "config-toml")]
+    fn conversation_tool_result_payload_summary_limit_can_be_overridden_from_toml() {
+        let raw = r#"
+[conversation]
+tool_result_payload_summary_limit_chars = 4096
+"#;
+        let parsed =
+            toml::from_str::<LoongClawConfig>(raw).expect("parse conversation config should pass");
+        assert_eq!(
+            parsed.conversation.tool_result_payload_summary_limit_chars,
+            4096
+        );
+        assert_eq!(
+            parsed
+                .conversation
+                .tool_result_payload_summary_limit_chars(),
+            4096
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn conversation_health_thresholds_can_be_overridden_from_toml() {
+        let raw = r#"
+[conversation]
+safe_lane_health_truncation_warn_threshold = 0.25
+safe_lane_health_truncation_critical_threshold = 0.75
+safe_lane_health_verify_failure_warn_threshold = 0.45
+safe_lane_health_replan_warn_threshold = 0.55
+"#;
+        let parsed =
+            toml::from_str::<LoongClawConfig>(raw).expect("parse conversation config should pass");
+        assert_eq!(
+            parsed
+                .conversation
+                .safe_lane_health_truncation_warn_threshold,
+            0.25
+        );
+        assert_eq!(
+            parsed
+                .conversation
+                .safe_lane_health_truncation_critical_threshold,
+            0.75
+        );
+        assert_eq!(
+            parsed
+                .conversation
+                .safe_lane_health_verify_failure_warn_threshold,
+            0.45
+        );
+        assert_eq!(
+            parsed.conversation.safe_lane_health_replan_warn_threshold,
+            0.55
+        );
+        assert_eq!(
+            parsed
+                .conversation
+                .safe_lane_health_truncation_warn_threshold(),
+            0.25
+        );
+        assert_eq!(
+            parsed
+                .conversation
+                .safe_lane_health_truncation_critical_threshold(),
+            0.75
+        );
+    }
+
+    #[test]
     fn conversation_defaults_are_stable() {
         let config = ConversationConfig::default();
         assert!(config.hybrid_lane_enabled);
@@ -929,6 +998,11 @@ max_followup_tool_payload_chars_total = 3200
         assert_eq!(config.safe_lane_risk_threshold, 4);
         assert_eq!(config.safe_lane_complexity_threshold, 6);
         assert_eq!(config.fast_lane_max_input_chars, 400);
+        assert_eq!(config.tool_result_payload_summary_limit_chars, 2_048);
+        assert_eq!(config.safe_lane_health_truncation_warn_threshold, 0.30);
+        assert_eq!(config.safe_lane_health_truncation_critical_threshold, 0.60);
+        assert_eq!(config.safe_lane_health_verify_failure_warn_threshold, 0.40);
+        assert_eq!(config.safe_lane_health_replan_warn_threshold, 0.50);
         assert!(
             config
                 .high_risk_keywords

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -345,6 +345,33 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
 
     #[test]
     #[cfg(feature = "config-toml")]
+    fn write_template_includes_tool_result_payload_summary_limit_default() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let temp_dir =
+            std::env::temp_dir().join(format!("loongclaw-template-tool-summary-limit-{unique}"));
+        std::fs::create_dir_all(&temp_dir).expect("create temp directory");
+        let config_path = temp_dir.join("config.toml");
+
+        write_template(Some(config_path.to_string_lossy().as_ref()), true)
+            .expect("write template should succeed");
+
+        let raw = std::fs::read_to_string(&config_path).expect("read template");
+        assert!(raw.contains("[conversation]"));
+        assert!(raw.contains("tool_result_payload_summary_limit_chars = 2048"));
+        assert!(raw.contains("safe_lane_health_truncation_warn_threshold = 0.3"));
+        assert!(raw.contains("safe_lane_health_truncation_critical_threshold = 0.6"));
+        assert!(raw.contains("safe_lane_health_verify_failure_warn_threshold = 0.4"));
+        assert!(raw.contains("safe_lane_health_replan_warn_threshold = 0.5"));
+
+        std::fs::remove_file(&config_path).ok();
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
     fn validate_file_returns_structured_diagnostics() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/app/src/conversation/analytics.rs
+++ b/crates/app/src/conversation/analytics.rs
@@ -21,6 +21,21 @@ pub struct SafeLaneMetricsSnapshot {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SafeLaneToolOutputSnapshot {
+    pub output_lines: u32,
+    pub result_lines: u32,
+    pub truncated_result_lines: u32,
+    pub any_truncated: bool,
+    pub truncation_ratio_milli: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SafeLaneHealthSignalSnapshot {
+    pub severity: String,
+    pub flags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SafeLaneEventSummary {
     pub lane_selected_events: u32,
     pub round_started_events: u32,
@@ -48,7 +63,20 @@ pub struct SafeLaneEventSummary {
     pub final_route_decision: Option<String>,
     pub final_route_reason: Option<String>,
     pub latest_metrics: Option<SafeLaneMetricsSnapshot>,
+    pub latest_tool_output: Option<SafeLaneToolOutputSnapshot>,
     pub metrics_snapshots_seen: u32,
+    pub tool_output_snapshots_seen: u32,
+    pub tool_output_truncated_events: u32,
+    pub tool_output_result_lines_total: u64,
+    pub tool_output_truncated_result_lines_total: u64,
+    pub tool_output_aggregate_truncation_ratio_milli: Option<u32>,
+    pub tool_output_truncation_verify_failed_events: u32,
+    pub tool_output_truncation_replan_events: u32,
+    pub tool_output_truncation_final_failure_events: u32,
+    pub latest_health_signal: Option<SafeLaneHealthSignalSnapshot>,
+    pub health_signal_snapshots_seen: u32,
+    pub health_signal_warn_events: u32,
+    pub health_signal_critical_events: u32,
     pub route_decision_counts: BTreeMap<String, u32>,
     pub route_reason_counts: BTreeMap<String, u32>,
     pub failure_code_counts: BTreeMap<String, u32>,
@@ -85,7 +113,16 @@ where
             continue;
         }
 
-        match record.event.as_str() {
+        let event_name = record.event.as_str();
+        let final_status_is_failed = event_name == "final_status"
+            && record
+                .payload
+                .get("status")
+                .and_then(Value::as_str)
+                .map(|status| status == "failed")
+                .unwrap_or(false);
+
+        match event_name {
             "lane_selected" => {
                 summary.lane_selected_events = summary.lane_selected_events.saturating_add(1);
             }
@@ -179,6 +216,60 @@ where
             summary.metrics_snapshots_seen = summary.metrics_snapshots_seen.saturating_add(1);
             summary.latest_metrics = Some(metrics);
         }
+        if let Some(tool_output) =
+            parse_tool_output_snapshot(record.payload.get("tool_output_stats"))
+        {
+            summary.tool_output_snapshots_seen =
+                summary.tool_output_snapshots_seen.saturating_add(1);
+            if tool_output.any_truncated || tool_output.truncated_result_lines > 0 {
+                summary.tool_output_truncated_events =
+                    summary.tool_output_truncated_events.saturating_add(1);
+                if event_name == "verify_failed" {
+                    summary.tool_output_truncation_verify_failed_events = summary
+                        .tool_output_truncation_verify_failed_events
+                        .saturating_add(1);
+                }
+                if event_name == "replan_triggered" {
+                    summary.tool_output_truncation_replan_events = summary
+                        .tool_output_truncation_replan_events
+                        .saturating_add(1);
+                }
+                if final_status_is_failed {
+                    summary.tool_output_truncation_final_failure_events = summary
+                        .tool_output_truncation_final_failure_events
+                        .saturating_add(1);
+                }
+            }
+            summary.tool_output_result_lines_total = summary
+                .tool_output_result_lines_total
+                .saturating_add(tool_output.result_lines as u64);
+            summary.tool_output_truncated_result_lines_total = summary
+                .tool_output_truncated_result_lines_total
+                .saturating_add(tool_output.truncated_result_lines as u64);
+            summary.tool_output_aggregate_truncation_ratio_milli = compute_truncation_ratio_milli(
+                summary.tool_output_truncated_result_lines_total,
+                summary.tool_output_result_lines_total,
+            );
+            summary.latest_tool_output = Some(tool_output);
+        }
+        if let Some(health_signal) =
+            parse_health_signal_snapshot(record.payload.get("health_signal"))
+        {
+            summary.health_signal_snapshots_seen =
+                summary.health_signal_snapshots_seen.saturating_add(1);
+            match health_signal.severity.as_str() {
+                "warn" => {
+                    summary.health_signal_warn_events =
+                        summary.health_signal_warn_events.saturating_add(1);
+                }
+                "critical" => {
+                    summary.health_signal_critical_events =
+                        summary.health_signal_critical_events.saturating_add(1);
+                }
+                _ => {}
+            }
+            summary.latest_health_signal = Some(health_signal);
+        }
     }
 
     summary
@@ -211,6 +302,92 @@ fn parse_metrics_snapshot(value: Option<&Value>) -> Option<SafeLaneMetricsSnapsh
             .and_then(Value::as_u64)
             .unwrap_or_default(),
     })
+}
+
+fn parse_tool_output_snapshot(value: Option<&Value>) -> Option<SafeLaneToolOutputSnapshot> {
+    let snapshot = value?;
+    let has_any = [
+        "output_lines",
+        "result_lines",
+        "truncated_result_lines",
+        "any_truncated",
+        "truncation_ratio_milli",
+    ]
+    .iter()
+    .any(|key| snapshot.get(*key).is_some());
+    if !has_any {
+        return None;
+    }
+
+    let output_lines = read_u32(snapshot, "output_lines");
+    let result_lines = read_u32(snapshot, "result_lines");
+    let truncated_result_lines = read_u32(snapshot, "truncated_result_lines").min(result_lines);
+    let any_truncated = snapshot
+        .get("any_truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(truncated_result_lines > 0);
+    let truncation_ratio_milli = snapshot
+        .get("truncation_ratio_milli")
+        .and_then(Value::as_u64)
+        .map(|raw| raw.min(1000) as u32)
+        .unwrap_or_else(|| {
+            if result_lines == 0 {
+                0
+            } else {
+                ((truncated_result_lines as u64)
+                    .saturating_mul(1000)
+                    .saturating_div(result_lines as u64))
+                .min(1000) as u32
+            }
+        });
+
+    Some(SafeLaneToolOutputSnapshot {
+        output_lines,
+        result_lines,
+        truncated_result_lines,
+        any_truncated,
+        truncation_ratio_milli,
+    })
+}
+
+fn compute_truncation_ratio_milli(truncated_lines: u64, result_lines: u64) -> Option<u32> {
+    if result_lines == 0 {
+        return None;
+    }
+    Some(
+        truncated_lines
+            .saturating_mul(1000)
+            .saturating_div(result_lines)
+            .min(u32::MAX as u64) as u32,
+    )
+}
+
+fn parse_health_signal_snapshot(value: Option<&Value>) -> Option<SafeLaneHealthSignalSnapshot> {
+    let signal = value?;
+    let severity = signal
+        .get("severity")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "unknown".to_owned());
+    let flags = signal
+        .get("flags")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if severity == "unknown" && flags.is_empty() {
+        return None;
+    }
+    Some(SafeLaneHealthSignalSnapshot { severity, flags })
 }
 
 fn is_safe_lane_event_name(event_name: &str) -> bool {
@@ -578,6 +755,173 @@ mod tests {
         assert_eq!(
             summary.session_governor_latest_recovery_success_streak_threshold,
             Some(3)
+        );
+    }
+
+    #[test]
+    fn summarize_safe_lane_events_tracks_tool_output_snapshot_rollups() {
+        let payloads = [
+            json!({
+                "type": "conversation_event",
+                "event": "plan_round_completed",
+                "payload": {
+                    "round": 0,
+                    "status": "succeeded",
+                    "tool_output_stats": {
+                        "output_lines": 2,
+                        "result_lines": 2,
+                        "truncated_result_lines": 1,
+                        "any_truncated": true,
+                        "truncation_ratio_milli": 500
+                    }
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "final_status",
+                "payload": {
+                    "status": "succeeded",
+                    "tool_output_stats": {
+                        "output_lines": 1,
+                        "result_lines": 1,
+                        "truncated_result_lines": 0,
+                        "any_truncated": false,
+                        "truncation_ratio_milli": 0
+                    }
+                }
+            })
+            .to_string(),
+        ];
+        let summary = summarize_safe_lane_events(payloads.iter().map(String::as_str));
+
+        assert_eq!(summary.tool_output_snapshots_seen, 2);
+        assert_eq!(summary.tool_output_truncated_events, 1);
+        assert_eq!(summary.tool_output_result_lines_total, 3);
+        assert_eq!(summary.tool_output_truncated_result_lines_total, 1);
+        assert_eq!(
+            summary.tool_output_aggregate_truncation_ratio_milli,
+            Some(333)
+        );
+        assert_eq!(summary.tool_output_truncation_verify_failed_events, 0);
+        assert_eq!(summary.tool_output_truncation_replan_events, 0);
+        assert_eq!(summary.tool_output_truncation_final_failure_events, 0);
+        assert_eq!(
+            summary.latest_tool_output,
+            Some(SafeLaneToolOutputSnapshot {
+                output_lines: 1,
+                result_lines: 1,
+                truncated_result_lines: 0,
+                any_truncated: false,
+                truncation_ratio_milli: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn summarize_safe_lane_events_tracks_truncation_failure_correlation_counters() {
+        let payloads = [
+            json!({
+                "type": "conversation_event",
+                "event": "verify_failed",
+                "payload": {
+                    "failure_code": "safe_lane_plan_verify_failed",
+                    "tool_output_stats": {
+                        "output_lines": 2,
+                        "result_lines": 2,
+                        "truncated_result_lines": 1,
+                        "any_truncated": true,
+                        "truncation_ratio_milli": 500
+                    }
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "replan_triggered",
+                "payload": {
+                    "tool_output_stats": {
+                        "output_lines": 1,
+                        "result_lines": 1,
+                        "truncated_result_lines": 1,
+                        "any_truncated": true,
+                        "truncation_ratio_milli": 1000
+                    }
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "final_status",
+                "payload": {
+                    "status": "failed",
+                    "failure_code": "safe_lane_plan_verify_failed",
+                    "tool_output_stats": {
+                        "output_lines": 1,
+                        "result_lines": 1,
+                        "truncated_result_lines": 1,
+                        "any_truncated": true,
+                        "truncation_ratio_milli": 1000
+                    }
+                }
+            })
+            .to_string(),
+        ];
+
+        let summary = summarize_safe_lane_events(payloads.iter().map(String::as_str));
+        assert_eq!(summary.tool_output_snapshots_seen, 3);
+        assert_eq!(summary.tool_output_truncated_events, 3);
+        assert_eq!(summary.tool_output_result_lines_total, 4);
+        assert_eq!(summary.tool_output_truncated_result_lines_total, 3);
+        assert_eq!(
+            summary.tool_output_aggregate_truncation_ratio_milli,
+            Some(750)
+        );
+        assert_eq!(summary.tool_output_truncation_verify_failed_events, 1);
+        assert_eq!(summary.tool_output_truncation_replan_events, 1);
+        assert_eq!(summary.tool_output_truncation_final_failure_events, 1);
+    }
+
+    #[test]
+    fn summarize_safe_lane_events_tracks_health_signal_rollups() {
+        let payloads = [
+            json!({
+                "type": "conversation_event",
+                "event": "plan_round_completed",
+                "payload": {
+                    "round": 0,
+                    "status": "failed",
+                    "health_signal": {
+                        "severity": "warn",
+                        "flags": ["truncation_pressure(0.300)"]
+                    }
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "final_status",
+                "payload": {
+                    "status": "failed",
+                    "health_signal": {
+                        "severity": "critical",
+                        "flags": ["terminal_instability"]
+                    }
+                }
+            })
+            .to_string(),
+        ];
+
+        let summary = summarize_safe_lane_events(payloads.iter().map(String::as_str));
+        assert_eq!(summary.health_signal_snapshots_seen, 2);
+        assert_eq!(summary.health_signal_warn_events, 1);
+        assert_eq!(summary.health_signal_critical_events, 1);
+        assert_eq!(
+            summary.latest_health_signal,
+            Some(SafeLaneHealthSignalSnapshot {
+                severity: "critical".to_owned(),
+                flags: vec!["terminal_instability".to_owned()],
+            })
         );
     }
 }

--- a/crates/app/src/conversation/lane_arbiter.rs
+++ b/crates/app/src/conversation/lane_arbiter.rs
@@ -84,7 +84,7 @@ impl LaneArbiterPolicy {
         let normalized = user_input.to_ascii_lowercase();
         self.high_risk_keywords
             .iter()
-            .filter(|keyword| normalized.contains(keyword.as_str()))
+            .filter(|keyword| keyword_matches_risk_signal(normalized.as_str(), keyword))
             .count()
             .saturating_mul(2) as u32
     }
@@ -154,6 +154,36 @@ fn default_high_risk_keywords() -> BTreeSet<String> {
     .collect()
 }
 
+fn keyword_matches_risk_signal(normalized_input: &str, keyword: &str) -> bool {
+    if should_use_word_boundary_match(keyword) {
+        return contains_with_word_boundaries(normalized_input, keyword);
+    }
+    normalized_input.contains(keyword)
+}
+
+fn should_use_word_boundary_match(keyword: &str) -> bool {
+    keyword.len() <= 4 && keyword.chars().all(|ch| ch.is_ascii_alphanumeric())
+}
+
+fn contains_with_word_boundaries(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return false;
+    }
+    haystack.match_indices(needle).any(|(start, _)| {
+        let end = start + needle.len();
+        let left = haystack[..start].chars().next_back();
+        let right = haystack[end..].chars().next();
+        is_word_boundary(left) && is_word_boundary(right)
+    })
+}
+
+fn is_word_boundary(ch: Option<char>) -> bool {
+    match ch {
+        None => true,
+        Some(value) => !value.is_ascii_alphanumeric(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -197,5 +227,21 @@ mod tests {
             "expected complexity reason, got: {:?}",
             decision.reasons
         );
+    }
+
+    #[test]
+    fn short_keyword_match_avoids_product_false_positive() {
+        let policy = LaneArbiterPolicy::default();
+        let decision = policy.decide("review product launch notes and summarize user feedback");
+        assert_eq!(decision.risk_score, 0);
+        assert_eq!(decision.lane, ExecutionLane::Fast);
+    }
+
+    #[test]
+    fn short_keyword_match_preserves_prod_signal_with_boundaries() {
+        let policy = LaneArbiterPolicy::default();
+        let decision = policy.decide("deploy the patch to prod after smoke tests");
+        assert_eq!(decision.risk_score, 4);
+        assert_eq!(decision.lane, ExecutionLane::Safe);
     }
 }

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -8,9 +8,11 @@ mod runtime;
 mod turn_coordinator;
 pub mod turn_engine;
 mod turn_loop;
+mod turn_shared;
 
 pub use analytics::{
-    ConversationEventRecord, SafeLaneEventSummary, SafeLaneFinalStatus, SafeLaneMetricsSnapshot,
+    ConversationEventRecord, SafeLaneEventSummary, SafeLaneFinalStatus,
+    SafeLaneHealthSignalSnapshot, SafeLaneMetricsSnapshot, SafeLaneToolOutputSnapshot,
     parse_conversation_event, summarize_safe_lane_events,
 };
 pub use lane_arbiter::{ExecutionLane, LaneArbiterPolicy, LaneDecision};

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -377,6 +377,151 @@ async fn handle_turn_with_runtime_tool_turn_raw_request_skips_second_pass_comple
     assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_honors_configured_tool_result_summary_limit_on_fast_lane() {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    std::fs::write(harness.temp_dir.join("large-note.md"), "x".repeat(8_000))
+        .expect("seed large test note");
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Reading large note.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "large-note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-fast-limit".to_owned(),
+                turn_id: "turn-fast-limit".to_owned(),
+                tool_call_id: "call-fast-limit".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.tool_result_payload_summary_limit_chars = 256;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-fast-limit",
+            "read large-note.md and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("tool turn should succeed");
+
+    let line = reply
+        .lines()
+        .find(|entry| entry.starts_with("[ok] "))
+        .expect("reply should include tool envelope line");
+    let envelope: Value = serde_json::from_str(
+        line.strip_prefix("[ok] ")
+            .expect("tool line should keep status prefix"),
+    )
+    .expect("tool envelope should be valid json");
+
+    assert_eq!(envelope["payload_truncated"], true);
+    assert!(
+        envelope["payload_chars"]
+            .as_u64()
+            .expect("payload chars should exist")
+            > 256
+    );
+    let summary = envelope["payload_summary"]
+        .as_str()
+        .expect("payload summary should be a string");
+    assert!(
+        summary.contains("...(truncated "),
+        "summary should contain truncation marker, got: {summary}"
+    );
+    assert!(
+        summary.chars().count() <= 420,
+        "summary should respect configured bound, chars={}",
+        summary.chars().count()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_honors_configured_tool_result_summary_limit_on_safe_lane_plan() {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    std::fs::write(harness.temp_dir.join("large-note.md"), "x".repeat(8_000))
+        .expect("seed large test note");
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Running deployment read checks.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "large-note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe-limit".to_owned(),
+                turn_id: "turn-safe-limit".to_owned(),
+                tool_call_id: "call-safe-limit".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.tool_result_payload_summary_limit_chars = 256;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-limit",
+            "deploy production safely and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("safe-lane plan turn should succeed");
+
+    let line = reply
+        .lines()
+        .find(|entry| entry.starts_with("[ok] "))
+        .expect("reply should include tool envelope line");
+    let envelope: Value = serde_json::from_str(
+        line.strip_prefix("[ok] ")
+            .expect("tool line should keep status prefix"),
+    )
+    .expect("tool envelope should be valid json");
+
+    assert_eq!(envelope["payload_truncated"], true);
+    assert!(
+        envelope["payload_chars"]
+            .as_u64()
+            .expect("payload chars should exist")
+            > 256
+    );
+    let summary = envelope["payload_summary"]
+        .as_str()
+        .expect("payload summary should be a string");
+    assert!(
+        summary.contains("...(truncated "),
+        "summary should contain truncation marker, got: {summary}"
+    );
+    assert!(
+        summary.chars().count() <= 420,
+        "summary should respect configured bound, chars={}",
+        summary.chars().count()
+    );
+}
+
 #[tokio::test]
 async fn handle_turn_with_runtime_safe_lane_honors_configured_tool_step_budget() {
     let runtime = FakeRuntime::with_turn_and_completion(
@@ -526,7 +671,7 @@ async fn handle_turn_with_runtime_safe_lane_plan_persists_runtime_events_when_en
         .expect("safe lane plan should produce a reply");
 
     let persisted = runtime.persisted.lock().expect("persisted lock");
-    let event_names = persisted
+    let event_records = persisted
         .iter()
         .filter_map(|(_, role, content)| {
             if role != "assistant" {
@@ -536,8 +681,15 @@ async fn handle_turn_with_runtime_safe_lane_plan_persists_runtime_events_when_en
             if parsed.get("type")?.as_str()? != "conversation_event" {
                 return None;
             }
-            parsed.get("event")?.as_str().map(ToOwned::to_owned)
+            Some((
+                parsed.get("event")?.as_str()?.to_owned(),
+                parsed.get("payload").cloned().unwrap_or(Value::Null),
+            ))
         })
+        .collect::<Vec<_>>();
+    let event_names = event_records
+        .iter()
+        .map(|(event, _)| event.to_owned())
         .collect::<Vec<_>>();
 
     assert!(
@@ -557,6 +709,53 @@ async fn handle_turn_with_runtime_safe_lane_plan_persists_runtime_events_when_en
     assert!(
         event_names.iter().any(|name| name == "final_status"),
         "expected final_status event, got: {event_names:?}"
+    );
+
+    let plan_round_completed_payload = event_records
+        .iter()
+        .find_map(|(event, payload)| (event == "plan_round_completed").then_some(payload))
+        .expect("plan_round_completed payload should exist");
+    let plan_stats = plan_round_completed_payload
+        .get("tool_output_stats")
+        .expect("plan_round_completed should include tool_output_stats");
+    assert_eq!(
+        plan_stats
+            .get("truncated_result_lines")
+            .and_then(Value::as_u64),
+        Some(0)
+    );
+    let plan_health = plan_round_completed_payload
+        .get("health_signal")
+        .expect("plan_round_completed should include health_signal");
+    assert_eq!(
+        plan_health.get("severity").and_then(Value::as_str),
+        Some("ok")
+    );
+    assert_eq!(
+        plan_health
+            .get("flags")
+            .and_then(Value::as_array)
+            .map(Vec::len),
+        Some(0)
+    );
+
+    let final_status_payload = event_records
+        .iter()
+        .find_map(|(event, payload)| (event == "final_status").then_some(payload))
+        .expect("final_status payload should exist");
+    let final_stats = final_status_payload
+        .get("tool_output_stats")
+        .expect("final_status should include tool_output_stats");
+    assert_eq!(
+        final_stats.get("result_lines").and_then(Value::as_u64),
+        Some(0)
+    );
+    let final_health = final_status_payload
+        .get("health_signal")
+        .expect("final_status should include health_signal");
+    assert_eq!(
+        final_health.get("severity").and_then(Value::as_str),
+        Some("ok")
     );
 }
 
@@ -2459,9 +2658,26 @@ async fn turn_engine_executes_known_tool_with_kernel() {
     let result = engine.execute_turn(&turn, Some(&ctx)).await;
     match result {
         TurnResult::FinalText(text) => {
+            let line = text.lines().next().expect("tool result line should exist");
+            let payload = line
+                .strip_prefix("[ok] ")
+                .expect("tool result line should keep [ok] prefix");
+            let envelope: Value =
+                serde_json::from_str(payload).expect("tool result envelope should be json");
             assert!(
-                text.contains("\"tool\":\"file.read\""),
+                payload.contains("\"tool\":\"file.read\""),
                 "expected echoed tool payload in output, got: {text}"
+            );
+            assert_eq!(envelope["status"], "ok");
+            assert_eq!(envelope["tool"], "file.read");
+            assert_eq!(envelope["tool_call_id"], "c1");
+            assert_eq!(envelope["payload_truncated"], false);
+            assert!(
+                envelope["payload_summary"]
+                    .as_str()
+                    .expect("payload summary should be string")
+                    .contains("\"path\":\"test.txt\""),
+                "expected payload summary to include original args, got: {envelope:?}"
             );
         }
         TurnResult::ToolDenied(reason) => {
@@ -2483,6 +2699,115 @@ async fn turn_engine_executes_known_tool_with_kernel() {
                 panic!("unexpected result: {:?}", other);
             }
         }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_truncates_oversized_tool_payload_summary() {
+    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
+    use loongclaw_kernel::CoreToolAdapter;
+
+    struct LargePayloadToolAdapter;
+
+    #[async_trait]
+    impl CoreToolAdapter for LargePayloadToolAdapter {
+        fn name(&self) -> &str {
+            "large-payload-tools"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool": request.tool_name,
+                    "blob": "x".repeat(10_000)
+                }),
+            })
+        }
+    }
+
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_tool_adapter(LargePayloadToolAdapter);
+    kernel
+        .set_default_core_tool_adapter("large-payload-tools")
+        .expect("set default");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let engine = TurnEngine::new(5);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "file.read".to_owned(),
+            args_json: json!({"path": "test.txt"}),
+            source: "provider_tool_call".to_owned(),
+            session_id: "s1".to_owned(),
+            turn_id: "t1".to_owned(),
+            tool_call_id: "c-large".to_owned(),
+        }],
+        raw_meta: serde_json::Value::Null,
+    };
+
+    let result = engine.execute_turn(&turn, Some(&ctx)).await;
+    match result {
+        TurnResult::FinalText(text) => {
+            let line = text.lines().next().expect("tool result line should exist");
+            let payload = line
+                .strip_prefix("[ok] ")
+                .expect("tool result line should keep [ok] prefix");
+            let envelope: Value =
+                serde_json::from_str(payload).expect("tool result envelope should be json");
+
+            assert_eq!(envelope["tool"], "file.read");
+            assert_eq!(envelope["tool_call_id"], "c-large");
+            assert_eq!(envelope["payload_truncated"], true);
+            assert!(
+                envelope["payload_chars"]
+                    .as_u64()
+                    .expect("payload chars should exist")
+                    > 2048
+            );
+            let summary = envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should be string");
+            assert!(
+                summary.contains("...(truncated "),
+                "expected truncated marker, got: {summary}"
+            );
+            assert!(
+                summary.chars().count() <= 2200,
+                "truncated summary should stay bounded, chars={}",
+                summary.chars().count()
+            );
+        }
+        other => panic!("expected FinalText, got {:?}", other),
     }
 }
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -37,11 +37,13 @@ use super::turn_engine::{
     KernelFailureClass, ProviderTurn, ToolIntent, TurnEngine, TurnFailure, TurnFailureKind,
     TurnResult, classify_kernel_error,
 };
+use super::turn_shared::{
+    build_tool_followup_user_prompt, compose_assistant_reply, join_non_empty_lines,
+    tool_result_contains_truncation_signal, user_requested_raw_tool_output,
+};
 
 #[derive(Default)]
 pub struct ConversationTurnCoordinator;
-
-const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct SafeLaneExecutionMetrics {
@@ -51,9 +53,32 @@ struct SafeLaneExecutionMetrics {
     verify_failures: u32,
     replans_triggered: u32,
     total_attempts_used: u64,
+    tool_output_result_lines_total: u64,
+    tool_output_truncated_result_lines_total: u64,
 }
 
 impl SafeLaneExecutionMetrics {
+    fn record_tool_output_stats(&mut self, stats: SafeLaneToolOutputStats) {
+        self.tool_output_result_lines_total = self
+            .tool_output_result_lines_total
+            .saturating_add(stats.result_lines as u64);
+        self.tool_output_truncated_result_lines_total = self
+            .tool_output_truncated_result_lines_total
+            .saturating_add(stats.truncated_result_lines as u64);
+    }
+
+    fn aggregate_tool_truncation_ratio_milli(self) -> Option<u32> {
+        if self.tool_output_result_lines_total == 0 {
+            return None;
+        }
+        Some(
+            self.tool_output_truncated_result_lines_total
+                .saturating_mul(1000)
+                .saturating_div(self.tool_output_result_lines_total)
+                .min(u32::MAX as u64) as u32,
+        )
+    }
+
     fn as_json(self) -> Value {
         json!({
             "rounds_started": self.rounds_started,
@@ -62,6 +87,9 @@ impl SafeLaneExecutionMetrics {
             "verify_failures": self.verify_failures,
             "replans_triggered": self.replans_triggered,
             "total_attempts_used": self.total_attempts_used,
+            "tool_output_result_lines_total": self.tool_output_result_lines_total,
+            "tool_output_truncated_result_lines_total": self.tool_output_truncated_result_lines_total,
+            "tool_output_aggregate_truncation_ratio_milli": self.aggregate_tool_truncation_ratio_milli(),
         })
     }
 }
@@ -69,6 +97,49 @@ impl SafeLaneExecutionMetrics {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct SafeLaneAdaptiveVerifyPolicyState {
     min_anchor_matches: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct SafeLaneToolOutputStats {
+    output_lines: usize,
+    result_lines: usize,
+    truncated_result_lines: usize,
+}
+
+impl SafeLaneToolOutputStats {
+    fn truncation_ratio_milli(self) -> usize {
+        if self.result_lines == 0 {
+            return 0;
+        }
+        self.truncated_result_lines
+            .saturating_mul(1000)
+            .saturating_div(self.result_lines)
+    }
+
+    fn as_json(self) -> Value {
+        json!({
+            "output_lines": self.output_lines,
+            "result_lines": self.result_lines,
+            "truncated_result_lines": self.truncated_result_lines,
+            "any_truncated": self.truncated_result_lines > 0,
+            "truncation_ratio_milli": self.truncation_ratio_milli(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SafeLaneRuntimeHealthSignal {
+    severity: &'static str,
+    flags: Vec<String>,
+}
+
+impl SafeLaneRuntimeHealthSignal {
+    fn as_json(&self) -> Value {
+        json!({
+            "severity": self.severity,
+            "flags": self.flags,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -198,9 +269,14 @@ impl ConversationTurnCoordinator {
                     )
                     .await
                 } else {
-                    TurnEngine::new(max_tool_steps)
-                        .execute_turn(&turn, kernel_ctx)
-                        .await
+                    TurnEngine::with_tool_result_payload_summary_limit(
+                        max_tool_steps,
+                        config
+                            .conversation
+                            .tool_result_payload_summary_limit_chars(),
+                    )
+                    .execute_turn(&turn, kernel_ctx)
+                    .await
                 };
                 let reply = match turn_result {
                     TurnResult::FinalText(tool_text) if had_tool_intents => {
@@ -461,11 +537,18 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
             kernel_ctx,
             config.conversation.safe_lane_verify_output_non_empty,
             seed_tool_outputs.clone(),
+            config
+                .conversation
+                .tool_result_payload_summary_limit_chars(),
         );
         let report = PlanExecutor::execute(&plan, &executor).await;
         metrics.total_attempts_used = metrics
             .total_attempts_used
             .saturating_add(report.attempts_used as u64);
+        let round_tool_outputs = executor.tool_outputs_snapshot().await;
+        let round_tool_output_stats =
+            summarize_safe_lane_tool_output_stats(round_tool_outputs.as_slice());
+        metrics.record_tool_output_stats(round_tool_output_stats);
 
         match report.status {
             PlanRunStatus::Succeeded => {
@@ -480,12 +563,20 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                         "status": "succeeded",
                         "attempts_used": report.attempts_used,
                         "elapsed_ms": report.elapsed_ms,
+                        "tool_output_stats": round_tool_output_stats.as_json(),
+                        "health_signal": derive_safe_lane_runtime_health_signal(
+                            config,
+                            metrics,
+                            false,
+                            None,
+                        )
+                        .as_json(),
                         "metrics": metrics.as_json(),
                     }),
                     kernel_ctx,
                 )
                 .await;
-                let tool_output = executor.joined_output().await;
+                let tool_output = round_tool_outputs.join("\n");
                 let verify_report = verify_safe_lane_final_output(
                     config,
                     tool_output.as_str(),
@@ -502,6 +593,14 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                             json!({
                                 "status": "succeeded",
                                 "round": round,
+                                "tool_output_stats": round_tool_output_stats.as_json(),
+                                "health_signal": derive_safe_lane_runtime_health_signal(
+                                    config,
+                                    metrics,
+                                    false,
+                                    None,
+                                )
+                                .as_json(),
                                 "metrics": metrics.as_json(),
                             }),
                             kernel_ctx,
@@ -546,6 +645,14 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                                 "failure_retryable": verify_failure.retryable,
                                 "route_decision": format_safe_lane_route_decision(verify_route.decision),
                                 "route_reason": verify_route.reason,
+                                "tool_output_stats": round_tool_output_stats.as_json(),
+                                "health_signal": derive_safe_lane_runtime_health_signal(
+                                    config,
+                                    metrics,
+                                    false,
+                                    None,
+                                )
+                                .as_json(),
                                 "metrics": metrics.as_json(),
                             }),
                             kernel_ctx,
@@ -574,6 +681,14 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                                     "failure_retryable": terminal_failure.retryable,
                                     "route_decision": format_safe_lane_route_decision(verify_route.decision),
                                     "route_reason": verify_route.reason,
+                                    "tool_output_stats": round_tool_output_stats.as_json(),
+                                    "health_signal": derive_safe_lane_runtime_health_signal(
+                                        config,
+                                        metrics,
+                                        true,
+                                        Some(terminal_failure.code.as_str()),
+                                    )
+                                    .as_json(),
                                     "metrics": metrics.as_json(),
                                 }),
                                 kernel_ctx,
@@ -593,6 +708,14 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                                 "detail": verify_error,
                                 "route_decision": format_safe_lane_route_decision(verify_route.decision),
                                 "route_reason": verify_route.reason,
+                                "tool_output_stats": round_tool_output_stats.as_json(),
+                                "health_signal": derive_safe_lane_runtime_health_signal(
+                                    config,
+                                    metrics,
+                                    false,
+                                    None,
+                                )
+                                .as_json(),
                                 "metrics": metrics.as_json(),
                             }),
                             kernel_ctx,
@@ -626,6 +749,14 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                         "failure_retryable": round_failure_meta.retryable,
                         "route_decision": format_safe_lane_route_decision(route.decision),
                         "route_reason": route.reason,
+                        "tool_output_stats": round_tool_output_stats.as_json(),
+                        "health_signal": derive_safe_lane_runtime_health_signal(
+                            config,
+                            metrics,
+                            false,
+                            None,
+                        )
+                        .as_json(),
                         "metrics": metrics.as_json(),
                     }),
                     kernel_ctx,
@@ -649,6 +780,14 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                             "seeded_outputs": seed_tool_outputs.len(),
                             "route_decision": format_safe_lane_route_decision(route.decision),
                             "route_reason": route.reason,
+                            "tool_output_stats": round_tool_output_stats.as_json(),
+                            "health_signal": derive_safe_lane_runtime_health_signal(
+                                config,
+                                metrics,
+                                false,
+                                None,
+                            )
+                            .as_json(),
                             "metrics": metrics.as_json(),
                         }),
                         kernel_ctx,
@@ -673,6 +812,14 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                             "failure_retryable": failure_meta.map(|failure| failure.retryable),
                             "route_decision": format_safe_lane_route_decision(route.decision),
                             "route_reason": route.reason,
+                            "tool_output_stats": round_tool_output_stats.as_json(),
+                            "health_signal": derive_safe_lane_runtime_health_signal(
+                                config,
+                                metrics,
+                                true,
+                                failure_meta.map(|failure| failure.code.as_str()),
+                            )
+                            .as_json(),
                             "metrics": metrics.as_json(),
                         }),
                         kernel_ctx,
@@ -800,6 +947,16 @@ fn safe_lane_failure_pressure(payload: &Value) -> u64 {
     }
 
     if payload
+        .get("tool_output_stats")
+        .and_then(|stats| stats.get("truncated_result_lines"))
+        .and_then(Value::as_u64)
+        .unwrap_or_default()
+        > 0
+    {
+        pressure = pressure.saturating_add(1);
+    }
+
+    if payload
         .get("metrics")
         .and_then(|metrics| metrics.get("verify_failures"))
         .and_then(Value::as_u64)
@@ -882,6 +1039,102 @@ fn build_safe_lane_plan_graph(
             max_total_attempts,
             max_wall_time_ms: config.conversation.safe_lane_plan_max_wall_time_ms.max(1),
         },
+    }
+}
+
+fn summarize_safe_lane_tool_output_stats(outputs: &[String]) -> SafeLaneToolOutputStats {
+    let mut stats = SafeLaneToolOutputStats::default();
+    for output in outputs {
+        for line in output
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+        {
+            stats.output_lines = stats.output_lines.saturating_add(1);
+            if !line.starts_with('[') {
+                continue;
+            }
+            stats.result_lines = stats.result_lines.saturating_add(1);
+            if tool_result_contains_truncation_signal(line) {
+                stats.truncated_result_lines = stats.truncated_result_lines.saturating_add(1);
+            }
+        }
+    }
+    stats
+}
+
+fn derive_safe_lane_runtime_health_signal(
+    config: &LoongClawConfig,
+    metrics: SafeLaneExecutionMetrics,
+    final_status_failed: bool,
+    final_failure_code: Option<&str>,
+) -> SafeLaneRuntimeHealthSignal {
+    let rounds_started = metrics.rounds_started as f64;
+    let replan_rate = if rounds_started > 0.0 {
+        metrics.replans_triggered as f64 / rounds_started
+    } else {
+        0.0
+    };
+    let verify_failure_rate = if rounds_started > 0.0 {
+        metrics.verify_failures as f64 / rounds_started
+    } else {
+        0.0
+    };
+    let aggregate_truncation_ratio = metrics
+        .aggregate_tool_truncation_ratio_milli()
+        .map(|milli| (milli as f64) / 1000.0);
+    let truncation_warn_threshold = config
+        .conversation
+        .safe_lane_health_truncation_warn_threshold();
+    let truncation_critical_threshold = config
+        .conversation
+        .safe_lane_health_truncation_critical_threshold();
+    let verify_failure_warn_threshold = config
+        .conversation
+        .safe_lane_health_verify_failure_warn_threshold();
+    let replan_warn_threshold = config.conversation.safe_lane_health_replan_warn_threshold();
+
+    let mut flags = Vec::new();
+    let mut has_critical = false;
+
+    if let Some(ratio) = aggregate_truncation_ratio {
+        if ratio >= truncation_critical_threshold {
+            flags.push(format!("truncation_severe({ratio:.3})"));
+            has_critical = true;
+        } else if ratio >= truncation_warn_threshold {
+            flags.push(format!("truncation_pressure({ratio:.3})"));
+        }
+    }
+
+    if verify_failure_rate >= verify_failure_warn_threshold {
+        flags.push(format!("verify_failure_pressure({verify_failure_rate:.3})"));
+    }
+    if replan_rate >= replan_warn_threshold {
+        flags.push(format!("replan_pressure({replan_rate:.3})"));
+    }
+
+    let terminal_instability = final_status_failed
+        && final_failure_code
+            .map(|code| {
+                code.contains("verify_failed")
+                    || code.contains("backpressure")
+                    || code.contains("session_governor")
+            })
+            .unwrap_or(false);
+    if terminal_instability {
+        flags.push("terminal_instability".to_owned());
+        has_critical = true;
+    }
+
+    SafeLaneRuntimeHealthSignal {
+        severity: if has_critical {
+            "critical"
+        } else if flags.is_empty() {
+            "ok"
+        } else {
+            "warn"
+        },
+        flags,
     }
 }
 
@@ -1692,6 +1945,7 @@ struct SafeLanePlanNodeExecutor<'a> {
     kernel_ctx: Option<&'a KernelContext>,
     verify_output_non_empty: bool,
     tool_outputs: Mutex<Vec<String>>,
+    tool_result_payload_summary_limit_chars: usize,
 }
 
 impl<'a> SafeLanePlanNodeExecutor<'a> {
@@ -1700,17 +1954,15 @@ impl<'a> SafeLanePlanNodeExecutor<'a> {
         kernel_ctx: Option<&'a KernelContext>,
         verify_output_non_empty: bool,
         seed_tool_outputs: Vec<String>,
+        tool_result_payload_summary_limit_chars: usize,
     ) -> Self {
         Self {
             tool_intents,
             kernel_ctx,
             verify_output_non_empty,
             tool_outputs: Mutex::new(seed_tool_outputs),
+            tool_result_payload_summary_limit_chars,
         }
-    }
-
-    async fn joined_output(&self) -> String {
-        self.tool_outputs.lock().await.join("\n")
     }
 
     async fn tool_outputs_snapshot(&self) -> Vec<String> {
@@ -1730,7 +1982,12 @@ impl PlanNodeExecutor for SafeLanePlanNodeExecutor<'_> {
                         node.id
                     ))
                 })?;
-                let output = execute_single_tool_intent(intent, self.kernel_ctx).await?;
+                let output = execute_single_tool_intent(
+                    intent,
+                    self.kernel_ctx,
+                    self.tool_result_payload_summary_limit_chars,
+                )
+                .await?;
                 self.tool_outputs.lock().await.push(output);
                 Ok(())
             }
@@ -1769,6 +2026,7 @@ fn parse_tool_node_index(node_id: &str) -> Result<usize, PlanNodeError> {
 async fn execute_single_tool_intent(
     intent: &ToolIntent,
     kernel_ctx: Option<&KernelContext>,
+    payload_summary_limit_chars: usize,
 ) -> Result<String, PlanNodeError> {
     if !crate::tools::is_known_tool_name(&intent.tool_name) {
         return Err(PlanNodeError::policy_denied(format!(
@@ -1798,7 +2056,11 @@ async fn execute_single_tool_intent(
                 message: format!("{error}"),
             }
         })?;
-    Ok(format!("[{}] {}", outcome.status, outcome.payload))
+    Ok(super::turn_engine::format_tool_result_line_with_limit(
+        intent,
+        &outcome,
+        payload_summary_limit_chars,
+    ))
 }
 
 fn build_tool_followup_messages(
@@ -1821,7 +2083,7 @@ fn build_tool_followup_messages(
     }));
     messages.push(json!({
         "role": "user",
-        "content": format!("{TOOL_FOLLOWUP_PROMPT}\n\nOriginal request:\n{user_input}"),
+        "content": build_tool_followup_user_prompt(user_input, None, Some(tool_result_text)),
     }));
     messages
 }
@@ -1846,69 +2108,59 @@ fn build_tool_failure_followup_messages(
     }));
     messages.push(json!({
         "role": "user",
-        "content": format!("{TOOL_FOLLOWUP_PROMPT}\n\nOriginal request:\n{user_input}"),
+        "content": build_tool_followup_user_prompt(user_input, None, None),
     }));
     messages
-}
-
-fn user_requested_raw_tool_output(user_input: &str) -> bool {
-    let normalized = user_input.to_ascii_lowercase();
-    [
-        "raw",
-        "json",
-        "payload",
-        "verbatim",
-        "exact output",
-        "full output",
-        "tool output",
-        "[ok]",
-    ]
-    .iter()
-    .any(|signal| normalized.contains(signal))
-}
-
-fn compose_assistant_reply(
-    assistant_preface: &str,
-    had_tool_intents: bool,
-    turn_result: TurnResult,
-) -> String {
-    match turn_result {
-        TurnResult::FinalText(text) => {
-            if had_tool_intents {
-                join_non_empty_lines(&[assistant_preface, text.as_str()])
-            } else {
-                text
-            }
-        }
-        TurnResult::NeedsApproval(reason) => {
-            let inline = format!("[tool_approval_required] {}", reason.reason);
-            join_non_empty_lines(&[assistant_preface, inline.as_str()])
-        }
-        TurnResult::ToolDenied(failure) => {
-            join_non_empty_lines(&[assistant_preface, failure.reason.as_str()])
-        }
-        TurnResult::ToolError(failure) => {
-            join_non_empty_lines(&[assistant_preface, failure.reason.as_str()])
-        }
-        TurnResult::ProviderError(reason) => {
-            let inline = format_provider_error_reply(reason.reason.as_str());
-            join_non_empty_lines(&[assistant_preface, inline.as_str()])
-        }
-    }
-}
-
-fn join_non_empty_lines(parts: &[&str]) -> String {
-    parts
-        .iter()
-        .map(|part| part.trim())
-        .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_tool_followup_messages_include_truncation_hint_for_truncated_tool_results() {
+        let messages = build_tool_followup_messages(
+            &[serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })],
+            "preface",
+            r#"[ok] {"payload_truncated":true,"payload_summary":"..."}"#,
+            "summarize note.md",
+        );
+
+        let user_prompt = messages
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+        assert!(
+            user_prompt.contains(crate::conversation::turn_shared::TOOL_TRUNCATION_HINT_PROMPT)
+        );
+        assert!(user_prompt.contains("Original request:\nsummarize note.md"));
+    }
+
+    #[test]
+    fn build_tool_failure_followup_messages_do_not_include_truncation_hint() {
+        let messages = build_tool_failure_followup_messages(
+            &[serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })],
+            "preface",
+            "tool_timeout ...(truncated 200 chars)",
+            "summarize note.md",
+        );
+
+        let user_prompt = messages
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+        assert!(
+            !user_prompt.contains(crate::conversation::turn_shared::TOOL_TRUNCATION_HINT_PROMPT)
+        );
+    }
 
     #[test]
     fn safe_lane_route_retryable_failure_replans_with_remaining_budget() {
@@ -2120,6 +2372,110 @@ mod tests {
         assert!(
             !emitted,
             "with adaptive sampling disabled, round-based sampling should still drop this event"
+        );
+    }
+
+    #[test]
+    fn safe_lane_failure_pressure_counts_truncated_tool_output_stats() {
+        let payload = json!({
+            "tool_output_stats": {
+                "output_lines": 1,
+                "result_lines": 1,
+                "truncated_result_lines": 1,
+                "any_truncated": true,
+                "truncation_ratio_milli": 1000
+            }
+        });
+        assert_eq!(safe_lane_failure_pressure(&payload), 1);
+    }
+
+    #[test]
+    fn safe_lane_tool_output_stats_detect_truncated_result_lines() {
+        let outputs = vec![
+            "[ok] {\"payload_truncated\":true}".to_owned(),
+            "[ok] {\"payload_truncated\":false}\n[tool_result_truncated] removed_chars=2"
+                .to_owned(),
+            "plain diagnostic line".to_owned(),
+        ];
+
+        let stats = summarize_safe_lane_tool_output_stats(outputs.as_slice());
+        assert_eq!(stats.output_lines, 4);
+        assert_eq!(stats.result_lines, 3);
+        assert_eq!(stats.truncated_result_lines, 2);
+        assert_eq!(stats.truncation_ratio_milli(), 666);
+        let encoded = stats.as_json();
+        assert_eq!(encoded["any_truncated"], true);
+        assert_eq!(encoded["truncation_ratio_milli"], 666);
+    }
+
+    #[test]
+    fn safe_lane_tool_output_stats_handles_mixed_multiline_blocks() {
+        let outputs = vec![
+            "\n[ok] {\"payload_truncated\":false}\nnot a result line\n[ok] {\"payload_truncated\":true}\n"
+                .to_owned(),
+            "[result] completed\n\n[ok] {\"payload_truncated\":false}".to_owned(),
+        ];
+
+        let stats = summarize_safe_lane_tool_output_stats(outputs.as_slice());
+        assert_eq!(stats.output_lines, 5);
+        assert_eq!(stats.result_lines, 4);
+        assert_eq!(stats.truncated_result_lines, 1);
+        assert_eq!(stats.truncation_ratio_milli(), 250);
+        let encoded = stats.as_json();
+        assert_eq!(encoded["any_truncated"], true);
+        assert_eq!(encoded["truncation_ratio_milli"], 250);
+    }
+
+    #[test]
+    fn runtime_health_signal_marks_warn_on_truncation_pressure() {
+        let mut config = LoongClawConfig::default();
+        config
+            .conversation
+            .safe_lane_health_truncation_warn_threshold = 0.20;
+        config
+            .conversation
+            .safe_lane_health_truncation_critical_threshold = 0.50;
+        let metrics = SafeLaneExecutionMetrics {
+            rounds_started: 2,
+            tool_output_result_lines_total: 4,
+            tool_output_truncated_result_lines_total: 1,
+            ..SafeLaneExecutionMetrics::default()
+        };
+
+        let signal = derive_safe_lane_runtime_health_signal(&config, metrics, false, None);
+        assert_eq!(signal.severity, "warn");
+        assert!(
+            signal
+                .flags
+                .iter()
+                .any(|value| value.contains("truncation_pressure(0.250)"))
+        );
+    }
+
+    #[test]
+    fn runtime_health_signal_marks_critical_on_terminal_instability() {
+        let config = LoongClawConfig::default();
+        let metrics = SafeLaneExecutionMetrics {
+            rounds_started: 2,
+            verify_failures: 1,
+            replans_triggered: 1,
+            tool_output_result_lines_total: 2,
+            tool_output_truncated_result_lines_total: 1,
+            ..SafeLaneExecutionMetrics::default()
+        };
+
+        let signal = derive_safe_lane_runtime_health_signal(
+            &config,
+            metrics,
+            true,
+            Some("safe_lane_plan_verify_failed_session_governor"),
+        );
+        assert_eq!(signal.severity, "critical");
+        assert!(
+            signal
+                .flags
+                .iter()
+                .any(|value| value == "terminal_instability")
         );
     }
 

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -2,7 +2,9 @@ use std::collections::BTreeSet;
 use std::fmt;
 use std::ops::Deref;
 
-use loongclaw_contracts::{Capability, KernelError, ToolCoreRequest, ToolPlaneError};
+use loongclaw_contracts::{
+    Capability, KernelError, ToolCoreOutcome, ToolCoreRequest, ToolPlaneError,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::context::KernelContext;
@@ -41,6 +43,20 @@ pub struct ToolOutcome {
     pub human_reason: Option<String>,
     pub audit_event_id: Option<String>,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolResultEnvelope {
+    pub status: String,
+    pub tool: String,
+    pub tool_call_id: String,
+    pub payload_summary: String,
+    pub payload_chars: usize,
+    pub payload_truncated: bool,
+}
+
+const TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS: usize = 2048;
+const MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS: usize = 256;
+const MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS: usize = 64_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -185,17 +201,94 @@ pub(crate) fn classify_kernel_error(error: &KernelError) -> KernelFailureClass {
     }
 }
 
+#[allow(dead_code)]
+pub(crate) fn format_tool_result_line(intent: &ToolIntent, outcome: &ToolCoreOutcome) -> String {
+    format_tool_result_line_with_limit(intent, outcome, TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS)
+}
+
+pub(crate) fn format_tool_result_line_with_limit(
+    intent: &ToolIntent,
+    outcome: &ToolCoreOutcome,
+    payload_summary_limit_chars: usize,
+) -> String {
+    let envelope = build_tool_result_envelope(intent, outcome, payload_summary_limit_chars);
+    let encoded = serde_json::to_string(&envelope).unwrap_or_else(|_| {
+        format!(
+            "{{\"status\":\"{}\",\"tool\":\"{}\",\"tool_call_id\":\"{}\",\"payload_summary\":\"[tool_payload_unserializable]\",\"payload_chars\":0,\"payload_truncated\":false}}",
+            outcome.status,
+            crate::tools::canonical_tool_name(intent.tool_name.as_str()),
+            intent.tool_call_id
+        )
+    });
+    format!("[{}] {encoded}", outcome.status)
+}
+
+fn build_tool_result_envelope(
+    intent: &ToolIntent,
+    outcome: &ToolCoreOutcome,
+    payload_summary_limit_chars: usize,
+) -> ToolResultEnvelope {
+    let normalized_limit = payload_summary_limit_chars.clamp(
+        MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+        MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+    );
+    let payload_text = serde_json::to_string(&outcome.payload)
+        .unwrap_or_else(|_| "[tool_payload_unserializable]".to_owned());
+    let (payload_summary, payload_chars, payload_truncated) =
+        truncate_by_chars(payload_text.as_str(), normalized_limit);
+
+    ToolResultEnvelope {
+        status: outcome.status.clone(),
+        tool: crate::tools::canonical_tool_name(intent.tool_name.as_str()).to_owned(),
+        tool_call_id: intent.tool_call_id.clone(),
+        payload_summary,
+        payload_chars,
+        payload_truncated,
+    }
+}
+
+fn truncate_by_chars(value: &str, limit: usize) -> (String, usize, bool) {
+    let total_chars = value.chars().count();
+    if total_chars <= limit {
+        return (value.to_owned(), total_chars, false);
+    }
+    let mut truncated = String::new();
+    for ch in value.chars().take(limit) {
+        truncated.push(ch);
+    }
+    let omitted = total_chars.saturating_sub(limit);
+    truncated.push_str(&format!("...(truncated {omitted} chars)"));
+    (truncated, total_chars, true)
+}
+
 /// Single orchestration boundary for tool-call evaluation and execution.
 ///
 /// `evaluate_turn` performs synchronous validation (no execution).
 /// `execute_turn` performs policy-gated tool execution through the kernel.
 pub struct TurnEngine {
     max_tool_steps: usize,
+    tool_result_payload_summary_limit_chars: usize,
 }
 
 impl TurnEngine {
     pub fn new(max_tool_steps: usize) -> Self {
-        Self { max_tool_steps }
+        Self::with_tool_result_payload_summary_limit(
+            max_tool_steps,
+            TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+        )
+    }
+
+    pub fn with_tool_result_payload_summary_limit(
+        max_tool_steps: usize,
+        tool_result_payload_summary_limit_chars: usize,
+    ) -> Self {
+        Self {
+            max_tool_steps,
+            tool_result_payload_summary_limit_chars: tool_result_payload_summary_limit_chars.clamp(
+                MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+                MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+            ),
+        }
     }
 
     /// Evaluate a provider turn and produce a deterministic result.
@@ -275,7 +368,11 @@ impl TurnEngine {
                 .await
             {
                 Ok(outcome) => {
-                    outputs.push(format!("[{}] {}", outcome.status, outcome.payload));
+                    outputs.push(format_tool_result_line_with_limit(
+                        intent,
+                        &outcome,
+                        self.tool_result_payload_summary_limit_chars,
+                    ));
                 }
                 Err(e) => {
                     let reason = format!("{e}");

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -11,11 +11,14 @@ use super::ProviderErrorMode;
 use super::persistence::{format_provider_error_reply, persist_error_turns, persist_success_turns};
 use super::runtime::{ConversationRuntime, DefaultConversationRuntime};
 use super::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+use super::turn_shared::{
+    build_tool_followup_user_prompt, compose_assistant_reply, join_non_empty_lines,
+    user_requested_raw_tool_output,
+};
 
 #[derive(Default)]
 pub struct ConversationTurnLoop;
 
-const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
 const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
 
 impl ConversationTurnLoop {
@@ -87,9 +90,14 @@ impl ConversationTurnLoop {
             let current_tool_name_signature =
                 had_tool_intents.then(|| tool_name_signature(&turn.tool_intents));
 
-            let turn_result = TurnEngine::new(policy.max_tool_steps_per_round)
-                .execute_turn(&turn, kernel_ctx)
-                .await;
+            let turn_result = TurnEngine::with_tool_result_payload_summary_limit(
+                policy.max_tool_steps_per_round,
+                config
+                    .conversation
+                    .tool_result_payload_summary_limit_chars(),
+            )
+            .execute_turn(&turn, kernel_ctx)
+            .await;
             let loop_supervisor_verdict = if let (Some(signature), Some(name_signature)) = (
                 current_tool_signature.as_deref(),
                 current_tool_name_signature.as_deref(),
@@ -333,7 +341,11 @@ fn append_tool_followup_messages(
     }
     messages.push(json!({
         "role": "user",
-        "content": build_tool_followup_prompt(user_input, loop_warning_reason),
+        "content": build_tool_followup_user_prompt(
+            user_input,
+            loop_warning_reason,
+            Some(tool_result_text),
+        ),
     }));
 }
 
@@ -366,7 +378,7 @@ fn append_tool_failure_followup_messages(
     }
     messages.push(json!({
         "role": "user",
-        "content": build_tool_followup_prompt(user_input, loop_warning_reason),
+        "content": build_tool_followup_user_prompt(user_input, loop_warning_reason, None),
     }));
 }
 
@@ -425,31 +437,6 @@ async fn request_completion_with_raw_fallback<R: ConversationRuntime + ?Sized>(
         }
         Err(_) => raw_reply.to_owned(),
     }
-}
-
-fn user_requested_raw_tool_output(user_input: &str) -> bool {
-    let normalized = user_input.to_ascii_lowercase();
-    [
-        "raw",
-        "json",
-        "payload",
-        "verbatim",
-        "exact output",
-        "full output",
-        "tool output",
-        "[ok]",
-    ]
-    .iter()
-    .any(|signal| normalized.contains(signal))
-}
-
-fn build_tool_followup_prompt(user_input: &str, loop_warning_reason: Option<&str>) -> String {
-    if let Some(reason) = loop_warning_reason {
-        return format!(
-            "{TOOL_FOLLOWUP_PROMPT}\n\nLoop warning:\n{reason}\nAvoid repeating the same tool call with unchanged results. Try a different tool, adjust arguments, or provide a best-effort final answer if evidence is sufficient.\n\nOriginal request:\n{user_input}"
-        );
-    }
-    format!("{TOOL_FOLLOWUP_PROMPT}\n\nOriginal request:\n{user_input}")
 }
 
 fn truncate_followup_tool_payload(label: &str, text: &str, max_chars: usize) -> String {
@@ -752,37 +739,55 @@ impl ToolLoopSupervisor {
     }
 }
 
-fn compose_assistant_reply(
-    assistant_preface: &str,
-    had_tool_intents: bool,
-    turn_result: TurnResult,
-) -> String {
-    match turn_result {
-        TurnResult::FinalText(text) => {
-            if had_tool_intents {
-                join_non_empty_lines(&[assistant_preface, text.as_str()])
-            } else {
-                text
-            }
-        }
-        TurnResult::NeedsApproval(reason) => {
-            let inline = format!("[tool_approval_required] {reason}");
-            join_non_empty_lines(&[assistant_preface, inline.as_str()])
-        }
-        TurnResult::ToolDenied(reason) => join_non_empty_lines(&[assistant_preface, &reason]),
-        TurnResult::ToolError(reason) => join_non_empty_lines(&[assistant_preface, &reason]),
-        TurnResult::ProviderError(reason) => {
-            let inline = format_provider_error_reply(&reason);
-            join_non_empty_lines(&[assistant_preface, inline.as_str()])
-        }
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-fn join_non_empty_lines(parts: &[&str]) -> String {
-    parts
-        .iter()
-        .map(|part| part.trim())
-        .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n")
+    #[test]
+    fn append_tool_followup_messages_adds_truncation_hint_to_user_prompt() {
+        let mut messages = Vec::new();
+        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
+
+        append_tool_followup_messages(
+            &mut messages,
+            "preface",
+            r#"[ok] {"payload_truncated":true,"payload_summary":"..."}"#,
+            "summarize note.md",
+            &mut budget,
+            None,
+        );
+
+        let user_prompt = messages
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+        assert!(
+            user_prompt.contains(crate::conversation::turn_shared::TOOL_TRUNCATION_HINT_PROMPT)
+        );
+    }
+
+    #[test]
+    fn append_tool_failure_followup_messages_omits_truncation_hint_in_user_prompt() {
+        let mut messages = Vec::new();
+        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
+
+        append_tool_failure_followup_messages(
+            &mut messages,
+            "preface",
+            "tool_timeout ...(truncated 200 chars)",
+            "summarize note.md",
+            &mut budget,
+            None,
+        );
+
+        let user_prompt = messages
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+        assert!(
+            !user_prompt.contains(crate::conversation::turn_shared::TOOL_TRUNCATION_HINT_PROMPT)
+        );
+    }
 }

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -1,0 +1,183 @@
+use super::persistence::format_provider_error_reply;
+use super::turn_engine::TurnResult;
+use serde_json::Value;
+
+pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
+pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
+
+pub fn user_requested_raw_tool_output(user_input: &str) -> bool {
+    let normalized = user_input.to_ascii_lowercase();
+    [
+        "raw",
+        "json",
+        "payload",
+        "verbatim",
+        "exact output",
+        "full output",
+        "tool output",
+        "[ok]",
+    ]
+    .iter()
+    .any(|signal| normalized.contains(signal))
+}
+
+pub fn compose_assistant_reply(
+    assistant_preface: &str,
+    had_tool_intents: bool,
+    turn_result: TurnResult,
+) -> String {
+    match turn_result {
+        TurnResult::FinalText(text) => {
+            if had_tool_intents {
+                join_non_empty_lines(&[assistant_preface, text.as_str()])
+            } else {
+                text
+            }
+        }
+        TurnResult::NeedsApproval(failure) => {
+            let inline = format!("[tool_approval_required] {}", failure.reason);
+            join_non_empty_lines(&[assistant_preface, inline.as_str()])
+        }
+        TurnResult::ToolDenied(failure) => {
+            join_non_empty_lines(&[assistant_preface, failure.reason.as_str()])
+        }
+        TurnResult::ToolError(failure) => {
+            join_non_empty_lines(&[assistant_preface, failure.reason.as_str()])
+        }
+        TurnResult::ProviderError(failure) => {
+            let inline = format_provider_error_reply(failure.reason.as_str());
+            join_non_empty_lines(&[assistant_preface, inline.as_str()])
+        }
+    }
+}
+
+pub fn tool_result_contains_truncation_signal(tool_result_text: &str) -> bool {
+    let normalized = tool_result_text.to_ascii_lowercase();
+    normalized.contains("...(truncated ")
+        || normalized.contains("... (truncated ")
+        || normalized.contains("[tool_result_truncated]")
+        || tool_result_text
+            .lines()
+            .any(line_contains_structured_truncation_signal)
+}
+
+fn line_contains_structured_truncation_signal(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let candidate = if trimmed.starts_with('[') {
+        trimmed
+            .split_once(' ')
+            .map(|(_, payload)| payload.trim())
+            .unwrap_or("")
+    } else {
+        trimmed
+    };
+    if !(candidate.starts_with('{') || candidate.starts_with('[')) {
+        return false;
+    }
+    let envelope = match serde_json::from_str::<Value>(candidate) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    envelope
+        .get("payload_truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+pub fn build_tool_followup_user_prompt(
+    user_input: &str,
+    loop_warning_reason: Option<&str>,
+    tool_result_text: Option<&str>,
+) -> String {
+    let mut sections = vec![TOOL_FOLLOWUP_PROMPT.to_owned()];
+    if let Some(reason) = loop_warning_reason {
+        sections.push(format!(
+            "Loop warning:\n{reason}\nAvoid repeating the same tool call with unchanged results. Try a different tool, adjust arguments, or provide a best-effort final answer if evidence is sufficient."
+        ));
+    }
+    if tool_result_text
+        .map(tool_result_contains_truncation_signal)
+        .unwrap_or(false)
+    {
+        sections.push(TOOL_TRUNCATION_HINT_PROMPT.to_owned());
+    }
+    sections.push(format!("Original request:\n{user_input}"));
+    sections.join("\n\n")
+}
+
+pub fn join_non_empty_lines(parts: &[&str]) -> String {
+    parts
+        .iter()
+        .map(|part| part.trim())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conversation::turn_engine::{TurnFailure, TurnResult};
+    use serde_json::json;
+
+    #[test]
+    fn raw_tool_output_detection_keeps_known_signals() {
+        assert!(user_requested_raw_tool_output("show raw tool output"));
+        assert!(user_requested_raw_tool_output("give exact output as JSON"));
+        assert!(!user_requested_raw_tool_output(
+            "summarize the result briefly"
+        ));
+    }
+
+    #[test]
+    fn compose_assistant_reply_keeps_tool_error_inline_reason() {
+        let reply = compose_assistant_reply(
+            "preface",
+            true,
+            TurnResult::ToolError(TurnFailure::retryable("tool_error", "temporary failure")),
+        );
+        assert_eq!(reply, "preface\ntemporary failure");
+    }
+
+    #[test]
+    fn truncation_signal_detection_matches_structured_tool_result() {
+        assert!(tool_result_contains_truncation_signal(
+            r#"[ok] {"payload_truncated":true}"#
+        ));
+        assert!(tool_result_contains_truncation_signal(
+            "payload ... (truncated 200 chars)"
+        ));
+        assert!(!tool_result_contains_truncation_signal(
+            r#"[ok] {"payload_truncated":false}"#
+        ));
+    }
+
+    #[test]
+    fn truncation_signal_detection_ignores_payload_summary_lookalikes() {
+        let deceptive_line = format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "payload_summary": r#"{"payload_truncated":true}"#,
+                "payload_truncated": false
+            })
+        );
+        assert!(!tool_result_contains_truncation_signal(
+            deceptive_line.as_str()
+        ));
+    }
+
+    #[test]
+    fn followup_prompt_includes_truncation_hint_when_needed() {
+        let prompt = build_tool_followup_user_prompt(
+            "summarize this result",
+            None,
+            Some(r#"[ok] {"payload_truncated":true}"#),
+        );
+        assert!(prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
+        assert!(prompt.contains("Original request:\nsummarize this result"));
+    }
+}


### PR DESCRIPTION
## Summary
- harden safe-lane runtime observability and health classification around tool-output truncation pressure
- make safe-lane health thresholds configurable with defaults, clamp rules, template rendering, and TOML override coverage
- emit machine-readable `health_signal` in safe-lane runtime events and aggregate these snapshots in analytics
- enrich `/safe_lane_summary` with aggregate truncation metrics, health payload lines, and health-event rollups
- add regression coverage for mixed multi-line tool outputs and truncation/failure correlation tracking

## Issue
- Refs #28

## Validation
- cargo fmt --all
- cargo test -p loongclaw-app --all-features
- cargo test --workspace --all-features
