### PR TITLE
Remove the legacy setup CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ LoongClaw is a layered Agentic OS kernel focused on stable kernel contracts, str
 <summary>Linux / macOS</summary>
 
 ```bash
-./scripts/install.sh --setup
+./scripts/install.sh --onboard
 ```
 </details>
 
@@ -81,7 +81,7 @@ LoongClaw is a layered Agentic OS kernel focused on stable kernel contracts, str
 <summary>Windows (PowerShell)</summary>
 
 ```powershell
-pwsh ./scripts/install.ps1 -Setup
+pwsh ./scripts/install.ps1 -Onboard
 ```
 </details>
 
@@ -95,10 +95,10 @@ cargo install --path crates/daemon
 
 ### First Chat in Under 5 Minutes
 
-1. Generate config and bootstrap local state:
+1. Run guided onboarding:
 
    ```bash
-   loongclaw setup
+   loongclaw onboard
    ```
 
 2. Set your provider API key:
@@ -239,7 +239,6 @@ Agent-facing tools:
 - Tool discovery across providers and scanned plugin descriptors
 
 **MVP Product Layer**
-- `setup` -- generate TOML config and bootstrap SQLite memory
 - `onboard` -- guided first-run with preflight diagnostics
 - `doctor` -- diagnostics with optional safe fixes (`--fix`) and machine-readable output (`--json`)
 - `chat` -- interactive CLI with sliding-window conversation memory
@@ -337,7 +336,7 @@ cargo build -p loongclaw-daemon --no-default-features --features "channel-cli,pr
 
 ## Configuration
 
-`loongclaw setup` defaults to referencing provider credentials through `provider.api_key`, so secrets stay outside the config file:
+`loongclaw onboard` defaults to referencing provider credentials through `provider.api_key`, so secrets stay outside the config file:
 
 ```toml
 [provider]

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -72,7 +72,7 @@ LoongClaw 是一个基于Rust构建的 Agentic OS 内核，专注于稳定且轻
 <summary>Linux / macOS</summary>
 
 ```bash
-./scripts/install.sh --setup
+./scripts/install.sh --onboard
 ```
 </details>
 
@@ -80,7 +80,7 @@ LoongClaw 是一个基于Rust构建的 Agentic OS 内核，专注于稳定且轻
 <summary>Windows (PowerShell)</summary>
 
 ```powershell
-pwsh ./scripts/install.ps1 -Setup
+pwsh ./scripts/install.ps1 -Onboard
 ```
 </details>
 
@@ -94,10 +94,10 @@ cargo install --path crates/daemon
 
 ### 5 分钟内开始首次对话
 
-1. 生成配置并引导本地状态：
+1. 运行引导式首次配置：
 
    ```bash
