### PR TITLE
feat(session): add session_unarchive tool surface

### DIFF
--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -299,8 +299,13 @@ mod tests {
             .expect("append first match");
         append_turn_direct("session-b", "assistant", "no relevant text here", &config)
             .expect("append unrelated turn");
-        append_turn_direct("session-a", "assistant", "latest timeout budget update", &config)
-            .expect("append latest match");
+        append_turn_direct(
+            "session-a",
+            "assistant",
+            "latest timeout budget update",
+            &config,
+        )
+        .expect("append latest match");
 
         let matches = search_transcript_direct(
             &["session-a".to_owned(), "session-b".to_owned()],
@@ -344,12 +349,16 @@ mod tests {
             sqlite_path: Some(db_path.clone()),
         };
 
-        append_turn_direct("session-a", "user", "archive inventory", &config)
-            .expect("append turn");
+        append_turn_direct("session-a", "user", "archive inventory", &config).expect("append turn");
 
-        let matches =
-            search_transcript_direct(&["session-a".to_owned()], "timeout budget", 20, 120, &config)
-                .expect("search transcript");
+        let matches = search_transcript_direct(
+            &["session-a".to_owned()],
+            "timeout budget",
+            20,
+            120,
+            &config,
+        )
+        .expect("search transcript");
 
         assert!(matches.is_empty(), "non-matching turns should be excluded");
 

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -11,7 +11,7 @@ mod sqlite;
 
 pub use kernel_adapter::MvpMemoryAdapter;
 #[cfg(feature = "memory-sqlite")]
-pub use sqlite::ConversationTurn;
+pub use sqlite::{ConversationTurn, TranscriptSearchMatch};
 
 pub fn execute_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
     execute_memory_core_with_config(request, runtime_config::get_memory_runtime_config())
@@ -115,6 +115,17 @@ pub fn ensure_memory_db_ready(
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<PathBuf, String> {
     sqlite::ensure_memory_db_ready(path, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn search_transcript_direct(
+    session_ids: &[String],
+    query: &str,
+    limit: usize,
+    excerpt_chars: usize,
+    config: &runtime_config::MemoryRuntimeConfig,
+) -> Result<Vec<TranscriptSearchMatch>, String> {
+    sqlite::search_transcript_direct(session_ids, query, limit, excerpt_chars, config)
 }
 
 #[cfg(test)]
@@ -262,6 +273,130 @@ mod tests {
         assert_eq!(turns.len(), 1);
         assert_eq!(turns[0].role, "user");
         assert_eq!(turns[0].content, "hello from transcript");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn search_transcript_direct_returns_recent_matching_turns() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-test-memory-search-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&tmp);
+        let db_path = tmp.join("search.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+        };
+
+        append_turn_direct("session-a", "user", "first timeout budget note", &config)
+            .expect("append first match");
+        append_turn_direct("session-b", "assistant", "no relevant text here", &config)
+            .expect("append unrelated turn");
+        append_turn_direct("session-a", "assistant", "latest timeout budget update", &config)
+            .expect("append latest match");
+
+        let matches = search_transcript_direct(
+            &["session-a".to_owned(), "session-b".to_owned()],
+            "timeout budget",
+            20,
+            120,
+            &config,
+        )
+        .expect("search transcript");
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].session_id, "session-a");
+        assert_eq!(matches[0].role, "assistant");
+        assert!(
+            matches[0].content_snippet.contains("timeout budget"),
+            "snippet should contain query"
+        );
+        assert!(
+            matches[0].turn_id > matches[1].turn_id,
+            "results should be newest first"
+        );
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn search_transcript_direct_excludes_non_matching_turns() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-test-memory-search-miss-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&tmp);
+        let db_path = tmp.join("search-miss.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+        };
+
+        append_turn_direct("session-a", "user", "archive inventory", &config)
+            .expect("append turn");
+
+        let matches =
+            search_transcript_direct(&["session-a".to_owned()], "timeout budget", 20, 120, &config)
+                .expect("search transcript");
+
+        assert!(matches.is_empty(), "non-matching turns should be excluded");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn search_transcript_direct_clamps_limit_and_excerpt() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-test-memory-search-clamp-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&tmp);
+        let db_path = tmp.join("search-clamp.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+        };
+        let long_prefix = "prefix ".repeat(20);
+        let long_suffix = " suffix".repeat(20);
+        let long_match = format!("{long_prefix}timeout budget{long_suffix}");
+
+        append_turn_direct("session-a", "user", "timeout budget alpha", &config)
+            .expect("append alpha");
+        append_turn_direct("session-a", "assistant", "timeout budget beta", &config)
+            .expect("append beta");
+        append_turn_direct("session-a", "assistant", &long_match, &config)
+            .expect("append long match");
+
+        let matches =
+            search_transcript_direct(&["session-a".to_owned()], "timeout budget", 0, 12, &config)
+                .expect("search transcript");
+
+        assert_eq!(matches.len(), 1, "limit should clamp to at least one");
+        assert!(
+            matches[0].content_snippet.len() <= 406,
+            "excerpt should clamp instead of returning the full long content"
+        );
+        assert!(
+            matches[0].content_snippet.contains("timeout budget"),
+            "snippet should preserve the matching phrase"
+        );
 
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir(&tmp);

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -255,7 +255,9 @@ pub(super) fn search_transcript_direct(
     );
 
     let mut params = Vec::with_capacity(session_ids.len() + 2);
-    params.push(rusqlite::types::Value::from(format!("%{normalized_query}%")));
+    params.push(rusqlite::types::Value::from(format!(
+        "%{normalized_query}%"
+    )));
     params.extend(
         session_ids
             .iter()
@@ -285,8 +287,7 @@ pub(super) fn search_transcript_direct(
 
     let mut matches = Vec::new();
     for row in rows {
-        matches
-            .push(row.map_err(|error| format!("decode transcript search row failed: {error}"))?);
+        matches.push(row.map_err(|error| format!("decode transcript search row failed: {error}"))?);
     }
     Ok(matches)
 }

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -17,6 +17,15 @@ pub struct ConversationTurn {
     pub ts: i64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranscriptSearchMatch {
+    pub turn_id: i64,
+    pub session_id: String,
+    pub role: String,
+    pub content_snippet: String,
+    pub ts: i64,
+}
+
 pub(super) fn append_turn(
     request: MemoryCoreRequest,
     config: &MemoryRuntimeConfig,
@@ -206,6 +215,82 @@ pub(super) fn window_direct(
         .map_err(|error| format!("decode memory turns failed: {error}"))
 }
 
+pub(super) fn search_transcript_direct(
+    session_ids: &[String],
+    query: &str,
+    limit: usize,
+    excerpt_chars: usize,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<TranscriptSearchMatch>, String> {
+    if session_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let normalized_query = query.trim();
+    if normalized_query.is_empty() {
+        return Err("memory.search_transcript requires a non-empty query".to_owned());
+    }
+
+    let search_limit = clamp_search_limit(limit);
+    let excerpt_limit = clamp_excerpt_chars(excerpt_chars);
+    let path = resolve_db_path(config);
+    ensure_sqlite_schema(&path)?;
+    let conn = rusqlite::Connection::open(&path)
+        .map_err(|error| format!("open sqlite memory db failed: {error}"))?;
+
+    let mut session_placeholders = Vec::with_capacity(session_ids.len());
+    for offset in 0..session_ids.len() {
+        session_placeholders.push(format!("?{}", offset + 2));
+    }
+    let limit_placeholder = session_ids.len() + 2;
+    let sql = format!(
+        "SELECT id, session_id, role, content, ts
+         FROM turns
+         WHERE content LIKE ?1
+           AND session_id IN ({})
+         ORDER BY ts DESC, id DESC
+         LIMIT ?{}",
+        session_placeholders.join(", "),
+        limit_placeholder
+    );
+
+    let mut params = Vec::with_capacity(session_ids.len() + 2);
+    params.push(rusqlite::types::Value::from(format!("%{normalized_query}%")));
+    params.extend(
+        session_ids
+            .iter()
+            .cloned()
+            .map(rusqlite::types::Value::from),
+    );
+    params.push(rusqlite::types::Value::from(search_limit as i64));
+
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|error| format!("prepare transcript search query failed: {error}"))?;
+    let rows = stmt
+        .query_map(
+            rusqlite::params_from_iter(params),
+            |row| -> rusqlite::Result<TranscriptSearchMatch> {
+                let content: String = row.get(3)?;
+                Ok(TranscriptSearchMatch {
+                    turn_id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    role: row.get(2)?,
+                    content_snippet: build_excerpt(&content, normalized_query, excerpt_limit),
+                    ts: row.get(4)?,
+                })
+            },
+        )
+        .map_err(|error| format!("query transcript search failed: {error}"))?;
+
+    let mut matches = Vec::new();
+    for row in rows {
+        matches
+            .push(row.map_err(|error| format!("decode transcript search row failed: {error}"))?);
+    }
+    Ok(matches)
+}
+
 pub(super) fn ensure_memory_db_ready(
     path: Option<PathBuf>,
     config: &MemoryRuntimeConfig,
@@ -225,6 +310,47 @@ fn default_window_size() -> usize {
 
 fn default_window_size_u64() -> u64 {
     default_window_size() as u64
+}
+
+fn clamp_search_limit(limit: usize) -> usize {
+    limit.clamp(1, 100)
+}
+
+fn clamp_excerpt_chars(excerpt_chars: usize) -> usize {
+    excerpt_chars.clamp(40, 400)
+}
+
+fn build_excerpt(content: &str, query: &str, excerpt_chars: usize) -> String {
+    if content.chars().count() <= excerpt_chars {
+        return content.to_owned();
+    }
+
+    let content_lower = content.to_lowercase();
+    let query_lower = query.to_lowercase();
+    let match_start = content_lower.find(&query_lower).unwrap_or(0);
+    let match_end = match_start.saturating_add(query_lower.len());
+
+    let mut start = match_start.saturating_sub(excerpt_chars / 2);
+    let mut end = start.saturating_add(excerpt_chars).min(content.len());
+    if end < match_end {
+        end = match_end.min(content.len());
+        start = end.saturating_sub(excerpt_chars);
+    }
+    while start > 0 && !content.is_char_boundary(start) {
+        start -= 1;
+    }
+    while end < content.len() && !content.is_char_boundary(end) {
+        end += 1;
+    }
+
+    let mut snippet = content[start..end].to_owned();
+    if start > 0 {
+        snippet.insert_str(0, "...");
+    }
+    if end < content.len() {
+        snippet.push_str("...");
+    }
+    snippet
 }
 
 fn unix_ts_now() -> i64 {

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -1138,6 +1138,7 @@ mod tests {
             expected.push("file_read");
             expected.push("file_write");
         }
+        expected.push("memory_search");
         expected.push("session_archive");
         expected.push("session_cancel");
         expected.push("session_events");
@@ -1264,6 +1265,37 @@ mod tests {
             .collect();
 
         assert!(names.contains(&"session_archive"));
+    }
+
+    #[test]
+    fn memory_search_appears_in_root_turn_request_body() {
+        let config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        let tool_definitions = crate::tools::provider_tool_definitions();
+        let body = build_turn_request_body(
+            &config,
+            &[],
+            "model-latest",
+            CompletionPayloadMode::default_for(&config.provider),
+            true,
+            &tool_definitions,
+        );
+        let tools = body["tools"].as_array().expect("tools array");
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+
+        assert!(names.contains(&"memory_search"));
     }
 
     #[test]

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -1143,6 +1143,7 @@ mod tests {
         expected.push("session_events");
         expected.push("session_recover");
         expected.push("session_status");
+        expected.push("session_unarchive");
         expected.push("session_wait");
         expected.push("sessions_history");
         expected.push("sessions_list");
@@ -1263,6 +1264,37 @@ mod tests {
             .collect();
 
         assert!(names.contains(&"session_archive"));
+    }
+
+    #[test]
+    fn session_unarchive_appears_in_root_turn_request_body() {
+        let config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        let tool_definitions = crate::tools::provider_tool_definitions();
+        let body = build_turn_request_body(
+            &config,
+            &[],
+            "model-latest",
+            CompletionPayloadMode::default_for(&config.provider),
+            true,
+            &tool_definitions,
+        );
+        let tools = body["tools"].as_array().expect("tools array");
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+
+        assert!(names.contains(&"session_unarchive"));
     }
 
     #[test]

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -562,10 +562,22 @@ impl SessionRepository {
                     MAX(t.ts) AS last_turn_at
                  FROM sessions s
                  LEFT JOIN (
-                    SELECT session_id, MAX(ts) AS archived_at
-                    FROM session_events
-                    WHERE event_kind = 'session_archived'
-                    GROUP BY session_id
+                    SELECT
+                        latest.session_id,
+                        CASE
+                            WHEN latest.event_kind = 'session_archived' THEN latest.ts
+                            ELSE NULL
+                        END AS archived_at
+                    FROM (
+                        SELECT se.session_id, se.event_kind, se.ts
+                        FROM session_events se
+                        JOIN (
+                            SELECT session_id, MAX(id) AS latest_id
+                            FROM session_events
+                            WHERE event_kind IN ('session_archived', 'session_unarchived')
+                            GROUP BY session_id
+                        ) selected ON selected.latest_id = se.id
+                    ) latest
                  ) archived ON archived.session_id = s.session_id
                  JOIN visible v ON v.session_id = s.session_id
                  LEFT JOIN turns t ON t.session_id = s.session_id
@@ -994,10 +1006,22 @@ impl SessionRepository {
                     MAX(t.ts) AS last_turn_at
                  FROM sessions s
                  LEFT JOIN (
-                    SELECT session_id, MAX(ts) AS archived_at
-                    FROM session_events
-                    WHERE event_kind = 'session_archived'
-                    GROUP BY session_id
+                    SELECT
+                        latest.session_id,
+                        CASE
+                            WHEN latest.event_kind = 'session_archived' THEN latest.ts
+                            ELSE NULL
+                        END AS archived_at
+                    FROM (
+                        SELECT se.session_id, se.event_kind, se.ts
+                        FROM session_events se
+                        JOIN (
+                            SELECT session_id, MAX(id) AS latest_id
+                            FROM session_events
+                            WHERE event_kind IN ('session_archived', 'session_unarchived')
+                            GROUP BY session_id
+                        ) selected ON selected.latest_id = se.id
+                    ) latest
                  ) archived ON archived.session_id = s.session_id
                  LEFT JOIN turns t ON t.session_id = s.session_id
                  WHERE s.session_id = ?1

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -323,9 +323,7 @@ fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> boo
     match tool_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
         | "session_archive" | "session_cancel" | "session_recover" | "session_unarchive"
-        | "session_wait" => {
-            config.sessions.enabled
-        }
+        | "session_wait" => config.sessions.enabled,
         "sessions_send" => config.messages.enabled,
         "delegate" | "delegate_async" => config.delegate.enabled,
         _ => true,

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -187,6 +187,15 @@ pub fn tool_catalog() -> ToolCatalog {
         provider_definition_builder: session_archive_definition,
     });
     descriptors.push(ToolDescriptor {
+        name: "session_unarchive",
+        provider_name: "session_unarchive",
+        aliases: &[],
+        description: "Restore a visible archived terminal session to default session listings",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: session_unarchive_definition,
+    });
+    descriptors.push(ToolDescriptor {
         name: "session_cancel",
         provider_name: "session_cancel",
         aliases: &[],
@@ -313,7 +322,8 @@ pub fn delegate_child_tool_view_for_config_with_delegate(
 fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> bool {
     match tool_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_archive" | "session_cancel" | "session_recover" | "session_wait" => {
+        | "session_archive" | "session_cancel" | "session_recover" | "session_unarchive"
+        | "session_wait" => {
             config.sessions.enabled
         }
         "sessions_send" => config.messages.enabled,
@@ -607,6 +617,42 @@ fn session_archive_definition(descriptor: &ToolDescriptor) -> Value {
                     "dry_run": {
                         "type": "boolean",
                         "description": "When true, preview which targets are archivable without mutating state."
+                    }
+                },
+                "oneOf": [
+                    { "required": ["session_id"] },
+                    { "required": ["session_ids"] }
+                ],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn session_unarchive_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Visible archived terminal session identifier to restore to default listings."
+                    },
+                    "session_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "Visible archived terminal session identifiers to restore in one request."
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "When true, preview which targets are unarchivable without mutating state."
                     }
                 },
                 "oneOf": [

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -148,7 +148,7 @@ pub fn tool_catalog() -> ToolCatalog {
         description: "Fetch session events for a visible session",
         execution_kind: ToolExecutionKind::App,
         availability: ToolAvailability::Runtime,
-            provider_definition_builder: session_events_definition,
+        provider_definition_builder: session_events_definition,
     });
     descriptors.push(ToolDescriptor {
         name: "memory_search",

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -148,7 +148,16 @@ pub fn tool_catalog() -> ToolCatalog {
         description: "Fetch session events for a visible session",
         execution_kind: ToolExecutionKind::App,
         availability: ToolAvailability::Runtime,
-        provider_definition_builder: session_events_definition,
+            provider_definition_builder: session_events_definition,
+    });
+    descriptors.push(ToolDescriptor {
+        name: "memory_search",
+        provider_name: "memory_search",
+        aliases: &[],
+        description: "Search visible transcript memory across persisted session turns",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: memory_search_definition,
     });
     descriptors.push(ToolDescriptor {
         name: "sessions_history",
@@ -322,8 +331,8 @@ pub fn delegate_child_tool_view_for_config_with_delegate(
 fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> bool {
     match tool_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_archive" | "session_cancel" | "session_recover" | "session_unarchive"
-        | "session_wait" => config.sessions.enabled,
+        | "memory_search" | "session_archive" | "session_cancel" | "session_recover"
+        | "session_unarchive" | "session_wait" => config.sessions.enabled,
         "sessions_send" => config.messages.enabled,
         "delegate" | "delegate_async" => config.delegate.enabled,
         _ => true,
@@ -485,6 +494,56 @@ fn sessions_history_definition(descriptor: &ToolDescriptor) -> Value {
                     }
                 },
                 "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn memory_search_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Non-empty transcript text to search for within visible session memory."
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional visible session identifier to search exclusively."
+                    },
+                    "session_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "Optional visible session identifiers to search in one request."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "description": "Maximum transcript matches to return."
+                    },
+                    "excerpt_chars": {
+                        "type": "integer",
+                        "minimum": 40,
+                        "maximum": 400,
+                        "description": "Approximate match snippet length in characters."
+                    }
+                },
+                "required": ["query"],
+                "oneOf": [
+                    { "required": ["query", "session_id"] },
+                    { "required": ["query", "session_ids"] },
+                    { "required": ["query"] }
+                ],
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/memory.rs
+++ b/crates/app/src/tools/memory.rs
@@ -81,8 +81,9 @@ pub(crate) fn execute_memory_search_tool_with_policies(
             "limit": request.limit.clamp(1, 100),
             "truncated": false,
         });
-        let returned_count = payload["matches"]
-            .as_array()
+        let returned_count = payload
+            .get("matches")
+            .and_then(Value::as_array)
             .map(Vec::len)
             .unwrap_or_default();
 
@@ -299,8 +300,10 @@ mod tests {
     }
 
     fn skipped_target<'a>(payload: &'a Value, session_id: &str) -> &'a Value {
-        payload["scope"]["skipped_targets"]
-            .as_array()
+        payload
+            .get("scope")
+            .and_then(|scope| scope.get("skipped_targets"))
+            .and_then(Value::as_array)
             .expect("skipped_targets array")
             .iter()
             .find(|item| item.get("session_id").and_then(Value::as_str) == Some(session_id))
@@ -399,10 +402,19 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        assert_eq!(outcome.payload["scope"]["mode"], "visible");
-        assert_eq!(outcome.payload["returned_count"], 2);
-        let matches = outcome.payload["matches"]
-            .as_array()
+        let scope = outcome.payload.get("scope").expect("scope payload");
+        assert_eq!(scope.get("mode").and_then(Value::as_str), Some("visible"));
+        assert_eq!(
+            outcome
+                .payload
+                .get("returned_count")
+                .and_then(Value::as_u64),
+            Some(2)
+        );
+        let matches = outcome
+            .payload
+            .get("matches")
+            .and_then(Value::as_array)
             .expect("matches array");
         let session_ids: Vec<&str> = matches
             .iter()
@@ -510,15 +522,26 @@ mod tests {
         )
         .expect("batch memory_search outcome");
 
-        assert_eq!(outcome.payload["scope"]["mode"], "batch");
-        assert_eq!(outcome.payload["returned_count"], 1);
+        let scope = outcome.payload.get("scope").expect("scope payload");
+        assert_eq!(scope.get("mode").and_then(Value::as_str), Some("batch"));
         assert_eq!(
-            skipped_target(&outcome.payload, "hidden-root")["result"],
-            "skipped_not_visible"
+            outcome
+                .payload
+                .get("returned_count")
+                .and_then(Value::as_u64),
+            Some(1)
         );
         assert_eq!(
-            skipped_target(&outcome.payload, "missing-session")["result"],
-            "skipped_not_found"
+            skipped_target(&outcome.payload, "hidden-root")
+                .get("result")
+                .and_then(Value::as_str),
+            Some("skipped_not_visible")
+        );
+        assert_eq!(
+            skipped_target(&outcome.payload, "missing-session")
+                .get("result")
+                .and_then(Value::as_str),
+            Some("skipped_not_found")
         );
     }
 
@@ -566,11 +589,19 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        let matches = outcome.payload["matches"]
-            .as_array()
+        let matches = outcome
+            .payload
+            .get("matches")
+            .and_then(Value::as_array)
             .expect("matches array");
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0]["session_id"], "archived-child");
+        assert_eq!(
+            matches
+                .first()
+                .and_then(|item| item.get("session_id"))
+                .and_then(Value::as_str),
+            Some("archived-child")
+        );
     }
 
     #[test]
@@ -599,10 +630,22 @@ mod tests {
         )
         .expect("legacy memory_search outcome");
 
-        assert_eq!(outcome.payload["returned_count"], 1);
         assert_eq!(
-            outcome.payload["matches"][0]["session_id"],
-            "delegate:legacy-child"
+            outcome
+                .payload
+                .get("returned_count")
+                .and_then(Value::as_u64),
+            Some(1)
+        );
+        assert_eq!(
+            outcome
+                .payload
+                .get("matches")
+                .and_then(Value::as_array)
+                .and_then(|matches| matches.first())
+                .and_then(|item| item.get("session_id"))
+                .and_then(Value::as_str),
+            Some("delegate:legacy-child")
         );
     }
 
@@ -643,8 +686,10 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        let matches = outcome.payload["matches"]
-            .as_array()
+        let matches = outcome
+            .payload
+            .get("matches")
+            .and_then(Value::as_array)
             .expect("matches array");
         assert!(
             matches.is_empty(),

--- a/crates/app/src/tools/memory.rs
+++ b/crates/app/src/tools/memory.rs
@@ -1,10 +1,10 @@
 use loongclaw_contracts::ToolCoreOutcome;
 use serde_json::{json, Value};
 
-use crate::config::ToolConfig;
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::config::SessionVisibility;
+use crate::config::ToolConfig;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::SessionRepository;
 
@@ -115,7 +115,10 @@ fn parse_memory_search_request(payload: Value) -> Result<MemorySearchRequest, St
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned);
-    let session_ids = object.get("session_ids").map(parse_session_ids).transpose()?;
+    let session_ids = object
+        .get("session_ids")
+        .map(parse_session_ids)
+        .transpose()?;
     if session_id.is_some() && session_ids.is_some() {
         return Err(
             "memory_search_invalid_request: session_id and session_ids are mutually exclusive"
@@ -127,10 +130,7 @@ fn parse_memory_search_request(payload: Value) -> Result<MemorySearchRequest, St
         query,
         session_id,
         session_ids,
-        limit: object
-            .get("limit")
-            .and_then(Value::as_u64)
-            .unwrap_or(20) as usize,
+        limit: object.get("limit").and_then(Value::as_u64).unwrap_or(20) as usize,
         excerpt_chars: object
             .get("excerpt_chars")
             .and_then(Value::as_u64)
@@ -169,7 +169,12 @@ fn resolve_search_scope(
     tool_config: &ToolConfig,
 ) -> Result<(&'static str, Vec<String>, Vec<Value>), String> {
     if let Some(session_id) = &request.session_id {
-        ensure_target_visible(repo, current_session_id, session_id, tool_config.sessions.visibility)?;
+        ensure_target_visible(
+            repo,
+            current_session_id,
+            session_id,
+            tool_config.sessions.visibility,
+        )?;
         return Ok(("single", vec![session_id.clone()], Vec::new()));
     }
 
@@ -250,7 +255,9 @@ fn classify_target_visibility(
 
     let is_visible = match visibility {
         SessionVisibility::SelfOnly => false,
-        SessionVisibility::Children => repo.is_session_visible(current_session_id, target_session_id)?,
+        SessionVisibility::Children => {
+            repo.is_session_visible(current_session_id, target_session_id)?
+        }
     };
     if is_visible {
         Ok(TargetVisibility::Visible)
@@ -369,8 +376,13 @@ mod tests {
 
         append_turn_direct("root-session", "user", "timeout budget root", &config)
             .expect("append root turn");
-        append_turn_direct("child-session", "assistant", "timeout budget child", &config)
-            .expect("append child turn");
+        append_turn_direct(
+            "child-session",
+            "assistant",
+            "timeout budget child",
+            &config,
+        )
+        .expect("append child turn");
         append_turn_direct("other-root", "assistant", "timeout budget hidden", &config)
             .expect("append hidden turn");
 
@@ -389,7 +401,9 @@ mod tests {
 
         assert_eq!(outcome.payload["scope"]["mode"], "visible");
         assert_eq!(outcome.payload["returned_count"], 2);
-        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        let matches = outcome.payload["matches"]
+            .as_array()
+            .expect("matches array");
         let session_ids: Vec<&str> = matches
             .iter()
             .filter_map(|item| item.get("session_id"))
@@ -474,8 +488,13 @@ mod tests {
         })
         .expect("create hidden");
 
-        append_turn_direct("child-session", "assistant", "timeout budget child", &config)
-            .expect("append child turn");
+        append_turn_direct(
+            "child-session",
+            "assistant",
+            "timeout budget child",
+            &config,
+        )
+        .expect("append child turn");
 
         let outcome = execute_app_tool_with_config(
             ToolCoreRequest {
@@ -525,8 +544,13 @@ mod tests {
             state: SessionState::Ready,
         })
         .expect("create archived child");
-        append_turn_direct("archived-child", "assistant", "restore inventory marker", &config)
-            .expect("append archived turn");
+        append_turn_direct(
+            "archived-child",
+            "assistant",
+            "restore inventory marker",
+            &config,
+        )
+        .expect("append archived turn");
         archive_completed_session(&repo, "archived-child", "root-session");
 
         let outcome = execute_app_tool_with_config(
@@ -542,7 +566,9 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        let matches = outcome.payload["matches"]
+            .as_array()
+            .expect("matches array");
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0]["session_id"], "archived-child");
     }
@@ -574,7 +600,10 @@ mod tests {
         .expect("legacy memory_search outcome");
 
         assert_eq!(outcome.payload["returned_count"], 1);
-        assert_eq!(outcome.payload["matches"][0]["session_id"], "delegate:legacy-child");
+        assert_eq!(
+            outcome.payload["matches"][0]["session_id"],
+            "delegate:legacy-child"
+        );
     }
 
     #[test]
@@ -614,7 +643,12 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        let matches = outcome.payload["matches"].as_array().expect("matches array");
-        assert!(matches.is_empty(), "session events should not be searchable transcript hits");
+        let matches = outcome.payload["matches"]
+            .as_array()
+            .expect("matches array");
+        assert!(
+            matches.is_empty(),
+            "session events should not be searchable transcript hits"
+        );
     }
 }

--- a/crates/app/src/tools/memory.rs
+++ b/crates/app/src/tools/memory.rs
@@ -1,0 +1,620 @@
+use loongclaw_contracts::ToolCoreOutcome;
+use serde_json::{json, Value};
+
+use crate::config::ToolConfig;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::config::SessionVisibility;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::SessionRepository;
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MemorySearchRequest {
+    query: String,
+    session_id: Option<String>,
+    session_ids: Option<Vec<String>>,
+    limit: usize,
+    excerpt_chars: usize,
+}
+
+pub(crate) fn execute_memory_search_tool_with_policies(
+    payload: Value,
+    current_session_id: &str,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (payload, current_session_id, memory_config, tool_config);
+        return Err(
+            "memory_search requires sqlite memory support (enable feature `memory-sqlite`)"
+                .to_owned(),
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        if !tool_config.sessions.enabled {
+            return Err("app_tool_disabled: session tools are disabled by config".to_owned());
+        }
+
+        let request = parse_memory_search_request(payload)?;
+        let repo = SessionRepository::new(memory_config)?;
+        let (mode, searched_session_ids, skipped_targets) =
+            resolve_search_scope(&repo, current_session_id, &request, tool_config)?;
+
+        let matches = crate::memory::search_transcript_direct(
+            &searched_session_ids,
+            &request.query,
+            request.limit,
+            request.excerpt_chars,
+            memory_config,
+        )?;
+        let mut payload = json!({
+            "query": request.query,
+            "scope": {
+                "mode": mode,
+                "current_session_id": current_session_id,
+                "searched_session_ids": searched_session_ids,
+                "searched_session_count": searched_session_ids.len(),
+                "skipped_targets": skipped_targets,
+            },
+            "matches": matches
+                .into_iter()
+                .map(|item| {
+                    json!({
+                        "session_id": item.session_id,
+                        "turn_id": item.turn_id,
+                        "role": item.role,
+                        "ts": item.ts,
+                        "content_snippet": item.content_snippet,
+                        "match": {
+                            "query": request.query,
+                            "match_kind": "substring",
+                            "excerpt_chars": request.excerpt_chars.clamp(40, 400),
+                        }
+                    })
+                })
+                .collect::<Vec<_>>(),
+            "returned_count": 0,
+            "limit": request.limit.clamp(1, 100),
+            "truncated": false,
+        });
+        let returned_count = payload["matches"]
+            .as_array()
+            .map(Vec::len)
+            .unwrap_or_default();
+
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("returned_count".to_owned(), json!(returned_count));
+        }
+
+        Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload,
+        })
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_memory_search_request(payload: Value) -> Result<MemorySearchRequest, String> {
+    let object = payload
+        .as_object()
+        .ok_or_else(|| "memory_search_invalid_request: payload must be an object".to_owned())?;
+    let query = object
+        .get("query")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "memory_search_invalid_request: query is required".to_owned())?
+        .to_owned();
+    let session_id = object
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let session_ids = object.get("session_ids").map(parse_session_ids).transpose()?;
+    if session_id.is_some() && session_ids.is_some() {
+        return Err(
+            "memory_search_invalid_request: session_id and session_ids are mutually exclusive"
+                .to_owned(),
+        );
+    }
+
+    Ok(MemorySearchRequest {
+        query,
+        session_id,
+        session_ids,
+        limit: object
+            .get("limit")
+            .and_then(Value::as_u64)
+            .unwrap_or(20) as usize,
+        excerpt_chars: object
+            .get("excerpt_chars")
+            .and_then(Value::as_u64)
+            .unwrap_or(120) as usize,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_session_ids(value: &Value) -> Result<Vec<String>, String> {
+    let items = value.as_array().ok_or_else(|| {
+        "memory_search_invalid_request: session_ids must be an array of strings".to_owned()
+    })?;
+    if items.is_empty() {
+        return Err("memory_search_invalid_request: session_ids cannot be empty".to_owned());
+    }
+
+    let mut session_ids = Vec::with_capacity(items.len());
+    for item in items {
+        let session_id = item
+            .as_str()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                "memory_search_invalid_request: session_ids must be non-empty strings".to_owned()
+            })?;
+        session_ids.push(session_id.to_owned());
+    }
+    Ok(session_ids)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn resolve_search_scope(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    request: &MemorySearchRequest,
+    tool_config: &ToolConfig,
+) -> Result<(&'static str, Vec<String>, Vec<Value>), String> {
+    if let Some(session_id) = &request.session_id {
+        ensure_target_visible(repo, current_session_id, session_id, tool_config.sessions.visibility)?;
+        return Ok(("single", vec![session_id.clone()], Vec::new()));
+    }
+
+    if let Some(session_ids) = &request.session_ids {
+        let mut visible = Vec::new();
+        let mut skipped = Vec::new();
+        for session_id in session_ids {
+            match classify_target_visibility(
+                repo,
+                current_session_id,
+                session_id,
+                tool_config.sessions.visibility,
+            )? {
+                TargetVisibility::Visible => visible.push(session_id.clone()),
+                TargetVisibility::NotVisible(message) => skipped.push(json!({
+                    "session_id": session_id,
+                    "result": "skipped_not_visible",
+                    "message": message,
+                })),
+                TargetVisibility::NotFound(message) => skipped.push(json!({
+                    "session_id": session_id,
+                    "result": "skipped_not_found",
+                    "message": message,
+                })),
+            }
+        }
+        return Ok(("batch", visible, skipped));
+    }
+
+    let visible_sessions = repo.list_visible_sessions(current_session_id)?;
+    Ok((
+        "visible",
+        visible_sessions
+            .into_iter()
+            .map(|session| session.session_id)
+            .collect(),
+        Vec::new(),
+    ))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn ensure_target_visible(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    target_session_id: &str,
+    visibility: SessionVisibility,
+) -> Result<(), String> {
+    match classify_target_visibility(repo, current_session_id, target_session_id, visibility)? {
+        TargetVisibility::Visible => Ok(()),
+        TargetVisibility::NotVisible(message) => Err(message),
+        TargetVisibility::NotFound(message) => Err(message),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+enum TargetVisibility {
+    Visible,
+    NotVisible(String),
+    NotFound(String),
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn classify_target_visibility(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    target_session_id: &str,
+    visibility: SessionVisibility,
+) -> Result<TargetVisibility, String> {
+    let summary = repo.load_session_summary_with_legacy_fallback(target_session_id)?;
+    if summary.is_none() {
+        return Ok(TargetVisibility::NotFound(format!(
+            "session_not_found: `{target_session_id}`"
+        )));
+    }
+    if current_session_id == target_session_id {
+        return Ok(TargetVisibility::Visible);
+    }
+
+    let is_visible = match visibility {
+        SessionVisibility::SelfOnly => false,
+        SessionVisibility::Children => repo.is_session_visible(current_session_id, target_session_id)?,
+    };
+    if is_visible {
+        Ok(TargetVisibility::Visible)
+    } else {
+        Ok(TargetVisibility::NotVisible(format!(
+            "visibility_denied: session `{target_session_id}` is not visible from `{current_session_id}`"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use loongclaw_contracts::ToolCoreRequest;
+    use serde_json::{json, Value};
+
+    use crate::config::ToolConfig;
+    use crate::memory::append_turn_direct;
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::repository::{
+        FinalizeSessionTerminalRequest, NewSessionEvent, NewSessionRecord, SessionKind,
+        SessionRepository, SessionState, TransitionSessionWithEventIfCurrentRequest,
+    };
+
+    use super::super::execute_app_tool_with_config;
+
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        let base = std::env::temp_dir().join(format!(
+            "loongclaw-memory-tool-{test_name}-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&base);
+        let db_path = base.join("memory.sqlite3");
+        let _ = fs::remove_file(&db_path);
+        MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+        }
+    }
+
+    fn skipped_target<'a>(payload: &'a Value, session_id: &str) -> &'a Value {
+        payload["scope"]["skipped_targets"]
+            .as_array()
+            .expect("skipped_targets array")
+            .iter()
+            .find(|item| item.get("session_id").and_then(Value::as_str) == Some(session_id))
+            .unwrap_or_else(|| panic!("missing skipped target `{session_id}`"))
+    }
+
+    fn archive_completed_session(
+        repo: &SessionRepository,
+        session_id: &str,
+        actor_session_id: &str,
+    ) {
+        repo.finalize_session_terminal(
+            session_id,
+            FinalizeSessionTerminalRequest {
+                state: SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some(actor_session_id.to_owned()),
+                event_payload_json: json!({}),
+                outcome_status: "completed".to_owned(),
+                outcome_payload_json: json!({}),
+            },
+        )
+        .expect("finalize completed");
+        repo.transition_session_with_event_if_current(
+            session_id,
+            TransitionSessionWithEventIfCurrentRequest {
+                expected_state: SessionState::Completed,
+                next_state: SessionState::Completed,
+                last_error: None,
+                event_kind: "session_archived".to_owned(),
+                actor_session_id: Some(actor_session_id.to_owned()),
+                event_payload_json: json!({
+                    "previous_state": "completed",
+                    "hides_from_sessions_list": true
+                }),
+            },
+        )
+        .expect("archive session")
+        .expect("archive transition result");
+    }
+
+    #[test]
+    fn memory_search_searches_visible_scope_by_default() {
+        let config = isolated_memory_config("visible-scope");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.create_session(NewSessionRecord {
+            session_id: "other-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Other".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create other root");
+
+        append_turn_direct("root-session", "user", "timeout budget root", &config)
+            .expect("append root turn");
+        append_turn_direct("child-session", "assistant", "timeout budget child", &config)
+            .expect("append child turn");
+        append_turn_direct("other-root", "assistant", "timeout budget hidden", &config)
+            .expect("append hidden turn");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget"
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("memory_search outcome");
+
+        assert_eq!(outcome.payload["scope"]["mode"], "visible");
+        assert_eq!(outcome.payload["returned_count"], 2);
+        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        let session_ids: Vec<&str> = matches
+            .iter()
+            .filter_map(|item| item.get("session_id"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(session_ids.contains(&"root-session"));
+        assert!(session_ids.contains(&"child-session"));
+        assert!(!session_ids.contains(&"other-root"));
+    }
+
+    #[test]
+    fn memory_search_rejects_invisible_single_target() {
+        let config = isolated_memory_config("single-target-visibility");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "other-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Other".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create other");
+
+        let error = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget",
+                    "session_id": "other-root"
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect_err("hidden single target should fail");
+
+        assert!(
+            error.contains("visibility_denied"),
+            "expected visibility_denied, got: {error}"
+        );
+    }
+
+    #[test]
+    fn memory_search_batch_reports_skipped_targets() {
+        let config = isolated_memory_config("batch-skips");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.create_session(NewSessionRecord {
+            session_id: "hidden-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Hidden".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create hidden");
+
+        append_turn_direct("child-session", "assistant", "timeout budget child", &config)
+            .expect("append child turn");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget",
+                    "session_ids": ["child-session", "hidden-root", "missing-session"]
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("batch memory_search outcome");
+
+        assert_eq!(outcome.payload["scope"]["mode"], "batch");
+        assert_eq!(outcome.payload["returned_count"], 1);
+        assert_eq!(
+            skipped_target(&outcome.payload, "hidden-root")["result"],
+            "skipped_not_visible"
+        );
+        assert_eq!(
+            skipped_target(&outcome.payload, "missing-session")["result"],
+            "skipped_not_found"
+        );
+    }
+
+    #[test]
+    fn memory_search_includes_archived_visible_sessions() {
+        let config = isolated_memory_config("archived-visible");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "archived-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Archived".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create archived child");
+        append_turn_direct("archived-child", "assistant", "restore inventory marker", &config)
+            .expect("append archived turn");
+        archive_completed_session(&repo, "archived-child", "root-session");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "restore inventory marker"
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("memory_search outcome");
+
+        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0]["session_id"], "archived-child");
+    }
+
+    #[test]
+    fn memory_search_supports_legacy_current_session_transcript() {
+        let config = isolated_memory_config("legacy-current");
+        let tool_config = ToolConfig::default();
+
+        append_turn_direct(
+            "delegate:legacy-child",
+            "assistant",
+            "legacy timeout budget note",
+            &config,
+        )
+        .expect("append legacy turn");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget"
+                }),
+            },
+            "delegate:legacy-child",
+            &config,
+            &tool_config,
+        )
+        .expect("legacy memory_search outcome");
+
+        assert_eq!(outcome.payload["returned_count"], 1);
+        assert_eq!(outcome.payload["matches"][0]["session_id"], "delegate:legacy-child");
+    }
+
+    #[test]
+    fn memory_search_does_not_return_session_events() {
+        let config = isolated_memory_config("ignores-events");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.append_event(NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "delegate_progress".to_owned(),
+            actor_session_id: None,
+            payload_json: json!({
+                "note": "timeout budget appears only in control-plane event"
+            }),
+        })
+        .expect("append control event");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget"
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("memory_search outcome");
+
+        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        assert!(matches.is_empty(), "session events should not be searchable transcript hits");
+    }
+}

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -74,7 +74,7 @@ pub fn execute_app_tool_with_config(
     };
     match canonical_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_cancel" | "session_archive" | "session_recover" => {
+        | "session_cancel" | "session_archive" | "session_recover" | "session_unarchive" => {
             session::execute_session_tool_with_policies(
                 request,
                 current_session_id,
@@ -292,12 +292,14 @@ mod tests {
             "- session_recover: Recover an overdue queued async delegate child session by marking it failed"
         ));
         assert!(snapshot
+            .contains("- session_unarchive: Restore a visible archived terminal session to default session listings"));
+        assert!(snapshot
             .contains("- session_wait: Wait for a visible session to reach a terminal state"));
         assert!(snapshot.contains("- session_events: Fetch session events for a visible session"));
 
         // Verify sorted canonical name order.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 13);
+        assert_eq!(lines.len(), 14);
         assert!(lines[0].starts_with("- delegate"));
         assert!(lines[1].starts_with("- delegate_async"));
         assert!(lines[2].starts_with("- file.read"));
@@ -307,17 +309,18 @@ mod tests {
         assert!(lines[6].starts_with("- session_events"));
         assert!(lines[7].starts_with("- session_recover"));
         assert!(lines[8].starts_with("- session_status"));
-        assert!(lines[9].starts_with("- session_wait"));
-        assert!(lines[10].starts_with("- sessions_history"));
-        assert!(lines[11].starts_with("- sessions_list"));
-        assert!(lines[12].starts_with("- shell.exec"));
+        assert!(lines[9].starts_with("- session_unarchive"));
+        assert!(lines[10].starts_with("- session_wait"));
+        assert!(lines[11].starts_with("- sessions_history"));
+        assert!(lines[12].starts_with("- sessions_list"));
+        assert!(lines[13].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 13);
+        assert_eq!(entries.len(), 14);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"delegate"));
         assert!(names.contains(&"delegate_async"));
@@ -328,6 +331,7 @@ mod tests {
         assert!(names.contains(&"session_cancel"));
         assert!(names.contains(&"session_events"));
         assert!(names.contains(&"session_recover"));
+        assert!(names.contains(&"session_unarchive"));
         assert!(names.contains(&"sessions_list"));
         assert!(names.contains(&"sessions_history"));
         assert!(names.contains(&"session_status"));
@@ -338,7 +342,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 13);
+        assert_eq!(defs.len(), 14);
 
         let names: Vec<&str> = defs
             .iter()
@@ -358,6 +362,7 @@ mod tests {
                 "session_events",
                 "session_recover",
                 "session_status",
+                "session_unarchive",
                 "session_wait",
                 "sessions_history",
                 "sessions_list",
@@ -439,6 +444,24 @@ mod tests {
             session_archive["function"]["parameters"]["oneOf"]
                 .as_array()
                 .expect("session_archive oneOf")
+                .len(),
+            2
+        );
+
+        let session_unarchive = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_unarchive")
+            .expect("session_unarchive definition");
+        let unarchive_properties = session_unarchive["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_unarchive properties");
+        assert!(unarchive_properties.contains_key("session_id"));
+        assert!(unarchive_properties.contains_key("session_ids"));
+        assert!(unarchive_properties.contains_key("dry_run"));
+        assert_eq!(
+            session_unarchive["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("session_unarchive oneOf")
                 .len(),
             2
         );
@@ -622,6 +645,21 @@ mod tests {
     }
 
     #[test]
+    fn session_unarchive_is_visible_in_root_and_hidden_in_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("session_unarchive"));
+
+        let child_view = planned_delegate_child_tool_view();
+        assert!(!child_view.contains("session_unarchive"));
+
+        let child_with_depth = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
+        );
+        assert!(!child_with_depth.contains("session_unarchive"));
+    }
+
+    #[test]
     fn runtime_tool_view_for_config_omits_disabled_session_and_delegate_tools() {
         let mut config = crate::config::ToolConfig::default();
         config.sessions.enabled = false;
@@ -638,6 +676,7 @@ mod tests {
         assert!(!view.contains("session_events"));
         assert!(!view.contains("session_archive"));
         assert!(!view.contains("session_recover"));
+        assert!(!view.contains("session_unarchive"));
         assert!(!view.contains("session_wait"));
     }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -9,6 +9,7 @@ mod catalog;
 pub(crate) mod delegate;
 mod file;
 mod kernel_adapter;
+mod memory;
 pub(crate) mod messaging;
 pub mod runtime_config;
 mod session;
@@ -82,6 +83,12 @@ pub fn execute_app_tool_with_config(
                 tool_config,
             )
         }
+        "memory_search" => memory::execute_memory_search_tool_with_policies(
+            request.payload,
+            current_session_id,
+            memory_config,
+            tool_config,
+        ),
         "sessions_send" => Err("app_tool_not_implemented: sessions_send".to_owned()),
         "session_wait" => Err("app_tool_not_implemented: session_wait".to_owned()),
         "delegate" => Err("app_tool_not_implemented: delegate".to_owned()),

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -279,6 +279,9 @@ mod tests {
         ));
         assert!(snapshot.contains("- file.read: Read file contents"));
         assert!(snapshot.contains("- file.write: Write file contents"));
+        assert!(snapshot.contains(
+            "- memory_search: Search visible transcript memory across persisted session turns"
+        ));
         assert!(snapshot.contains("- shell.exec: Execute shell commands"));
         assert!(
             snapshot.contains("- sessions_list: List visible sessions and their high-level state")
@@ -306,34 +309,36 @@ mod tests {
 
         // Verify sorted canonical name order.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 14);
+        assert_eq!(lines.len(), 15);
         assert!(lines[0].starts_with("- delegate"));
         assert!(lines[1].starts_with("- delegate_async"));
         assert!(lines[2].starts_with("- file.read"));
         assert!(lines[3].starts_with("- file.write"));
-        assert!(lines[4].starts_with("- session_archive"));
-        assert!(lines[5].starts_with("- session_cancel"));
-        assert!(lines[6].starts_with("- session_events"));
-        assert!(lines[7].starts_with("- session_recover"));
-        assert!(lines[8].starts_with("- session_status"));
-        assert!(lines[9].starts_with("- session_unarchive"));
-        assert!(lines[10].starts_with("- session_wait"));
-        assert!(lines[11].starts_with("- sessions_history"));
-        assert!(lines[12].starts_with("- sessions_list"));
-        assert!(lines[13].starts_with("- shell.exec"));
+        assert!(lines[4].starts_with("- memory_search"));
+        assert!(lines[5].starts_with("- session_archive"));
+        assert!(lines[6].starts_with("- session_cancel"));
+        assert!(lines[7].starts_with("- session_events"));
+        assert!(lines[8].starts_with("- session_recover"));
+        assert!(lines[9].starts_with("- session_status"));
+        assert!(lines[10].starts_with("- session_unarchive"));
+        assert!(lines[11].starts_with("- session_wait"));
+        assert!(lines[12].starts_with("- sessions_history"));
+        assert!(lines[13].starts_with("- sessions_list"));
+        assert!(lines[14].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 14);
+        assert_eq!(entries.len(), 15);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"delegate"));
         assert!(names.contains(&"delegate_async"));
         assert!(names.contains(&"shell.exec"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
+        assert!(names.contains(&"memory_search"));
         assert!(names.contains(&"session_archive"));
         assert!(names.contains(&"session_cancel"));
         assert!(names.contains(&"session_events"));
@@ -349,7 +354,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 14);
+        assert_eq!(defs.len(), 15);
 
         let names: Vec<&str> = defs
             .iter()
@@ -364,6 +369,7 @@ mod tests {
                 "delegate_async",
                 "file_read",
                 "file_write",
+                "memory_search",
                 "session_archive",
                 "session_cancel",
                 "session_events",
@@ -490,6 +496,26 @@ mod tests {
             2
         );
 
+        let memory_search = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "memory_search")
+            .expect("memory_search definition");
+        let memory_search_properties = memory_search["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("memory_search properties");
+        assert!(memory_search_properties.contains_key("query"));
+        assert!(memory_search_properties.contains_key("session_id"));
+        assert!(memory_search_properties.contains_key("session_ids"));
+        assert!(memory_search_properties.contains_key("limit"));
+        assert!(memory_search_properties.contains_key("excerpt_chars"));
+        assert_eq!(
+            memory_search["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("memory_search oneOf")
+                .len(),
+            3
+        );
+
         let sessions_list = defs
             .iter()
             .find(|item| item["function"]["name"] == "sessions_list")
@@ -512,6 +538,7 @@ mod tests {
         assert_eq!(canonical_tool_name("file_write"), "file.write");
         assert_eq!(canonical_tool_name("shell_exec"), "shell.exec");
         assert_eq!(canonical_tool_name("shell"), "shell.exec");
+        assert_eq!(canonical_tool_name("memory_search"), "memory_search");
         assert_eq!(canonical_tool_name("file.read"), "file.read");
     }
 
@@ -598,6 +625,7 @@ mod tests {
         assert!(view.contains("sessions_history"));
         assert!(view.contains("session_status"));
         assert!(view.contains("session_events"));
+        assert!(view.contains("memory_search"));
         assert!(view.contains("session_archive"));
         assert!(view.contains("session_cancel"));
         assert!(view.contains("session_recover"));
@@ -652,6 +680,21 @@ mod tests {
     }
 
     #[test]
+    fn memory_search_is_visible_in_root_and_hidden_in_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("memory_search"));
+
+        let child_view = planned_delegate_child_tool_view();
+        assert!(!child_view.contains("memory_search"));
+
+        let child_with_depth = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
+        );
+        assert!(!child_with_depth.contains("memory_search"));
+    }
+
+    #[test]
     fn session_unarchive_is_visible_in_root_and_hidden_in_child_views() {
         let root_view = runtime_tool_view();
         assert!(root_view.contains("session_unarchive"));
@@ -681,6 +724,7 @@ mod tests {
         assert!(!view.contains("sessions_history"));
         assert!(!view.contains("session_status"));
         assert!(!view.contains("session_events"));
+        assert!(!view.contains("memory_search"));
         assert!(!view.contains("session_archive"));
         assert!(!view.contains("session_recover"));
         assert!(!view.contains("session_unarchive"));

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -717,11 +717,7 @@ fn execute_session_unarchive(
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
     if request.use_legacy_single_response() {
-        let target_session_id = request
-            .target
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_session_id(&request.target.session_ids)?;
         let repo = SessionRepository::new(config)?;
         ensure_visible(
             &repo,

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -5343,18 +5343,12 @@ mod tests {
         assert_eq!(outcome.payload["dry_run"], true);
         assert_eq!(outcome.payload["requested_count"], 4);
         assert_eq!(outcome.payload["result_counts"]["would_apply"], 1);
-        assert_eq!(
-            outcome.payload["result_counts"]["skipped_not_archived"],
-            1
-        );
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_archived"], 1);
         assert_eq!(
             outcome.payload["result_counts"]["skipped_not_archivable"],
             1
         );
-        assert_eq!(
-            outcome.payload["result_counts"]["skipped_not_visible"],
-            1
-        );
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_visible"], 1);
 
         let ready = batch_result(&outcome.payload, "ready-to-unarchive");
         assert_eq!(ready["result"], "would_apply");
@@ -5470,18 +5464,12 @@ mod tests {
         assert_eq!(outcome.payload["dry_run"], false);
         assert_eq!(outcome.payload["requested_count"], 4);
         assert_eq!(outcome.payload["result_counts"]["applied"], 1);
-        assert_eq!(
-            outcome.payload["result_counts"]["skipped_not_archived"],
-            1
-        );
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_archived"], 1);
         assert_eq!(
             outcome.payload["result_counts"]["skipped_not_archivable"],
             1
         );
-        assert_eq!(
-            outcome.payload["result_counts"]["skipped_not_visible"],
-            1
-        );
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_visible"], 1);
 
         let ready = batch_result(&outcome.payload, "ready-to-unarchive");
         assert_eq!(ready["result"], "applied");

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -145,6 +145,12 @@ struct SessionArchivePlan {
 }
 
 #[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionUnarchivePlan {
+    expected_state: SessionState,
+}
+
+#[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq)]
 struct SessionToolActionOutcome {
     inspection: Value,
@@ -249,6 +255,9 @@ pub fn execute_session_tool_with_policies(
             }
             "session_archive" => {
                 execute_session_archive(request.payload, current_session_id, config, tool_config)
+            }
+            "session_unarchive" => {
+                execute_session_unarchive(request.payload, current_session_id, config, tool_config)
             }
             "session_recover" => {
                 execute_session_recover(request.payload, current_session_id, config, tool_config)
@@ -700,6 +709,57 @@ fn execute_session_archive(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn execute_session_unarchive(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let request = parse_session_mutation_request(&payload)?;
+    if request.use_legacy_single_response() {
+        let target_session_id = request
+            .target
+            .session_ids
+            .first()
+            .expect("legacy single request requires one session id");
+        let repo = SessionRepository::new(config)?;
+        ensure_visible(
+            &repo,
+            current_session_id,
+            target_session_id,
+            tool_config.sessions.visibility,
+        )?;
+        let snapshot = inspect_visible_session_with_policies(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            10,
+        )?;
+        let unarchive_plan = build_session_unarchive_plan(&snapshot)?;
+        let outcome = apply_session_unarchive_plan(
+            &repo,
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            &snapshot,
+            &unarchive_plan,
+        )?;
+        let mut payload = outcome.inspection;
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("unarchive_action".to_owned(), outcome.action);
+        }
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload,
+        });
+    }
+
+    Err("session_unarchive_batch_not_implemented".to_owned())
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn build_session_archive_plan(
     snapshot: &SessionInspectionSnapshot,
 ) -> Result<SessionArchivePlan, String> {
@@ -717,6 +777,28 @@ fn build_session_archive_plan(
     }
 
     Ok(SessionArchivePlan {
+        expected_state: snapshot.session.state,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_session_unarchive_plan(
+    snapshot: &SessionInspectionSnapshot,
+) -> Result<SessionUnarchivePlan, String> {
+    if !session_state_is_terminal(snapshot.session.state) {
+        return Err(format!(
+            "session_unarchive_not_archivable: session `{}` is not terminal",
+            snapshot.session.session_id
+        ));
+    }
+    if snapshot.session.archived_at.is_none() {
+        return Err(format!(
+            "session_unarchive_not_unarchivable: session `{}` is not archived",
+            snapshot.session.session_id
+        ));
+    }
+
+    Ok(SessionUnarchivePlan {
         expected_state: snapshot.session.state,
     })
 }
@@ -765,6 +847,53 @@ fn apply_session_archive_plan(
     Ok(SessionToolActionOutcome {
         inspection: session_inspection_payload(archived_snapshot),
         action: session_archive_action_json(archive_plan),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn apply_session_unarchive_plan(
+    repo: &SessionRepository,
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    snapshot: &SessionInspectionSnapshot,
+    unarchive_plan: &SessionUnarchivePlan,
+) -> Result<SessionToolActionOutcome, String> {
+    let transitioned = repo.transition_session_with_event_if_current(
+        target_session_id,
+        crate::session::repository::TransitionSessionWithEventIfCurrentRequest {
+            expected_state: unarchive_plan.expected_state,
+            next_state: unarchive_plan.expected_state,
+            last_error: snapshot.session.last_error.clone(),
+            event_kind: "session_unarchived".to_owned(),
+            actor_session_id: Some(current_session_id.to_owned()),
+            event_payload_json: json!({
+                "previous_state": unarchive_plan.expected_state.as_str(),
+                "restores_to_sessions_list": true,
+            }),
+        },
+    )?;
+    if transitioned.is_none() {
+        let latest = repo
+            .load_session_summary_with_legacy_fallback(target_session_id)?
+            .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
+        return Err(format!(
+            "session_unarchive_state_changed: session `{target_session_id}` is no longer unarchivable from state `{}`",
+            latest.state.as_str()
+        ));
+    }
+
+    let unarchived_snapshot = inspect_visible_session_with_policies(
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    )?;
+    Ok(SessionToolActionOutcome {
+        inspection: session_inspection_payload(unarchived_snapshot),
+        action: session_unarchive_action_json(unarchive_plan),
     })
 }
 
@@ -891,6 +1020,16 @@ fn session_archive_action_json(plan: &SessionArchivePlan) -> Value {
         "previous_state": plan.expected_state.as_str(),
         "next_state": plan.expected_state.as_str(),
         "hides_from_sessions_list": true,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_unarchive_action_json(plan: &SessionUnarchivePlan) -> Value {
+    json!({
+        "kind": "session_unarchived",
+        "previous_state": plan.expected_state.as_str(),
+        "next_state": plan.expected_state.as_str(),
+        "restores_to_sessions_list": true,
     })
 }
 
@@ -4891,6 +5030,94 @@ mod tests {
 
         assert_eq!(status.payload["session"]["archived"], true);
         assert!(status.payload["session"]["archived_at"].is_number());
+    }
+
+    #[test]
+    fn session_unarchive_restores_archived_terminal_visible_session() {
+        let config = isolated_memory_config("session-unarchive-single");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+        repo.finalize_session_terminal(
+            "child-session",
+            FinalizeSessionTerminalRequest {
+                state: SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                event_payload_json: json!({
+                    "result": "ok"
+                }),
+                outcome_status: "ok".to_owned(),
+                outcome_payload_json: json!({
+                    "child_session_id": "child-session",
+                    "result": "ok"
+                }),
+            },
+        )
+        .expect("finalize child");
+        execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("archive child");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_unarchive".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_unarchive outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["session"]["session_id"], "child-session");
+        assert_eq!(outcome.payload["session"]["state"], "completed");
+        assert_eq!(outcome.payload["session"]["archived"], false);
+        assert!(outcome.payload["session"]["archived_at"].is_null());
+        assert_eq!(
+            outcome.payload["unarchive_action"]["kind"],
+            "session_unarchived"
+        );
+
+        let status = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(status.payload["session"]["archived"], false);
+        assert!(status.payload["session"]["archived_at"].is_null());
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -756,7 +756,27 @@ fn execute_session_unarchive(
         });
     }
 
-    Err("session_unarchive_batch_not_implemented".to_owned())
+    let mut results = Vec::with_capacity(request.target.session_ids.len());
+    for target_session_id in &request.target.session_ids {
+        results.push(execute_session_unarchive_batch_result(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            request.dry_run,
+        )?);
+    }
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: session_batch_payload(
+            "session_unarchive",
+            current_session_id,
+            request.dry_run,
+            request.target.session_ids.len(),
+            results,
+        ),
+    })
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -895,6 +915,119 @@ fn apply_session_unarchive_plan(
         inspection: session_inspection_payload(unarchived_snapshot),
         action: session_unarchive_action_json(unarchive_plan),
     })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_session_unarchive_batch_result(
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    dry_run: bool,
+) -> Result<SessionBatchResultRecord, String> {
+    let repo = SessionRepository::new(config)?;
+    if let Err(error) = ensure_visible(
+        &repo,
+        current_session_id,
+        target_session_id,
+        tool_config.sessions.visibility,
+    ) {
+        return Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "skipped_not_visible",
+            Some(error),
+            None,
+            None,
+        ));
+    }
+
+    let snapshot = match inspect_visible_session_with_policies(
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    ) {
+        Ok(snapshot) => snapshot,
+        Err(error) if is_session_visibility_skip_error(&error) => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_visible",
+                Some(error),
+                None,
+                None,
+            ));
+        }
+        Err(error) => return Err(error),
+    };
+    let inspection = session_inspection_payload(snapshot.clone());
+    let unarchive_plan = match build_session_unarchive_plan(&snapshot) {
+        Ok(plan) => plan,
+        Err(error) if error.starts_with("session_unarchive_not_unarchivable:") => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_archived",
+                Some(error),
+                None,
+                Some(inspection),
+            ));
+        }
+        Err(error) => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_archivable",
+                Some(error),
+                None,
+                Some(inspection),
+            ));
+        }
+    };
+    let action = session_unarchive_action_json(&unarchive_plan);
+    if dry_run {
+        return Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "would_apply",
+            None,
+            Some(action),
+            Some(inspection),
+        ));
+    }
+
+    match apply_session_unarchive_plan(
+        &repo,
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        &snapshot,
+        &unarchive_plan,
+    ) {
+        Ok(outcome) => Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "applied",
+            None,
+            Some(outcome.action),
+            Some(outcome.inspection),
+        )),
+        Err(error) if error.starts_with("session_unarchive_state_changed:") => {
+            Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_state_changed",
+                Some(error),
+                Some(action),
+                inspect_visible_session_with_policies(
+                    target_session_id,
+                    current_session_id,
+                    config,
+                    tool_config,
+                    10,
+                )
+                .ok()
+                .map(session_inspection_payload),
+            ))
+        }
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -5118,6 +5251,277 @@ mod tests {
 
         assert_eq!(status.payload["session"]["archived"], false);
         assert!(status.payload["session"]["archived_at"].is_null());
+    }
+
+    #[test]
+    fn session_unarchive_batch_dry_run_reports_mixed_results_without_mutation() {
+        let config = isolated_memory_config("session-unarchive-batch-dry-run");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "ready-to-unarchive".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Archived".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create archivable child");
+        repo.create_session(NewSessionRecord {
+            session_id: "already-visible".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Visible".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create visible child");
+        repo.create_session(NewSessionRecord {
+            session_id: "running-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Running".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create running child");
+        repo.create_session(NewSessionRecord {
+            session_id: "hidden-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Hidden".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create hidden root");
+
+        for session_id in ["ready-to-unarchive", "already-visible"] {
+            repo.finalize_session_terminal(
+                session_id,
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({ "result": "ok" }),
+                    outcome_status: "ok".to_owned(),
+                    outcome_payload_json: json!({ "child_session_id": session_id }),
+                },
+            )
+            .expect("finalize child");
+        }
+        execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_id": "ready-to-unarchive"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("archive ready-to-unarchive child");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_unarchive".to_owned(),
+                payload: json!({
+                    "session_ids": ["ready-to-unarchive", "already-visible", "running-child", "hidden-root"],
+                    "dry_run": true
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_unarchive batch dry_run outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool"], "session_unarchive");
+        assert_eq!(outcome.payload["dry_run"], true);
+        assert_eq!(outcome.payload["requested_count"], 4);
+        assert_eq!(outcome.payload["result_counts"]["would_apply"], 1);
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_archived"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_archivable"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_visible"],
+            1
+        );
+
+        let ready = batch_result(&outcome.payload, "ready-to-unarchive");
+        assert_eq!(ready["result"], "would_apply");
+        assert_eq!(ready["inspection"]["session"]["archived"], true);
+        assert_eq!(ready["action"]["kind"], "session_unarchived");
+
+        let visible = batch_result(&outcome.payload, "already-visible");
+        assert_eq!(visible["result"], "skipped_not_archived");
+        assert_eq!(visible["inspection"]["session"]["archived"], false);
+
+        let running = batch_result(&outcome.payload, "running-child");
+        assert_eq!(running["result"], "skipped_not_archivable");
+        assert_eq!(running["inspection"]["session"]["state"], "running");
+
+        let hidden = batch_result(&outcome.payload, "hidden-root");
+        assert_eq!(hidden["result"], "skipped_not_visible");
+        assert!(hidden["inspection"].is_null());
+
+        assert!(repo
+            .load_session_summary_with_legacy_fallback("ready-to-unarchive")
+            .expect("load archived summary")
+            .expect("archived session")
+            .archived_at
+            .is_some());
+    }
+
+    #[test]
+    fn session_unarchive_batch_apply_reports_partial_success() {
+        let config = isolated_memory_config("session-unarchive-batch-apply");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "ready-to-unarchive".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Archived".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create archivable child");
+        repo.create_session(NewSessionRecord {
+            session_id: "already-visible".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Visible".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create visible child");
+        repo.create_session(NewSessionRecord {
+            session_id: "running-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Running".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create running child");
+        repo.create_session(NewSessionRecord {
+            session_id: "hidden-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Hidden".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create hidden root");
+
+        for session_id in ["ready-to-unarchive", "already-visible"] {
+            repo.finalize_session_terminal(
+                session_id,
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({ "result": "ok" }),
+                    outcome_status: "ok".to_owned(),
+                    outcome_payload_json: json!({ "child_session_id": session_id }),
+                },
+            )
+            .expect("finalize child");
+        }
+        execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_id": "ready-to-unarchive"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("archive ready-to-unarchive child");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_unarchive".to_owned(),
+                payload: json!({
+                    "session_ids": ["ready-to-unarchive", "already-visible", "running-child", "hidden-root"]
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_unarchive batch apply outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool"], "session_unarchive");
+        assert_eq!(outcome.payload["dry_run"], false);
+        assert_eq!(outcome.payload["requested_count"], 4);
+        assert_eq!(outcome.payload["result_counts"]["applied"], 1);
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_archived"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_archivable"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_visible"],
+            1
+        );
+
+        let ready = batch_result(&outcome.payload, "ready-to-unarchive");
+        assert_eq!(ready["result"], "applied");
+        assert_eq!(ready["inspection"]["session"]["archived"], false);
+        assert_eq!(ready["action"]["kind"], "session_unarchived");
+        assert_eq!(
+            ready["inspection"]["recent_events"]
+                .as_array()
+                .expect("ready recent events")
+                .last()
+                .expect("ready latest event")["event_kind"],
+            "session_unarchived"
+        );
+
+        let visible = batch_result(&outcome.payload, "already-visible");
+        assert_eq!(visible["result"], "skipped_not_archived");
+        assert_eq!(visible["inspection"]["session"]["archived"], false);
+
+        let running = batch_result(&outcome.payload, "running-child");
+        assert_eq!(running["result"], "skipped_not_archivable");
+        assert_eq!(running["inspection"]["session"]["state"], "running");
+
+        let hidden = batch_result(&outcome.payload, "hidden-root");
+        assert_eq!(hidden["result"], "skipped_not_visible");
+        assert!(hidden["inspection"].is_null());
+
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("ready-to-unarchive")
+                .expect("load ready summary")
+                .expect("ready session")
+                .archived_at,
+            None
+        );
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("already-visible")
+                .expect("load visible summary")
+                .expect("visible session")
+                .archived_at,
+            None
+        );
     }
 
     #[test]

--- a/docs/plans/2026-03-13-memory-search-design.md
+++ b/docs/plans/2026-03-13-memory-search-design.md
@@ -1,0 +1,375 @@
+# Memory Search Design
+
+## Context
+
+LoongClaw's current thick app-layer tool surface is centered on session inspection and delegation:
+
+- `sessions_list`
+- `sessions_history`
+- `session_status`
+- `session_events`
+- `session_archive`
+- `session_unarchive`
+- `session_cancel`
+- `session_recover`
+- `session_wait`
+- `sessions_send`
+- `delegate`
+- `delegate_async`
+
+That surface is now substantially stronger, but it still lacks a truthful memory retrieval primitive.
+The app already persists transcript turns into SQLite and already has session visibility rules, yet
+the only memory-facing behavior exposed to the model is indirect session history inspection.
+
+External comparison points in the same direction, but also clarifies what *not* to do:
+
+- OpenClaw's `memory_search` rides on a much heavier substrate with indexed Markdown memories,
+  FTS, embeddings, and hybrid retrieval.
+- ZeroClaw's memory recall similarly depends on FTS, vector search, hybrid merge, and pluggable
+  memory backends.
+- NanoBot and NanoClaw both reinforce that memory and scheduling are useful, but their broader
+  runtime architecture is substantially heavier than LoongClaw's current app substrate.
+
+The correct next step for LoongClaw is not "semantic memory." It is a truthful transcript-backed
+search primitive over the durable data the app already owns.
+
+## Problem
+
+Operators and models can inspect a known session's history, but they cannot ask the system to find
+where a fact, phrase, or prior instruction appeared within the caller's visible transcript scope.
+
+Today that means:
+
+- history can only be inspected session-by-session
+- agents must already know which session to inspect
+- archived but still relevant sessions are harder to rediscover
+- transcript persistence exists, but there is no direct search affordance over it
+
+This is a real product gap and a better target than broadening into scheduler, browser, or fake
+semantic-memory claims.
+
+## Goals
+
+- Add a truthful `memory_search` app tool for transcript retrieval.
+- Search only over persisted transcript turns in SQLite `turns`.
+- Reuse existing session visibility rules instead of broadening authority.
+- Support single-target, batch-target, and default visible-scope searches.
+- Return enough structure for agents to identify where a hit came from without dumping full
+  transcript bodies.
+- Keep the tool contract honest about match semantics in this phase.
+
+## Non-Goals
+
+- No embeddings, vector search, BM25, hybrid recall, or semantic ranking.
+- No search over `session_events` or other control-plane records.
+- No new long-term memory store distinct from transcript persistence.
+- No full-content export behavior; complete transcript reading remains `sessions_history`.
+- No pagination or streaming in the first slice.
+- No scheduler, cron, browser, or web retrieval work in this phase.
+
+## Chosen Primitive
+
+Add `memory_search`.
+
+`memory_search` searches durable transcript turns that are visible from the calling session and
+returns structured matches. It is intentionally transcript search, not knowledge-base search and
+not semantic recall.
+
+The tool should be described truthfully:
+
+- source: transcript turns already written to SQLite
+- match type: exact text / substring-style search
+- authority: existing visible session scope only
+- output: match records with snippets and identifiers, not synthesized answers
+
+## Scope Rules
+
+### Visible scope
+
+When the request does not specify a target session, `memory_search` searches the caller's current
+visible scope:
+
+- the current root session plus visible descendant delegate sessions
+- or only `self` when session visibility is configured that way
+
+### Single-target scope
+
+When the request specifies `session_id`, the tool searches only that target session.
+
+Rules:
+
+- target must be visible under the existing visibility model
+- target may be archived; archive affects inventory visibility, not transcript existence
+- legacy current-session transcript rows remain eligible through the same best-effort fallback used
+  elsewhere in session inspection
+
+### Batch scope
+
+When the request specifies `session_ids`, the tool searches the visible subset of those targets.
+
+Rules:
+
+- visible targets are searched
+- hidden or missing targets are reported in structured skipped metadata
+- one bad target must not fail the entire batch request
+
+## Request Contract
+
+`memory_search` accepts these fields:
+
+- `query` (required)
+- `session_id` (optional, mutually exclusive with `session_ids`)
+- `session_ids` (optional, mutually exclusive with `session_id`)
+- `limit` (optional, default `20`, max `100`)
+- `excerpt_chars` (optional, default `120`, clamped to a safe range)
+
+Request rules:
+
+- `query` must be a non-empty string after trimming
+- `session_id` and `session_ids` cannot both be present
+- no explicit target means "search visible scope"
+- single-target invisible requests fail like existing direct inspection tools
+- batch requests use best-effort result accounting instead of failing on partial invisibility
+
+Representative requests:
+
+```json
+{
+  "query": "timeout budget"
+}
+```
+
+```json
+{
+  "query": "handoff note",
+  "session_id": "delegate:child-123",
+  "limit": 10,
+  "excerpt_chars": 160
+}
+```
+
+```json
+{
+  "query": "memory adapter",
+  "session_ids": ["root-a", "delegate:child-1", "hidden-root"],
+  "limit": 25
+}
+```
+
+## Response Contract
+
+The top-level response should stay simple and explicit:
+
+- `query`
+- `scope`
+- `matches`
+- `returned_count`
+- `limit`
+- `truncated`
+
+### Scope payload
+
+`scope` should include:
+
+- `mode`: `visible`, `single`, or `batch`
+- `current_session_id`
+- `searched_session_ids`
+- `searched_session_count`
+- `skipped_targets` for batch requests
+
+`skipped_targets` should classify each skipped target, for example:
+
+- `skipped_not_visible`
+- `skipped_not_found`
+
+### Match payload
+
+Each match should include:
+
+- `session_id`
+- `turn_id`
+- `role`
+- `ts`
+- `content_snippet`
+- `match`
+
+`match` should include:
+
+- `query`
+- `match_kind` with phase-one value `substring`
+- `excerpt_chars`
+
+Representative match shape:
+
+```json
+{
+  "session_id": "delegate:child-123",
+  "turn_id": 91,
+  "role": "assistant",
+  "ts": 1763020000,
+  "content_snippet": "...timeout budget was reduced after the second retry spike...",
+  "match": {
+    "query": "timeout budget",
+    "match_kind": "substring",
+    "excerpt_chars": 120
+  }
+}
+```
+
+## Query Semantics
+
+Phase one should deliberately use the simplest honest query semantics:
+
+- search only `turns.content`
+- perform substring-style text matching
+- order hits by most recent first: `ts DESC`, then `id DESC`
+
+This is intentionally not positioned as "best" or "most relevant" retrieval. It is recent-first
+transcript search over exact stored text.
+
+## Why Not FTS Or Semantic Memory Yet
+
+LoongClaw does not yet have the supporting substrate required to make stronger claims:
+
+- no memory-specific chunking pipeline
+- no embedding lifecycle
+- no vector index maintenance
+- no hybrid merge semantics
+- no durable semantic-retrieval contract already exposed elsewhere in the app
+
+Adding a tool named `memory_search` that clearly performs transcript text search is still honest.
+Adding a tool that implies semantic recall without those supporting layers would not be.
+
+This design leaves a clean future path:
+
+- phase 1: `LIKE` / substring transcript search
+- future phase: SQLite FTS5 keyword search
+- later phase: hybrid or semantic retrieval only once indexing and consistency semantics are real
+
+## Internal Design
+
+### Storage and query layer
+
+Add a transcript search helper on top of the existing SQLite memory store.
+
+The query should:
+
+- read from `turns`
+- restrict to resolved target session ids
+- match on `content`
+- return `id`, `session_id`, `role`, `content`, and `ts`
+
+The helper should not search `session_events`, because control-plane events are intentionally kept
+out of transcript history and should stay out of transcript search results too.
+
+### Visibility layer
+
+Reuse the existing session repository and visibility semantics:
+
+- `list_visible_sessions`
+- `is_session_visible`
+- legacy current-session fallback where already supported
+
+This ensures `memory_search` behaves like the session tool family rather than introducing a second
+visibility model.
+
+### Tool layer
+
+Expose `memory_search` as a real app tool:
+
+- add it to the tool catalog and provider definitions
+- gate it under session-tool enablement for this phase
+- implement it in a dedicated tool module rather than expanding `session.rs` further
+
+This keeps the new tool aligned with the thick app-layer direction while containing code growth.
+
+## Error Model
+
+Representative direct errors:
+
+- `memory_search_invalid_request: ...`
+- `visibility_denied: ...`
+- `session_not_found: ...`
+
+Batch requests should not fail for hidden or missing targets. Those targets should instead appear
+under `scope.skipped_targets`.
+
+No matches is not an error. It should return:
+
+- `matches: []`
+- `returned_count: 0`
+- `truncated: false`
+
+## Testing Plan
+
+Minimum required coverage:
+
+- single-session search returns structured hits with `turn_id`, `role`, `ts`, and snippet
+- default visible-scope search includes current root plus visible descendant delegate sessions
+- delegated child search cannot reach hidden or sibling sessions outside visibility rules
+- archived visible sessions still contribute searchable transcript hits
+- legacy current-session transcript rows can be searched without backfilling `sessions`
+- single-target hidden session returns `visibility_denied`
+- batch search returns mixed searched and skipped target accounting
+- search results never include control-plane session events
+- `limit` and `excerpt_chars` clamping works as documented
+- no-hit queries return an empty result set rather than an error
+
+## Alternatives Considered
+
+### 1. Expose only `memory_window` or `memory_get`
+
+Pros:
+
+- smaller implementation
+- almost no new query semantics
+
+Cons:
+
+- does not solve rediscovery
+- overlaps heavily with `sessions_history`
+- weaker user value than true transcript search
+
+Rejected because the next thick tool should increase retrieval power, not just add another way to
+read already-known history.
+
+### 2. Build scheduler or cron tools first
+
+Pros:
+
+- externally comparable repos often expose scheduling primitives
+
+Cons:
+
+- LoongClaw does not yet have a truthful durable scheduler substrate
+- delivery semantics, retries, ownership, and restart behavior are still undefined
+
+Rejected because it would force a wider and less honest control surface than the app currently
+supports.
+
+### 3. Jump directly to semantic memory
+
+Pros:
+
+- richer retrieval story
+
+Cons:
+
+- requires a much heavier substrate than LoongClaw currently has
+- would encourage product claims the runtime cannot yet back up
+
+Rejected because the product direction is "few but thick and truthful," not "broad but suggestive."
+
+## Why This Design
+
+`memory_search` is the strongest next tool LoongClaw can add without pretending to have a larger
+memory system than it does.
+
+It deepens real substrate that already exists:
+
+- durable transcript persistence
+- session visibility rules
+- session archive lifecycle
+- app-layer orchestration tools
+
+And it does so without widening into adjacent surfaces that still lack honest runtime backing.

--- a/docs/plans/2026-03-13-memory-search-implementation-plan.md
+++ b/docs/plans/2026-03-13-memory-search-implementation-plan.md
@@ -1,0 +1,335 @@
+# Memory Search Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a truthful `memory_search` app tool that searches visible transcript turns and returns structured snippet matches without claiming semantic memory.
+
+**Architecture:** Implement transcript search on top of the existing SQLite `turns` store, reuse session visibility and legacy fallback rules from the session repository, and expose `memory_search` as a new app-layer tool with a narrow provider schema. Land the feature through TDD in small slices: repository-free query helper first, then app-tool surface and scope resolution, then product docs and full verification.
+
+**Tech Stack:** Rust, `rusqlite`, existing LoongClaw app tool catalog and dispatcher, SQLite-backed session repository, Cargo tests.
+
+---
+
+### Task 1: Add the failing transcript-search memory tests
+
+**Files:**
+- Modify: `crates/app/src/memory/mod.rs`
+- Modify: `crates/app/src/memory/sqlite.rs`
+
+**Step 1: Write the failing tests**
+
+Add focused unit tests in `crates/app/src/memory/mod.rs` or `crates/app/src/memory/sqlite.rs` for:
+
+- `search_transcript_direct_returns_recent_matching_turns`
+- `search_transcript_direct_excludes_non_matching_turns`
+- `search_transcript_direct_clamps_limit_and_excerpt`
+
+The tests should:
+
+- create an isolated SQLite path with `MemoryRuntimeConfig`
+- append several turns across one or more sessions
+- search for a phrase that appears in multiple rows
+- assert that results include `turn_id`, `session_id`, `role`, `ts`, and a clipped snippet
+- assert newest-first ordering
+- assert a no-match query returns an empty list
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app search_transcript_direct -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- compile or test failure because transcript-search helpers and result structs do not exist yet
+
+**Step 3: Write minimal implementation**
+
+Implement the minimum SQLite search support in `crates/app/src/memory/sqlite.rs`:
+
+- add a search result struct that includes `turn_id`, `session_id`, `role`, `content`, and `ts`
+- add a helper that executes a substring-style query against `turns.content`
+- add safe clamping for limit and excerpt sizes
+- add a direct helper callable from tests
+
+Keep the implementation narrow:
+
+- search only `turns`
+- use recent-first ordering
+- do not add FTS, extra indexes, or semantic-ranking behavior
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app search_transcript_direct -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- the new transcript-search tests pass
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/memory/mod.rs crates/app/src/memory/sqlite.rs
+git commit -m "feat(app): add transcript memory search helpers"
+```
+
+### Task 2: Add the failing app-tool behavior tests for `memory_search`
+
+**Files:**
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/catalog.rs`
+- Create: `crates/app/src/tools/memory.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing tests**
+
+Add focused app-tool tests alongside the existing session-tool coverage, preferably in
+`crates/app/src/tools/memory.rs` if that module owns its own tests.
+
+Add tests for:
+
+- `memory_search_searches_visible_scope_by_default`
+- `memory_search_rejects_invisible_single_target`
+- `memory_search_batch_reports_skipped_targets`
+- `memory_search_includes_archived_visible_sessions`
+- `memory_search_supports_legacy_current_session_transcript`
+- `memory_search_does_not_return_session_events`
+
+Test fixtures should:
+
+- build isolated `MemoryRuntimeConfig`
+- create root and delegate-child sessions with `SessionRepository`
+- archive one finished visible session to prove archived transcripts still search
+- append transcript turns and control-plane events separately
+- execute the tool through `execute_app_tool_with_config`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app memory_search_ -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- compile or test failure because the tool is not cataloged or implemented yet
+
+**Step 3: Write minimal implementation**
+
+Implement the app-layer tool:
+
+- add `memory_search` to `crates/app/src/tools/catalog.rs`
+- expose a provider schema with `query`, `session_id`, `session_ids`, `limit`, and `excerpt_chars`
+- route `memory_search` from `crates/app/src/tools/mod.rs`
+- create `crates/app/src/tools/memory.rs` to own:
+  - request parsing
+  - visible-scope target resolution
+  - single-target visibility checks
+  - batch skipped-target accounting
+  - snippet shaping and top-level response payload
+
+Reuse existing session visibility and legacy-fallback behavior rather than re-inventing it.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app memory_search_ -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- the new `memory_search` app-tool tests pass
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/mod.rs crates/app/src/tools/catalog.rs crates/app/src/tools/memory.rs crates/app/src/tools/session.rs
+git commit -m "feat(app): add memory search tool surface"
+```
+
+### Task 3: Add provider-view and runtime registration coverage
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add or extend tests to prove:
+
+- `memory_search` appears in the runtime tool registry when session tools are enabled
+- provider tool definitions include the new function schema
+- canonical tool-name resolution works for `memory_search`
+
+If existing tests already cover adjacent registry behavior, extend them with `memory_search`
+assertions instead of creating redundant new fixtures.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app tool_registry -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- failure because the registry/provider surface does not yet advertise `memory_search` completely
+
+**Step 3: Write minimal implementation**
+
+Adjust the tool view and registration paths so `memory_search` is treated as a truthful runtime app
+tool in the same enablement family as other session-scoped app tools.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app tool_registry -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- the registry/provider assertions pass
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/catalog.rs crates/app/src/tools/mod.rs
+git commit -m "feat(app): advertise memory search runtime tool"
+```
+
+### Task 4: Update product docs and acceptance criteria
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Write the doc changes**
+
+Update product-facing docs to reflect the new tool:
+
+- add `memory_search` to the accepted root tool surface
+- document the truthful phase-one scope: transcript search over visible sessions
+- note that semantic memory, FTS, and vector retrieval remain out of scope
+
+Keep the wording aligned with the design doc rather than promising future capabilities as if they
+already ship.
+
+**Step 2: Review the doc diff**
+
+Run:
+
+```bash
+git diff -- docs/product-specs/index.md docs/roadmap.md
+```
+
+Expected:
+
+- only the documented `memory_search` surface and roadmap wording changed
+
+**Step 3: Commit**
+
+```bash
+git add docs/product-specs/index.md docs/roadmap.md
+git commit -m "docs: describe memory search tool surface"
+```
+
+### Task 5: Full verification and cleanup
+
+**Files:**
+- Modify if needed: any files touched above
+
+**Step 1: Run focused package tests**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app memory_search_ search_transcript_direct tool_registry -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- focused new coverage passes
+
+**Step 2: Run the full app package tests**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- all `loongclaw-app` tests pass
+
+**Step 3: Run formatting**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all
+```
+
+Expected:
+
+- no formatting errors
+
+**Step 4: Re-run the full app package tests after formatting**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- all `loongclaw-app` tests still pass after formatting
+
+**Step 5: Compile daemon tests without running**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-daemon --no-run
+```
+
+Expected:
+
+- daemon targets compile successfully, proving the app-tool surface change does not break daemon integration
+
+**Step 6: Inspect the final branch state**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -6
+```
+
+Expected:
+
+- clean worktree
+- small, isolated commits for helpers, tool surface, docs, and formatting if needed
+
+**Step 7: Commit any final formatting-only adjustments**
+
+```bash
+git add -A
+git commit -m "style(rust): format memory search changes"
+```
+
+Only do this step if formatting changed tracked files and those changes are not already included in
+an earlier commit.

--- a/docs/plans/2026-03-13-session-unarchive-design.md
+++ b/docs/plans/2026-03-13-session-unarchive-design.md
@@ -1,0 +1,236 @@
+# Session Unarchive Design
+
+## Context
+
+LoongClaw now has a truthful `session_archive` primitive for inventory cleanup of visible
+terminal sessions. That solved the first half of the operator lifecycle: a finished session can be
+retired from default `sessions_list` inventory without deleting history or pretending to close a
+live route.
+
+The next honest gap is reversibility. Once a session is archived, an operator can still inspect it
+directly, but there is no durable tool to restore it back into default inventory. That creates an
+asymmetry:
+
+- `session_archive` is explicit and auditable
+- rediscovery is possible through direct inspection or `include_archived=true`
+- restoration back into the default list is not yet explicit or auditable
+
+This is a better target than a fake `session_close`. External comparison showed that OpenClaw does
+not provide a meaningful reopen path after close/delete, and LoongClaw still lacks truthful
+route-unbinding or root-session successor semantics for fixed ids like `telegram:<chat_id>` and
+`feishu:<chat_id>`.
+
+## Problem
+
+Operators can archive visible terminal sessions, but cannot later restore them into default
+inventory without manual rediscovery workarounds. The current archive-state derivation also only
+looks for `session_archived`, which is sufficient for archive-only behavior but becomes incorrect as
+soon as a reversible lifecycle exists.
+
+## Goals
+
+- Add a truthful `session_unarchive` operator primitive for visible archived terminal sessions.
+- Preserve the event-sourced audit trail instead of replacing archive state with mutable flags.
+- Make archive state derivation correct under both archive and unarchive actions.
+- Reuse the existing single-target and batch mutation patterns already used by
+  `session_archive`, `session_cancel`, and `session_recover`.
+- Keep archived sessions directly inspectable before and after restoration.
+
+## Non-Goals
+
+- No fake `session_close`, route shutdown, or inbound channel unbinding.
+- No reopen / successor-session model for fixed channel-backed root ids.
+- No transcript deletion, rewriting, or terminal outcome mutation.
+- No mutation of non-terminal sessions.
+- No hidden side effects beyond inventory visibility.
+
+## Chosen Primitive
+
+Add `session_unarchive`.
+
+`session_unarchive` restores a visible archived terminal session back into the default
+`sessions_list` inventory. It does not change execution state, transcript rows, or terminal
+outcomes.
+
+This keeps the tool truthful:
+
+- `session_archive` hides a finished session from default inventory
+- `session_unarchive` restores that finished session to default inventory
+- neither tool claims to shut down runtime routing or reopen live execution
+
+## Scope Rules
+
+`session_unarchive` is allowed only when all of the following are true:
+
+- target session is visible from the caller under existing visibility rules
+- target session is currently archived
+- target session is terminal: `completed`, `failed`, or `timed_out`
+
+The terminal-state requirement keeps archive and unarchive as pure inventory hygiene over finished
+work, rather than broad session-lifecycle control.
+
+## State Model
+
+Archive is still not a new execution state. Session execution state remains:
+
+- `ready`
+- `running`
+- `completed`
+- `failed`
+- `timed_out`
+
+Archive is an inventory overlay represented on summaries as:
+
+- `archived: boolean`
+- `archived_at: integer|null`
+
+The key refinement is how that overlay is derived.
+
+## Persistence Model
+
+Archive lifecycle remains event-sourced:
+
+- `session_archive` appends `session_archived`
+- `session_unarchive` appends `session_unarchived`
+
+The repository must no longer ask only "has this session ever been archived?" Instead it must look
+at the most recent archive control event for the session and derive state from that event:
+
+- latest control event = `session_archived` => session is archived, `archived_at = event.ts`
+- latest control event = `session_unarchived` => session is not archived, `archived_at = null`
+- no archive control event => session is not archived, `archived_at = null`
+
+To avoid incorrect ties from second-granularity timestamps, "latest" should be resolved primarily by
+session-event row `id`, not only by `ts`.
+
+## Repository Semantics
+
+Both visible-session listing and single-session summary loading must use the same archive-state
+derivation so the tool layer does not drift from inventory behavior.
+
+Recommended query shape:
+
+- restrict to archive-control events: `session_archived`, `session_unarchived`
+- pick the latest control event per session using descending event `id`
+- project:
+  - archived flag from latest event kind
+  - `archived_at` only when latest event kind is `session_archived`
+
+This avoids introducing a mutable `sessions.archived_at` column and preserves the full audit trail.
+
+## Tool Semantics
+
+### Single-target mode
+
+Request:
+
+```json
+{
+  "session_id": "delegate:child-123"
+}
+```
+
+Response shape follows the existing single-target mutation pattern:
+
+- returns the normal inspection payload
+- adds `unarchive_action`
+
+Representative action payload:
+
+```json
+{
+  "kind": "session_unarchived",
+  "previous_state": "completed",
+  "next_state": "completed",
+  "restores_to_sessions_list": true
+}
+```
+
+### Batch mode
+
+Request:
+
+```json
+{
+  "session_ids": ["delegate:child-1", "delegate:child-2"],
+  "dry_run": true
+}
+```
+
+Batch result classifications:
+
+- `would_apply`
+- `applied`
+- `skipped_not_visible`
+- `skipped_not_archived`
+- `skipped_not_archivable`
+- `skipped_state_changed`
+
+`skipped_not_archived` is separate from `skipped_not_archivable` so operators can distinguish "not
+currently archived" from "wrong lifecycle state".
+
+## Inspection And Listing Semantics
+
+`session_status`, `session_events`, and `sessions_history` remain available for archived sessions and
+for later-unarchived sessions. `session_events` naturally exposes both `session_archived` and
+`session_unarchived`.
+
+`sessions_list` behavior becomes:
+
+- archived sessions are still excluded by default
+- `include_archived=true` returns both archived and non-archived visible sessions
+- after `session_unarchive`, the target reappears in default `sessions_list`
+
+`session_wait` remains unchanged because archive lifecycle does not alter terminality.
+
+## Error Model
+
+Representative rejections:
+
+- `session_unarchive_not_archivable: session \`...\` is not terminal`
+- `session_unarchive_not_unarchivable: session \`...\` is not archived`
+- `visibility_denied: ...`
+- `session_unarchive_state_changed: session \`...\` is no longer unarchivable from state \`...\``
+
+The `state_changed` branch covers races where another actor archives, unarchives, or otherwise
+mutates the target after inspection.
+
+## Alternatives Considered
+
+### 1. Mutable `sessions.archived_at` field
+
+Pros:
+
+- simpler query path
+
+Cons:
+
+- weaker audit trail
+- duplicates information already present in durable events
+- makes archive lifecycle less transparent in `session_events`
+
+Rejected because LoongClaw's session surface is explicitly trying to stay auditable and truthful.
+
+### 2. List-layer filtering without durable unarchive state
+
+Pros:
+
+- smaller change set
+
+Cons:
+
+- inventory behavior can drift from inspection behavior
+- no durable record of restoration
+- weak operator evidence for who restored a session and when
+
+Rejected because it is not robust enough for a control-plane primitive.
+
+## Why This Design
+
+This is the smallest reversible lifecycle that stays honest:
+
+- it deepens the existing archive primitive instead of widening the surface with a fake close
+- it keeps state event-sourced and auditable
+- it fixes the underlying repository model rather than papering over it in the tool layer
+- it gives operators a complete archive / restore inventory workflow without claiming runtime
+  semantics LoongClaw does not yet have

--- a/docs/plans/2026-03-13-session-unarchive-implementation-plan.md
+++ b/docs/plans/2026-03-13-session-unarchive-implementation-plan.md
@@ -1,0 +1,251 @@
+# Session Unarchive Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a truthful `session_unarchive` primitive that restores visible archived terminal
+sessions to default `sessions_list` inventory and updates archive-state derivation to use the latest
+archive control event.
+
+**Architecture:** Keep archive lifecycle event-sourced. Introduce `session_unarchived` as a durable
+control event, teach repository summary queries to derive archive state from the latest archive
+control event (`session_archived` or `session_unarchived`), and expose `session_unarchive` with the
+same single-target / batch / `dry_run` mutation pattern used elsewhere in the session tool surface.
+
+**Tech Stack:** Rust, rusqlite, serde_json, sqlite-backed session repository, cargo test
+
+---
+
+### Task 1: Document the reversible archive design
+
+**Files:**
+- Create: `docs/plans/2026-03-13-session-unarchive-design.md`
+- Create: `docs/plans/2026-03-13-session-unarchive-implementation-plan.md`
+
+**Step 1: Write the design doc**
+
+Capture:
+
+- why `session_unarchive` is the next truthful primitive
+- why `session_close` is still rejected
+- why latest archive control event must win
+- why repository derivation should prefer event `id` over `ts`
+
+**Step 2: Write the implementation plan**
+
+Break implementation into TDD-sized tasks with exact files and commands.
+
+**Step 3: Commit**
+
+```bash
+git add docs/plans/2026-03-13-session-unarchive-design.md docs/plans/2026-03-13-session-unarchive-implementation-plan.md
+git commit -m "docs(plans): design session unarchive tool"
+```
+
+### Task 2: Add the first failing `session_unarchive` test
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing test**
+
+Add a test proving that:
+
+- a visible archived terminal child can be unarchived
+- the returned payload includes `unarchive_action`
+- the target becomes non-archived in the returned inspection payload
+- `session_status` still reports the target and now marks it unarchived
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_unarchive_restores_archived_terminal_visible_session -- --nocapture --test-threads=1
+```
+
+Expected: FAIL because `session_unarchive` is not implemented.
+
+**Step 3: Write minimal implementation**
+
+Implement the smallest code path needed for single-target unarchive behavior in the session tool
+layer.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and confirm PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/session.rs
+git commit -m "feat(app): add single-session unarchive flow"
+```
+
+### Task 3: Add the failing repository regression for archive-state derivation
+
+**Files:**
+- Modify: `crates/app/src/session/repository.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests proving that:
+
+- a session archived and then unarchived reports `archived_at = null`
+- `sessions_list` default output includes that session again
+- `include_archived=true` still shows genuinely archived sessions
+- the latest archive control event wins even when both archive and unarchive events exist
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_unarchive -- --nocapture --test-threads=1
+```
+
+Expected: FAIL because repository summary queries still only read `session_archived`.
+
+**Step 3: Write minimal implementation**
+
+Update repository summary loading to derive archive state from the latest archive control event,
+preferring event `id` ordering.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same command and confirm PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/session/repository.rs crates/app/src/tools/session.rs
+git commit -m "feat(app): derive archive state from latest control event"
+```
+
+### Task 4: Add batch and `dry_run` unarchive coverage
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests proving that:
+
+- batch `session_unarchive` supports `session_ids`
+- `dry_run=true` previews mixed results without mutation
+- already-visible non-archived sessions are classified as `skipped_not_archived`
+- non-terminal or hidden sessions classify correctly
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_unarchive_batch -- --nocapture --test-threads=1
+```
+
+Expected: FAIL on missing batch behavior.
+
+**Step 3: Write minimal implementation**
+
+Extend the existing mutation helper pattern used by `session_archive` to implement batch
+`session_unarchive`.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same command and confirm PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/session.rs
+git commit -m "feat(app): add batch session unarchive support"
+```
+
+### Task 5: Update the tool surface and product docs
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/provider/mod.rs`
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Write the failing tests**
+
+Add or update tests proving that:
+
+- `session_unarchive` appears in the root tool surface
+- delegated child views still do not gain it
+- provider request bodies expose its schema
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_unarchive -- --nocapture --test-threads=1
+```
+
+Expected: FAIL on catalog / provider assertions.
+
+**Step 3: Write minimal implementation**
+
+Add tool catalog entries, schema definition, visibility wiring, and product-doc updates that match
+the implemented behavior.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same command and confirm PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/catalog.rs crates/app/src/tools/mod.rs crates/app/src/provider/mod.rs docs/product-specs/index.md docs/roadmap.md
+git commit -m "feat(app): expose session unarchive tool surface"
+```
+
+### Task 6: Run full verification
+
+**Files:**
+- No code changes expected
+
+**Step 1: Run focused tests**
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_unarchive -- --nocapture --test-threads=1
+```
+
+Expected: PASS
+
+**Step 2: Run package test suite**
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --nocapture --test-threads=1
+```
+
+Expected: PASS
+
+**Step 3: Run daemon compile verification**
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-daemon --no-run
+```
+
+Expected: PASS
+
+**Step 4: Run formatting**
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all
+```
+
+Expected: no diff
+
+**Step 5: Inspect and commit any final cleanups**
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -14,7 +14,7 @@ Product specs describe **what** the product does from the user's perspective, no
 As an operator using LoongClaw's tool-calling runtime, I want to inspect active sessions and delegate focused subtasks into child sessions so that I can keep orchestration explicit, auditable, and bounded.
 
 ## Acceptance Criteria
-- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
+- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
 - [x] Delegated child sessions run with a restricted tool surface derived from config rather than inheriting the full root tool set.
 - [x] Delegated child sessions can use `session_status` and `sessions_history` for self-inspection only, and never gain `sessions_list`.
 - [x] Nested delegation is bounded by `tools.delegate.max_depth` and enforced from session lineage, not by ad-hoc one-off checks.
@@ -33,8 +33,10 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_cancel` can immediately cancel a visible queued async delegate child and can request cooperative cancellation for a visible running async delegate child without broadening child-session authority.
 - [x] `session_recover` can mark a visible overdue queued or overdue running async delegate child as failed and persist both a terminal outcome and structured recovery event without broadening child-session authority.
 - [x] `session_archive` can mark a visible terminal session as archived, preserve direct inspection and event history, and hide archived sessions from default `sessions_list` results while allowing explicit rediscovery via `include_archived=true`.
+- [x] `session_unarchive` can restore a visible archived terminal session back into default `sessions_list` inventory, preserve direct inspection and event history, and record a durable `session_unarchived` control event.
 - [x] `session_cancel` and `session_recover` accept either `session_id` or `session_ids`, support `dry_run` preview, and return per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
 - [x] `session_archive` accepts either `session_id` or `session_ids`, supports `dry_run` preview, and returns per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
+- [x] `session_unarchive` accepts either `session_id` or `session_ids`, supports `dry_run` preview, and returns per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
 - [x] `sessions_send` can send plain outbound text to a known channel-backed root session (`telegram:<chat_id>` or `feishu:<chat_id>`), recording a non-transcript control event without executing a target-side provider turn or mutating transcript rows.
 
 ## Current Limits
@@ -42,6 +44,7 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
 - `sessions_send` is intentionally narrow: only known root sessions backed by currently supported Telegram or Feishu targets are eligible.
 - `session_archive` only applies to already-terminal visible sessions; it is inventory cleanup, not route shutdown, transcript deletion, or true session close.
+- `session_unarchive` only applies to already-archived terminal visible sessions; it restores default listing visibility, not execution, routing, or a new live session epoch.
 - `session_cancel` cancels queued async children immediately, but running cancellation is cooperative at turn-loop checkpoints rather than hard process preemption.
 - `session_recover` only handles overdue async delegate children in `ready` or `running`; it is an operator-driven recovery path, not hard kill, retry, or automatic restart recovery.
 - Batch remediation is best-effort per target. Mixed applicability returns structured per-target results rather than an atomic all-or-nothing transaction.
@@ -50,7 +53,6 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - Async delegation has no hard kill, retry queue, or post-restart recovery semantics in this phase.
 - Legacy fallback is best-effort for the current session only. Historical rows without `sessions` metadata cannot recover descendant lineage because `turns` do not encode parentage.
 - Child tool allowlists only activate runtime-supported tools. Unknown or planned tool names are ignored.
-- There is no `session_unarchive` tool in this phase. Archive is durable until explicitly rediscovered through inspection.
 
 ## Out of Scope
 - Durable delegate queues or leased worker pools

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -14,7 +14,7 @@ Product specs describe **what** the product does from the user's perspective, no
 As an operator using LoongClaw's tool-calling runtime, I want to inspect active sessions and delegate focused subtasks into child sessions so that I can keep orchestration explicit, auditable, and bounded.
 
 ## Acceptance Criteria
-- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
+- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `memory_search`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
 - [x] Delegated child sessions run with a restricted tool surface derived from config rather than inheriting the full root tool set.
 - [x] Delegated child sessions can use `session_status` and `sessions_history` for self-inspection only, and never gain `sessions_list`.
 - [x] Nested delegation is bounded by `tools.delegate.max_depth` and enforced from session lineage, not by ad-hoc one-off checks.
@@ -38,13 +38,16 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_archive` accepts either `session_id` or `session_ids`, supports `dry_run` preview, and returns per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
 - [x] `session_unarchive` accepts either `session_id` or `session_ids`, supports `dry_run` preview, and returns per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
 - [x] `sessions_send` can send plain outbound text to a known channel-backed root session (`telegram:<chat_id>` or `feishu:<chat_id>`), recording a non-transcript control event without executing a target-side provider turn or mutating transcript rows.
+- [x] `memory_search` can search persisted transcript turns across the caller's visible session scope, or within explicitly targeted visible sessions, and return structured recent-first match snippets without searching control-plane `session_events`.
 
 ## Current Limits
 - `delegate_async` uses a subprocess one-shot worker (`loongclawd run-turn`) rather than a durable queue or resident worker pool.
 - Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
 - `sessions_send` is intentionally narrow: only known root sessions backed by currently supported Telegram or Feishu targets are eligible.
+- `memory_search` is transcript text search only. It does not claim embedding-based, vector, BM25, hybrid, or semantic memory recall in this phase.
 - `session_archive` only applies to already-terminal visible sessions; it is inventory cleanup, not route shutdown, transcript deletion, or true session close.
 - `session_unarchive` only applies to already-archived terminal visible sessions; it restores default listing visibility, not execution, routing, or a new live session epoch.
+- `memory_search` only searches persisted transcript rows in `turns`; it does not search `session_events`, external knowledge stores, or detached long-term memory documents.
 - `session_cancel` cancels queued async children immediately, but running cancellation is cooperative at turn-loop checkpoints rather than hard process preemption.
 - `session_recover` only handles overdue async delegate children in `ready` or `running`; it is an operator-driven recovery path, not hard kill, retry, or automatic restart recovery.
 - Batch remediation is best-effort per target. Mixed applicability returns structured per-target results rather than an atomic all-or-nothing transaction.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,13 +200,14 @@ Delivered in current baseline:
   - per-session runtime tool views derived from config
   - sqlite-backed session registry and session event history
   - durable terminal outcomes for delegated child sessions
-  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
+  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
     with optional incremental event-tail return via `after_id`, draining unseen events through the
     current cursor and terminal completion
   - filtered `sessions_list` discovery for visible stale delegates, with optional lifecycle payloads
     and stable lifecycle-anchor reads that do not depend on recent-event windows
-  - durable session archival for visible terminal sessions, including default list exclusion,
-    `include_archived` rediscovery, and batch / `dry_run` operator flows
+  - durable session archive / unarchive lifecycle for visible terminal sessions, including default
+    list exclusion, `include_archived` rediscovery, latest-control-event archive derivation, and
+    batch / `dry_run` operator flows
   - batch `session_status` inspection targeting with `session_ids`, reusing the existing
     inspection payload while preserving legacy single-target response shape
   - batch `session_wait` targeting with `session_ids`, shared bounded wait context, and per-target

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,9 +200,11 @@ Delivered in current baseline:
   - per-session runtime tool views derived from config
   - sqlite-backed session registry and session event history
   - durable terminal outcomes for delegated child sessions
-  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
+  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `memory_search`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
     with optional incremental event-tail return via `after_id`, draining unseen events through the
     current cursor and terminal completion
+  - transcript-backed `memory_search` over visible session scope or explicit visible targets, with
+    structured recent-first snippet matches and no control-plane event search
   - filtered `sessions_list` discovery for visible stale delegates, with optional lifecycle payloads
     and stable lifecycle-anchor reads that do not depend on recent-event windows
   - durable session archive / unarchive lifecycle for visible terminal sessions, including default


### PR DESCRIPTION
## Summary

- add a truthful `session_unarchive` operator primitive for visible archived terminal sessions
- restore archived terminal sessions back into default `sessions_list` inventory
- add single-target and batch `session_unarchive` flows while preserving direct inspection and transcript history
- record durable `session_unarchived` control events and keep archive state derived from the latest archive-control event instead of assuming archive-only history

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

Scope note: this PR is intentionally stacked on `feat/session-archive-base-20260313` so the review diff only contains the `session_unarchive` delta.

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

Risk note: the change is a narrow lifecycle increment on top of the existing archive model and keeps restore semantics explicit instead of reopening live sessions.

## Validation

- [x] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional checks executed:

- [x] `<local-absolute-path> test -p loongclaw-app -- --nocapture --test-threads=1`
- [x] `<local-absolute-path> test -p loongclaw-daemon --no-run`

## Stack Context

- Base branch: `feat/session-archive-base-20260313`
- This PR is intentionally stacked on `feat/session-archive-base-20260313` so the review diff only contains the `session_unarchive` delta.

## Linked Issues

Closes #87