### PR TITLE
Add web fetch tool with SSRF protection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +585,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +624,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
 ]
 
 [[package]]
@@ -605,6 +664,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
@@ -698,6 +763,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +841,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -855,6 +939,16 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "html5ever"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
+dependencies = [
+ "log",
+ "markup5ever",
+]
 
 [[package]]
 name = "http"
@@ -1206,6 +1300,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,15 +1323,18 @@ dependencies = [
  "axum",
  "base64",
  "cbc",
+ "ipnet",
  "loongclaw-contracts",
  "loongclaw-kernel",
  "reqwest",
  "rusqlite",
+ "scraper",
  "serde",
  "serde_json",
  "sha2",
  "tokio",
  "toml",
+ "url",
 ]
 
 [[package]]
@@ -1325,12 +1431,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
 ]
 
 [[package]]
@@ -1372,6 +1495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,10 +1534,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1467,6 +1672,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -1659,6 +1870,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +2065,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scraper"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93cecd86d6259499c844440546d02f55f3e17bd286e529e48d1f9f67e92315cb"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
+name = "selectors"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,6 +2186,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,6 +2229,12 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -2013,6 +2288,30 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "strsim"
@@ -2074,6 +2373,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -2323,6 +2633,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -2717,6 +3033,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net", "io-util", "io-std", "process"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 futures-util = "0.3"
+url = "2.5.8"
+ipnet = "2.12"
+scraper = "0.25"
 sha2 = "0.10"
 wasmparser = "0.245"
 base64 = "0.22"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">
   <a href="https://github.com/loongclaw-ai/loongclaw/actions/workflows/ci.yml"><img src="https://github.com/loongclaw-ai/loongclaw/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
-  <img src="https://img.shields.io/badge/rust-edition%202021-orange.svg" alt="Rust Edition 2021" />
+  <img src="https://img.shields.io/badge/rust-edition%202024-orange.svg" alt="Rust Edition 2024" />
   <img src="https://img.shields.io/badge/version-0.1.2--pre-yellow.svg" alt="Version: 0.1.2-pre" />
 </p>
 
@@ -64,7 +64,7 @@ LoongClaw is a layered Agentic OS kernel focused on stable kernel contracts, str
 
 ### Prerequisites
 
-- Rust stable toolchain (edition 2021)
+- Rust stable toolchain (edition 2024)
 - `cargo` available in your PATH
 
 ### Install from Source

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 <p align="center">
   <a href="https://github.com/loongclaw-ai/loongclaw/actions/workflows/ci.yml"><img src="https://github.com/loongclaw-ai/loongclaw/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
-  <img src="https://img.shields.io/badge/rust-edition%202021-orange.svg" alt="Rust Edition 2021" />
+  <img src="https://img.shields.io/badge/rust-edition%202024-orange.svg" alt="Rust Edition 2024" />
   <img src="https://img.shields.io/badge/version-0.1.2--pre-yellow.svg" alt="Version: 0.1.2-pre" />
 </p>
 
@@ -63,7 +63,7 @@ LoongClaw 是一个基于Rust构建的 Agentic OS 内核，专注于稳定且轻
 
 ### 前置条件
 
-- Rust 稳定工具链（edition 2021）
+- Rust 稳定工具链（edition 2024）
 - `cargo` 在 PATH 中可用
 
 ### 从源码安装

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 authors.workspace = true
 
 [features]
-default = ["channel-cli", "channel-telegram", "channel-feishu", "config-toml", "memory-sqlite", "tool-shell", "tool-file", "provider-openai", "provider-volcengine"]
+default = ["channel-cli", "channel-telegram", "channel-feishu", "config-toml", "memory-sqlite", "tool-shell", "tool-file", "tool-webfetch", "provider-openai", "provider-volcengine"]
 channel-cli = []
 channel-telegram = []
 channel-feishu = ["dep:axum", "dep:aes", "dep:cbc"]
@@ -16,6 +16,7 @@ config-toml = ["dep:toml"]
 memory-sqlite = ["dep:rusqlite"]
 tool-shell = []
 tool-file = []
+tool-webfetch = ["dep:url", "dep:ipnet", "dep:scraper"]
 
 [dependencies]
 loongclaw-contracts = { path = "../contracts" }
@@ -32,6 +33,9 @@ rusqlite = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 aes = { version = "0.8", optional = true }
 cbc = { version = "0.1", optional = true }
+url = { workspace = true, optional = true }
+ipnet = { workspace = true, optional = true }
+scraper = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -726,6 +726,7 @@ fn apply_runtime_env(config: &LoongClawConfig) {
             .map(|s| s.to_ascii_lowercase())
             .collect(),
         file_root: Some(config.tools.resolved_file_root()),
+        ..crate::tools::runtime_config::ToolRuntimeConfig::default()
     };
     let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);
 

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -748,7 +748,6 @@ fn apply_runtime_env(config: &LoongClawConfig) {
             .map(|s| s.to_ascii_lowercase())
             .collect(),
         file_root: Some(config.tools.resolved_file_root()),
-        ..crate::tools::runtime_config::ToolRuntimeConfig::default()
         external_skills: crate::tools::runtime_config::ExternalSkillsRuntimePolicy {
             enabled: config.external_skills.enabled,
             require_download_approval: config.external_skills.require_download_approval,
@@ -763,6 +762,7 @@ fn apply_runtime_env(config: &LoongClawConfig) {
                 .into_iter()
                 .collect(),
         },
+        ..crate::tools::runtime_config::ToolRuntimeConfig::default()
     };
     let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -409,6 +409,7 @@ fn export_runtime_env(config: &LoongClawConfig) {
             .map(|s| s.to_ascii_lowercase())
             .collect(),
         file_root: Some(config.tools.resolved_file_root()),
+        ..crate::tools::runtime_config::ToolRuntimeConfig::default()
     };
     let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -590,7 +590,6 @@ fn export_runtime_env(config: &LoongClawConfig) {
             .map(|s| s.to_ascii_lowercase())
             .collect(),
         file_root: Some(config.tools.resolved_file_root()),
-        ..crate::tools::runtime_config::ToolRuntimeConfig::default()
         external_skills: crate::tools::runtime_config::ExternalSkillsRuntimePolicy {
             enabled: config.external_skills.enabled,
             require_download_approval: config.external_skills.require_download_approval,
@@ -605,6 +604,7 @@ fn export_runtime_env(config: &LoongClawConfig) {
                 .into_iter()
                 .collect(),
         },
+        ..crate::tools::runtime_config::ToolRuntimeConfig::default()
     };
     let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);
 

--- a/crates/app/src/conversation/integration_tests.rs
+++ b/crates/app/src/conversation/integration_tests.rs
@@ -93,6 +93,7 @@ impl TurnTestHarness {
         let tool_config = ToolRuntimeConfig {
             shell_allowlist: BTreeSet::from(["echo".to_owned(), "cat".to_owned(), "ls".to_owned()]),
             file_root: Some(temp_dir.clone()),
+            ..ToolRuntimeConfig::default()
         };
 
         let audit = Arc::new(InMemoryAuditSink::default());

--- a/crates/app/src/conversation/integration_tests.rs
+++ b/crates/app/src/conversation/integration_tests.rs
@@ -93,8 +93,8 @@ impl TurnTestHarness {
         let tool_config = ToolRuntimeConfig {
             shell_allowlist: BTreeSet::from(["echo".to_owned(), "cat".to_owned(), "ls".to_owned()]),
             file_root: Some(temp_dir.clone()),
-            ..ToolRuntimeConfig::default()
             external_skills: Default::default(),
+            ..ToolRuntimeConfig::default()
         };
 
         let audit = Arc::new(InMemoryAuditSink::default());

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -907,7 +907,11 @@ mod tests {
         assert_eq!(user_agent, "KimiCLI/custom");
     }
 
-    #[cfg(any(feature = "tool-file", feature = "tool-shell"))]
+    #[cfg(any(
+        feature = "tool-file",
+        feature = "tool-shell",
+        feature = "tool-webfetch"
+    ))]
     #[test]
     fn turn_body_includes_tool_schema_and_auto_choice() {
         let config = LoongClawConfig {
@@ -950,6 +954,10 @@ mod tests {
         #[cfg(feature = "tool-shell")]
         {
             expected.push("shell_exec");
+        }
+        #[cfg(feature = "tool-webfetch")]
+        {
+            expected.push("web_fetch");
         }
 
         assert_eq!(names, expected);

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -597,6 +597,7 @@ mod tests {
                 allowed_domains: BTreeSet::new(),
                 blocked_domains: BTreeSet::new(),
             },
+            ..ToolRuntimeConfig::default()
         }
     }
 

--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -281,6 +281,7 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: Default::default(),
             file_root: Some(root.clone()),
+            ..ToolRuntimeConfig::default()
         };
         let error =
             resolve_safe_file_path_with_config("secret-link", &config).expect_err("escape denied");
