### PR TITLE
feat(channel-telegram): add agent typing feedback

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -271,6 +271,12 @@ pub trait ChannelAdapter {
     fn name(&self) -> &str;
     async fn receive_batch(&mut self) -> CliResult<Vec<ChannelInboundMessage>>;
     async fn send_text(&self, target: &ChannelOutboundTarget, text: &str) -> CliResult<()>;
+    async fn start_typing(&self, _target: &ChannelOutboundTarget) -> CliResult<()> {
+        Ok(())
+    }
+    async fn stop_typing(&self, _target: &ChannelOutboundTarget) -> CliResult<()> {
+        Ok(())
+    }
     async fn ack_inbound(&mut self, _message: &ChannelInboundMessage) -> CliResult<()> {
         Ok(())
     }
@@ -290,7 +296,7 @@ async fn process_channel_batch<A, F>(
     mut process: F,
 ) -> CliResult<bool>
 where
-    A: ChannelAdapter + Send + ?Sized,
+    A: ChannelAdapter + Send + Sync + ?Sized,
     F: FnMut(ChannelInboundMessage) -> ChannelProcessFuture,
 {
     if batch.is_empty() {
@@ -303,6 +309,8 @@ where
             runtime.mark_run_start().await?;
         }
 
+        let _ = adapter.start_typing(&message.reply_target).await;
+
         let result = async {
             let reply = process(message.clone()).await?;
             adapter.send_text(&message.reply_target, &reply).await?;
@@ -310,6 +318,8 @@ where
             Ok::<(), String>(())
         }
         .await;
+
+        let _ = adapter.stop_typing(&message.reply_target).await;
 
         if let Some(runtime) = runtime {
             runtime.mark_run_end().await?;
@@ -936,6 +946,8 @@ mod tests {
         sent: Arc<Mutex<Vec<(ChannelOutboundTarget, String)>>>,
         acked: Arc<Mutex<Vec<Option<String>>>>,
         completed_batches: Arc<Mutex<usize>>,
+        typing_events: Arc<Mutex<Vec<String>>>,
+        fail_send: Arc<Mutex<bool>>,
     }
 
     #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
@@ -950,10 +962,29 @@ mod tests {
         }
 
         async fn send_text(&self, target: &ChannelOutboundTarget, text: &str) -> CliResult<()> {
+            if *self.fail_send.lock().expect("fail send flag") {
+                return Err("send failed".to_owned());
+            }
             self.sent
                 .lock()
                 .expect("sent log")
                 .push((target.clone(), text.to_owned()));
+            Ok(())
+        }
+
+        async fn start_typing(&self, target: &ChannelOutboundTarget) -> CliResult<()> {
+            self.typing_events
+                .lock()
+                .expect("typing log")
+                .push(format!("start:{}", target.id));
+            Ok(())
+        }
+
+        async fn stop_typing(&self, target: &ChannelOutboundTarget) -> CliResult<()> {
+            self.typing_events
+                .lock()
+                .expect("typing log")
+                .push(format!("stop:{}", target.id));
             Ok(())
         }
 
@@ -1015,6 +1046,14 @@ mod tests {
             .await
             .expect("default ack hook should succeed");
         adapter
+            .start_typing(&message.reply_target)
+            .await
+            .expect("default typing start hook should succeed");
+        adapter
+            .stop_typing(&message.reply_target)
+            .await
+            .expect("default typing stop hook should succeed");
+        adapter
             .complete_batch()
             .await
             .expect("default batch completion hook should succeed");
@@ -1057,7 +1096,76 @@ mod tests {
             adapter.acked.lock().expect("ack log").as_slice(),
             &[Some("101".to_owned())]
         );
+        assert_eq!(
+            adapter.typing_events.lock().expect("typing log").as_slice(),
+            &["start:1".to_owned(), "stop:1".to_owned()]
+        );
         assert_eq!(*adapter.completed_batches.lock().expect("completed"), 1);
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[tokio::test]
+    async fn process_channel_batch_stops_typing_when_processing_fails() {
+        let mut adapter = RecordingAdapter::default();
+        let batch = vec![ChannelInboundMessage {
+            session: ChannelSession::new(ChannelPlatform::Telegram, "1"),
+            reply_target: ChannelOutboundTarget::telegram_chat(1),
+            text: "hello".to_owned(),
+            delivery: ChannelDelivery {
+                ack_cursor: Some("101".to_owned()),
+                source_message_id: Some("55".to_owned()),
+            },
+        }];
+
+        let error = process_channel_batch(&mut adapter, batch, None, |_message| {
+            Box::pin(async move { Err("process failed".to_owned()) })
+        })
+        .await
+        .expect_err("batch should fail");
+
+        assert_eq!(error, "process failed");
+        assert!(adapter.sent.lock().expect("sent log").is_empty());
+        assert!(adapter.acked.lock().expect("ack log").is_empty());
+        assert_eq!(
+            adapter.typing_events.lock().expect("typing log").as_slice(),
+            &["start:1".to_owned(), "stop:1".to_owned()]
+        );
+        assert_eq!(*adapter.completed_batches.lock().expect("completed"), 0);
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[tokio::test]
+    async fn process_channel_batch_stops_typing_when_send_fails() {
+        let mut adapter = RecordingAdapter::default();
+        *adapter.fail_send.lock().expect("fail send flag") = true;
+        let batch = vec![ChannelInboundMessage {
+            session: ChannelSession::new(ChannelPlatform::Telegram, "1"),
+            reply_target: ChannelOutboundTarget::telegram_chat(1),
+            text: "hello".to_owned(),
+            delivery: ChannelDelivery {
+                ack_cursor: Some("101".to_owned()),
+                source_message_id: Some("55".to_owned()),
+            },
+        }];
+
+        let error = process_channel_batch(
+            &mut adapter,
+            batch,
+            None,
+            |message: ChannelInboundMessage| {
+                Box::pin(async move { Ok(format!("reply: {}", message.text)) })
+            },
+        )
+        .await
+        .expect_err("batch should fail");
+
+        assert_eq!(error, "send failed");
+        assert!(adapter.acked.lock().expect("ack log").is_empty());
+        assert_eq!(
+            adapter.typing_events.lock().expect("typing log").as_slice(),
+            &["start:1".to_owned(), "stop:1".to_owned()]
+        );
+        assert_eq!(*adapter.completed_batches.lock().expect("completed"), 0);
     }
 
     #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]

--- a/crates/app/src/channel/telegram.rs
+++ b/crates/app/src/channel/telegram.rs
@@ -137,11 +137,24 @@ impl TelegramAdapter {
         }
     }
 
+    fn abort_all_typing_handles(&self) {
+        let mut handles = self.typing_handles_guard();
+        for (_, handle) in handles.drain() {
+            handle.abort();
+        }
+    }
+
     fn typing_handles_guard(&self) -> MutexGuard<'_, HashMap<i64, tokio::task::JoinHandle<()>>> {
         match self.typing_handles.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         }
+    }
+}
+
+impl Drop for TelegramAdapter {
+    fn drop(&mut self) {
+        self.abort_all_typing_handles();
     }
 }
 
@@ -601,6 +614,35 @@ mod tests {
             .stop_typing(&target)
             .await
             .expect("stop typing should succeed");
+    }
+
+    #[tokio::test]
+    async fn telegram_adapter_drop_aborts_active_typing_handles() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let dropped_for_task = Arc::clone(&dropped);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let _flag = DropFlag(dropped_for_task);
+            let _ = started_tx.send(());
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+
+        let adapter = test_adapter();
+        adapter
+            .typing_handles
+            .lock()
+            .expect("typing handles lock")
+            .insert(123, handle);
+
+        started_rx.await.expect("typing task should start");
+
+        drop(adapter);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "dropping the adapter should abort active typing handles"
+        );
     }
 
     #[tokio::test]

