### PR TITLE
refactor(channel): let registry descriptors drive snapshots

### DIFF
--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -86,6 +86,9 @@ impl ChannelStatusSnapshot {
     }
 }
 
+type ChannelSnapshotBuilder =
+    fn(&ChannelRegistryDescriptor, &LoongClawConfig, &Path, u64) -> Vec<ChannelStatusSnapshot>;
+
 #[derive(Debug, Clone, Copy)]
 struct ChannelRegistryDescriptor {
     platform: ChannelPlatform,
@@ -93,6 +96,33 @@ struct ChannelRegistryDescriptor {
     aliases: &'static [&'static str],
     transport: &'static str,
     operations: &'static [ChannelCatalogOperation],
+    build_snapshots: ChannelSnapshotBuilder,
+}
+
+impl ChannelRegistryDescriptor {
+    fn id(self) -> &'static str {
+        self.platform.as_str()
+    }
+
+    fn catalog_entry(self) -> ChannelCatalogEntry {
+        ChannelCatalogEntry {
+            id: self.id(),
+            label: self.label,
+            aliases: self.aliases.to_vec(),
+            transport: self.transport,
+            operations: self.operations.to_vec(),
+        }
+    }
+
+    fn matches_normalized(self, normalized: &str) -> bool {
+        self.id() == normalized
+            || self.label.eq_ignore_ascii_case(normalized)
+            || self
+                .aliases
+                .iter()
+                .copied()
+                .any(|alias| alias.eq_ignore_ascii_case(normalized))
+    }
 }
 
 const TELEGRAM_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
@@ -128,6 +158,7 @@ const CHANNEL_REGISTRY: &[ChannelRegistryDescriptor] = &[
         aliases: &[],
         transport: "telegram_bot_api_polling",
         operations: TELEGRAM_OPERATIONS,
+        build_snapshots: build_telegram_snapshots,
     },
     ChannelRegistryDescriptor {
         platform: ChannelPlatform::Feishu,
@@ -135,19 +166,15 @@ const CHANNEL_REGISTRY: &[ChannelRegistryDescriptor] = &[
         aliases: &["lark"],
         transport: "feishu_openapi_webhook",
         operations: FEISHU_OPERATIONS,
+        build_snapshots: build_feishu_snapshots,
     },
 ];
 
 pub fn list_channel_catalog() -> Vec<ChannelCatalogEntry> {
     CHANNEL_REGISTRY
         .iter()
-        .map(|descriptor| ChannelCatalogEntry {
-            id: descriptor.platform.as_str(),
-            label: descriptor.label,
-            aliases: descriptor.aliases.to_vec(),
-            transport: descriptor.transport,
-            operations: descriptor.operations.to_vec(),
-        })
+        .copied()
+        .map(ChannelRegistryDescriptor::catalog_entry)
         .collect()
 }
 
@@ -157,17 +184,11 @@ pub fn normalize_channel_platform(raw: &str) -> Option<ChannelPlatform> {
         return None;
     }
 
-    CHANNEL_REGISTRY.iter().find_map(|descriptor| {
-        if descriptor.platform.as_str() == normalized {
-            return Some(descriptor.platform);
-        }
-        descriptor
-            .aliases
-            .iter()
-            .copied()
-            .find(|alias| *alias == normalized)
-            .map(|_| descriptor.platform)
-    })
+    CHANNEL_REGISTRY
+        .iter()
+        .copied()
+        .find(|descriptor| descriptor.matches_normalized(normalized.as_str()))
+        .map(|descriptor| descriptor.platform)
 }
 
 pub fn channel_status_snapshots(config: &LoongClawConfig) -> Vec<ChannelStatusSnapshot> {
@@ -183,28 +204,12 @@ fn channel_status_snapshots_with_now(
     runtime_dir: &Path,
     now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
-    let mut snapshots = Vec::new();
-    for descriptor in CHANNEL_REGISTRY {
-        match descriptor.platform {
-            ChannelPlatform::Telegram => {
-                snapshots.extend(build_telegram_snapshots(
-                    descriptor,
-                    config,
-                    runtime_dir,
-                    now_ms,
-                ));
-            }
-            ChannelPlatform::Feishu => {
-                snapshots.extend(build_feishu_snapshots(
-                    descriptor,
-                    config,
-                    runtime_dir,
-                    now_ms,
-                ));
-            }
-        }
-    }
-    snapshots
+    CHANNEL_REGISTRY
+        .iter()
+        .flat_map(|descriptor| {
+            (descriptor.build_snapshots)(descriptor, config, runtime_dir, now_ms)
+        })
+        .collect()
 }
 
 fn build_telegram_snapshots(
@@ -721,6 +726,10 @@ mod tests {
     fn normalize_channel_platform_maps_lark_alias_to_feishu() {
         assert_eq!(
             normalize_channel_platform("lark"),
+            Some(ChannelPlatform::Feishu)
+        );
+        assert_eq!(
+            normalize_channel_platform(" Feishu/Lark "),
             Some(ChannelPlatform::Feishu)
         );
         assert_eq!(

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-13T08:09:50Z
+- Generated at: 2026-03-13T11:32:56Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -11,8 +11,8 @@
 ## Hotspot Metrics
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
-| spec_runtime | `crates/spec/src/spec_runtime.rs` | 2913 | 3600 | 687 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
-| spec_execution | `crates/spec/src/spec_execution.rs` | 1466 | 3700 | 2234 | 22 | 80 | 58 | n/a | n/a | N/A | n/a |
+| spec_runtime | `crates/spec/src/spec_runtime.rs` | 2926 | 3600 | 674 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
+| spec_execution | `crates/spec/src/spec_execution.rs` | 1467 | 3700 | 2233 | 22 | 80 | 58 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 234 | 1000 | 766 | 5 | 20 | 15 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 620 | 650 | 30 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
@@ -37,8 +37,8 @@
 - [Release template](TEMPLATE.md)
 - [CI workflow](../../.github/workflows/ci.yml)
 
-<!-- arch-hotspot key=spec_runtime lines=2913 functions=47 -->
-<!-- arch-hotspot key=spec_execution lines=1466 functions=22 -->
+<!-- arch-hotspot key=spec_runtime lines=2926 functions=47 -->
+<!-- arch-hotspot key=spec_execution lines=1467 functions=22 -->
 <!-- arch-hotspot key=provider_mod lines=234 functions=5 -->
 <!-- arch-hotspot key=memory_mod lines=620 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary
- let each channel registry descriptor own its snapshot builder instead of relying on a central platform match
- reuse descriptor metadata for catalog rendering and platform normalization
- accept the displayed `Feishu/Lark` label when normalizing channel platform input

## Why
- keeps loongclaw closer to the metadata-driven channel registry shape used by openclaw while staying lightweight on alpha-test
- reduces the number of places that must change when adding future channels or high-quality stubs
- avoids pulling the larger integration-branch abstractions into this small follow-up PR

## Validation
- `<local-absolute-path> test -p loongclaw-app channel::registry::tests:: --all-features --target-dir target/codex-alpha-registry-descriptors-pr`
- `<local-absolute-path> clippy -p loongclaw-app --all-targets --all-features --target-dir target/codex-alpha-registry-descriptors-pr -- -D warnings`
- `<local-absolute-path> fmt --all --check`
- `<local-absolute-path> test --workspace --all-features --target-dir target/codex-alpha-registry-descriptors-pr -- --test-threads=1`