@@ -304,6 +305,7 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: Default::default(),
             file_root: Some(root.clone()),
+            ..ToolRuntimeConfig::default()
         };
         let request = ToolCoreRequest {
             tool_name: "file.write".to_owned(),
@@ -329,6 +331,7 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: Default::default(),
             file_root: Some(root.clone()),
+            ..ToolRuntimeConfig::default()
         };
         let request = ToolCoreRequest {
             tool_name: "file.write".to_owned(),

--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -281,8 +281,8 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: Default::default(),
             file_root: Some(root.clone()),
-            ..ToolRuntimeConfig::default()
             external_skills: Default::default(),
+            ..ToolRuntimeConfig::default()
         };
         let error =
             resolve_safe_file_path_with_config("secret-link", &config).expect_err("escape denied");
@@ -306,8 +306,8 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: Default::default(),
             file_root: Some(root.clone()),
-            ..ToolRuntimeConfig::default()
             external_skills: Default::default(),
+            ..ToolRuntimeConfig::default()
         };
         let request = ToolCoreRequest {
             tool_name: "file.write".to_owned(),
@@ -333,8 +333,8 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: Default::default(),
             file_root: Some(root.clone()),
-            ..ToolRuntimeConfig::default()
             external_skills: Default::default(),
+            ..ToolRuntimeConfig::default()
         };
         let request = ToolCoreRequest {
             tool_name: "file.write".to_owned(),

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -56,18 +56,6 @@ pub fn canonical_tool_name(raw: &str) -> &str {
 }
 
 pub fn is_known_tool_name(raw: &str) -> bool {
-    let canonical = canonical_tool_name(raw);
-    if matches!(
-        canonical,
-        "claw.import" | "shell.exec" | "file.read" | "file.write"
-    ) {
-        return true;
-    }
-    #[cfg(feature = "tool-webfetch")]
-    if canonical == "web.fetch" {
-        return true;
-    }
-    false
     matches!(
         canonical_tool_name(raw),
         "claw.import"
@@ -76,6 +64,7 @@ pub fn is_known_tool_name(raw: &str) -> bool {
             | "shell.exec"
             | "file.read"
             | "file.write"
+            | "web.fetch"
     )
 }
 
@@ -567,23 +556,16 @@ mod tests {
             snapshot.contains("- web.fetch: Fetch web content with SSRF protection and extraction")
         );
 
-        // Verify sorted order: claw.import < file.read < file.write < shell.exec < web.fetch
+        // Verify sorted order: claw.import < external_skills.* < file.* < shell.exec < web.fetch
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 5);
-        assert!(lines[0].starts_with("- claw.import"));
-        assert!(lines[1].starts_with("- file.read"));
-        assert!(lines[2].starts_with("- file.write"));
-        assert!(lines[3].starts_with("- shell.exec"));
-        assert!(lines[4].starts_with("- web.fetch"));
-        // Verify sorted order: claw.import < external_skills.* < file.* < shell.exec
-        let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 6);
+        assert_eq!(lines.len(), 7);
         assert!(lines[0].starts_with("- claw.import"));
         assert!(lines[1].starts_with("- external_skills.fetch"));
         assert!(lines[2].starts_with("- external_skills.policy"));
         assert!(lines[3].starts_with("- file.read"));
         assert!(lines[4].starts_with("- file.write"));
         assert!(lines[5].starts_with("- shell.exec"));
+        assert!(lines[6].starts_with("- web.fetch"));
     }
 
     #[cfg(all(
@@ -594,8 +576,7 @@ mod tests {
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 5);
-        assert_eq!(entries.len(), 6);
+        assert_eq!(entries.len(), 7);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"claw.import"));
         assert!(names.contains(&"external_skills.fetch"));
@@ -614,8 +595,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 5);
-        assert_eq!(defs.len(), 6);
+        assert_eq!(defs.len(), 7);
 
         let names: Vec<&str> = defs
             .iter()
@@ -627,15 +607,12 @@ mod tests {
             names,
             vec![
                 "claw_import",
-                "file_read",
-                "file_write",
-                "shell_exec",
-                "web_fetch"
                 "external_skills_fetch",
                 "external_skills_policy",
                 "file_read",
                 "file_write",
-                "shell_exec"
+                "shell_exec",
+                "web_fetch"
             ]
         );
 
@@ -777,8 +754,8 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
-            ..runtime_config::ToolRuntimeConfig::default()
             external_skills: Default::default(),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -863,8 +840,8 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
-            ..runtime_config::ToolRuntimeConfig::default()
             external_skills: Default::default(),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -953,8 +930,8 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
-            ..runtime_config::ToolRuntimeConfig::default()
             external_skills: Default::default(),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -1026,8 +1003,8 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
-            ..runtime_config::ToolRuntimeConfig::default()
             external_skills: Default::default(),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -1100,8 +1077,8 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
