### PR TITLE
fix(windows): increase stack size for debug builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-args=/STACK:8000000"]
+
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "link-args=/STACK:8000000"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "link-args=/STACK:8000000"]

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 /.loongclaw.local.toml
 /.env.local
 .worktrees/
+.idea
+.vscode
+.zed
+.claude


### PR DESCRIPTION
## Problem
Windows debug builds were failing with `STATUS_STACK_OVERFLOW` error.

## Root Cause
- Debug builds have larger stack frames due to lack of optimization and inlining
- Windows default stack size (1-2MB) is smaller than Linux/macOS
- Complex codebase (especially new ACP/provider runtime features) exceeds this limit

## Solution
Added `.cargo/config.toml` to increase stack size to 8MB for all Windows targets:
```toml
[target.x86_64-pc-windows-msvc]
rustflags = ["-C", "link-args=/STACK:8000000"]
```

## Testing
- ✅ Debug builds now run successfully on Windows
- ✅ Release builds continue to work (optimizations reduce stack usage)

## Changes
- `.cargo/config.toml` - Increase stack size for Windows targets
- `.gitignore` - Add common IDE folder ignores

🤖 Generated with [Claude Code](https://claude.com/claude-code)