### PR TITLE
feat(memory): add transcript-backed memory_search

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -222,10 +222,10 @@ pub(crate) async fn send_text_to_known_session(
                 })?;
                 let adapter = telegram::TelegramAdapter::new(config, token);
                 adapter.send_text(target, text).await?;
-                return Ok(ChannelSendReceipt {
+                Ok(ChannelSendReceipt {
                     channel: "telegram",
                     target: chat_id.to_string(),
-                });
+                })
             }
         }
         "feishu" => {
@@ -257,10 +257,10 @@ pub(crate) async fn send_text_to_known_session(
                     ));
                 }
                 feishu::run_feishu_send(config, target, text, false).await?;
-                return Ok(ChannelSendReceipt {
+                Ok(ChannelSendReceipt {
                     channel: "feishu",
                     target: target.to_owned(),
-                });
+                })
             }
         }
         _ => Err(format!("sessions_send_channel_unsupported: `{session_id}`")),

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -39,7 +39,7 @@ pub struct SessionToolConfig {
     pub history_limit: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct MessageToolConfig {
     #[serde(default)]
     pub enabled: bool,
@@ -96,12 +96,6 @@ impl Default for SessionToolConfig {
             list_limit: default_session_list_limit(),
             history_limit: default_session_history_limit(),
         }
-    }
-}
-
-impl Default for MessageToolConfig {
-    fn default() -> Self {
-        Self { enabled: false }
     }
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -3957,7 +3957,7 @@ async fn handle_turn_with_runtime_uses_session_tool_view_from_runtime() {
             .lock()
             .expect("built tool views lock")
             .as_slice(),
-        &[child_view.clone()]
+        std::slice::from_ref(&child_view)
     );
     assert_eq!(
         runtime

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -6,6 +6,7 @@ use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 #[cfg(feature = "memory-sqlite")]
 use std::{
+    io::{self, Write},
     path::{Path, PathBuf},
     process::Stdio,
 };
@@ -313,7 +314,9 @@ fn spawn_async_delegate_detached(
                 label,
                 error.clone(),
             ) {
-                eprintln!(
+                let mut stderr = io::stderr().lock();
+                let _ = writeln!(
+                    &mut stderr,
                     "error: async delegate spawn failure persistence failed for `{child_session_id}`: {finalize_error}; original spawn error: {error}"
                 );
             }
@@ -407,10 +410,10 @@ impl DefaultAppToolDispatcher {
     pub fn runtime() -> Self {
         #[cfg(feature = "memory-sqlite")]
         {
-            return Self::production(
+            Self::production(
                 crate::memory::runtime_config::get_memory_runtime_config().clone(),
                 ToolConfig::default(),
-            );
+            )
         }
         #[cfg(not(feature = "memory-sqlite"))]
         Self::new(
@@ -734,9 +737,9 @@ impl TurnEngine {
         // Execute each tool intent through the kernel
         let mut outputs = Vec::new();
         for intent in &turn.tool_intents {
-            let descriptor = catalog
-                .resolve(&intent.tool_name)
-                .expect("tool descriptor should remain resolvable after validation");
+            let Some(descriptor) = catalog.resolve(&intent.tool_name) else {
+                return TurnResult::ToolDenied(format!("tool_not_found: {}", intent.tool_name));
+            };
             let request = ToolCoreRequest {
                 tool_name: descriptor.name.to_owned(),
                 payload: intent.args_json.clone(),

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -462,10 +462,10 @@ fn ensure_session_registered(
 fn default_app_tool_dispatcher(config: &LoongClawConfig) -> DefaultAppToolDispatcher {
     #[cfg(feature = "memory-sqlite")]
     {
-        return DefaultAppToolDispatcher::production_with_config(
+        DefaultAppToolDispatcher::production_with_config(
             memory_runtime_config_for(config),
             config.clone(),
-        );
+        )
     }
     #[cfg(not(feature = "memory-sqlite"))]
     DefaultAppToolDispatcher::new(memory_runtime_config_for(config), config.tools.clone())

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -299,8 +299,13 @@ mod tests {
             .expect("append first match");
         append_turn_direct("session-b", "assistant", "no relevant text here", &config)
             .expect("append unrelated turn");
-        append_turn_direct("session-a", "assistant", "latest timeout budget update", &config)
-            .expect("append latest match");
+        append_turn_direct(
+            "session-a",
+            "assistant",
+            "latest timeout budget update",
+            &config,
+        )
+        .expect("append latest match");
 
         let matches = search_transcript_direct(
             &["session-a".to_owned(), "session-b".to_owned()],
@@ -344,12 +349,16 @@ mod tests {
             sqlite_path: Some(db_path.clone()),
         };
 
-        append_turn_direct("session-a", "user", "archive inventory", &config)
-            .expect("append turn");
+        append_turn_direct("session-a", "user", "archive inventory", &config).expect("append turn");
 
-        let matches =
-            search_transcript_direct(&["session-a".to_owned()], "timeout budget", 20, 120, &config)
-                .expect("search transcript");
+        let matches = search_transcript_direct(
+            &["session-a".to_owned()],
+            "timeout budget",
+            20,
+            120,
+            &config,
+        )
+        .expect("search transcript");
 
         assert!(matches.is_empty(), "non-matching turns should be excluded");
 

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -11,7 +11,7 @@ mod sqlite;
 
 pub use kernel_adapter::MvpMemoryAdapter;
 #[cfg(feature = "memory-sqlite")]
-pub use sqlite::ConversationTurn;
+pub use sqlite::{ConversationTurn, TranscriptSearchMatch};
 
 pub fn execute_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
     execute_memory_core_with_config(request, runtime_config::get_memory_runtime_config())
@@ -115,6 +115,17 @@ pub fn ensure_memory_db_ready(
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<PathBuf, String> {
     sqlite::ensure_memory_db_ready(path, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn search_transcript_direct(
+    session_ids: &[String],
+    query: &str,
+    limit: usize,
+    excerpt_chars: usize,
+    config: &runtime_config::MemoryRuntimeConfig,
+) -> Result<Vec<TranscriptSearchMatch>, String> {
+    sqlite::search_transcript_direct(session_ids, query, limit, excerpt_chars, config)
 }
 
 #[cfg(test)]
@@ -262,6 +273,130 @@ mod tests {
         assert_eq!(turns.len(), 1);
         assert_eq!(turns[0].role, "user");
         assert_eq!(turns[0].content, "hello from transcript");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn search_transcript_direct_returns_recent_matching_turns() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-test-memory-search-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&tmp);
+        let db_path = tmp.join("search.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+        };
+
+        append_turn_direct("session-a", "user", "first timeout budget note", &config)
+            .expect("append first match");
+        append_turn_direct("session-b", "assistant", "no relevant text here", &config)
+            .expect("append unrelated turn");
+        append_turn_direct("session-a", "assistant", "latest timeout budget update", &config)
+            .expect("append latest match");
+
+        let matches = search_transcript_direct(
+            &["session-a".to_owned(), "session-b".to_owned()],
+            "timeout budget",
+            20,
+            120,
+            &config,
+        )
+        .expect("search transcript");
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].session_id, "session-a");
+        assert_eq!(matches[0].role, "assistant");
+        assert!(
+            matches[0].content_snippet.contains("timeout budget"),
+            "snippet should contain query"
+        );
+        assert!(
+            matches[0].turn_id > matches[1].turn_id,
+            "results should be newest first"
+        );
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn search_transcript_direct_excludes_non_matching_turns() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-test-memory-search-miss-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&tmp);
+        let db_path = tmp.join("search-miss.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+        };
+
+        append_turn_direct("session-a", "user", "archive inventory", &config)
+            .expect("append turn");
+
+        let matches =
+            search_transcript_direct(&["session-a".to_owned()], "timeout budget", 20, 120, &config)
+                .expect("search transcript");
+
+        assert!(matches.is_empty(), "non-matching turns should be excluded");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn search_transcript_direct_clamps_limit_and_excerpt() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-test-memory-search-clamp-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&tmp);
+        let db_path = tmp.join("search-clamp.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+        };
+        let long_prefix = "prefix ".repeat(20);
+        let long_suffix = " suffix".repeat(20);
+        let long_match = format!("{long_prefix}timeout budget{long_suffix}");
+
+        append_turn_direct("session-a", "user", "timeout budget alpha", &config)
+            .expect("append alpha");
+        append_turn_direct("session-a", "assistant", "timeout budget beta", &config)
+            .expect("append beta");
+        append_turn_direct("session-a", "assistant", &long_match, &config)
+            .expect("append long match");
+
+        let matches =
+            search_transcript_direct(&["session-a".to_owned()], "timeout budget", 0, 12, &config)
+                .expect("search transcript");
+
+        assert_eq!(matches.len(), 1, "limit should clamp to at least one");
+        assert!(
+            matches[0].content_snippet.len() <= 406,
+            "excerpt should clamp instead of returning the full long content"
+        );
+        assert!(
+            matches[0].content_snippet.contains("timeout budget"),
+            "snippet should preserve the matching phrase"
+        );
 
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir(&tmp);

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -255,7 +255,9 @@ pub(super) fn search_transcript_direct(
     );
 
     let mut params = Vec::with_capacity(session_ids.len() + 2);
-    params.push(rusqlite::types::Value::from(format!("%{normalized_query}%")));
+    params.push(rusqlite::types::Value::from(format!(
+        "%{normalized_query}%"
+    )));
     params.extend(
         session_ids
             .iter()
@@ -285,8 +287,7 @@ pub(super) fn search_transcript_direct(
 
     let mut matches = Vec::new();
     for row in rows {
-        matches
-            .push(row.map_err(|error| format!("decode transcript search row failed: {error}"))?);
+        matches.push(row.map_err(|error| format!("decode transcript search row failed: {error}"))?);
     }
     Ok(matches)
 }

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -17,6 +17,15 @@ pub struct ConversationTurn {
     pub ts: i64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranscriptSearchMatch {
+    pub turn_id: i64,
+    pub session_id: String,
+    pub role: String,
+    pub content_snippet: String,
+    pub ts: i64,
+}
+
 pub(super) fn append_turn(
     request: MemoryCoreRequest,
     config: &MemoryRuntimeConfig,
@@ -206,6 +215,82 @@ pub(super) fn window_direct(
         .map_err(|error| format!("decode memory turns failed: {error}"))
 }
 
+pub(super) fn search_transcript_direct(
+    session_ids: &[String],
+    query: &str,
+    limit: usize,
+    excerpt_chars: usize,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<TranscriptSearchMatch>, String> {
+    if session_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let normalized_query = query.trim();
+    if normalized_query.is_empty() {
+        return Err("memory.search_transcript requires a non-empty query".to_owned());
+    }
+
+    let search_limit = clamp_search_limit(limit);
+    let excerpt_limit = clamp_excerpt_chars(excerpt_chars);
+    let path = resolve_db_path(config);
+    ensure_sqlite_schema(&path)?;
+    let conn = rusqlite::Connection::open(&path)
+        .map_err(|error| format!("open sqlite memory db failed: {error}"))?;
+
+    let mut session_placeholders = Vec::with_capacity(session_ids.len());
+    for offset in 0..session_ids.len() {
+        session_placeholders.push(format!("?{}", offset + 2));
+    }
+    let limit_placeholder = session_ids.len() + 2;
+    let sql = format!(
+        "SELECT id, session_id, role, content, ts
+         FROM turns
+         WHERE content LIKE ?1
+           AND session_id IN ({})
+         ORDER BY ts DESC, id DESC
+         LIMIT ?{}",
+        session_placeholders.join(", "),
+        limit_placeholder
+    );
+
+    let mut params = Vec::with_capacity(session_ids.len() + 2);
+    params.push(rusqlite::types::Value::from(format!("%{normalized_query}%")));
+    params.extend(
+        session_ids
+            .iter()
+            .cloned()
+            .map(rusqlite::types::Value::from),
+    );
+    params.push(rusqlite::types::Value::from(search_limit as i64));
+
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|error| format!("prepare transcript search query failed: {error}"))?;
+    let rows = stmt
+        .query_map(
+            rusqlite::params_from_iter(params),
+            |row| -> rusqlite::Result<TranscriptSearchMatch> {
+                let content: String = row.get(3)?;
+                Ok(TranscriptSearchMatch {
+                    turn_id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    role: row.get(2)?,
+                    content_snippet: build_excerpt(&content, normalized_query, excerpt_limit),
+                    ts: row.get(4)?,
+                })
+            },
+        )
+        .map_err(|error| format!("query transcript search failed: {error}"))?;
+
+    let mut matches = Vec::new();
+    for row in rows {
+        matches
+            .push(row.map_err(|error| format!("decode transcript search row failed: {error}"))?);
+    }
+    Ok(matches)
+}
+
 pub(super) fn ensure_memory_db_ready(
     path: Option<PathBuf>,
     config: &MemoryRuntimeConfig,
@@ -225,6 +310,47 @@ fn default_window_size() -> usize {
 
 fn default_window_size_u64() -> u64 {
     default_window_size() as u64
+}
+
+fn clamp_search_limit(limit: usize) -> usize {
+    limit.clamp(1, 100)
+}
+
+fn clamp_excerpt_chars(excerpt_chars: usize) -> usize {
+    excerpt_chars.clamp(40, 400)
+}
+
+fn build_excerpt(content: &str, query: &str, excerpt_chars: usize) -> String {
+    if content.chars().count() <= excerpt_chars {
+        return content.to_owned();
+    }
+
+    let content_lower = content.to_lowercase();
+    let query_lower = query.to_lowercase();
+    let match_start = content_lower.find(&query_lower).unwrap_or(0);
+    let match_end = match_start.saturating_add(query_lower.len());
+
+    let mut start = match_start.saturating_sub(excerpt_chars / 2);
+    let mut end = start.saturating_add(excerpt_chars).min(content.len());
+    if end < match_end {
+        end = match_end.min(content.len());
+        start = end.saturating_sub(excerpt_chars);
+    }
+    while start > 0 && !content.is_char_boundary(start) {
+        start -= 1;
+    }
+    while end < content.len() && !content.is_char_boundary(end) {
+        end += 1;
+    }
+
+    let mut snippet = content[start..end].to_owned();
+    if start > 0 {
+        snippet.insert_str(0, "...");
+    }
+    if end < content.len() {
+        snippet.push_str("...");
+    }
+    snippet
 }
 
 fn unix_ts_now() -> i64 {

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -1138,6 +1138,7 @@ mod tests {
             expected.push("file_read");
             expected.push("file_write");
         }
+        expected.push("memory_search");
         expected.push("session_archive");
         expected.push("session_cancel");
         expected.push("session_events");
@@ -1264,6 +1265,37 @@ mod tests {
             .collect();
 
         assert!(names.contains(&"session_archive"));
+    }
+
+    #[test]
+    fn memory_search_appears_in_root_turn_request_body() {
+        let config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        let tool_definitions = crate::tools::provider_tool_definitions();
+        let body = build_turn_request_body(
+            &config,
+            &[],
+            "model-latest",
+            CompletionPayloadMode::default_for(&config.provider),
+            true,
+            &tool_definitions,
+        );
+        let tools = body["tools"].as_array().expect("tools array");
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+
+        assert!(names.contains(&"memory_search"));
     }
 
     #[test]

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -150,7 +150,16 @@ pub fn tool_catalog() -> ToolCatalog {
         description: "Fetch session events for a visible session",
         execution_kind: ToolExecutionKind::App,
         availability: ToolAvailability::Runtime,
-        provider_definition_builder: session_events_definition,
+            provider_definition_builder: session_events_definition,
+    });
+    descriptors.push(ToolDescriptor {
+        name: "memory_search",
+        provider_name: "memory_search",
+        aliases: &[],
+        description: "Search visible transcript memory across persisted session turns",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: memory_search_definition,
     });
     descriptors.push(ToolDescriptor {
         name: "sessions_history",
@@ -324,8 +333,8 @@ pub fn delegate_child_tool_view_for_config_with_delegate(
 fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> bool {
     match tool_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_archive" | "session_cancel" | "session_recover" | "session_unarchive"
-        | "session_wait" => config.sessions.enabled,
+        | "memory_search" | "session_archive" | "session_cancel" | "session_recover"
+        | "session_unarchive" | "session_wait" => config.sessions.enabled,
         "sessions_send" => config.messages.enabled,
         "delegate" | "delegate_async" => config.delegate.enabled,
         _ => true,
@@ -487,6 +496,56 @@ fn sessions_history_definition(descriptor: &ToolDescriptor) -> Value {
                     }
                 },
                 "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn memory_search_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Non-empty transcript text to search for within visible session memory."
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional visible session identifier to search exclusively."
+                    },
+                    "session_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "Optional visible session identifiers to search in one request."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "description": "Maximum transcript matches to return."
+                    },
+                    "excerpt_chars": {
+                        "type": "integer",
+                        "minimum": 40,
+                        "maximum": 400,
+                        "description": "Approximate match snippet length in characters."
+                    }
+                },
+                "required": ["query"],
+                "oneOf": [
+                    { "required": ["query", "session_id"] },
+                    { "required": ["query", "session_ids"] },
+                    { "required": ["query"] }
+                ],
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -150,7 +150,7 @@ pub fn tool_catalog() -> ToolCatalog {
         description: "Fetch session events for a visible session",
         execution_kind: ToolExecutionKind::App,
         availability: ToolAvailability::Runtime,
-            provider_definition_builder: session_events_definition,
+        provider_definition_builder: session_events_definition,
     });
     descriptors.push(ToolDescriptor {
         name: "memory_search",

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -29,9 +29,7 @@ pub struct ToolDescriptor {
 
 impl ToolDescriptor {
     pub fn matches_name(&self, raw: &str) -> bool {
-        self.name == raw
-            || self.provider_name == raw
-            || self.aliases.iter().any(|alias| *alias == raw)
+        self.name == raw || self.provider_name == raw || self.aliases.contains(&raw)
     }
 
     pub fn provider_definition(&self) -> Value {

--- a/crates/app/src/tools/memory.rs
+++ b/crates/app/src/tools/memory.rs
@@ -81,8 +81,9 @@ pub(crate) fn execute_memory_search_tool_with_policies(
             "limit": request.limit.clamp(1, 100),
             "truncated": false,
         });
-        let returned_count = payload["matches"]
-            .as_array()
+        let returned_count = payload
+            .get("matches")
+            .and_then(Value::as_array)
             .map(Vec::len)
             .unwrap_or_default();
 
@@ -299,8 +300,10 @@ mod tests {
     }
 
     fn skipped_target<'a>(payload: &'a Value, session_id: &str) -> &'a Value {
-        payload["scope"]["skipped_targets"]
-            .as_array()
+        payload
+            .get("scope")
+            .and_then(|scope| scope.get("skipped_targets"))
+            .and_then(Value::as_array)
             .expect("skipped_targets array")
             .iter()
             .find(|item| item.get("session_id").and_then(Value::as_str) == Some(session_id))
@@ -399,10 +402,19 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        assert_eq!(outcome.payload["scope"]["mode"], "visible");
-        assert_eq!(outcome.payload["returned_count"], 2);
-        let matches = outcome.payload["matches"]
-            .as_array()
+        let scope = outcome.payload.get("scope").expect("scope payload");
+        assert_eq!(scope.get("mode").and_then(Value::as_str), Some("visible"));
+        assert_eq!(
+            outcome
+                .payload
+                .get("returned_count")
+                .and_then(Value::as_u64),
+            Some(2)
+        );
+        let matches = outcome
+            .payload
+            .get("matches")
+            .and_then(Value::as_array)
             .expect("matches array");
         let session_ids: Vec<&str> = matches
             .iter()
@@ -510,15 +522,26 @@ mod tests {
         )
         .expect("batch memory_search outcome");
 
-        assert_eq!(outcome.payload["scope"]["mode"], "batch");
-        assert_eq!(outcome.payload["returned_count"], 1);
+        let scope = outcome.payload.get("scope").expect("scope payload");
+        assert_eq!(scope.get("mode").and_then(Value::as_str), Some("batch"));
         assert_eq!(
-            skipped_target(&outcome.payload, "hidden-root")["result"],
-            "skipped_not_visible"
+            outcome
+                .payload
+                .get("returned_count")
+                .and_then(Value::as_u64),
+            Some(1)
         );
         assert_eq!(
-            skipped_target(&outcome.payload, "missing-session")["result"],
-            "skipped_not_found"
+            skipped_target(&outcome.payload, "hidden-root")
+                .get("result")
+                .and_then(Value::as_str),
+            Some("skipped_not_visible")
+        );
+        assert_eq!(
+            skipped_target(&outcome.payload, "missing-session")
+                .get("result")
+                .and_then(Value::as_str),
+            Some("skipped_not_found")
         );
     }
 
@@ -566,11 +589,19 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        let matches = outcome.payload["matches"]
-            .as_array()
+        let matches = outcome
+            .payload
+            .get("matches")
+            .and_then(Value::as_array)
             .expect("matches array");
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0]["session_id"], "archived-child");
+        assert_eq!(
+            matches
+                .first()
+                .and_then(|item| item.get("session_id"))
+                .and_then(Value::as_str),
+            Some("archived-child")
+        );
     }
 
     #[test]
@@ -599,10 +630,22 @@ mod tests {
         )
         .expect("legacy memory_search outcome");
 
-        assert_eq!(outcome.payload["returned_count"], 1);
         assert_eq!(
-            outcome.payload["matches"][0]["session_id"],
-            "delegate:legacy-child"
+            outcome
+                .payload
+                .get("returned_count")
+                .and_then(Value::as_u64),
+            Some(1)
+        );
+        assert_eq!(
+            outcome
+                .payload
+                .get("matches")
+                .and_then(Value::as_array)
+                .and_then(|matches| matches.first())
+                .and_then(|item| item.get("session_id"))
+                .and_then(Value::as_str),
+            Some("delegate:legacy-child")
         );
     }
 
@@ -643,8 +686,10 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        let matches = outcome.payload["matches"]
-            .as_array()
+        let matches = outcome
+            .payload
+            .get("matches")
+            .and_then(Value::as_array)
             .expect("matches array");
         assert!(
             matches.is_empty(),

--- a/crates/app/src/tools/memory.rs
+++ b/crates/app/src/tools/memory.rs
@@ -1,10 +1,10 @@
 use loongclaw_contracts::ToolCoreOutcome;
 use serde_json::{json, Value};
 
-use crate::config::ToolConfig;
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::config::SessionVisibility;
+use crate::config::ToolConfig;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::SessionRepository;
 
@@ -115,7 +115,10 @@ fn parse_memory_search_request(payload: Value) -> Result<MemorySearchRequest, St
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned);
-    let session_ids = object.get("session_ids").map(parse_session_ids).transpose()?;
+    let session_ids = object
+        .get("session_ids")
+        .map(parse_session_ids)
+        .transpose()?;
     if session_id.is_some() && session_ids.is_some() {
         return Err(
             "memory_search_invalid_request: session_id and session_ids are mutually exclusive"
@@ -127,10 +130,7 @@ fn parse_memory_search_request(payload: Value) -> Result<MemorySearchRequest, St
         query,
         session_id,
         session_ids,
-        limit: object
-            .get("limit")
-            .and_then(Value::as_u64)
-            .unwrap_or(20) as usize,
+        limit: object.get("limit").and_then(Value::as_u64).unwrap_or(20) as usize,
         excerpt_chars: object
             .get("excerpt_chars")
             .and_then(Value::as_u64)
@@ -169,7 +169,12 @@ fn resolve_search_scope(
     tool_config: &ToolConfig,
 ) -> Result<(&'static str, Vec<String>, Vec<Value>), String> {
     if let Some(session_id) = &request.session_id {
-        ensure_target_visible(repo, current_session_id, session_id, tool_config.sessions.visibility)?;
+        ensure_target_visible(
+            repo,
+            current_session_id,
+            session_id,
+            tool_config.sessions.visibility,
+        )?;
         return Ok(("single", vec![session_id.clone()], Vec::new()));
     }
 
@@ -250,7 +255,9 @@ fn classify_target_visibility(
 
     let is_visible = match visibility {
         SessionVisibility::SelfOnly => false,
-        SessionVisibility::Children => repo.is_session_visible(current_session_id, target_session_id)?,
+        SessionVisibility::Children => {
+            repo.is_session_visible(current_session_id, target_session_id)?
+        }
     };
     if is_visible {
         Ok(TargetVisibility::Visible)
@@ -369,8 +376,13 @@ mod tests {
 
         append_turn_direct("root-session", "user", "timeout budget root", &config)
             .expect("append root turn");
-        append_turn_direct("child-session", "assistant", "timeout budget child", &config)
-            .expect("append child turn");
+        append_turn_direct(
+            "child-session",
+            "assistant",
+            "timeout budget child",
+            &config,
+        )
+        .expect("append child turn");
         append_turn_direct("other-root", "assistant", "timeout budget hidden", &config)
             .expect("append hidden turn");
 
@@ -389,7 +401,9 @@ mod tests {
 
         assert_eq!(outcome.payload["scope"]["mode"], "visible");
         assert_eq!(outcome.payload["returned_count"], 2);
-        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        let matches = outcome.payload["matches"]
+            .as_array()
+            .expect("matches array");
         let session_ids: Vec<&str> = matches
             .iter()
             .filter_map(|item| item.get("session_id"))
@@ -474,8 +488,13 @@ mod tests {
         })
         .expect("create hidden");
 
-        append_turn_direct("child-session", "assistant", "timeout budget child", &config)
-            .expect("append child turn");
+        append_turn_direct(
+            "child-session",
+            "assistant",
+            "timeout budget child",
+            &config,
+        )
+        .expect("append child turn");
 
         let outcome = execute_app_tool_with_config(
             ToolCoreRequest {
@@ -525,8 +544,13 @@ mod tests {
             state: SessionState::Ready,
         })
         .expect("create archived child");
-        append_turn_direct("archived-child", "assistant", "restore inventory marker", &config)
-            .expect("append archived turn");
+        append_turn_direct(
+            "archived-child",
+            "assistant",
+            "restore inventory marker",
+            &config,
+        )
+        .expect("append archived turn");
         archive_completed_session(&repo, "archived-child", "root-session");
 
         let outcome = execute_app_tool_with_config(
@@ -542,7 +566,9 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        let matches = outcome.payload["matches"]
+            .as_array()
+            .expect("matches array");
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0]["session_id"], "archived-child");
     }
@@ -574,7 +600,10 @@ mod tests {
         .expect("legacy memory_search outcome");
 
         assert_eq!(outcome.payload["returned_count"], 1);
-        assert_eq!(outcome.payload["matches"][0]["session_id"], "delegate:legacy-child");
+        assert_eq!(
+            outcome.payload["matches"][0]["session_id"],
+            "delegate:legacy-child"
+        );
     }
 
     #[test]
@@ -614,7 +643,12 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        let matches = outcome.payload["matches"].as_array().expect("matches array");
-        assert!(matches.is_empty(), "session events should not be searchable transcript hits");
+        let matches = outcome.payload["matches"]
+            .as_array()
+            .expect("matches array");
+        assert!(
+            matches.is_empty(),
+            "session events should not be searchable transcript hits"
+        );
     }
 }

--- a/crates/app/src/tools/memory.rs
+++ b/crates/app/src/tools/memory.rs
@@ -1,0 +1,620 @@
+use loongclaw_contracts::ToolCoreOutcome;
+use serde_json::{json, Value};
+
+use crate::config::ToolConfig;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::config::SessionVisibility;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::SessionRepository;
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MemorySearchRequest {
+    query: String,
+    session_id: Option<String>,
+    session_ids: Option<Vec<String>>,
+    limit: usize,
+    excerpt_chars: usize,
+}
+
+pub(crate) fn execute_memory_search_tool_with_policies(
+    payload: Value,
+    current_session_id: &str,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (payload, current_session_id, memory_config, tool_config);
+        return Err(
+            "memory_search requires sqlite memory support (enable feature `memory-sqlite`)"
+                .to_owned(),
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        if !tool_config.sessions.enabled {
+            return Err("app_tool_disabled: session tools are disabled by config".to_owned());
+        }
+
+        let request = parse_memory_search_request(payload)?;
+        let repo = SessionRepository::new(memory_config)?;
+        let (mode, searched_session_ids, skipped_targets) =
+            resolve_search_scope(&repo, current_session_id, &request, tool_config)?;
+
+        let matches = crate::memory::search_transcript_direct(
+            &searched_session_ids,
+            &request.query,
+            request.limit,
+            request.excerpt_chars,
+            memory_config,
+        )?;
+        let mut payload = json!({
+            "query": request.query,
+            "scope": {
+                "mode": mode,
+                "current_session_id": current_session_id,
+                "searched_session_ids": searched_session_ids,
+                "searched_session_count": searched_session_ids.len(),
+                "skipped_targets": skipped_targets,
+            },
+            "matches": matches
+                .into_iter()
+                .map(|item| {
+                    json!({
+                        "session_id": item.session_id,
+                        "turn_id": item.turn_id,
+                        "role": item.role,
+                        "ts": item.ts,
+                        "content_snippet": item.content_snippet,
+                        "match": {
+                            "query": request.query,
+                            "match_kind": "substring",
+                            "excerpt_chars": request.excerpt_chars.clamp(40, 400),
+                        }
+                    })
+                })
+                .collect::<Vec<_>>(),
+            "returned_count": 0,
+            "limit": request.limit.clamp(1, 100),
+            "truncated": false,
+        });
+        let returned_count = payload["matches"]
+            .as_array()
+            .map(Vec::len)
+            .unwrap_or_default();
+
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("returned_count".to_owned(), json!(returned_count));
+        }
+
+        Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload,
+        })
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_memory_search_request(payload: Value) -> Result<MemorySearchRequest, String> {
+    let object = payload
+        .as_object()
+        .ok_or_else(|| "memory_search_invalid_request: payload must be an object".to_owned())?;
+    let query = object
+        .get("query")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "memory_search_invalid_request: query is required".to_owned())?
+        .to_owned();
+    let session_id = object
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let session_ids = object.get("session_ids").map(parse_session_ids).transpose()?;
+    if session_id.is_some() && session_ids.is_some() {
+        return Err(
+            "memory_search_invalid_request: session_id and session_ids are mutually exclusive"
+                .to_owned(),
+        );
+    }
+
+    Ok(MemorySearchRequest {
+        query,
+        session_id,
+        session_ids,
+        limit: object
+            .get("limit")
+            .and_then(Value::as_u64)
+            .unwrap_or(20) as usize,
+        excerpt_chars: object
+            .get("excerpt_chars")
+            .and_then(Value::as_u64)
+            .unwrap_or(120) as usize,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_session_ids(value: &Value) -> Result<Vec<String>, String> {
+    let items = value.as_array().ok_or_else(|| {
+        "memory_search_invalid_request: session_ids must be an array of strings".to_owned()
+    })?;
+    if items.is_empty() {
+        return Err("memory_search_invalid_request: session_ids cannot be empty".to_owned());
+    }
+
+    let mut session_ids = Vec::with_capacity(items.len());
+    for item in items {
+        let session_id = item
+            .as_str()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                "memory_search_invalid_request: session_ids must be non-empty strings".to_owned()
+            })?;
+        session_ids.push(session_id.to_owned());
+    }
+    Ok(session_ids)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn resolve_search_scope(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    request: &MemorySearchRequest,
+    tool_config: &ToolConfig,
+) -> Result<(&'static str, Vec<String>, Vec<Value>), String> {
+    if let Some(session_id) = &request.session_id {
+        ensure_target_visible(repo, current_session_id, session_id, tool_config.sessions.visibility)?;
+        return Ok(("single", vec![session_id.clone()], Vec::new()));
+    }
+
+    if let Some(session_ids) = &request.session_ids {
+        let mut visible = Vec::new();
+        let mut skipped = Vec::new();
+        for session_id in session_ids {
+            match classify_target_visibility(
+                repo,
+                current_session_id,
+                session_id,
+                tool_config.sessions.visibility,
+            )? {
+                TargetVisibility::Visible => visible.push(session_id.clone()),
+                TargetVisibility::NotVisible(message) => skipped.push(json!({
+                    "session_id": session_id,
+                    "result": "skipped_not_visible",
+                    "message": message,
+                })),
+                TargetVisibility::NotFound(message) => skipped.push(json!({
+                    "session_id": session_id,
+                    "result": "skipped_not_found",
+                    "message": message,
+                })),
+            }
+        }
+        return Ok(("batch", visible, skipped));
+    }
+
+    let visible_sessions = repo.list_visible_sessions(current_session_id)?;
+    Ok((
+        "visible",
+        visible_sessions
+            .into_iter()
+            .map(|session| session.session_id)
+            .collect(),
+        Vec::new(),
+    ))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn ensure_target_visible(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    target_session_id: &str,
+    visibility: SessionVisibility,
+) -> Result<(), String> {
+    match classify_target_visibility(repo, current_session_id, target_session_id, visibility)? {
+        TargetVisibility::Visible => Ok(()),
+        TargetVisibility::NotVisible(message) => Err(message),
+        TargetVisibility::NotFound(message) => Err(message),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+enum TargetVisibility {
+    Visible,
+    NotVisible(String),
+    NotFound(String),
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn classify_target_visibility(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    target_session_id: &str,
+    visibility: SessionVisibility,
+) -> Result<TargetVisibility, String> {
+    let summary = repo.load_session_summary_with_legacy_fallback(target_session_id)?;
+    if summary.is_none() {
+        return Ok(TargetVisibility::NotFound(format!(
+            "session_not_found: `{target_session_id}`"
+        )));
+    }
+    if current_session_id == target_session_id {
+        return Ok(TargetVisibility::Visible);
+    }
+
+    let is_visible = match visibility {
+        SessionVisibility::SelfOnly => false,
+        SessionVisibility::Children => repo.is_session_visible(current_session_id, target_session_id)?,
+    };
+    if is_visible {
+        Ok(TargetVisibility::Visible)
+    } else {
+        Ok(TargetVisibility::NotVisible(format!(
+            "visibility_denied: session `{target_session_id}` is not visible from `{current_session_id}`"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use loongclaw_contracts::ToolCoreRequest;
+    use serde_json::{json, Value};
+
+    use crate::config::ToolConfig;
+    use crate::memory::append_turn_direct;
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::repository::{
+        FinalizeSessionTerminalRequest, NewSessionEvent, NewSessionRecord, SessionKind,
+        SessionRepository, SessionState, TransitionSessionWithEventIfCurrentRequest,
+    };
+
+    use super::super::execute_app_tool_with_config;
+
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        let base = std::env::temp_dir().join(format!(
+            "loongclaw-memory-tool-{test_name}-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&base);
+        let db_path = base.join("memory.sqlite3");
+        let _ = fs::remove_file(&db_path);
+        MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+        }
+    }
+
+    fn skipped_target<'a>(payload: &'a Value, session_id: &str) -> &'a Value {
+        payload["scope"]["skipped_targets"]
+            .as_array()
+            .expect("skipped_targets array")
+            .iter()
+            .find(|item| item.get("session_id").and_then(Value::as_str) == Some(session_id))
+            .unwrap_or_else(|| panic!("missing skipped target `{session_id}`"))
+    }
+
+    fn archive_completed_session(
+        repo: &SessionRepository,
+        session_id: &str,
+        actor_session_id: &str,
+    ) {
+        repo.finalize_session_terminal(
+            session_id,
+            FinalizeSessionTerminalRequest {
+                state: SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some(actor_session_id.to_owned()),
+                event_payload_json: json!({}),
+                outcome_status: "completed".to_owned(),
+                outcome_payload_json: json!({}),
+            },
+        )
+        .expect("finalize completed");
+        repo.transition_session_with_event_if_current(
+            session_id,
+            TransitionSessionWithEventIfCurrentRequest {
+                expected_state: SessionState::Completed,
+                next_state: SessionState::Completed,
+                last_error: None,
+                event_kind: "session_archived".to_owned(),
+                actor_session_id: Some(actor_session_id.to_owned()),
+                event_payload_json: json!({
+                    "previous_state": "completed",
+                    "hides_from_sessions_list": true
+                }),
+            },
+        )
+        .expect("archive session")
+        .expect("archive transition result");
+    }
+
+    #[test]
+    fn memory_search_searches_visible_scope_by_default() {
+        let config = isolated_memory_config("visible-scope");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.create_session(NewSessionRecord {
+            session_id: "other-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Other".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create other root");
+
+        append_turn_direct("root-session", "user", "timeout budget root", &config)
+            .expect("append root turn");
+        append_turn_direct("child-session", "assistant", "timeout budget child", &config)
+            .expect("append child turn");
+        append_turn_direct("other-root", "assistant", "timeout budget hidden", &config)
+            .expect("append hidden turn");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget"
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("memory_search outcome");
+
+        assert_eq!(outcome.payload["scope"]["mode"], "visible");
+        assert_eq!(outcome.payload["returned_count"], 2);
+        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        let session_ids: Vec<&str> = matches
+            .iter()
+            .filter_map(|item| item.get("session_id"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(session_ids.contains(&"root-session"));
+        assert!(session_ids.contains(&"child-session"));
+        assert!(!session_ids.contains(&"other-root"));
+    }
+
+    #[test]
+    fn memory_search_rejects_invisible_single_target() {
+        let config = isolated_memory_config("single-target-visibility");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "other-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Other".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create other");
+
+        let error = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget",
+                    "session_id": "other-root"
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect_err("hidden single target should fail");
+
+        assert!(
+            error.contains("visibility_denied"),
+            "expected visibility_denied, got: {error}"
+        );
+    }
+
+    #[test]
+    fn memory_search_batch_reports_skipped_targets() {
+        let config = isolated_memory_config("batch-skips");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.create_session(NewSessionRecord {
+            session_id: "hidden-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Hidden".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create hidden");
+
+        append_turn_direct("child-session", "assistant", "timeout budget child", &config)
+            .expect("append child turn");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget",
+                    "session_ids": ["child-session", "hidden-root", "missing-session"]
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("batch memory_search outcome");
+
+        assert_eq!(outcome.payload["scope"]["mode"], "batch");
+        assert_eq!(outcome.payload["returned_count"], 1);
+        assert_eq!(
+            skipped_target(&outcome.payload, "hidden-root")["result"],
+            "skipped_not_visible"
+        );
+        assert_eq!(
+            skipped_target(&outcome.payload, "missing-session")["result"],
+            "skipped_not_found"
+        );
+    }
+
+    #[test]
+    fn memory_search_includes_archived_visible_sessions() {
+        let config = isolated_memory_config("archived-visible");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "archived-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Archived".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create archived child");
+        append_turn_direct("archived-child", "assistant", "restore inventory marker", &config)
+            .expect("append archived turn");
+        archive_completed_session(&repo, "archived-child", "root-session");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "restore inventory marker"
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("memory_search outcome");
+
+        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0]["session_id"], "archived-child");
+    }
+
+    #[test]
+    fn memory_search_supports_legacy_current_session_transcript() {
+        let config = isolated_memory_config("legacy-current");
+        let tool_config = ToolConfig::default();
+
+        append_turn_direct(
+            "delegate:legacy-child",
+            "assistant",
+            "legacy timeout budget note",
+            &config,
+        )
+        .expect("append legacy turn");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget"
+                }),
+            },
+            "delegate:legacy-child",
+            &config,
+            &tool_config,
+        )
+        .expect("legacy memory_search outcome");
+
+        assert_eq!(outcome.payload["returned_count"], 1);
+        assert_eq!(outcome.payload["matches"][0]["session_id"], "delegate:legacy-child");
+    }
+
+    #[test]
+    fn memory_search_does_not_return_session_events() {
+        let config = isolated_memory_config("ignores-events");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.append_event(NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "delegate_progress".to_owned(),
+            actor_session_id: None,
+            payload_json: json!({
+                "note": "timeout budget appears only in control-plane event"
+            }),
+        })
+        .expect("append control event");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget"
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("memory_search outcome");
+
+        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        assert!(matches.is_empty(), "session events should not be searchable transcript hits");
+    }
+}

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -275,6 +275,9 @@ mod tests {
         ));
         assert!(snapshot.contains("- file.read: Read file contents"));
         assert!(snapshot.contains("- file.write: Write file contents"));
+        assert!(snapshot.contains(
+            "- memory_search: Search visible transcript memory across persisted session turns"
+        ));
         assert!(snapshot.contains("- shell.exec: Execute shell commands"));
         assert!(
             snapshot.contains("- sessions_list: List visible sessions and their high-level state")
@@ -302,34 +305,36 @@ mod tests {
 
         // Verify sorted canonical name order.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 14);
+        assert_eq!(lines.len(), 15);
         assert!(lines[0].starts_with("- delegate"));
         assert!(lines[1].starts_with("- delegate_async"));
         assert!(lines[2].starts_with("- file.read"));
         assert!(lines[3].starts_with("- file.write"));
-        assert!(lines[4].starts_with("- session_archive"));
-        assert!(lines[5].starts_with("- session_cancel"));
-        assert!(lines[6].starts_with("- session_events"));
-        assert!(lines[7].starts_with("- session_recover"));
-        assert!(lines[8].starts_with("- session_status"));
-        assert!(lines[9].starts_with("- session_unarchive"));
-        assert!(lines[10].starts_with("- session_wait"));
-        assert!(lines[11].starts_with("- sessions_history"));
-        assert!(lines[12].starts_with("- sessions_list"));
-        assert!(lines[13].starts_with("- shell.exec"));
+        assert!(lines[4].starts_with("- memory_search"));
+        assert!(lines[5].starts_with("- session_archive"));
+        assert!(lines[6].starts_with("- session_cancel"));
+        assert!(lines[7].starts_with("- session_events"));
+        assert!(lines[8].starts_with("- session_recover"));
+        assert!(lines[9].starts_with("- session_status"));
+        assert!(lines[10].starts_with("- session_unarchive"));
+        assert!(lines[11].starts_with("- session_wait"));
+        assert!(lines[12].starts_with("- sessions_history"));
+        assert!(lines[13].starts_with("- sessions_list"));
+        assert!(lines[14].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 14);
+        assert_eq!(entries.len(), 15);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"delegate"));
         assert!(names.contains(&"delegate_async"));
         assert!(names.contains(&"shell.exec"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
+        assert!(names.contains(&"memory_search"));
         assert!(names.contains(&"session_archive"));
         assert!(names.contains(&"session_cancel"));
         assert!(names.contains(&"session_events"));
@@ -345,7 +350,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 14);
+        assert_eq!(defs.len(), 15);
 
         let names: Vec<&str> = defs
             .iter()
@@ -360,6 +365,7 @@ mod tests {
                 "delegate_async",
                 "file_read",
                 "file_write",
+                "memory_search",
                 "session_archive",
                 "session_cancel",
                 "session_events",
@@ -486,6 +492,26 @@ mod tests {
             2
         );
 
+        let memory_search = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "memory_search")
+            .expect("memory_search definition");
+        let memory_search_properties = memory_search["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("memory_search properties");
+        assert!(memory_search_properties.contains_key("query"));
+        assert!(memory_search_properties.contains_key("session_id"));
+        assert!(memory_search_properties.contains_key("session_ids"));
+        assert!(memory_search_properties.contains_key("limit"));
+        assert!(memory_search_properties.contains_key("excerpt_chars"));
+        assert_eq!(
+            memory_search["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("memory_search oneOf")
+                .len(),
+            3
+        );
+
         let sessions_list = defs
             .iter()
             .find(|item| item["function"]["name"] == "sessions_list")
@@ -508,6 +534,7 @@ mod tests {
         assert_eq!(canonical_tool_name("file_write"), "file.write");
         assert_eq!(canonical_tool_name("shell_exec"), "shell.exec");
         assert_eq!(canonical_tool_name("shell"), "shell.exec");
+        assert_eq!(canonical_tool_name("memory_search"), "memory_search");
         assert_eq!(canonical_tool_name("file.read"), "file.read");
     }
 
@@ -594,6 +621,7 @@ mod tests {
         assert!(view.contains("sessions_history"));
         assert!(view.contains("session_status"));
         assert!(view.contains("session_events"));
+        assert!(view.contains("memory_search"));
         assert!(view.contains("session_archive"));
         assert!(view.contains("session_cancel"));
         assert!(view.contains("session_recover"));
@@ -648,6 +676,21 @@ mod tests {
     }
 
     #[test]
+    fn memory_search_is_visible_in_root_and_hidden_in_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("memory_search"));
+
+        let child_view = planned_delegate_child_tool_view();
+        assert!(!child_view.contains("memory_search"));
+
+        let child_with_depth = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
+        );
+        assert!(!child_with_depth.contains("memory_search"));
+    }
+
+    #[test]
     fn session_unarchive_is_visible_in_root_and_hidden_in_child_views() {
         let root_view = runtime_tool_view();
         assert!(root_view.contains("session_unarchive"));
@@ -677,6 +720,7 @@ mod tests {
         assert!(!view.contains("sessions_history"));
         assert!(!view.contains("session_status"));
         assert!(!view.contains("session_events"));
+        assert!(!view.contains("memory_search"));
         assert!(!view.contains("session_archive"));
         assert!(!view.contains("session_recover"));
         assert!(!view.contains("session_unarchive"));

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -9,6 +9,7 @@ mod catalog;
 pub(crate) mod delegate;
 mod file;
 mod kernel_adapter;
+mod memory;
 pub(crate) mod messaging;
 pub mod runtime_config;
 mod session;
@@ -82,6 +83,12 @@ pub fn execute_app_tool_with_config(
                 tool_config,
             )
         }
+        "memory_search" => memory::execute_memory_search_tool_with_policies(
+            request.payload,
+            current_session_id,
+            memory_config,
+            tool_config,
+        ),
         "sessions_send" => Err("app_tool_not_implemented: sessions_send".to_owned()),
         "session_wait" => Err("app_tool_not_implemented: session_wait".to_owned()),
         "delegate" => Err("app_tool_not_implemented: delegate".to_owned()),

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -204,8 +204,16 @@ pub fn capability_snapshot_for_view(view: &ToolView) -> String {
 /// The output shape matches OpenAI-compatible `tools=[{type:function,...}]`.
 /// Order is deterministic for stable prompting/tests.
 pub fn provider_tool_definitions() -> Vec<Value> {
-    try_provider_tool_definitions_for_view(&runtime_tool_view())
-        .expect("runtime tool view should always be advertisable")
+    match try_provider_tool_definitions_for_view(&runtime_tool_view()) {
+        Ok(definitions) => definitions,
+        Err(error) => {
+            debug_assert!(
+                false,
+                "runtime tool view should always be advertisable: {error}"
+            );
+            Vec::new()
+        }
+    }
 }
 
 pub fn try_provider_tool_definitions_for_view(view: &ToolView) -> Result<Vec<Value>, String> {

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -119,6 +119,44 @@ impl SessionMutationRequest {
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn legacy_single_target_session_id(request: &SessionTargetRequest) -> Result<&str, String> {
+    request
+        .session_ids
+        .first()
+        .map(String::as_str)
+        .ok_or_else(|| {
+            "session_tool_invariant_violation: legacy single request requires one session id"
+                .to_owned()
+        })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn set_batch_result(
+    results: &mut [Option<SessionBatchResultRecord>],
+    index: usize,
+    result: SessionBatchResultRecord,
+) -> Result<(), String> {
+    let slot = results
+        .get_mut(index)
+        .ok_or_else(|| format!("session_batch_result_index_out_of_bounds: index {index}"))?;
+    *slot = Some(result);
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn collect_batch_results(
+    results: Vec<Option<SessionBatchResultRecord>>,
+) -> Result<Vec<SessionBatchResultRecord>, String> {
+    results
+        .into_iter()
+        .enumerate()
+        .map(|(index, result)| {
+            result.ok_or_else(|| format!("session_batch_result_missing: index {index}"))
+        })
+        .collect()
+}
+
+#[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SessionRecoverPlan {
     expected_state: SessionState,
@@ -255,10 +293,7 @@ pub(super) async fn wait_for_session_tool_with_policies(
     let event_limit = tool_config.sessions.history_limit.min(50);
 
     if request.legacy_single {
-        let target_session_id = request
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_target_session_id(&request)?;
         return wait_for_single_session_with_policies(
             target_session_id,
             current_session_id,
@@ -443,10 +478,7 @@ fn execute_session_status(
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_target_request(&payload)?;
     if request.legacy_single {
-        let target_session_id = request
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_target_session_id(&request)?;
         let snapshot = inspect_visible_session_with_policies(
             target_session_id,
             current_session_id,
@@ -491,11 +523,7 @@ fn execute_session_recover(
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
     if request.use_legacy_single_response() {
-        let target_session_id = request
-            .target
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_target_session_id(&request.target)?;
         let repo = SessionRepository::new(config)?;
         ensure_visible(
             &repo,
@@ -562,11 +590,7 @@ fn execute_session_cancel(
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
     if request.use_legacy_single_response() {
-        let target_session_id = request
-            .target
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_target_session_id(&request.target)?;
         let repo = SessionRepository::new(config)?;
         ensure_visible(
             &repo,
@@ -633,11 +657,7 @@ fn execute_session_archive(
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
     if request.use_legacy_single_response() {
-        let target_session_id = request
-            .target
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_target_session_id(&request.target)?;
         let repo = SessionRepository::new(config)?;
         ensure_visible(
             &repo,
@@ -704,11 +724,7 @@ fn execute_session_unarchive(
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
     if request.use_legacy_single_response() {
-        let target_session_id = request
-            .target
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_target_session_id(&request.target)?;
         let repo = SessionRepository::new(config)?;
         ensure_visible(
             &repo,
@@ -1261,13 +1277,17 @@ async fn wait_for_session_batch_with_policies(
             &target_session_id,
             tool_config.sessions.visibility,
         ) {
-            results[index] = Some(session_batch_result(
-                target_session_id,
-                "skipped_not_visible",
-                Some(error),
-                None,
-                None,
-            ));
+            set_batch_result(
+                &mut results,
+                index,
+                session_batch_result(
+                    target_session_id,
+                    "skipped_not_visible",
+                    Some(error),
+                    None,
+                    None,
+                ),
+            )?;
             continue;
         }
         pending.push(SessionWaitTargetState {
@@ -1295,13 +1315,17 @@ async fn wait_for_session_batch_with_policies(
             ) {
                 Ok(observation) => observation,
                 Err(error) if is_session_visibility_skip_error(&error) => {
-                    results[target.index] = Some(session_batch_result(
-                        target.session_id,
-                        "skipped_not_visible",
-                        Some(error),
-                        None,
-                        None,
-                    ));
+                    set_batch_result(
+                        &mut results,
+                        target.index,
+                        session_batch_result(
+                            target.session_id,
+                            "skipped_not_visible",
+                            Some(error),
+                            None,
+                            None,
+                        ),
+                    )?;
                     continue;
                 }
                 Err(error) => return Err(error),
@@ -1313,24 +1337,28 @@ async fn wait_for_session_batch_with_policies(
             target.observed_events.extend(observation.tail_events);
             target.latest_inspection = Some(snapshot.clone());
             if session_state_is_terminal(snapshot.session.state) {
-                results[target.index] = Some(session_batch_result(
-                    target.session_id,
-                    "ok",
-                    None,
-                    None,
-                    Some(wait_payload(
-                        snapshot,
-                        "completed",
-                        after_id,
-                        timeout_ms,
-                        if after_id.is_some() {
-                            std::mem::take(&mut target.observed_events)
-                        } else {
-                            Vec::new()
-                        },
-                        target.next_after_id,
-                    )),
-                ));
+                set_batch_result(
+                    &mut results,
+                    target.index,
+                    session_batch_result(
+                        target.session_id,
+                        "ok",
+                        None,
+                        None,
+                        Some(wait_payload(
+                            snapshot,
+                            "completed",
+                            after_id,
+                            timeout_ms,
+                            if after_id.is_some() {
+                                std::mem::take(&mut target.observed_events)
+                            } else {
+                                Vec::new()
+                            },
+                            target.next_after_id,
+                        )),
+                    ),
+                )?;
                 continue;
             }
             next_pending.push(target);
@@ -1344,10 +1372,7 @@ async fn wait_for_session_batch_with_policies(
                     current_session_id,
                     after_id,
                     timeout_ms,
-                    results
-                        .into_iter()
-                        .map(|result| result.expect("batch wait result"))
-                        .collect::<Vec<_>>(),
+                    collect_batch_results(results)?,
                 ),
             });
         }
@@ -1355,28 +1380,34 @@ async fn wait_for_session_batch_with_policies(
         let elapsed_ms = started_at.elapsed().as_millis() as u64;
         if elapsed_ms >= timeout_ms {
             for mut target in pending.into_iter() {
-                let snapshot = target
-                    .latest_inspection
-                    .take()
-                    .expect("pending batch wait target inspection");
-                results[target.index] = Some(session_batch_result(
-                    target.session_id,
-                    "timeout",
-                    None,
-                    None,
-                    Some(wait_payload(
-                        snapshot,
+                let Some(snapshot) = target.latest_inspection.take() else {
+                    return Err(format!(
+                        "session_wait_missing_inspection: `{}`",
+                        target.session_id
+                    ));
+                };
+                set_batch_result(
+                    &mut results,
+                    target.index,
+                    session_batch_result(
+                        target.session_id,
                         "timeout",
-                        after_id,
-                        timeout_ms,
-                        if after_id.is_some() {
-                            target.observed_events
-                        } else {
-                            Vec::new()
-                        },
-                        target.next_after_id,
-                    )),
-                ));
+                        None,
+                        None,
+                        Some(wait_payload(
+                            snapshot,
+                            "timeout",
+                            after_id,
+                            timeout_ms,
+                            if after_id.is_some() {
+                                target.observed_events
+                            } else {
+                                Vec::new()
+                            },
+                            target.next_after_id,
+                        )),
+                    ),
+                )?;
             }
 
             return Ok(ToolCoreOutcome {
@@ -1385,10 +1416,7 @@ async fn wait_for_session_batch_with_policies(
                     current_session_id,
                     after_id,
                     timeout_ms,
-                    results
-                        .into_iter()
-                        .map(|result| result.expect("batch wait result"))
-                        .collect::<Vec<_>>(),
+                    collect_batch_results(results)?,
                 ),
             });
         }
@@ -1700,11 +1728,14 @@ fn apply_session_recover_plan(
     );
     let event_payload_json = match recover_plan.recovery_kind {
         RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED => {
+            let queued_at = recover_plan.queued_at.ok_or_else(|| {
+                format!(
+                    "session_recover_missing_queued_at: session `{target_session_id}` requires queued_at"
+                )
+            })?;
             build_queued_async_overdue_recovery_payload(
                 snapshot.session.label.as_deref(),
-                recover_plan
-                    .queued_at
-                    .expect("queued async overdue recovery requires queued_at"),
+                queued_at,
                 recover_plan.elapsed_seconds,
                 recover_plan.timeout_seconds,
                 recover_plan.deadline_at,
@@ -1723,7 +1754,7 @@ fn apply_session_recover_plan(
                 &recovery_error,
             )
         }
-        other => unreachable!("unsupported session recovery kind `{other}`"),
+        other => return Err(format!("session_recover_unsupported_kind: `{other}`")),
     };
     let finalized = repo.finalize_session_terminal_if_current(
         target_session_id,
@@ -1873,7 +1904,7 @@ fn session_recovery_error(plan: &SessionRecoverPlan) -> String {
             "delegate_async_running_overdue_marked_failed: running delegate child exceeded timeout after {}s (threshold {}s)",
             plan.elapsed_seconds, plan.timeout_seconds
         ),
-        other => unreachable!("unsupported session recovery kind `{other}`"),
+        other => format!("session_recover_unsupported_kind: `{other}`"),
     }
 }
 
@@ -2562,10 +2593,11 @@ fn session_batch_payload_with_optional_dry_run(
         "results": results.into_iter().map(session_batch_result_json).collect::<Vec<_>>(),
     });
     if let Some(dry_run) = dry_run {
-        payload
-            .as_object_mut()
-            .expect("session batch payload object")
-            .insert("dry_run".to_owned(), Value::Bool(dry_run));
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("dry_run".to_owned(), Value::Bool(dry_run));
+        } else {
+            debug_assert!(false, "session batch payload object");
+        }
     }
     payload
 }
@@ -2583,17 +2615,15 @@ fn session_wait_batch_payload(
         results.len(),
         results,
     );
-    payload
-        .as_object_mut()
-        .expect("session wait batch payload object")
-        .insert("timeout_ms".to_owned(), Value::from(timeout_ms));
-    payload
-        .as_object_mut()
-        .expect("session wait batch payload object")
-        .insert(
+    if let Some(object) = payload.as_object_mut() {
+        object.insert("timeout_ms".to_owned(), Value::from(timeout_ms));
+        object.insert(
             "after_id".to_owned(),
             after_id.map(Value::from).unwrap_or(Value::Null),
         );
+    } else {
+        debug_assert!(false, "session wait batch payload object");
+    }
     payload
 }
 
@@ -2741,15 +2771,16 @@ fn session_summary_json_with_delegate_lifecycle(
 ) -> Value {
     let mut payload = session_summary_json(session);
     if include_delegate_lifecycle {
-        payload
-            .as_object_mut()
-            .expect("session summary json object")
-            .insert(
+        if let Some(object) = payload.as_object_mut() {
+            object.insert(
                 "delegate_lifecycle".to_owned(),
                 delegate_lifecycle
                     .map(session_delegate_lifecycle_json)
                     .unwrap_or(Value::Null),
             );
+        } else {
+            debug_assert!(false, "session summary json object");
+        }
     }
     payload
 }

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -1,3 +1,12 @@
+#![allow(
+    clippy::await_holding_lock,
+    clippy::expect_used,
+    clippy::indexing_slicing
+)]
+
+// These daemon tests intentionally serialize env-dependent subprocess cases
+// and use direct JSON assertions to keep the harness straightforward.
+
 use super::*;
 use clap::Parser;
 use std::path::PathBuf;

--- a/crates/daemon/tests/delegate_async_observability.rs
+++ b/crates/daemon/tests/delegate_async_observability.rs
@@ -1,3 +1,13 @@
+#![allow(
+    clippy::await_holding_lock,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::map_err_ignore
+)]
+
+// This integration harness intentionally serializes env-dependent subprocess tests
+// and uses direct JSON assertions for readability.
+
 use async_trait::async_trait;
 use loongclaw_app as mvp;
 use loongclaw_contracts::ToolCoreRequest;

--- a/docs/plans/2026-03-13-memory-search-design.md
+++ b/docs/plans/2026-03-13-memory-search-design.md
@@ -1,0 +1,375 @@
+# Memory Search Design
+
+## Context
+
+LoongClaw's current thick app-layer tool surface is centered on session inspection and delegation:
+
+- `sessions_list`
+- `sessions_history`
+- `session_status`
+- `session_events`
+- `session_archive`
+- `session_unarchive`
+- `session_cancel`
+- `session_recover`
+- `session_wait`
+- `sessions_send`
+- `delegate`
+- `delegate_async`
+
+That surface is now substantially stronger, but it still lacks a truthful memory retrieval primitive.
+The app already persists transcript turns into SQLite and already has session visibility rules, yet
+the only memory-facing behavior exposed to the model is indirect session history inspection.
+
+External comparison points in the same direction, but also clarifies what *not* to do:
+
+- OpenClaw's `memory_search` rides on a much heavier substrate with indexed Markdown memories,
+  FTS, embeddings, and hybrid retrieval.
+- ZeroClaw's memory recall similarly depends on FTS, vector search, hybrid merge, and pluggable
+  memory backends.
+- NanoBot and NanoClaw both reinforce that memory and scheduling are useful, but their broader
+  runtime architecture is substantially heavier than LoongClaw's current app substrate.
+
+The correct next step for LoongClaw is not "semantic memory." It is a truthful transcript-backed
+search primitive over the durable data the app already owns.
+
+## Problem
+
+Operators and models can inspect a known session's history, but they cannot ask the system to find
+where a fact, phrase, or prior instruction appeared within the caller's visible transcript scope.
+
+Today that means:
+
+- history can only be inspected session-by-session
+- agents must already know which session to inspect
+- archived but still relevant sessions are harder to rediscover
+- transcript persistence exists, but there is no direct search affordance over it
+
+This is a real product gap and a better target than broadening into scheduler, browser, or fake
+semantic-memory claims.
+
+## Goals
+
+- Add a truthful `memory_search` app tool for transcript retrieval.
+- Search only over persisted transcript turns in SQLite `turns`.
+- Reuse existing session visibility rules instead of broadening authority.
+- Support single-target, batch-target, and default visible-scope searches.
+- Return enough structure for agents to identify where a hit came from without dumping full
+  transcript bodies.
+- Keep the tool contract honest about match semantics in this phase.
+
+## Non-Goals
+
+- No embeddings, vector search, BM25, hybrid recall, or semantic ranking.
+- No search over `session_events` or other control-plane records.
+- No new long-term memory store distinct from transcript persistence.
+- No full-content export behavior; complete transcript reading remains `sessions_history`.
+- No pagination or streaming in the first slice.
+- No scheduler, cron, browser, or web retrieval work in this phase.
+
+## Chosen Primitive
+
+Add `memory_search`.
+
+`memory_search` searches durable transcript turns that are visible from the calling session and
+returns structured matches. It is intentionally transcript search, not knowledge-base search and
+not semantic recall.
+
+The tool should be described truthfully:
+
+- source: transcript turns already written to SQLite
+- match type: exact text / substring-style search
+- authority: existing visible session scope only
+- output: match records with snippets and identifiers, not synthesized answers
+
+## Scope Rules
+
+### Visible scope
+
+When the request does not specify a target session, `memory_search` searches the caller's current
+visible scope:
+
+- the current root session plus visible descendant delegate sessions
+- or only `self` when session visibility is configured that way
+
+### Single-target scope
+
+When the request specifies `session_id`, the tool searches only that target session.
+
+Rules:
+
+- target must be visible under the existing visibility model
+- target may be archived; archive affects inventory visibility, not transcript existence
+- legacy current-session transcript rows remain eligible through the same best-effort fallback used
+  elsewhere in session inspection
+
+### Batch scope
+
+When the request specifies `session_ids`, the tool searches the visible subset of those targets.
+
+Rules:
+
+- visible targets are searched
+- hidden or missing targets are reported in structured skipped metadata
+- one bad target must not fail the entire batch request
+
+## Request Contract
+
+`memory_search` accepts these fields:
+
+- `query` (required)
+- `session_id` (optional, mutually exclusive with `session_ids`)
+- `session_ids` (optional, mutually exclusive with `session_id`)
+- `limit` (optional, default `20`, max `100`)
+- `excerpt_chars` (optional, default `120`, clamped to a safe range)
+
+Request rules:
+
+- `query` must be a non-empty string after trimming
+- `session_id` and `session_ids` cannot both be present
+- no explicit target means "search visible scope"
+- single-target invisible requests fail like existing direct inspection tools
+- batch requests use best-effort result accounting instead of failing on partial invisibility
+
+Representative requests:
+
+```json
+{
+  "query": "timeout budget"
+}
+```
+
+```json
+{
+  "query": "handoff note",
+  "session_id": "delegate:child-123",
+  "limit": 10,
+  "excerpt_chars": 160
+}
+```
+
+```json
+{
+  "query": "memory adapter",
+  "session_ids": ["root-a", "delegate:child-1", "hidden-root"],
+  "limit": 25
+}
+```
+
+## Response Contract
+
+The top-level response should stay simple and explicit:
+
+- `query`
+- `scope`
+- `matches`
+- `returned_count`
+- `limit`
+- `truncated`
+
+### Scope payload
+
+`scope` should include:
+
+- `mode`: `visible`, `single`, or `batch`
+- `current_session_id`
+- `searched_session_ids`
+- `searched_session_count`
+- `skipped_targets` for batch requests
+
+`skipped_targets` should classify each skipped target, for example:
+
+- `skipped_not_visible`
+- `skipped_not_found`
+
+### Match payload
+
+Each match should include:
+
+- `session_id`
+- `turn_id`
+- `role`
+- `ts`
+- `content_snippet`
+- `match`
+
+`match` should include:
+
+- `query`
+- `match_kind` with phase-one value `substring`
+- `excerpt_chars`
+
+Representative match shape:
+
+```json
+{
+  "session_id": "delegate:child-123",
+  "turn_id": 91,
+  "role": "assistant",
+  "ts": 1763020000,
+  "content_snippet": "...timeout budget was reduced after the second retry spike...",
+  "match": {
+    "query": "timeout budget",
+    "match_kind": "substring",
+    "excerpt_chars": 120
+  }
+}
+```
+
+## Query Semantics
+
+Phase one should deliberately use the simplest honest query semantics:
+
+- search only `turns.content`
+- perform substring-style text matching
+- order hits by most recent first: `ts DESC`, then `id DESC`
+
+This is intentionally not positioned as "best" or "most relevant" retrieval. It is recent-first
+transcript search over exact stored text.
+
+## Why Not FTS Or Semantic Memory Yet
+
+LoongClaw does not yet have the supporting substrate required to make stronger claims:
+
+- no memory-specific chunking pipeline
+- no embedding lifecycle
+- no vector index maintenance
+- no hybrid merge semantics
+- no durable semantic-retrieval contract already exposed elsewhere in the app
+
+Adding a tool named `memory_search` that clearly performs transcript text search is still honest.
+Adding a tool that implies semantic recall without those supporting layers would not be.
+
+This design leaves a clean future path:
+
+- phase 1: `LIKE` / substring transcript search
+- future phase: SQLite FTS5 keyword search
+- later phase: hybrid or semantic retrieval only once indexing and consistency semantics are real
+
+## Internal Design
+
+### Storage and query layer
+
+Add a transcript search helper on top of the existing SQLite memory store.
+
+The query should:
+
+- read from `turns`
+- restrict to resolved target session ids
+- match on `content`
+- return `id`, `session_id`, `role`, `content`, and `ts`
+
+The helper should not search `session_events`, because control-plane events are intentionally kept
+out of transcript history and should stay out of transcript search results too.
+
+### Visibility layer
+
+Reuse the existing session repository and visibility semantics:
+
+- `list_visible_sessions`
+- `is_session_visible`
+- legacy current-session fallback where already supported
+
+This ensures `memory_search` behaves like the session tool family rather than introducing a second
+visibility model.
+
+### Tool layer
+
+Expose `memory_search` as a real app tool:
+
+- add it to the tool catalog and provider definitions
+- gate it under session-tool enablement for this phase
+- implement it in a dedicated tool module rather than expanding `session.rs` further
+
+This keeps the new tool aligned with the thick app-layer direction while containing code growth.
+
+## Error Model
+
+Representative direct errors:
+
+- `memory_search_invalid_request: ...`
+- `visibility_denied: ...`
+- `session_not_found: ...`
+
+Batch requests should not fail for hidden or missing targets. Those targets should instead appear
+under `scope.skipped_targets`.
+
+No matches is not an error. It should return:
+
+- `matches: []`
+- `returned_count: 0`
+- `truncated: false`
+
+## Testing Plan
+
+Minimum required coverage:
+
+- single-session search returns structured hits with `turn_id`, `role`, `ts`, and snippet
+- default visible-scope search includes current root plus visible descendant delegate sessions
+- delegated child search cannot reach hidden or sibling sessions outside visibility rules
+- archived visible sessions still contribute searchable transcript hits
+- legacy current-session transcript rows can be searched without backfilling `sessions`
+- single-target hidden session returns `visibility_denied`
+- batch search returns mixed searched and skipped target accounting
+- search results never include control-plane session events
+- `limit` and `excerpt_chars` clamping works as documented
+- no-hit queries return an empty result set rather than an error
+
+## Alternatives Considered
+
+### 1. Expose only `memory_window` or `memory_get`
+
+Pros:
+
+- smaller implementation
+- almost no new query semantics
+
+Cons:
+
+- does not solve rediscovery
+- overlaps heavily with `sessions_history`
+- weaker user value than true transcript search
+
+Rejected because the next thick tool should increase retrieval power, not just add another way to
+read already-known history.
+
+### 2. Build scheduler or cron tools first
+
+Pros:
+
+- externally comparable repos often expose scheduling primitives
+
+Cons:
+
+- LoongClaw does not yet have a truthful durable scheduler substrate
+- delivery semantics, retries, ownership, and restart behavior are still undefined
+
+Rejected because it would force a wider and less honest control surface than the app currently
+supports.
+
+### 3. Jump directly to semantic memory
+
+Pros:
+
+- richer retrieval story
+
+Cons:
+
+- requires a much heavier substrate than LoongClaw currently has
+- would encourage product claims the runtime cannot yet back up
+
+Rejected because the product direction is "few but thick and truthful," not "broad but suggestive."
+
+## Why This Design
+
+`memory_search` is the strongest next tool LoongClaw can add without pretending to have a larger
+memory system than it does.
+
+It deepens real substrate that already exists:
+
+- durable transcript persistence
+- session visibility rules
+- session archive lifecycle
+- app-layer orchestration tools
+
+And it does so without widening into adjacent surfaces that still lack honest runtime backing.

--- a/docs/plans/2026-03-13-memory-search-implementation-plan.md
+++ b/docs/plans/2026-03-13-memory-search-implementation-plan.md
@@ -1,0 +1,335 @@
+# Memory Search Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a truthful `memory_search` app tool that searches visible transcript turns and returns structured snippet matches without claiming semantic memory.
+
+**Architecture:** Implement transcript search on top of the existing SQLite `turns` store, reuse session visibility and legacy fallback rules from the session repository, and expose `memory_search` as a new app-layer tool with a narrow provider schema. Land the feature through TDD in small slices: repository-free query helper first, then app-tool surface and scope resolution, then product docs and full verification.
+
+**Tech Stack:** Rust, `rusqlite`, existing LoongClaw app tool catalog and dispatcher, SQLite-backed session repository, Cargo tests.
+
+---
+
+### Task 1: Add the failing transcript-search memory tests
+
+**Files:**
+- Modify: `crates/app/src/memory/mod.rs`
+- Modify: `crates/app/src/memory/sqlite.rs`
+
+**Step 1: Write the failing tests**
+
+Add focused unit tests in `crates/app/src/memory/mod.rs` or `crates/app/src/memory/sqlite.rs` for:
+
+- `search_transcript_direct_returns_recent_matching_turns`
+- `search_transcript_direct_excludes_non_matching_turns`
+- `search_transcript_direct_clamps_limit_and_excerpt`
+
+The tests should:
+
+- create an isolated SQLite path with `MemoryRuntimeConfig`
+- append several turns across one or more sessions
+- search for a phrase that appears in multiple rows
+- assert that results include `turn_id`, `session_id`, `role`, `ts`, and a clipped snippet
+- assert newest-first ordering
+- assert a no-match query returns an empty list
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app search_transcript_direct -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- compile or test failure because transcript-search helpers and result structs do not exist yet
+
+**Step 3: Write minimal implementation**
+
+Implement the minimum SQLite search support in `crates/app/src/memory/sqlite.rs`:
+
+- add a search result struct that includes `turn_id`, `session_id`, `role`, `content`, and `ts`
+- add a helper that executes a substring-style query against `turns.content`
+- add safe clamping for limit and excerpt sizes
+- add a direct helper callable from tests
+
+Keep the implementation narrow:
+
+- search only `turns`
+- use recent-first ordering
+- do not add FTS, extra indexes, or semantic-ranking behavior
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app search_transcript_direct -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- the new transcript-search tests pass
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/memory/mod.rs crates/app/src/memory/sqlite.rs
+git commit -m "feat(app): add transcript memory search helpers"
+```
+
+### Task 2: Add the failing app-tool behavior tests for `memory_search`
+
+**Files:**
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/catalog.rs`
+- Create: `crates/app/src/tools/memory.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing tests**
+
+Add focused app-tool tests alongside the existing session-tool coverage, preferably in
+`crates/app/src/tools/memory.rs` if that module owns its own tests.
+
+Add tests for:
+
+- `memory_search_searches_visible_scope_by_default`
+- `memory_search_rejects_invisible_single_target`
+- `memory_search_batch_reports_skipped_targets`
+- `memory_search_includes_archived_visible_sessions`
+- `memory_search_supports_legacy_current_session_transcript`
+- `memory_search_does_not_return_session_events`
+
+Test fixtures should:
+
+- build isolated `MemoryRuntimeConfig`
+- create root and delegate-child sessions with `SessionRepository`
+- archive one finished visible session to prove archived transcripts still search
+- append transcript turns and control-plane events separately
+- execute the tool through `execute_app_tool_with_config`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app memory_search_ -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- compile or test failure because the tool is not cataloged or implemented yet
+
+**Step 3: Write minimal implementation**
+
+Implement the app-layer tool:
+
+- add `memory_search` to `crates/app/src/tools/catalog.rs`
+- expose a provider schema with `query`, `session_id`, `session_ids`, `limit`, and `excerpt_chars`
+- route `memory_search` from `crates/app/src/tools/mod.rs`
+- create `crates/app/src/tools/memory.rs` to own:
+  - request parsing
+  - visible-scope target resolution
+  - single-target visibility checks
+  - batch skipped-target accounting
+  - snippet shaping and top-level response payload
+
+Reuse existing session visibility and legacy-fallback behavior rather than re-inventing it.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app memory_search_ -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- the new `memory_search` app-tool tests pass
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/mod.rs crates/app/src/tools/catalog.rs crates/app/src/tools/memory.rs crates/app/src/tools/session.rs
+git commit -m "feat(app): add memory search tool surface"
+```
+
+### Task 3: Add provider-view and runtime registration coverage
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add or extend tests to prove:
+
+- `memory_search` appears in the runtime tool registry when session tools are enabled
+- provider tool definitions include the new function schema
+- canonical tool-name resolution works for `memory_search`
+
+If existing tests already cover adjacent registry behavior, extend them with `memory_search`
+assertions instead of creating redundant new fixtures.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app tool_registry -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- failure because the registry/provider surface does not yet advertise `memory_search` completely
+
+**Step 3: Write minimal implementation**
+
+Adjust the tool view and registration paths so `memory_search` is treated as a truthful runtime app
+tool in the same enablement family as other session-scoped app tools.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app tool_registry -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- the registry/provider assertions pass
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/catalog.rs crates/app/src/tools/mod.rs
+git commit -m "feat(app): advertise memory search runtime tool"
+```
+
+### Task 4: Update product docs and acceptance criteria
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Write the doc changes**
+
+Update product-facing docs to reflect the new tool:
+
+- add `memory_search` to the accepted root tool surface
+- document the truthful phase-one scope: transcript search over visible sessions
+- note that semantic memory, FTS, and vector retrieval remain out of scope
+
+Keep the wording aligned with the design doc rather than promising future capabilities as if they
+already ship.
+
+**Step 2: Review the doc diff**
+
+Run:
+
+```bash
+git diff -- docs/product-specs/index.md docs/roadmap.md
+```
+
+Expected:
+
+- only the documented `memory_search` surface and roadmap wording changed
+
+**Step 3: Commit**
+
+```bash
+git add docs/product-specs/index.md docs/roadmap.md
+git commit -m "docs: describe memory search tool surface"
+```
+
+### Task 5: Full verification and cleanup
+
+**Files:**
+- Modify if needed: any files touched above
+
+**Step 1: Run focused package tests**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app memory_search_ search_transcript_direct tool_registry -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- focused new coverage passes
+
+**Step 2: Run the full app package tests**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- all `loongclaw-app` tests pass
+
+**Step 3: Run formatting**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all
+```
+
+Expected:
+
+- no formatting errors
+
+**Step 4: Re-run the full app package tests after formatting**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- all `loongclaw-app` tests still pass after formatting
+
+**Step 5: Compile daemon tests without running**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-daemon --no-run
+```
+
+Expected:
+
+- daemon targets compile successfully, proving the app-tool surface change does not break daemon integration
+
+**Step 6: Inspect the final branch state**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -6
+```
+
+Expected:
+
+- clean worktree
+- small, isolated commits for helpers, tool surface, docs, and formatting if needed
+
+**Step 7: Commit any final formatting-only adjustments**
+
+```bash
+git add -A
+git commit -m "style(rust): format memory search changes"
+```
+
+Only do this step if formatting changed tracked files and those changes are not already included in
+an earlier commit.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -14,7 +14,7 @@ Product specs describe **what** the product does from the user's perspective, no
 As an operator using LoongClaw's tool-calling runtime, I want to inspect active sessions and delegate focused subtasks into child sessions so that I can keep orchestration explicit, auditable, and bounded.
 
 ## Acceptance Criteria
-- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
+- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `memory_search`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
 - [x] Delegated child sessions run with a restricted tool surface derived from config rather than inheriting the full root tool set.
 - [x] Delegated child sessions can use `session_status` and `sessions_history` for self-inspection only, and never gain `sessions_list`.
 - [x] Nested delegation is bounded by `tools.delegate.max_depth` and enforced from session lineage, not by ad-hoc one-off checks.
@@ -38,13 +38,16 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_archive` accepts either `session_id` or `session_ids`, supports `dry_run` preview, and returns per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
 - [x] `session_unarchive` accepts either `session_id` or `session_ids`, supports `dry_run` preview, and returns per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
 - [x] `sessions_send` can send plain outbound text to a known channel-backed root session (`telegram:<chat_id>` or `feishu:<chat_id>`), recording a non-transcript control event without executing a target-side provider turn or mutating transcript rows.
+- [x] `memory_search` can search persisted transcript turns across the caller's visible session scope, or within explicitly targeted visible sessions, and return structured recent-first match snippets without searching control-plane `session_events`.
 
 ## Current Limits
 - `delegate_async` uses a subprocess one-shot worker (`loongclawd run-turn`) rather than a durable queue or resident worker pool.
 - Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
 - `sessions_send` is intentionally narrow: only known root sessions backed by currently supported Telegram or Feishu targets are eligible.
+- `memory_search` is transcript text search only. It does not claim embedding-based, vector, BM25, hybrid, or semantic memory recall in this phase.
 - `session_archive` only applies to already-terminal visible sessions; it is inventory cleanup, not route shutdown, transcript deletion, or true session close.
 - `session_unarchive` only applies to already-archived terminal visible sessions; it restores default listing visibility, not execution, routing, or a new live session epoch.
+- `memory_search` only searches persisted transcript rows in `turns`; it does not search `session_events`, external knowledge stores, or detached long-term memory documents.
 - `session_cancel` cancels queued async children immediately, but running cancellation is cooperative at turn-loop checkpoints rather than hard process preemption.
 - `session_recover` only handles overdue async delegate children in `ready` or `running`; it is an operator-driven recovery path, not hard kill, retry, or automatic restart recovery.
 - Batch remediation is best-effort per target. Mixed applicability returns structured per-target results rather than an atomic all-or-nothing transaction.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,9 +200,11 @@ Delivered in current baseline:
   - per-session runtime tool views derived from config
   - sqlite-backed session registry and session event history
   - durable terminal outcomes for delegated child sessions
-  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
+  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `memory_search`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
     with optional incremental event-tail return via `after_id`, draining unseen events through the
     current cursor and terminal completion
+  - transcript-backed `memory_search` over visible session scope or explicit visible targets, with
+    structured recent-first snippet matches and no control-plane event search
   - filtered `sessions_list` discovery for visible stale delegates, with optional lifecycle payloads
     and stable lifecycle-anchor reads that do not depend on recent-event windows
   - durable session archive / unarchive lifecycle for visible terminal sessions, including default


### PR DESCRIPTION
## Summary

- add transcript-backed search helpers over persisted SQLite transcript turns
- expose an app-layer `memory_search` tool with visibility-aware default, single-session, and batch-session scope handling
- advertise `memory_search` in the runtime catalog, provider tool schema, and product docs
- this change is needed to give archived session history a truthful search surface instead of forcing manual transcript inspection

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

Scope note: this PR is intentionally stacked on top of `#88` so reviewers only see the `memory_search` increment.

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

Risk note: the feature is scoped to one new tool surface with focused regression coverage for helper behavior, visibility, and provider payload contracts.

## Validation

- [x] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional checks executed:

- [x] `<local-absolute-path> test -p loongclaw-app -- --nocapture --test-threads=1`
- [x] `<local-absolute-path> test -p loongclaw-daemon --no-run`

## Stack Context

- Base branch: `feat/session-unarchive-pr-20260313`
- This PR is intentionally stacked on top of `#88` so reviewers only see the `memory_search` increment. After the lower stack lands, this PR can be retargeted to `alpha-test`.

## Linked Issues

Closes #91