### PR TITLE
refactor: surface catalog-only channels in daemon CLI

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -41,8 +41,8 @@ mod telegram;
 
 pub use registry::{
     ChannelCatalogEntry, ChannelCatalogOperation, ChannelOperationHealth, ChannelOperationStatus,
-    ChannelStatusSnapshot, channel_status_snapshots, list_channel_catalog,
-    normalize_channel_platform,
+    ChannelStatusSnapshot, catalog_only_channel_entries, channel_status_snapshots,
+    list_channel_catalog, normalize_channel_platform,
 };
 pub use runtime_state::ChannelOperationRuntime;
 use runtime_state::ChannelOperationRuntimeTracker;

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{collections::BTreeSet, path::Path};
 
 use serde::Serialize;
 
@@ -148,6 +148,28 @@ pub fn list_channel_catalog() -> Vec<ChannelCatalogEntry> {
             transport: descriptor.transport,
             operations: descriptor.operations.to_vec(),
         })
+        .collect()
+}
+
+pub fn catalog_only_channel_entries(
+    snapshots: &[ChannelStatusSnapshot],
+) -> Vec<ChannelCatalogEntry> {
+    let catalog = list_channel_catalog();
+    catalog_only_channel_entries_from(&catalog, snapshots)
+}
+
+fn catalog_only_channel_entries_from(
+    catalog: &[ChannelCatalogEntry],
+    snapshots: &[ChannelStatusSnapshot],
+) -> Vec<ChannelCatalogEntry> {
+    let snapshot_ids = snapshots
+        .iter()
+        .map(|snapshot| snapshot.id)
+        .collect::<BTreeSet<_>>();
+    catalog
+        .iter()
+        .filter(|entry| !snapshot_ids.contains(entry.id))
+        .cloned()
         .collect()
 }
 
@@ -742,6 +764,65 @@ mod tests {
         assert_eq!(feishu.operations.len(), 2);
         assert_eq!(feishu.operations[0].command, "feishu-send");
         assert_eq!(feishu.operations[1].command, "feishu-serve");
+    }
+
+    #[test]
+    fn catalog_only_channel_entries_skip_platforms_that_already_have_status_snapshots() {
+        let catalog = vec![
+            ChannelCatalogEntry {
+                id: "telegram",
+                label: "Telegram",
+                aliases: vec![],
+                transport: "telegram_bot_api_polling",
+                operations: vec![ChannelCatalogOperation {
+                    id: "serve",
+                    label: "reply loop",
+                    command: "telegram-serve",
+                    tracks_runtime: true,
+                }],
+            },
+            ChannelCatalogEntry {
+                id: "discord",
+                label: "Discord",
+                aliases: vec![],
+                transport: "discord_gateway",
+                operations: vec![ChannelCatalogOperation {
+                    id: "send",
+                    label: "direct send",
+                    command: "discord-send",
+                    tracks_runtime: false,
+                }],
+            },
+        ];
+        let snapshots = vec![ChannelStatusSnapshot {
+            id: "telegram",
+            configured_account_id: "default".to_owned(),
+            configured_account_label: "default".to_owned(),
+            is_default_account: true,
+            default_account_source: ChannelDefaultAccountSelectionSource::Fallback,
+            label: "Telegram",
+            aliases: vec![],
+            transport: "telegram_bot_api_polling",
+            compiled: true,
+            enabled: false,
+            api_base_url: Some("https://api.telegram.org".to_owned()),
+            notes: vec![],
+            operations: vec![ChannelOperationStatus {
+                id: "serve",
+                label: "reply loop",
+                command: "telegram-serve",
+                health: ChannelOperationHealth::Disabled,
+                detail: "disabled".to_owned(),
+                issues: vec![],
+                runtime: None,
+            }],
+        }];
+
+        let catalog_only = catalog_only_channel_entries_from(&catalog, &snapshots);
+
+        assert_eq!(catalog_only.len(), 1);
+        assert_eq!(catalog_only[0].id, "discord");
+        assert_eq!(catalog_only[0].operations[0].command, "discord-send");
     }
 
     #[test]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -966,11 +966,13 @@ async fn run_list_models_cli(config_path: Option<&str>, as_json: bool) -> CliRes
 fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
     let (resolved_path, config) = mvp::config::load(config_path)?;
     let snapshots = mvp::channel::channel_status_snapshots(&config);
