### PR TITLE
refactor(feishu): make outbound target routing explicit

### DIFF
--- a/crates/app/src/channel/feishu/adapter.rs
+++ b/crates/app/src/channel/feishu/adapter.rs
@@ -20,6 +20,35 @@ pub(super) struct FeishuAdapter {
     tenant_access_token: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FeishuSendTarget<'a> {
+    MessageReply(&'a str),
+    ReceiveId(&'a str),
+}
+
+fn resolve_feishu_send_target<'a>(
+    target: &'a ChannelOutboundTarget,
+) -> CliResult<FeishuSendTarget<'a>> {
+    if target.platform != ChannelPlatform::Feishu {
+        return Err(format!(
+            "feishu adapter cannot send to {} target",
+            target.platform.as_str()
+        ));
+    }
+
+    match target.kind {
+        ChannelOutboundTargetKind::MessageReply => {
+            Ok(FeishuSendTarget::MessageReply(target.trimmed_id()?))
+        }
+        ChannelOutboundTargetKind::ReceiveId => {
+            Ok(FeishuSendTarget::ReceiveId(target.trimmed_id()?))
+        }
+        ChannelOutboundTargetKind::Conversation => Err(
+            "feishu adapter does not support conversation targets for outbound sends".to_owned(),
+        ),
+    }
+}
+
 impl FeishuAdapter {
     pub(super) fn new(config: &ResolvedFeishuChannelConfig) -> CliResult<Self> {
         let app_id = config
@@ -155,19 +184,12 @@ impl FeishuAdapter {
         &self,
         target: &'a ChannelOutboundTarget,
     ) -> CliResult<&'a str> {
-        if target.platform != ChannelPlatform::Feishu {
-            return Err(format!(
-                "feishu adapter cannot send to {} target",
-                target.platform.as_str()
-            ));
+        match resolve_feishu_send_target(target)? {
+            FeishuSendTarget::ReceiveId(receive_id) => Ok(receive_id),
+            FeishuSendTarget::MessageReply(_) => {
+                Err("feishu card send requires receive_id target, got message_reply".to_owned())
+            }
         }
-        if target.kind != ChannelOutboundTargetKind::ReceiveId {
-            return Err(format!(
-                "feishu direct send requires receive_id target, got {}",
-                target.kind.as_str()
-            ));
-        }
-        target.trimmed_id()
     }
 }
 
@@ -182,25 +204,66 @@ impl ChannelAdapter for FeishuAdapter {
     }
 
     async fn send_text(&self, target: &ChannelOutboundTarget, text: &str) -> CliResult<()> {
-        if target.platform != ChannelPlatform::Feishu {
-            return Err(format!(
-                "feishu adapter cannot send to {} target",
-                target.platform.as_str()
-            ));
-        }
-
-        match target.kind {
-            ChannelOutboundTargetKind::MessageReply => {
-                self.send_reply(target.trimmed_id()?, text).await
-            }
-            ChannelOutboundTargetKind::ReceiveId => {
-                self.send_message(target.trimmed_id()?, "text", json!({"text": text}))
+        match resolve_feishu_send_target(target)? {
+            FeishuSendTarget::MessageReply(message_id) => self.send_reply(message_id, text).await,
+            FeishuSendTarget::ReceiveId(receive_id) => {
+                self.send_message(receive_id, "text", json!({"text": text}))
                     .await
             }
-            ChannelOutboundTargetKind::Conversation => Err(
-                "feishu adapter does not support conversation targets for outbound sends"
-                    .to_owned(),
-            ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_feishu_send_target_supports_reply_and_receive_id_targets() {
+        let reply = ChannelOutboundTarget::feishu_message_reply(" om_1 ");
+        let receive_id = ChannelOutboundTarget::feishu_receive_id(" ou_1 ");
+
+        assert_eq!(
+            resolve_feishu_send_target(&reply).expect("message reply target"),
+            FeishuSendTarget::MessageReply("om_1")
+        );
+        assert_eq!(
+            resolve_feishu_send_target(&receive_id).expect("receive id target"),
+            FeishuSendTarget::ReceiveId("ou_1")
+        );
+    }
+
+    #[test]
+    fn resolve_feishu_send_target_rejects_conversation_targets() {
+        let target = ChannelOutboundTarget::new(
+            ChannelPlatform::Feishu,
+            ChannelOutboundTargetKind::Conversation,
+            "oc_1",
+        );
+
+        assert_eq!(
+            resolve_feishu_send_target(&target)
+                .expect_err("conversation target should be rejected"),
+            "feishu adapter does not support conversation targets for outbound sends"
+        );
+    }
+
+    #[test]
+    fn resolve_receive_id_target_rejects_reply_targets_for_cards() {
+        let adapter = FeishuAdapter {
+            app_id: "cli_a".to_owned(),
+            app_secret: "secret".to_owned(),
+            base_url: "https://open.feishu.cn".to_owned(),
+            receive_id_type: "open_id".to_owned(),
+            tenant_access_token: None,
+        };
+        let target = ChannelOutboundTarget::feishu_message_reply("om_1");
+
+        assert_eq!(
+            adapter
+                .resolve_receive_id_target(&target)
+                .expect_err("reply target should be rejected for card send"),
+            "feishu card send requires receive_id target, got message_reply"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add a Feishu-local send target resolver that makes `message_reply` and `receive_id` routing explicit in the driver
- keep `send_text` reply behavior and card-send validation aligned behind the same adapter-owned boundary
- add focused adapter tests so reply/direct-send semantics stay explicit as shared channel abstractions evolve
- this change is needed to prevent Feishu-specific outbound semantics from being inferred indirectly across multiple validation paths

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

Scope note: this PR is intentionally limited to `crates/app/src/channel/feishu/adapter.rs`.

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

Risk note: the change stays inside the Feishu adapter boundary and adds targeted tests for the accepted/rejected outbound target kinds.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p loongclaw-app --all-targets --all-features --target-dir target/codex-alpha-feishu-pr -- -D warnings`
- [x] `cargo test --workspace --all-features --target-dir target/codex-alpha-feishu-pr -- --test-threads=1`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional checks:

- `<local-absolute-path> test -p loongclaw-app feishu_ --all-features --target-dir target/codex-alpha-feishu-pr`
- `git diff --check`

## Linked Issues

Closes #134
Related to #126