### PR TITLE
feat: close the external skills managed runtime loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,10 +671,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1183,6 +1210,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1259,7 @@ dependencies = [
  "axum",
  "base64",
  "cbc",
+ "flate2",
  "loongclaw-contracts",
  "loongclaw-kernel",
  "reqwest",
@@ -1227,6 +1267,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tokio",
  "toml",
 ]
@@ -1361,6 +1402,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1488,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "postcard"
@@ -1656,6 +1713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1962,6 +2028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2127,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3051,6 +3134,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 futures-util = "0.3"
 sha2 = "0.10"
+flate2 = "1"
+tar = "0.4"
 wasmparser = "0.245"
 base64 = "0.22"
 ed25519-dalek = "2.2"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ cargo install --path crates/daemon
 ```
 </details>
 
+`--onboard` runs `loongclaw onboard` without `--force`, so rerunning this quickstart will stop before overwriting an existing config.
+
 ### First Chat in Under 5 Minutes
 
 1. Run guided onboarding:

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ enabled = true
 require_download_approval = true
 allowed_domains = ["skills.sh", "clawhub.io"]
 blocked_domains = ["*.evil.example"]
+auto_expose_installed = true
 ```
 
 Agent-facing tools:
@@ -219,6 +220,25 @@ Agent-facing tools:
   - Requires `approval_granted=true` when approval guard is enabled.
   - Saves artifact under `<tools.file_root>/external-skills-downloads/`.
   - Enforces allowlist/blocklist before network download.
+- `external_skills_install`
+  - Requires local `path`.
+  - Accepts a directory containing `SKILL.md` or a local `.tgz` / `.tar.gz` archive.
+  - Installs the skill under `<tools.file_root>/external-skills-installed/` by default.
+- `external_skills_list`
+  - Lists managed installed skills that are available for invocation.
+- `external_skills_inspect`
+  - Returns metadata and a short preview for an installed skill.
+- `external_skills_invoke`
+  - Loads an installed skill's `SKILL.md` instructions into the conversation loop.
+- `external_skills_remove`
+  - Removes a managed installed skill and updates the local index.
+
+Recommended runtime flow:
+
+1. Download with `external_skills.fetch`
+2. Install with `external_skills.install`
+3. Discover with `external_skills.list`
+4. Load instructions with `external_skills.invoke`
 
 ## Key Features
 
@@ -242,7 +262,7 @@ Agent-facing tools:
 - `onboard` -- guided first-run with preflight diagnostics
 - `doctor` -- diagnostics with optional safe fixes (`--fix`) and machine-readable output (`--json`)
 - `chat` -- interactive CLI with sliding-window conversation memory
-- Core tools: `shell.exec`, `file.read`, `file.write`, `external_skills.policy`, `external_skills.fetch`
+- Core tools: `shell.exec`, `file.read`, `file.write`, `external_skills.policy`, `external_skills.fetch`, `external_skills.install`, `external_skills.list`, `external_skills.inspect`, `external_skills.invoke`, `external_skills.remove`
 - Providers: OpenAI-compatible, Volcengine custom endpoint
 - Channels: CLI, Telegram polling, Feishu encrypted webhook
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,6 +92,8 @@ cargo install --path crates/daemon
 ```
 </details>
 
+`--onboard` 现在调用的是不带 `--force` 的 `loongclaw onboard`，因此重复执行这条 quickstart 时会先停止，而不会直接覆盖已有配置。
+
 ### 5 分钟内开始首次对话
 
 1. 运行引导式首次配置：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -172,6 +172,7 @@ enabled = true
 require_download_approval = true
 allowed_domains = ["skills.sh", "clawhub.io"]
 blocked_domains = ["*.evil.example"]
+auto_expose_installed = true
 ```
 
 面向 agent 的工具：
@@ -185,6 +186,25 @@ blocked_domains = ["*.evil.example"]
   - 当授权门禁开启时必须传 `approval_granted=true`。
   - 下载文件落在 `<tools.file_root>/external-skills-downloads/`。
   - 下载前强制执行白/黑名单校验。
+- `external_skills_install`
+  - 必填本地 `path`。
+  - 支持包含 `SKILL.md` 的目录，或本地 `.tgz` / `.tar.gz` 压缩包。
+  - 默认安装到 `<tools.file_root>/external-skills-installed/`。
+- `external_skills_list`
+  - 列出当前可调用的受管 skills。
+- `external_skills_inspect`
+  - 返回已安装 skill 的元数据与预览。
+- `external_skills_invoke`
+  - 把已安装 skill 的 `SKILL.md` 指令加载进对话流程。
+- `external_skills_remove`
+  - 删除受管 skill 并更新本地索引。
+
+推荐运行时流程：
+
+1. 先用 `external_skills.fetch` 下载
+2. 再用 `external_skills.install` 安装
+3. 用 `external_skills.list` 查看
+4. 用 `external_skills.invoke` 加载指令
 
 ## 核心功能
 
@@ -208,7 +228,7 @@ blocked_domains = ["*.evil.example"]
 - `onboard` -- 引导式首次运行，带预检诊断
 - `doctor` -- 诊断工具，可选安全修复 (`--fix`) 和机器可读输出 (`--json`)
 - `chat` -- 交互式 CLI，滑动窗口对话记忆
-- 核心工具：`shell.exec`、`file.read`、`file.write`、`external_skills.policy`、`external_skills.fetch`
+- 核心工具：`shell.exec`、`file.read`、`file.write`、`external_skills.policy`、`external_skills.fetch`、`external_skills.install`、`external_skills.list`、`external_skills.inspect`、`external_skills.invoke`、`external_skills.remove`
 - Provider：OpenAI 兼容、火山引擎自定义端点
 - 通道：CLI、Telegram 轮询、飞书加密 webhook
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -26,6 +26,8 @@ serde_json.workspace = true
 toml = { workspace = true, optional = true }
 reqwest.workspace = true
 sha2.workspace = true
+flate2.workspace = true
+tar.workspace = true
 tokio.workspace = true
 base64.workspace = true
 rusqlite = { workspace = true, optional = true }

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -761,6 +761,8 @@ fn apply_runtime_env(config: &LoongClawConfig) {
                 .normalized_blocked_domains()
                 .into_iter()
                 .collect(),
+            install_root: config.external_skills.resolved_install_root(),
+            auto_expose_installed: config.external_skills.auto_expose_installed,
         },
     };
     let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -603,6 +603,8 @@ fn export_runtime_env(config: &LoongClawConfig) {
                 .normalized_blocked_domains()
                 .into_iter()
                 .collect(),
+            install_root: config.external_skills.resolved_install_root(),
+            auto_expose_installed: config.external_skills.auto_expose_installed,
         },
     };
     let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -668,12 +668,15 @@ api_key_env = "{secret}"
         assert!(raw.contains("[external_skills]"));
         assert!(raw.contains("enabled = false"));
         assert!(raw.contains("require_download_approval = true"));
+        assert!(raw.contains("auto_expose_installed = true"));
 
         let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
         assert!(!loaded.external_skills.enabled);
         assert!(loaded.external_skills.require_download_approval);
         assert!(loaded.external_skills.allowed_domains.is_empty());
         assert!(loaded.external_skills.blocked_domains.is_empty());
+        assert!(loaded.external_skills.install_root.is_none());
+        assert!(loaded.external_skills.auto_expose_installed);
 
         let _ = fs::remove_file(path);
     }

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -28,6 +28,10 @@ pub struct ExternalSkillsConfig {
     pub allowed_domains: Vec<String>,
     #[serde(default)]
     pub blocked_domains: Vec<String>,
+    #[serde(default)]
+    pub install_root: Option<String>,
+    #[serde(default = "default_auto_expose_installed")]
+    pub auto_expose_installed: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -128,6 +132,8 @@ impl Default for ExternalSkillsConfig {
             require_download_approval: default_require_download_approval(),
             allowed_domains: Vec::new(),
             blocked_domains: Vec::new(),
+            install_root: None,
+            auto_expose_installed: default_auto_expose_installed(),
         }
     }
 }
@@ -148,6 +154,10 @@ impl ExternalSkillsConfig {
 
     pub fn normalized_blocked_domains(&self) -> Vec<String> {
         normalize_domain_entries(&self.blocked_domains)
+    }
+
+    pub fn resolved_install_root(&self) -> Option<PathBuf> {
+        self.install_root.as_deref().map(expand_path)
     }
 }
 
@@ -227,6 +237,10 @@ const fn default_require_download_approval() -> bool {
     true
 }
 
+const fn default_auto_expose_installed() -> bool {
+    true
+}
+
 fn normalize_domain_entries(entries: &[String]) -> Vec<String> {
     let mut normalized = BTreeSet::new();
     for entry in entries {
@@ -279,6 +293,8 @@ mod tests {
         assert!(config.require_download_approval);
         assert!(config.allowed_domains.is_empty());
         assert!(config.blocked_domains.is_empty());
+        assert!(config.install_root.is_none());
+        assert!(config.auto_expose_installed);
     }
 
     #[test]
@@ -296,6 +312,8 @@ mod tests {
                 "bad.example".to_owned(),
                 " ".to_owned(),
             ],
+            install_root: Some("~/skills".to_owned()),
+            auto_expose_installed: true,
         };
         assert_eq!(
             config.normalized_allowed_domains(),
@@ -304,6 +322,21 @@ mod tests {
         assert_eq!(
             config.normalized_blocked_domains(),
             vec!["bad.example".to_owned()]
+        );
+    }
+
+    #[test]
+    fn external_skills_resolved_install_root_expands_user_home() {
+        let config = ExternalSkillsConfig {
+            install_root: Some("~/demo-skills".to_owned()),
+            ..ExternalSkillsConfig::default()
+        };
+
+        assert!(
+            config
+                .resolved_install_root()
+                .expect("install root should resolve")
+                .ends_with("demo-skills")
         );
     }
 }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2914,7 +2914,10 @@ async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
                 "payload summary should keep invoke instructions intact: {envelope:?}"
             );
         }
