### PR TITLE
feat(kernel): add additive builder/runtime migration surface

### DIFF
--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    ops::Deref,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -69,6 +70,17 @@ pub struct LoongClawKernel<P: PolicyEngine> {
     clock: Arc<dyn Clock>,
     audit: Arc<dyn AuditSink>,
     event_seq: AtomicU64,
+}
+
+/// Additive migration alias for the legacy kernel surface.
+///
+/// During the compatibility window this still exposes the executable
+/// `LoongClawKernel` API, while also supporting `.build()` into the new
+/// frozen `Kernel<P>` handle.
+pub type KernelBuilder<P> = LoongClawKernel<P>;
+
+pub struct Kernel<P: PolicyEngine> {
+    inner: LoongClawKernel<P>,
 }
 
 impl<P: PolicyEngine> LoongClawKernel<P> {
@@ -193,6 +205,11 @@ impl<P: PolicyEngine> LoongClawKernel<P> {
         self.memory_plane
             .set_default_core_adapter(name)
             .map_err(KernelError::from)
+    }
+
+    #[must_use]
+    pub fn build(self) -> Kernel<P> {
+        Kernel { inner: self }
     }
 
     pub fn issue_token(
@@ -819,5 +836,205 @@ impl<P: PolicyEngine> LoongClawKernel<P> {
             agent_id,
             kind,
         }
+    }
+}
+
+impl<P: PolicyEngine> Kernel<P> {
+    pub fn get_namespace(&self, pack_id: &str) -> Option<&loongclaw_contracts::Namespace> {
+        self.inner.get_namespace(pack_id)
+    }
+
+    pub fn issue_token(
+        &self,
+        pack_id: &str,
+        agent_id: &str,
+        ttl_s: u64,
+    ) -> Result<CapabilityToken, KernelError> {
+        self.inner.issue_token(pack_id, agent_id, ttl_s)
+    }
+
+    pub fn revoke_token(
+        &self,
+        token_id: &str,
+        actor_agent_id: Option<&str>,
+    ) -> Result<(), KernelError> {
+        self.inner.revoke_token(token_id, actor_agent_id)
+    }
+
+    pub fn revoke_generation(&self, below: u64) {
+        self.inner.revoke_generation(below);
+    }
+
+    pub fn record_audit_event(
+        &self,
+        agent_id: Option<&str>,
+        kind: AuditEventKind,
+    ) -> Result<(), KernelError> {
+        self.inner.record_audit_event(agent_id, kind)
+    }
+
+    pub async fn execute_task(
+        &self,
+        pack_id: &str,
+        token: &CapabilityToken,
+        task: TaskIntent,
+    ) -> Result<KernelDispatch, KernelError> {
+        self.inner.execute_task(pack_id, token, task).await
+    }
+
+    pub async fn execute_connector_core(
+        &self,
+        pack_id: &str,
+        token: &CapabilityToken,
+        core_name: Option<&str>,
+        command: ConnectorCommand,
+    ) -> Result<ConnectorDispatch, KernelError> {
+        self.inner
+            .execute_connector_core(pack_id, token, core_name, command)
+            .await
+    }
+
+    pub async fn execute_connector_extension(
+        &self,
+        pack_id: &str,
+        token: &CapabilityToken,
+        extension_name: &str,
+        core_name: Option<&str>,
+        command: ConnectorCommand,
+    ) -> Result<ConnectorDispatch, KernelError> {
+        self.inner
+            .execute_connector_extension(pack_id, token, extension_name, core_name, command)
+            .await
+    }
+
+    pub async fn execute_runtime_core(
+        &self,
+        pack_id: &str,
+        token: &CapabilityToken,
+        required_capabilities: &BTreeSet<Capability>,
+        core_name: Option<&str>,
+        request: RuntimeCoreRequest,
+    ) -> Result<RuntimeCoreOutcome, KernelError> {
+        self.inner
+            .execute_runtime_core(pack_id, token, required_capabilities, core_name, request)
+            .await
+    }
+
+    pub async fn execute_runtime_extension(
+        &self,
+        pack_id: &str,
+        token: &CapabilityToken,
+        required_capabilities: &BTreeSet<Capability>,
+        extension_name: &str,
+        core_name: Option<&str>,
+        request: RuntimeExtensionRequest,
+    ) -> Result<RuntimeExtensionOutcome, KernelError> {
+        self.inner
+            .execute_runtime_extension(
+                pack_id,
+                token,
+                required_capabilities,
+                extension_name,
+                core_name,
+                request,
+            )
+            .await
+    }
+
+    pub async fn execute_tool_core(
+        &self,
+        pack_id: &str,
+        token: &CapabilityToken,
+        required_capabilities: &BTreeSet<Capability>,
+        core_name: Option<&str>,
+        request: ToolCoreRequest,
+    ) -> Result<ToolCoreOutcome, KernelError> {
+        self.inner
+            .execute_tool_core(pack_id, token, required_capabilities, core_name, request)
+            .await
+    }
+
+    pub async fn execute_tool_extension(
+        &self,
+        pack_id: &str,
+        token: &CapabilityToken,
+        required_capabilities: &BTreeSet<Capability>,
+        extension_name: &str,
+        core_name: Option<&str>,
+        request: ToolExtensionRequest,
+    ) -> Result<ToolExtensionOutcome, KernelError> {
+        self.inner
+            .execute_tool_extension(
+                pack_id,
+                token,
+                required_capabilities,
+                extension_name,
+                core_name,
+                request,
+            )
+            .await
+    }
+
+    pub async fn execute_memory_core(
+        &self,
+        pack_id: &str,
+        token: &CapabilityToken,
+        required_capabilities: &BTreeSet<Capability>,
+        core_name: Option<&str>,
+        request: MemoryCoreRequest,
+    ) -> Result<MemoryCoreOutcome, KernelError> {
+        self.inner
+            .execute_memory_core(pack_id, token, required_capabilities, core_name, request)
+            .await
+    }
+
+    pub async fn execute_memory_extension(
+        &self,
+        pack_id: &str,
+        token: &CapabilityToken,
+        required_capabilities: &BTreeSet<Capability>,
+        extension_name: &str,
+        core_name: Option<&str>,
+        request: MemoryExtensionRequest,
+    ) -> Result<MemoryExtensionOutcome, KernelError> {
+        self.inner
+            .execute_memory_extension(
+                pack_id,
+                token,
+                required_capabilities,
+                extension_name,
+                core_name,
+                request,
+            )
+            .await
+    }
+}
+
+impl<P: PolicyEngine> AsRef<LoongClawKernel<P>> for Kernel<P> {
+    fn as_ref(&self) -> &LoongClawKernel<P> {
+        &self.inner
+    }
+}
+
+impl<P: PolicyEngine> Deref for Kernel<P> {
+    type Target = LoongClawKernel<P>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[cfg(test)]
+mod send_sync_tests {
+    use super::*;
+    use crate::StaticPolicyEngine;
+
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+
+    #[test]
+    fn kernel_is_send_and_sync() {
+        assert_send::<Kernel<StaticPolicyEngine>>();
+        assert_sync::<Kernel<StaticPolicyEngine>>();
     }
 }

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -50,7 +50,7 @@ pub use integration::{
     AutoProvisionAgent, AutoProvisionRequest, ChannelConfig, IntegrationCatalog, IntegrationHotfix,
     ProviderConfig, ProviderTemplate, ProvisionAction, ProvisionPlan,
 };
-pub use kernel::{ConnectorDispatch, KernelDispatch, LoongClawKernel};
+pub use kernel::{ConnectorDispatch, Kernel, KernelBuilder, KernelDispatch, LoongClawKernel};
 pub use memory::{
     CoreMemoryAdapter, MemoryCoreOutcome, MemoryCoreRequest, MemoryExtensionAdapter,
     MemoryExtensionOutcome, MemoryExtensionRequest, MemoryPlane, MemoryTier,

--- a/crates/kernel/src/tests.rs
+++ b/crates/kernel/src/tests.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     errors::{ConnectorError, KernelError, PolicyError},
     harness::HarnessAdapter,
-    kernel::LoongClawKernel,
+    kernel::{KernelBuilder, LoongClawKernel},
     memory::{
         CoreMemoryAdapter, MemoryCoreOutcome, MemoryCoreRequest, MemoryExtensionAdapter,
         MemoryExtensionOutcome, MemoryExtensionRequest,
@@ -1986,4 +1986,61 @@ fn namespace_membrane_defaults_to_pack_id() {
 
     let ns = kernel.get_namespace("sales-intel").unwrap();
     assert_eq!(ns.membrane, "sales-intel");
+}
+
+#[tokio::test]
+async fn kernel_is_usable_from_concurrent_tasks() {
+    let mut builder = KernelBuilder::new(StaticPolicyEngine::default());
+    builder
+        .register_pack(sample_pack())
+        .expect("pack should register");
+    builder.register_core_connector_adapter(MockCoreConnector);
+    builder
+        .set_default_core_connector_adapter("http-core")
+        .expect("default connector adapter should register");
+    let kernel = Arc::new(builder.build());
+
+    let token = kernel
+        .issue_token("sales-intel", "agent-alpha", 120)
+        .expect("token should issue");
+
+    let mut handles = Vec::new();
+    for i in 0..4 {
+        let kernel = Arc::clone(&kernel);
+        let token = token.clone();
+        handles.push(tokio::spawn(async move {
+            kernel
+                .execute_connector_core(
+                    "sales-intel",
+                    &token,
+                    None,
+                    ConnectorCommand {
+                        connector_name: "crm".to_owned(),
+                        operation: "lookup".to_owned(),
+                        required_capabilities: BTreeSet::from([Capability::InvokeConnector]),
+                        payload: json!({"id": format!("concurrent-{i}")}),
+                    },
+                )
+                .await
+        }));
+    }
+
+    for (i, handle) in handles.into_iter().enumerate() {
+        let dispatch = handle
+            .await
+            .expect("task should not panic")
+            .expect("concurrent dispatch should succeed");
+        assert_eq!(dispatch.connector_name, "crm");
+        assert_eq!(dispatch.outcome.status, "ok");
+        assert_eq!(
+            dispatch.outcome.payload,
+            json!({
+                "tier": "core",
+                "adapter": "http-core",
+                "connector": "crm",
+                "operation": "lookup",
+                "payload": {"id": format!("concurrent-{i}")},
+            })
+        );
+    }
 }

--- a/crates/spec/src/kernel_bootstrap.rs
+++ b/crates/spec/src/kernel_bootstrap.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 
 use kernel::{
-    AuditSink, Capability, Clock, ExecutionRoute, HarnessKind, InMemoryAuditSink, LoongClawKernel,
+    AuditSink, Capability, Clock, ExecutionRoute, HarnessKind, InMemoryAuditSink,
+    Kernel as FrozenKernel, KernelBuilder as RuntimeKernelBuilder, LoongClawKernel,
     StaticPolicyEngine, SystemClock, VerticalPackManifest,
 };
 
@@ -46,37 +47,87 @@ impl KernelBuilder {
     /// Build and return a fully configured kernel with all builtin adapters
     /// and the default pack manifest registered.
     pub fn build(self) -> LoongClawKernel<StaticPolicyEngine> {
-        let native_tool_executor = self.native_tool_executor;
-        let mut kernel = match (self.clock, self.audit) {
-            (Some(clock), Some(audit)) => {
-                LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit)
-            }
-            (Some(clock), None) => LoongClawKernel::with_runtime(
-                StaticPolicyEngine::default(),
-                clock,
-                Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
-            ),
-            (None, Some(audit)) => LoongClawKernel::with_runtime(
-                StaticPolicyEngine::default(),
-                Arc::new(SystemClock) as Arc<dyn Clock>,
-                audit,
-            ),
-            (None, None) => LoongClawKernel::with_runtime(
-                StaticPolicyEngine::default(),
-                Arc::new(SystemClock) as Arc<dyn Clock>,
-                Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
-            ),
-        };
-        register_builtin_adapters(&mut kernel, native_tool_executor);
-        // The default pack manifest is hardcoded and always valid; ignore the
-        // impossible error branch to avoid panicking in production.
-        let _ = kernel.register_pack(default_pack_manifest());
-        kernel
+        configured_builder(self.clock, self.audit, self.native_tool_executor)
     }
 }
 
+/// Additive bootstrap entrypoint that exposes the new builder/runtime split
+/// without breaking the legacy `KernelBuilder` API.
+///
+/// The returned runtime handle dereferences to the legacy kernel surface so
+/// helper code typed against `&LoongClawKernel<_>` can continue to work while
+/// callers migrate toward the explicit `Kernel<P>` name.
+#[derive(Default)]
+pub struct BootstrapBuilder {
+    clock: Option<Arc<dyn Clock>>,
+    audit: Option<Arc<dyn AuditSink>>,
+    native_tool_executor: Option<crate::NativeToolExecutor>,
+}
+
+impl BootstrapBuilder {
+    pub fn clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = Some(clock);
+        self
+    }
+
+    pub fn audit(mut self, audit: Arc<dyn AuditSink>) -> Self {
+        self.audit = Some(audit);
+        self
+    }
+
+    pub fn native_tool_executor(mut self, executor: crate::NativeToolExecutor) -> Self {
+        self.native_tool_executor = Some(executor);
+        self
+    }
+
+    pub fn build(self) -> FrozenKernel<StaticPolicyEngine> {
+        self.into_builder().build()
+    }
+
+    /// Return the additive migration builder surface.
+    ///
+    /// This remains a compatibility alias over `LoongClawKernel`, so it keeps
+    /// the legacy executable API while also supporting `.build()` into
+    /// `Kernel<P>`.
+    pub fn into_builder(self) -> RuntimeKernelBuilder<StaticPolicyEngine> {
+        configured_builder(self.clock, self.audit, self.native_tool_executor)
+    }
+}
+
+fn configured_builder(
+    clock: Option<Arc<dyn Clock>>,
+    audit: Option<Arc<dyn AuditSink>>,
+    native_tool_executor: Option<crate::NativeToolExecutor>,
+) -> RuntimeKernelBuilder<StaticPolicyEngine> {
+    let mut kernel = match (clock, audit) {
+        (Some(clock), Some(audit)) => {
+            RuntimeKernelBuilder::with_runtime(StaticPolicyEngine::default(), clock, audit)
+        }
+        (Some(clock), None) => RuntimeKernelBuilder::with_runtime(
+            StaticPolicyEngine::default(),
+            clock,
+            Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
+        ),
+        (None, Some(audit)) => RuntimeKernelBuilder::with_runtime(
+            StaticPolicyEngine::default(),
+            Arc::new(SystemClock) as Arc<dyn Clock>,
+            audit,
+        ),
+        (None, None) => RuntimeKernelBuilder::with_runtime(
+            StaticPolicyEngine::default(),
+            Arc::new(SystemClock) as Arc<dyn Clock>,
+            Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
+        ),
+    };
+    register_builtin_adapters(&mut kernel, native_tool_executor);
+    // The default pack manifest is hardcoded and always valid; ignore the
+    // impossible error branch to avoid panicking in production.
+    let _ = kernel.register_pack(default_pack_manifest());
+    kernel
+}
+
 fn register_builtin_adapters(
-    kernel: &mut LoongClawKernel<StaticPolicyEngine>,
+    kernel: &mut RuntimeKernelBuilder<StaticPolicyEngine>,
     native_tool_executor: Option<crate::NativeToolExecutor>,
 ) {
     kernel.register_harness_adapter(EmbeddedPiHarness {
@@ -134,7 +185,7 @@ pub fn default_pack_manifest() -> VerticalPackManifest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kernel::FixedClock;
+    use kernel::{FixedClock, LoongClawKernel};
 
     #[test]
     fn builder_default_creates_kernel() {
@@ -155,6 +206,46 @@ mod tests {
         let token = kernel
             .issue_token(DEFAULT_PACK_ID, "test-agent", 60)
             .expect("token issue should succeed with custom clock/audit");
+        assert!(!token.token_id.is_empty());
+    }
+
+    #[test]
+    fn into_builder_allows_extra_registration_before_freeze() {
+        let mut builder = BootstrapBuilder::default().into_builder();
+        builder
+            .register_pack(VerticalPackManifest {
+                pack_id: "extra-pack".to_owned(),
+                domain: "engineering".to_owned(),
+                version: "0.1.0".to_owned(),
+                default_route: ExecutionRoute {
+                    harness_kind: HarnessKind::EmbeddedPi,
+                    adapter: Some("pi-local".to_owned()),
+                },
+                allowed_connectors: BTreeSet::new(),
+                granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                metadata: BTreeMap::new(),
+            })
+            .expect("extra pack should register");
+
+        let kernel = builder.build();
+        let token = kernel
+            .issue_token("extra-pack", "test-agent", 60)
+            .expect("token issue should succeed for extra pack");
+        assert!(!token.token_id.is_empty());
+    }
+
+    #[test]
+    fn bootstrap_builder_runtime_derefs_to_legacy_kernel_helpers() {
+        fn issue_default_pack_token(
+            kernel: &LoongClawKernel<StaticPolicyEngine>,
+        ) -> kernel::CapabilityToken {
+            kernel
+                .issue_token(DEFAULT_PACK_ID, "test-agent", 60)
+                .expect("token issue should succeed via legacy helper signature")
+        }
+
+        let kernel = BootstrapBuilder::default().build();
+        let token = issue_default_pack_token(&kernel);
         assert!(!token.token_id.is_empty());
     }
 }

--- a/crates/spec/src/lib.rs
+++ b/crates/spec/src/lib.rs
@@ -9,7 +9,7 @@ pub mod programmatic;
 pub mod spec_execution;
 pub mod spec_runtime;
 
-pub use kernel_bootstrap::{KernelBuilder, default_pack_manifest};
+pub use kernel_bootstrap::{BootstrapBuilder, KernelBuilder, default_pack_manifest};
 pub use programmatic::{
     acquire_programmatic_circuit_slot, execute_programmatic_tool_call,
     record_programmatic_circuit_outcome,


### PR DESCRIPTION
## Summary

- add additive `kernel::KernelBuilder<P>` and `kernel::Kernel<P>` surfaces without removing `LoongClawKernel<P>`
- add `spec::BootstrapBuilder` as a new bootstrap entrypoint while preserving the legacy `spec::KernelBuilder`
- let `Kernel<P>` dereference to the legacy `&LoongClawKernel<_>` helper surface so existing read-only helpers keep working during migration
- add send/sync, concurrency, and bootstrap compatibility regression coverage

## Scope

- [x] Small and focused
- [ ] Includes docs updates (PR contract + migration guidance)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

Touches the central kernel/bootstrap API used across the workspace, but keeps the exported surface backward compatible. Key invariants:
- `LoongClawKernel<P>` remains available for existing callers.
- `Kernel<P>` is an additive frozen runtime handle.
- `Kernel<P>` still bridges into legacy read-only helper signatures through `Deref` / `AsRef`.
- `loongclaw-spec::KernelBuilder` stays intact; `BootstrapBuilder` is additive.

## Breaking Change / Migration

This PR is **not** a breaking public API change.

Migration notes:
- existing `LoongClawKernel<P>` and `loongclaw-spec::KernelBuilder` call sites continue to work unchanged
- callers can opt into `KernelBuilder<P>::build()` to obtain the new `Kernel<P>` runtime handle
- callers can adopt `BootstrapBuilder::build()` for the new spec bootstrap path
- callers that still need extra registration before freeze can use `BootstrapBuilder::into_builder()` and then call `.build()`

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] targeted regression: `cargo test -p loongclaw-kernel kernel_is_usable_from_concurrent_tasks`
- [x] targeted regression: `cargo test -p loongclaw-spec kernel_bootstrap::tests::`
- [x] branch synced with current `alpha-test`

## Linked Issues

Architecture audit C5
