### PR TITLE
Use --locked in installer build commands

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -30,7 +30,7 @@ $repoRoot = Resolve-Path (Join-Path $scriptDir "..")
 Write-Host "==> Building loongclaw (release)"
 Push-Location $repoRoot
 try {
-    cargo build -p loongclaw-daemon --bin loongclaw --release | Out-Host
+    cargo build -p loongclaw-daemon --bin loongclaw --release --locked | Out-Host
 } finally {
     Pop-Location
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,7 +52,7 @@ repo_root="$(cd "${script_dir}/.." && pwd)"
 printf '==> Building loongclaw (release)\n'
 (
   cd "${repo_root}"
-  cargo build -p loongclaw-daemon --bin loongclaw --release
+  cargo build -p loongclaw-daemon --bin loongclaw --release --locked
 )
 
 mkdir -p "${prefix}"


### PR DESCRIPTION
## Summary

- Add `--locked` to installer build command in `scripts/install.sh`.
- Add `--locked` to installer build command in `scripts/install.ps1`.
- Why this change is needed: installer builds should stay lockfile-resolved for reproducibility.

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:
N/A.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional scenario checks executed:
- Verified installer build invocations in both scripts include `--locked`.

## Linked Issues

Closes #57
