### PR TITLE
refactor: codebase quality improvements from systematic evaluation

### DIFF
--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -18,6 +18,7 @@ use super::runtime::DefaultConversationRuntime;
 use super::*;
 use crate::CliResult;
 use crate::KernelContext;
+use crate::memory::MEMORY_OP_WINDOW;
 
 struct FakeRuntime {
     seed_messages: Vec<Value>,
@@ -1550,7 +1551,7 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_forces_no_replan() 
             &self,
             request: MemoryCoreRequest,
         ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
-            if request.operation == "window" {
+            if request.operation == MEMORY_OP_WINDOW {
                 return Ok(MemoryCoreOutcome {
                     status: "ok".to_owned(),
                     payload: json!({
@@ -1798,7 +1799,7 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_requests_extended_h
                 .lock()
                 .expect("memory invocations lock")
                 .push(request.clone());
-            if request.operation == "window" {
+            if request.operation == MEMORY_OP_WINDOW {
                 return Ok(MemoryCoreOutcome {
                     status: "ok".to_owned(),
                     payload: json!({
@@ -1895,7 +1896,7 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_requests_extended_h
         .clone();
     let window_request = captured
         .iter()
-        .find(|request| request.operation == "window")
+        .find(|request| request.operation == MEMORY_OP_WINDOW)
         .expect("window request should be issued");
     assert_eq!(
         window_request.payload["session_id"],

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1345,7 +1345,7 @@ async fn load_safe_lane_history_signals_for_governor(
         .safe_lane_session_governor_window_turns();
     if let Some(ctx) = kernel_ctx {
         let request = MemoryCoreRequest {
-            operation: "window".to_owned(),
+            operation: memory::MEMORY_OP_WINDOW.to_owned(),
             payload: json!({
                 "session_id": session_id,
                 "limit": window_turns,

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -476,7 +476,7 @@ mod tests {
         };
         let default_window = execute_memory_core_with_config(
             MemoryCoreRequest {
-                operation: "window".to_owned(),
+                operation: MEMORY_OP_WINDOW.to_owned(),
                 payload: json!({
                     "session_id": "window-semantics-session",
                 }),
@@ -504,7 +504,7 @@ mod tests {
         };
         let capped_window = execute_memory_core_with_config(
             MemoryCoreRequest {
-                operation: "window".to_owned(),
+                operation: MEMORY_OP_WINDOW.to_owned(),
                 payload: json!({
                     "session_id": "window-semantics-session",
                 }),

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -182,7 +182,7 @@ pub(super) fn window_direct_with_options(
     config: &MemoryRuntimeConfig,
 ) -> Result<Vec<ConversationTurn>, String> {
     let request = MemoryCoreRequest {
-        operation: "window".to_owned(),
+        operation: MEMORY_OP_WINDOW.to_owned(),
         payload: json!({
             "session_id": session_id,
             "limit": limit,

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use serde_json::{Value, json};
@@ -22,9 +23,9 @@ use error_policy::{
 };
 use model_selection::{fetch_available_models_with_policy, resolve_request_models};
 use payload_adaptation::{
-    CompletionPayloadMode, adapt_payload_mode_for_error, build_completion_request_body,
-    build_turn_request_body, parse_provider_api_error, should_disable_tool_schema_for_error,
-    should_try_next_model_on_error,
+    CompletionPayloadMode, ProviderApiError, adapt_payload_mode_for_error,
+    build_completion_request_body, build_turn_request_body, parse_provider_api_error,
+    should_disable_tool_schema_for_error, should_try_next_model_on_error,
 };
 
 pub use shape::extract_provider_turn;
@@ -147,7 +148,6 @@ pub fn build_messages_for_session(
 pub async fn request_completion(config: &LoongClawConfig, messages: &[Value]) -> CliResult<String> {
     validate_provider_configuration(config)?;
     validate_provider_feature_gate(config)?;
-
     let endpoint = config.provider.endpoint();
     let headers = transport::build_request_headers(&config.provider)?;
     let request_policy = policy::ProviderRequestPolicy::from_config(&config.provider);
@@ -183,7 +183,6 @@ pub async fn request_turn(
 ) -> CliResult<crate::conversation::turn_engine::ProviderTurn> {
     validate_provider_configuration(config)?;
     validate_provider_feature_gate(config)?;
-
     let endpoint = config.provider.endpoint();
     let headers = transport::build_request_headers(&config.provider)?;
     let request_policy = policy::ProviderRequestPolicy::from_config(&config.provider);
@@ -242,20 +241,30 @@ struct ProviderRequestContext<'a> {
     auto_model_mode: bool,
 }
 
-async fn request_completion_with_model(
+/// Caller hook signal: `Retry` = handled, loop again; `Continue` = fall through.
+enum ErrorHookAction {
+    Retry,
+    Continue,
+}
+
+/// Generic retry loop shared by completion and turn request paths.
+async fn execute_with_retry<T>(
     config: &LoongClawConfig,
-    messages: &[Value],
     model: &str,
     request_context: &ProviderRequestContext<'_>,
-) -> Result<String, ModelRequestError> {
+    mut build_body: impl FnMut(CompletionPayloadMode) -> Value,
+    extract_result: impl Fn(&Value, usize) -> Result<T, ModelRequestError>,
+    mut on_error_hook: impl FnMut(&ProviderApiError) -> ErrorHookAction,
+) -> Result<T, ModelRequestError> {
     let mut attempt = 0usize;
     let mut backoff_ms = request_context.request_policy.initial_backoff_ms;
     let mut payload_mode = CompletionPayloadMode::default_for(&config.provider);
     let mut tried_payload_modes = vec![payload_mode];
+    let max_attempts = request_context.request_policy.max_attempts;
 
     loop {
         attempt += 1;
-        let body = build_completion_request_body(config, messages, model, payload_mode);
+        let body = build_body(payload_mode);
         let mut req = request_context
             .client
             .post(request_context.endpoint)
@@ -273,25 +282,21 @@ async fn request_completion_with_model(
                     .map_err(|error| ModelRequestError {
                         message: format!(
                             "provider response decode failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                            max_attempts = request_context.request_policy.max_attempts
                         ),
                         try_next_model: false,
                     })?;
 
                 if status.is_success() {
-                    let content = shape::extract_message_content(&response_body).ok_or_else(|| {
-                        ModelRequestError {
-                            message: format!(
-                                "provider response missing choices[0].message.content for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}",
-                                max_attempts = request_context.request_policy.max_attempts
-                            ),
-                            try_next_model: false,
-                        }
-                    })?;
-                    return Ok(content);
+                    return extract_result(&response_body, attempt);
                 }
 
                 let api_error = parse_provider_api_error(&response_body);
+
+                // Caller-specific error hook (e.g. tool-schema disable for turn path).
+                if matches!(on_error_hook(&api_error), ErrorHookAction::Retry) {
+                    continue;
+                }
+
                 if let Some(next_mode) =
                     adapt_payload_mode_for_error(payload_mode, &config.provider, &api_error)
                     && !tried_payload_modes.contains(&next_mode)
@@ -302,9 +307,7 @@ async fn request_completion_with_model(
                 }
 
                 let status_code = status.as_u16();
-                if attempt < request_context.request_policy.max_attempts
-                    && policy::should_retry_status(status_code)
-                {
+                if attempt < max_attempts && policy::should_retry_status(status_code) {
                     sleep(Duration::from_millis(backoff_ms)).await;
                     backoff_ms = policy::next_backoff_ms(
                         backoff_ms,
@@ -325,15 +328,12 @@ async fn request_completion_with_model(
                 return Err(ModelRequestError {
                     message: format!(
                         "provider returned status {status_code} for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}",
-                        max_attempts = request_context.request_policy.max_attempts
                     ),
                     try_next_model: false,
                 });
             }
             Err(error) => {
-                if attempt < request_context.request_policy.max_attempts
-                    && policy::should_retry_error(&error)
-                {
+                if attempt < max_attempts && policy::should_retry_error(&error) {
                     sleep(Duration::from_millis(backoff_ms)).await;
                     backoff_ms = policy::next_backoff_ms(
                         backoff_ms,
@@ -344,7 +344,6 @@ async fn request_completion_with_model(
                 return Err(ModelRequestError {
                     message: format!(
                         "provider request failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                        max_attempts = request_context.request_policy.max_attempts
                     ),
                     try_next_model: false,
                 });
@@ -353,128 +352,75 @@ async fn request_completion_with_model(
     }
 }
 
+async fn request_completion_with_model(
+    config: &LoongClawConfig,
+    messages: &[Value],
+    model: &str,
+    request_context: &ProviderRequestContext<'_>,
+) -> Result<String, ModelRequestError> {
+    let max_attempts = request_context.request_policy.max_attempts;
+    execute_with_retry(
+        config,
+        model,
+        request_context,
+        |payload_mode| build_completion_request_body(config, messages, model, payload_mode),
+        |response_body, attempt| {
+            shape::extract_message_content(response_body).ok_or_else(|| ModelRequestError {
+                message: format!(
+                    "provider response missing choices[0].message.content for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}",
+                ),
+                try_next_model: false,
+            })
+        },
+        |_api_error: &ProviderApiError| ErrorHookAction::Continue,
+    )
+    .await
+}
+
 async fn request_turn_with_model(
     config: &LoongClawConfig,
     messages: &[Value],
     model: &str,
     request_context: &ProviderRequestContext<'_>,
 ) -> Result<crate::conversation::turn_engine::ProviderTurn, ModelRequestError> {
-    let mut attempt = 0usize;
-    let mut backoff_ms = request_context.request_policy.initial_backoff_ms;
-    let mut payload_mode = CompletionPayloadMode::default_for(&config.provider);
-    let mut tried_payload_modes = vec![payload_mode];
+    let max_attempts = request_context.request_policy.max_attempts;
     let tool_definitions = super::tools::provider_tool_definitions();
-    let mut include_tool_schema = !tool_definitions.is_empty();
+    let include_tool_schema = AtomicBool::new(!tool_definitions.is_empty());
 
-    loop {
-        attempt += 1;
-        let body = build_turn_request_body(
-            config,
-            messages,
-            model,
-            payload_mode,
-            include_tool_schema,
-            &tool_definitions,
-        );
-        let mut req = request_context
-            .client
-            .post(request_context.endpoint)
-            .headers(request_context.headers.clone())
-            .json(&body);
-        if let Some(auth_header) = config.provider.authorization_header() {
-            req = req.header(reqwest::header::AUTHORIZATION, auth_header);
-        }
-
-        match req.send().await {
-            Ok(response) => {
-                let status = response.status();
-                let response_body = transport::decode_response_body(response)
-                    .await
-                    .map_err(|error| ModelRequestError {
-                        message: format!(
-                            "provider response decode failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                            max_attempts = request_context.request_policy.max_attempts
-                        ),
-                        try_next_model: false,
-                    })?;
-
-                if status.is_success() {
-                    let turn = shape::extract_provider_turn(&response_body).ok_or_else(|| {
-                        ModelRequestError {
-                            message: format!(
-                                "provider response missing choices[0].message for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}",
-                                max_attempts = request_context.request_policy.max_attempts
-                            ),
-                            try_next_model: false,
-                        }
-                    })?;
-                    return Ok(turn);
-                }
-
-                let api_error = parse_provider_api_error(&response_body);
-                if include_tool_schema && should_disable_tool_schema_for_error(&api_error) {
-                    include_tool_schema = false;
-                    continue;
-                }
-                if let Some(next_mode) =
-                    adapt_payload_mode_for_error(payload_mode, &config.provider, &api_error)
-                    && !tried_payload_modes.contains(&next_mode)
-                {
-                    payload_mode = next_mode;
-                    tried_payload_modes.push(next_mode);
-                    continue;
-                }
-
-                let status_code = status.as_u16();
-                if attempt < request_context.request_policy.max_attempts
-                    && policy::should_retry_status(status_code)
-                {
-                    sleep(Duration::from_millis(backoff_ms)).await;
-                    backoff_ms = policy::next_backoff_ms(
-                        backoff_ms,
-                        request_context.request_policy.max_backoff_ms,
-                    );
-                    continue;
-                }
-
-                if request_context.auto_model_mode && should_try_next_model_on_error(&api_error) {
-                    return Err(ModelRequestError {
-                        message: format!(
-                            "model `{model}` rejected by provider endpoint; trying next candidate. status {status_code}: {response_body}"
-                        ),
-                        try_next_model: true,
-                    });
-                }
-
-                return Err(ModelRequestError {
-                    message: format!(
-                        "provider returned status {status_code} for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}",
-                        max_attempts = request_context.request_policy.max_attempts
-                    ),
-                    try_next_model: false,
-                });
+    execute_with_retry(
+        config,
+        model,
+        request_context,
+        |payload_mode| {
+            build_turn_request_body(
+                config,
+                messages,
+                model,
+                payload_mode,
+                include_tool_schema.load(Ordering::Relaxed),
+                &tool_definitions,
+            )
+        },
+        |response_body, attempt| {
+            shape::extract_provider_turn(response_body).ok_or_else(|| ModelRequestError {
+                message: format!(
+                    "provider response missing choices[0].message for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}",
+                ),
+                try_next_model: false,
+            })
+        },
+        |api_error| {
+            if include_tool_schema.load(Ordering::Relaxed)
+                && should_disable_tool_schema_for_error(api_error)
+            {
+                include_tool_schema.store(false, Ordering::Relaxed);
+                ErrorHookAction::Retry
+            } else {
+                ErrorHookAction::Continue
             }
-            Err(error) => {
-                if attempt < request_context.request_policy.max_attempts
-                    && policy::should_retry_error(&error)
-                {
-                    sleep(Duration::from_millis(backoff_ms)).await;
-                    backoff_ms = policy::next_backoff_ms(
-                        backoff_ms,
-                        request_context.request_policy.max_backoff_ms,
-                    );
-                    continue;
-                }
-                return Err(ModelRequestError {
-                    message: format!(
-                        "provider request failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                        max_attempts = request_context.request_policy.max_attempts
-                    ),
-                    try_next_model: false,
-                });
-            }
-        }
-    }
+        },
+    )
+    .await
 }
 
 #[cfg(test)]
@@ -488,9 +434,8 @@ mod tests {
     };
     use serde_json::json;
 
-    #[test]
-    fn message_builder_includes_system_prompt() {
-        let config = LoongClawConfig {
+    fn default_test_config() -> LoongClawConfig {
+        LoongClawConfig {
             provider: ProviderConfig::default(),
             cli: crate::config::CliChannelConfig::default(),
             telegram: crate::config::TelegramChannelConfig::default(),
@@ -499,7 +444,12 @@ mod tests {
             tools: ToolConfig::default(),
             external_skills: ExternalSkillsConfig::default(),
             memory: MemoryConfig::default(),
-        };
+        }
+    }
+
+    #[test]
+    fn message_builder_includes_system_prompt() {
+        let config = default_test_config();
 
         let messages =
             build_messages_for_session(&config, "noop-session", true).expect("build messages");
@@ -509,16 +459,7 @@ mod tests {
 
     #[test]
     fn build_messages_includes_capability_snapshot_block() {
-        let config = LoongClawConfig {
-            provider: ProviderConfig::default(),
-            cli: crate::config::CliChannelConfig::default(),
-            telegram: crate::config::TelegramChannelConfig::default(),
-            feishu: FeishuChannelConfig::default(),
-            conversation: ConversationConfig::default(),
-            tools: ToolConfig::default(),
-            external_skills: ExternalSkillsConfig::default(),
-            memory: MemoryConfig::default(),
-        };
+        let config = default_test_config();
 
         let messages =
             build_messages_for_session(&config, "noop-session", true).expect("build messages");
@@ -545,16 +486,7 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     #[test]
     fn build_messages_skips_internal_conversation_events_in_history_window() {
-        let mut config = LoongClawConfig {
-            provider: ProviderConfig::default(),
-            cli: crate::config::CliChannelConfig::default(),
-            telegram: crate::config::TelegramChannelConfig::default(),
-            feishu: FeishuChannelConfig::default(),
-            conversation: ConversationConfig::default(),
-            tools: ToolConfig::default(),
-            external_skills: ExternalSkillsConfig::default(),
-            memory: MemoryConfig::default(),
-        };
+        let mut config = default_test_config();
 
         let session_id = format!(
             "provider-history-filter-{}",
@@ -626,16 +558,7 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     #[test]
     fn build_messages_skips_unknown_history_roles() {
-        let mut config = LoongClawConfig {
-            provider: ProviderConfig::default(),
-            cli: crate::config::CliChannelConfig::default(),
-            telegram: crate::config::TelegramChannelConfig::default(),
-            feishu: FeishuChannelConfig::default(),
-            conversation: ConversationConfig::default(),
-            tools: ToolConfig::default(),
-            external_skills: ExternalSkillsConfig::default(),
-            memory: MemoryConfig::default(),
-        };
+        let mut config = default_test_config();
 
         let session_id = format!(
             "provider-history-role-filter-{}",
@@ -698,16 +621,7 @@ mod tests {
 
     #[test]
     fn message_builder_uses_rendered_prompt_from_pack_metadata() {
-        let mut config = LoongClawConfig {
-            provider: ProviderConfig::default(),
-            cli: crate::config::CliChannelConfig::default(),
-            telegram: crate::config::TelegramChannelConfig::default(),
-            feishu: FeishuChannelConfig::default(),
-            tools: ToolConfig::default(),
-            external_skills: ExternalSkillsConfig::default(),
-            memory: MemoryConfig::default(),
-            conversation: crate::config::ConversationConfig::default(),
-        };
+        let mut config = default_test_config();
         config.cli.personality = Some(crate::prompt::PromptPersonality::FriendlyCollab);
         config.cli.system_prompt = String::new();
 
@@ -721,16 +635,7 @@ mod tests {
 
     #[test]
     fn message_builder_keeps_legacy_inline_prompt_when_pack_is_disabled() {
-        let mut config = LoongClawConfig {
-            provider: ProviderConfig::default(),
-            cli: crate::config::CliChannelConfig::default(),
-            telegram: crate::config::TelegramChannelConfig::default(),
-            feishu: FeishuChannelConfig::default(),
-            tools: ToolConfig::default(),
-            external_skills: ExternalSkillsConfig::default(),
-            memory: MemoryConfig::default(),
-            conversation: crate::config::ConversationConfig::default(),
-        };
+        let mut config = default_test_config();
         config.cli.prompt_pack_id = None;
         config.cli.personality = None;
         config.cli.system_prompt = "You are a legacy inline prompt.".to_owned();
@@ -752,16 +657,7 @@ mod tests {
         let db_path = tmp.join("provider-summary.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let mut config = LoongClawConfig {
-            provider: ProviderConfig::default(),
-            cli: crate::config::CliChannelConfig::default(),
-            telegram: crate::config::TelegramChannelConfig::default(),
-            feishu: FeishuChannelConfig::default(),
-            tools: ToolConfig::default(),
-            external_skills: ExternalSkillsConfig::default(),
-            memory: MemoryConfig::default(),
-            conversation: crate::config::ConversationConfig::default(),
-        };
+        let mut config = default_test_config();
         config.memory.sqlite_path = db_path.display().to_string();
         config.memory.profile = crate::config::MemoryProfile::WindowPlusSummary;
         config.memory.sliding_window = 2;
@@ -796,16 +692,7 @@ mod tests {
 
     #[test]
     fn completion_body_includes_reasoning_effort_when_configured() {
-        let mut config = LoongClawConfig {
-            provider: ProviderConfig::default(),
-            cli: crate::config::CliChannelConfig::default(),
-            telegram: crate::config::TelegramChannelConfig::default(),
-            feishu: FeishuChannelConfig::default(),
-            conversation: ConversationConfig::default(),
-            tools: ToolConfig::default(),
-            external_skills: ExternalSkillsConfig::default(),
-            memory: MemoryConfig::default(),
-        };
+        let mut config = default_test_config();
         config.provider.reasoning_effort = Some(ReasoningEffort::High);
 
         let body = build_completion_request_body(
@@ -819,19 +706,8 @@ mod tests {
 
     #[test]
     fn kimi_coding_completion_body_adds_extra_body_thinking() {
-        let mut config = LoongClawConfig {
-            provider: ProviderConfig {
-                kind: ProviderKind::KimiCoding,
-                ..ProviderConfig::default()
-            },
-            cli: crate::config::CliChannelConfig::default(),
-            telegram: crate::config::TelegramChannelConfig::default(),
-            feishu: FeishuChannelConfig::default(),
-            tools: ToolConfig::default(),
-            external_skills: ExternalSkillsConfig::default(),
-            memory: MemoryConfig::default(),
-            conversation: crate::config::ConversationConfig::default(),
-        };
+        let mut config = default_test_config();
+        config.provider.kind = ProviderKind::KimiCoding;
         config.provider.reasoning_effort = Some(ReasoningEffort::High);
 
         let body = build_completion_request_body(
@@ -861,16 +737,7 @@ mod tests {
 
     #[test]
     fn completion_body_omits_optional_fields_when_not_configured() {
-        let config = LoongClawConfig {
-            provider: ProviderConfig::default(),
-            cli: crate::config::CliChannelConfig::default(),
-            telegram: crate::config::TelegramChannelConfig::default(),
-            feishu: FeishuChannelConfig::default(),
-            conversation: ConversationConfig::default(),
-            tools: ToolConfig::default(),
-            external_skills: ExternalSkillsConfig::default(),
-            memory: MemoryConfig::default(),
-        };
+        let config = default_test_config();
 
         let body = build_completion_request_body(
             &config,
@@ -920,16 +787,7 @@ mod tests {
     #[cfg(any(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn turn_body_includes_tool_schema_and_auto_choice() {
-        let config = LoongClawConfig {
-            provider: ProviderConfig::default(),
-            cli: crate::config::CliChannelConfig::default(),
-            telegram: crate::config::TelegramChannelConfig::default(),
-            feishu: FeishuChannelConfig::default(),
-            conversation: ConversationConfig::default(),
-            tools: ToolConfig::default(),
-            external_skills: ExternalSkillsConfig::default(),
-            memory: MemoryConfig::default(),
-        };
+        let config = default_test_config();
 
         let body = build_turn_request_body(
             &config,
@@ -1117,43 +975,21 @@ mod tests {
 
     #[test]
     fn validate_provider_configuration_rejects_plain_kimi_on_coding_endpoint() {
-        let config = LoongClawConfig {
-            provider: ProviderConfig {
-                kind: ProviderKind::Kimi,
-                base_url: "https://api.kimi.com/coding".to_owned(),
-                chat_completions_path: "/v1/chat/completions".to_owned(),
-                ..ProviderConfig::default()
-            },
-            cli: crate::config::CliChannelConfig::default(),
-            telegram: crate::config::TelegramChannelConfig::default(),
-            feishu: FeishuChannelConfig::default(),
-            tools: ToolConfig::default(),
-            external_skills: ExternalSkillsConfig::default(),
-            memory: MemoryConfig::default(),
-            conversation: crate::config::ConversationConfig::default(),
-        };
+        let mut config = default_test_config();
+        config.provider.kind = ProviderKind::Kimi;
+        config.provider.base_url = "https://api.kimi.com/coding".to_owned();
+        config.provider.chat_completions_path = "/v1/chat/completions".to_owned();
         let error = validate_provider_configuration(&config).expect_err("misconfig should fail");
         assert!(error.contains("use `kind = \"kimi_coding\"`"));
     }
 
     #[test]
     fn validate_provider_configuration_rejects_incompatible_kimi_coding_user_agent() {
-        let config = LoongClawConfig {
-            provider: ProviderConfig {
-                kind: ProviderKind::KimiCoding,
-                headers: [("User-Agent".to_owned(), "LoongClaw/0.1".to_owned())]
-                    .into_iter()
-                    .collect(),
-                ..ProviderConfig::default()
-            },
-            cli: crate::config::CliChannelConfig::default(),
-            telegram: crate::config::TelegramChannelConfig::default(),
-            feishu: FeishuChannelConfig::default(),
-            tools: ToolConfig::default(),
-            external_skills: ExternalSkillsConfig::default(),
-            memory: MemoryConfig::default(),
-            conversation: crate::config::ConversationConfig::default(),
-        };
+        let mut config = default_test_config();
+        config.provider.kind = ProviderKind::KimiCoding;
+        config.provider.headers = [("User-Agent".to_owned(), "LoongClaw/0.1".to_owned())]
+            .into_iter()
+            .collect();
         let error = validate_provider_configuration(&config).expect_err("invalid ua");
         assert!(error.contains("KimiCLI/"));
     }

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -1067,7 +1067,7 @@ async fn run_spec_pressure_once(
     spec: &RunnerSpec,
     scenario: &ProgrammaticPressureScenario,
 ) -> CliResult<ScenarioRunSample> {
-    let report = execute_spec(spec.clone(), false).await;
+    let report = execute_spec(spec, false).await;
     let blocked = report.operation_kind == "blocked" || report.blocked_reason.is_some();
 
     let mut sample = ScenarioRunSample {

--- a/crates/contracts/src/fault.rs
+++ b/crates/contracts/src/fault.rs
@@ -118,8 +118,18 @@ impl Fault {
                 token_id: format!("pack:{pack_id}"),
                 capability,
             },
-            other => Self::Panic {
-                message: other.to_string(),
+            KernelError::PackNotFound(_)
+            | KernelError::DuplicatePack(_)
+            | KernelError::ConnectorNotAllowed { .. }
+            | KernelError::Pack(_)
+            | KernelError::Harness(_)
+            | KernelError::Connector(_)
+            | KernelError::RuntimePlane(_)
+            | KernelError::ToolPlane(_)
+            | KernelError::MemoryPlane(_)
+            | KernelError::Integration(_)
+            | KernelError::Audit(_) => Self::Panic {
+                message: err.to_string(),
             },
         }
     }

--- a/crates/contracts/src/task_state.rs
+++ b/crates/contracts/src/task_state.rs
@@ -38,8 +38,7 @@ impl TaskState {
                 task_id: intent.task_id,
             }),
             other => Err(format!(
-                "invalid transition: cannot move to InSend from {:?}",
-                std::mem::discriminant(&other)
+                "invalid transition: cannot move to InSend from {other:?}"
             )),
         }
     }
@@ -48,8 +47,7 @@ impl TaskState {
         match self {
             Self::InSend { task_id } => Ok(Self::InReply { task_id }),
             other => Err(format!(
-                "invalid transition: cannot move to InReply from {:?}",
-                std::mem::discriminant(&other)
+                "invalid transition: cannot move to InReply from {other:?}"
             )),
         }
     }
@@ -58,8 +56,7 @@ impl TaskState {
         match self {
             Self::InReply { .. } => Ok(Self::Completed(outcome)),
             other => Err(format!(
-                "invalid transition: cannot move to Completed from {:?}",
-                std::mem::discriminant(&other)
+                "invalid transition: cannot move to Completed from {other:?}"
             )),
         }
     }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -641,7 +641,7 @@ fn init_spec_cli(output_path: &str) -> CliResult<()> {
 
 async fn run_spec_cli(spec_path: &str, print_audit: bool) -> CliResult<()> {
     let spec = read_spec_file(spec_path)?;
-    let report = execute_spec(spec, print_audit).await;
+    let report = execute_spec(&spec, print_audit).await;
     let pretty = serde_json::to_string_pretty(&report)
         .map_err(|error| format!("serialize spec run report failed: {error}"))?;
     println!("{pretty}");

--- a/crates/daemon/src/tests/architecture.rs
+++ b/crates/daemon/src/tests/architecture.rs
@@ -51,7 +51,7 @@ async fn execute_spec_allows_execution_with_clean_architecture_guard() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "task");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert!(report.blocked_reason.is_none());
@@ -119,7 +119,7 @@ async fn execute_spec_blocks_when_architecture_guard_detects_core_mutation() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert_eq!(report.outcome["status"], "blocked");
     assert!(report.blocked_reason.is_some());

--- a/crates/daemon/src/tests/programmatic.rs
+++ b/crates/daemon/src/tests/programmatic.rs
@@ -66,7 +66,7 @@ async fn execute_spec_programmatic_tool_call_supports_templates_and_steps() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -147,7 +147,7 @@ async fn execute_spec_programmatic_tool_call_enforces_max_call_budget() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "blocked",
         "blocked_reason={:?}, outcome={}",
@@ -258,7 +258,7 @@ async fn execute_spec_programmatic_tool_call_blocks_when_caller_not_allowlisted(
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "blocked",
         "blocked_reason={:?}, outcome={}",
@@ -344,7 +344,7 @@ async fn execute_spec_programmatic_tool_call_connector_batch_parallel_succeeds()
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -449,7 +449,7 @@ async fn execute_spec_programmatic_tool_call_connector_batch_continue_on_error()
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -545,7 +545,7 @@ async fn execute_spec_programmatic_tool_call_conditional_step_routes_branch() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -626,7 +626,7 @@ async fn execute_spec_programmatic_tool_call_connector_batch_budget_checks_total
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "blocked",
         "blocked_reason={:?}, outcome={}",
@@ -712,7 +712,7 @@ async fn execute_spec_programmatic_tool_call_retry_recovers_transient_failure() 
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -791,7 +791,7 @@ async fn execute_spec_programmatic_tool_call_applies_connector_rate_limits() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -859,7 +859,7 @@ async fn execute_spec_programmatic_tool_call_rejects_invalid_rate_limit_policy()
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "blocked",
         "blocked_reason={:?}, outcome={}",
@@ -970,7 +970,7 @@ async fn execute_spec_programmatic_tool_call_circuit_breaker_blocks_followup_bat
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -1046,7 +1046,7 @@ async fn execute_spec_programmatic_tool_call_rejects_invalid_circuit_policy() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "blocked",
         "blocked_reason={:?}, outcome={}",
@@ -1131,7 +1131,7 @@ async fn execute_spec_programmatic_tool_call_retry_jitter_tracks_backoff_budget(
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -1259,7 +1259,7 @@ async fn execute_spec_programmatic_tool_call_parallel_batch_caps_peak_inflight_b
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -1380,7 +1380,7 @@ async fn execute_spec_programmatic_tool_call_weighted_fairness_avoids_low_priori
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -1519,7 +1519,7 @@ async fn execute_spec_programmatic_tool_call_adaptive_budget_reduces_on_failures
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -1629,7 +1629,7 @@ async fn execute_spec_programmatic_tool_call_default_adaptive_policy_skips_not_f
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -1742,7 +1742,7 @@ async fn execute_spec_programmatic_tool_call_adaptive_policy_can_reduce_on_any_e
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",
@@ -1827,7 +1827,7 @@ async fn execute_spec_programmatic_tool_call_rejects_invalid_concurrency_policy(
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "blocked",
         "blocked_reason={:?}, outcome={}",
@@ -1902,7 +1902,7 @@ async fn execute_spec_programmatic_tool_call_rejects_empty_adaptive_reduce_on_po
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "blocked",
         "blocked_reason={:?}, outcome={}",
@@ -2112,7 +2112,7 @@ async fn execute_spec_programmatic_tool_call_adaptive_budget_respects_min_floor_
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(
         report.operation_kind, "programmatic_tool_call",
         "blocked_reason={:?}, outcome={}",

--- a/crates/daemon/src/tests/spec_runtime.rs
+++ b/crates/daemon/src/tests/spec_runtime.rs
@@ -54,7 +54,7 @@ async fn execute_spec_returns_blocked_instead_of_panicking_on_operation_error() 
         },
     };
 
-    let report = execute_spec(spec.clone(), true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert!(
         report
@@ -452,7 +452,7 @@ async fn execute_spec_blocks_when_security_scan_profile_sha256_mismatches() {
         },
     };
 
-    let report = execute_spec(spec.clone(), true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert!(
         report
@@ -673,7 +673,7 @@ async fn execute_spec_blocks_when_security_scan_profile_signature_mismatches() {
         },
     };
 
-    let report = execute_spec(spec.clone(), true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert!(
         report
@@ -722,7 +722,7 @@ async fn execute_spec_runs_runtime_extension_and_captures_audit() {
         },
     };
 
-    let report = execute_spec(spec.clone(), true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "runtime_extension");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     let events = report.audit_events.expect("audit should be included");
@@ -778,7 +778,7 @@ async fn execute_spec_auto_provisions_provider_and_channel_when_missing() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -833,7 +833,7 @@ async fn execute_spec_applies_hotfix_endpoint_before_invocation() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(
         report.outcome["outcome"]["payload"]["endpoint"],
@@ -905,7 +905,7 @@ async fn execute_spec_scans_plugin_files_and_absorbs_them_for_hotplug() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(report.plugin_scan_reports.len(), 1);
@@ -1002,7 +1002,7 @@ async fn execute_spec_blocks_when_bridge_matrix_does_not_support_plugin() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert_eq!(report.outcome["status"], "blocked");
     assert_eq!(report.plugin_activation_plans.len(), 1);
@@ -1113,7 +1113,7 @@ async fn execute_spec_skips_blocked_plugins_when_bridge_enforcement_is_disabled(
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(report.plugin_activation_plans.len(), 1);
@@ -1234,7 +1234,7 @@ async fn execute_spec_bootstrap_applies_only_bridges_allowed_by_bootstrap_policy
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(report.plugin_activation_plans.len(), 1);
@@ -1348,7 +1348,7 @@ async fn execute_spec_bootstrap_enforcement_blocks_when_ready_plugins_are_deferr
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert_eq!(report.outcome["status"], "blocked");
     assert!(
@@ -1419,7 +1419,7 @@ async fn execute_spec_blocks_on_bridge_support_checksum_mismatch() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert_eq!(report.outcome["status"], "blocked");
     assert!(
@@ -1481,7 +1481,7 @@ async fn execute_spec_blocks_on_bridge_support_sha256_mismatch() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert_eq!(report.outcome["status"], "blocked");
     assert!(
@@ -1542,7 +1542,7 @@ async fn execute_spec_allows_execution_when_bridge_support_sha256_matches() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "task");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert!(report.blocked_reason.is_none());
@@ -1638,7 +1638,7 @@ async fn execute_spec_enriches_plugin_bridge_metadata_and_emits_bridge_execution
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -1779,7 +1779,7 @@ async fn execute_spec_wasm_component_bridge_executes_when_runtime_enabled() {
         },
     };
 
-    let report = execute_spec(spec.clone(), true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -1848,7 +1848,7 @@ async fn execute_spec_wasm_component_bridge_executes_when_runtime_enabled() {
     assert!(provider.metadata.contains_key("plugin_source_path"));
     assert!(provider.metadata.contains_key("component_resolved_path"));
 
-    let cached_report = execute_spec(spec, true).await;
+    let cached_report = execute_spec(&spec, true).await;
     assert_eq!(
         cached_report.outcome["outcome"]["payload"]["bridge_execution"]["runtime"]["cache_hit"],
         true
@@ -1987,7 +1987,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_component_sha256_mismatc
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     let security = report
         .security_scan_report
@@ -2123,7 +2123,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_metadata_pin_conflicts_w
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -2255,7 +2255,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_hash_pin_required_but_mi
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     let security = report
         .security_scan_report
@@ -2392,7 +2392,7 @@ async fn execute_spec_wasm_component_bridge_blocks_artifact_outside_runtime_pref
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -2533,7 +2533,7 @@ async fn execute_spec_wasm_component_bridge_blocks_symlink_escape_under_allowed_
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -2665,7 +2665,7 @@ async fn execute_spec_wasm_component_bridge_blocks_non_regular_artifact_path() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -2798,7 +2798,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_module_size_exceeds_runt
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -2890,7 +2890,7 @@ async fn execute_spec_blocks_when_wasm_runtime_enabled_without_allowed_prefixes(
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert!(
         report
@@ -3016,7 +3016,7 @@ async fn execute_spec_security_scan_blocks_wasm_plugin_with_wasi_import() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert!(
         report
@@ -3163,7 +3163,7 @@ async fn execute_spec_security_scan_allows_clean_wasm_with_hash_pin() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "task");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     let security = report
@@ -3292,7 +3292,7 @@ async fn execute_spec_security_scan_allows_clean_wasm_with_metadata_hash_pin() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "task");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     let security = report
@@ -3426,7 +3426,7 @@ async fn execute_spec_security_scan_blocks_when_metadata_hash_pin_is_invalid() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     let security = report
         .security_scan_report
@@ -3557,7 +3557,7 @@ async fn execute_spec_security_scan_blocks_when_metadata_pin_conflicts_with_poli
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     let security = report
         .security_scan_report
@@ -3679,7 +3679,7 @@ async fn execute_spec_security_scan_emits_audit_summary_when_not_blocking() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "task");
     let security = report
         .security_scan_report
@@ -3833,7 +3833,7 @@ async fn execute_spec_security_scan_exports_siem_record_with_truncation() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "task");
     let security = report
         .security_scan_report
@@ -3974,7 +3974,7 @@ async fn execute_spec_security_scan_siem_fail_closed_blocks_execution() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert!(
         report
@@ -4122,7 +4122,7 @@ async fn execute_spec_security_scan_covers_deferred_plugins_not_only_applied_sub
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert!(
         report
@@ -4181,7 +4181,7 @@ async fn execute_spec_default_medium_policy_blocks_high_risk_tool_call_without_a
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert_eq!(report.outcome["status"], "blocked");
     assert!(report.approval_guard.requires_human_approval);
@@ -4232,7 +4232,7 @@ async fn execute_spec_per_call_approval_allows_high_risk_tool_call() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "tool_core");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert!(report.approval_guard.requires_human_approval);
@@ -4277,7 +4277,7 @@ async fn execute_spec_one_time_full_access_allows_high_risk_tool_call() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "tool_core");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert!(report.approval_guard.requires_human_approval);
@@ -4321,7 +4321,7 @@ async fn execute_spec_strict_mode_requires_approval_for_low_risk_tool_call() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert!(report.approval_guard.requires_human_approval);
     assert!(!report.approval_guard.approved);
@@ -4360,7 +4360,7 @@ async fn execute_spec_default_medium_policy_allows_low_risk_tool_call_without_ap
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "tool_core");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert!(!report.approval_guard.requires_human_approval);
@@ -4440,7 +4440,7 @@ async fn execute_spec_tool_core_can_run_claw_import_plan_via_native_tool_runtime
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "tool_core");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(report.outcome["outcome"]["payload"]["source"], "nanobot");
@@ -4525,7 +4525,7 @@ async fn execute_spec_tool_extension_can_hot_handle_claw_import_via_core_wrapper
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "tool_extension");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -4626,7 +4626,7 @@ async fn execute_spec_tool_extension_can_discover_multiple_sources() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "tool_extension");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(report.outcome["outcome"]["payload"]["action"], "discover");
@@ -4723,7 +4723,7 @@ async fn execute_spec_tool_extension_can_merge_profiles_without_merging_prompt_l
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "tool_extension");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -4829,7 +4829,7 @@ async fn execute_spec_tool_extension_apply_selected_safe_merge_keeps_native_prom
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "tool_extension");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -4898,7 +4898,7 @@ async fn execute_spec_denylist_overrides_other_approvals() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert!(report.approval_guard.denylisted);
     assert!(!report.approval_guard.approved);
@@ -4951,7 +4951,7 @@ async fn execute_spec_one_time_full_access_expired_is_rejected() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert!(!report.approval_guard.approved);
     assert!(report.approval_guard.reason.contains("expired"));
@@ -4996,7 +4996,7 @@ async fn execute_spec_one_time_full_access_with_zero_remaining_uses_is_rejected(
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert!(!report.approval_guard.approved);
     assert!(report.approval_guard.reason.contains("no remaining uses"));
@@ -5110,7 +5110,7 @@ async fn execute_spec_bootstrap_max_tasks_limits_applied_plugins() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "task");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(report.plugin_bootstrap_reports.len(), 1);
@@ -5230,7 +5230,7 @@ async fn execute_spec_scans_multiple_roots_and_absorbs_per_root() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "task");
     assert_eq!(report.plugin_scan_reports.len(), 2);
     assert_eq!(report.plugin_absorb_reports.len(), 2);
@@ -5345,7 +5345,7 @@ async fn execute_spec_plugin_scan_is_transactional_when_blocked() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "blocked");
     assert!(
         report
@@ -5469,7 +5469,7 @@ async fn execute_spec_bootstrap_budget_is_global_across_multiple_roots() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "task");
     assert_eq!(report.plugin_bootstrap_reports.len(), 2);
     let total_applied: usize = report
@@ -5611,7 +5611,7 @@ async fn execute_spec_tool_search_honors_deferred_filter_and_examples() {
         },
     };
 
-    let report_hidden_deferred = execute_spec(base_spec.clone(), true).await;
+    let report_hidden_deferred = execute_spec(&base_spec, true).await;
     assert_eq!(
         report_hidden_deferred.operation_kind, "tool_search",
         "blocked_reason={:?}, outcome={}",
@@ -5627,7 +5627,7 @@ async fn execute_spec_tool_search_honors_deferred_filter_and_examples() {
         include_examples: true,
     };
 
-    let report_visible_deferred = execute_spec(visible_spec, true).await;
+    let report_visible_deferred = execute_spec(&visible_spec, true).await;
     assert_eq!(
         report_visible_deferred.operation_kind, "tool_search",
         "blocked_reason={:?}, outcome={}",
@@ -5734,7 +5734,7 @@ async fn execute_spec_tool_search_uses_translation_bridge_kind_for_unabsorbed_pl
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "tool_search");
     assert_eq!(report.outcome["returned"], 1);
     assert_eq!(report.outcome["results"][0]["provider_id"], "rusty-search");

--- a/crates/daemon/src/tests/spec_runtime_bridge/http_json.rs
+++ b/crates/daemon/src/tests/spec_runtime_bridge/http_json.rs
@@ -104,7 +104,7 @@ async fn execute_spec_http_json_bridge_executes_against_local_server() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     server.join().expect("join local http server");
     let runtime = &report.outcome["outcome"]["payload"]["bridge_execution"]["runtime"];
 
@@ -215,7 +215,7 @@ async fn execute_spec_http_json_bridge_blocks_when_protocol_authorization_fails(
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     let runtime = &report.outcome["outcome"]["payload"]["bridge_execution"]["runtime"];
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(
@@ -353,7 +353,7 @@ async fn execute_spec_http_json_bridge_strict_contract_fails_on_method_mismatch(
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     server.join().expect("join local http server");
     let runtime = &report.outcome["outcome"]["payload"]["bridge_execution"]["runtime"];
 
@@ -477,7 +477,7 @@ async fn execute_spec_http_json_bridge_strict_contract_fails_on_id_mismatch() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     server.join().expect("join local http server");
     let runtime = &report.outcome["outcome"]["payload"]["bridge_execution"]["runtime"];
 
@@ -605,7 +605,7 @@ async fn execute_spec_http_json_bridge_strict_contract_executes_on_matching_fram
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     server.join().expect("join local http server");
     let runtime = &report.outcome["outcome"]["payload"]["bridge_execution"]["runtime"];
 

--- a/crates/daemon/src/tests/spec_runtime_bridge/process_stdio.rs
+++ b/crates/daemon/src/tests/spec_runtime_bridge/process_stdio.rs
@@ -91,7 +91,7 @@ async fn execute_spec_process_stdio_bridge_executes_when_enabled_and_allowed() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     let runtime = &report.outcome["outcome"]["payload"]["bridge_execution"]["runtime"];
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
@@ -214,7 +214,7 @@ async fn execute_spec_process_stdio_bridge_blocks_when_command_not_allowlisted()
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -321,7 +321,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_invalid_json_line_response()
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -436,7 +436,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_id_mismatch() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -545,7 +545,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_method_mismatch() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -653,7 +653,7 @@ async fn execute_spec_process_stdio_bridge_blocks_when_protocol_authorization_fa
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -777,7 +777,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_recv_timeout() {
         },
     };
 
-    let report = execute_spec(spec, true).await;
+    let report = execute_spec(&spec, true).await;
     assert_eq!(report.operation_kind, "connector_legacy");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(

--- a/crates/spec/src/spec_execution.rs
+++ b/crates/spec/src/spec_execution.rs
@@ -42,8 +42,8 @@ pub use bridge_support_policy::{
 };
 pub use security_scan_policy::{load_security_scan_profile_from_path, security_scan_policy};
 
-pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunReport {
-    let mut spec = spec;
+pub async fn execute_spec(spec: &RunnerSpec, include_audit: bool) -> SpecRunReport {
+    let mut pack = spec.pack.clone();
     let audit_sink = Arc::new(InMemoryAuditSink::default());
     let mut kernel = crate::kernel_bootstrap::KernelBuilder::default()
         .clock(Arc::new(SystemClock) as Arc<dyn Clock>)
@@ -54,7 +54,7 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
     let mut blocked_reason = None;
     let mut bridge_support_checksum = None;
     let mut bridge_support_sha256 = None;
-    let approval_guard = evaluate_approval_guard(&spec);
+    let approval_guard = evaluate_approval_guard(spec);
     let mut self_awareness = None;
     let mut architecture_guard = None;
     let mut plugin_scan_reports = Vec::new();
@@ -63,7 +63,7 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
     let mut plugin_bootstrap_reports = Vec::new();
     let mut plugin_bootstrap_queue = Vec::new();
     let mut plugin_absorb_reports = Vec::new();
-    let security_scan_policy = match security_scan_policy(&spec) {
+    let security_scan_policy = match security_scan_policy(spec) {
         Ok(policy) => policy,
         Err(error) => {
             blocked_reason = Some(match blocked_reason {
@@ -73,7 +73,7 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
             None
         }
     };
-    let security_process_allowlist = security_scan_process_allowlist(&spec);
+    let security_process_allowlist = security_scan_process_allowlist(spec);
     let mut security_scan_report = security_scan_policy
         .as_ref()
         .map(|_| SecurityScanReport::default());
@@ -156,8 +156,8 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
 
     if let Some(reason) = blocked_reason.clone() {
         return build_blocked_spec_run_report(
-            spec.pack.pack_id,
-            spec.agent_id,
+            pack.pack_id.clone(),
+            spec.agent_id.clone(),
             reason,
             approval_guard,
             bridge_support_checksum,
@@ -184,8 +184,8 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
         let scanner = PluginScanner::new();
         let translator = PluginTranslator::new();
         let bootstrap_executor = PluginBootstrapExecutor::new();
-        let bootstrap_policy = bootstrap_policy(&spec);
-        let (bridge_matrix, enforce_bridge_support) = bridge_support_matrix(&spec);
+        let bootstrap_policy = bootstrap_policy(spec);
+        let (bridge_matrix, enforce_bridge_support) = bridge_support_matrix(spec);
         let mut pending_absorb_inputs = Vec::new();
         let mut remaining_bootstrap_budget =
             bootstrap_policy.as_ref().map(|policy| policy.max_tasks);
@@ -280,7 +280,7 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
 
         if blocked_reason.is_none() {
             for pending in pending_absorb_inputs {
-                let absorb = scanner.absorb(&mut integration_catalog, &mut spec.pack, &pending);
+                let absorb = scanner.absorb(&mut integration_catalog, &mut pack, &pending);
                 plugin_absorb_reports.push(absorb);
             }
         }
@@ -290,12 +290,7 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
         (security_scan_policy.as_ref(), security_scan_report.as_mut())
         && let Some(export_spec) = policy.siem_export.as_ref().filter(|value| value.enabled)
     {
-        match emit_security_scan_siem_record(
-            &spec.pack.pack_id,
-            &spec.agent_id,
-            report,
-            export_spec,
-        ) {
+        match emit_security_scan_siem_record(&pack.pack_id, &spec.agent_id, report, export_spec) {
             Ok(export_report) => report.siem_export = Some(export_report),
             Err(error) => {
                 report.siem_export = Some(SecuritySiemExportReport {
@@ -316,7 +311,7 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
 
     if let Some(report) = security_scan_report.as_ref()
         && let Err(error) =
-            emit_security_scan_audit_event(&kernel, &spec.pack.pack_id, &spec.agent_id, report)
+            emit_security_scan_audit_event(&kernel, &pack.pack_id, &spec.agent_id, report)
         && blocked_reason.is_none()
     {
         blocked_reason = Some(error);
@@ -324,8 +319,8 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
 
     if let Some(reason) = blocked_reason.clone() {
         return build_blocked_spec_run_report(
-            spec.pack.pack_id,
-            spec.agent_id,
+            pack.pack_id.clone(),
+            spec.agent_id.clone(),
             reason,
             approval_guard,
             bridge_support_checksum,
@@ -362,10 +357,10 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
             required_capabilities: auto.required_capabilities.clone(),
         };
 
-        match agent.plan(&integration_catalog, &spec.pack, &request) {
+        match agent.plan(&integration_catalog, &pack, &request) {
             Ok(plan) => {
                 if !plan.is_noop() {
-                    if let Err(error) = integration_catalog.apply_plan(&mut spec.pack, &plan) {
+                    if let Err(error) = integration_catalog.apply_plan(&mut pack, &plan) {
                         blocked_reason =
                             Some(format!("applying auto-provision plan failed: {error}"));
                     } else {
@@ -390,8 +385,8 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
 
     if let Some(reason) = blocked_reason.clone() {
         return build_blocked_spec_run_report(
-            spec.pack.pack_id,
-            spec.agent_id,
+            pack.pack_id.clone(),
+            spec.agent_id.clone(),
             reason,
             approval_guard,
             bridge_support_checksum,
@@ -413,14 +408,14 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
     }
 
     let shared_catalog = Arc::new(Mutex::new(integration_catalog.clone()));
-    let bridge_runtime_policy = bridge_runtime_policy(&spec, security_scan_policy.as_ref());
+    let bridge_runtime_policy = bridge_runtime_policy(spec, security_scan_policy.as_ref());
     register_dynamic_catalog_connectors(&mut kernel, shared_catalog, bridge_runtime_policy);
 
-    if let Err(error) = kernel.register_pack(spec.pack.clone()) {
+    if let Err(error) = kernel.register_pack(pack.clone()) {
         let reason = format!("spec pack registration failed: {error}");
         return build_blocked_spec_run_report(
-            spec.pack.pack_id,
-            spec.agent_id,
+            pack.pack_id.clone(),
+            spec.agent_id.clone(),
             reason,
             approval_guard,
             bridge_support_checksum,
@@ -442,8 +437,8 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
     }
     if let Err(error) = apply_default_selection(&mut kernel, spec.defaults.as_ref()) {
         return build_blocked_spec_run_report(
-            spec.pack.pack_id,
-            spec.agent_id,
+            pack.pack_id.clone(),
+            spec.agent_id.clone(),
             error,
             approval_guard,
             bridge_support_checksum,
@@ -464,13 +459,13 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
         );
     }
 
-    let token = match kernel.issue_token(&spec.pack.pack_id, &spec.agent_id, spec.ttl_s) {
+    let token = match kernel.issue_token(&pack.pack_id, &spec.agent_id, spec.ttl_s) {
         Ok(token) => token,
         Err(error) => {
             let reason = format!("token issue for spec failed: {error}");
             return build_blocked_spec_run_report(
-                spec.pack.pack_id,
-                spec.agent_id,
+                pack.pack_id.clone(),
+                spec.agent_id.clone(),
                 reason,
                 approval_guard,
                 bridge_support_checksum,
@@ -494,7 +489,7 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
 
     let (operation_kind, outcome) = match execute_spec_operation(
         &kernel,
-        &spec.pack.pack_id,
+        &pack.pack_id,
         &token,
         &integration_catalog,
         &plugin_scan_reports,
@@ -506,8 +501,8 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
         Ok(result) => result,
         Err(error) => {
             return build_blocked_spec_run_report(
-                spec.pack.pack_id,
-                spec.agent_id,
+                pack.pack_id.clone(),
+                spec.agent_id.clone(),
                 error,
                 approval_guard,
                 bridge_support_checksum,
@@ -530,8 +525,8 @@ pub async fn execute_spec(spec: RunnerSpec, include_audit: bool) -> SpecRunRepor
     };
 
     SpecRunReport {
-        pack_id: spec.pack.pack_id,
-        agent_id: spec.agent_id,
+        pack_id: pack.pack_id.clone(),
+        agent_id: spec.agent_id.clone(),
         operation_kind,
         blocked_reason,
         approval_guard,


### PR DESCRIPTION
## Summary

- Systematic codebase evaluation across all 7 crates with 16 agent passes (evaluation, challenge review, implementation, code review) identified and implemented 5 quality improvements
- Improves error diagnostics, compile-time safety, code consistency, reduces duplication, and eliminates unnecessary allocations in benchmark hot paths

### Changes

- **contracts/task_state.rs**: Replace `std::mem::discriminant()` with Debug formatting in 3 transition error messages
- **contracts/fault.rs**: Replace catch-all `other =>` in `Fault::from_kernel_error()` with explicit enumeration of all 11 `KernelError` variants for compile-time exhaustiveness
- **app/memory**: Replace `"window"` string literals with `MEMORY_OP_WINDOW` constant in 6 locations
- **app/provider/mod.rs**: Extract duplicated retry/backoff logic into shared `execute_with_retry()` (1160 → 996 lines)
- **spec/spec_execution.rs**: Change `execute_spec` to accept `&RunnerSpec` instead of owned value; only clone the mutated `pack` field internally
- **bench+daemon**: Update ~60 `execute_spec` call sites to pass by reference

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] `task verify` (full local verification including architecture, conventions, docs, deny)
- [x] Pre-commit hook passed
- [x] Code review by superpowers:code-reviewer agent

**Stats:** 15 files changed, +262 / -423 lines, 654 tests pass

### Deferred items (for future work)

- **D1**: spec→app architecture violation — needs design discussion on abstracting `claw.import` behind a trait
- **D2**: Reduce 32 clones in `execute_spec` body — large refactor, coupled with D1
- **D3**: Reduce `build_blocked_spec_run_report` from 19 parameters to builder struct

## Linked Issues

N/A — originated from systematic codebase evaluation