### PR TITLE
fix(telegram): preserve forum topic routing

### DIFF
--- a/crates/app/src/channel/telegram.rs
+++ b/crates/app/src/channel/telegram.rs
@@ -124,7 +124,6 @@ impl TelegramAdapter {
         thread_id: Option<i64>,
         text: &str,
     ) -> CliResult<()> {
-        let thread_id = telegram_forum_topic_id(thread_id);
         let url = self.api_url("sendMessage");
         let client = reqwest::Client::new();
         let mut body = json!({
@@ -132,9 +131,7 @@ impl TelegramAdapter {
             "text": text,
             "disable_web_page_preview": true,
         });
-        if let Some(thread_id) = thread_id {
-            body["message_thread_id"] = json!(thread_id);
-        }
+        insert_telegram_thread_id(&mut body, thread_id);
 
         let payload = client
             .post(url)
@@ -212,6 +209,16 @@ fn telegram_inbound_thread_id(message: &Value) -> Option<i64> {
         return None;
     }
     telegram_forum_topic_id(message.get("message_thread_id").and_then(Value::as_i64))
+}
+
+fn insert_telegram_thread_id(body: &mut Value, thread_id: Option<i64>) {
+    let Some(thread_id) = telegram_forum_topic_id(thread_id) else {
+        return;
+    };
+    let Some(object) = body.as_object_mut() else {
+        return;
+    };
+    object.insert("message_thread_id".to_owned(), json!(thread_id));
 }
 
 fn telegram_typing_target(chat_id: i64, thread_id: Option<i64>) -> TelegramTypingTarget {
@@ -305,11 +312,7 @@ impl ChannelAdapter for TelegramAdapter {
                     "chat_id": chat_id,
                     "action": "typing",
                 });
-                if let Some(thread_id) = thread_id {
-                    if let Some(thread_id) = telegram_forum_topic_id(Some(thread_id)) {
-                        body["message_thread_id"] = json!(thread_id);
-                    }
-                }
+                insert_telegram_thread_id(&mut body, thread_id);
                 let _ = client.post(&url).json(&body).send().await;
                 tokio::time::sleep(TELEGRAM_TYPING_REFRESH_INTERVAL).await;
             }

--- a/crates/app/src/channel/telegram.rs
+++ b/crates/app/src/channel/telegram.rs
@@ -17,6 +17,14 @@ use super::{
     ChannelOutboundTargetKind, ChannelPlatform, ChannelSession,
 };
 
+const TELEGRAM_GENERAL_TOPIC_ID: i64 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct TelegramTypingTarget {
+    chat_id: i64,
+    thread_id: Option<i64>,
+}
+
 pub(super) struct TelegramAdapter {
     account_id: String,
     token: String,
@@ -24,7 +32,7 @@ pub(super) struct TelegramAdapter {
     timeout_s: u64,
     offset_tracker: TelegramOffsetTracker,
     allowlist: BTreeSet<i64>,
-    typing_handles: Mutex<HashMap<i64, tokio::task::JoinHandle<()>>>,
+    typing_handles: Mutex<HashMap<TelegramTypingTarget, tokio::task::JoinHandle<()>>>,
 }
 
 const TELEGRAM_TYPING_REFRESH_INTERVAL: Duration = Duration::from_secs(4);
@@ -110,28 +118,112 @@ impl TelegramAdapter {
         )
     }
 