--- a/crates/app/src/channel/telegram.rs
+++ b/crates/app/src/channel/telegram.rs
@@ -1,7 +1,9 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashMap},
     fs,
     path::{Path, PathBuf},
+    sync::{Mutex, MutexGuard},
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -22,7 +24,10 @@ pub(super) struct TelegramAdapter {
     timeout_s: u64,
     offset_tracker: TelegramOffsetTracker,
     allowlist: BTreeSet<i64>,
+    typing_handles: Mutex<HashMap<i64, tokio::task::JoinHandle<()>>>,
 }
+
+const TELEGRAM_TYPING_REFRESH_INTERVAL: Duration = Duration::from_secs(4);
 
 struct TelegramOffsetTracker {
     offset_path: PathBuf,
@@ -92,6 +97,7 @@ impl TelegramAdapter {
             timeout_s: config.polling_timeout_s.clamp(1, 50),
             offset_tracker: TelegramOffsetTracker::new(offset_path, next_offset),
             allowlist: config.allowed_chat_ids.iter().copied().collect(),
+            typing_handles: Mutex::new(HashMap::new()),
         }
     }
 
@@ -102,6 +108,40 @@ impl TelegramAdapter {
             self.token,
             method
         )
+    }
+
+    fn parse_conversation_chat_id(target: &ChannelOutboundTarget) -> CliResult<i64> {
+        if target.platform != ChannelPlatform::Telegram {
+            return Err(format!(
+                "telegram adapter cannot send to {} target",
+                target.platform.as_str()
+            ));
+        }
+        if target.kind != ChannelOutboundTargetKind::Conversation {
+            return Err(format!(
+                "telegram adapter requires conversation target, got {}",
+                target.kind.as_str()
+            ));
+        }
+
+        target
+            .trimmed_id()?
+            .parse::<i64>()
+            .map_err(|error| format!("invalid telegram chat id `{}`: {error}", target.id))
+    }
+
+    fn stop_typing_handle(&self, chat_id: i64) {
+        let handle = self.typing_handles_guard().remove(&chat_id);
+        if let Some(handle) = handle {
+            handle.abort();
+        }
+    }
+
+    fn typing_handles_guard(&self) -> MutexGuard<'_, HashMap<i64, tokio::task::JoinHandle<()>>> {
+        match self.typing_handles.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
     }
 }
 
