### PR TITLE
Align architecture docs with tracked spec->app deviation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,12 +20,14 @@ contracts (leaf — zero internal deps)
 ├── kernel → contracts
 ├── protocol (independent leaf)
 ├── app → contracts, kernel
-├── spec → contracts, kernel, protocol
+├── spec → contracts, kernel, protocol (+ app: known deviation, tracked as D1)
 ├── bench → contracts, kernel, spec
 └── daemon (binary) → all of the above
 ```
 
 Non-negotiable: no dependency cycles. See [Core Beliefs](docs/design-docs/core-beliefs.md).
+Current tracked deviation: D1 keeps `spec -> app` temporary and must be retired by architectural
+refactor, not normalized as permanent layering.
 
 ## 3. Commands
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,12 +12,14 @@ contracts (leaf -- zero internal deps)
 ├── kernel --> contracts
 ├── protocol (independent leaf)
 ├── app --> contracts, kernel
-├── spec --> contracts, kernel, protocol
+├── spec --> contracts, kernel, protocol (+ app: known deviation, tracked as D1)
 ├── bench --> contracts, kernel, spec
 └── daemon (binary) --> all of the above
 ```
 
 No dependency cycles. This is non-negotiable.
+Tracked deviation D1: `spec -> app` is currently allowed for transitional runtime coupling and
+must be removed in a follow-up architecture refactor.
 
 | Crate | Role |
 |-------|------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,12 +20,14 @@ contracts (leaf — zero internal deps)
 ├── kernel → contracts
 ├── protocol (independent leaf)
 ├── app → contracts, kernel
-├── spec → contracts, kernel, protocol
+├── spec → contracts, kernel, protocol (+ app: known deviation, tracked as D1)
 ├── bench → contracts, kernel, spec
 └── daemon (binary) → all of the above
 ```
 
 Non-negotiable: no dependency cycles. See [Core Beliefs](docs/design-docs/core-beliefs.md).
+Current tracked deviation: D1 keeps `spec -> app` temporary and must be retired by architectural
+refactor, not normalized as permanent layering.
 
 ## 3. Commands
 


### PR DESCRIPTION
## Summary

- Align architecture docs with enforced dependency graph by documenting tracked deviation `D1` (`spec -> app`) in:
  - `AGENTS.md`
  - `CLAUDE.md`
  - `ARCHITECTURE.md`
- Why this change is needed: contract docs and enforcement must remain consistent.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:
N/A.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional scenario checks executed:
- `./scripts/check_dep_graph.sh`

## Linked Issues

Closes #53
