### PR TITLE
Polish remaining onboarding language after setup removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ tuning without forcing everything into the system prompt.
 ## Migration And Import
 
 LoongClaw can discover legacy claw homes during onboarding and offer an import
-before the rest of first-run setup continues.
+before the rest of onboarding continues.
 
 - Recommended path: import a single highest-confidence source.
 - Advanced path: plan multiple sources, merge only the profile lane, and keep prompt/system identity single-source.

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -5,6 +5,8 @@ use std::{collections::BTreeSet, fs, path::Path, sync::Arc};
 
 #[cfg(test)]
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+#[cfg(test)]
+use clap::CommandFactory;
 use clap::{Parser, Subcommand, ValueEnum};
 #[cfg(test)]
 use kernel::{AuditEventKind, ExecutionRoute, HarnessKind, PluginBridgeKind, VerticalPackManifest};
@@ -151,7 +153,7 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         fail_on_diagnostics: bool,
     },
-    /// Guided onboarding for fast first-chat setup with preflight diagnostics
+    /// Guided onboarding for a fast first chat with preflight diagnostics
     Onboard {
         #[arg(long)]
         output: Option<String>,
@@ -199,7 +201,7 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         force: bool,
     },
-    /// Run setup diagnostics and optionally apply safe config/path fixes
+    /// Run configuration diagnostics and optionally apply safe config/path fixes
     Doctor {
         #[arg(long)]
         config: Option<String>,
@@ -1054,6 +1056,19 @@ fn write_json_file<T: Serialize>(path: &str, value: &T) -> CliResult<()> {
 #[cfg(test)]
 mod cli_tests {
     use super::*;
+
+    #[test]
+    fn root_help_uses_onboarding_language() {
+        let mut command = Cli::command();
+        let mut rendered = Vec::new();
+        command
+            .write_long_help(&mut rendered)
+            .expect("render root help");
+        let help = String::from_utf8(rendered).expect("help is valid utf-8");
+
+        assert!(help.contains("onboarding"));
+        assert!(!help.contains("setup"));
+    }
 
     #[test]
     fn setup_subcommand_is_removed() {

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -171,7 +171,7 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
         }
         if has_failures {
             return Err(
-                "onboard preflight failed. rerun with --skip-model-probe if your provider blocks model listing during setup"
+                "onboard preflight failed. rerun with --skip-model-probe if your provider blocks model listing during onboarding"
                     .to_owned(),
             );
         }

--- a/docs/plans/2026-03-12-setup-removal-user-facing-polish-design.md
+++ b/docs/plans/2026-03-12-setup-removal-user-facing-polish-design.md
@@ -1,0 +1,43 @@
+# User-Facing Setup Removal Polish Design
+
+## Goal
+
+Finish the `setup` removal from the current operator experience without rewriting historical
+design records. After this change, current CLI help, onboarding feedback, install helpers, and
+active README guidance should consistently describe `onboard` as the first-run path.
+
+## Scope
+
+In scope:
+
+- current CLI help text emitted by `loongclaw --help`
+- onboarding/preflight error strings shown to operators
+- active README content and install helper wording
+- regression tests that lock the user-facing wording boundary
+
+Out of scope:
+
+- historical records under `docs/plans/`
+- internal code comments that are not emitted to operators
+- broad terminology rewrites unrelated to the removed subcommand
+
+## Approach
+
+1. Add a regression test around CLI help output so `setup` does not reappear in current help text.
+2. Update user-facing strings that still use `setup` as a first-run noun where it can imply the
+   removed command still exists.
+3. Keep changes narrowly scoped to active user surfaces so the branch remains easy to review and
+   safe to land on `alpha-test`.
+
+## User-Facing Decisions
+
+- `onboard` remains the only first-run entrypoint.
+- Generic wording like "setup" is replaced where it can create command confusion.
+- `doctor` keeps its purpose but is described as diagnostics/config repair, not "setup diagnostics".
+- Historical planning docs are intentionally left untouched to preserve design history.
+
+## Validation
+
+- unit/regression tests for CLI help text
+- targeted daemon onboarding tests
+- format, clippy, and the relevant package tests before completion

--- a/docs/plans/2026-03-12-setup-removal-user-facing-polish.md
+++ b/docs/plans/2026-03-12-setup-removal-user-facing-polish.md
@@ -1,0 +1,95 @@
+# User-Facing Setup Removal Polish Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove the last user-visible `setup` wording that can imply the deleted CLI subcommand still exists.
+
+**Architecture:** Keep the already-merged command removal intact and tighten only the user-facing surfaces that remain live today. Cover the CLI help boundary with a regression test, then update active onboarding/help/docs strings to consistently describe onboarding and diagnostics.
+
+**Tech Stack:** Rust, Clap, cargo test, Markdown docs
+
+---
+
+### Task 1: Lock CLI help wording
+
+**Files:**
+- Modify: `crates/daemon/src/main.rs`
+
+**Step 1: Write the failing test**
+
+Add a CLI regression test that renders `Cli::command()` help output and asserts:
+- help contains `onboarding`
+- help does not contain `setup`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon --manifest-path Cargo.toml cli_tests::root_help_uses_onboarding_language`
+Expected: FAIL because current help text still contains `setup`.
+
+**Step 3: Write minimal implementation**
+
+Update the `Onboard` and `Doctor` subcommand descriptions so current help no longer uses `setup`
+wording that points users toward the removed command.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon --manifest-path Cargo.toml cli_tests::root_help_uses_onboarding_language`
+Expected: PASS.
+
+### Task 2: Clean onboarding and active docs
+
+**Files:**
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+
+**Step 1: Write the failing test**
+
+Add a focused assertion in onboarding tests for the non-interactive model-probe failure message, or
+extract the string behind a helper and test that helper directly.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon --manifest-path Cargo.toml onboard`
+Expected: FAIL because the current retry hint still says `during setup`.
+
+**Step 3: Write minimal implementation**
+
+Replace user-facing wording with `onboarding` / `first-run` phrasing in the onboarding retry hint
+and in active README text where the legacy noun still appears.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon --manifest-path Cargo.toml onboard`
+Expected: PASS.
+
+### Task 3: Verify and finalize
+
+**Files:**
+- Modify: none expected
+
+**Step 1: Run format check**
+
+Run: `cargo fmt --all --manifest-path Cargo.toml -- --check`
+Expected: PASS.
+
+**Step 2: Run lint**
+
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+Expected: PASS.
+
+**Step 3: Run relevant package tests**
+
+Run:
+- `cargo test -p loongclaw-daemon --manifest-path Cargo.toml`
+- `cargo test -p loongclaw-app --manifest-path Cargo.toml`
+
+Expected: PASS.
+
+**Step 4: Inspect diff and commit**
+
+Run:
+- `git status --short`
+- `git diff --stat`
+
+Then create a focused commit for the user-facing polish.


### PR DESCRIPTION
Closes #32

## Summary
- remove the last current CLI help text that still used `setup` wording after the subcommand was deleted
- update onboarding retry guidance and active README copy to stay aligned with `loongclaw onboard`
- add design/implementation notes plus a regression test that keeps root help output on onboarding-first language

## Validation
- `cargo fmt --all --manifest-path Cargo.toml -- --check`
- `cargo test -p loongclaw-daemon --manifest-path Cargo.toml cli_tests::root_help_uses_onboarding_language`
- `cargo test -p loongclaw-daemon --manifest-path Cargo.toml`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
