### PR TITLE
Make CodeQL analyze failures blocking

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,6 @@ jobs:
         if: steps.ghas.outputs.enabled == 'true'
         uses: github/codeql-action/analyze@v4
         timeout-minutes: 10
-        continue-on-error: true
 
       - name: Skip CodeQL when GHAS is unavailable
         if: steps.ghas.outputs.enabled != 'true'


### PR DESCRIPTION
## Summary

- Remove `continue-on-error: true` from CodeQL `Analyze` step.
- Why this change is needed: when GHAS is enabled, security analysis failures should fail the workflow.

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:
Security gate behavior is tightened. Repos with GHAS enabled now get blocking CodeQL analyze results; GHAS-unavailable path remains unchanged and explicitly skipped.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional scenario checks executed:
- Workflow inspection confirming `Analyze` step is now blocking when executed.

## Linked Issues

Closes #61
