### PR TITLE
refactor(channel): drive doctor checks from registry metadata

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -40,9 +40,9 @@ mod runtime_state;
 mod telegram;
 
 pub use registry::{
-    ChannelCatalogEntry, ChannelCatalogOperation, ChannelOperationHealth, ChannelOperationStatus,
-    ChannelStatusSnapshot, channel_status_snapshots, list_channel_catalog,
-    normalize_channel_platform,
+    ChannelCatalogEntry, ChannelCatalogOperation, ChannelDoctorCheckSpec, ChannelOperationHealth,
+    ChannelOperationStatus, ChannelStatusSnapshot, channel_doctor_check_spec,
+    channel_status_snapshots, list_channel_catalog, normalize_channel_platform,
 };
 pub use runtime_state::ChannelOperationRuntime;
 use runtime_state::ChannelOperationRuntimeTracker;

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -17,6 +17,12 @@ pub struct ChannelCatalogOperation {
     pub tracks_runtime: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChannelDoctorCheckSpec {
+    pub config_name: &'static str,
+    pub runtime_name: Option<&'static str>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ChannelCatalogEntry {
     pub id: &'static str,
@@ -87,38 +93,68 @@ impl ChannelStatusSnapshot {
 }
 
 #[derive(Debug, Clone, Copy)]
+struct ChannelOperationDescriptor {
+    catalog: ChannelCatalogOperation,
+    doctor_check: Option<ChannelDoctorCheckSpec>,
+}
+
+impl ChannelOperationDescriptor {
+    fn catalog(self) -> ChannelCatalogOperation {
+        self.catalog
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 struct ChannelRegistryDescriptor {
     platform: ChannelPlatform,
     label: &'static str,
     aliases: &'static [&'static str],
     transport: &'static str,
-    operations: &'static [ChannelCatalogOperation],
+    operations: &'static [ChannelOperationDescriptor],
 }
 
-const TELEGRAM_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
-    id: "serve",
-    label: "reply loop",
-    command: "telegram-serve",
-    tracks_runtime: true,
+const TELEGRAM_SERVE_OPERATION: ChannelOperationDescriptor = ChannelOperationDescriptor {
+    catalog: ChannelCatalogOperation {
+        id: "serve",
+        label: "reply loop",
+        command: "telegram-serve",
+        tracks_runtime: true,
+    },
+    doctor_check: Some(ChannelDoctorCheckSpec {
+        config_name: "telegram channel",
+        runtime_name: Some("telegram channel runtime"),
+    }),
 };
 
-const TELEGRAM_OPERATIONS: &[ChannelCatalogOperation] = &[TELEGRAM_SERVE_OPERATION];
+const TELEGRAM_OPERATIONS: &[ChannelOperationDescriptor] = &[TELEGRAM_SERVE_OPERATION];
 
-const FEISHU_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
-    id: "send",
-    label: "direct send",
-    command: "feishu-send",
-    tracks_runtime: false,
+const FEISHU_SEND_OPERATION: ChannelOperationDescriptor = ChannelOperationDescriptor {
+    catalog: ChannelCatalogOperation {
+        id: "send",
+        label: "direct send",
+        command: "feishu-send",
+        tracks_runtime: false,
+    },
+    doctor_check: Some(ChannelDoctorCheckSpec {
+        config_name: "feishu direct send",
+        runtime_name: None,
+    }),
 };
 
-const FEISHU_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
-    id: "serve",
-    label: "webhook reply server",
-    command: "feishu-serve",
-    tracks_runtime: true,
+const FEISHU_SERVE_OPERATION: ChannelOperationDescriptor = ChannelOperationDescriptor {
+    catalog: ChannelCatalogOperation {
+        id: "serve",
+        label: "webhook reply server",
+        command: "feishu-serve",
+        tracks_runtime: true,
+    },
+    doctor_check: Some(ChannelDoctorCheckSpec {
+        config_name: "feishu webhook verification",
+        runtime_name: Some("feishu webhook runtime"),
+    }),
 };
 
-const FEISHU_OPERATIONS: &[ChannelCatalogOperation] =
+const FEISHU_OPERATIONS: &[ChannelOperationDescriptor] =
     &[FEISHU_SEND_OPERATION, FEISHU_SERVE_OPERATION];
 
 const CHANNEL_REGISTRY: &[ChannelRegistryDescriptor] = &[
@@ -146,9 +182,29 @@ pub fn list_channel_catalog() -> Vec<ChannelCatalogEntry> {
             label: descriptor.label,
             aliases: descriptor.aliases.to_vec(),
             transport: descriptor.transport,
-            operations: descriptor.operations.to_vec(),
+            operations: descriptor
+                .operations
+                .iter()
+                .map(|entry| entry.catalog)
+                .collect(),
         })
         .collect()
+}
+
+pub fn channel_doctor_check_spec(
+    channel_id: &str,
+    operation_id: &str,
+) -> Option<ChannelDoctorCheckSpec> {
+    CHANNEL_REGISTRY.iter().find_map(|descriptor| {
+        if descriptor.platform.as_str() != channel_id {
+            return None;
+        }
+        descriptor
+            .operations
+            .iter()
+            .find(|entry| entry.catalog.id == operation_id)
+            .and_then(|entry| entry.doctor_check)
+    })
 }
 
 pub fn normalize_channel_platform(raw: &str) -> Option<ChannelPlatform> {
@@ -268,22 +324,22 @@ fn build_telegram_snapshot_for_account(
 
     let operation = if !compiled {
         unsupported_operation(
-            TELEGRAM_SERVE_OPERATION,
+            TELEGRAM_SERVE_OPERATION.catalog(),
             "binary built without feature `channel-telegram`".to_owned(),
         )
     } else if !resolved.enabled {
         disabled_operation(
-            TELEGRAM_SERVE_OPERATION,
+            TELEGRAM_SERVE_OPERATION.catalog(),
             "disabled by telegram account configuration".to_owned(),
         )
     } else if !issues.is_empty() {
-        misconfigured_operation(TELEGRAM_SERVE_OPERATION, issues)
+        misconfigured_operation(TELEGRAM_SERVE_OPERATION.catalog(), issues)
     } else {
-        ready_operation(TELEGRAM_SERVE_OPERATION)
+        ready_operation(TELEGRAM_SERVE_OPERATION.catalog())
     };
     let operation = attach_runtime(
         ChannelPlatform::Telegram,
-        TELEGRAM_SERVE_OPERATION,
+        TELEGRAM_SERVE_OPERATION.catalog(),
         operation,
         resolved.account.id.as_str(),
         resolved.account.label.as_str(),
@@ -411,38 +467,38 @@ fn build_feishu_snapshot_for_account(
 
     let send_operation = if !compiled {
         unsupported_operation(
-            FEISHU_SEND_OPERATION,
+            FEISHU_SEND_OPERATION.catalog(),
             "binary built without feature `channel-feishu`".to_owned(),
         )
     } else if !resolved.enabled {
         disabled_operation(
-            FEISHU_SEND_OPERATION,
+            FEISHU_SEND_OPERATION.catalog(),
             "disabled by feishu account configuration".to_owned(),
         )
     } else if !send_issues.is_empty() {
-        misconfigured_operation(FEISHU_SEND_OPERATION, send_issues)
+        misconfigured_operation(FEISHU_SEND_OPERATION.catalog(), send_issues)
     } else {
-        ready_operation(FEISHU_SEND_OPERATION)
+        ready_operation(FEISHU_SEND_OPERATION.catalog())
     };
 
     let serve_operation = if !compiled {
         unsupported_operation(
-            FEISHU_SERVE_OPERATION,
+            FEISHU_SERVE_OPERATION.catalog(),
             "binary built without feature `channel-feishu`".to_owned(),
         )
     } else if !resolved.enabled {
         disabled_operation(
-            FEISHU_SERVE_OPERATION,
+            FEISHU_SERVE_OPERATION.catalog(),
             "disabled by feishu account configuration".to_owned(),
         )
     } else if !serve_issues.is_empty() {
-        misconfigured_operation(FEISHU_SERVE_OPERATION, serve_issues)
+        misconfigured_operation(FEISHU_SERVE_OPERATION.catalog(), serve_issues)
     } else {
-        ready_operation(FEISHU_SERVE_OPERATION)
+        ready_operation(FEISHU_SERVE_OPERATION.catalog())
     };
     let send_operation = attach_runtime(
         ChannelPlatform::Feishu,
-        FEISHU_SEND_OPERATION,
+        FEISHU_SEND_OPERATION.catalog(),
         send_operation,
         resolved.account.id.as_str(),
         resolved.account.label.as_str(),
@@ -451,7 +507,7 @@ fn build_feishu_snapshot_for_account(
     );
     let serve_operation = attach_runtime(
         ChannelPlatform::Feishu,
-        FEISHU_SERVE_OPERATION,
+        FEISHU_SERVE_OPERATION.catalog(),
         serve_operation,
         resolved.account.id.as_str(),
         resolved.account.label.as_str(),
@@ -515,11 +571,11 @@ fn build_invalid_telegram_snapshot(
 ) -> ChannelStatusSnapshot {
     let operation = if !compiled {
         unsupported_operation(
-            TELEGRAM_SERVE_OPERATION,
+            TELEGRAM_SERVE_OPERATION.catalog(),
             "binary built without feature `channel-telegram`".to_owned(),
         )
     } else {
-        misconfigured_operation(TELEGRAM_SERVE_OPERATION, vec![error.clone()])
+        misconfigured_operation(TELEGRAM_SERVE_OPERATION.catalog(), vec![error.clone()])
     };
 
     let mut notes = vec![
@@ -561,19 +617,19 @@ fn build_invalid_feishu_snapshot(
 ) -> ChannelStatusSnapshot {
     let send_operation = if !compiled {
         unsupported_operation(
-            FEISHU_SEND_OPERATION,
+            FEISHU_SEND_OPERATION.catalog(),
             "binary built without feature `channel-feishu`".to_owned(),
         )
     } else {
-        misconfigured_operation(FEISHU_SEND_OPERATION, vec![error.clone()])
+        misconfigured_operation(FEISHU_SEND_OPERATION.catalog(), vec![error.clone()])
     };
     let serve_operation = if !compiled {
         unsupported_operation(
-            FEISHU_SERVE_OPERATION,
+            FEISHU_SERVE_OPERATION.catalog(),
             "binary built without feature `channel-feishu`".to_owned(),
         )
     } else {
-        misconfigured_operation(FEISHU_SERVE_OPERATION, vec![error.clone()])
+        misconfigured_operation(FEISHU_SERVE_OPERATION.catalog(), vec![error.clone()])
     };
 
     let mut notes = vec![
@@ -742,6 +798,32 @@ mod tests {
         assert_eq!(feishu.operations.len(), 2);
         assert_eq!(feishu.operations[0].command, "feishu-send");
         assert_eq!(feishu.operations[1].command, "feishu-serve");
+    }
+
+    #[test]
+    fn channel_doctor_check_spec_uses_operation_specific_labels() {
+        assert_eq!(
+            channel_doctor_check_spec("telegram", "serve"),
+            Some(ChannelDoctorCheckSpec {
+                config_name: "telegram channel",
+                runtime_name: Some("telegram channel runtime"),
+            })
+        );
+        assert_eq!(
+            channel_doctor_check_spec("feishu", "send"),
+            Some(ChannelDoctorCheckSpec {
+                config_name: "feishu direct send",
+                runtime_name: None,
+            })
+        );
+        assert_eq!(
+            channel_doctor_check_spec("feishu", "serve"),
+            Some(ChannelDoctorCheckSpec {
+                config_name: "feishu webhook verification",
+                runtime_name: Some("feishu webhook runtime"),
+            })
+        );
+        assert_eq!(channel_doctor_check_spec("feishu", "missing"), None);
     }
 
     #[test]

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -35,12 +35,6 @@ struct DoctorSummary {
     fail: usize,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct DoctorChannelCheckSpec {
-    config_name: &'static str,
-    runtime_name: Option<&'static str>,
-}
-
 pub(crate) async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
     let (config_path, mut config) = mvp::config::load(options.config.as_deref())?;
     let mut checks = Vec::new();
@@ -307,7 +301,8 @@ fn build_channel_surface_checks(
             });
         }
         for operation in &snapshot.operations {
-            let Some(spec) = doctor_check_spec(snapshot.id, operation.id) else {
+            let Some(spec) = mvp::channel::channel_doctor_check_spec(snapshot.id, operation.id)
+            else {
                 continue;
             };
             checks.push(DoctorCheck {
@@ -339,24 +334,6 @@ fn scoped_doctor_check_name(
         return base_name.to_owned();
     }
     format!("{base_name} [{}]", snapshot.configured_account_label)
-}
-
-fn doctor_check_spec(channel_id: &str, operation_id: &str) -> Option<DoctorChannelCheckSpec> {
-    match (channel_id, operation_id) {
-        ("telegram", "serve") => Some(DoctorChannelCheckSpec {
-            config_name: "telegram channel",
-            runtime_name: Some("telegram channel runtime"),
-        }),
-        ("feishu", "send") => Some(DoctorChannelCheckSpec {
-            config_name: "feishu channel",
-            runtime_name: None,
-        }),
-        ("feishu", "serve") => Some(DoctorChannelCheckSpec {
-            config_name: "feishu webhook verification",
-            runtime_name: Some("feishu webhook runtime"),
-        }),
-        _ => None,
-    }
 }
 
 fn doctor_check_level_for_health(health: mvp::channel::ChannelOperationHealth) -> DoctorCheckLevel {
@@ -1008,6 +985,42 @@ mod tests {
                 && check.level == DoctorCheckLevel::Warn
                 && check.detail.contains("alerts")
                 && check.detail.contains("default_account")
+        }));
+    }
+
+    #[test]
+    fn build_channel_surface_checks_uses_operation_specific_doctor_name_for_feishu_send() {
+        let snapshots = vec![ChannelStatusSnapshot {
+            id: "feishu",
+            configured_account_id: "feishu_cli_a1b2c3".to_owned(),
+            configured_account_label: "feishu_cli_a1b2c3".to_owned(),
+            is_default_account: true,
+            default_account_source:
+                mvp::config::ChannelDefaultAccountSelectionSource::RuntimeIdentity,
+            label: "Feishu/Lark",
+            aliases: vec!["lark"],
+            transport: "feishu_openapi_webhook",
+            compiled: true,
+            enabled: true,
+            api_base_url: Some("https://open.feishu.cn".to_owned()),
+            notes: Vec::new(),
+            operations: vec![ChannelOperationStatus {
+                id: "send",
+                label: "direct send",
+                command: "feishu-send",
+                health: ChannelOperationHealth::Ready,
+                detail: "ready".to_owned(),
+                issues: Vec::new(),
+                runtime: None,
+            }],
+        }];
+
+        let checks = build_channel_surface_checks(&snapshots);
+
+        assert!(checks.iter().any(|check| {
+            check.name == "feishu direct send"
+                && check.level == DoctorCheckLevel::Pass
+                && check.detail == "ready"
         }));
     }
 }

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-13T08:09:50Z
+- Generated at: 2026-03-13T12:07:00Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -11,8 +11,8 @@
 ## Hotspot Metrics
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
-| spec_runtime | `crates/spec/src/spec_runtime.rs` | 2913 | 3600 | 687 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
-| spec_execution | `crates/spec/src/spec_execution.rs` | 1466 | 3700 | 2234 | 22 | 80 | 58 | n/a | n/a | N/A | n/a |
+| spec_runtime | `crates/spec/src/spec_runtime.rs` | 2926 | 3600 | 674 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
+| spec_execution | `crates/spec/src/spec_execution.rs` | 1467 | 3700 | 2233 | 22 | 80 | 58 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 234 | 1000 | 766 | 5 | 20 | 15 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 620 | 650 | 30 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
@@ -37,8 +37,8 @@
 - [Release template](TEMPLATE.md)
 - [CI workflow](../../.github/workflows/ci.yml)
 
-<!-- arch-hotspot key=spec_runtime lines=2913 functions=47 -->
-<!-- arch-hotspot key=spec_execution lines=1466 functions=22 -->
+<!-- arch-hotspot key=spec_runtime lines=2926 functions=47 -->
+<!-- arch-hotspot key=spec_execution lines=1467 functions=22 -->
 <!-- arch-hotspot key=provider_mod lines=234 functions=5 -->
 <!-- arch-hotspot key=memory_mod lines=620 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary
- move channel doctor check labels out of `crates/daemon/src/doctor_cli.rs` and into app-level channel registry metadata
- expose a registry lookup helper so daemon doctor checks follow channel operation metadata instead of a local `(channel_id, operation_id)` match table
- make Feishu send doctor output more explicit as `feishu direct send`, keeping runtime names on the operation metadata path for future channels and stubs

## Why
- adding a new channel surface should not require updating both registry metadata and daemon hardcoded doctor labels
- this keeps channel capability metadata closer to the provider registry boundary, which is a better fit for future high-quality stub channels
- it is a small follow-up to PR #84 without pulling in heavier abstractions

## Validation
- `<local-absolute-path> test -p loongclaw-daemon build_channel_surface_checks_uses_operation_specific_doctor_name_for_feishu_send --all-features --target-dir <local-absolute-path>`
- `<local-absolute-path> test -p loongclaw-app channel::registry::tests:: --all-features --target-dir <local-absolute-path>`
- `<local-absolute-path> test -p loongclaw-daemon build_channel_surface_checks_ --all-features --target-dir <local-absolute-path>`
- `<local-absolute-path> fmt --all --check`
- `<local-absolute-path> clippy -p loongclaw-app -p loongclaw-daemon --all-targets --all-features --target-dir <local-absolute-path> -- -D warnings`
- `<local-absolute-path> test --workspace --all-features --target-dir <local-absolute-path> -- --test-threads=1`
- `./scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md`