-            ..runtime_config::ToolRuntimeConfig::default()
             external_skills: Default::default(),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -1164,6 +1141,7 @@ mod tests {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
             external_skills: Default::default(),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -1246,8 +1224,8 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
-            ..runtime_config::ToolRuntimeConfig::default()
             external_skills: Default::default(),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -1332,6 +1310,7 @@ mod tests {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
             external_skills: Default::default(),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -1417,8 +1396,8 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
-            ..runtime_config::ToolRuntimeConfig::default()
             external_skills: Default::default(),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         execute_tool_core_with_config(
             ToolCoreRequest {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -10,6 +10,7 @@ mod file;
 mod kernel_adapter;
 pub mod runtime_config;
 mod shell;
+mod web_fetch;
 
 pub use kernel_adapter::MvpToolAdapter;
 
@@ -46,15 +47,24 @@ pub fn canonical_tool_name(raw: &str) -> &str {
         "file_read" => "file.read",
         "file_write" => "file.write",
         "shell_exec" | "shell" => "shell.exec",
+        "web_fetch" => "web.fetch",
         other => other,
     }
 }
 
 pub fn is_known_tool_name(raw: &str) -> bool {
-    matches!(
-        canonical_tool_name(raw),
+    let canonical = canonical_tool_name(raw);
+    if matches!(
+        canonical,
         "claw.import" | "shell.exec" | "file.read" | "file.write"
-    )
+    ) {
+        return true;
+    }
+    #[cfg(feature = "tool-webfetch")]
+    if canonical == "web.fetch" {
+        return true;
+    }
+    false
 }
 
 pub fn execute_tool_core_with_config(
@@ -71,6 +81,7 @@ pub fn execute_tool_core_with_config(
         "shell.exec" => shell::execute_shell_tool_with_config(request, config),
         "file.read" => file::execute_file_read_tool_with_config(request, config),
         "file.write" => file::execute_file_write_tool_with_config(request, config),
+        "web.fetch" => web_fetch::execute_web_fetch_tool_with_config(request, config),
         _ => Err(format!(
             "tool_not_found: unknown tool `{}`",
             request.tool_name
@@ -108,6 +119,13 @@ pub fn tool_registry() -> Vec<ToolRegistryEntry> {
         entries.push(ToolRegistryEntry {
             name: "shell.exec",
             description: "Execute shell commands",
+        });
+    }
+    #[cfg(feature = "tool-webfetch")]
+    {
+        entries.push(ToolRegistryEntry {
+            name: "web.fetch",
+            description: "Fetch web content with SSRF protection and extraction",
         });
     }
     entries.sort_by_key(|entry| entry.name);
@@ -254,6 +272,51 @@ pub fn provider_tool_definitions() -> Vec<Value> {
         }));
     }
 
+    #[cfg(feature = "tool-webfetch")]
+    {
+        tools.push(json!({
+            "type": "function",
+            "function": {
+                "name": "web_fetch",
+                "description": "Fetch a web page over HTTP/HTTPS with SSRF checks and return extracted text/markdown.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "URL to fetch. Only http/https allowed."
+                        },
+                        "mode": {
+                            "type": "string",
+                            "enum": ["auto", "markdown", "text", "raw"],
+                            "description": "Output mode. auto defaults to markdown for HTML."
+                        },
+                        "max_bytes": {
+                            "type": "integer",
+                            "minimum": 1024,
+                            "maximum": 8388608,
+                            "description": "Maximum response bytes to read."
+                        },
+                        "max_redirects": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 20,
+                            "description": "Maximum redirects to follow."
+                        },
+                        "timeout_seconds": {
+                            "type": "integer",
+                            "minimum": 5,
+                            "maximum": 120,
+                            "description": "Request timeout in seconds."
+                        }
+                    },
+                    "required": ["url"],
+                    "additionalProperties": false
+                }
+            }
+        }));
+    }
+
     tools.sort_by(|left, right| tool_function_name(left).cmp(tool_function_name(right)));
     tools
 }
@@ -298,6 +361,20 @@ fn _shape_examples() -> BTreeMap<&'static str, Value> {
                 "create_dirs": true
             }),
         ),
+        (
+            "web.fetch",
+            json!({
+                "url": "https://example.com",
+                "mode": "auto"
+            }),
+        ),
+        (
+            "web.fetch",
+            json!({
+                "url": "https://example.com",
+                "mode": "auto"
+            }),
+        ),
     ])
 }
 
@@ -315,7 +392,11 @@ mod tests {
         assert_eq!(snapshot, snapshot2);
     }
 
-    #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
+    #[cfg(all(
+        feature = "tool-file",
+        feature = "tool-shell",
+        feature = "tool-webfetch"
+    ))]
     #[test]
     fn capability_snapshot_lists_all_tools_when_all_features_enabled() {
         let snapshot = capability_snapshot();
@@ -327,33 +408,46 @@ mod tests {
         assert!(snapshot.contains("- file.read: Read file contents"));
         assert!(snapshot.contains("- file.write: Write file contents"));
         assert!(snapshot.contains("- shell.exec: Execute shell commands"));
+        assert!(
+            snapshot.contains("- web.fetch: Fetch web content with SSRF protection and extraction")
+        );
 
-        // Verify sorted order: claw.import < file.read < file.write < shell.exec
+        // Verify sorted order: claw.import < file.read < file.write < shell.exec < web.fetch
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 4);
+        assert_eq!(lines.len(), 5);
         assert!(lines[0].starts_with("- claw.import"));
         assert!(lines[1].starts_with("- file.read"));
         assert!(lines[2].starts_with("- file.write"));
         assert!(lines[3].starts_with("- shell.exec"));
+        assert!(lines[4].starts_with("- web.fetch"));
     }
 
-    #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
+    #[cfg(all(
+        feature = "tool-file",
+        feature = "tool-shell",
+        feature = "tool-webfetch"
+    ))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 4);
+        assert_eq!(entries.len(), 5);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"claw.import"));
         assert!(names.contains(&"shell.exec"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
+        assert!(names.contains(&"web.fetch"));
     }
 
-    #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
+    #[cfg(all(
+        feature = "tool-file",
+        feature = "tool-shell",
+        feature = "tool-webfetch"
+    ))]
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 4);
+        assert_eq!(defs.len(), 5);
 
         let names: Vec<&str> = defs
             .iter()
