### PR TITLE
Gate release workflow on verification checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,6 @@ jobs:
         if: steps.ghas.outputs.enabled == 'true'
         uses: github/codeql-action/analyze@v4
         timeout-minutes: 10
-        continue-on-error: true
 
       - name: Skip CodeQL when GHAS is unavailable
         if: steps.ghas.outputs.enabled != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,49 @@ env:
   PACKAGE_NAME: loongclaw
 
 jobs:
+  verify-release:
+    name: Verify release gates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.93.0
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Cargo Artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy check
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Test (workspace)
+        run: cargo test --workspace --locked
+
+      - name: Test (all features)
+        run: cargo test --workspace --all-features --locked
+
+      - name: Docs build
+        run: cargo doc --workspace --no-deps
+
+      - name: Dependency graph contract
+        run: ./scripts/check_dep_graph.sh
+
+      - name: Strict architecture contract
+        run: LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
+
   build-binaries:
     name: Build ${{ matrix.target }} on ${{ matrix.os }}
+    needs: verify-release
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Add blocking `verify-release` job in release workflow.
- Gate build/publish on release verification checks:
  - fmt
  - strict clippy
  - workspace tests + all-features tests
  - docs build
  - dependency graph contract check
  - strict architecture check
- Why this change is needed: release publish must not proceed without quality/security gates.

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:
Release behavior is intentionally stricter. Tag/dispatch release runs now block on verification before artifact publication.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional scenario checks executed:
- Workflow structure review ensuring `build-binaries` depends on `verify-release`.

## Linked Issues

Closes #52