-        other => panic!("unexpected result: {other:?}"),
+        other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => panic!("unexpected result: {other:?}"),
     }
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2822,6 +2822,103 @@ async fn turn_engine_truncates_oversized_tool_payload_summary() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
+    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
+    use loongclaw_kernel::CoreToolAdapter;
+
+    struct ExternalSkillInvokeAdapter;
+
+    #[async_trait]
+    impl CoreToolAdapter for ExternalSkillInvokeAdapter {
+        fn name(&self) -> &str {
+            "external-skill-invoke-adapter"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool": request.tool_name,
+                    "instructions": "Follow the managed skill instruction. ".repeat(200),
+                    "invocation_summary": "Loaded managed external skill instructions."
+                }),
+            })
+        }
+    }
+
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_tool_adapter(ExternalSkillInvokeAdapter);
+    kernel
+        .set_default_core_tool_adapter("external-skill-invoke-adapter")
+        .expect("set default");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let engine = TurnEngine::new(5);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "external_skills.invoke".to_owned(),
+            args_json: json!({"skill_id": "demo-skill"}),
+            source: "provider_tool_call".to_owned(),
+            session_id: "s1".to_owned(),
+            turn_id: "t1".to_owned(),
+            tool_call_id: "c-skill".to_owned(),
+        }],
+        raw_meta: serde_json::Value::Null,
+    };
+
+    let result = engine.execute_turn(&turn, Some(&ctx)).await;
+    match result {
+        TurnResult::FinalText(text) => {
+            let line = text.lines().next().expect("tool result line should exist");
+            let payload = line
+                .strip_prefix("[ok] ")
+                .expect("tool result line should keep [ok] prefix");
+            let envelope: Value =
+                serde_json::from_str(payload).expect("tool result envelope should be valid json");
+            assert_eq!(envelope["tool"], "external_skills.invoke");
+            assert_eq!(envelope["payload_truncated"], json!(false));
+            assert!(
+                envelope["payload_summary"]
+                    .as_str()
+                    .expect("payload summary should be text")
+                    .contains("Follow the managed skill instruction."),
+                "payload summary should keep invoke instructions intact: {envelope:?}"
+            );
+        }
+        other => panic!("unexpected result: {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn turn_engine_execute_turn_denied_without_capability() {
     use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -11,8 +11,6 @@ use crate::CliResult;
 use crate::KernelContext;
 
 use super::super::config::LoongClawConfig;
-#[cfg(feature = "memory-sqlite")]
-use super::super::memory;
 use super::ProviderErrorMode;
 use super::analytics::{
     SafeLaneEventSummary, parse_conversation_event, summarize_safe_lane_events,
@@ -1348,7 +1346,7 @@ async fn load_safe_lane_history_signals_for_governor(
         .safe_lane_session_governor_window_turns();
     if let Some(ctx) = kernel_ctx {
         let request = MemoryCoreRequest {
-            operation: memory::MEMORY_OP_WINDOW.to_owned(),
+            operation: crate::memory::MEMORY_OP_WINDOW.to_owned(),
             payload: json!({
                 "session_id": session_id,
                 "limit": window_turns,
@@ -1371,7 +1369,7 @@ async fn load_safe_lane_history_signals_for_governor(
 
     #[cfg(feature = "memory-sqlite")]
     {
-        if let Ok(turns) = memory::window_direct_extended(session_id, window_turns) {
+        if let Ok(turns) = crate::memory::window_direct_extended(session_id, window_turns) {
             let assistant_contents = turns
                 .iter()
                 .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.as_str()))

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -45,6 +45,8 @@ use super::turn_shared::{
 #[derive(Default)]
 pub struct ConversationTurnCoordinator;
 
+const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "A managed external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct SafeLaneExecutionMetrics {
     rounds_started: u32,
@@ -2080,6 +2082,17 @@ fn build_tool_followup_messages(
             "content": preface,
         }));
     }
+    if let Some(skill_context) = parse_external_skill_invoke_context(tool_result_text) {
+        messages.push(json!({
+            "role": "system",
+            "content": build_external_skill_system_message(&skill_context),
+        }));
+        messages.push(json!({
+            "role": "user",
+            "content": build_external_skill_followup_user_prompt(user_input, &skill_context),
+        }));
+        return messages;
+    }
     messages.push(json!({
         "role": "assistant",
         "content": format!("[tool_result]\n{tool_result_text}"),
@@ -2089,6 +2102,78 @@ fn build_tool_followup_messages(
         "content": build_tool_followup_user_prompt(user_input, None, Some(tool_result_text)),
     }));
     messages
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExternalSkillInvokeContext {
+    skill_id: String,
+    display_name: String,
+    instructions: String,
+}
+
+fn parse_external_skill_invoke_context(
+    tool_result_text: &str,
+) -> Option<ExternalSkillInvokeContext> {
+    let trimmed = tool_result_text.trim();
+    let mut lines = trimmed.lines().filter(|line| !line.trim().is_empty());
+    let line = lines.next()?;
+    if lines.next().is_some() {
+        return None;
+    }
+    let payload = line.strip_prefix("[ok] ")?;
+    let envelope: Value = serde_json::from_str(payload).ok()?;
+    if envelope.get("tool")?.as_str()? != "external_skills.invoke" {
+        return None;
+    }
+    let payload_summary = envelope.get("payload_summary")?.as_str()?;
+    let payload_json: Value = serde_json::from_str(payload_summary).ok()?;
+    let instructions = payload_json
+        .get("instructions")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_owned();
+    let skill_id = payload_json
+        .get("skill_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("external-skill")
+        .to_owned();
+    let display_name = payload_json
+        .get("display_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(skill_id.as_str())
+        .to_owned();
+    Some(ExternalSkillInvokeContext {
+        skill_id,
+        display_name,
+        instructions,
+    })
+}
+
+fn build_external_skill_system_message(skill_context: &ExternalSkillInvokeContext) -> String {
+    format!(
+        "Managed external skill `{}` ({}) is now active for this task. Treat the following `SKILL.md` content as trusted runtime guidance until superseded.\n\n{}",
+        skill_context.skill_id, skill_context.display_name, skill_context.instructions
+    )
+}
+
+fn build_external_skill_followup_user_prompt(
+    user_input: &str,
+    skill_context: &ExternalSkillInvokeContext,
+) -> String {
+    [
+        EXTERNAL_SKILL_FOLLOWUP_PROMPT.to_owned(),
+        format!(
+            "Loaded managed external skill:\n- id: {}\n- name: {}",
+            skill_context.skill_id, skill_context.display_name
+        ),
+        format!("Original request:\n{user_input}"),
+    ]
+    .join("\n\n")
 }
 
 fn build_tool_failure_followup_messages(
@@ -2162,6 +2247,41 @@ mod tests {
             .expect("user followup prompt should exist");
         assert!(
             !user_prompt.contains(crate::conversation::turn_shared::TOOL_TRUNCATION_HINT_PROMPT)
+        );
+    }
+
+    #[test]
+    fn build_tool_followup_messages_promotes_external_skill_invoke_to_system_context() {
+        let messages = build_tool_followup_messages(
+            &[serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })],
+            "preface",
+            r#"[ok] {"status":"ok","tool":"external_skills.invoke","tool_call_id":"call-1","payload_summary":"{\"skill_id\":\"demo-skill\",\"display_name\":\"Demo Skill\",\"instructions\":\"Follow the managed skill instruction before answering.\"}","payload_chars":180,"payload_truncated":false}"#,
+            "summarize note.md",
+        );
+
+        assert!(
+            messages.iter().any(|message| message.get("role")
+                == Some(&Value::String("system".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| content
+                        .contains("Follow the managed skill instruction before answering."))
+                    .unwrap_or(false)),
+            "safe-lane followup should promote invoked external skill instructions into system context: {messages:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .filter(
+                    |message| message.get("role") == Some(&Value::String("assistant".to_owned()))
+                )
+                .filter_map(|message| message.get("content").and_then(Value::as_str))
+                .all(|content| !content.contains("[tool_result]\n[ok]")),
+            "safe-lane followup should not carry invoke payload forward as an ordinary assistant tool_result: {messages:?}"
         );
     }
 

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -229,10 +229,11 @@ fn build_tool_result_envelope(
     outcome: &ToolCoreOutcome,
     payload_summary_limit_chars: usize,
 ) -> ToolResultEnvelope {
-    let normalized_limit = payload_summary_limit_chars.clamp(
-        MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
-        MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
-    );
+    let normalized_limit = effective_payload_summary_limit(intent, payload_summary_limit_chars)
+        .clamp(
+            MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+            MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+        );
     let payload_text = serde_json::to_string(&outcome.payload)
         .unwrap_or_else(|_| "[tool_payload_unserializable]".to_owned());
     let (payload_summary, payload_chars, payload_truncated) =
@@ -246,6 +247,13 @@ fn build_tool_result_envelope(
         payload_chars,
         payload_truncated,
     }
+}
+
+fn effective_payload_summary_limit(intent: &ToolIntent, default_limit: usize) -> usize {
+    if crate::tools::canonical_tool_name(intent.tool_name.as_str()) == "external_skills.invoke" {
+        return MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS;
+    }
+    default_limit
 }
 
 fn truncate_by_chars(value: &str, limit: usize) -> (String, usize, bool) {

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -12,8 +12,9 @@ use super::persistence::{format_provider_error_reply, persist_error_turns, persi
 use super::runtime::{ConversationRuntime, DefaultConversationRuntime};
 use super::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
 use super::turn_shared::{
+    build_external_skill_followup_user_prompt, build_external_skill_system_message,
     build_tool_followup_user_prompt, compose_assistant_reply, join_non_empty_lines,
-    user_requested_raw_tool_output,
+    parse_external_skill_invoke_context, user_requested_raw_tool_output,
 };
 
 #[derive(Default)]
@@ -328,6 +329,27 @@ fn append_tool_followup_messages(
             "role": "assistant",
             "content": preface,
         }));
+    }
+    if let Some(skill_context) = parse_external_skill_invoke_context(tool_result_text) {
+        messages.push(json!({
+            "role": "system",
+            "content": build_external_skill_system_message(&skill_context),
+        }));
+        if let Some(reason) = loop_warning_reason {
+            messages.push(json!({
+                "role": "assistant",
+                "content": format!("[tool_loop_warning]\n{reason}"),
+            }));
+        }
+        messages.push(json!({
+            "role": "user",
+            "content": build_external_skill_followup_user_prompt(
+                user_input,
+                loop_warning_reason,
+                &skill_context,
+            ),
+        }));
+        return;
     }
     let bounded_result = followup_payload_budget.truncate_payload("tool_result", tool_result_text);
     messages.push(json!({
@@ -789,6 +811,80 @@ mod tests {
             .expect("user followup prompt should exist");
         assert!(
             !user_prompt.contains(crate::conversation::turn_shared::TOOL_TRUNCATION_HINT_PROMPT)
+        );
+    }
+
+    #[test]
+    fn append_tool_followup_messages_promotes_external_skill_invoke_into_system_context() {
+        let mut messages = Vec::new();
+        let mut budget = FollowupPayloadBudget::new(64, 64);
+
+        append_tool_followup_messages(
+            &mut messages,
+            "preface",
+            r#"[ok] {"status":"ok","tool":"external_skills.invoke","tool_call_id":"call-1","payload_summary":"{\"skill_id\":\"demo-skill\",\"display_name\":\"Demo Skill\",\"instructions\":\"Follow the managed skill instruction before answering.\"}","payload_chars":180,"payload_truncated":false}"#,
+            "summarize note.md",
+            &mut budget,
+            None,
+        );
+
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[1]["role"], "system");
+        let system_content = messages[1]["content"]
+            .as_str()
+            .expect("system content should exist");
+        assert!(system_content.contains("Demo Skill"));
+        assert!(system_content.contains("Follow the managed skill instruction before answering."));
+        assert!(
+            !system_content.contains("[tool_result_truncated]"),
+            "invoke instructions should not be funneled through followup truncation markers"
+        );
+
+        let user_prompt = messages[2]["content"]
+            .as_str()
+            .expect("user prompt should exist");
+        assert!(user_prompt.contains("managed external skill"));
+        assert!(user_prompt.contains("Original request:\nsummarize note.md"));
+    }
+
+    #[test]
+    fn append_tool_followup_messages_keeps_large_external_skill_instructions_intact() {
+        let mut messages = Vec::new();
+        let mut budget = FollowupPayloadBudget::new(32, 32);
+        let instructions = format!("prefix {}\nsuffix-marker", "x".repeat(512));
+        let payload_summary = serde_json::json!({
+            "skill_id": "demo-skill",
+            "display_name": "Demo Skill",
+            "instructions": instructions,
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "external_skills.invoke",
+                "tool_call_id": "call-2",
+                "payload_summary": payload_summary,
+                "payload_chars": 2048,
+                "payload_truncated": false
+            })
+        );
+
+        append_tool_followup_messages(
+            &mut messages,
+            "",
+            tool_result.as_str(),
+            "apply the skill",
+            &mut budget,
+            None,
+        );
+
+        let system_content = messages[0]["content"]
+            .as_str()
+            .expect("system content should exist");
+        assert!(
+            system_content.contains("suffix-marker"),
+            "system context should preserve the tail of large invoke instructions"
         );
     }
 }

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -4,6 +4,14 @@ use serde_json::Value;
 
 pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
 pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
+pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "A managed external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalSkillInvokeContext {
+    pub skill_id: String,
+    pub display_name: String,
+    pub instructions: String,
+}
 
 pub fn user_requested_raw_tool_output(user_input: &str) -> bool {
     let normalized = user_input.to_ascii_lowercase();
@@ -108,6 +116,44 @@ pub fn build_tool_followup_user_prompt(
     sections.join("\n\n")
 }
 
+pub fn parse_external_skill_invoke_context(
+    tool_result_text: &str,
+) -> Option<ExternalSkillInvokeContext> {
+    tool_result_text
+        .trim()
+        .lines()
+        .filter_map(parse_external_skill_invoke_context_line)
+        .next()
+}
+
+pub fn build_external_skill_system_message(skill_context: &ExternalSkillInvokeContext) -> String {
+    format!(
+        "Managed external skill `{}` ({}) is now active for this task. Treat the following `SKILL.md` content as trusted runtime guidance until superseded.\n\n{}",
+        skill_context.skill_id, skill_context.display_name, skill_context.instructions
+    )
+}
+
+pub fn build_external_skill_followup_user_prompt(
+    user_input: &str,
+    loop_warning_reason: Option<&str>,
+    skill_context: &ExternalSkillInvokeContext,
+) -> String {
+    let mut sections = vec![
+        EXTERNAL_SKILL_FOLLOWUP_PROMPT.to_owned(),
+        format!(
+            "Loaded managed external skill:\n- id: {}\n- name: {}",
+            skill_context.skill_id, skill_context.display_name
+        ),
+    ];
+    if let Some(reason) = loop_warning_reason {
+        sections.push(format!(
+            "Loop warning:\n{reason}\nAvoid repeating the same tool call with unchanged results. Try a different tool, adjust arguments, or provide a best-effort final answer if evidence is sufficient."
+        ));
+    }
+    sections.push(format!("Original request:\n{user_input}"));
+    sections.join("\n\n")
+}
+
 pub fn join_non_empty_lines(parts: &[&str]) -> String {
     parts
         .iter()
@@ -115,6 +161,52 @@ pub fn join_non_empty_lines(parts: &[&str]) -> String {
         .filter(|part| !part.is_empty())
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn parse_external_skill_invoke_context_line(line: &str) -> Option<ExternalSkillInvokeContext> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let payload = trimmed.strip_prefix("[ok] ")?;
+    let envelope: Value = serde_json::from_str(payload).ok()?;
+    if envelope.get("tool")?.as_str()? != "external_skills.invoke" {
+        return None;
+    }
+    if envelope
+        .get("payload_truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    let payload_summary = envelope.get("payload_summary")?.as_str()?;
+    let payload_json: Value = serde_json::from_str(payload_summary).ok()?;
+    let instructions = payload_json
+        .get("instructions")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_owned();
+    let skill_id = payload_json
+        .get("skill_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("external-skill")
+        .to_owned();
+    let display_name = payload_json
+        .get("display_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(skill_id.as_str())
+        .to_owned();
+    Some(ExternalSkillInvokeContext {
+        skill_id,
+        display_name,
+        instructions,
+    })
 }
 
 #[cfg(test)]
@@ -179,5 +271,32 @@ mod tests {
         );
         assert!(prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
         assert!(prompt.contains("Original request:\nsummarize this result"));
+    }
+
+    #[test]
+    fn parse_external_skill_invoke_context_extracts_full_instructions() {
+        let instructions = format!("prefix {}\nsuffix-marker", "x".repeat(256));
+        let payload = json!({
+            "skill_id": "demo-skill",
+            "display_name": "Demo Skill",
+            "instructions": instructions,
+        });
+        let line = format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "tool": "external_skills.invoke",
+                "tool_call_id": "call-1",
+                "payload_summary": serde_json::to_string(&payload).expect("encode payload"),
+                "payload_chars": 512,
+                "payload_truncated": false
+            })
+        );
+
+        let parsed = parse_external_skill_invoke_context(line.as_str())
+            .expect("invoke context should parse");
+        assert_eq!(parsed.skill_id, "demo-skill");
+        assert_eq!(parsed.display_name, "Demo Skill");
+        assert!(parsed.instructions.contains("suffix-marker"));
     }
 }

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -881,9 +881,9 @@ fn render_external_skill_profile_note_addendum(
     let mut lines = vec!["## Imported External Skills Artifacts".to_owned()];
     for artifact in artifacts {
         lines.push(format!(
-            "- kind={} path={}",
+            "- kind={} label={}",
             artifact.kind.as_id(),
-            artifact.path.display()
+            external_skill_artifact_label(artifact)
         ));
     }
     if !declared_skills.is_empty() {
@@ -905,6 +905,17 @@ fn render_external_skill_profile_note_addendum(
         }
     }
     Some(lines.join("\n"))
+}
+
+fn external_skill_artifact_label(artifact: &ExternalSkillArtifact) -> String {
+    artifact
+        .path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(artifact.kind.as_id())
+        .to_owned()
 }
 
 fn merge_profile_note_addendum(existing: Option<&str>, addendum: &str) -> Option<String> {
@@ -1272,6 +1283,10 @@ mod tests {
         assert!(addendum.contains("kind=skills_catalog"));
         assert!(addendum.contains("kind=skills_lock"));
         assert!(addendum.contains("kind=codex_skills_dir"));
+        assert!(
+            !addendum.contains(root.display().to_string().as_str()),
+            "profile note addendum should not leak absolute local paths"
+        );
 
         fs::remove_dir_all(&root).ok();
     }
@@ -1312,6 +1327,34 @@ mod tests {
             config.memory.profile_note.as_deref(),
             Some(first_note.as_str()),
             "profile note should remain stable after duplicate apply"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn external_skill_profile_note_addendum_does_not_embed_absolute_paths() {
+        let root = unique_temp_dir("loongclaw-import-external-skill-redacted-paths");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(&root, "SKILLS.md", "# Skills\n\n- custom/skill-a\n");
+        fs::create_dir_all(root.join(".codex/skills")).expect("create codex skills dir");
+
+        let mapping = plan_external_skill_mapping(&root);
+        let addendum = mapping
+            .profile_note_addendum
+            .as_deref()
+            .expect("profile note addendum should exist");
+
+        assert!(
+            !addendum.contains(&root.display().to_string()),
+            "profile note addendum must not leak absolute import roots: {addendum}"
+        );
+        assert!(
+            !addendum.contains("/private/")
+                && !addendum.contains("/Users/")
+                && !addendum.contains("\\\\")
+                && !addendum.contains(":\\"),
+            "profile note addendum must not contain absolute local filesystem paths: {addendum}"
         );
 
         fs::remove_dir_all(&root).ok();

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -621,7 +621,7 @@ fn external_skill_probe_roots(input_path: &Path) -> Vec<PathBuf> {
 
 fn external_skill_warning(artifact: &ExternalSkillArtifact) -> String {
     format!(
-        "detected external skills artifact `{}` ({}); LoongClaw imports prompt/profile content but does not auto-wire external skill runtimes",
+        "detected external skills artifact `{}` ({}); LoongClaw imports prompt/profile content but does not auto-install the runtime, so use the explicit external skills lifecycle (`fetch` -> `install` -> `list` -> `invoke`) when you want the skill available in chat",
         artifact.path.display(),
         artifact.kind.as_id()
     )
@@ -1274,6 +1274,17 @@ mod tests {
         assert!(addendum.contains("kind=codex_skills_dir"));
 
         fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn external_skill_warning_points_to_explicit_runtime_lifecycle() {
+        let warning = external_skill_warning(&ExternalSkillArtifact {
+            kind: ExternalSkillArtifactKind::SkillsDir,
+            path: PathBuf::from("/tmp/demo/skills"),
+        });
+        assert!(warning.contains("fetch"));
+        assert!(warning.contains("install"));
+        assert!(warning.contains("invoke"));
     }
 
     #[test]

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -437,6 +437,8 @@ async fn request_turn_with_model(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use super::model_selection::rank_model_candidates;
     use super::payload_adaptation::{ReasoningField, TemperatureField, TokenLimitField};
     use super::*;
@@ -445,6 +447,8 @@ mod tests {
         ProviderConfig, ProviderKind, ReasoningEffort, ToolConfig,
     };
     use serde_json::json;
+
+    static PROVIDER_TEST_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     fn write_provider_test_file(root: &std::path::Path, relative: &str, content: &str) {
         let path = root.join(relative);
@@ -461,8 +465,9 @@ mod tests {
         crate::tools::runtime_config::ToolRuntimeConfig,
         std::path::PathBuf,
     ) {
+        let sequence = PROVIDER_TEST_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
         let root = std::env::temp_dir().join(format!(
-            "loongclaw-provider-ext-skills-{}",
+            "loongclaw-provider-ext-skills-{}-{sequence}",
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("clock should be after epoch")

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -34,12 +34,24 @@ pub fn build_system_message(
     config: &LoongClawConfig,
     include_system_prompt: bool,
 ) -> Option<Value> {
+    build_system_message_with_tool_runtime_config(
+        config,
+        include_system_prompt,
+        crate::tools::runtime_config::get_tool_runtime_config(),
+    )
+}
+
+fn build_system_message_with_tool_runtime_config(
+    config: &LoongClawConfig,
+    include_system_prompt: bool,
+    tool_runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
+) -> Option<Value> {
     if !include_system_prompt {
         return None;
     }
     let system_prompt = config.cli.resolved_system_prompt();
     let system = system_prompt.trim();
-    let snapshot = super::tools::capability_snapshot();
+    let snapshot = super::tools::capability_snapshot_with_config(tool_runtime_config);
     let content = if system.is_empty() {
         snapshot
     } else {
@@ -434,6 +446,71 @@ mod tests {
     };
     use serde_json::json;
 
+    fn write_provider_test_file(root: &std::path::Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent directory");
+        }
+        std::fs::write(path, content).expect("write fixture");
+    }
+
+    fn install_skill_for_provider_snapshot_test(
+        auto_expose_installed: bool,
+    ) -> (
+        LoongClawConfig,
+        crate::tools::runtime_config::ToolRuntimeConfig,
+        std::path::PathBuf,
+    ) {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-provider-ext-skills-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+        write_provider_test_file(
+            &root,
+            "skills/demo-skill/SKILL.md",
+            "# Demo Skill\n\nUse this skill for provider prompt verification.\n",
+        );
+
+        let tool_runtime_config = crate::tools::runtime_config::ToolRuntimeConfig {
+            shell_allowlist: std::collections::BTreeSet::new(),
+            file_root: Some(root.clone()),
+            external_skills: crate::tools::runtime_config::ExternalSkillsRuntimePolicy {
+                enabled: true,
+                require_download_approval: true,
+                allowed_domains: std::collections::BTreeSet::new(),
+                blocked_domains: std::collections::BTreeSet::new(),
+                install_root: None,
+                auto_expose_installed,
+            },
+        };
+        crate::tools::execute_tool_core_with_config(
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "skills/demo-skill"
+                }),
+            },
+            &tool_runtime_config,
+        )
+        .expect("install should succeed");
+
+        let config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            conversation: ConversationConfig::default(),
+            tools: ToolConfig::default(),
+            external_skills: ExternalSkillsConfig::default(),
+            memory: MemoryConfig::default(),
+        };
+        (config, tool_runtime_config, root)
+    }
+
     fn default_test_config() -> LoongClawConfig {
         LoongClawConfig {
             provider: ProviderConfig::default(),
@@ -481,6 +558,39 @@ mod tests {
             system_content.contains("- file.write: Write file contents"),
             "system prompt should list file.write tool"
         );
+    }
+
+    #[test]
+    fn build_system_message_can_include_installed_external_skills_snapshot() {
+        let (config, tool_runtime_config, root) = install_skill_for_provider_snapshot_test(true);
+
+        let system_message =
+            build_system_message_with_tool_runtime_config(&config, true, &tool_runtime_config)
+                .expect("system message");
+        let system_content = system_message["content"].as_str().expect("system content");
+
+        assert!(system_content.contains("[available_external_skills]"));
+        assert!(
+            system_content
+                .contains("- demo-skill: Use this skill for provider prompt verification.")
+        );
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn build_system_message_omits_installed_external_skills_when_auto_expose_is_disabled() {
+        let (config, tool_runtime_config, root) = install_skill_for_provider_snapshot_test(false);
+
+        let system_message =
+            build_system_message_with_tool_runtime_config(&config, true, &tool_runtime_config)
+                .expect("system message");
+        let system_content = system_message["content"].as_str().expect("system content");
+
+        assert!(!system_content.contains("[available_external_skills]"));
+        assert!(!system_content.contains("demo-skill"));
+
+        std::fs::remove_dir_all(root).ok();
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -812,7 +922,12 @@ mod tests {
         let mut expected = Vec::new();
         expected.push("claw_import");
         expected.push("external_skills_fetch");
+        expected.push("external_skills_inspect");
+        expected.push("external_skills_install");
+        expected.push("external_skills_invoke");
+        expected.push("external_skills_list");
         expected.push("external_skills_policy");
+        expected.push("external_skills_remove");
         #[cfg(feature = "tool-file")]
         {
             expected.push("file_read");

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -919,15 +919,16 @@ mod tests {
             .filter_map(Value::as_str)
             .collect();
 
-        let mut expected = Vec::new();
-        expected.push("claw_import");
-        expected.push("external_skills_fetch");
-        expected.push("external_skills_inspect");
-        expected.push("external_skills_install");
-        expected.push("external_skills_invoke");
-        expected.push("external_skills_list");
-        expected.push("external_skills_policy");
-        expected.push("external_skills_remove");
+        let mut expected = vec![
+            "claw_import",
+            "external_skills_fetch",
+            "external_skills_inspect",
+            "external_skills_install",
+            "external_skills_invoke",
+            "external_skills_list",
+            "external_skills_policy",
+            "external_skills_remove",
+        ];
         #[cfg(feature = "tool-file")]
         {
             expected.push("file_read");

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -571,8 +571,9 @@ mod tests {
 
         assert!(system_content.contains("[available_external_skills]"));
         assert!(
-            system_content
-                .contains("- demo-skill: Use this skill for provider prompt verification.")
+            system_content.contains(
+                "- demo-skill: installed managed external skill; use external_skills.inspect or external_skills.invoke for details"
+            )
         );
 
         std::fs::remove_dir_all(root).ok();

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -49,6 +49,9 @@ struct ExternalSkillsPolicyOverride {
     blocked_domains: Option<BTreeSet<String>>,
 }
 
+#[derive(Debug, Default)]
+struct ScopedDirCleanup(Option<PathBuf>);
+
 static EXTERNAL_SKILLS_POLICY_OVERRIDE: OnceLock<RwLock<ExternalSkillsPolicyOverride>> =
     OnceLock::new();
 
@@ -361,18 +364,19 @@ pub(super) fn execute_external_skills_install_tool_with_config(
         ));
     }
 
-    let (skill_root, source_kind) = if source_file_type.is_dir() {
+    let (skill_root, source_kind, cleanup_root) = if source_file_type.is_dir() {
         let skill_root = resolve_skill_root(&source_path)?;
-        (skill_root, "directory")
+        (skill_root, "directory", None)
     } else if source_file_type.is_file() {
-        let skill_root = extract_archive_to_staging(&source_path, &install_root)?;
-        (skill_root, "archive")
+        let (staging_root, skill_root) = extract_archive_to_staging(&source_path, &install_root)?;
+        (skill_root, "archive", Some(staging_root))
     } else {
         return Err(format!(
             "external skill source {} must be a directory or a regular file",
             source_path.display()
         ));
     };
+    let _cleanup_root = ScopedDirCleanup::new(cleanup_root);
 
     let skill_md_path = skill_root.join(DEFAULT_SKILL_FILENAME);
     let skill_markdown = fs::read_to_string(&skill_md_path).map_err(|error| {
@@ -436,10 +440,6 @@ pub(super) fn execute_external_skills_install_tool_with_config(
     });
     persist_installed_skill_index(&install_root, &mut index)?;
 
-    if source_kind == "archive" {
-        fs::remove_dir_all(&skill_root).ok();
-    }
-
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
@@ -463,12 +463,17 @@ pub(super) fn execute_external_skills_list_tool_with_config(
     require_enabled_runtime_policy(config)?;
     let install_root = resolve_install_root(config);
     let index = load_installed_skill_index(&install_root)?;
+    let skills = index
+        .skills
+        .into_iter()
+        .map(|entry| rehydrate_installed_skill_entry(&install_root, entry))
+        .collect::<Result<Vec<_>, _>>()?;
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
             "adapter": "core-tools",
             "tool_name": request.tool_name,
-            "skills": index.skills,
+            "skills": skills,
         }),
     })
 }
@@ -491,13 +496,7 @@ pub(super) fn execute_external_skills_inspect_tool_with_config(
     require_enabled_runtime_policy(config)?;
 
     let install_root = resolve_install_root(config);
-    let entry = installed_skill_by_id(&load_installed_skill_index(&install_root)?, skill_id)?;
-    let instructions = fs::read_to_string(&entry.skill_md_path).map_err(|error| {
-        format!(
-            "failed to read installed skill {}: {error}",
-            entry.skill_md_path
-        )
-    })?;
+    let (entry, instructions) = load_installed_skill_material(&install_root, skill_id)?;
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
@@ -527,18 +526,12 @@ pub(super) fn execute_external_skills_invoke_tool_with_config(
     require_enabled_runtime_policy(config)?;
 
     let install_root = resolve_install_root(config);
-    let entry = installed_skill_by_id(&load_installed_skill_index(&install_root)?, skill_id)?;
+    let (entry, instructions) = load_installed_skill_material(&install_root, skill_id)?;
     if !entry.active {
         return Err(format!(
             "external skill `{skill_id}` is installed but inactive"
         ));
     }
-    let instructions = fs::read_to_string(&entry.skill_md_path).map_err(|error| {
-        format!(
-            "failed to read installed skill {}: {error}",
-            entry.skill_md_path
-        )
-    })?;
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
@@ -667,6 +660,20 @@ impl ExternalSkillsPolicyOverride {
             || self.require_download_approval.is_some()
             || self.allowed_domains.is_some()
             || self.blocked_domains.is_some()
+    }
+}
+
+impl ScopedDirCleanup {
+    fn new(path: Option<PathBuf>) -> Self {
+        Self(path)
+    }
+}
+
+impl Drop for ScopedDirCleanup {
+    fn drop(&mut self) {
+        if let Some(path) = self.0.take() {
+            fs::remove_dir_all(path).ok();
+        }
     }
 }
 
@@ -911,7 +918,10 @@ fn resolve_skill_root(root: &Path) -> Result<PathBuf, String> {
     }
 }
 
-fn extract_archive_to_staging(archive_path: &Path, install_root: &Path) -> Result<PathBuf, String> {
+fn extract_archive_to_staging(
+    archive_path: &Path,
+    install_root: &Path,
+) -> Result<(PathBuf, PathBuf), String> {
     let filename = archive_path
         .file_name()
         .and_then(|value| value.to_str())
@@ -937,47 +947,57 @@ fn extract_archive_to_staging(archive_path: &Path, install_root: &Path) -> Resul
             staging_root.display()
         )
     })?;
-    let file = fs::File::open(archive_path).map_err(|error| {
-        format!(
-            "failed to open external skill archive {}: {error}",
-            archive_path.display()
-        )
-    })?;
-    let decoder = GzDecoder::new(file);
-    let mut archive = Archive::new(decoder);
-    for entry in archive.entries().map_err(|error| {
-        format!(
-            "failed to read external skill archive {}: {error}",
-            archive_path.display()
-        )
-    })? {
-        let mut entry = entry.map_err(|error| {
+    let extraction = (|| -> Result<PathBuf, String> {
+        let file = fs::File::open(archive_path).map_err(|error| {
             format!(
-                "failed to inspect external skill archive {}: {error}",
+                "failed to open external skill archive {}: {error}",
                 archive_path.display()
             )
         })?;
-        let entry_type = entry.header().entry_type();
-        if entry_type.is_symlink() || entry_type.is_hard_link() {
-            return Err(format!(
-                "external skill archive {} cannot contain symlinks or hard links",
-                archive_path.display()
-            ));
-        }
-        if !(entry_type.is_dir() || entry_type.is_file()) {
-            return Err(format!(
-                "external skill archive {} contains unsupported entry types; only files and directories are allowed",
-                archive_path.display()
-            ));
-        }
-        entry.unpack_in(&staging_root).map_err(|error| {
+        let decoder = GzDecoder::new(file);
+        let mut archive = Archive::new(decoder);
+        for entry in archive.entries().map_err(|error| {
             format!(
-                "failed to extract external skill archive {}: {error}",
+                "failed to read external skill archive {}: {error}",
                 archive_path.display()
             )
-        })?;
+        })? {
+            let mut entry = entry.map_err(|error| {
+                format!(
+                    "failed to inspect external skill archive {}: {error}",
+                    archive_path.display()
+                )
+            })?;
+            let entry_type = entry.header().entry_type();
+            if entry_type.is_symlink() || entry_type.is_hard_link() {
+                return Err(format!(
+                    "external skill archive {} cannot contain symlinks or hard links",
+                    archive_path.display()
+                ));
+            }
+            if !(entry_type.is_dir() || entry_type.is_file()) {
+                return Err(format!(
+                    "external skill archive {} contains unsupported entry types; only files and directories are allowed",
+                    archive_path.display()
+                ));
+            }
+            entry.unpack_in(&staging_root).map_err(|error| {
+                format!(
+                    "failed to extract external skill archive {}: {error}",
+                    archive_path.display()
+                )
+            })?;
+        }
+        resolve_skill_root(&staging_root)
+    })();
+
+    match extraction {
+        Ok(skill_root) => Ok((staging_root, skill_root)),
+        Err(error) => {
+            fs::remove_dir_all(&staging_root).ok();
+            Err(error)
+        }
     }
-    resolve_skill_root(&staging_root)
 }
 
 fn find_skill_roots(root: &Path) -> Result<Vec<PathBuf>, String> {
@@ -1277,8 +1297,14 @@ pub(super) fn installed_skill_snapshot_lines_with_config(
     Ok(index
         .skills
         .into_iter()
-        .filter(|entry| entry.active)
-        .map(|entry| format!("- {}: {}", entry.skill_id, INSTALLED_SKILL_SNAPSHOT_HINT))
+        .filter_map(|entry| {
+            if !entry.active {
+                return None;
+            }
+            rehydrate_installed_skill_entry(&install_root, entry)
+                .ok()
+                .map(|entry| format!("- {}: {}", entry.skill_id, INSTALLED_SKILL_SNAPSHOT_HINT))
+        })
         .collect())
 }
 
@@ -1326,6 +1352,71 @@ fn normalize_loaded_skill_entry(
     entry.install_path = install_path.display().to_string();
     entry.skill_md_path = skill_md_path.display().to_string();
     Ok(entry)
+}
+
+fn load_installed_skill_material(
+    install_root: &Path,
+    skill_id: &str,
+) -> Result<(InstalledSkillEntry, String), String> {
+    let entry = installed_skill_by_id(&load_installed_skill_index(install_root)?, skill_id)?;
+    let entry = rehydrate_installed_skill_entry(install_root, entry)?;
+    let instructions = load_managed_skill_markdown(&entry)?;
+    Ok((entry, instructions))
+}
+
+fn rehydrate_installed_skill_entry(
+    install_root: &Path,
+    mut entry: InstalledSkillEntry,
+) -> Result<InstalledSkillEntry, String> {
+    let install_path = managed_skill_install_path(install_root, entry.skill_id.as_str())?;
+    let install_metadata = fs::symlink_metadata(&install_path).map_err(|error| {
+        format!(
+            "failed to inspect managed external skill install {}: {error}",
+            install_path.display()
+        )
+    })?;
+    let install_file_type = install_metadata.file_type();
+    if install_file_type.is_symlink() {
+        return Err(format!(
+            "managed external skill install {} cannot be a symlink",
+            install_path.display()
+        ));
+    }
+    if !install_file_type.is_dir() {
+        return Err(format!(
+            "managed external skill install {} must be a directory",
+            install_path.display()
+        ));
+    }
+
+    entry.install_path = install_path.display().to_string();
+    entry.skill_md_path = install_path
+        .join(DEFAULT_SKILL_FILENAME)
+        .display()
+        .to_string();
+
+    let skill_markdown = load_managed_skill_markdown(&entry)?;
+    entry.display_name =
+        derive_skill_display_name(skill_markdown.as_str(), entry.skill_id.as_str());
+    entry.summary = derive_skill_summary(skill_markdown.as_str());
+    entry.sha256 = format!("{:x}", Sha256::digest(skill_markdown.as_bytes()));
+    Ok(entry)
+}
+
+fn load_managed_skill_markdown(entry: &InstalledSkillEntry) -> Result<String, String> {
+    let install_path = PathBuf::from(entry.install_path.as_str());
+    if !contains_regular_skill_markdown(&install_path)? {
+        return Err(format!(
+            "managed external skill install {} is missing `{DEFAULT_SKILL_FILENAME}`",
+            install_path.display()
+        ));
+    }
+    fs::read_to_string(&entry.skill_md_path).map_err(|error| {
+        format!(
+            "failed to read installed skill {}: {error}",
+            entry.skill_md_path
+        )
+    })
 }
 
 fn managed_skill_install_path(install_root: &Path, skill_id: &str) -> Result<PathBuf, String> {
@@ -1978,6 +2069,152 @@ mod tests {
     }
 
     #[test]
+    fn tampered_index_metadata_is_rehydrated_from_managed_skill_markdown() {
+        let root = unique_temp_dir("loongclaw-ext-skill-index-metadata");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "source/demo-skill/SKILL.md",
+            "# Demo Skill\n\nPrefer evidence over stale index metadata.\n",
+        );
+        let config = managed_runtime_config(&root);
+
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("install should succeed");
+
+        let install_root = root.join("external-skills-installed");
+        let index_path = install_root.join("index.json");
+        let mut index: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&index_path).expect("read index"))
+                .expect("parse index");
+        index["skills"][0]["display_name"] = json!("Forged Display");
+        index["skills"][0]["summary"] = json!("Forged summary");
+        index["skills"][0]["sha256"] = json!("forged-digest");
+        fs::write(
+            &index_path,
+            serde_json::to_string_pretty(&index).expect("encode tampered index"),
+        )
+        .expect("write tampered index");
+
+        let list_outcome = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.list".to_owned(),
+                payload: json!({}),
+            },
+            &config,
+        )
+        .expect("list should succeed with rehydrated metadata");
+        assert_eq!(
+            list_outcome.payload["skills"][0]["display_name"],
+            "Demo Skill"
+        );
+        assert_eq!(
+            list_outcome.payload["skills"][0]["summary"],
+            "Prefer evidence over stale index metadata."
+        );
+        assert_ne!(list_outcome.payload["skills"][0]["sha256"], "forged-digest");
+
+        let invoke_outcome = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.invoke".to_owned(),
+                payload: json!({
+                    "skill_id": "demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("invoke should succeed with rehydrated metadata");
+        assert_eq!(invoke_outcome.payload["display_name"], "Demo Skill");
+        assert_eq!(
+            invoke_outcome.payload["summary"],
+            "Prefer evidence over stale index metadata."
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn inspect_rejects_symlinked_managed_install_directory() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_temp_dir("loongclaw-ext-skill-install-symlink-swap");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "source/demo-skill/SKILL.md",
+            "# Demo Skill\n\nManaged install should stay real.\n",
+        );
+        let config = managed_runtime_config(&root);
+
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("install should succeed");
+
+        let install_path = root.join("external-skills-installed").join("demo-skill");
+        fs::remove_dir_all(&install_path).expect("remove managed install");
+
+        let escape_root = unique_temp_dir("loongclaw-ext-skill-install-symlink-target");
+        fs::create_dir_all(&escape_root).expect("create escape root");
+        write_file(
+            &escape_root,
+            "SKILL.md",
+            "# Escape Skill\n\nDo not follow symlinked installs.\n",
+        );
+        symlink(&escape_root, &install_path).expect("create managed install symlink");
+
+        let error = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.inspect".to_owned(),
+                payload: json!({
+                    "skill_id": "demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect_err("inspect should reject symlinked managed installs");
+        assert!(error.contains("cannot be a symlink"));
+
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.remove".to_owned(),
+                payload: json!({
+                    "skill_id": "demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("remove should delete only the managed symlink");
+
+        assert!(
+            escape_root.exists(),
+            "managed remove must not delete the symlink target"
+        );
+        assert!(
+            !install_path.exists(),
+            "managed symlink should be removed from install root"
+        );
+
+        fs::remove_dir_all(&root).ok();
+        fs::remove_dir_all(&escape_root).ok();
+    }
+
+    #[test]
     fn install_from_tar_gz_archive_extracts_wrapped_skill_root() {
         let root = unique_temp_dir("loongclaw-ext-skill-install-archive");
         fs::create_dir_all(&root).expect("create fixture root");
@@ -2016,6 +2253,22 @@ mod tests {
                 .join("demo-skill")
                 .join("SKILL.md")
                 .exists()
+        );
+        let install_root = root.join("external-skills-installed");
+        let staging_entries = fs::read_dir(&install_root)
+            .expect("install root should exist")
+            .map(|entry| {
+                entry
+                    .expect("read install root entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .filter(|name| name.starts_with(".staging-"))
+            .collect::<Vec<_>>();
+        assert!(
+            staging_entries.is_empty(),
+            "successful archive install must clean staging directories: {staging_entries:?}"
         );
 
         fs::remove_dir_all(&root).ok();
@@ -2071,6 +2324,22 @@ mod tests {
         )
         .expect_err("archive symlink should be rejected");
         assert!(error.contains("cannot contain symlinks or hard links"));
+        let install_root = root.join("external-skills-installed");
+        let staging_entries = fs::read_dir(&install_root)
+            .expect("install root should exist")
+            .map(|entry| {
+                entry
+                    .expect("read install root entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .filter(|name| name.starts_with(".staging-"))
+            .collect::<Vec<_>>();
+        assert!(
+            staging_entries.is_empty(),
+            "failed archive install must not leave staging directories behind: {staging_entries:?}"
+        );
 
         fs::remove_dir_all(&root).ok();
     }

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -7,13 +7,38 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use flate2::read::GzDecoder;
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
+use tar::Archive;
 
 const DEFAULT_DOWNLOAD_DIR_NAME: &str = "external-skills-downloads";
+const DEFAULT_INSTALL_DIR_NAME: &str = "external-skills-installed";
+const DEFAULT_SKILL_FILENAME: &str = "SKILL.md";
+const DEFAULT_INDEX_FILENAME: &str = "index.json";
 const DEFAULT_MAX_DOWNLOAD_BYTES: usize = 5 * 1024 * 1024;
 const HARD_MAX_DOWNLOAD_BYTES: usize = 20 * 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct InstalledSkillEntry {
+    skill_id: String,
+    display_name: String,
+    summary: String,
+    source_kind: String,
+    source_path: String,
+    install_path: String,
+    skill_md_path: String,
+    sha256: String,
+    installed_at_unix: u64,
+    active: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct InstalledSkillIndex {
+    skills: Vec<InstalledSkillEntry>,
+}
 
 #[derive(Debug, Clone, Default)]
 struct ExternalSkillsPolicyOverride {
@@ -175,13 +200,7 @@ pub(super) fn execute_external_skills_fetch_tool_with_config(
         ));
     }
 
-    let policy = resolve_effective_policy(config)?;
-    if !policy.enabled {
-        return Err(
-            "external skills runtime is disabled; enable `external_skills.enabled = true` first"
-                .to_owned(),
-        );
-    }
+    let policy = require_enabled_runtime_policy(config)?;
 
     if let Some(rule) = first_matching_domain_rule(&host, &policy.blocked_domains) {
         return Err(format!(
@@ -293,6 +312,275 @@ pub(super) fn execute_external_skills_fetch_tool_with_config(
     })
 }
 
+pub(super) fn execute_external_skills_install_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "external_skills.install payload must be an object".to_owned())?;
+    let raw_path = payload
+        .get("path")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "external_skills.install requires payload.path".to_owned())?;
+    let replace = payload
+        .get("replace")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let explicit_skill_id = payload
+        .get("skill_id")
+        .and_then(Value::as_str)
+        .map(str::trim);
+
+    require_enabled_runtime_policy(config)?;
+
+    let source_path = super::file::resolve_safe_file_path_with_config(raw_path, config)?;
+    let install_root = resolve_install_root(config);
+    fs::create_dir_all(&install_root).map_err(|error| {
+        format!(
+            "failed to create external skills install root {}: {error}",
+            install_root.display()
+        )
+    })?;
+
+    let (skill_root, source_kind) = if source_path.is_dir() {
+        let skill_root = resolve_skill_root(&source_path)?;
+        (skill_root, "directory")
+    } else {
+        let skill_root = extract_archive_to_staging(&source_path, &install_root)?;
+        (skill_root, "archive")
+    };
+
+    let skill_md_path = skill_root.join(DEFAULT_SKILL_FILENAME);
+    let skill_markdown = fs::read_to_string(&skill_md_path).map_err(|error| {
+        format!(
+            "failed to read installed skill source {}: {error}",
+            skill_md_path.display()
+        )
+    })?;
+    let skill_id = explicit_skill_id
+        .and_then(|value| (!value.is_empty()).then_some(value))
+        .map(normalize_skill_id)
+        .transpose()?
+        .unwrap_or_else(|| derive_skill_id(&skill_root));
+    let display_name = derive_skill_display_name(skill_markdown.as_str(), skill_id.as_str());
+    let summary = derive_skill_summary(skill_markdown.as_str());
+
+    let mut index = load_installed_skill_index(&install_root)?;
+    if !replace && index.skills.iter().any(|entry| entry.skill_id == skill_id) {
+        return Err(format!(
+            "external skill `{skill_id}` is already installed; pass payload.replace=true to replace it"
+        ));
+    }
+
+    let destination_root = install_root.join(skill_id.as_str());
+    if destination_root.exists() {
+        fs::remove_dir_all(&destination_root).map_err(|error| {
+            format!(
+                "failed to remove existing installed skill {}: {error}",
+                destination_root.display()
+            )
+        })?;
+    }
+    copy_dir_recursive(&skill_root, &destination_root)?;
+
+    let installed_skill_md_path = destination_root.join(DEFAULT_SKILL_FILENAME);
+    let installed_skill_markdown =
+        fs::read_to_string(&installed_skill_md_path).map_err(|error| {
+            format!(
+                "failed to verify installed skill {}: {error}",
+                installed_skill_md_path.display()
+            )
+        })?;
+    let digest = format!("{:x}", Sha256::digest(installed_skill_markdown.as_bytes()));
+    let installed_at_unix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+
+    index.skills.retain(|entry| entry.skill_id != skill_id);
+    index.skills.push(InstalledSkillEntry {
+        skill_id: skill_id.clone(),
+        display_name,
+        summary,
+        source_kind: source_kind.to_owned(),
+        source_path: source_path.display().to_string(),
+        install_path: destination_root.display().to_string(),
+        skill_md_path: installed_skill_md_path.display().to_string(),
+        sha256: digest.clone(),
+        installed_at_unix,
+        active: true,
+    });
+    persist_installed_skill_index(&install_root, &mut index)?;
+
+    if source_kind == "archive" {
+        fs::remove_dir_all(&skill_root).ok();
+    }
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": request.tool_name,
+            "skill_id": skill_id,
+            "source_kind": source_kind,
+            "source_path": source_path.display().to_string(),
+            "install_path": destination_root.display().to_string(),
+            "skill_md_path": installed_skill_md_path.display().to_string(),
+            "sha256": digest,
+            "replaced": replace,
+        }),
+    })
+}
+
+pub(super) fn execute_external_skills_list_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let install_root = resolve_install_root(config);
+    let index = load_installed_skill_index(&install_root)?;
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": request.tool_name,
+            "skills": index.skills,
+        }),
+    })
+}
+
+pub(super) fn execute_external_skills_inspect_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "external_skills.inspect payload must be an object".to_owned())?;
+    let skill_id = payload
+        .get("skill_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "external_skills.inspect requires payload.skill_id".to_owned())?;
+    let install_root = resolve_install_root(config);
+    let entry = installed_skill_by_id(&load_installed_skill_index(&install_root)?, skill_id)?;
+    let instructions = fs::read_to_string(&entry.skill_md_path).map_err(|error| {
+        format!(
+            "failed to read installed skill {}: {error}",
+            entry.skill_md_path
+        )
+    })?;
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": request.tool_name,
+            "skill": entry,
+            "instructions_preview": build_preview(instructions.as_str(), 240),
+        }),
+    })
+}
+
+pub(super) fn execute_external_skills_invoke_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "external_skills.invoke payload must be an object".to_owned())?;
+    let skill_id = payload
+        .get("skill_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "external_skills.invoke requires payload.skill_id".to_owned())?;
+
+    require_enabled_runtime_policy(config)?;
+
+    let install_root = resolve_install_root(config);
+    let entry = installed_skill_by_id(&load_installed_skill_index(&install_root)?, skill_id)?;
+    if !entry.active {
+        return Err(format!(
+            "external skill `{skill_id}` is installed but inactive"
+        ));
+    }
+    let instructions = fs::read_to_string(&entry.skill_md_path).map_err(|error| {
+        format!(
+            "failed to read installed skill {}: {error}",
+            entry.skill_md_path
+        )
+    })?;
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": request.tool_name,
+            "skill_id": entry.skill_id,
+            "display_name": entry.display_name,
+            "summary": entry.summary,
+            "install_path": entry.install_path,
+            "skill_md_path": entry.skill_md_path,
+            "instructions": instructions,
+            "invocation_summary": format!(
+                "Loaded external skill `{}`. Apply the instructions in `SKILL.md` before continuing the task.",
+                skill_id
+            ),
+        }),
+    })
+}
+
+pub(super) fn execute_external_skills_remove_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "external_skills.remove payload must be an object".to_owned())?;
+    let skill_id = payload
+        .get("skill_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "external_skills.remove requires payload.skill_id".to_owned())?;
+
+    let install_root = resolve_install_root(config);
+    let mut index = load_installed_skill_index(&install_root)?;
+    let Some(position) = index
+        .skills
+        .iter()
+        .position(|entry| entry.skill_id == skill_id)
+    else {
+        return Err(format!("external skill `{skill_id}` is not installed"));
+    };
+    let entry = index.skills.remove(position);
+    let install_path = PathBuf::from(entry.install_path.clone());
+    if install_path.exists() {
+        fs::remove_dir_all(&install_path).map_err(|error| {
+            format!(
+                "failed to remove installed skill {}: {error}",
+                install_path.display()
+            )
+        })?;
+    }
+    persist_installed_skill_index(&install_root, &mut index)?;
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": request.tool_name,
+            "skill_id": skill_id,
+            "removed": true,
+        }),
+    })
+}
+
 fn policy_override_store() -> &'static RwLock<ExternalSkillsPolicyOverride> {
     EXTERNAL_SKILLS_POLICY_OVERRIDE
         .get_or_init(|| RwLock::new(ExternalSkillsPolicyOverride::default()))
@@ -312,6 +600,19 @@ fn resolve_effective_policy(
         .read()
         .map_err(|error| format!("external skills policy lock poisoned: {error}"))?;
     Ok(build_effective_policy(config, &override_state))
+}
+
+fn require_enabled_runtime_policy(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<super::runtime_config::ExternalSkillsRuntimePolicy, String> {
+    let policy = resolve_effective_policy(config)?;
+    if !policy.enabled {
+        return Err(
+            "external skills runtime is disabled; enable `external_skills.enabled = true` first"
+                .to_owned(),
+        );
+    }
+    Ok(policy)
 }
 
 fn build_effective_policy(
@@ -555,17 +856,334 @@ fn split_stem_and_ext(filename: &str) -> (&str, &str) {
     (filename, "")
 }
 
+fn resolve_install_root(config: &super::runtime_config::ToolRuntimeConfig) -> PathBuf {
+    if let Some(path) = config.external_skills.install_root.clone() {
+        return path;
+    }
+    let root = config
+        .file_root
+        .clone()
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    root.join(DEFAULT_INSTALL_DIR_NAME)
+}
+
+fn resolve_skill_root(root: &Path) -> Result<PathBuf, String> {
+    if root.join(DEFAULT_SKILL_FILENAME).is_file() {
+        return Ok(root.to_path_buf());
+    }
+    let candidates = find_skill_roots(root)?;
+    match candidates.as_slice() {
+        [] => Err(format!(
+            "external skill source {} does not contain `{DEFAULT_SKILL_FILENAME}`",
+            root.display()
+        )),
+        [single] => Ok(single.clone()),
+        _ => Err(format!(
+            "external skill source {} contains multiple `{DEFAULT_SKILL_FILENAME}` roots; provide a more specific path",
+            root.display()
+        )),
+    }
+}
+
+fn extract_archive_to_staging(archive_path: &Path, install_root: &Path) -> Result<PathBuf, String> {
+    let filename = archive_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if !(filename.ends_with(".tgz") || filename.ends_with(".tar.gz")) {
+        return Err(format!(
+            "external skill archive {} must end with .tgz or .tar.gz",
+            archive_path.display()
+        ));
+    }
+
+    let staging_root = install_root.join(format!(
+        ".staging-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0)
+    ));
+    fs::create_dir_all(&staging_root).map_err(|error| {
+        format!(
+            "failed to create external skill staging directory {}: {error}",
+            staging_root.display()
+        )
+    })?;
+    let file = fs::File::open(archive_path).map_err(|error| {
+        format!(
+            "failed to open external skill archive {}: {error}",
+            archive_path.display()
+        )
+    })?;
+    let decoder = GzDecoder::new(file);
+    let mut archive = Archive::new(decoder);
+    for entry in archive.entries().map_err(|error| {
+        format!(
+            "failed to read external skill archive {}: {error}",
+            archive_path.display()
+        )
+    })? {
+        let mut entry = entry.map_err(|error| {
+            format!(
+                "failed to inspect external skill archive {}: {error}",
+                archive_path.display()
+            )
+        })?;
+        entry.unpack_in(&staging_root).map_err(|error| {
+            format!(
+                "failed to extract external skill archive {}: {error}",
+                archive_path.display()
+            )
+        })?;
+    }
+    resolve_skill_root(&staging_root)
+}
+
+fn find_skill_roots(root: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut roots = Vec::new();
+    visit_skill_roots(root, &mut roots)?;
+    roots.sort();
+    roots.dedup();
+    Ok(roots)
+}
+
+fn visit_skill_roots(root: &Path, roots: &mut Vec<PathBuf>) -> Result<(), String> {
+    let metadata = fs::metadata(root).map_err(|error| {
+        format!(
+            "failed to inspect external skill source {}: {error}",
+            root.display()
+        )
+    })?;
+    if !metadata.is_dir() {
+        return Ok(());
+    }
+    if root.join(DEFAULT_SKILL_FILENAME).is_file() {
+        roots.push(root.to_path_buf());
+        return Ok(());
+    }
+    for entry in fs::read_dir(root).map_err(|error| {
+        format!(
+            "failed to read external skill source {}: {error}",
+            root.display()
+        )
+    })? {
+        let entry = entry.map_err(|error| {
+            format!(
+                "failed to traverse external skill source {}: {error}",
+                root.display()
+            )
+        })?;
+        let path = entry.path();
+        if path.is_dir() {
+            visit_skill_roots(&path, roots)?;
+        }
+    }
+    Ok(())
+}
+
+fn derive_skill_id(root: &Path) -> String {
+    let fallback = root
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("external-skill");
+    normalize_skill_id(fallback).unwrap_or_else(|_| "external-skill".to_owned())
+}
+
+fn normalize_skill_id(raw: &str) -> Result<String, String> {
+    let mut normalized = String::new();
+    let mut last_dash = false;
+    for ch in raw.trim().chars() {
+        let mapped = if ch.is_ascii_alphanumeric() {
+            Some(ch.to_ascii_lowercase())
+        } else if matches!(ch, '-' | '_' | ' ' | '.') {
+            Some('-')
+        } else {
+            None
+        };
+        if let Some(value) = mapped {
+            if value == '-' {
+                if !last_dash {
+                    normalized.push(value);
+                }
+                last_dash = true;
+            } else {
+                normalized.push(value);
+                last_dash = false;
+            }
+        }
+    }
+    let normalized = normalized.trim_matches('-').to_owned();
+    if normalized.is_empty() {
+        return Err(format!("invalid external skill id `{raw}`"));
+    }
+    Ok(normalized)
+}
+
+fn derive_skill_display_name(skill_markdown: &str, fallback: &str) -> String {
+    for line in skill_markdown.lines() {
+        let trimmed = line.trim();
+        if let Some(title) = trimmed.strip_prefix("# ") {
+            let title = title.trim();
+            if !title.is_empty() {
+                return title.to_owned();
+            }
+        }
+    }
+    fallback.to_owned()
+}
+
+fn derive_skill_summary(skill_markdown: &str) -> String {
+    for line in skill_markdown.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        return build_preview(trimmed, 120);
+    }
+    "No summary provided.".to_owned()
+}
+
+fn build_preview(content: &str, max_chars: usize) -> String {
+    let char_count = content.chars().count();
+    if char_count <= max_chars {
+        return content.to_owned();
+    }
+    let mut out = String::new();
+    for ch in content.chars().take(max_chars) {
+        out.push(ch);
+    }
+    out.push_str("...");
+    out
+}
+
+fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<(), String> {
+    fs::create_dir_all(destination).map_err(|error| {
+        format!(
+            "failed to create external skill destination {}: {error}",
+            destination.display()
+        )
+    })?;
+    for entry in fs::read_dir(source).map_err(|error| {
+        format!(
+            "failed to read external skill source {}: {error}",
+            source.display()
+        )
+    })? {
+        let entry = entry.map_err(|error| {
+            format!(
+                "failed to traverse external skill source {}: {error}",
+                source.display()
+            )
+        })?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if source_path.is_dir() {
+            copy_dir_recursive(&source_path, &destination_path)?;
+        } else {
+            fs::copy(&source_path, &destination_path).map_err(|error| {
+                format!(
+                    "failed to copy external skill file {} to {}: {error}",
+                    source_path.display(),
+                    destination_path.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn load_installed_skill_index(root: &Path) -> Result<InstalledSkillIndex, String> {
+    let index_path = root.join(DEFAULT_INDEX_FILENAME);
+    if !index_path.exists() {
+        return Ok(InstalledSkillIndex::default());
+    }
+    let raw = fs::read_to_string(&index_path).map_err(|error| {
+        format!(
+            "failed to read external skills index {}: {error}",
+            index_path.display()
+        )
+    })?;
+    let mut index: InstalledSkillIndex = serde_json::from_str(raw.as_str()).map_err(|error| {
+        format!(
+            "failed to parse external skills index {}: {error}",
+            index_path.display()
+        )
+    })?;
+    index
+        .skills
+        .sort_by(|left, right| left.skill_id.cmp(&right.skill_id));
+    Ok(index)
+}
+
+fn persist_installed_skill_index(
+    root: &Path,
+    index: &mut InstalledSkillIndex,
+) -> Result<(), String> {
+    index
+        .skills
+        .sort_by(|left, right| left.skill_id.cmp(&right.skill_id));
+    fs::create_dir_all(root).map_err(|error| {
+        format!(
+            "failed to create external skills install root {}: {error}",
+            root.display()
+        )
+    })?;
+    let index_path = root.join(DEFAULT_INDEX_FILENAME);
+    let encoded = serde_json::to_string_pretty(index)
+        .map_err(|error| format!("failed to encode external skills index: {error}"))?;
+    fs::write(&index_path, encoded).map_err(|error| {
+        format!(
+            "failed to write external skills index {}: {error}",
+            index_path.display()
+        )
+    })
+}
+
+fn installed_skill_by_id(
+    index: &InstalledSkillIndex,
+    skill_id: &str,
+) -> Result<InstalledSkillEntry, String> {
+    index
+        .skills
+        .iter()
+        .find(|entry| entry.skill_id == skill_id)
+        .cloned()
+        .ok_or_else(|| format!("external skill `{skill_id}` is not installed"))
+}
+
+pub(super) fn installed_skill_snapshot_lines_with_config(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<Vec<String>, String> {
+    let policy = resolve_effective_policy(config)?;
+    if !policy.enabled || !policy.auto_expose_installed {
+        return Ok(Vec::new());
+    }
+    let install_root = resolve_install_root(config);
+    let index = load_installed_skill_index(&install_root)?;
+    Ok(index
+        .skills
+        .into_iter()
+        .filter(|entry| entry.active)
+        .map(|entry| format!("- {}: {}", entry.skill_id, entry.summary))
+        .collect())
+}
+
 fn policy_payload(policy: &super::runtime_config::ExternalSkillsRuntimePolicy) -> Value {
     json!({
         "enabled": policy.enabled,
         "require_download_approval": policy.require_download_approval,
         "allowed_domains": policy.allowed_domains.iter().cloned().collect::<Vec<_>>(),
         "blocked_domains": policy.blocked_domains.iter().cloned().collect::<Vec<_>>(),
+        "install_root": policy.install_root.as_ref().map(|path| path.display().to_string()),
+        "auto_expose_installed": policy.auto_expose_installed,
     })
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
     use std::sync::Mutex;
 
     use super::*;
@@ -596,6 +1214,39 @@ mod tests {
                 require_download_approval: true,
                 allowed_domains: BTreeSet::new(),
                 blocked_domains: BTreeSet::new(),
+                install_root: None,
+                auto_expose_installed: true,
+            },
+        }
+    }
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    fn write_file(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create fixture parent directory");
+        }
+        fs::write(path, content).expect("write fixture");
+    }
+
+    fn managed_runtime_config(root: &Path) -> ToolRuntimeConfig {
+        ToolRuntimeConfig {
+            shell_allowlist: BTreeSet::new(),
+            file_root: Some(root.to_path_buf()),
+            external_skills: ExternalSkillsRuntimePolicy {
+                enabled: true,
+                require_download_approval: true,
+                allowed_domains: BTreeSet::new(),
+                blocked_domains: BTreeSet::new(),
+                install_root: None,
+                auto_expose_installed: true,
             },
         }
     }
@@ -805,5 +1456,359 @@ mod tests {
             )
             .expect("reset policy should succeed");
         });
+    }
+
+    #[test]
+    fn install_from_directory_writes_managed_index_and_copy() {
+        let root = unique_temp_dir("loongclaw-ext-skill-install-dir");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "source/demo-skill/SKILL.md",
+            "# Demo Skill\n\nUse this skill when the task needs deployment discipline.\n",
+        );
+        let config = managed_runtime_config(&root);
+
+        let outcome = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("install should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["skill_id"], "demo-skill");
+        assert!(
+            root.join("external-skills-installed")
+                .join("index.json")
+                .exists(),
+            "managed external skill index should exist"
+        );
+        assert!(
+            root.join("external-skills-installed")
+                .join("demo-skill")
+                .join("SKILL.md")
+                .exists(),
+            "managed external skill copy should exist"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn install_requires_enabled_runtime() {
+        let root = unique_temp_dir("loongclaw-ext-skill-install-disabled");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "source/demo-skill/SKILL.md",
+            "# Demo Skill\n\nInstall should require enabled runtime.\n",
+        );
+        let mut config = managed_runtime_config(&root);
+        config.external_skills.enabled = false;
+
+        let error = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect_err("disabled runtime should block install");
+
+        assert!(error.contains("external skills runtime is disabled"));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn list_and_invoke_installed_skill_return_managed_metadata() {
+        let root = unique_temp_dir("loongclaw-ext-skill-list-invoke");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "source/demo-skill/SKILL.md",
+            "# Demo Skill\n\nPrefer explicit verification before completion.\n",
+        );
+        let config = managed_runtime_config(&root);
+
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("install should succeed");
+
+        let list_outcome = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.list".to_owned(),
+                payload: json!({}),
+            },
+            &config,
+        )
+        .expect("list should succeed");
+        assert_eq!(list_outcome.status, "ok");
+        assert_eq!(list_outcome.payload["skills"][0]["skill_id"], "demo-skill");
+
+        let invoke_outcome = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.invoke".to_owned(),
+                payload: json!({
+                    "skill_id": "demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("invoke should succeed");
+        assert_eq!(invoke_outcome.status, "ok");
+        assert_eq!(invoke_outcome.payload["skill_id"], "demo-skill");
+        assert!(
+            invoke_outcome.payload["instructions"]
+                .as_str()
+                .expect("instructions should be text")
+                .contains("Demo Skill")
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn invoke_requires_enabled_runtime() {
+        let root = unique_temp_dir("loongclaw-ext-skill-invoke-disabled");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "source/demo-skill/SKILL.md",
+            "# Demo Skill\n\nInvoke should require enabled runtime.\n",
+        );
+        let enabled_config = managed_runtime_config(&root);
+
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &enabled_config,
+        )
+        .expect("install should succeed");
+
+        let mut disabled_config = enabled_config.clone();
+        disabled_config.external_skills.enabled = false;
+        let error = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.invoke".to_owned(),
+                payload: json!({
+                    "skill_id": "demo-skill"
+                }),
+            },
+            &disabled_config,
+        )
+        .expect_err("disabled runtime should block invoke");
+
+        assert!(error.contains("external skills runtime is disabled"));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn remove_installed_skill_clears_managed_entry() {
+        let root = unique_temp_dir("loongclaw-ext-skill-remove");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "source/demo-skill/SKILL.md",
+            "# Demo Skill\n\nKeep output concise.\n",
+        );
+        let config = managed_runtime_config(&root);
+
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("install should succeed");
+
+        let remove_outcome = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.remove".to_owned(),
+                payload: json!({
+                    "skill_id": "demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("remove should succeed");
+        assert_eq!(remove_outcome.status, "ok");
+        assert_eq!(remove_outcome.payload["removed"], json!(true));
+
+        let list_outcome = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.list".to_owned(),
+                payload: json!({}),
+            },
+            &config,
+        )
+        .expect("list should succeed after remove");
+        assert_eq!(list_outcome.payload["skills"], json!([]));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn install_from_tar_gz_archive_extracts_wrapped_skill_root() {
+        let root = unique_temp_dir("loongclaw-ext-skill-install-archive");
+        fs::create_dir_all(&root).expect("create fixture root");
+        let archive_source_root = root.join("archive-src");
+        write_file(
+            &archive_source_root,
+            "bundle/demo-skill/SKILL.md",
+            "# Demo Skill\n\nArchive-installed skill.\n",
+        );
+        let archive_path = root.join("demo-skill.tar.gz");
+        {
+            let tar_gz = fs::File::create(&archive_path).expect("create archive");
+            let encoder = flate2::write::GzEncoder::new(tar_gz, flate2::Compression::default());
+            let mut tar = tar::Builder::new(encoder);
+            tar.append_dir_all("bundle", archive_source_root.join("bundle"))
+                .expect("append archive directory");
+            tar.finish().expect("finish archive");
+        }
+
+        let config = managed_runtime_config(&root);
+        let outcome = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "demo-skill.tar.gz"
+                }),
+            },
+            &config,
+        )
+        .expect("archive install should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["source_kind"], "archive");
+        assert!(
+            root.join("external-skills-installed")
+                .join("demo-skill")
+                .join("SKILL.md")
+                .exists()
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn inspect_returns_preview_and_missing_skill_md_is_rejected() {
+        let root = unique_temp_dir("loongclaw-ext-skill-inspect");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "source/demo-skill/SKILL.md",
+            "# Demo Skill\n\nInspectable skill content.\n",
+        );
+        let config = managed_runtime_config(&root);
+
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("install should succeed");
+
+        let inspect_outcome = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.inspect".to_owned(),
+                payload: json!({
+                    "skill_id": "demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("inspect should succeed");
+        assert_eq!(inspect_outcome.status, "ok");
+        assert!(
+            inspect_outcome.payload["instructions_preview"]
+                .as_str()
+                .expect("preview should exist")
+                .contains("Inspectable skill content")
+        );
+
+        let missing_root = unique_temp_dir("loongclaw-ext-skill-missing");
+        fs::create_dir_all(&missing_root).expect("create missing fixture root");
+        write_file(
+            &missing_root,
+            "source/not-a-skill/README.md",
+            "missing skill file",
+        );
+        let missing_config = managed_runtime_config(&missing_root);
+        let error = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/not-a-skill"
+                }),
+            },
+            &missing_config,
+        )
+        .expect_err("missing skill file should fail");
+        assert!(error.contains("SKILL.md"));
+
+        fs::remove_dir_all(&root).ok();
+        fs::remove_dir_all(&missing_root).ok();
+    }
+
+    #[test]
+    fn installed_skill_snapshot_is_hidden_when_runtime_is_disabled() {
+        let root = unique_temp_dir("loongclaw-ext-skill-snapshot-disabled");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "source/demo-skill/SKILL.md",
+            "# Demo Skill\n\nSnapshot should not auto-expose disabled runtime.\n",
+        );
+        let enabled_config = managed_runtime_config(&root);
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &enabled_config,
+        )
+        .expect("install should succeed");
+
+        let mut disabled_config = enabled_config.clone();
+        disabled_config.external_skills.enabled = false;
+
+        let lines = installed_skill_snapshot_lines_with_config(&disabled_config)
+            .expect("snapshot should succeed");
+        assert!(
+            lines.is_empty(),
+            "disabled runtime should not expose skills"
+        );
+
+        fs::remove_dir_all(&root).ok();
     }
 }

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -394,6 +394,7 @@ pub(super) fn execute_external_skills_install_tool_with_config(
     let summary = derive_skill_summary(skill_markdown.as_str());
 
     let mut index = load_installed_skill_index(&install_root)?;
+    let previous_index = index.clone();
     if !replace && index.skills.iter().any(|entry| entry.skill_id == skill_id) {
         return Err(format!(
             "external skill `{skill_id}` is already installed; pass payload.replace=true to replace it"
@@ -401,17 +402,12 @@ pub(super) fn execute_external_skills_install_tool_with_config(
     }
 
     let destination_root = managed_skill_install_path(&install_root, skill_id.as_str())?;
-    if destination_root.exists() {
-        fs::remove_dir_all(&destination_root).map_err(|error| {
-            format!(
-                "failed to remove existing installed skill {}: {error}",
-                destination_root.display()
-            )
-        })?;
-    }
-    copy_dir_recursive(&skill_root, &destination_root)?;
+    let incoming_root =
+        unique_managed_install_transition_path(&install_root, skill_id.as_str(), "incoming")?;
+    let _incoming_cleanup = ScopedDirCleanup::new(Some(incoming_root.clone()));
+    copy_dir_recursive(&skill_root, &incoming_root)?;
 
-    let installed_skill_md_path = destination_root.join(DEFAULT_SKILL_FILENAME);
+    let installed_skill_md_path = incoming_root.join(DEFAULT_SKILL_FILENAME);
     let installed_skill_markdown =
         fs::read_to_string(&installed_skill_md_path).map_err(|error| {
             format!(
@@ -433,12 +429,86 @@ pub(super) fn execute_external_skills_install_tool_with_config(
         source_kind: source_kind.to_owned(),
         source_path: source_path.display().to_string(),
         install_path: destination_root.display().to_string(),
-        skill_md_path: installed_skill_md_path.display().to_string(),
+        skill_md_path: destination_root
+            .join(DEFAULT_SKILL_FILENAME)
+            .display()
+            .to_string(),
         sha256: digest.clone(),
         installed_at_unix,
         active: true,
     });
-    persist_installed_skill_index(&install_root, &mut index)?;
+
+    let backup_root = if destination_root.exists() {
+        Some(unique_managed_install_transition_path(
+            &install_root,
+            skill_id.as_str(),
+            "backup",
+        )?)
+    } else {
+        None
+    };
+    if let Some(backup_root) = backup_root.as_ref() {
+        fs::rename(&destination_root, backup_root).map_err(|error| {
+            format!(
+                "failed to stage previous installed skill {} for replacement: {error}",
+                destination_root.display()
+            )
+        })?;
+    }
+
+    if let Err(error) = fs::rename(&incoming_root, &destination_root) {
+        if let Some(backup_root) = backup_root.as_ref() {
+            fs::rename(backup_root, &destination_root).ok();
+        }
+        return Err(format!(
+            "failed to activate managed external skill install {}: {error}",
+            destination_root.display()
+        ));
+    }
+
+    if let Err(error) = persist_installed_skill_index(&install_root, &mut index) {
+        let mut rollback_notes = vec![format!("failed to update external skills index: {error}")];
+
+        if destination_root.exists() {
+            fs::remove_dir_all(&destination_root).map_err(|remove_error| {
+                format!(
+                    "{}; rollback failed to remove incomplete install {}: {remove_error}",
+                    rollback_notes.join(""),
+                    destination_root.display()
+                )
+            })?;
+        }
+
+        if let Some(backup_root) = backup_root.as_ref() {
+            fs::rename(backup_root, &destination_root).map_err(|restore_error| {
+                format!(
+                    "{}; rollback failed to restore previous install from {}: {restore_error}",
+                    rollback_notes.join(""),
+                    backup_root.display()
+                )
+            })?;
+        }
+
+        let mut rollback_index = previous_index;
+        if let Err(restore_error) =
+            persist_installed_skill_index(&install_root, &mut rollback_index)
+        {
+            rollback_notes.push(format!(
+                "; rollback failed to restore previous index: {restore_error}"
+            ));
+        }
+
+        return Err(rollback_notes.join(""));
+    }
+
+    if let Some(backup_root) = backup_root {
+        fs::remove_dir_all(&backup_root).map_err(|error| {
+            format!(
+                "failed to remove replaced external skill backup {}: {error}",
+                backup_root.display()
+            )
+        })?;
+    }
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
@@ -449,7 +519,7 @@ pub(super) fn execute_external_skills_install_tool_with_config(
             "source_kind": source_kind,
             "source_path": source_path.display().to_string(),
             "install_path": destination_root.display().to_string(),
-            "skill_md_path": installed_skill_md_path.display().to_string(),
+            "skill_md_path": destination_root.join(DEFAULT_SKILL_FILENAME).display().to_string(),
             "sha256": digest,
             "replaced": replace,
         }),
@@ -877,6 +947,19 @@ fn unique_output_path(dir: &Path, filename: &str) -> PathBuf {
     } else {
         dir.join(format!("{stem}-{suffix}.{ext}"))
     }
+}
+
+fn unique_managed_install_transition_path(
+    install_root: &Path,
+    skill_id: &str,
+    phase: &str,
+) -> Result<PathBuf, String> {
+    let normalized_skill_id = normalize_skill_id(skill_id)?;
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    Ok(install_root.join(format!(".{phase}-{normalized_skill_id}-{nanos}")))
 }
 
 fn split_stem_and_ext(filename: &str) -> (&str, &str) {
@@ -1979,6 +2062,108 @@ mod tests {
         .expect("list should succeed after remove");
         assert_eq!(list_outcome.payload["skills"], json!([]));
 
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replace_failed_install_preserves_previous_managed_skill() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = unique_temp_dir("loongclaw-ext-skill-replace-rollback");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "source/demo-skill-v1/SKILL.md",
+            "# Demo Skill\n\nStable installed skill.\n",
+        );
+        write_file(
+            &root,
+            "source/demo-skill-v2/SKILL.md",
+            "# Demo Skill\n\nReplacement should fail safely.\n",
+        );
+        write_file(
+            &root,
+            "source/demo-skill-v2/private.txt",
+            "copy should fail on unreadable file",
+        );
+        let unreadable_path = root.join("source/demo-skill-v2/private.txt");
+        let mut perms = fs::metadata(&unreadable_path)
+            .expect("read metadata")
+            .permissions();
+        perms.set_mode(0o000);
+        fs::set_permissions(&unreadable_path, perms).expect("set unreadable permissions");
+
+        let config = managed_runtime_config(&root);
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill-v1",
+                    "skill_id": "demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("initial install should succeed");
+
+        let error = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill-v2",
+                    "skill_id": "demo-skill",
+                    "replace": true
+                }),
+            },
+            &config,
+        )
+        .expect_err("replacement install should fail");
+        assert!(
+            error.contains("failed to copy external skill file"),
+            "unexpected replacement failure: {error}"
+        );
+
+        let invoke_outcome = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.invoke".to_owned(),
+                payload: json!({
+                    "skill_id": "demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("previous install should remain available after failed replace");
+        assert!(
+            invoke_outcome.payload["instructions"]
+                .as_str()
+                .expect("instructions should be text")
+                .contains("Stable installed skill"),
+            "failed replace must preserve previous managed install"
+        );
+
+        let install_root = root.join("external-skills-installed");
+        let transient_entries = fs::read_dir(&install_root)
+            .expect("install root should exist")
+            .map(|entry| {
+                entry
+                    .expect("read install root entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .filter(|name| name.starts_with(".incoming-") || name.starts_with(".backup-"))
+            .collect::<Vec<_>>();
+        assert!(
+            transient_entries.is_empty(),
+            "failed replace must clean temporary directories: {transient_entries:?}"
+        );
+
+        let mut cleanup_perms = fs::metadata(&unreadable_path)
+            .expect("read metadata for cleanup")
+            .permissions();
+        cleanup_perms.set_mode(0o644);
+        fs::set_permissions(&unreadable_path, cleanup_perms).ok();
         fs::remove_dir_all(&root).ok();
     }
 

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -648,7 +648,7 @@ pub(super) fn execute_external_skills_remove_tool_with_config(
         return Err(format!("external skill `{skill_id}` is not installed"));
     };
     let entry = index.skills.remove(position);
-    let install_path = PathBuf::from(entry.install_path.clone());
+    let install_path = PathBuf::from(entry.install_path);
     if install_path.exists() {
         fs::remove_dir_all(&install_path).map_err(|error| {
             format!(
@@ -1891,7 +1891,7 @@ mod tests {
         )
         .expect("install should succeed");
 
-        let mut disabled_config = enabled_config.clone();
+        let mut disabled_config = enabled_config;
         disabled_config.external_skills.enabled = false;
 
         for (tool_name, payload) in [
@@ -1999,7 +1999,7 @@ mod tests {
         )
         .expect("install should succeed");
 
-        let mut disabled_config = enabled_config.clone();
+        let mut disabled_config = enabled_config;
         disabled_config.external_skills.enabled = false;
         let error = crate::tools::execute_tool_core_with_config(
             ToolCoreRequest {
@@ -2644,7 +2644,7 @@ mod tests {
         )
         .expect("install should succeed");
 
-        let mut disabled_config = enabled_config.clone();
+        let mut disabled_config = enabled_config;
         disabled_config.external_skills.enabled = false;
 
         let lines = installed_skill_snapshot_lines_with_config(&disabled_config)

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::BTreeSet,
     fs,
-    io::Read,
+    io::{ErrorKind, Read},
     path::{Path, PathBuf},
     sync::{OnceLock, RwLock},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -20,6 +20,7 @@ const DEFAULT_SKILL_FILENAME: &str = "SKILL.md";
 const DEFAULT_INDEX_FILENAME: &str = "index.json";
 const DEFAULT_MAX_DOWNLOAD_BYTES: usize = 5 * 1024 * 1024;
 const HARD_MAX_DOWNLOAD_BYTES: usize = 20 * 1024 * 1024;
+const INSTALLED_SKILL_SNAPSHOT_HINT: &str = "installed managed external skill; use external_skills.inspect or external_skills.invoke for details";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct InstalledSkillEntry {
@@ -346,12 +347,31 @@ pub(super) fn execute_external_skills_install_tool_with_config(
         )
     })?;
 
-    let (skill_root, source_kind) = if source_path.is_dir() {
+    let source_metadata = fs::symlink_metadata(&source_path).map_err(|error| {
+        format!(
+            "failed to inspect external skill source {}: {error}",
+            source_path.display()
+        )
+    })?;
+    let source_file_type = source_metadata.file_type();
+    if source_file_type.is_symlink() {
+        return Err(format!(
+            "external skill source {} cannot be a symlink",
+            source_path.display()
+        ));
+    }
+
+    let (skill_root, source_kind) = if source_file_type.is_dir() {
         let skill_root = resolve_skill_root(&source_path)?;
         (skill_root, "directory")
-    } else {
+    } else if source_file_type.is_file() {
         let skill_root = extract_archive_to_staging(&source_path, &install_root)?;
         (skill_root, "archive")
+    } else {
+        return Err(format!(
+            "external skill source {} must be a directory or a regular file",
+            source_path.display()
+        ));
     };
 
     let skill_md_path = skill_root.join(DEFAULT_SKILL_FILENAME);
@@ -376,7 +396,7 @@ pub(super) fn execute_external_skills_install_tool_with_config(
         ));
     }
 
-    let destination_root = install_root.join(skill_id.as_str());
+    let destination_root = managed_skill_install_path(&install_root, skill_id.as_str())?;
     if destination_root.exists() {
         fs::remove_dir_all(&destination_root).map_err(|error| {
             format!(
@@ -440,6 +460,7 @@ pub(super) fn execute_external_skills_list_tool_with_config(
     request: ToolCoreRequest,
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
+    require_enabled_runtime_policy(config)?;
     let install_root = resolve_install_root(config);
     let index = load_installed_skill_index(&install_root)?;
     Ok(ToolCoreOutcome {
@@ -466,6 +487,9 @@ pub(super) fn execute_external_skills_inspect_tool_with_config(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "external_skills.inspect requires payload.skill_id".to_owned())?;
+
+    require_enabled_runtime_policy(config)?;
+
     let install_root = resolve_install_root(config);
     let entry = installed_skill_by_id(&load_installed_skill_index(&install_root)?, skill_id)?;
     let instructions = fs::read_to_string(&entry.skill_md_path).map_err(|error| {
@@ -548,6 +572,8 @@ pub(super) fn execute_external_skills_remove_tool_with_config(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "external_skills.remove requires payload.skill_id".to_owned())?;
+
+    require_enabled_runtime_policy(config)?;
 
     let install_root = resolve_install_root(config);
     let mut index = load_installed_skill_index(&install_root)?;
@@ -868,7 +894,7 @@ fn resolve_install_root(config: &super::runtime_config::ToolRuntimeConfig) -> Pa
 }
 
 fn resolve_skill_root(root: &Path) -> Result<PathBuf, String> {
-    if root.join(DEFAULT_SKILL_FILENAME).is_file() {
+    if contains_regular_skill_markdown(root)? {
         return Ok(root.to_path_buf());
     }
     let candidates = find_skill_roots(root)?;
@@ -931,6 +957,19 @@ fn extract_archive_to_staging(archive_path: &Path, install_root: &Path) -> Resul
                 archive_path.display()
             )
         })?;
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_symlink() || entry_type.is_hard_link() {
+            return Err(format!(
+                "external skill archive {} cannot contain symlinks or hard links",
+                archive_path.display()
+            ));
+        }
+        if !(entry_type.is_dir() || entry_type.is_file()) {
+            return Err(format!(
+                "external skill archive {} contains unsupported entry types; only files and directories are allowed",
+                archive_path.display()
+            ));
+        }
         entry.unpack_in(&staging_root).map_err(|error| {
             format!(
                 "failed to extract external skill archive {}: {error}",
@@ -950,16 +989,29 @@ fn find_skill_roots(root: &Path) -> Result<Vec<PathBuf>, String> {
 }
 
 fn visit_skill_roots(root: &Path, roots: &mut Vec<PathBuf>) -> Result<(), String> {
-    let metadata = fs::metadata(root).map_err(|error| {
+    let metadata = fs::symlink_metadata(root).map_err(|error| {
         format!(
             "failed to inspect external skill source {}: {error}",
             root.display()
         )
     })?;
-    if !metadata.is_dir() {
-        return Ok(());
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        return Err(format!(
+            "external skill source {} cannot contain symlinks",
+            root.display()
+        ));
     }
-    if root.join(DEFAULT_SKILL_FILENAME).is_file() {
+    if !file_type.is_dir() {
+        if file_type.is_file() {
+            return Ok(());
+        }
+        return Err(format!(
+            "external skill source {} contains unsupported file types",
+            root.display()
+        ));
+    }
+    if contains_regular_skill_markdown(root)? {
         roots.push(root.to_path_buf());
         return Ok(());
     }
@@ -976,8 +1028,26 @@ fn visit_skill_roots(root: &Path, roots: &mut Vec<PathBuf>) -> Result<(), String
             )
         })?;
         let path = entry.path();
-        if path.is_dir() {
+        let metadata = fs::symlink_metadata(&path).map_err(|error| {
+            format!(
+                "failed to inspect external skill source {}: {error}",
+                path.display()
+            )
+        })?;
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
+            return Err(format!(
+                "external skill source {} cannot contain symlinks",
+                path.display()
+            ));
+        }
+        if file_type.is_dir() {
             visit_skill_roots(&path, roots)?;
+        } else if !file_type.is_file() {
+            return Err(format!(
+                "external skill source {} contains unsupported file types",
+                path.display()
+            ));
         }
     }
     Ok(())
@@ -1059,6 +1129,25 @@ fn build_preview(content: &str, max_chars: usize) -> String {
 }
 
 fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(source).map_err(|error| {
+        format!(
+            "failed to inspect external skill source {}: {error}",
+            source.display()
+        )
+    })?;
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        return Err(format!(
+            "external skill source {} cannot contain symlinks",
+            source.display()
+        ));
+    }
+    if !file_type.is_dir() {
+        return Err(format!(
+            "external skill source {} must be a directory during install copy",
+            source.display()
+        ));
+    }
     fs::create_dir_all(destination).map_err(|error| {
         format!(
             "failed to create external skill destination {}: {error}",
@@ -1079,9 +1168,22 @@ fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<(), String> {
         })?;
         let source_path = entry.path();
         let destination_path = destination.join(entry.file_name());
-        if source_path.is_dir() {
+        let metadata = fs::symlink_metadata(&source_path).map_err(|error| {
+            format!(
+                "failed to inspect external skill source {}: {error}",
+                source_path.display()
+            )
+        })?;
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
+            return Err(format!(
+                "external skill source {} cannot contain symlinks",
+                source_path.display()
+            ));
+        }
+        if file_type.is_dir() {
             copy_dir_recursive(&source_path, &destination_path)?;
-        } else {
+        } else if file_type.is_file() {
             fs::copy(&source_path, &destination_path).map_err(|error| {
                 format!(
                     "failed to copy external skill file {} to {}: {error}",
@@ -1089,6 +1191,11 @@ fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<(), String> {
                     destination_path.display()
                 )
             })?;
+        } else {
+            return Err(format!(
+                "external skill source {} contains unsupported file types",
+                source_path.display()
+            ));
         }
     }
     Ok(())
@@ -1111,6 +1218,11 @@ fn load_installed_skill_index(root: &Path) -> Result<InstalledSkillIndex, String
             index_path.display()
         )
     })?;
+    index.skills = index
+        .skills
+        .into_iter()
+        .map(|entry| normalize_loaded_skill_entry(root, entry))
+        .collect::<Result<Vec<_>, _>>()?;
     index
         .skills
         .sort_by(|left, right| left.skill_id.cmp(&right.skill_id));
@@ -1166,8 +1278,64 @@ pub(super) fn installed_skill_snapshot_lines_with_config(
         .skills
         .into_iter()
         .filter(|entry| entry.active)
-        .map(|entry| format!("- {}: {}", entry.skill_id, entry.summary))
+        .map(|entry| format!("- {}: {}", entry.skill_id, INSTALLED_SKILL_SNAPSHOT_HINT))
         .collect())
+}
+
+fn contains_regular_skill_markdown(root: &Path) -> Result<bool, String> {
+    let skill_md_path = root.join(DEFAULT_SKILL_FILENAME);
+    let metadata = match fs::symlink_metadata(&skill_md_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(format!(
+                "failed to inspect external skill source {}: {error}",
+                skill_md_path.display()
+            ));
+        }
+    };
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        return Err(format!(
+            "external skill source {} cannot use a symlinked `{DEFAULT_SKILL_FILENAME}`",
+            root.display()
+        ));
+    }
+    if !file_type.is_file() {
+        return Err(format!(
+            "external skill source {} must contain a regular `{DEFAULT_SKILL_FILENAME}` file",
+            root.display()
+        ));
+    }
+    Ok(true)
+}
+
+fn normalize_loaded_skill_entry(
+    install_root: &Path,
+    mut entry: InstalledSkillEntry,
+) -> Result<InstalledSkillEntry, String> {
+    let normalized_skill_id = normalize_skill_id(entry.skill_id.as_str())?;
+    if normalized_skill_id != entry.skill_id {
+        return Err(format!(
+            "external skills index contains non-normalized skill id `{}`",
+            entry.skill_id
+        ));
+    }
+    let install_path = managed_skill_install_path(install_root, entry.skill_id.as_str())?;
+    let skill_md_path = install_path.join(DEFAULT_SKILL_FILENAME);
+    entry.install_path = install_path.display().to_string();
+    entry.skill_md_path = skill_md_path.display().to_string();
+    Ok(entry)
+}
+
+fn managed_skill_install_path(install_root: &Path, skill_id: &str) -> Result<PathBuf, String> {
+    let normalized_skill_id = normalize_skill_id(skill_id)?;
+    if normalized_skill_id != skill_id {
+        return Err(format!(
+            "external skill id `{skill_id}` must be normalized before path resolution"
+        ));
+    }
+    Ok(install_root.join(skill_id))
 }
 
 fn policy_payload(policy: &super::runtime_config::ExternalSkillsRuntimePolicy) -> Value {
@@ -1528,6 +1696,59 @@ mod tests {
     }
 
     #[test]
+    fn list_inspect_and_remove_require_enabled_runtime() {
+        let root = unique_temp_dir("loongclaw-ext-skill-disabled-management");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "source/demo-skill/SKILL.md",
+            "# Demo Skill\n\nManagement operations should require enabled runtime.\n",
+        );
+        let enabled_config = managed_runtime_config(&root);
+
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &enabled_config,
+        )
+        .expect("install should succeed");
+
+        let mut disabled_config = enabled_config.clone();
+        disabled_config.external_skills.enabled = false;
+
+        for (tool_name, payload) in [
+            ("external_skills.list", json!({})),
+            (
+                "external_skills.inspect",
+                json!({ "skill_id": "demo-skill" }),
+            ),
+            (
+                "external_skills.remove",
+                json!({ "skill_id": "demo-skill" }),
+            ),
+        ] {
+            let error = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: tool_name.to_owned(),
+                    payload,
+                },
+                &disabled_config,
+            )
+            .expect_err("disabled runtime should block lifecycle management");
+            assert!(
+                error.contains("external skills runtime is disabled"),
+                "unexpected error for {tool_name}: {error}"
+            );
+        }
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
     fn list_and_invoke_installed_skill_return_managed_metadata() {
         let root = unique_temp_dir("loongclaw-ext-skill-list-invoke");
         fs::create_dir_all(&root).expect("create fixture root");
@@ -1671,6 +1892,92 @@ mod tests {
     }
 
     #[test]
+    fn tampered_index_paths_do_not_escape_managed_install_root() {
+        let root = unique_temp_dir("loongclaw-ext-skill-index-tamper");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "source/demo-skill/SKILL.md",
+            "# Demo Skill\n\nInspectable managed content.\n",
+        );
+        let config = managed_runtime_config(&root);
+
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("install should succeed");
+
+        let install_root = root.join("external-skills-installed");
+        let index_path = install_root.join("index.json");
+        let escape_root = unique_temp_dir("loongclaw-ext-skill-index-escape");
+        fs::create_dir_all(&escape_root).expect("create escape root");
+        write_file(
+            &escape_root,
+            "SKILL.md",
+            "# Escape Skill\n\nDo not trust me.\n",
+        );
+
+        let mut index: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&index_path).expect("read index"))
+                .expect("parse index");
+        index["skills"][0]["install_path"] = json!(escape_root.display().to_string());
+        index["skills"][0]["skill_md_path"] =
+            json!(escape_root.join("SKILL.md").display().to_string());
+        fs::write(
+            &index_path,
+            serde_json::to_string_pretty(&index).expect("encode tampered index"),
+        )
+        .expect("write tampered index");
+
+        let inspect_outcome = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.inspect".to_owned(),
+                payload: json!({
+                    "skill_id": "demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("inspect should stay inside managed root");
+        assert!(
+            inspect_outcome.payload["instructions_preview"]
+                .as_str()
+                .expect("preview should exist")
+                .contains("Inspectable managed content"),
+            "inspect should read the managed skill content"
+        );
+
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.remove".to_owned(),
+                payload: json!({
+                    "skill_id": "demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("remove should stay inside managed root");
+
+        assert!(
+            escape_root.exists(),
+            "tampered install path outside managed root must not be removed"
+        );
+        assert!(
+            !install_root.join("demo-skill").exists(),
+            "managed install should be removed"
+        );
+
+        fs::remove_dir_all(&root).ok();
+        fs::remove_dir_all(&escape_root).ok();
+    }
+
+    #[test]
     fn install_from_tar_gz_archive_extracts_wrapped_skill_root() {
         let root = unique_temp_dir("loongclaw-ext-skill-install-archive");
         fs::create_dir_all(&root).expect("create fixture root");
@@ -1710,6 +2017,60 @@ mod tests {
                 .join("SKILL.md")
                 .exists()
         );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn install_from_archive_rejects_symlink_entries() {
+        let root = unique_temp_dir("loongclaw-ext-skill-archive-symlink");
+        fs::create_dir_all(&root).expect("create fixture root");
+        let archive_path = root.join("demo-skill.tar.gz");
+        {
+            let tar_gz = fs::File::create(&archive_path).expect("create archive");
+            let encoder = flate2::write::GzEncoder::new(tar_gz, flate2::Compression::default());
+            let mut tar = tar::Builder::new(encoder);
+
+            let skill_bytes = b"# Demo Skill\n\nArchive symlink should fail.\n";
+            let mut skill_header = tar::Header::new_gnu();
+            skill_header
+                .set_path("bundle/demo-skill/SKILL.md")
+                .expect("set skill path");
+            skill_header.set_size(skill_bytes.len() as u64);
+            skill_header.set_mode(0o644);
+            skill_header.set_cksum();
+            tar.append(&skill_header, &skill_bytes[..])
+                .expect("append skill file");
+
+            let mut symlink_header = tar::Header::new_gnu();
+            symlink_header
+                .set_path("bundle/demo-skill/leak.txt")
+                .expect("set symlink path");
+            symlink_header.set_entry_type(tar::EntryType::Symlink);
+            symlink_header
+                .set_link_name("/etc/passwd")
+                .expect("set symlink target");
+            symlink_header.set_size(0);
+            symlink_header.set_mode(0o777);
+            symlink_header.set_cksum();
+            tar.append(&symlink_header, std::io::empty())
+                .expect("append symlink");
+
+            tar.finish().expect("finish archive");
+        }
+
+        let config = managed_runtime_config(&root);
+        let error = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "demo-skill.tar.gz"
+                }),
+            },
+            &config,
+        )
+        .expect_err("archive symlink should be rejected");
+        assert!(error.contains("cannot contain symlinks or hard links"));
 
         fs::remove_dir_all(&root).ok();
     }
@@ -1776,6 +2137,36 @@ mod tests {
 
         fs::remove_dir_all(&root).ok();
         fs::remove_dir_all(&missing_root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_rejects_symlinked_skill_markdown() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_temp_dir("loongclaw-ext-skill-symlinked-skill-md");
+        fs::create_dir_all(root.join("source/demo-skill")).expect("create skill directory");
+        write_file(&root, "outside.md", "# Outside\n\nDo not follow.\n");
+        symlink(
+            root.join("outside.md"),
+            root.join("source/demo-skill").join("SKILL.md"),
+        )
+        .expect("create symlink");
+
+        let config = managed_runtime_config(&root);
+        let error = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect_err("symlinked skill markdown should be rejected");
+        assert!(error.contains("symlink"));
+
+        fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -118,7 +118,7 @@ pub(super) fn execute_file_write_tool_with_config(
 }
 
 #[cfg(feature = "tool-file")]
-fn resolve_safe_file_path_with_config(
+pub(super) fn resolve_safe_file_path_with_config(
     raw: &str,
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<PathBuf, String> {

--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "tool-file")]
 use std::{
     ffi::OsString,
     fs,
@@ -117,7 +116,6 @@ pub(super) fn execute_file_write_tool_with_config(
     }
 }
 
-#[cfg(feature = "tool-file")]
 pub(super) fn resolve_safe_file_path_with_config(
     raw: &str,
     config: &super::runtime_config::ToolRuntimeConfig,
@@ -138,7 +136,6 @@ pub(super) fn resolve_safe_file_path_with_config(
     resolve_path_within_root(&root, &normalized)
 }
 
-#[cfg(feature = "tool-file")]
 fn canonicalize_or_fallback(path: PathBuf) -> Result<PathBuf, String> {
     if path.exists() {
         return fs::canonicalize(&path)
@@ -147,7 +144,6 @@ fn canonicalize_or_fallback(path: PathBuf) -> Result<PathBuf, String> {
     Ok(normalize_without_fs_access(&path))
 }
 
-#[cfg(feature = "tool-file")]
 fn resolve_path_within_root(root: &Path, normalized: &Path) -> Result<PathBuf, String> {
     ensure_path_within_root(root, normalized)?;
 
@@ -179,7 +175,6 @@ fn resolve_path_within_root(root: &Path, normalized: &Path) -> Result<PathBuf, S
     Ok(reconstructed)
 }
 
-#[cfg(feature = "tool-file")]
 fn ensure_path_within_root(root: &Path, path: &Path) -> Result<(), String> {
     if path.starts_with(root) {
         return Ok(());
@@ -191,7 +186,6 @@ fn ensure_path_within_root(root: &Path, path: &Path) -> Result<(), String> {
     ))
 }
 
-#[cfg(feature = "tool-file")]
 fn split_existing_ancestor(path: &Path) -> Result<(PathBuf, Vec<OsString>), String> {
     let mut cursor = path.to_path_buf();
     let mut suffix = Vec::new();
@@ -219,7 +213,6 @@ fn split_existing_ancestor(path: &Path) -> Result<(PathBuf, Vec<OsString>), Stri
     }
 }
 
-#[cfg(feature = "tool-file")]
 fn normalize_without_fs_access(path: &Path) -> PathBuf {
     let mut parts = Vec::new();
     for component in path.components() {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -44,8 +44,13 @@ pub fn execute_tool_core(request: ToolCoreRequest) -> Result<ToolCoreOutcome, St
 pub fn canonical_tool_name(raw: &str) -> &str {
     match raw {
         "claw_import" | "import_claw" => "claw.import",
+        "external_skills_inspect" => "external_skills.inspect",
+        "external_skills_install" => "external_skills.install",
+        "external_skills_invoke" => "external_skills.invoke",
+        "external_skills_list" => "external_skills.list",
         "external_skills_policy" => "external_skills.policy",
         "external_skills_fetch" => "external_skills.fetch",
+        "external_skills_remove" => "external_skills.remove",
         "file_read" => "file.read",
         "file_write" => "file.write",
         "shell_exec" | "shell" => "shell.exec",
@@ -57,8 +62,13 @@ pub fn is_known_tool_name(raw: &str) -> bool {
     matches!(
         canonical_tool_name(raw),
         "claw.import"
+            | "external_skills.inspect"
+            | "external_skills.install"
+            | "external_skills.invoke"
+            | "external_skills.list"
             | "external_skills.policy"
             | "external_skills.fetch"
+            | "external_skills.remove"
             | "shell.exec"
             | "file.read"
             | "file.write"
@@ -76,11 +86,26 @@ pub fn execute_tool_core_with_config(
     };
     match canonical_name {
         "claw.import" => claw_import::execute_claw_import_tool_with_config(request, config),
+        "external_skills.inspect" => {
+            external_skills::execute_external_skills_inspect_tool_with_config(request, config)
+        }
+        "external_skills.install" => {
+            external_skills::execute_external_skills_install_tool_with_config(request, config)
+        }
+        "external_skills.invoke" => {
+            external_skills::execute_external_skills_invoke_tool_with_config(request, config)
+        }
+        "external_skills.list" => {
+            external_skills::execute_external_skills_list_tool_with_config(request, config)
+        }
         "external_skills.policy" => {
             external_skills::execute_external_skills_policy_tool_with_config(request, config)
         }
         "external_skills.fetch" => {
             external_skills::execute_external_skills_fetch_tool_with_config(request, config)
+        }
+        "external_skills.remove" => {
+            external_skills::execute_external_skills_remove_tool_with_config(request, config)
         }
         "shell.exec" => shell::execute_shell_tool_with_config(request, config),
         "file.read" => file::execute_file_read_tool_with_config(request, config),
@@ -111,8 +136,28 @@ pub fn tool_registry() -> Vec<ToolRegistryEntry> {
         description: "Download external skills artifacts with domain policy and approval guards",
     });
     entries.push(ToolRegistryEntry {
+        name: "external_skills.inspect",
+        description: "Read metadata for an installed external skill",
+    });
+    entries.push(ToolRegistryEntry {
+        name: "external_skills.install",
+        description: "Install a managed external skill from a local directory or archive",
+    });
+    entries.push(ToolRegistryEntry {
+        name: "external_skills.invoke",
+        description: "Load an installed external skill into the conversation loop",
+    });
+    entries.push(ToolRegistryEntry {
+        name: "external_skills.list",
+        description: "List managed external skills available for invocation",
+    });
+    entries.push(ToolRegistryEntry {
         name: "external_skills.policy",
         description: "Read/update external skills domain allow/block policy at runtime",
+    });
+    entries.push(ToolRegistryEntry {
+        name: "external_skills.remove",
+        description: "Remove an installed external skill from the managed runtime",
     });
     #[cfg(feature = "tool-file")]
     {
@@ -139,10 +184,21 @@ pub fn tool_registry() -> Vec<ToolRegistryEntry> {
 /// Produce a deterministic text block listing available tools,
 /// suitable for appending to the system prompt.
 pub fn capability_snapshot() -> String {
+    capability_snapshot_with_config(runtime_config::get_tool_runtime_config())
+}
+
+pub fn capability_snapshot_with_config(config: &runtime_config::ToolRuntimeConfig) -> String {
     let entries = tool_registry();
     let mut lines = vec!["[available_tools]".to_owned()];
     for entry in &entries {
         lines.push(format!("- {}: {}", entry.name, entry.description));
+    }
+    if let Ok(skill_lines) = external_skills::installed_skill_snapshot_lines_with_config(config)
+        && !skill_lines.is_empty()
+    {
+        lines.push(String::new());
+        lines.push("[available_external_skills]".to_owned());
+        lines.extend(skill_lines);
     }
     lines.join("\n")
 }
@@ -295,6 +351,104 @@ pub fn provider_tool_definitions() -> Vec<Value> {
                     }
                 },
                 "required": ["url"],
+                "additionalProperties": false
+            }
+        }
+    }));
+
+    tools.push(json!({
+        "type": "function",
+        "function": {
+            "name": "external_skills_inspect",
+            "description": "Read metadata and a short preview for an installed external skill.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "skill_id": {
+                        "type": "string",
+                        "description": "Managed external skill identifier."
+                    }
+                },
+                "required": ["skill_id"],
+                "additionalProperties": false
+            }
+        }
+    }));
+
+    tools.push(json!({
+        "type": "function",
+        "function": {
+            "name": "external_skills_install",
+            "description": "Install a managed external skill from a local directory or local .tgz/.tar.gz archive under the configured file root.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to a local directory containing SKILL.md or a local .tgz/.tar.gz archive."
+                    },
+                    "skill_id": {
+                        "type": "string",
+                        "description": "Optional explicit managed skill id override."
+                    },
+                    "replace": {
+                        "type": "boolean",
+                        "description": "Replace an existing installed skill with the same id. Defaults to false."
+                    }
+                },
+                "required": ["path"],
+                "additionalProperties": false
+            }
+        }
+    }));
+
+    tools.push(json!({
+        "type": "function",
+        "function": {
+            "name": "external_skills_invoke",
+            "description": "Load an installed external skill's SKILL.md instructions into the conversation loop.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "skill_id": {
+                        "type": "string",
+                        "description": "Managed external skill identifier."
+                    }
+                },
+                "required": ["skill_id"],
+                "additionalProperties": false
+            }
+        }
+    }));
+
+    tools.push(json!({
+        "type": "function",
+        "function": {
+            "name": "external_skills_list",
+            "description": "List managed external skills available for invocation.",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+                "additionalProperties": false
+            }
+        }
+    }));
+
+    tools.push(json!({
+        "type": "function",
+        "function": {
+            "name": "external_skills_remove",
+            "description": "Remove an installed external skill from the managed runtime.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "skill_id": {
+                        "type": "string",
+                        "description": "Managed external skill identifier."
+                    }
+                },
+                "required": ["skill_id"],
                 "additionalProperties": false
             }
         }
@@ -464,6 +618,68 @@ mod tests {
         assert_eq!(snapshot, snapshot2);
     }
 
+    #[test]
+    fn capability_snapshot_can_include_installed_external_skills() {
+        use std::{
+            fs,
+            path::{Path, PathBuf},
+            time::{SystemTime, UNIX_EPOCH},
+        };
+
+        fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        }
+
+        fn write_file(root: &Path, relative: &str, content: &str) {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent directory");
+            }
+            fs::write(path, content).expect("write fixture");
+        }
+
+        let root = unique_temp_dir("loongclaw-tool-capability-snapshot-skills");
+        fs::create_dir_all(&root).expect("create fixture root");
+        write_file(
+            &root,
+            "skills/demo-skill/SKILL.md",
+            "# Demo Skill\n\nUse this skill for explicit verification.\n",
+        );
+
+        let config = runtime_config::ToolRuntimeConfig {
+            shell_allowlist: BTreeSet::new(),
+            file_root: Some(root.clone()),
+            external_skills: runtime_config::ExternalSkillsRuntimePolicy {
+                enabled: true,
+                require_download_approval: true,
+                allowed_domains: BTreeSet::new(),
+                blocked_domains: BTreeSet::new(),
+                install_root: None,
+                auto_expose_installed: true,
+            },
+        };
+        execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "skills/demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("install should succeed");
+
+        let snapshot = capability_snapshot_with_config(&config);
+        assert!(snapshot.contains("[available_external_skills]"));
+        assert!(snapshot.contains("- demo-skill: Use this skill for explicit verification."));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn capability_snapshot_lists_all_tools_when_all_features_enabled() {
@@ -474,31 +690,56 @@ mod tests {
             )
         );
         assert!(snapshot.contains("- external_skills.fetch: Download external skills artifacts with domain policy and approval guards"));
+        assert!(snapshot.contains("- external_skills.install: Install a managed external skill from a local directory or archive"));
+        assert!(
+            snapshot.contains(
+                "- external_skills.inspect: Read metadata for an installed external skill"
+            )
+        );
+        assert!(snapshot.contains(
+            "- external_skills.invoke: Load an installed external skill into the conversation loop"
+        ));
+        assert!(snapshot.contains(
+            "- external_skills.list: List managed external skills available for invocation"
+        ));
         assert!(snapshot.contains("- external_skills.policy: Read/update external skills domain allow/block policy at runtime"));
+        assert!(snapshot.contains(
+            "- external_skills.remove: Remove an installed external skill from the managed runtime"
+        ));
         assert!(snapshot.contains("- file.read: Read file contents"));
         assert!(snapshot.contains("- file.write: Write file contents"));
         assert!(snapshot.contains("- shell.exec: Execute shell commands"));
 
         // Verify sorted order: claw.import < external_skills.* < file.* < shell.exec
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 6);
+        assert_eq!(lines.len(), 11);
         assert!(lines[0].starts_with("- claw.import"));
         assert!(lines[1].starts_with("- external_skills.fetch"));
-        assert!(lines[2].starts_with("- external_skills.policy"));
-        assert!(lines[3].starts_with("- file.read"));
-        assert!(lines[4].starts_with("- file.write"));
-        assert!(lines[5].starts_with("- shell.exec"));
+        assert!(lines[2].starts_with("- external_skills.inspect"));
+        assert!(lines[3].starts_with("- external_skills.install"));
+        assert!(lines[4].starts_with("- external_skills.invoke"));
+        assert!(lines[5].starts_with("- external_skills.list"));
+        assert!(lines[6].starts_with("- external_skills.policy"));
+        assert!(lines[7].starts_with("- external_skills.remove"));
+        assert!(lines[8].starts_with("- file.read"));
+        assert!(lines[9].starts_with("- file.write"));
+        assert!(lines[10].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 6);
+        assert_eq!(entries.len(), 11);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"claw.import"));
         assert!(names.contains(&"external_skills.fetch"));
+        assert!(names.contains(&"external_skills.install"));
+        assert!(names.contains(&"external_skills.inspect"));
+        assert!(names.contains(&"external_skills.invoke"));
+        assert!(names.contains(&"external_skills.list"));
         assert!(names.contains(&"external_skills.policy"));
+        assert!(names.contains(&"external_skills.remove"));
         assert!(names.contains(&"shell.exec"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
@@ -508,7 +749,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 6);
+        assert_eq!(defs.len(), 11);
 
         let names: Vec<&str> = defs
             .iter()
@@ -521,7 +762,12 @@ mod tests {
             vec![
                 "claw_import",
                 "external_skills_fetch",
+                "external_skills_inspect",
+                "external_skills_install",
+                "external_skills_invoke",
+                "external_skills_list",
                 "external_skills_policy",
+                "external_skills_remove",
                 "file_read",
                 "file_write",
                 "shell_exec"
@@ -582,6 +828,26 @@ mod tests {
             canonical_tool_name("external_skills_fetch"),
             "external_skills.fetch"
         );
+        assert_eq!(
+            canonical_tool_name("external_skills_install"),
+            "external_skills.install"
+        );
+        assert_eq!(
+            canonical_tool_name("external_skills_list"),
+            "external_skills.list"
+        );
+        assert_eq!(
+            canonical_tool_name("external_skills_inspect"),
+            "external_skills.inspect"
+        );
+        assert_eq!(
+            canonical_tool_name("external_skills_invoke"),
+            "external_skills.invoke"
+        );
+        assert_eq!(
+            canonical_tool_name("external_skills_remove"),
+            "external_skills.remove"
+        );
         assert_eq!(canonical_tool_name("file_read"), "file.read");
         assert_eq!(canonical_tool_name("file_write"), "file.write");
         assert_eq!(canonical_tool_name("shell_exec"), "shell.exec");
@@ -597,6 +863,16 @@ mod tests {
         assert!(is_known_tool_name("external_skills_policy"));
         assert!(is_known_tool_name("external_skills.fetch"));
         assert!(is_known_tool_name("external_skills_fetch"));
+        assert!(is_known_tool_name("external_skills.install"));
+        assert!(is_known_tool_name("external_skills_install"));
+        assert!(is_known_tool_name("external_skills.list"));
+        assert!(is_known_tool_name("external_skills_list"));
+        assert!(is_known_tool_name("external_skills.inspect"));
+        assert!(is_known_tool_name("external_skills_inspect"));
+        assert!(is_known_tool_name("external_skills.invoke"));
+        assert!(is_known_tool_name("external_skills_invoke"));
+        assert!(is_known_tool_name("external_skills.remove"));
+        assert!(is_known_tool_name("external_skills_remove"));
         assert!(is_known_tool_name("file.read"));
         assert!(is_known_tool_name("file_read"));
         assert!(is_known_tool_name("file.write"));

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -126,39 +126,40 @@ pub struct ToolRegistryEntry {
 
 /// Returns a sorted list of all registered tools, gated by feature flags.
 pub fn tool_registry() -> Vec<ToolRegistryEntry> {
-    let mut entries = Vec::new();
-    entries.push(ToolRegistryEntry {
-        name: "claw.import",
-        description: "Import legacy Claw configs into native LoongClaw settings",
-    });
-    entries.push(ToolRegistryEntry {
-        name: "external_skills.fetch",
-        description: "Download external skills artifacts with domain policy and approval guards",
-    });
-    entries.push(ToolRegistryEntry {
-        name: "external_skills.inspect",
-        description: "Read metadata for an installed external skill",
-    });
-    entries.push(ToolRegistryEntry {
-        name: "external_skills.install",
-        description: "Install a managed external skill from a local directory or archive",
-    });
-    entries.push(ToolRegistryEntry {
-        name: "external_skills.invoke",
-        description: "Load an installed external skill into the conversation loop",
-    });
-    entries.push(ToolRegistryEntry {
-        name: "external_skills.list",
-        description: "List managed external skills available for invocation",
-    });
-    entries.push(ToolRegistryEntry {
-        name: "external_skills.policy",
-        description: "Read/update external skills domain allow/block policy at runtime",
-    });
-    entries.push(ToolRegistryEntry {
-        name: "external_skills.remove",
-        description: "Remove an installed external skill from the managed runtime",
-    });
+    let mut entries = vec![
+        ToolRegistryEntry {
+            name: "claw.import",
+            description: "Import legacy Claw configs into native LoongClaw settings",
+        },
+        ToolRegistryEntry {
+            name: "external_skills.fetch",
+            description: "Download external skills artifacts with domain policy and approval guards",
+        },
+        ToolRegistryEntry {
+            name: "external_skills.inspect",
+            description: "Read metadata for an installed external skill",
+        },
+        ToolRegistryEntry {
+            name: "external_skills.install",
+            description: "Install a managed external skill from a local directory or archive",
+        },
+        ToolRegistryEntry {
+            name: "external_skills.invoke",
+            description: "Load an installed external skill into the conversation loop",
+        },
+        ToolRegistryEntry {
+            name: "external_skills.list",
+            description: "List managed external skills available for invocation",
+        },
+        ToolRegistryEntry {
+            name: "external_skills.policy",
+            description: "Read/update external skills domain allow/block policy at runtime",
+        },
+        ToolRegistryEntry {
+            name: "external_skills.remove",
+            description: "Remove an installed external skill from the managed runtime",
+        },
+    ];
     #[cfg(feature = "tool-file")]
     {
         entries.push(ToolRegistryEntry {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -676,7 +676,9 @@ mod tests {
 
         let snapshot = capability_snapshot_with_config(&config);
         assert!(snapshot.contains("[available_external_skills]"));
-        assert!(snapshot.contains("- demo-skill: Use this skill for explicit verification."));
+        assert!(snapshot.contains(
+            "- demo-skill: installed managed external skill; use external_skills.inspect or external_skills.invoke for details"
+        ));
 
         fs::remove_dir_all(&root).ok();
     }

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -8,6 +8,8 @@ pub struct ExternalSkillsRuntimePolicy {
     pub require_download_approval: bool,
     pub allowed_domains: BTreeSet<String>,
     pub blocked_domains: BTreeSet<String>,
+    pub install_root: Option<PathBuf>,
+    pub auto_expose_installed: bool,
 }
 
 impl Default for ExternalSkillsRuntimePolicy {
@@ -17,6 +19,8 @@ impl Default for ExternalSkillsRuntimePolicy {
             require_download_approval: true,
             allowed_domains: BTreeSet::new(),
             blocked_domains: BTreeSet::new(),
+            install_root: None,
+            auto_expose_installed: true,
         }
     }
 }
@@ -53,6 +57,11 @@ impl ToolRuntimeConfig {
             parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL").unwrap_or(true);
         let allowed_domains = parse_env_domain_list("LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS");
         let blocked_domains = parse_env_domain_list("LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS");
+        let install_root = std::env::var("LOONGCLAW_EXTERNAL_SKILLS_INSTALL_ROOT")
+            .ok()
+            .map(PathBuf::from);
+        let auto_expose_installed =
+            parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED").unwrap_or(true);
 
         Self {
             shell_allowlist,
@@ -62,6 +71,8 @@ impl ToolRuntimeConfig {
                 require_download_approval,
                 allowed_domains,
                 blocked_domains,
+                install_root,
+                auto_expose_installed,
             },
         }
     }
@@ -123,6 +134,8 @@ mod tests {
         assert!(config.external_skills.require_download_approval);
         assert!(config.external_skills.allowed_domains.is_empty());
         assert!(config.external_skills.blocked_domains.is_empty());
+        assert!(config.external_skills.install_root.is_none());
+        assert!(config.external_skills.auto_expose_installed);
     }
 
     #[test]
@@ -137,6 +150,8 @@ mod tests {
                 require_download_approval: false,
                 allowed_domains: BTreeSet::from(["skills.sh".to_owned()]),
                 blocked_domains: BTreeSet::new(),
+                install_root: Some(PathBuf::from("/tmp/test-root/skills")),
+                auto_expose_installed: false,
             },
         };
         assert!(config.shell_allowlist.contains("git"));
@@ -146,6 +161,11 @@ mod tests {
         assert!(config.external_skills.enabled);
         assert!(!config.external_skills.require_download_approval);
         assert!(config.external_skills.allowed_domains.contains("skills.sh"));
+        assert_eq!(
+            config.external_skills.install_root,
+            Some(PathBuf::from("/tmp/test-root/skills"))
+        );
+        assert!(!config.external_skills.auto_expose_installed);
     }
 
     #[test]
@@ -198,6 +218,11 @@ mod tests {
             "LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS",
             "malicious.example",
         );
+        crate::process_env::set_var(
+            "LOONGCLAW_EXTERNAL_SKILLS_INSTALL_ROOT",
+            "/tmp/managed-skills",
+        );
+        crate::process_env::set_var("LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED", "false");
 
         let config = ToolRuntimeConfig::from_env();
         assert!(config.external_skills.enabled);
@@ -215,10 +240,17 @@ mod tests {
                 .blocked_domains
                 .contains("malicious.example")
         );
+        assert_eq!(
+            config.external_skills.install_root,
+            Some(PathBuf::from("/tmp/managed-skills"))
+        );
+        assert!(!config.external_skills.auto_expose_installed);
 
         crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_ENABLED");
         crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL");
         crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS");
         crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS");
+        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_INSTALL_ROOT");
+        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED");
     }
 }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 
 [features]
 default = ["mvp"]
-mvp = ["loongclaw-app/default"]
+mvp = ["loongclaw-app/default", "memory-sqlite"]
 channel-cli = ["loongclaw-app/channel-cli"]
 channel-telegram = ["loongclaw-app/channel-telegram"]
 channel-feishu = ["loongclaw-app/channel-feishu"]

--- a/docs/plans/2026-03-12-external-skills-runtime-closure-design.md
+++ b/docs/plans/2026-03-12-external-skills-runtime-closure-design.md
@@ -1,0 +1,415 @@
+# External Skills Runtime Closure Design
+
+Date: 2026-03-12
+Status: Approved for implementation
+
+## Summary
+
+LoongClaw already has the first half of an external-skills story:
+
+- `external_skills.policy` guards runtime enablement, approval, and
+  domain allow/block policy
+- `external_skills.fetch` downloads artifacts under a managed directory
+- migration can detect legacy skill catalogs and preserve them as durable
+  profile metadata
+
+What LoongClaw does not have yet is the second half:
+
+- install a downloaded or local skill package into a managed runtime root
+- list and inspect installed skills
+- expose installed skills to the model in a deterministic way
+- let the model explicitly load a skill's instructions into the conversation
+
+The recommended design is to treat external skills as managed instruction
+packages, not as dynamically generated native function tools.
+
+That means:
+
+- keep the built-in tool registry mostly static
+- add explicit lifecycle tools for install, list, inspect, invoke, and remove
+- surface installed skills as runtime context the model can discover
+- make skill invocation return deterministic instruction payloads that the
+  existing turn loop can feed back into later provider rounds
+
+This closes the runtime loop without forcing a full dynamic provider-tool
+registry or a new plugin execution bridge.
+
+## Product Goals
+
+- Close the runtime gap between external skill download and usable skill
+  invocation.
+- Keep the safety model explicit and deterministic.
+- Preserve the current security posture:
+  downloads remain opt-in, approval-gated, and domain-restricted.
+- Keep skill installation auditable and reversible.
+- Make installed skills discoverable by the model and by operators.
+- Keep the implementation compatible with the current static built-in tool
+  architecture.
+
+## Non-Goals For This Slice
+
+- No per-skill dynamic OpenAI function registration.
+- No remote auto-install directly from a URL in a single step.
+- No automatic execution of arbitrary scripts embedded in skill packages.
+- No full ecosystem packaging/signing rollout yet.
+- No hidden auto-mount of legacy migrated skills.
+
+## Current State
+
+Today the external-skills path stops in two places:
+
+1. Download path
+   - `external_skills.fetch` validates policy and writes raw bytes to
+     `external-skills-downloads/`
+2. Migration path
+   - legacy `SKILLS.md`, `skills-lock.json`, `.codex/skills`, `.claude/skills`,
+     and `skills/` artifacts are detected and summarized into
+     `memory.profile_note`
+
+This produces auditability but not a usable runtime.
+
+The current conversation/provider/tool stack also assumes a static tool set:
+
+- `tool_registry()` is static
+- `provider_tool_definitions()` is static
+- `is_known_tool_name()` rejects unknown names
+- `execute_tool_core_with_config()` dispatches through a static match
+
+That makes a "one installed skill = one dynamic function tool" design much
+more invasive than it looks.
+
+## Design Principle: Skills Are Managed Instruction Packages
+
+In LoongClaw's current product shape, an external skill is closer to a
+portable instruction bundle than to a native connector or executable plugin.
+
+That aligns with existing migration research:
+
+- upstream claws often compose prompts from identity, memory, bootstrap files,
+  and skills
+- migration already preserves skills as prompt/runtime context rather than as
+  native adapters
+
+So the runtime closure should preserve that semantic model:
+
+- installation manages package lifecycle
+- invocation loads instructions into the conversation
+- execution still happens through the normal model + built-in tool loop
+
+## Approaches Considered
+
+### Approach 1: Dynamic Per-Skill Function Tools
+
+Install each skill and turn it into a unique provider function definition.
+
+Pros:
+
+- feels like native tool calling
+- the model can call specific skill names directly
+
+Cons:
+
+- requires dynamic provider schema generation
+- requires dynamic known-tool gating and dynamic dispatch
+- increases failure surface across provider, conversation, and core tools
+- makes package metadata shape part of the model tool contract immediately
+
+### Approach 2: Managed Lifecycle Tools Plus Explicit Skill Invocation
+
+Keep the built-in tool set static and add:
+
+- `external_skills.install`
+- `external_skills.list`
+- `external_skills.inspect`
+- `external_skills.invoke`
+- `external_skills.remove`
+
+Installed skills are surfaced in capability context, and `invoke` returns the
+resolved skill instructions and metadata for later model turns.
+
+Pros:
+
+- matches current architecture
+- closes the loop without dynamic tool registration
+- keeps auditability and testing straightforward
+- preserves the semantic meaning of skills as instruction packages
+
+Cons:
+
+- the model has to call a generic tool rather than a per-skill function
+
+### Approach 3: Prompt-Only Auto-Mount
+
+Install skills and silently append all active skill instructions to the system
+prompt or profile memory.
+
+Pros:
+
+- easiest runtime integration
+
+Cons:
+
+- hidden state and prompt bloat
+- poor operator visibility
+- no explicit invocation boundary
+- hard to test and reason about
+
+## Decision
+
+Adopt Approach 2.
+
+LoongClaw should add a managed external-skills lifecycle with explicit
+installation and invocation tools, while keeping the provider-facing function
+tool surface static.
+
+## User-Facing Runtime Model
+
+### 1. Download
+
+The operator or model uses `external_skills.fetch` to download a package under
+the managed downloads directory.
+
+### 2. Install
+
+The operator or model uses `external_skills.install` with either:
+
+- a local directory containing `SKILL.md`
+- a local `.tgz` / `.tar.gz` package
+
+Installation:
+
+- validates source path safety
+- extracts archives into a temporary staging area
+- locates a single skill root containing `SKILL.md`
+- derives or validates a stable `skill_id`
+- copies the normalized skill into a managed installs directory
+- updates an installed-skill index
+
+### 3. Discover
+
+The operator or model uses `external_skills.list` to discover installed skills.
+
+Each entry includes:
+
+- `skill_id`
+- source kind/path
+- install path
+- content summary
+- whether the skill is currently active
+- package digest if available
+
+### 4. Inspect
+
+The operator or model uses `external_skills.inspect` to read structured skill
+metadata before invoking it.
+
+### 5. Invoke
+
+The operator or model uses `external_skills.invoke` with a `skill_id`.
+
+The tool returns:
+
+- resolved `skill_id`
+- install path
+- source metadata
+- the loaded `SKILL.md` instructions
+- a short invocation summary suitable for tool-result feedback
+
+The existing conversation turn loop can then feed that tool result back into
+later provider rounds, allowing the model to follow the skill instructions in a
+controlled and explicit way.
+
+### 6. Remove
+
+The operator or model uses `external_skills.remove` to uninstall a managed
+skill and update the index.
+
+## Package Contract
+
+This slice intentionally uses a minimal package contract.
+
+### Supported Inputs
+
+- local directory
+- local `.tgz`
+- local `.tar.gz`
+
+### Required Content
+
+- exactly one installable skill root
+- root must contain `SKILL.md`
+
+### Optional Content
+
+- `assets/`
+- `references/`
+- `scripts/`
+- supporting markdown/docs under the skill root
+
+### Deferred Contract
+
+This slice does not require:
+
+- signed manifests
+- semantic version fields
+- a separate machine-readable manifest file
+
+Those belong to the later community plugin/package supply-chain work.
+
+## Managed Layout
+
+Under the configured file root:
+
+- `external-skills-downloads/`
+  - raw fetched artifacts
+- `external-skills-installed/`
+  - one directory per installed skill
+- `external-skills-installed/index.json`
+  - machine-readable installed-skill registry
+
+Each installed skill entry stores:
+
+- `skill_id`
+- `display_name`
+- `installed_at_unix`
+- `source_kind`
+- `source_path`
+- `install_path`
+- `skill_md_path`
+- `sha256`
+- `active`
+
+## Config Evolution
+
+Extend `[external_skills]` with:
+
+- `install_root`
+  - optional
+  - defaults under the configured file root
+- `auto_expose_installed`
+  - default `true`
+  - controls whether installed skills appear in the capability snapshot
+
+Keep existing fields unchanged:
+
+- `enabled`
+- `require_download_approval`
+- `allowed_domains`
+- `blocked_domains`
+
+## Runtime Configuration
+
+`ToolRuntimeConfig` should mirror the new external-skills settings so tool
+executors do not need to query environment variables or parse config ad hoc.
+
+## Provider And Prompt Exposure
+
+The provider tool schema remains static, but it gains new built-in functions:
+
+- `external_skills_install`
+- `external_skills_list`
+- `external_skills_inspect`
+- `external_skills_invoke`
+- `external_skills_remove`
+
+The capability snapshot should also gain a deterministic section:
+
+- `[available_external_skills]`
+- one line per active installed skill:
+  `- <skill_id>: <summary>`
+
+This gives the model two discovery channels:
+
+- structured lifecycle tools
+- human-readable installed-skill list inside the system prompt
+
+## Dispatch Model
+
+`execute_tool_core_with_config()` stays static at the top level.
+
+The new dispatch is:
+
+- lifecycle tool name is static
+- lifecycle tool internally resolves `skill_id`
+- lifecycle tool loads managed install state
+
+That avoids dynamic function registration while still making the runtime fully
+usable.
+
+## Migration Integration
+
+Migration should remain explicit and non-magical:
+
+- legacy skills are still detected and preserved in `profile_note`
+- warnings should say LoongClaw does not auto-install migrated skill runtimes
+- migration docs should point to the new install/list/invoke loop as the next
+  operator step
+
+This preserves safety and keeps imported metadata auditable.
+
+## Error Handling
+
+Installation errors must be explicit and deterministic:
+
+- source path escapes configured file root
+- archive cannot be read
+- archive contains no `SKILL.md`
+- archive contains multiple candidate roots
+- install target already exists without replacement approval
+- malformed or empty `SKILL.md`
+
+Invocation errors must distinguish:
+
+- unknown `skill_id`
+- inactive skill
+- missing `SKILL.md`
+- unreadable managed install
+
+Removal errors must distinguish:
+
+- unknown `skill_id`
+- managed path missing
+- index update failure
+
+## Testing Strategy
+
+### Config And Runtime
+
+- default config includes new external-skills runtime fields
+- runtime config mirrors config correctly
+
+### Install Path
+
+- install from directory succeeds
+- install from `.tar.gz` succeeds
+- missing `SKILL.md` fails
+- multiple roots fail deterministically
+- duplicate installs require explicit replace behavior
+
+### Registry And Exposure
+
+- tool registry includes new static lifecycle tools
+- capability snapshot includes `[available_external_skills]` when enabled
+- provider tool definitions include the new lifecycle functions
+
+### Invoke Path
+
+- invoke returns deterministic instruction payload
+- invoke rejects missing/inactive skills
+
+### Remove Path
+
+- remove updates index and filesystem state
+
+### Regression
+
+- existing `external_skills.fetch` and `external_skills.policy` tests remain
+  green
+- migration tests remain green
+
+## Rollout Notes
+
+This slice intentionally stops short of dynamic executable plugins and signed
+package supply chain. It provides a complete operator-visible runtime loop for
+instruction-style skills while preserving LoongClaw's current static tool
+architecture and safety posture.

--- a/docs/plans/2026-03-12-external-skills-runtime-closure.md
+++ b/docs/plans/2026-03-12-external-skills-runtime-closure.md
@@ -1,0 +1,422 @@
+# External Skills Runtime Closure Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Turn external skills from a download-only and migration-only feature into a managed runtime loop with install, list, inspect, invoke, and remove lifecycle tools.
+
+**Architecture:** Keep the top-level provider/tool surface static, add managed lifecycle tools under `external_skills.*`, store installed skills under a deterministic managed root with a JSON index, and expose installed skills to the model through both structured lifecycle tools and a deterministic capability snapshot section. Skills remain instruction packages loaded into the existing conversation loop, not dynamically generated native function tools.
+
+**Tech Stack:** Rust, serde/json/toml config, `loongclaw-app`, `loongclaw-daemon`, existing provider/tool runtime, new archive extraction dependencies if needed, Rust unit tests.
+
+---
+
+### Task 1: Extend External Skills Config And Runtime Types
+
+**Files:**
+- Modify: `crates/app/src/config/tools_memory.rs`
+- Modify: `crates/app/src/config/runtime.rs`
+- Modify: `crates/app/src/tools/runtime_config.rs`
+- Test: `crates/app/src/config/tools_memory.rs`
+- Test: `crates/app/src/tools/runtime_config.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[test]
+fn external_skills_defaults_include_managed_install_settings() {
+    let config = ExternalSkillsConfig::default();
+    assert!(!config.enabled);
+    assert!(config.require_download_approval);
+    assert!(config.install_root.is_none());
+    assert!(config.auto_expose_installed);
+}
+
+#[test]
+fn tool_runtime_config_from_env_defaults_external_skills_install_flags() {
+    let config = ToolRuntimeConfig::default();
+    assert!(config.external_skills.install_root.is_none());
+    assert!(config.external_skills.auto_expose_installed);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app external_skills_defaults_include_managed_install_settings -- --exact`
+
+Expected: FAIL because `install_root` and `auto_expose_installed` do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- `install_root: Option<String>` to config
+- `auto_expose_installed: bool` to config
+- normalized helpers and runtime mirrored fields in `ToolRuntimeConfig`
+- default config rendering/loading coverage
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app config::tools_memory:: -- --nocapture`
+
+Run: `cargo test -p loongclaw-app tools::runtime_config:: -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/config/tools_memory.rs crates/app/src/config/runtime.rs crates/app/src/tools/runtime_config.rs
+git commit -m "feat: extend external skills runtime config"
+```
+
+### Task 2: Add Managed Skill Index And Install Helpers
+
+**Files:**
+- Modify: `crates/app/src/tools/external_skills.rs`
+- Modify: `crates/app/Cargo.toml`
+- Test: `crates/app/src/tools/external_skills.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[test]
+fn install_skill_from_directory_writes_index_and_managed_copy() {
+    let root = unique_temp_dir("external-skills-install-dir");
+    let source = root.join("demo-skill");
+    fs::create_dir_all(&source).unwrap();
+    fs::write(source.join("SKILL.md"), "# Demo Skill\n\nUse this skill.").unwrap();
+
+    let config = test_tool_runtime_config_with_external_skills(&root, true);
+    let outcome = execute_external_skills_install_tool_with_config(
+        tool_request("external_skills.install", json!({ "path": source.display().to_string() })),
+        &config,
+    )
+    .expect("install should succeed");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["skill_id"], "demo-skill");
+    assert!(root.join("external-skills-installed").join("index.json").exists());
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app install_skill_from_directory_writes_index_and_managed_copy -- --exact`
+
+Expected: FAIL because there is no install path or managed index yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- managed install root resolution helpers
+- installed skill index structs and JSON persistence
+- safe local path resolution for install sources
+- directory install path with `SKILL.md` validation
+- archive extraction support for `.tgz` / `.tar.gz`
+- managed copy into `external-skills-installed/<skill_id>/`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app tools::external_skills:: -- --nocapture`
+
+Expected: PASS for the new install-path tests.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/Cargo.toml crates/app/src/tools/external_skills.rs
+git commit -m "feat: add managed external skill installation"
+```
+
+### Task 3: Add Lifecycle Tools For List, Inspect, Invoke, And Remove
+
+**Files:**
+- Modify: `crates/app/src/tools/external_skills.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Test: `crates/app/src/tools/external_skills.rs`
+- Test: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[test]
+fn list_installed_skills_returns_active_entries() {
+    let fixture = install_demo_skill_fixture();
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "external_skills.list".to_owned(),
+            payload: json!({}),
+        },
+        &fixture.config,
+    )
+    .expect("list should succeed");
+
+    assert_eq!(outcome.payload["skills"][0]["skill_id"], "demo-skill");
+}
+
+#[test]
+fn invoke_installed_skill_returns_skill_markdown_and_metadata() {
+    let fixture = install_demo_skill_fixture();
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "external_skills.invoke".to_owned(),
+            payload: json!({ "skill_id": "demo-skill" }),
+        },
+        &fixture.config,
+    )
+    .expect("invoke should succeed");
+
+    assert!(outcome.payload["instructions"].as_str().unwrap().contains("Demo Skill"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app invoke_installed_skill_returns_skill_markdown_and_metadata -- --exact`
+
+Expected: FAIL because these lifecycle tools do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add static lifecycle tools:
+
+- `external_skills.install`
+- `external_skills.list`
+- `external_skills.inspect`
+- `external_skills.invoke`
+- `external_skills.remove`
+
+Wire them into:
+
+- `canonical_tool_name()`
+- `is_known_tool_name()`
+- `execute_tool_core_with_config()`
+- `tool_registry()`
+- `provider_tool_definitions()`
+- shape examples and tests
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app tools::tests::provider_tool_definitions_are_stable_and_complete -- --exact`
+
+Run: `cargo test -p loongclaw-app tools::external_skills:: -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/external_skills.rs crates/app/src/tools/mod.rs
+git commit -m "feat: add external skills lifecycle tools"
+```
+
+### Task 4: Expose Installed Skills In Capability Snapshot
+
+**Files:**
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/provider/mod.rs`
+- Test: `crates/app/src/tools/mod.rs`
+- Test: `crates/app/src/provider/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[test]
+fn capability_snapshot_lists_installed_external_skills_when_enabled() {
+    let snapshot = capability_snapshot_with_config(&fixture.config);
+    assert!(snapshot.contains("[available_external_skills]"));
+    assert!(snapshot.contains("- demo-skill:"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app capability_snapshot_lists_installed_external_skills_when_enabled -- --exact`
+
+Expected: FAIL because the snapshot has no installed-skill section yet.
+
+**Step 3: Write minimal implementation**
+
+Add a runtime-aware capability snapshot helper that:
+
+- keeps the existing `[available_tools]` block deterministic
+- appends `[available_external_skills]` when exposure is enabled and the index
+  is non-empty
+
+Update provider system-message builders to use the runtime-aware snapshot path.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app tools::tests:: -- --nocapture`
+
+Run: `cargo test -p loongclaw-app provider::tests:: -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/mod.rs crates/app/src/provider/mod.rs
+git commit -m "feat: expose installed external skills in capability snapshot"
+```
+
+### Task 5: Tighten Error Contracts And Duplicate-Install Behavior
+
+**Files:**
+- Modify: `crates/app/src/tools/external_skills.rs`
+- Test: `crates/app/src/tools/external_skills.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[test]
+fn install_rejects_source_without_skill_md() {
+    let fixture = empty_external_skills_fixture();
+    let err = execute_external_skills_install_tool_with_config(
+        tool_request("external_skills.install", json!({ "path": fixture.source.display().to_string() })),
+        &fixture.config,
+    )
+    .expect_err("install should fail");
+
+    assert!(err.contains("SKILL.md"));
+}
+
+#[test]
+fn install_rejects_duplicate_without_replace() {
+    let fixture = install_demo_skill_fixture();
+    let err = execute_external_skills_install_tool_with_config(
+        tool_request("external_skills.install", json!({ "path": fixture.source.display().to_string() })),
+        &fixture.config,
+    )
+    .expect_err("duplicate install should fail");
+
+    assert!(err.contains("already installed"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app install_rejects_duplicate_without_replace -- --exact`
+
+Expected: FAIL because duplicate-install behavior is not implemented yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- deterministic duplicate install rejection
+- optional `replace=true` support
+- explicit error strings for missing `SKILL.md`, missing `skill_id`, bad
+  archive roots, unknown remove targets, and unknown invoke targets
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app tools::external_skills:: -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/external_skills.rs
+git commit -m "fix: harden external skill lifecycle errors"
+```
+
+### Task 6: Update Migration Messaging And Readme Documentation
+
+**Files:**
+- Modify: `crates/app/src/migration/mod.rs`
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+- Test: `crates/app/src/migration/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests like:
+
+```rust
+#[test]
+fn external_skill_warning_points_to_explicit_runtime_install_flow() {
+    let warning = external_skill_warning(&artifact_fixture("skills_dir"));
+    assert!(warning.contains("install"));
+    assert!(warning.contains("invoke"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app external_skill_warning_points_to_explicit_runtime_install_flow -- --exact`
+
+Expected: FAIL because the warning still says LoongClaw does not auto-wire the runtime.
+
+**Step 3: Write minimal implementation**
+
+Update migration warning/docs to say:
+
+- migrated skills are still not auto-installed
+- the new runtime flow is `fetch/install/list/invoke`
+
+Update README examples and tool lists accordingly.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app migration:: -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/migration/mod.rs README.md README.zh-CN.md
+git commit -m "docs: document external skills runtime lifecycle"
+```
+
+### Task 7: Full Verification
+
+**Files:**
+- No code changes required
+
+**Step 1: Run focused external-skills tests**
+
+Run: `cargo test -p loongclaw-app external_skills -- --nocapture`
+
+Expected: PASS.
+
+**Step 2: Run provider and migration regressions**
+
+Run: `cargo test -p loongclaw-app provider::tests:: -- --nocapture`
+
+Run: `cargo test -p loongclaw-app migration:: -- --nocapture`
+
+Expected: PASS.
+
+**Step 3: Run full workspace tests**
+
+Run: `cargo test`
+
+Expected: PASS across the workspace.
+
+**Step 4: Inspect working tree**
+
+Run: `git status --short`
+
+Expected: only external-skills runtime closure files are modified.
+
+**Step 5: Commit**
+
+```bash
+git add docs/plans/2026-03-12-external-skills-runtime-closure-design.md docs/plans/2026-03-12-external-skills-runtime-closure.md
+git add crates/app/src/config/tools_memory.rs crates/app/src/config/runtime.rs crates/app/src/tools/runtime_config.rs crates/app/src/tools/external_skills.rs crates/app/src/tools/mod.rs crates/app/src/provider/mod.rs crates/app/src/migration/mod.rs README.md README.zh-CN.md crates/app/Cargo.toml
+git commit -m "feat: close external skills runtime lifecycle"
+```

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -11,7 +11,7 @@ Usage: pwsh ./scripts/install.ps1 [-Prefix <dir>] [-Onboard]
 
 Options:
   -Prefix <dir>   Install directory for loongclaw (default: $HOME/.local/bin)
-  -Onboard        Run 'loongclaw onboard --force' after install
+  -Onboard        Run 'loongclaw onboard' after install
 "@
 }
 
@@ -47,7 +47,7 @@ Write-Host "==> Installed loongclaw to $destBinary"
 
 if ($Onboard) {
     Write-Host "==> Running guided onboarding"
-    & $destBinary onboard --force | Out-Host
+    & $destBinary onboard | Out-Host
 }
 
 $pathItems = ($env:PATH -split [IO.Path]::PathSeparator)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@ Usage: ./scripts/install.sh [--prefix <dir>] [--onboard]
 
 Options:
   --prefix <dir>   Install directory for loongclaw (default: $HOME/.local/bin)
-  --onboard        Run `loongclaw onboard --force` after install
+  --onboard        Run `loongclaw onboard` after install
   -h, --help       Show this help
 USAGE
 }
@@ -62,7 +62,7 @@ printf '==> Installed loongclaw to %s\n' "${prefix}/loongclaw"
 
 if [[ "${run_onboard}" -eq 1 ]]; then
   printf '==> Running guided onboarding\n'
-  "${prefix}/loongclaw" onboard --force
+  "${prefix}/loongclaw" onboard
 fi
 
 case ":${PATH}:" in


### PR DESCRIPTION
## Summary
- add a managed external-skills lifecycle with install, list, inspect, invoke, and remove tools
- wire install-root and auto-expose settings through config, runtime config, capability snapshots, and provider system prompts
- tighten runtime gating so disabled external skills no longer install, invoke, or auto-expose, and document the explicit lifecycle in migration warnings and READMEs

## Validation
- [x] cargo fmt --check
- [x] cargo test

Closes #39
