### PR TITLE
Document verify tooling prerequisites and fallback checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,12 @@ Thanks for contributing. This guide defines the baseline workflow for external a
 
 - Rust stable toolchain installed.
 - `cargo` available in shell.
+- `task` CLI installed (`go-task`), required for `task verify` / `task verify:full`.
+- Go toolchain installed (required by `task check:conventions`).
+- `cargo-deny` installed (required by `task check:deny`).
 - GitHub account with fork access.
+- Convention checks require the `convention-engineering` skill script at
+  `~/.claude/skills/convention-engineering/scripts/main.go` (see `Taskfile.yml`).
 
 ## Contribution Tracks
 
@@ -26,6 +31,24 @@ Required checks:
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-features
+```
+
+Canonical local gate:
+
+```bash
+task verify
+```
+
+If `task`/`go`/convention skill dependencies are unavailable locally, run at least CI parity plus
+architecture/dep-graph checks directly:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace
+cargo test --workspace --all-features
+scripts/check_architecture_boundaries.sh
+scripts/check_dep_graph.sh
 ```
 
 ### Track B: Higher-risk changes

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 <p align="center">
   <a href="https://github.com/loongclaw-ai/loongclaw/actions/workflows/ci.yml"><img src="https://github.com/loongclaw-ai/loongclaw/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
-  <img src="https://img.shields.io/badge/rust-edition%202021-orange.svg" alt="Rust Edition 2021" />
-  <img src="https://img.shields.io/badge/version-0.1.2--pre-yellow.svg" alt="Version: 0.1.2-pre" />
+  <img src="https://img.shields.io/badge/rust-edition%202024-orange.svg" alt="Rust Edition 2024" />
+  <img src="https://img.shields.io/badge/version-0.1.2-yellow.svg" alt="Version: 0.1.2" />
 </p>
 
 <p align="center">
@@ -161,7 +161,7 @@ cargo run -p loongclaw-daemon --bin loongclawd -- acp-observability --json
 
 ### Prerequisites
 
-- Rust stable toolchain (edition 2021)
+- Rust stable toolchain (edition 2024)
 - `cargo` available in your PATH
 
 ### Install from Source

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,8 +10,8 @@
 <p align="center">
   <a href="https://github.com/loongclaw-ai/loongclaw/actions/workflows/ci.yml"><img src="https://github.com/loongclaw-ai/loongclaw/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
-  <img src="https://img.shields.io/badge/rust-edition%202021-orange.svg" alt="Rust Edition 2021" />
-  <img src="https://img.shields.io/badge/version-0.1.2--pre-yellow.svg" alt="Version: 0.1.2-pre" />
+  <img src="https://img.shields.io/badge/rust-edition%202024-orange.svg" alt="Rust Edition 2024" />
+  <img src="https://img.shields.io/badge/version-0.1.2-yellow.svg" alt="Version: 0.1.2" />
 </p>
 
 <p align="center">
@@ -63,7 +63,7 @@ LoongClaw 是一个基于Rust构建的 Agentic OS 内核，专注于稳定且轻
 
 ### 前置条件
 
-- Rust 稳定工具链（edition 2021）
+- Rust 稳定工具链（edition 2024）
 - `cargo` 在 PATH 中可用
 
 ### 从源码安装


### PR DESCRIPTION
## Summary

- Document missing `task verify` prerequisites in `CONTRIBUTING.md`:
  - `task` (`go-task`)
  - Go toolchain
  - `cargo-deny`
  - convention-engineering skill path used by `Taskfile.yml`
- Add fallback direct-check command set for environments missing optional tooling.
- Why this change is needed: contributor docs must match declared verification workflow dependencies.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:
N/A.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional scenario checks executed:
- Verified documented prerequisites against `Taskfile.yml` preconditions and `verify` task chain.

## Linked Issues

Closes #59