-    fn parse_conversation_chat_id(target: &ChannelOutboundTarget) -> CliResult<i64> {
-        if target.platform != ChannelPlatform::Telegram {
-            return Err(format!(
-                "telegram adapter cannot send to {} target",
-                target.platform.as_str()
-            ));
-        }
-        if target.kind != ChannelOutboundTargetKind::Conversation {
-            return Err(format!(
-                "telegram adapter requires conversation target, got {}",
-                target.kind.as_str()
-            ));
+    async fn send_text_to_target(
+        &self,
+        chat_id: i64,
+        thread_id: Option<i64>,
+        text: &str,
+    ) -> CliResult<()> {
+        let thread_id = telegram_forum_topic_id(thread_id);
+        let url = self.api_url("sendMessage");
+        let client = reqwest::Client::new();
+        let mut body = json!({
+            "chat_id": chat_id,
+            "text": text,
+            "disable_web_page_preview": true,
+        });
+        if let Some(thread_id) = thread_id {
+            body["message_thread_id"] = json!(thread_id);
         }
 
-        target
-            .trimmed_id()?
-            .parse::<i64>()
-            .map_err(|error| format!("invalid telegram chat id `{}`: {error}", target.id))
+        let payload = client
+            .post(url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| format!("telegram sendMessage failed: {error}"))?
+            .json::<Value>()
+            .await
+            .map_err(|error| format!("telegram sendMessage decode failed: {error}"))?;
+
+        if !payload.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+            return Err(format!("telegram sendMessage not ok: {payload}"));
+        }
+        Ok(())
+    }
+}
+
+fn telegram_chat_thread_target(chat_id: i64, thread_id: i64) -> ChannelOutboundTarget {
+    ChannelOutboundTarget::new(
+        ChannelPlatform::Telegram,
+        ChannelOutboundTargetKind::Conversation,
+        format!("{chat_id}:topic:{thread_id}"),
+    )
+}
+
+fn parse_telegram_conversation_target(
+    target: &ChannelOutboundTarget,
+) -> CliResult<(i64, Option<i64>)> {
+    if target.platform != ChannelPlatform::Telegram {
+        return Err(format!(
+            "telegram adapter cannot send to {} target",
+            target.platform.as_str()
+        ));
+    }
+    if target.kind != ChannelOutboundTargetKind::Conversation {
+        return Err(format!(
+            "telegram adapter requires conversation target, got {}",
+            target.kind.as_str()
+        ));
     }
 
-    fn stop_typing_handle(&self, chat_id: i64) {
-        let handle = self.typing_handles_guard().remove(&chat_id);
+    let trimmed = target.trimmed_id()?;
+    if let Some((chat_id, thread_id)) = trimmed.split_once(":topic:") {
+        let chat_id = chat_id
+            .trim()
+            .parse::<i64>()
+            .map_err(|error| format!("invalid telegram chat id `{chat_id}`: {error}"))?;
+        let thread_id = thread_id
+            .trim()
+            .parse::<i64>()
+            .map_err(|error| format!("invalid telegram thread id `{thread_id}`: {error}"))?;
+        return Ok((chat_id, Some(thread_id)));
+    }
+
+    let chat_id = trimmed
+        .parse::<i64>()
+        .map_err(|error| format!("invalid telegram chat id `{}`: {error}", target.id))?;
+    Ok((chat_id, None))
+}
+
+fn telegram_forum_topic_id(thread_id: Option<i64>) -> Option<i64> {
+    thread_id
+        .filter(|thread_id| *thread_id > 0)
+        .filter(|thread_id| *thread_id != TELEGRAM_GENERAL_TOPIC_ID)
+}
+
+fn telegram_inbound_thread_id(message: &Value) -> Option<i64> {
+    let is_forum = message
+        .get("chat")
+        .and_then(|chat| chat.get("is_forum"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !is_forum {
+        return None;
+    }
+    telegram_forum_topic_id(message.get("message_thread_id").and_then(Value::as_i64))
+}
+
+fn telegram_typing_target(chat_id: i64, thread_id: Option<i64>) -> TelegramTypingTarget {
+    TelegramTypingTarget {
+        chat_id,
+        thread_id: telegram_forum_topic_id(thread_id),
+    }
+}
+
+impl TelegramAdapter {
+    fn stop_typing_handle(&self, target: TelegramTypingTarget) {
+        let handle = self.typing_handles_guard().remove(&target);
         if let Some(handle) = handle {
             handle.abort();
         }
@@ -144,7 +236,9 @@ impl TelegramAdapter {
         }
     }
 
-    fn typing_handles_guard(&self) -> MutexGuard<'_, HashMap<i64, tokio::task::JoinHandle<()>>> {
+    fn typing_handles_guard(
+        &self,
+    ) -> MutexGuard<'_, HashMap<TelegramTypingTarget, tokio::task::JoinHandle<()>>> {
         match self.typing_handles.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
@@ -194,56 +288,40 @@ impl ChannelAdapter for TelegramAdapter {
     }
 
     async fn send_text(&self, target: &ChannelOutboundTarget, text: &str) -> CliResult<()> {
-        let chat_id = Self::parse_conversation_chat_id(target)?;
-
-        let url = self.api_url("sendMessage");
-        let client = reqwest::Client::new();
-        let body = json!({
-            "chat_id": chat_id,
-            "text": text,
-            "disable_web_page_preview": true,
-        });
-
-        let payload = client
-            .post(url)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|error| format!("telegram sendMessage failed: {error}"))?
-            .json::<Value>()
-            .await
-            .map_err(|error| format!("telegram sendMessage decode failed: {error}"))?;
-
-        if !payload.get("ok").and_then(Value::as_bool).unwrap_or(false) {
-            return Err(format!("telegram sendMessage not ok: {payload}"));
-        }
-        Ok(())
+        let (chat_id, thread_id) = parse_telegram_conversation_target(target)?;
+        self.send_text_to_target(chat_id, thread_id, text).await
     }
 
     async fn start_typing(&self, target: &ChannelOutboundTarget) -> CliResult<()> {
-        let chat_id = Self::parse_conversation_chat_id(target)?;
-        self.stop_typing_handle(chat_id);
+        let (chat_id, thread_id) = parse_telegram_conversation_target(target)?;
+        let typing_target = telegram_typing_target(chat_id, thread_id);
+        self.stop_typing_handle(typing_target);
 
         let client = reqwest::Client::new();
         let url = self.api_url("sendChatAction");
         let handle = tokio::spawn(async move {
             loop {
-                let body = json!({
+                let mut body = json!({
                     "chat_id": chat_id,
                     "action": "typing",
                 });
+                if let Some(thread_id) = thread_id {
+                    if let Some(thread_id) = telegram_forum_topic_id(Some(thread_id)) {
+                        body["message_thread_id"] = json!(thread_id);
+                    }
+                }
                 let _ = client.post(&url).json(&body).send().await;
                 tokio::time::sleep(TELEGRAM_TYPING_REFRESH_INTERVAL).await;
             }
         });
 
-        self.typing_handles_guard().insert(chat_id, handle);
+        self.typing_handles_guard().insert(typing_target, handle);
         Ok(())
     }
 
     async fn stop_typing(&self, target: &ChannelOutboundTarget) -> CliResult<()> {
-        let chat_id = Self::parse_conversation_chat_id(target)?;
-        self.stop_typing_handle(chat_id);
+        let (chat_id, thread_id) = parse_telegram_conversation_target(target)?;
+        self.stop_typing_handle(telegram_typing_target(chat_id, thread_id));
         Ok(())
     }
 
@@ -303,13 +381,28 @@ pub(super) fn parse_telegram_updates(
             continue;
         }
 
-        inbox.push(ChannelInboundMessage {
-            session: ChannelSession::with_account(
+        let thread_id = telegram_inbound_thread_id(&message);
+        let session = match thread_id {
+            Some(thread_id) => ChannelSession::with_account_and_thread(
+                ChannelPlatform::Telegram,
+                account_id,
+                chat_id.to_string(),
+                thread_id.to_string(),
+            ),
+            None => ChannelSession::with_account(
                 ChannelPlatform::Telegram,
                 account_id,
                 chat_id.to_string(),
             ),
-            reply_target: ChannelOutboundTarget::telegram_chat(chat_id),
+        };
+        let reply_target = match thread_id {
+            Some(thread_id) => telegram_chat_thread_target(chat_id, thread_id),
+            None => ChannelOutboundTarget::telegram_chat(chat_id),
+        };
+
+        inbox.push(ChannelInboundMessage {
+            session,
+            reply_target,
             text,
             delivery: ChannelDelivery {
                 ack_cursor: Some(update_id.saturating_add(1).to_string()),
@@ -363,6 +456,13 @@ mod tests {
     use std::sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
+    };
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        sync::mpsc,
+        thread,
+        time::Duration,
     };
 
     struct DropFlag(Arc<AtomicBool>);
@@ -465,6 +565,172 @@ mod tests {
 
         assert!(inbox.is_empty());
         assert_eq!(next_offset, Some(9));
+    }
+
+    #[test]
+    fn telegram_parser_uses_forum_topic_context_for_sessions_and_reply_targets() {
+        let payload = json!({
+            "ok": true,
+            "result": [
+                {
+                    "update_id": 100,
+                    "message": {
+                        "message_id": 42,
+                        "message_thread_id": 7,
+                        "text": "topic hello",
+                        "chat": {"id": 123, "is_forum": true}
+                    }
+                }
+            ]
+        });
+
+        let allowlist = BTreeSet::from([123_i64]);
+        let (inbox, next_offset) = parse_telegram_updates(&payload, &allowlist, 50, "bot_123456")
+            .expect("parse telegram forum topic updates");
+
+        assert_eq!(inbox.len(), 1);
+        assert_eq!(inbox[0].session.session_key(), "telegram:bot_123456:123:7");
+        assert_eq!(inbox[0].reply_target, telegram_chat_thread_target(123, 7));
+        assert_eq!(inbox[0].text, "topic hello");
+        assert_eq!(inbox[0].delivery.ack_cursor.as_deref(), Some("101"));
+        assert_eq!(next_offset, Some(101));
+    }
+
+    #[tokio::test]
+    async fn telegram_send_text_omits_message_thread_id_for_general_topic_targets() {
+        let (base_url, requests, server) =
+            spawn_request_sequence_server(vec![(200, r#"{"ok":true}"#.to_owned())]);
+        let adapter = TelegramAdapter {
+            account_id: "bot_123456".to_owned(),
+            token: "telegram-token".to_owned(),
+            base_url,
+            timeout_s: 5,
+            offset_tracker: TelegramOffsetTracker::new(temp_offset_path("general-topic"), 0),
+            allowlist: BTreeSet::new(),
+            typing_handles: Mutex::new(HashMap::new()),
+        };
+
+        adapter
+            .send_text(
+                &telegram_chat_thread_target(123, TELEGRAM_GENERAL_TOPIC_ID),
+                "hello telegram general",
+            )
+            .await
+            .expect("telegram general topic send should succeed");
+
+        let request = requests
+            .recv_timeout(Duration::from_secs(2))
+            .expect("capture telegram send request");
+
+        assert!(request.contains(r#""chat_id":123"#));
+        assert!(!request.contains(r#""message_thread_id":"#));
+
+        server.join().expect("join telegram general topic server");
+    }
+
+    #[tokio::test]
+    async fn telegram_send_text_includes_message_thread_id_for_forum_topics() {
+        let (base_url, requests, server) =
+            spawn_request_sequence_server(vec![(200, r#"{"ok":true}"#.to_owned())]);
+        let adapter = TelegramAdapter {
+            account_id: "bot_123456".to_owned(),
+            token: "telegram-token".to_owned(),
+            base_url,
+            timeout_s: 5,
+            offset_tracker: TelegramOffsetTracker::new(temp_offset_path("forum-topic"), 0),
+            allowlist: BTreeSet::new(),
+            typing_handles: Mutex::new(HashMap::new()),
+        };
+
+        adapter
+            .send_text(&telegram_chat_thread_target(123, 7), "hello telegram topic")
+            .await
+            .expect("telegram topic send should succeed");
+
+        let request = requests
+            .recv_timeout(Duration::from_secs(2))
+            .expect("capture telegram topic send request");
+
+        assert!(request.contains(r#""chat_id":123"#));
+        assert!(request.contains(r#""message_thread_id":7"#));
+
+        server.join().expect("join telegram topic server");
+    }
+
+    #[tokio::test]
+    async fn telegram_start_typing_omits_message_thread_id_for_general_topic_targets() {
+        let (base_url, requests, server) =
+            spawn_request_sequence_server(vec![(200, r#"{"ok":true}"#.to_owned())]);
+        let adapter = TelegramAdapter {
+            account_id: "bot_123456".to_owned(),
+            token: "telegram-token".to_owned(),
+            base_url,
+            timeout_s: 5,
+            offset_tracker: TelegramOffsetTracker::new(temp_offset_path("typing-general-topic"), 0),
+            allowlist: BTreeSet::new(),
+            typing_handles: Mutex::new(HashMap::new()),
+        };
+        let target = telegram_chat_thread_target(123, TELEGRAM_GENERAL_TOPIC_ID);
+
+        adapter
+            .start_typing(&target)
+            .await
+            .expect("start typing for telegram general topic should succeed");
+
+        let request =
+            tokio::task::spawn_blocking(move || requests.recv_timeout(Duration::from_secs(2)))
+                .await
+                .expect("join telegram typing capture task")
+                .expect("capture telegram typing request");
+
+        assert!(request.contains(r#""chat_id":123"#));
+        assert!(!request.contains(r#""message_thread_id":"#));
+
+        adapter
+            .stop_typing(&target)
+            .await
+            .expect("stop typing for telegram general topic should succeed");
+
+        server
+            .join()
+            .expect("join telegram general topic typing server");
+    }
+
+    #[tokio::test]
+    async fn telegram_start_typing_includes_message_thread_id_for_forum_topics() {
+        let (base_url, requests, server) =
+            spawn_request_sequence_server(vec![(200, r#"{"ok":true}"#.to_owned())]);
+        let adapter = TelegramAdapter {
+            account_id: "bot_123456".to_owned(),
+            token: "telegram-token".to_owned(),
+            base_url,
+            timeout_s: 5,
+            offset_tracker: TelegramOffsetTracker::new(temp_offset_path("typing-topic"), 0),
+            allowlist: BTreeSet::new(),
+            typing_handles: Mutex::new(HashMap::new()),
+        };
+        let target = telegram_chat_thread_target(123, 7);
+
+        adapter
+            .start_typing(&target)
+            .await
+            .expect("start typing for telegram topic should succeed");
+
+        let request =
+            tokio::task::spawn_blocking(move || requests.recv_timeout(Duration::from_secs(2)))
+                .await
+                .expect("join telegram typing capture task")
+                .expect("capture telegram typing request");
+
+        assert!(request.contains(r#""chat_id":123"#));
+        assert!(request.contains(r#""message_thread_id":7"#));
+
+        adapter
+            .stop_typing(&target)
+            .await
+            .expect("stop typing for telegram topic should succeed");
+
+        server.join().expect("join telegram topic typing server");
     }
 
     #[test]
@@ -573,7 +839,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn telegram_start_typing_replaces_existing_handle_for_chat() {
+    async fn telegram_start_typing_replaces_existing_handle_for_same_target() {
         let adapter = test_adapter();
         let target = ChannelOutboundTarget::telegram_chat(123);
         let dropped = Arc::new(AtomicBool::new(false));
@@ -589,7 +855,7 @@ mod tests {
             .typing_handles
             .lock()
             .expect("typing handles lock")
-            .insert(123, handle);
+            .insert(telegram_typing_target(123, None), handle);
 
         started_rx.await.expect("typing task should start");
 
@@ -617,6 +883,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn telegram_start_typing_keeps_distinct_handles_for_different_topics() {
+        let adapter = test_adapter();
+        let topic_a = telegram_chat_thread_target(123, 7);
+        let topic_b = telegram_chat_thread_target(123, 8);
+
+        adapter
+            .start_typing(&topic_a)
+            .await
+            .expect("start typing for first topic should succeed");
+        adapter
+            .start_typing(&topic_b)
+            .await
+            .expect("start typing for second topic should succeed");
+
+        assert_eq!(
+            adapter
+                .typing_handles
+                .lock()
+                .expect("typing handles lock")
+                .len(),
+            2
+        );
+
+        adapter
+            .stop_typing(&topic_a)
+            .await
+            .expect("stop typing for first topic should succeed");
+        adapter
+            .stop_typing(&topic_b)
+            .await
+            .expect("stop typing for second topic should succeed");
+    }
+
+    #[tokio::test]
     async fn telegram_adapter_drop_aborts_active_typing_handles() {
         let dropped = Arc::new(AtomicBool::new(false));
         let dropped_for_task = Arc::clone(&dropped);
@@ -632,7 +932,7 @@ mod tests {
             .typing_handles
             .lock()
             .expect("typing handles lock")
-            .insert(123, handle);
+            .insert(telegram_typing_target(123, None), handle);
 
         started_rx.await.expect("typing task should start");
 
@@ -680,5 +980,97 @@ mod tests {
             error,
             "telegram adapter requires conversation target, got message_reply"
         );
+    }
+
+    fn temp_offset_path(name: &str) -> std::path::PathBuf {
+        let unique = format!(
+            "loongclaw-telegram-send-{name}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        );
+        std::env::temp_dir().join(unique).join("offset.txt")
+    }
+
+    fn spawn_request_sequence_server(
+        responses: Vec<(u16, String)>,
+    ) -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind telegram test server");
+        let address = listener.local_addr().expect("telegram test server address");
+        let (tx, rx) = mpsc::channel();
+
+        let handle = thread::spawn(move || {
+            for (status_code, response_body) in responses {
+                let (mut stream, _) = listener.accept().expect("accept telegram request");
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(2)))
+                    .expect("set telegram read timeout");
+
+                let mut request = Vec::new();
+                let mut buffer = [0_u8; 1024];
+                loop {
+                    match stream.read(&mut buffer) {
+                        Ok(0) => break,
+                        Ok(read) => {
+                            request.extend_from_slice(&buffer[..read]);
+                            if request_complete(request.as_slice()) {
+                                break;
+                            }
+                        }
+                        Err(error)
+                            if matches!(
+                                error.kind(),
+                                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                            ) =>
+                        {
+                            break;
+                        }
+                        Err(error) => panic!("read telegram test request failed: {error}"),
+                    }
+                }
+
+                let body = extract_request_body(request.as_slice());
+                tx.send(body).expect("capture telegram request body");
+
+                let response = format!(
+                    "HTTP/1.1 {} OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    status_code,
+                    response_body.len(),
+                    response_body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write telegram test response");
+            }
+        });
+
+        (format!("http://{address}"), rx, handle)
+    }
+
+    fn request_complete(buffer: &[u8]) -> bool {
+        let Some(header_end) = buffer.windows(4).position(|window| window == b"\r\n\r\n") else {
+            return false;
+        };
+        let header_end = header_end + 4;
+        let content_length = String::from_utf8_lossy(&buffer[..header_end])
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                if !name.eq_ignore_ascii_case("content-length") {
+                    return None;
+                }
+                value.trim().parse::<usize>().ok()
+            })
+            .unwrap_or(0);
+        buffer.len() >= header_end + content_length
+    }
+
+    fn extract_request_body(request: &[u8]) -> String {
+        let request = String::from_utf8_lossy(request);
+        request
+            .split_once("\r\n\r\n")
+            .map(|(_, body)| body.to_owned())
+            .unwrap_or_default()
     }
 }


### PR DESCRIPTION
## Summary
- preserve Telegram forum topic context in inbound sessions and reply targets
- route outbound `send_text` and `start_typing` through topic-aware targets, omitting the general topic thread id
- key typing handles by `chat_id + topic` so different forum topics do not clobber each other

## Validation
- `<local-absolute-path> test -p loongclaw-app telegram_ --all-features --target-dir target/codex-alpha-telegram-pr`
- `<local-absolute-path> fmt --all --check`
- `git diff --check`
- `<local-absolute-path> test --workspace --all-features --target-dir target/codex-alpha-telegram-pr -- --test-threads=1`

## Notes
- kept scope to `crates/app/src/channel/telegram.rs` only to make this a small replay PR on top of `alpha-test`
- follow-up should be a Feishu/Lark-only PR that makes reply/send target resolution explicit inside the Feishu adapter without widening shared abstractions yet