-   loongclaw setup
+   loongclaw onboard
    ```
 
 2. 设置 provider API 密钥：
@@ -205,7 +205,6 @@ blocked_domains = ["*.evil.example"]
 - 自动发现 provider 和已扫描插件中的可用工具
 
 **MVP 产品层**
-- `setup` -- 生成 TOML 配置并引导 SQLite 内存
 - `onboard` -- 引导式首次运行，带预检诊断
 - `doctor` -- 诊断工具，可选安全修复 (`--fix`) 和机器可读输出 (`--json`)
 - `chat` -- 交互式 CLI，滑动窗口对话记忆
@@ -302,7 +301,7 @@ cargo build -p loongclaw-daemon --no-default-features --features "channel-cli,pr
 
 ## 配置
 
-`loongclaw setup` 默认通过 `provider.api_key` 引用 provider 凭据，这样密钥不会直接落在配置文件里：
+`loongclaw onboard` 默认通过 `provider.api_key` 引用 provider 凭据，这样密钥不会直接落在配置文件里：
 
 ```toml
 [provider]

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -109,7 +109,7 @@ pub fn load(path: Option<&str>) -> CliResult<(PathBuf, LoongClawConfig)> {
     let config_path = path.map(expand_path).unwrap_or_else(default_config_path);
     let raw = fs::read_to_string(&config_path).map_err(|error| {
         format!(
-            "failed to read config {}: {error}. run `loongclaw setup` first",
+            "failed to read config {}: {error}. run `loongclaw onboard` first",
             config_path.display()
         )
     })?;
@@ -137,7 +137,7 @@ pub fn validate_file_with_locale(
     let config_path = path.map(expand_path).unwrap_or_else(default_config_path);
     let raw = fs::read_to_string(&config_path).map_err(|error| {
         format!(
-            "failed to read config {}: {error}. run `loongclaw setup` first",
+            "failed to read config {}: {error}. run `loongclaw onboard` first",
             config_path.display()
         )
     })?;
@@ -502,12 +502,12 @@ api_key_env = "$OPENAI_API_KEY"
     }
 
     #[test]
-    fn load_missing_config_guides_user_to_loongclaw_setup() {
+    fn load_missing_config_guides_user_to_loongclaw_onboard() {
         let missing = unique_config_path("loongclaw-config-missing");
         let path_string = missing.display().to_string();
 
         let error = load(Some(&path_string)).expect_err("missing config should fail");
-        assert!(error.contains("run `loongclaw setup` first"));
+        assert!(error.contains("run `loongclaw onboard` first"));
     }
 
     #[test]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -138,13 +138,6 @@ enum Commands {
         #[arg(long, default_value_t = 1.5)]
         min_speedup_ratio: f64,
     },
-    /// Generate a beginner-friendly TOML config and bootstrap local state
-    Setup {
-        #[arg(long)]
-        output: Option<String>,
-        #[arg(long, default_value_t = false)]
-        force: bool,
-    },
     /// Validate config semantics and report structured diagnostics
     ValidateConfig {
         #[arg(long)]
@@ -349,7 +342,6 @@ async fn main() {
             enforce_gate,
             min_speedup_ratio,
         ),
-        Commands::Setup { output, force } => run_setup_cli(output.as_deref(), force),
         Commands::ValidateConfig {
             config,
             json,
@@ -651,35 +643,6 @@ async fn run_spec_cli(spec_path: &str, print_audit: bool) -> CliResult<()> {
     let pretty = serde_json::to_string_pretty(&report)
         .map_err(|error| format!("serialize spec run report failed: {error}"))?;
     println!("{pretty}");
-    Ok(())
-}
-
-fn run_setup_cli(output: Option<&str>, force: bool) -> CliResult<()> {
-    let path = mvp::config::write_template(output, force)?;
-    #[cfg(feature = "memory-sqlite")]
-    {
-        let path_str = path
-            .to_str()
-            .ok_or_else(|| format!("config path is not valid UTF-8: {}", path.display()))?;
-        let (_, parsed) = mvp::config::load(Some(path_str))?;
-        let mem_config =
-            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&parsed.memory);
-        let memory_db = mvp::memory::ensure_memory_db_ready(
-            Some(parsed.memory.resolved_sqlite_path()),
-            &mem_config,
-        )
-        .map_err(|error| format!("failed to bootstrap sqlite memory: {error}"))?;
-        println!(
-            "setup complete\n- config: {}\n- sqlite memory: {}",
-            path.display(),
-            memory_db.display()
-        );
-    }
-    #[cfg(not(feature = "memory-sqlite"))]
-    {
-        println!("setup complete\n- config: {}", path.display());
-    }
-    println!("next step: loongclaw chat --config {}", path.display());
     Ok(())
 }
 
@@ -1091,6 +1054,17 @@ fn write_json_file<T: Serialize>(path: &str, value: &T) -> CliResult<()> {
 #[cfg(test)]
 mod cli_tests {
     use super::*;
+
+    #[test]
+    fn setup_subcommand_is_removed() {
+        let error = Cli::try_parse_from(["loongclaw", "setup"])
+            .expect_err("`setup` should no longer parse as a valid subcommand");
+        assert!(
+            error
+                .to_string()
+                .contains("unrecognized subcommand 'setup'")
+        );
+    }
 
     #[test]
     fn safe_lane_summary_cli_rejects_zero_limit() {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -267,7 +267,7 @@ Focus: ship a low-friction daily-usable daemon entry for non-developers.
 
 Delivered in current baseline:
 
-- `setup` command to generate TOML configuration and bootstrap local state
+- `onboard` command as the primary first-run configuration and diagnostics flow
 - `chat` command as baseline CLI channel
 - first-party Telegram polling channel adapter
 - first-party Feishu webhook channel adapter
@@ -291,7 +291,7 @@ Remaining deliverables:
 - OpenAI-compatible protocol adapter hardening and Volcengine custom adapter profile
 - beginner installation pipeline:
   - prebuilt binaries
-  - one-command setup on macOS/Linux/Windows
+  - one-command onboarding on macOS/Linux/Windows
   - guided onboarding flow and diagnostics
 
 Acceptance criteria:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,17 +1,17 @@
 param(
     [string]$Prefix = "$HOME/.local/bin",
-    [switch]$Setup
+    [switch]$Onboard
 )
 
 $ErrorActionPreference = "Stop"
 
 function Write-Usage {
     @"
-Usage: pwsh ./scripts/install.ps1 [-Prefix <dir>] [-Setup]
+Usage: pwsh ./scripts/install.ps1 [-Prefix <dir>] [-Onboard]
 
 Options:
   -Prefix <dir>   Install directory for loongclaw (default: $HOME/.local/bin)
-  -Setup          Run 'loongclaw setup --force' after install
+  -Onboard        Run 'loongclaw onboard --force' after install
 "@
 }
 
@@ -45,9 +45,9 @@ Copy-Item -Force $sourceBinary $destBinary
 
 Write-Host "==> Installed loongclaw to $destBinary"
 
-if ($Setup) {
-    Write-Host "==> Running initial setup"
-    & $destBinary setup --force | Out-Host
+if ($Onboard) {
+    Write-Host "==> Running guided onboarding"
+    & $destBinary onboard --force | Out-Host
 }
 
 $pathItems = ($env:PATH -split [IO.Path]::PathSeparator)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,17 +3,17 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: ./scripts/install.sh [--prefix <dir>] [--setup]
+Usage: ./scripts/install.sh [--prefix <dir>] [--onboard]
 
 Options:
   --prefix <dir>   Install directory for loongclaw (default: $HOME/.local/bin)
-  --setup          Run `loongclaw setup --force` after install
+  --onboard        Run `loongclaw onboard --force` after install
   -h, --help       Show this help
 USAGE
 }
 
 prefix="${HOME}/.local/bin"
-run_setup=0
+run_onboard=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -25,8 +25,8 @@ while [[ $# -gt 0 ]]; do
       prefix="$2"
       shift 2
       ;;
-    --setup)
-      run_setup=1
+    --onboard)
+      run_onboard=1
       shift
       ;;
     -h|--help)
@@ -60,9 +60,9 @@ install -m 755 "${repo_root}/target/release/loongclaw" "${prefix}/loongclaw"
 
 printf '==> Installed loongclaw to %s\n' "${prefix}/loongclaw"
 
-if [[ "${run_setup}" -eq 1 ]]; then
-  printf '==> Running initial setup\n'
-  "${prefix}/loongclaw" setup --force
+if [[ "${run_onboard}" -eq 1 ]]; then
+  printf '==> Running guided onboarding\n'
+  "${prefix}/loongclaw" onboard --force
 fi
 
 case ":${PATH}:" in


### PR DESCRIPTION
Closes #30

## Summary
- remove the legacy `setup` CLI subcommand and its execution path
- point runtime guidance, install helpers, and README first-run flows to `loongclaw onboard`
- add regression coverage that rejects `loongclaw setup`

## Validation
- `cargo fmt --all --manifest-path Cargo.toml -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p loongclaw-app --manifest-path Cargo.toml`
- `cargo test -p loongclaw-daemon --manifest-path Cargo.toml`
