### PR TITLE
Harden default shell allowlist and approval policy

### DIFF
--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -225,12 +225,7 @@ fn default_sqlite_path() -> String {
 }
 
 fn default_shell_allowlist() -> Vec<String> {
-    vec![
-        "echo".to_owned(),
-        "cat".to_owned(),
-        "ls".to_owned(),
-        "pwd".to_owned(),
-    ]
+    vec!["echo".to_owned(), "pwd".to_owned()]
 }
 
 const fn default_require_download_approval() -> bool {

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -44,7 +44,7 @@ impl ToolRuntimeConfig {
     pub fn from_env() -> Self {
         let shell_allowlist = std::env::var("LOONGCLAW_SHELL_ALLOWLIST")
             .ok()
-            .unwrap_or_else(|| "echo,cat,ls,pwd".to_owned())
+            .unwrap_or_else(|| "echo,pwd".to_owned())
             .split([',', ';', ' '])
             .map(str::trim)
             .filter(|v| !v.is_empty())
@@ -171,7 +171,7 @@ mod tests {
     #[test]
     fn from_env_parses_default_allowlist() {
         // When the env var is not set, from_env falls back to the hardcoded
-        // defaults: echo, cat, ls, pwd.
+        // defaults: echo, pwd.
         let config = ToolRuntimeConfig::from_env();
         // We can't guarantee the env var is unset in all CI environments,
         // but the parser itself should produce a non-empty set either way.

--- a/crates/kernel/src/policy.rs
+++ b/crates/kernel/src/policy.rs
@@ -35,6 +35,8 @@ const SHELL_APPROVAL_REQUIRED_COMMANDS: &[&str] = &[
     "perl",
     "ruby",
     "php",
+    "cat",
+    "ls",
     "pwsh",
     "powershell",
 ];
@@ -277,6 +279,24 @@ mod tests {
         );
         let decision = default_tool_policy(&request);
         assert!(matches!(decision, PolicyDecision::RequireApproval(_)));
+    }
+
+    #[test]
+    fn static_policy_requires_approval_for_file_listing_commands() {
+        let cat_request = policy_request(
+            "shell.exec",
+            json!({"command": "cat", "args": ["/etc/hosts"]}),
+        );
+        let ls_request = policy_request("shell.exec", json!({"command": "ls", "args": ["/"]}));
+
+        assert!(matches!(
+            default_tool_policy(&cat_request),
+            PolicyDecision::RequireApproval(_)
+        ));
+        assert!(matches!(
+            default_tool_policy(&ls_request),
+            PolicyDecision::RequireApproval(_)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Harden default `shell.exec` behavior by removing `cat`/`ls` from default shell allowlist fallbacks.
- Require explicit approval for `cat` and `ls` via static shell policy.
- Add regression coverage for approval-required file listing commands.
- Why this change is needed: default policy previously allowed easy file disclosure primitives without approval, which weakened practical file-root boundaries.

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:
This changes default tool policy behavior and approval gates for shell commands. Impact is intentional tightening: safer defaults, but operators relying on unrestricted `cat`/`ls` will now need explicit approval flow.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional scenario checks executed:
- `cargo test -q -p loongclaw-kernel static_policy_requires_approval_for_file_listing_commands`
- `cargo test -q -p loongclaw-app from_env_parses_default_allowlist`
- `cargo clippy -p loongclaw-kernel -p loongclaw-app --all-targets --all-features -- -D warnings`

Before/after behavior:
- Before: default shell allowlist included `echo,cat,ls,pwd`; `cat`/`ls` were not approval-required by static policy.
- After: default shell allowlist fallback is reduced to `echo,pwd`; `cat`/`ls` require approval by static policy.
- Regression coverage: environment/default parsing and policy approval gate behavior covered by the tests listed above.

## Linked Issues

Closes #49