@@ -141,23 +181,7 @@ impl ChannelAdapter for TelegramAdapter {
     }
 
     async fn send_text(&self, target: &ChannelOutboundTarget, text: &str) -> CliResult<()> {
-        if target.platform != ChannelPlatform::Telegram {
-            return Err(format!(
-                "telegram adapter cannot send to {} target",
-                target.platform.as_str()
-            ));
-        }
-        if target.kind != ChannelOutboundTargetKind::Conversation {
-            return Err(format!(
-                "telegram adapter requires conversation target, got {}",
-                target.kind.as_str()
-            ));
-        }
-
-        let chat_id = target
-            .trimmed_id()?
-            .parse::<i64>()
-            .map_err(|error| format!("invalid telegram chat id `{}`: {error}", target.id))?;
+        let chat_id = Self::parse_conversation_chat_id(target)?;
 
         let url = self.api_url("sendMessage");
         let client = reqwest::Client::new();
@@ -180,6 +204,33 @@ impl ChannelAdapter for TelegramAdapter {
         if !payload.get("ok").and_then(Value::as_bool).unwrap_or(false) {
             return Err(format!("telegram sendMessage not ok: {payload}"));
         }
+        Ok(())
+    }
+
+    async fn start_typing(&self, target: &ChannelOutboundTarget) -> CliResult<()> {
+        let chat_id = Self::parse_conversation_chat_id(target)?;
+        self.stop_typing_handle(chat_id);
+
+        let client = reqwest::Client::new();
+        let url = self.api_url("sendChatAction");
+        let handle = tokio::spawn(async move {
+            loop {
+                let body = json!({
+                    "chat_id": chat_id,
+                    "action": "typing",
+                });
+                let _ = client.post(&url).json(&body).send().await;
+                tokio::time::sleep(TELEGRAM_TYPING_REFRESH_INTERVAL).await;
+            }
+        });
+
+        self.typing_handles_guard().insert(chat_id, handle);
+        Ok(())
+    }
+
+    async fn stop_typing(&self, target: &ChannelOutboundTarget) -> CliResult<()> {
+        let chat_id = Self::parse_conversation_chat_id(target)?;
+        self.stop_typing_handle(chat_id);
         Ok(())
     }
 
@@ -296,6 +347,38 @@ fn save_offset(path: &Path, next_offset: i64) -> CliResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    fn test_adapter() -> TelegramAdapter {
+        let unique = format!(
+            "loongclaw-telegram-typing-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        );
+        let path = std::env::temp_dir().join(unique).join("offset.txt");
+        TelegramAdapter {
+            account_id: "bot_123456".to_owned(),
+            token: "fake-token".to_owned(),
+            base_url: "http://127.0.0.1:9".to_owned(),
+            timeout_s: 1,
+            offset_tracker: TelegramOffsetTracker::new(path, 0),
+            allowlist: BTreeSet::from([123_i64]),
+            typing_handles: Mutex::new(HashMap::new()),
+        }
+    }
 
     #[test]
     fn offset_file_roundtrip() {
@@ -447,5 +530,113 @@ mod tests {
 
         let offset = load_offset_for_account(home.as_path(), "bot_123456");
         assert_eq!(offset, Some(77));
+    }
+
+    #[tokio::test]
+    async fn telegram_stop_typing_is_idempotent_and_clears_handle() {
+        let adapter = test_adapter();
+        let target = ChannelOutboundTarget::telegram_chat(123);
+
+        adapter
+            .start_typing(&target)
+            .await
+            .expect("start typing should succeed");
+        adapter
+            .stop_typing(&target)
+            .await
+            .expect("first stop typing should succeed");
+        adapter
+            .stop_typing(&target)
+            .await
+            .expect("second stop typing should succeed");
+
+        assert!(
+            adapter
+                .typing_handles
+                .lock()
+                .expect("typing handles lock")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn telegram_start_typing_replaces_existing_handle_for_chat() {
+        let adapter = test_adapter();
+        let target = ChannelOutboundTarget::telegram_chat(123);
+        let dropped = Arc::new(AtomicBool::new(false));
+        let dropped_for_task = Arc::clone(&dropped);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let _flag = DropFlag(dropped_for_task);
+            let _ = started_tx.send(());
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+
+        adapter
+            .typing_handles
+            .lock()
+            .expect("typing handles lock")
+            .insert(123, handle);
+
+        started_rx.await.expect("typing task should start");
+
+        adapter
+            .start_typing(&target)
+            .await
+            .expect("start typing should succeed");
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        assert!(dropped.load(Ordering::SeqCst));
+        assert_eq!(
+            adapter
+                .typing_handles
+                .lock()
+                .expect("typing handles lock")
+                .len(),
+            1
+        );
+
+        adapter
+            .stop_typing(&target)
+            .await
+            .expect("stop typing should succeed");
+    }
+
+    #[tokio::test]
+    async fn telegram_typing_rejects_non_telegram_target() {
+        let adapter = test_adapter();
+        let target = ChannelOutboundTarget::new(
+            ChannelPlatform::Feishu,
+            ChannelOutboundTargetKind::Conversation,
+            "oc_123",
+        );
+
+        let error = adapter
+            .start_typing(&target)
+            .await
+            .expect_err("non telegram target should fail");
+
+        assert_eq!(error, "telegram adapter cannot send to feishu target");
+    }
+
+    #[tokio::test]
+    async fn telegram_typing_rejects_non_conversation_target() {
+        let adapter = test_adapter();
+        let target = ChannelOutboundTarget::new(
+            ChannelPlatform::Telegram,
+            ChannelOutboundTargetKind::MessageReply,
+            "123",
+        );
+
+        let error = adapter
+            .start_typing(&target)
+            .await
+            .expect_err("non conversation target should fail");
+
+        assert_eq!(
+            error,
+            "telegram adapter requires conversation target, got message_reply"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add optional channel typing lifecycle hooks to `ChannelAdapter` and drive them from the shared channel batch processing path
- implement Telegram `sendChatAction`-based typing refresh with per-chat handle replacement and idempotent stop semantics
- add regression coverage for successful and failing batch paths plus Telegram typing target validation and handle lifecycle

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional validation:
- `cargo test -p loongclaw-app channel::`

Known issue observed on current `alpha-test` baseline while running `cargo test --workspace --all-features`:
- unrelated failure in `provider::tests::model_catalog_singleflight_recovers_when_leader_panics`

## Linked Issues

Closes #