+    let catalog_only = mvp::channel::catalog_only_channel_entries(&snapshots);
 
     if as_json {
         let payload = json!({
             "config": resolved_path.display().to_string(),
             "channels": snapshots,
+            "catalog_only_channels": catalog_only,
         });
         let pretty = serde_json::to_string_pretty(&payload)
             .map_err(|error| format!("serialize channel status output failed: {error}"))?;
@@ -980,7 +982,11 @@ fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
 
     println!(
         "{}",
-        render_channel_snapshots_text(&resolved_path.display().to_string(), &snapshots)
+        render_channel_snapshots_text(
+            &resolved_path.display().to_string(),
+            &snapshots,
+            &catalog_only,
+        )
     );
     Ok(())
 }
@@ -988,6 +994,7 @@ fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
 fn render_channel_snapshots_text(
     config_path: &str,
     snapshots: &[mvp::channel::ChannelStatusSnapshot],
+    catalog_only: &[mvp::channel::ChannelCatalogEntry],
 ) -> String {
     let mut lines = vec![format!("config={config_path}")];
     for snapshot in snapshots {
@@ -1059,6 +1066,26 @@ fn render_channel_snapshots_text(
             }
             for issue in &operation.issues {
                 lines.push(format!("    issue: {issue}"));
+            }
+        }
+    }
+    if !catalog_only.is_empty() {
+        lines.push("catalog-only channels:".to_owned());
+        for entry in catalog_only {
+            let aliases = if entry.aliases.is_empty() {
+                "-".to_owned()
+            } else {
+                entry.aliases.join(",")
+            };
+            lines.push(format!(
+                "{} [{}] aliases={} transport={}",
+                entry.label, entry.id, aliases, entry.transport
+            ));
+            for operation in &entry.operations {
+                lines.push(format!(
+                    "  catalog op {} ({}) tracks_runtime={}",
+                    operation.id, operation.command, operation.tracks_runtime
+                ));
             }
         }
     }

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -77,7 +77,7 @@ fn render_channel_snapshots_text_reports_aliases_and_operation_health() {
     config.feishu.app_secret = Some("app-secret".to_owned());
 
     let snapshots = mvp::channel::channel_status_snapshots(&config);
-    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots);
+    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots, &[]);
 
     assert!(rendered.contains("config=/tmp/loongclaw.toml"));
     assert!(rendered.contains("Feishu/Lark [feishu]"));
@@ -111,7 +111,7 @@ fn render_channel_snapshots_text_reports_configured_accounts_for_multi_account_c
     .expect("deserialize multi-account config");
 
     let snapshots = mvp::channel::channel_status_snapshots(&config);
-    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots);
+    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots, &[]);
 
     assert!(rendered.contains("configured_account=work-bot"));
     assert!(rendered.contains("configured_account=personal"));
@@ -140,9 +140,31 @@ fn render_channel_snapshots_text_reports_default_account_marker() {
     .expect("deserialize multi-account config");
 
     let snapshots = mvp::channel::channel_status_snapshots(&config);
-    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots);
+    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots, &[]);
 
     assert!(rendered.contains("configured_account=work-bot"));
     assert!(rendered.contains("default_account=true"));
     assert!(rendered.contains("default_source=explicit_default"));
+}
+
+#[test]
+fn render_channel_snapshots_text_reports_catalog_only_channels() {
+    let catalog_only = vec![mvp::channel::ChannelCatalogEntry {
+        id: "discord",
+        label: "Discord",
+        aliases: vec!["discord-bot"],
+        transport: "discord_gateway",
+        operations: vec![mvp::channel::ChannelCatalogOperation {
+            id: "send",
+            label: "direct send",
+            command: "discord-send",
+            tracks_runtime: false,
+        }],
+    }];
+
+    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &[], &catalog_only);
+
+    assert!(rendered.contains("catalog-only channels:"));
+    assert!(rendered.contains("Discord [discord] aliases=discord-bot transport=discord_gateway"));
+    assert!(rendered.contains("catalog op send (discord-send) tracks_runtime=false"));
 }


### PR DESCRIPTION
## Summary
- add a channel-registry helper that exposes catalog entries missing runtime status snapshots
- surface catalog-only channels in `loongclaw channels` text and JSON output
- refresh the March 2026 architecture drift report required by governance

## Validation
- cargo fmt --all --check
- git diff --check
- cargo test -p loongclaw-app channel::registry::tests:: --all-features --target-dir <local-absolute-path>
- cargo test -p loongclaw-daemon render_channel_snapshots_text_ --all-features --target-dir <local-absolute-path>
- cargo clippy -p loongclaw-app -p loongclaw-daemon --all-targets --all-features --target-dir <local-absolute-path> -- -D warnings
- cargo test --workspace --all-features --target-dir <local-absolute-path> -- --test-threads=1
- ./scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md