### PR TITLE
docs: add harness engineering documentation structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,13 @@ Use `task verify` for the stricter local superset (architecture, conventions, do
 |------|-------|
 | Core principles | `docs/design-docs/core-beliefs.md` |
 | Layered architecture | `docs/design-docs/layered-kernel-design.md` |
+| Design decisions & patterns | `docs/DESIGN.md` |
+| Design docs catalog | `docs/design-docs/index.md` |
+| Harness engineering | `docs/design-docs/harness-engineering.md` |
 | Roadmap | `docs/roadmap.md` |
 | Reliability invariants | `docs/RELIABILITY.md` |
+| Quality scores & gaps | `docs/QUALITY_SCORE.md` |
+| Tech debt tracker | `docs/plans/tech-debt-tracker.md` |
 | Release process docs | `docs/releases/` |
 | Product requirements | `docs/product-specs/` |
 | Contributing recipes | `CONTRIBUTING.md` |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,7 +116,10 @@ mechanically where possible.
 | Topic | Document |
 |-------|----------|
 | Full layer specification (L0-L9) | [Layered Kernel Design](docs/design-docs/layered-kernel-design.md) |
+| Harness engineering & backpressure | [Harness Engineering](docs/design-docs/harness-engineering.md) |
+| Design decisions & patterns | [Design Index](docs/DESIGN.md) |
 | Stage-based roadmap | [Roadmap](docs/roadmap.md) |
 | Build and kernel invariants | [Reliability](docs/RELIABILITY.md) |
+| Domain quality grades | [Quality Score](docs/QUALITY_SCORE.md) |
 | Contributor workflow and recipes | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | Examples and spec files | [Examples](examples/README.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,13 @@ Use `task verify` for the stricter local superset (architecture, conventions, do
 |------|-------|
 | Core principles | `docs/design-docs/core-beliefs.md` |
 | Layered architecture | `docs/design-docs/layered-kernel-design.md` |
+| Design decisions & patterns | `docs/DESIGN.md` |
+| Design docs catalog | `docs/design-docs/index.md` |
+| Harness engineering | `docs/design-docs/harness-engineering.md` |
 | Roadmap | `docs/roadmap.md` |
 | Reliability invariants | `docs/RELIABILITY.md` |
+| Quality scores & gaps | `docs/QUALITY_SCORE.md` |
+| Tech debt tracker | `docs/plans/tech-debt-tracker.md` |
 | Release process docs | `docs/releases/` |
 | Product requirements | `docs/product-specs/` |
 | Contributing recipes | `CONTRIBUTING.md` |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,36 @@
+# Design
+
+High-level index for design philosophy, decisions, and patterns in LoongClaw.
+
+## Philosophy
+
+LoongClaw follows an **agent-first** design philosophy where the repository itself is the system of record. Design decisions, architectural context, and engineering principles live in code and docs, not in chat threads. See [Core Beliefs](design-docs/core-beliefs.md) for the full set of golden principles.
+
+## Architecture
+
+The kernel enforces a layered execution model (L0-L9) with strict dependency direction. Every execution path routes through capability, policy, and audit gates. See [ARCHITECTURE.md](../ARCHITECTURE.md) for the crate DAG and layer overview.
+
+Full specification: [Layered Kernel Design](design-docs/layered-kernel-design.md)
+
+## Design Documents
+
+See [Design Docs Index](design-docs/index.md) for the full catalog of design documents and tracked decisions.
+
+## Key Patterns
+
+| Pattern | Description | Where Enforced |
+|---------|-------------|----------------|
+| Core/Extension split | Every execution plane has a core adapter and optional extensions | `kernel/src/tool.rs`, `runtime.rs`, `memory.rs`, `connector.rs` |
+| Capability-gated access | Every resource access requires an explicit capability token | `kernel/src/policy.rs` |
+| Rule of Two | Tool calls require both LLM intent and deterministic policy approval | `kernel/src/policy.rs` |
+| Registry pattern | Adapters registered by name into `BTreeMap<String, Arc<dyn Trait>>` | All execution planes |
+| Generation-based revocation | `AtomicU64` threshold invalidates all tokens with generation <= N | `kernel/src/kernel.rs` |
+| Policy extension chain | Chain-of-responsibility: multiple extensions evaluated in order, any can deny | `kernel/src/policy_ext.rs` |
+
+## Product Specifications
+
+See [Product Specs Index](product-specs/index.md) for user-facing requirements.
+
+## Plans
+
+Active execution plans live in [`plans/`](plans/). See [Tech Debt Tracker](plans/tech-debt-tracker.md) for known architectural drift.

--- a/docs/QUALITY_SCORE.md
+++ b/docs/QUALITY_SCORE.md
@@ -1,0 +1,43 @@
+# Quality Score
+
+Domain grades for LoongClaw. Updated periodically to track gaps, prioritize cleanup, and measure harness maturity.
+
+## Domain Grades
+
+| Domain | Grade | Last Reviewed | Gaps |
+|--------|-------|---------------|------|
+| Contracts (L0) | A | 2026-03-13 | `#[non_exhaustive]` applied; membrane field not yet enforced at runtime |
+| Kernel Security (L1) | B+ | 2026-03-13 | Policy only gates `shell.exec`; `file.read`/`file.write` bypass policy check |
+| Execution Planes (L2) | B | 2026-03-13 | Core/extension pattern solid; no WASM fuel metering yet |
+| Orchestration (L3) | B | 2026-03-13 | HarnessBroker routes correctly; no pluggable context engine |
+| Observability (L4) | C+ | 2026-03-13 | Audit events in-memory only; no HMAC chain; no persistent sink |
+| Vertical Packs (L5) | B | 2026-03-13 | Pack validation works; namespace struct exists but not enforced |
+| Protocol (L5.5) | B+ | 2026-03-13 | Transport contracts and typed routing operational |
+| Integration (L6) | B | 2026-03-13 | Plugin scanning works; hotplug lifecycle incomplete |
+| Plugin IR (L7) | B- | 2026-03-13 | Bridge inference works; multi-language support limited |
+| Self-Awareness (L8) | B- | 2026-03-13 | Snapshots generated but not continuous; no drift detection agent |
+| Bootstrap (L9) | B | 2026-03-13 | Activation plans work; no policy-bounded bootstrap validation |
+| Context/Memory | C | 2026-03-13 | SQLite turns only; no scopes, no provenance, no FTS5 |
+| Documentation | A- | 2026-03-13 | Strong coverage; missing design index and quality tracking |
+| CI/Enforcement | A | 2026-03-13 | 8 workflows, convention engineering, architecture checks |
+| Contributor Experience | A- | 2026-03-13 | Clear tracks and recipes; could add more examples |
+
+## Grading Criteria
+
+- **A**: Full test coverage, no known debt, documentation current, mechanical enforcement
+- **B**: Adequate coverage, minor debt tracked, docs mostly current
+- **C**: Coverage gaps, significant debt, stale or missing docs
+- **D**: Minimal coverage, blocking debt, docs unreliable
+- **F**: Untested, untracked, undocumented
+
+## Harness Maturity Assessment
+
+| Criterion | Status |
+|-----------|--------|
+| Agent entry point (AGENTS.md) | Present, 80 lines, mirrored with CLAUDE.md |
+| Architecture defined with enforcement | Present, DAG + boundary checks + CI |
+| Progressive disclosure hierarchy | Present, 3-tier structure |
+| Execution plans tracked | 41 phase plans in `docs/plans/` |
+| Mechanical enforcement | 8 CI workflows, convention engineering, pre-commit |
+| Quality tracked | This file |
+| External context captured | Core beliefs principle #8 requires it |

--- a/docs/design-docs/harness-engineering.md
+++ b/docs/design-docs/harness-engineering.md
@@ -1,0 +1,137 @@
+# Harness Engineering in LoongClaw
+
+> Based on [OpenAI's harness engineering framework](https://openai.com/index/harness-engineering/) (February 2026), mapped to LoongClaw's architecture.
+
+## What is Harness Engineering?
+
+Harness engineering is designing the full environment of scaffolding, constraints, and feedback loops surrounding AI agents. It sits above prompt engineering and context engineering in a three-layer hierarchy:
+
+| Layer | Question | Design Target |
+|-------|----------|---------------|
+| Prompt Engineering | "What should be asked?" | Instruction text to the LLM |
+| Context Engineering | "What should be shown?" | All tokens visible during reasoning |
+| **Harness Engineering** | "How should the whole environment be designed?" | External constraints, feedback loops, operational systems |
+
+**Central thesis**: The bottleneck in agent performance is often not model intelligence, but environment design.
+
+---
+
+## LoongClaw's Harness Components
+
+### Stage 1: Intent Capture & Orchestration
+
+| Component | Location | What it does |
+|-----------|----------|--------------|
+| `HarnessBroker` | `kernel/src/harness.rs` | Routes `TaskIntent` to registered `HarnessAdapter` by `ExecutionRoute` |
+| `HarnessAdapter` trait | `kernel/src/harness.rs` | Async trait: `name()`, `kind()`, `execute(HarnessRequest) -> HarnessOutcome` |
+| `HarnessKind` enum | `contracts/src/contracts.rs` | Two dispatch kinds: `EmbeddedPi` (in-process), `Acp` (external protocol) |
+| `ExecutionRoute` | `contracts/src/contracts.rs` | Pack-level default route binding harness kind to adapter |
+| `VerticalPackManifest` | `contracts/src/pack.rs` | Domain packaging: capabilities, allowed connectors, default route |
+
+### Stage 2: Tool Call Execution
+
+Every tool call passes through the capability gate:
+
+```
+CapabilityToken → PolicyEngine → PolicyExtensionChain → ToolPlane → CoreToolAdapter → Audit
+```
+
+Current tool registry: `shell.exec`, `file.read`, `file.write`.
+
+### Stage 3: Context Management & Memory
+
+| Layer | Status |
+|-------|--------|
+| Working context (system prompt + tool snapshot + sliding window) | Implemented |
+| Session state (SQLite turns table) | Implemented |
+| Long-term memory | Not implemented |
+
+### Stage 4: Result Verification & Iteration
+
+- `ConversationTurnLoop`: Multi-round agent loop (max 4 rounds default)
+- `ToolLoopSupervisor`: Detects infinite loops, ping-pong, failure streaks
+- `FollowupPayloadBudget`: Caps tool output size per round
+
+### Stage 5: Completion and Handoff
+
+Turn persistence to SQLite. Audit event recording. Structured progress artifacts are a gap.
+
+---
+
+## Architectural Constraints as Harness
+
+### Compile-Time Backpressure (Upstream)
+
+The workspace clippy configuration mechanically prevents agent-generated anti-patterns:
+
+| Lint | Why |
+|------|-----|
+| `unwrap_used`, `expect_used` | Forces proper error handling |
+| `panic`, `todo`, `unimplemented` | Prevents incomplete stubs |
+| `indexing_slicing` | Forces bounds-checked `.get()` |
+| `print_stdout`, `print_stderr` | Prevents debug output leaking |
+| `unsafe_code` | No unsafe in the workspace |
+
+### Dependency DAG as Constraint
+
+The 7-crate DAG prevents circular dependencies and implementation leakage. Enforced by `scripts/check_dep_graph.sh` and `task check:architecture`.
+
+### Testing as Downstream Backpressure
+
+8 test tiers (T0-T7) from [Layered Kernel Design](layered-kernel-design.md) provide downstream constraints, from contract serialization tests to self-governance architecture guards.
+
+### Pre-Commit Hook as Gate
+
+`scripts/pre-commit` runs CI-parity cargo checks before every commit.
+
+---
+
+## The Backpressure Principle
+
+The ratio of upstream + downstream constraints determines maximum safe agent autonomy:
+
+```
+Upstream constraints              Downstream constraints
+(compile-time lints,              (tests, CI gates,
+ type system, DAG,                 pre-commit hooks,
+ policy engine)                    audit trail)
+        |                                  |
+        +------------------+---------------+
+                           |
+                  Maximum safe autonomy
+```
+
+LoongClaw's position: **strong upstream** (strict lints, capability tokens, policy engine, type-safe contracts) + **strong downstream** (CI workflows, pre-commit hook, convention engineering, architecture checks).
+
+---
+
+## Context Files as System of Record
+
+Progressive disclosure hierarchy:
+
+| Tier | Files | Loading |
+|------|-------|---------|
+| Hot | `AGENTS.md` / `CLAUDE.md` | Auto-loaded every session |
+| Specialized | Design docs, domain indices | Loaded when working on that domain |
+| Cold | Roadmap, reliability, product specs, plans | Accessed on demand |
+
+---
+
+## Key Gaps for Harness Maturity
+
+Ranked by impact on agent reliability:
+
+1. **Context Engine** — No pluggable context assembly. Conversation loop hardcodes sliding window.
+2. **Observation Masking** — Old tool outputs not replaced with placeholders when context nears limits.
+3. **Token-Aware Budgets** — Current payload budget tracks characters, not tokens.
+4. **Persistent Audit Sink** — Audit events are in-memory only, lost on restart.
+5. **Structured Progress Artifacts** — No mechanism for agents to persist progress across sessions.
+
+---
+
+## References
+
+- [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/) (February 2026)
+- [Martin Fowler: Harness Engineering](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html)
+- [Layered Kernel Design](layered-kernel-design.md)
+- [Core Beliefs](core-beliefs.md)

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -1,0 +1,36 @@
+# Design Documents Index
+
+Catalog of design documents and architectural decisions.
+
+## Active Design Documents
+
+| Document | Scope | Status |
+|----------|-------|--------|
+| [Core Beliefs](core-beliefs.md) | Engineering principles and taste enforcement | Living |
+| [Layered Kernel Design](layered-kernel-design.md) | L0-L9 kernel layer specification and boundary rules | Living |
+| [Provider Runtime Roadmap](provider-runtime-roadmap.md) | Provider/runtime evolution strategy | Active |
+| [ACP/ACPX Pre-Embed](acp-acpx-preembed.md) | Advanced cryptographic primitives | Active |
+| [Harness Engineering](harness-engineering.md) | Environment design for agent-driven development | Active |
+
+## Tracked Deviations
+
+| ID | Description | Status | Tracking |
+|----|-------------|--------|----------|
+| D1 | `spec -> app` dependency (transitional runtime coupling) | Open | Must be retired by architecture refactor |
+
+## Decision Log
+
+Decisions from the research repository that are accepted into this codebase:
+
+| ID | Decision | Status |
+|----|----------|--------|
+| D-001 | Zircon-style capability model (handle + rights, membrane revocation) | Accepted |
+| D-002 | Hybrid agent lifecycle (Actix states + Erlang/OTP supervision) | Accepted |
+| D-015 | OAuth 2.1 external + capability internal auth | Accepted |
+| D-016 | MemoryStore trait (4 typed async methods) | Accepted |
+| D-017 | MemoryScope enum (Task, Session, Agent, Global) | Accepted |
+| D-018 | SQLite + FTS5 default backend (WAL, feature-gated sqlite-vec) | Accepted |
+| D-019 | Mandatory provenance fields | Accepted |
+| D-020 | Configurable trust scoring (Tier 0-3) | Accepted |
+| D-021 | Blake3 content hashing | Accepted |
+| D-022 | Capability-scoped deletion (revocation cascades) | Accepted |

--- a/docs/plans/tech-debt-tracker.md
+++ b/docs/plans/tech-debt-tracker.md
@@ -1,0 +1,26 @@
+# Tech Debt Tracker
+
+Living record of known architectural drift and technical debt. Updated as items are discovered or resolved.
+
+## Active Debt
+
+| ID | Description | Severity | Domain | Discovered |
+|----|-------------|----------|--------|------------|
+| TD-001 | D1: `spec -> app` dependency violates strict DAG | High | Architecture | 2026-03-11 |
+| TD-002 | Policy engine only gates `shell.exec`; `file.read`/`file.write` bypass Rule of Two | High | Security (L1) | 2026-03-10 |
+| TD-003 | `membrane` field on CapabilityToken exists but never checked in authorization | Medium | Security (L1) | 2026-03-10 |
+| TD-004 | `call_depth` in PolicyContext never incremented, always 0 | Medium | Security (L1) | 2026-03-10 |
+| TD-005 | Namespace struct is field-only, no scoped enforcement | Medium | Packs (L5) | 2026-03-10 |
+| TD-006 | Audit events in-memory only, lost on restart | High | Observability (L4) | 2026-03-10 |
+| TD-007 | No HMAC chain on audit events (tamper evidence absent) | High | Observability (L4) | 2026-03-10 |
+| TD-008 | Context assembly hardcodes sliding window, no pluggable ContextEngine | Medium | Context/Memory | 2026-03-10 |
+| TD-009 | Payload budget tracks characters, not tokens | Low | Context/Memory | 2026-03-10 |
+| TD-010 | Memory has no scopes (Task/Session/Agent/Global), flat session_id only | Medium | Context/Memory | 2026-03-10 |
+| TD-011 | No FTS5 index for full-text search on memory | Low | Context/Memory | 2026-03-10 |
+| TD-012 | Plugin security scanner type exists but scanner logic absent | Medium | Integration (L6) | 2026-03-10 |
+| TD-013 | WASM fuel metering / epoch interruption not implemented | Medium | Execution (L2) | 2026-03-10 |
+
+## Resolved
+
+| ID | Description | Resolution | Date |
+|----|-------------|------------|------|


### PR DESCRIPTION
## Summary

- Add progressive-disclosure documentation harness based on [OpenAI's harness engineering framework](https://openai.com/index/harness-engineering/)
- New files: `docs/design-docs/index.md` (decision catalog), `docs/design-docs/harness-engineering.md` (framework mapping), `docs/DESIGN.md` (design domain index), `docs/QUALITY_SCORE.md` (domain grades), `docs/plans/tech-debt-tracker.md` (architectural drift tracking)
- Updated `AGENTS.md`, `CLAUDE.md`, and `ARCHITECTURE.md` with cross-references to new docs (mirror consistency maintained)

## Motivation

The repository has strong harness engineering primitives (strict lints, CI gates, convention enforcement) but lacked explicit documentation tying them together. This PR completes the agent-legibility harness by adding:

1. A **design docs index** cataloging all design decisions and tracked deviations (D1, D-001 through D-022)
2. A **harness engineering design doc** mapping OpenAI's 5-stage framework to LoongClaw's architecture
3. A **design domain index** as a hub-and-spoke entry point for design context
4. A **quality score** grading each architectural domain with identified gaps
5. A **tech debt tracker** with 13 identified items from the gap analysis

## Test plan

- [x] `scripts/check-docs.sh` passes (CLAUDE.md == AGENTS.md mirror verified)
- [x] No code changes — docs only
- [x] AGENTS.md stays under 100-line budget (85 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)