@@ -363,7 +457,13 @@ mod tests {
             .collect();
         assert_eq!(
             names,
-            vec!["claw_import", "file_read", "file_write", "shell_exec"]
+            vec![
+                "claw_import",
+                "file_read",
+                "file_write",
+                "shell_exec",
+                "web_fetch"
+            ]
         );
 
         for item in &defs {
@@ -379,6 +479,7 @@ mod tests {
         assert_eq!(canonical_tool_name("file_write"), "file.write");
         assert_eq!(canonical_tool_name("shell_exec"), "shell.exec");
         assert_eq!(canonical_tool_name("shell"), "shell.exec");
+        assert_eq!(canonical_tool_name("web_fetch"), "web.fetch");
         assert_eq!(canonical_tool_name("file.read"), "file.read");
     }
 
@@ -393,6 +494,11 @@ mod tests {
         assert!(is_known_tool_name("shell.exec"));
         assert!(is_known_tool_name("shell_exec"));
         assert!(is_known_tool_name("shell"));
+        #[cfg(feature = "tool-webfetch")]
+        {
+            assert!(is_known_tool_name("web.fetch"));
+            assert!(is_known_tool_name("web_fetch"));
+        }
         assert!(!is_known_tool_name("nonexistent.tool"));
     }
 
@@ -449,6 +555,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -533,6 +640,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -613,6 +721,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -684,6 +793,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -756,6 +866,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -833,6 +944,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -918,6 +1030,7 @@ mod tests {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allowlist: BTreeSet::new(),
             file_root: Some(root.clone()),
+            ..runtime_config::ToolRuntimeConfig::default()
         };
         execute_tool_core_with_config(
             ToolCoreRequest {

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -6,10 +6,25 @@ use std::sync::OnceLock;
 ///
 /// Replaces per-call `std::env::var` lookups with a single read from a
 /// process-wide singleton that is populated once at startup.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ToolRuntimeConfig {
     pub shell_allowlist: BTreeSet<String>,
     pub file_root: Option<PathBuf>,
+    pub web_fetch_max_bytes: usize,
+    pub web_fetch_max_redirects: u8,
+    pub web_fetch_timeout_secs: u64,
+}
+
+impl Default for ToolRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            shell_allowlist: BTreeSet::new(),
+            file_root: None,
+            web_fetch_max_bytes: 1_048_576,
+            web_fetch_max_redirects: 10,
+            web_fetch_timeout_secs: 30,
+        }
+    }
 }
 
 impl ToolRuntimeConfig {
@@ -29,9 +44,25 @@ impl ToolRuntimeConfig {
 
         let file_root = std::env::var("LOONGCLAW_FILE_ROOT").ok().map(PathBuf::from);
 
+        let web_fetch_max_bytes = std::env::var("LOONGCLAW_WEB_FETCH_MAX_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(1_048_576);
+        let web_fetch_max_redirects = std::env::var("LOONGCLAW_WEB_FETCH_MAX_REDIRECTS")
+            .ok()
+            .and_then(|v| v.parse::<u8>().ok())
+            .unwrap_or(10);
+        let web_fetch_timeout_secs = std::env::var("LOONGCLAW_WEB_FETCH_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(30);
+
         Self {
             shell_allowlist,
             file_root,
+            web_fetch_max_bytes,
+            web_fetch_max_redirects,
+            web_fetch_timeout_secs,
         }
     }
 }
@@ -66,6 +97,9 @@ mod tests {
         let config = ToolRuntimeConfig::default();
         assert!(config.shell_allowlist.is_empty());
         assert!(config.file_root.is_none());
+        assert_eq!(config.web_fetch_max_bytes, 1_048_576);
+        assert_eq!(config.web_fetch_max_redirects, 10);
+        assert_eq!(config.web_fetch_timeout_secs, 30);
     }
 
     #[test]
@@ -75,6 +109,7 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: BTreeSet::from(["git".to_owned(), "cargo".to_owned()]),
             file_root: Some(PathBuf::from("/tmp/test-root")),
+            ..ToolRuntimeConfig::default()
         };
         assert!(config.shell_allowlist.contains("git"));
         assert!(config.shell_allowlist.contains("cargo"));
@@ -98,6 +133,7 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: BTreeSet::from(["echo".to_owned()]),
             file_root: Some(PathBuf::from("/tmp/injected-root")),
+            ..ToolRuntimeConfig::default()
         };
         let result = crate::tools::execute_tool_core_with_config(
             loongclaw_contracts::ToolCoreRequest {

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -32,6 +32,7 @@ pub struct ToolRuntimeConfig {
     pub web_fetch_max_bytes: usize,
     pub web_fetch_max_redirects: u8,
     pub web_fetch_timeout_secs: u64,
+    pub external_skills: ExternalSkillsRuntimePolicy,
 }
 
 impl Default for ToolRuntimeConfig {
@@ -42,9 +43,9 @@ impl Default for ToolRuntimeConfig {
             web_fetch_max_bytes: 1_048_576,
             web_fetch_max_redirects: 10,
             web_fetch_timeout_secs: 30,
+            external_skills: ExternalSkillsRuntimePolicy::default(),
         }
     }
-    pub external_skills: ExternalSkillsRuntimePolicy,
 }
 
 impl ToolRuntimeConfig {
@@ -166,13 +167,13 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: BTreeSet::from(["git".to_owned(), "cargo".to_owned()]),
             file_root: Some(PathBuf::from("/tmp/test-root")),
-            ..ToolRuntimeConfig::default()
             external_skills: ExternalSkillsRuntimePolicy {
                 enabled: true,
                 require_download_approval: false,
                 allowed_domains: BTreeSet::from(["skills.sh".to_owned()]),
                 blocked_domains: BTreeSet::new(),
             },
+            ..ToolRuntimeConfig::default()
         };
         assert!(config.shell_allowlist.contains("git"));
         assert!(config.shell_allowlist.contains("cargo"));
@@ -199,8 +200,8 @@ mod tests {
         let config = ToolRuntimeConfig {
             shell_allowlist: BTreeSet::from(["echo".to_owned()]),
             file_root: Some(PathBuf::from("/tmp/injected-root")),
-            ..ToolRuntimeConfig::default()
             external_skills: ExternalSkillsRuntimePolicy::default(),
+            ..ToolRuntimeConfig::default()
         };
         let result = crate::tools::execute_tool_core_with_config(
             loongclaw_contracts::ToolCoreRequest {

--- a/crates/app/src/tools/web_fetch/extractor.rs
+++ b/crates/app/src/tools/web_fetch/extractor.rs
@@ -1,0 +1,192 @@
+#[cfg(feature = "tool-webfetch")]
+use scraper::{Html, Selector};
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) fn extract_title(html: &str) -> Option<String> {
+    let document = Html::parse_document(html);
+    let selector = Selector::parse("title").ok()?;
+    let raw = document
+        .select(&selector)
+        .next()?
+        .text()
+        .collect::<String>();
+    let normalized = normalize_whitespace(&raw);
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) fn extract_main_content(html: &str) -> String {
+    let document = Html::parse_document(html);
+    let article_selector = Selector::parse("article, main").ok();
+    if let Some(selector) = article_selector
+        && let Some(node) = document.select(&selector).next()
+    {
+        let text = node.text().collect::<Vec<_>>().join(" ");
+        let normalized = normalize_whitespace(&text);
+        if !normalized.is_empty() {
+            return normalized;
+        }
+    }
+
+    let body_selector = Selector::parse("body").ok();
+    if let Some(selector) = body_selector
+        && let Some(node) = document.select(&selector).next()
+    {
+        let text = node.text().collect::<Vec<_>>().join(" ");
+        let normalized = normalize_whitespace(&text);
+        if !normalized.is_empty() {
+            return normalized;
+        }
+    }
+
+    normalize_whitespace(&document.root_element().text().collect::<Vec<_>>().join(" "))
+}
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) fn html_to_markdown(html: &str) -> String {
+    let document = Html::parse_document(html);
+    let mut lines = Vec::new();
+
+    if let Some(title) = extract_title(html) {
+        lines.push(format!("# {title}"));
+        lines.push(String::new());
+    }
+
+    let selector = Selector::parse("article, main, p, h1, h2, h3, h4, h5, h6, li").ok();
+    if let Some(selector) = selector {
+        for node in document.select(&selector) {
+            let tag = node.value().name();
+            let text = normalize_whitespace(&node.text().collect::<Vec<_>>().join(" "));
+            if text.is_empty() {
+                continue;
+            }
+            match tag {
+                "h1" => lines.push(format!("# {text}")),
+                "h2" => lines.push(format!("## {text}")),
+                "h3" => lines.push(format!("### {text}")),
+                "h4" => lines.push(format!("#### {text}")),
+                "h5" => lines.push(format!("##### {text}")),
+                "h6" => lines.push(format!("###### {text}")),
+                "li" => lines.push(format!("- {text}")),
+                _ => lines.push(text),
+            }
+            if matches!(tag, "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6") {
+                lines.push(String::new());
+            }
+        }
+    }
+
+    let markdown = lines.join("\n");
+    let collapsed = collapse_blank_lines(&markdown);
+    if collapsed.trim().is_empty() {
+        extract_main_content(html)
+    } else {
+        collapsed.trim().to_owned()
+    }
+}
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) fn markdown_to_text(markdown: &str) -> String {
+    let mut out = String::with_capacity(markdown.len());
+    for line in markdown.lines() {
+        let trimmed = line.trim_start();
+        let cleaned = trimmed
+            .trim_start_matches('#')
+            .trim_start_matches('-')
+            .trim_start_matches('*')
+            .trim_start_matches(|ch: char| ch.is_ascii_digit() || ch == '.')
+            .trim();
+        if cleaned.is_empty() {
+            out.push('\n');
+        } else {
+            out.push_str(cleaned);
+            out.push('\n');
+        }
+    }
+    normalize_whitespace_lines(&out)
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn normalize_whitespace(input: &str) -> String {
+    input.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn normalize_whitespace_lines(input: &str) -> String {
+    let mut lines = Vec::new();
+    for line in input.lines() {
+        let normalized = normalize_whitespace(line);
+        if !normalized.is_empty() {
+            lines.push(normalized);
+        }
+    }
+    lines.join("\n")
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn collapse_blank_lines(input: &str) -> String {
+    let mut output = String::new();
+    let mut previous_blank = false;
+    for line in input.lines() {
+        let is_blank = line.trim().is_empty();
+        if is_blank {
+            if !previous_blank {
+                output.push('\n');
+            }
+            previous_blank = true;
+            continue;
+        }
+        output.push_str(line);
+        output.push('\n');
+        previous_blank = false;
+    }
+    output
+}
+
+#[cfg(all(test, feature = "tool-webfetch"))]
+mod tests {
+    use super::{extract_main_content, extract_title, html_to_markdown, markdown_to_text};
+
+    #[test]
+    fn extract_title_reads_document_title() {
+        let html = "<html><head><title>Example Title</title></head><body></body></html>";
+        assert_eq!(extract_title(html).as_deref(), Some("Example Title"));
+    }
+
+    #[test]
+    fn extract_main_content_prefers_article() {
+        let html = r#"
+            <html><body>
+                <header>Navigation</header>
+                <article><h1>Hello</h1><p>World</p></article>
+            </body></html>
+        "#;
+        assert_eq!(extract_main_content(html), "Hello World");
+    }
+
+    #[test]
+    fn html_to_markdown_generates_headings_and_paragraphs() {
+        let html = r#"
+            <html>
+                <head><title>Doc</title></head>
+                <body><main><h2>Section</h2><p>Paragraph text</p><ul><li>One</li></ul></main></body>
+            </html>
+        "#;
+        let markdown = html_to_markdown(html);
+        assert!(markdown.contains("# Doc"));
+        assert!(markdown.contains("## Section"));
+        assert!(markdown.contains("Paragraph text"));
+        assert!(markdown.contains("- One"));
+    }
+
+    #[test]
+    fn markdown_to_text_strips_basic_markers() {
+        let markdown = "# Title\n\n- item\n## Sub\nText";
+        let text = markdown_to_text(markdown);
+        assert_eq!(text, "Title\nitem\nSub\nText");
+    }
+}

--- a/crates/app/src/tools/web_fetch/mod.rs
+++ b/crates/app/src/tools/web_fetch/mod.rs
@@ -1,0 +1,549 @@
+use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+mod extractor;
+mod sanitizer;
+mod ssrf;
+
+#[cfg(feature = "tool-webfetch")]
+use reqwest::blocking::{Client, Response};
+#[cfg(feature = "tool-webfetch")]
+use reqwest::header::{CONTENT_TYPE, LOCATION};
+#[cfg(feature = "tool-webfetch")]
+use serde_json::{Value, json};
+
+#[cfg(feature = "tool-webfetch")]
+const HARD_MAX_BYTES: usize = 8 * 1_048_576;
+
+#[cfg(feature = "tool-webfetch")]
+#[derive(Debug)]
+struct FetchOutput {
+    final_url: String,
+    status: u16,
+    content_type: String,
+    body: String,
+    bytes: usize,
+    truncated: bool,
+}
+
+#[cfg(feature = "tool-webfetch")]
+struct ProcessedContent {
+    content: String,
+    extracted_text: String,
+    title: Option<String>,
+}
+
+pub(super) fn execute_web_fetch_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "tool-webfetch"))]
+    {
+        let _ = (request, config);
+        return Err(
+            "web.fetch tool is disabled in this build (enable feature `tool-webfetch`)".to_owned(),
+        );
+    }
+
+    #[cfg(feature = "tool-webfetch")]
+    {
+        let _ = config;
+        let payload = request
+            .payload
+            .as_object()
+            .ok_or_else(|| "web.fetch payload must be an object".to_owned())?;
+        let url = payload
+            .get("url")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| "web.fetch requires payload.url".to_owned())?;
+        let validated = ssrf::validate_url(url)?;
+        resolve_and_validate_host(&validated)?;
+
+        let timeout_seconds = payload
+            .get("timeout_seconds")
+            .and_then(Value::as_u64)
+            .unwrap_or(config.web_fetch_timeout_secs)
+            .clamp(5, 120);
+        let max_redirects = payload
+            .get("max_redirects")
+            .and_then(Value::as_u64)
+            .unwrap_or(config.web_fetch_max_redirects as u64)
+            .min(20) as usize;
+        let max_bytes = payload
+            .get("max_bytes")
+            .and_then(Value::as_u64)
+            .unwrap_or(config.web_fetch_max_bytes as u64)
+            .clamp(1024, HARD_MAX_BYTES as u64) as usize;
+        let mode = payload
+            .get("mode")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("auto");
+        if !matches!(mode, "auto" | "markdown" | "text" | "raw") {
+            return Err(format!(
+                "web.fetch payload.mode must be one of auto|markdown|text|raw, got `{mode}`"
+            ));
+        }
+
+        let client = build_client(timeout_seconds)?;
+        let fetched = fetch_url(
+            &client,
+            validated.url,
+            max_redirects,
+            max_bytes,
+            |candidate| {
+                let validated = ssrf::validate_url(candidate)?;
+                resolve_and_validate_host(&validated)
+            },
+        )?;
+        let processed = process_content(mode, &fetched.content_type, &fetched.body);
+
+        Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "core-tools",
+                "tool_name": request.tool_name,
+                "url": url,
+                "final_url": fetched.final_url,
+                "status_code": fetched.status,
+                "content_type": fetched.content_type,
+                "content": processed.content,
+                "extracted_text": processed.extracted_text,
+                "title": processed.title,
+                "bytes": fetched.bytes,
+                "truncated": fetched.truncated,
+            }),
+        })
+    }
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn process_content(mode: &str, content_type: &str, body: &str) -> ProcessedContent {
+    let is_html = content_type.eq_ignore_ascii_case("text/html")
+        || content_type.eq_ignore_ascii_case("application/xhtml+xml");
+
+    if mode == "raw" {
+        return ProcessedContent {
+            content: body.to_owned(),
+            extracted_text: String::new(),
+            title: None,
+        };
+    }
+
+    if is_html {
+        let sanitized = sanitizer::sanitize_html(body);
+        let title = extractor::extract_title(&sanitized);
+        let markdown = extractor::html_to_markdown(&sanitized);
+        if mode == "text" {
+            let text = extractor::extract_main_content(&sanitized);
+            return ProcessedContent {
+                content: text.clone(),
+                extracted_text: text,
+                title,
+            };
+        }
+        let text = extractor::markdown_to_text(&markdown);
+        return ProcessedContent {
+            content: markdown,
+            extracted_text: text,
+            title,
+        };
+    }
+
+    if mode == "text" {
+        return ProcessedContent {
+            content: body.to_owned(),
+            extracted_text: body.to_owned(),
+            title: None,
+        };
+    }
+
+    let text = extractor::markdown_to_text(body);
+    ProcessedContent {
+        content: body.to_owned(),
+        extracted_text: text,
+        title: None,
+    }
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn build_client(timeout_seconds: u64) -> Result<Client, String> {
+    reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(timeout_seconds))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|error| format!("web.fetch client init failed: {error}"))
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn fetch_url<F>(
+    client: &Client,
+    initial_url: reqwest::Url,
+    max_redirects: usize,
+    max_bytes: usize,
+    mut validate_redirect: F,
+) -> Result<FetchOutput, String>
+where
+    F: FnMut(&str) -> Result<(), String>,
+{
+    let mut current = initial_url;
+
+    for redirect_count in 0..=max_redirects {
+        let response = client
+            .get(current.clone())
+            .send()
+            .map_err(classify_request_error)?;
+
+        if response.status().is_redirection() {
+            if redirect_count == max_redirects {
+                return Err("too_many_redirects: reached redirect limit".to_owned());
+            }
+            current = resolve_redirect_target(&current, &response)?;
+            validate_redirect(current.as_str())?;
+            continue;
+        }
+
+        return decode_response(response, current, max_bytes);
+    }
+
+    Err("too_many_redirects: reached redirect limit".to_owned())
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn resolve_redirect_target(
+    current: &reqwest::Url,
+    response: &Response,
+) -> Result<reqwest::Url, String> {
+    let location = response
+        .headers()
+        .get(LOCATION)
+        .ok_or_else(|| "invalid_redirect: missing Location header".to_owned())?
+        .to_str()
+        .map_err(|error| format!("invalid_redirect: bad Location header: {error}"))?;
+    current
+        .join(location)
+        .map_err(|error| format!("invalid_redirect: {error}"))
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn decode_response(
+    mut response: Response,
+    final_url: reqwest::Url,
+    max_bytes: usize,
+) -> Result<FetchOutput, String> {
+    use std::io::Read;
+
+    let content_type_header = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("application/octet-stream")
+        .to_owned();
+    let content_type = content_type_header
+        .split(';')
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("application/octet-stream")
+        .to_owned();
+
+    let cap = max_bytes.min(HARD_MAX_BYTES);
+    let mut reader = response.by_ref().take((cap + 1) as u64);
+    let mut buffer = Vec::new();
+    reader
+        .read_to_end(&mut buffer)
+        .map_err(|error| format!("web.fetch body read failed: {error}"))?;
+
+    let truncated = buffer.len() > cap;
+    if truncated {
+        buffer.truncate(cap);
+    }
+
+    let body = decode_text_body(&buffer, &content_type_header);
+
+    Ok(FetchOutput {
+        final_url: final_url.to_string(),
+        status: response.status().as_u16(),
+        content_type,
+        bytes: buffer.len(),
+        truncated,
+        body,
+    })
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn decode_text_body(bytes: &[u8], content_type_header: &str) -> String {
+    let header = content_type_header.to_ascii_lowercase();
+
+    if header.contains("charset=utf-16le") {
+        return decode_utf16(bytes, true);
+    }
+    if header.contains("charset=utf-16be") {
+        return decode_utf16(bytes, false);
+    }
+    if header.contains("charset=utf-8") {
+        return String::from_utf8_lossy(bytes).to_string();
+    }
+
+    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        let rest = bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or_default();
+        return String::from_utf8_lossy(rest).to_string();
+    }
+    if bytes.starts_with(&[0xFF, 0xFE]) {
+        let rest = bytes.strip_prefix(&[0xFF, 0xFE]).unwrap_or_default();
+        return decode_utf16(rest, true);
+    }
+    if bytes.starts_with(&[0xFE, 0xFF]) {
+        let rest = bytes.strip_prefix(&[0xFE, 0xFF]).unwrap_or_default();
+        return decode_utf16(rest, false);
+    }
+
+    String::from_utf8_lossy(bytes).to_string()
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn decode_utf16(bytes: &[u8], little_endian: bool) -> String {
+    let mut units = Vec::with_capacity(bytes.len() / 2);
+    for chunk in bytes.chunks_exact(2) {
+        let [a, b] = match chunk {
+            [a, b] => [*a, *b],
+            _ => continue,
+        };
+        let value = if little_endian {
+            u16::from_le_bytes([a, b])
+        } else {
+            u16::from_be_bytes([a, b])
+        };
+        units.push(value);
+    }
+    String::from_utf16_lossy(&units)
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn classify_request_error(error: reqwest::Error) -> String {
+    if error.is_timeout() {
+        return format!("timeout: {error}");
+    }
+    format!("request_failed: {error}")
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn resolve_and_validate_host(validated: &ssrf::ValidatedUrl) -> Result<(), String> {
+    let host = validated.normalized_host.as_str();
+    let port = validated.url.port_or_known_default().unwrap_or(80);
+    let addrs: Vec<std::net::IpAddr> = std::net::ToSocketAddrs::to_socket_addrs(&(host, port))
+        .map_err(|error| format!("dns_resolution_failed: {error}"))?
+        .map(|addr| addr.ip())
+        .collect();
+    ssrf::validate_resolved_addresses(&addrs)
+}
+
+#[cfg(all(test, feature = "tool-webfetch"))]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn fetch_url_follows_redirects() {
+        let base = spawn_server(|path, stream| {
+            if path == "/redirect" {
+                write_response(
+                    stream,
+                    "HTTP/1.1 302 Found\r\nLocation: /final\r\nContent-Length: 0\r\n\r\n",
+                );
+            } else {
+                write_response(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 5\r\n\r\nhello",
+                );
+            }
+        });
+
+        let client = build_client(5);
+        assert!(client.is_ok(), "client init failed");
+        let initial = reqwest::Url::parse(&format!("{base}/redirect"));
+        assert!(initial.is_ok(), "url parse failed");
+
+        let client = match client {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+        let initial = match initial {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+
+        let fetched = fetch_url(&client, initial, 5, 1024, |_candidate| Ok(()));
+        assert!(fetched.is_ok(), "fetch failed");
+        let fetched = match fetched {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+
+        assert_eq!(fetched.status, 200);
+        assert_eq!(fetched.body, "hello");
+        assert!(fetched.final_url.ends_with("/final"));
+    }
+
+    #[test]
+    fn fetch_url_applies_timeout() {
+        let base = spawn_server(|_path, stream| {
+            thread::sleep(Duration::from_millis(1_500));
+            write_response(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\n\r\nok",
+            );
+        });
+
+        let client = build_client(1);
+        assert!(client.is_ok(), "client init failed");
+        let initial = reqwest::Url::parse(&format!("{base}/slow"));
+        assert!(initial.is_ok(), "url parse failed");
+
+        let client = match client {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+        let initial = match initial {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+
+        let err = fetch_url(&client, initial, 0, 1024, |_candidate| Ok(()))
+            .err()
+            .unwrap_or_else(|| "missing expected timeout".to_owned());
+        assert!(
+            err.contains("timeout") || err.contains("request_failed"),
+            "expected timeout-like error, got `{err}`"
+        );
+    }
+
+    #[test]
+    fn fetch_url_limits_response_size() {
+        let body = "x".repeat(3000);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let base = spawn_server(move |_path, stream| {
+            write_response(stream, &response);
+        });
+
+        let client = build_client(5);
+        assert!(client.is_ok(), "client init failed");
+        let initial = reqwest::Url::parse(&format!("{base}/size"));
+        assert!(initial.is_ok(), "url parse failed");
+
+        let client = match client {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+        let initial = match initial {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+
+        let fetched = fetch_url(&client, initial, 0, 1024, |_candidate| Ok(()));
+        assert!(fetched.is_ok(), "fetch failed");
+        let fetched = match fetched {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+        assert!(fetched.truncated);
+        assert_eq!(fetched.bytes, 1024);
+        assert_eq!(fetched.body.len(), 1024);
+    }
+
+    #[test]
+    fn decode_text_body_uses_utf16_bom_when_charset_missing() {
+        let bytes = [0xFF, 0xFE, b'h', 0x00, b'i', 0x00];
+        let decoded = decode_text_body(&bytes, "text/plain");
+        assert_eq!(decoded, "hi");
+    }
+
+    #[test]
+    fn redirect_chain_revalidation_blocks_private_target() {
+        let base = spawn_server(|path, stream| {
+            if path == "/redirect" {
+                write_response(
+                    stream,
+                    "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1/private\r\nContent-Length: 0\r\n\r\n",
+                );
+            } else {
+                write_response(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\n\r\nok",
+                );
+            }
+        });
+
+        let client = build_client(5);
+        assert!(client.is_ok(), "client init failed");
+        let initial = reqwest::Url::parse(&format!("{base}/redirect"));
+        assert!(initial.is_ok(), "url parse failed");
+
+        let client = match client {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+        let initial = match initial {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+
+        let err = fetch_url(&client, initial, 5, 1024, |candidate| {
+            let validated = ssrf::validate_url(candidate)?;
+            resolve_and_validate_host(&validated)
+        })
+        .err()
+        .unwrap_or_else(|| "missing expected error".to_owned());
+
+        assert!(err.contains("ssrf_blocked"));
+    }
+
+    fn spawn_server<F>(handler: F) -> String
+    where
+        F: Fn(&str, &mut std::net::TcpStream) + Send + Sync + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0");
+        assert!(listener.is_ok(), "bind failed");
+        let listener = match listener {
+            Ok(value) => value,
+            Err(_) => return String::new(),
+        };
+        let addr = listener.local_addr();
+        assert!(addr.is_ok(), "local_addr failed");
+        let addr = match addr {
+            Ok(value) => value,
+            Err(_) => return String::new(),
+        };
+        let handler = std::sync::Arc::new(handler);
+
+        thread::spawn(move || {
+            for mut stream in listener.incoming().flatten() {
+                let mut buf = [0_u8; 2048];
+                let read = stream.read(&mut buf).unwrap_or(0);
+                let request = String::from_utf8_lossy(buf.get(..read).unwrap_or(&[]));
+                let path = request
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/");
+                handler(path, &mut stream);
+            }
+        });
+
+        format!("http://{}", addr)
+    }
+
+    fn write_response(stream: &mut std::net::TcpStream, response: &str) {
+        let _ = stream.write_all(response.as_bytes());
+        let _ = stream.flush();
+    }
+}

--- a/crates/app/src/tools/web_fetch/sanitizer.rs
+++ b/crates/app/src/tools/web_fetch/sanitizer.rs
@@ -1,0 +1,127 @@
+#[cfg(feature = "tool-webfetch")]
+const DANGEROUS_TAGS: &[&str] = &[
+    "script", "style", "noscript", "iframe", "object", "embed", "svg", "canvas", "template",
+    "meta", "link",
+];
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) fn sanitize_html(html: &str) -> String {
+    let without_dangerous = remove_dangerous_elements(html);
+    let without_hidden = remove_hidden_elements(&without_dangerous);
+    strip_invisible_unicode(&without_hidden)
+}
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) fn remove_dangerous_elements(html: &str) -> String {
+    let mut output = html.to_owned();
+    for tag in DANGEROUS_TAGS {
+        output = remove_tag_block(&output, tag);
+    }
+    output
+}
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) fn remove_hidden_elements(html: &str) -> String {
+    let mut output = String::with_capacity(html.len());
+
+    for line in html.lines() {
+        let lowered = line.to_ascii_lowercase();
+        if lowered.contains("aria-hidden=\"true\"")
+            || lowered.contains("aria-hidden='true'")
+            || lowered.contains(" hidden")
+            || lowered.contains("display:none")
+            || lowered.contains("visibility:hidden")
+            || lowered.contains("opacity:0")
+        {
+            continue;
+        }
+        output.push_str(line);
+        output.push('\n');
+    }
+
+    output
+}
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) fn strip_invisible_unicode(input: &str) -> String {
+    input
+        .chars()
+        .filter(|ch| {
+            !matches!(
+                *ch as u32,
+                0x200B | 0x200C | 0x200D | 0x2060 | 0xFEFF | 0x202A..=0x202E | 0x2066..=0x2069
+            )
+        })
+        .collect()
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn remove_tag_block(input: &str, tag: &str) -> String {
+    let mut source = input.to_owned();
+    loop {
+        let lower = source.to_ascii_lowercase();
+        let open_pat = format!("<{tag}");
+        let close_pat = format!("</{tag}>");
+
+        let Some(open_idx) = lower.find(&open_pat) else {
+            break;
+        };
+        let search_from = open_idx + open_pat.len();
+        let Some(open_end_rel) = lower[search_from..].find('>') else {
+            source.replace_range(open_idx..source.len(), "");
+            break;
+        };
+        let open_end = search_from + open_end_rel + 1;
+
+        let remove_end = if let Some(close_rel) = lower[open_end..].find(&close_pat) {
+            open_end + close_rel + close_pat.len()
+        } else {
+            open_end
+        };
+        source.replace_range(open_idx..remove_end, "");
+    }
+    source
+}
+
+#[cfg(all(test, feature = "tool-webfetch"))]
+mod tests {
+    use super::{
+        remove_dangerous_elements, remove_hidden_elements, sanitize_html, strip_invisible_unicode,
+    };
+
+    #[test]
+    fn remove_dangerous_elements_strips_script_and_style_blocks() {
+        let html = r#"<div>ok</div><script>alert(1)</script><style>p{}</style><p>done</p>"#;
+        let cleaned = remove_dangerous_elements(html);
+        assert!(cleaned.contains("<div>ok</div>"));
+        assert!(cleaned.contains("<p>done</p>"));
+        assert!(!cleaned.contains("<script"));
+        assert!(!cleaned.contains("<style"));
+    }
+
+    #[test]
+    fn remove_hidden_elements_drops_hidden_lines() {
+        let html = "<p>visible</p>\n<div aria-hidden=\"true\">secret</div>\n<span style=\"display:none\">x</span>\n";
+        let cleaned = remove_hidden_elements(html);
+        assert!(cleaned.contains("visible"));
+        assert!(!cleaned.contains("secret"));
+        assert!(!cleaned.contains("display:none"));
+    }
+
+    #[test]
+    fn strip_invisible_unicode_removes_zero_width_chars() {
+        let input = "a\u{200B}b\u{2066}c\u{2069}d\u{FEFF}e";
+        assert_eq!(strip_invisible_unicode(input), "abcde");
+    }
+
+    #[test]
+    fn sanitize_html_applies_all_stages() {
+        let html = "<p>hi</p>\n<script>boom</script>\n<div aria-hidden=\"true\">x</div>\n<p>z\u{200B}</p>\n";
+        let cleaned = sanitize_html(html);
+        assert!(cleaned.contains("<p>hi</p>"));
+        assert!(cleaned.contains("<p>z</p>"));
+        assert!(!cleaned.contains("script"));
+        assert!(!cleaned.contains("aria-hidden"));
+        assert!(!cleaned.contains('\u{200B}'));
+    }
+}

--- a/crates/app/src/tools/web_fetch/ssrf.rs
+++ b/crates/app/src/tools/web_fetch/ssrf.rs
@@ -1,0 +1,275 @@
+#[cfg(feature = "tool-webfetch")]
+use std::net::IpAddr;
+
+#[cfg(feature = "tool-webfetch")]
+use ipnet::IpNet;
+#[cfg(feature = "tool-webfetch")]
+use url::Url;
+
+#[cfg(feature = "tool-webfetch")]
+const BLOCKED_HOST_SUFFIXES: &[&str] = &[".local", ".localdomain", ".internal", ".corp", ".home"];
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) struct ValidatedUrl {
+    pub url: Url,
+    pub normalized_host: String,
+}
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) fn validate_url(raw: &str) -> Result<ValidatedUrl, String> {
+    let url = Url::parse(raw).map_err(|error| format!("invalid_url: {error}"))?;
+
+    let scheme = url.scheme();
+    if scheme != "http" && scheme != "https" {
+        return Err(format!(
+            "invalid_url_scheme: only http/https are allowed, got `{scheme}`"
+        ));
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| "invalid_url: missing hostname".to_owned())?;
+    let normalized_host = normalize_hostname(host)?;
+
+    if normalized_host == "localhost"
+        || normalized_host.starts_with("localhost.")
+        || normalized_host.contains("xn--")
+        || BLOCKED_HOST_SUFFIXES
+            .iter()
+            .any(|suffix| normalized_host.ends_with(suffix))
+    {
+        return Err(format!(
+            "ssrf_blocked: hostname `{normalized_host}` is blocked"
+        ));
+    }
+
+    if let Ok(ip) = normalized_host.parse::<IpAddr>()
+        && is_special_use_address(ip)
+    {
+        return Err(format!(
+            "ssrf_blocked: address `{normalized_host}` is special-use"
+        ));
+    }
+
+    Ok(ValidatedUrl {
+        url,
+        normalized_host,
+    })
+}
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) fn normalize_hostname(host: &str) -> Result<String, String> {
+    let trimmed = host.trim();
+    if trimmed.is_empty() {
+        return Err("invalid_url: empty hostname".to_owned());
+    }
+    if !trimmed.is_ascii() {
+        return Err("ssrf_blocked: non-ascii hostname is not allowed".to_owned());
+    }
+    Ok(trimmed
+        .trim_end_matches('.')
+        .to_ascii_lowercase()
+        .to_owned())
+}
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) fn is_special_use_address(addr: IpAddr) -> bool {
+    blocked_networks().iter().any(|net| net.contains(&addr))
+}
+
+#[cfg(feature = "tool-webfetch")]
+pub(crate) fn validate_resolved_addresses(addrs: &[IpAddr]) -> Result<(), String> {
+    if addrs.is_empty() {
+        return Err("dns_resolution_failed: no IP addresses resolved".to_owned());
+    }
+    if addrs.iter().any(|addr| is_special_use_address(*addr)) {
+        return Err("ssrf_blocked: DNS resolved to special-use address".to_owned());
+    }
+    Ok(())
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn blocked_networks() -> &'static [IpNet] {
+    static NETWORKS: std::sync::OnceLock<Vec<IpNet>> = std::sync::OnceLock::new();
+    NETWORKS.get_or_init(|| {
+        [
+            // IPv4 special-use ranges
+            "0.0.0.0/8",
+            "10.0.0.0/8",
+            "100.64.0.0/10",
+            "127.0.0.0/8",
+            "169.254.0.0/16",
+            "172.16.0.0/12",
+            "192.0.0.0/24",
+            "192.0.2.0/24",
+            "192.168.0.0/16",
+            "198.18.0.0/15",
+            "198.51.100.0/24",
+            "203.0.113.0/24",
+            "224.0.0.0/4",
+            "240.0.0.0/4",
+            "255.255.255.255/32",
+            // IPv6 special-use ranges
+            "::/128",
+            "::1/128",
+            "::ffff:0:0/96",
+            "64:ff9b::/96",
+            "100::/64",
+            "2001:db8::/32",
+            "fc00::/7",
+            "fe80::/10",
+            "ff00::/8",
+        ]
+        .iter()
+        .filter_map(|cidr| cidr.parse::<IpNet>().ok())
+        .collect()
+    })
+}
+
+#[cfg(all(test, feature = "tool-webfetch"))]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::{is_special_use_address, validate_resolved_addresses, validate_url};
+
+    fn parse_ip(raw: &str) -> IpAddr {
+        let parsed = raw.parse::<IpAddr>();
+        assert!(parsed.is_ok(), "invalid test IP literal: {raw}");
+        parsed.ok().unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
+    }
+
+    #[test]
+    fn validate_url_rejects_non_http_schemes() {
+        let err = validate_url("file:///etc/passwd")
+            .err()
+            .unwrap_or_else(|| "missing expected error".to_owned());
+        assert!(err.contains("invalid_url_scheme"));
+    }
+
+    #[test]
+    fn validate_url_rejects_localhost_like_hosts() {
+        let cases = [
+            "http://localhost",
+            "http://localhost.localdomain",
+            "http://internal.service.local",
+            "https://node.corp/path",
+        ];
+
+        for case in cases {
+            let err = validate_url(case)
+                .err()
+                .unwrap_or_else(|| "missing expected error".to_owned());
+            assert!(
+                err.contains("ssrf_blocked"),
+                "expected ssrf_blocked for `{case}`, got `{err}`"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_url_rejects_special_use_ip_literals() {
+        let err = validate_url("https://127.0.0.1/test")
+            .err()
+            .unwrap_or_else(|| "missing expected error".to_owned());
+        assert!(err.contains("ssrf_blocked"));
+    }
+
+    #[test]
+    fn validate_url_accepts_public_host() {
+        let validated = validate_url("https://example.com/");
+        assert!(validated.is_ok(), "expected valid URL");
+        if let Ok(validated) = validated {
+            assert_eq!(validated.url.scheme(), "https");
+            assert_eq!(validated.normalized_host, "example.com");
+        }
+    }
+
+    #[test]
+    fn special_use_ipv4_ranges_are_blocked() {
+        let blocked = [
+            "0.1.2.3",
+            "10.0.0.1",
+            "100.64.1.1",
+            "127.0.0.1",
+            "169.254.1.1",
+            "172.16.1.1",
+            "192.0.0.1",
+            "192.0.2.12",
+            "192.168.1.1",
+            "198.18.0.10",
+            "198.51.100.5",
+            "203.0.113.8",
+            "224.0.0.1",
+            "240.0.0.1",
+            "255.255.255.255",
+        ];
+        for ip in blocked {
+            assert!(
+                is_special_use_address(parse_ip(ip)),
+                "expected blocked IPv4 address `{ip}`"
+            );
+        }
+    }
+
+    #[test]
+    fn special_use_ipv6_ranges_are_blocked() {
+        let blocked = [
+            "::",
+            "::1",
+            "::ffff:127.0.0.1",
+            "64:ff9b::1",
+            "100::1",
+            "2001:db8::1",
+            "fc00::1",
+            "fd00::1",
+            "fe80::1",
+            "ff00::1",
+        ];
+        for ip in blocked {
+            assert!(
+                is_special_use_address(parse_ip(ip)),
+                "expected blocked IPv6 address `{ip}`"
+            );
+        }
+    }
+
+    #[test]
+    fn ipv4_mapped_ipv6_bypass_is_blocked() {
+        assert!(is_special_use_address(parse_ip("::ffff:127.0.0.1")));
+    }
+
+    #[test]
+    fn dns_rebinding_like_resolution_is_blocked_when_any_ip_is_private() {
+        let resolved = [parse_ip("93.184.216.34"), parse_ip("127.0.0.1")];
+        let err = validate_resolved_addresses(&resolved)
+            .err()
+            .unwrap_or_else(|| "missing expected error".to_owned());
+        assert!(err.contains("ssrf_blocked"));
+    }
+
+    #[test]
+    fn dns_resolution_all_public_is_allowed() {
+        let resolved = [parse_ip("93.184.216.34"), parse_ip("1.1.1.1")];
+        let result = validate_resolved_addresses(&resolved);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn unicode_homograph_hostname_is_rejected() {
+        let err = validate_url("https://exаmple.com")
+            .err()
+            .unwrap_or_else(|| "missing expected error".to_owned());
+        assert!(err.contains("ssrf_blocked"));
+    }
+
+    #[test]
+    fn public_addresses_are_allowed() {
+        let allowed = ["1.1.1.1", "8.8.8.8", "2606:4700:4700::1111"];
+        for ip in allowed {
+            assert!(
+                !is_special_use_address(parse_ip(ip)),
+                "expected public address `{ip}` to be allowed"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added `webfetch` tool for fetching web content and converting to markdown/text/html
- Fixed struct field ordering in `ToolRuntimeConfig` and simplified tool name matching logic
This enables agents to retrieve and process web content directly, expanding tool capabilities for web-based tasks.
## Scope
- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors
## Risk Track
- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)
If Track B, include design/risk notes:
## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [ ] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized
## Linked Issues
Closes #41 