### PR TITLE
refactor(tools): unify non-delegate app tool runtime

### DIFF
--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1,25 +1,18 @@
 use async_trait::async_trait;
-use futures_util::FutureExt;
-use std::any::Any;
 use std::collections::BTreeSet;
-use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 #[cfg(feature = "memory-sqlite")]
 use std::{
-    io::{self, Write},
     path::{Path, PathBuf},
     process::Stdio,
 };
 
 use loongclaw_contracts::{Capability, KernelError, ToolCoreOutcome, ToolCoreRequest};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 
 use crate::config::{LoongClawConfig, SessionVisibility, ToolConfig};
 use crate::context::KernelContext;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
-#[cfg(feature = "memory-sqlite")]
-use crate::session::recovery::{build_async_spawn_failure_recovery_payload, RECOVERY_EVENT_KIND};
 use crate::tools::{
     delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
     runtime_tool_view, runtime_tool_view_for_config, tool_catalog, ToolExecutionKind, ToolView,
@@ -165,155 +158,6 @@ impl crate::tools::delegate::AsyncDelegateSpawner for SubprocessAsyncDelegateSpa
     }
 }
 
-#[cfg(feature = "memory-sqlite")]
-fn finalize_async_delegate_spawn_failure(
-    memory_config: &MemoryRuntimeConfig,
-    child_session_id: &str,
-    parent_session_id: &str,
-    label: Option<String>,
-    error: String,
-) -> Result<(), String> {
-    let repo = crate::session::repository::SessionRepository::new(memory_config)?;
-    let outcome = crate::tools::delegate::delegate_error_outcome(
-        child_session_id.to_owned(),
-        label,
-        error.clone(),
-        0,
-    );
-    repo.finalize_session_terminal(
-        child_session_id,
-        crate::session::repository::FinalizeSessionTerminalRequest {
-            state: crate::session::repository::SessionState::Failed,
-            last_error: Some(error.clone()),
-            event_kind: "delegate_spawn_failed".to_owned(),
-            actor_session_id: Some(parent_session_id.to_owned()),
-            event_payload_json: json!({
-                "error": error,
-            }),
-            outcome_status: outcome.status,
-            outcome_payload_json: outcome.payload,
-        },
-    )?;
-    Ok(())
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn finalize_async_delegate_spawn_failure_with_recovery(
-    memory_config: &MemoryRuntimeConfig,
-    child_session_id: &str,
-    parent_session_id: &str,
-    label: Option<String>,
-    error: String,
-) -> Result<(), String> {
-    let recovery_label = label.clone();
-    match finalize_async_delegate_spawn_failure(
-        memory_config,
-        child_session_id,
-        parent_session_id,
-        label,
-        error.clone(),
-    ) {
-        Ok(()) => Ok(()),
-        Err(finalize_error) => {
-            let repo = crate::session::repository::SessionRepository::new(memory_config)?;
-            let recovery_error = format!(
-                "delegate_async_spawn_failure_persist_failed: {finalize_error}; original spawn error: {error}"
-            );
-            match repo.transition_session_with_event_if_current(
-                child_session_id,
-                crate::session::repository::TransitionSessionWithEventIfCurrentRequest {
-                    expected_state: crate::session::repository::SessionState::Ready,
-                    next_state: crate::session::repository::SessionState::Failed,
-                    last_error: Some(recovery_error.clone()),
-                    event_kind: RECOVERY_EVENT_KIND.to_owned(),
-                    actor_session_id: Some(parent_session_id.to_owned()),
-                    event_payload_json: build_async_spawn_failure_recovery_payload(
-                        recovery_label.as_deref(),
-                        &error,
-                        &recovery_error,
-                    ),
-                },
-            ) {
-                Ok(Some(_)) => Ok(()),
-                Ok(None) => {
-                    let current_state = repo
-                        .load_session(child_session_id)?
-                        .map(|session| session.state.as_str().to_owned())
-                        .unwrap_or_else(|| "missing".to_owned());
-                    Err(format!(
-                        "{recovery_error}; delegate_async_spawn_recovery_skipped_from_state: {current_state}"
-                    ))
-                }
-                Err(recovery_event_error) => match repo.update_session_state_if_current(
-                    child_session_id,
-                    crate::session::repository::SessionState::Ready,
-                    crate::session::repository::SessionState::Failed,
-                    Some(recovery_error.clone()),
-                ) {
-                    Ok(Some(_)) => Ok(()),
-                    Ok(None) => {
-                        let current_state = repo
-                            .load_session(child_session_id)?
-                            .map(|session| session.state.as_str().to_owned())
-                            .unwrap_or_else(|| "missing".to_owned());
-                        Err(format!(
-                            "{recovery_error}; delegate_async_spawn_recovery_skipped_from_state: {current_state}"
-                        ))
-                    }
-                    Err(mark_error) => Err(format!(
-                        "{recovery_error}; delegate_async_spawn_recovery_failed: {mark_error}; delegate_async_spawn_recovery_event_failed: {recovery_event_error}"
-                    )),
-                },
-            }
-        }
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn format_async_delegate_spawn_panic(panic_payload: Box<dyn Any + Send>) -> String {
-    let panic_payload = match panic_payload.downcast::<String>() {
-        Ok(message) => return format!("delegate_async_spawn_panic: {}", *message),
-        Err(panic_payload) => panic_payload,
-    };
-    match panic_payload.downcast::<&'static str>() {
-        Ok(message) => format!("delegate_async_spawn_panic: {}", *message),
-        Err(_) => "delegate_async_spawn_panic".to_owned(),
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn spawn_async_delegate_detached(
-    runtime_handle: tokio::runtime::Handle,
-    memory_config: MemoryRuntimeConfig,
-    spawner: Arc<dyn AsyncDelegateSpawner>,
-    request: AsyncDelegateSpawnRequest,
-) {
-    let child_session_id = request.child_session_id.clone();
-    let parent_session_id = request.parent_session_id.clone();
-    let label = request.label.clone();
-    runtime_handle.spawn(async move {
-        let spawn_failure = match AssertUnwindSafe(spawner.spawn(request)).catch_unwind().await {
-            Ok(Ok(())) => None,
-            Ok(Err(error)) => Some(error),
-            Err(panic_payload) => Some(format_async_delegate_spawn_panic(panic_payload)),
-        };
-        if let Some(error) = spawn_failure {
-            if let Err(finalize_error) = finalize_async_delegate_spawn_failure_with_recovery(
-                &memory_config,
-                &child_session_id,
-                &parent_session_id,
-                label,
-                error.clone(),
-            ) {
-                let mut stderr = io::stderr().lock();
-                let _ = writeln!(
-                    &mut stderr,
-                    "error: async delegate spawn failure persistence failed for `{child_session_id}`: {finalize_error}; original spawn error: {error}"
-                );
-            }
-        }
-    });
-}
 pub struct NoopAppToolDispatcher;
 
 #[async_trait]

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1,8 +1,5 @@
 use async_trait::async_trait;
-use futures_util::FutureExt;
-use std::any::Any;
 use std::collections::BTreeSet;
-use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 #[cfg(feature = "memory-sqlite")]
 use std::{
@@ -13,19 +10,18 @@ use std::{
 
 use loongclaw_contracts::{Capability, KernelError, ToolCoreOutcome, ToolCoreRequest};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 
 use crate::config::{LoongClawConfig, SessionVisibility, ToolConfig};
 use crate::context::KernelContext;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
-#[cfg(feature = "memory-sqlite")]
-use crate::session::recovery::{build_async_spawn_failure_recovery_payload, RECOVERY_EVENT_KIND};
 use crate::tools::{
     delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
     runtime_tool_view, runtime_tool_view_for_config, tool_catalog, ToolExecutionKind, ToolView,
 };
 
 use super::runtime::SessionContext;
+
+pub use crate::tools::delegate::{AsyncDelegateSpawnRequest, AsyncDelegateSpawner};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProviderTurn {
@@ -81,20 +77,6 @@ pub trait AppToolDispatcher: Send + Sync {
     ) -> Result<ToolCoreOutcome, String>;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AsyncDelegateSpawnRequest {
-    pub child_session_id: String,
-    pub parent_session_id: String,
-    pub task: String,
-    pub label: Option<String>,
-    pub timeout_seconds: u64,
-}
-
-#[async_trait]
-pub trait AsyncDelegateSpawner: Send + Sync {
-    async fn spawn(&self, request: AsyncDelegateSpawnRequest) -> Result<(), String>;
-}
-
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AsyncDelegateSubprocessPlan {
@@ -106,7 +88,7 @@ struct AsyncDelegateSubprocessPlan {
 fn build_async_delegate_subprocess_plan(
     executable_path: &Path,
     config_path: Option<&str>,
-    request: &AsyncDelegateSpawnRequest,
+    request: &crate::tools::delegate::AsyncDelegateSpawnRequest,
 ) -> AsyncDelegateSubprocessPlan {
     let mut args = vec!["run-turn".to_owned()];
     if let Some(config_path) = config_path.map(str::trim).filter(|value| !value.is_empty()) {
@@ -154,8 +136,11 @@ impl SubprocessAsyncDelegateSpawner {
 
 #[cfg(feature = "memory-sqlite")]
 #[async_trait]
-impl AsyncDelegateSpawner for SubprocessAsyncDelegateSpawner {
-    async fn spawn(&self, request: AsyncDelegateSpawnRequest) -> Result<(), String> {
+impl crate::tools::delegate::AsyncDelegateSpawner for SubprocessAsyncDelegateSpawner {
+    async fn spawn(
+        &self,
+        request: crate::tools::delegate::AsyncDelegateSpawnRequest,
+    ) -> Result<(), String> {
         let plan = build_async_delegate_subprocess_plan(
             &self.executable_path,
             self.config_path.as_deref(),
@@ -323,7 +308,6 @@ fn spawn_async_delegate_detached(
         }
     });
 }
-
 pub struct NoopAppToolDispatcher;
 
 #[async_trait]
@@ -343,7 +327,7 @@ pub struct DefaultAppToolDispatcher {
     memory_config: MemoryRuntimeConfig,
     tool_config: ToolConfig,
     app_config: Option<Arc<LoongClawConfig>>,
-    async_delegate_spawner: Option<Arc<dyn AsyncDelegateSpawner>>,
+    async_delegate_spawner: Option<Arc<dyn crate::tools::delegate::AsyncDelegateSpawner>>,
 }
 
 impl DefaultAppToolDispatcher {
@@ -397,7 +381,7 @@ impl DefaultAppToolDispatcher {
     pub fn with_async_delegate_spawner(
         memory_config: MemoryRuntimeConfig,
         tool_config: ToolConfig,
-        async_delegate_spawner: Arc<dyn AsyncDelegateSpawner>,
+        async_delegate_spawner: Arc<dyn crate::tools::delegate::AsyncDelegateSpawner>,
     ) -> Self {
         Self {
             memory_config,
@@ -469,100 +453,6 @@ impl DefaultAppToolDispatcher {
     ) -> Result<ToolView, String> {
         Ok(runtime_tool_view_for_config(&self.tool_config))
     }
-
-    #[cfg(feature = "memory-sqlite")]
-    async fn execute_delegate_async(
-        &self,
-        session_context: &SessionContext,
-        payload: serde_json::Value,
-    ) -> Result<ToolCoreOutcome, String> {
-        if !self.tool_config.delegate.enabled {
-            return Err("app_tool_disabled: delegate is disabled by config".to_owned());
-        }
-
-        let delegate_request = crate::tools::delegate::parse_delegate_request_with_default_timeout(
-            &payload,
-            self.tool_config.delegate.timeout_seconds,
-        )?;
-        let spawner = self
-            .async_delegate_spawner
-            .as_ref()
-            .ok_or_else(|| "delegate_async_not_configured".to_owned())?;
-        let runtime_handle = tokio::runtime::Handle::try_current()
-            .map_err(|error| format!("delegate_async_runtime_unavailable: {error}"))?;
-        let repo = crate::session::repository::SessionRepository::new(&self.memory_config)?;
-        let current_depth = repo.session_lineage_depth(&session_context.session_id)?;
-        let next_child_depth = current_depth.saturating_add(1);
-        if next_child_depth > self.tool_config.delegate.max_depth {
-            return Err(format!(
-                "delegate_depth_exceeded: next child depth {next_child_depth} exceeds configured max_depth {}",
-                self.tool_config.delegate.max_depth
-            ));
-        }
-
-        let child_session_id = crate::tools::delegate::next_delegate_session_id();
-        let child_label = delegate_request.label.clone();
-        repo.create_session_with_event(
-            crate::session::repository::CreateSessionWithEventRequest {
-                session: crate::session::repository::NewSessionRecord {
-                    session_id: child_session_id.clone(),
-                    kind: crate::session::repository::SessionKind::DelegateChild,
-                    parent_session_id: Some(session_context.session_id.clone()),
-                    label: child_label.clone(),
-                    state: crate::session::repository::SessionState::Ready,
-                },
-                event_kind: "delegate_queued".to_owned(),
-                actor_session_id: Some(session_context.session_id.clone()),
-                event_payload_json: json!({
-                    "task": delegate_request.task.clone(),
-                    "label": child_label.clone(),
-                    "timeout_seconds": delegate_request.timeout_seconds,
-                }),
-            },
-        )?;
-
-        let spawn_request = AsyncDelegateSpawnRequest {
-            child_session_id: child_session_id.clone(),
-            parent_session_id: session_context.session_id.clone(),
-            task: delegate_request.task,
-            label: child_label.clone(),
-            timeout_seconds: delegate_request.timeout_seconds,
-        };
-
-        spawn_async_delegate_detached(
-            runtime_handle,
-            self.memory_config.clone(),
-            Arc::clone(spawner),
-            spawn_request,
-        );
-
-        Ok(crate::tools::delegate::delegate_async_queued_outcome(
-            child_session_id,
-            delegate_request.label,
-            delegate_request.timeout_seconds,
-        ))
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    async fn execute_sessions_send(
-        &self,
-        session_context: &SessionContext,
-        payload: serde_json::Value,
-    ) -> Result<ToolCoreOutcome, String> {
-        let app_config = self
-            .app_config
-            .as_ref()
-            .ok_or_else(|| "sessions_send_not_configured".to_owned())?;
-        let effective_tool_config = self.effective_tool_config_for_session(session_context);
-        crate::tools::messaging::execute_sessions_send_with_config(
-            payload,
-            &session_context.session_id,
-            &self.memory_config,
-            &effective_tool_config,
-            app_config.as_ref(),
-        )
-        .await
-    }
 }
 
 impl Default for DefaultAppToolDispatcher {
@@ -590,33 +480,17 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
             }
         }
         let effective_tool_config = self.effective_tool_config_for_session(session_context);
-        if canonical_tool_name == "session_wait" {
-            return crate::tools::wait_for_session_with_config(
-                request.payload,
-                &session_context.session_id,
-                &self.memory_config,
-                &effective_tool_config,
-            )
-            .await;
-        }
-        #[cfg(feature = "memory-sqlite")]
-        if canonical_tool_name == "sessions_send" {
-            return self
-                .execute_sessions_send(session_context, request.payload)
-                .await;
-        }
-        #[cfg(feature = "memory-sqlite")]
-        if canonical_tool_name == "delegate_async" {
-            return self
-                .execute_delegate_async(session_context, request.payload)
-                .await;
-        }
-        crate::tools::execute_app_tool_with_config(
+        crate::tools::execute_app_tool_with_runtime_support(
             request,
             &session_context.session_id,
             &self.memory_config,
             &effective_tool_config,
+            crate::tools::AppToolRuntimeSupport {
+                app_config: self.app_config.as_deref(),
+                async_delegate_spawner: self.async_delegate_spawner.clone(),
+            },
         )
+        .await
     }
 }
 
@@ -792,7 +666,7 @@ mod tests {
 
     #[test]
     fn delegate_async_subprocess_plan_includes_config_path_and_delegate_child_flag() {
-        let request = AsyncDelegateSpawnRequest {
+        let request = crate::tools::delegate::AsyncDelegateSpawnRequest {
             child_session_id: "delegate:child-1".to_owned(),
             parent_session_id: "root-session".to_owned(),
             task: "child task".to_owned(),

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
+use futures_util::FutureExt;
+use std::any::Any;
 use std::collections::BTreeSet;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 #[cfg(feature = "memory-sqlite")]
 use std::{
@@ -10,10 +13,13 @@ use std::{
 
 use loongclaw_contracts::{Capability, KernelError, ToolCoreOutcome, ToolCoreRequest};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use crate::config::{LoongClawConfig, SessionVisibility, ToolConfig};
 use crate::context::KernelContext;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::recovery::{build_async_spawn_failure_recovery_payload, RECOVERY_EVENT_KIND};
 use crate::tools::{
     delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
     runtime_tool_view, runtime_tool_view_for_config, tool_catalog, ToolExecutionKind, ToolView,

--- a/crates/app/src/tools/delegate.rs
+++ b/crates/app/src/tools/delegate.rs
@@ -1,8 +1,13 @@
+use std::any::Any;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use async_trait::async_trait;
+use futures_util::FutureExt;
 use loongclaw_contracts::ToolCoreOutcome;
 use serde_json::{json, Value};
+use std::panic::AssertUnwindSafe;
 
 #[cfg(test)]
 pub const DEFAULT_TIMEOUT_SECONDS: u64 = 60;
@@ -12,6 +17,20 @@ pub struct DelegateRequest {
     pub task: String,
     pub label: Option<String>,
     pub timeout_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AsyncDelegateSpawnRequest {
+    pub child_session_id: String,
+    pub parent_session_id: String,
+    pub task: String,
+    pub label: Option<String>,
+    pub timeout_seconds: u64,
+}
+
+#[async_trait]
+pub trait AsyncDelegateSpawner: Send + Sync {
+    async fn spawn(&self, request: AsyncDelegateSpawnRequest) -> Result<(), String>;
 }
 
 #[cfg(test)]
@@ -120,6 +139,219 @@ pub fn delegate_error_outcome(
             "error": error,
         }),
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn finalize_async_delegate_spawn_failure(
+    memory_config: &crate::memory::runtime_config::MemoryRuntimeConfig,
+    child_session_id: &str,
+    parent_session_id: &str,
+    label: Option<String>,
+    error: String,
+) -> Result<(), String> {
+    let repo = crate::session::repository::SessionRepository::new(memory_config)?;
+    let outcome = delegate_error_outcome(child_session_id.to_owned(), label, error.clone(), 0);
+    repo.finalize_session_terminal(
+        child_session_id,
+        crate::session::repository::FinalizeSessionTerminalRequest {
+            state: crate::session::repository::SessionState::Failed,
+            last_error: Some(error.clone()),
+            event_kind: "delegate_spawn_failed".to_owned(),
+            actor_session_id: Some(parent_session_id.to_owned()),
+            event_payload_json: json!({
+                "error": error,
+            }),
+            outcome_status: outcome.status,
+            outcome_payload_json: outcome.payload,
+        },
+    )?;
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn finalize_async_delegate_spawn_failure_with_recovery(
+    memory_config: &crate::memory::runtime_config::MemoryRuntimeConfig,
+    child_session_id: &str,
+    parent_session_id: &str,
+    label: Option<String>,
+    error: String,
+) -> Result<(), String> {
+    let recovery_label = label.clone();
+    match finalize_async_delegate_spawn_failure(
+        memory_config,
+        child_session_id,
+        parent_session_id,
+        label,
+        error.clone(),
+    ) {
+        Ok(()) => Ok(()),
+        Err(finalize_error) => {
+            let repo = crate::session::repository::SessionRepository::new(memory_config)?;
+            let recovery_error = format!(
+                "delegate_async_spawn_failure_persist_failed: {finalize_error}; original spawn error: {error}"
+            );
+            match repo.transition_session_with_event_if_current(
+                child_session_id,
+                crate::session::repository::TransitionSessionWithEventIfCurrentRequest {
+                    expected_state: crate::session::repository::SessionState::Ready,
+                    next_state: crate::session::repository::SessionState::Failed,
+                    last_error: Some(recovery_error.clone()),
+                    event_kind: crate::session::recovery::RECOVERY_EVENT_KIND.to_owned(),
+                    actor_session_id: Some(parent_session_id.to_owned()),
+                    event_payload_json:
+                        crate::session::recovery::build_async_spawn_failure_recovery_payload(
+                            recovery_label.as_deref(),
+                            &error,
+                            &recovery_error,
+                        ),
+                },
+            ) {
+                Ok(Some(_)) => Ok(()),
+                Ok(None) => {
+                    let current_state = repo
+                        .load_session(child_session_id)?
+                        .map(|session| session.state.as_str().to_owned())
+                        .unwrap_or_else(|| "missing".to_owned());
+                    Err(format!(
+                        "{recovery_error}; delegate_async_spawn_recovery_skipped_from_state: {current_state}"
+                    ))
+                }
+                Err(recovery_event_error) => match repo.update_session_state_if_current(
+                    child_session_id,
+                    crate::session::repository::SessionState::Ready,
+                    crate::session::repository::SessionState::Failed,
+                    Some(recovery_error.clone()),
+                ) {
+                    Ok(Some(_)) => Ok(()),
+                    Ok(None) => {
+                        let current_state = repo
+                            .load_session(child_session_id)?
+                            .map(|session| session.state.as_str().to_owned())
+                            .unwrap_or_else(|| "missing".to_owned());
+                        Err(format!(
+                            "{recovery_error}; delegate_async_spawn_recovery_skipped_from_state: {current_state}"
+                        ))
+                    }
+                    Err(mark_error) => Err(format!(
+                        "{recovery_error}; delegate_async_spawn_recovery_failed: {mark_error}; delegate_async_spawn_recovery_event_failed: {recovery_event_error}"
+                    )),
+                },
+            }
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn format_async_delegate_spawn_panic(panic_payload: Box<dyn Any + Send>) -> String {
+    let panic_payload = match panic_payload.downcast::<String>() {
+        Ok(message) => return format!("delegate_async_spawn_panic: {}", *message),
+        Err(panic_payload) => panic_payload,
+    };
+    match panic_payload.downcast::<&'static str>() {
+        Ok(message) => format!("delegate_async_spawn_panic: {}", *message),
+        Err(_) => "delegate_async_spawn_panic".to_owned(),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn spawn_async_delegate_detached(
+    runtime_handle: tokio::runtime::Handle,
+    memory_config: crate::memory::runtime_config::MemoryRuntimeConfig,
+    spawner: Arc<dyn AsyncDelegateSpawner>,
+    request: AsyncDelegateSpawnRequest,
+) {
+    let child_session_id = request.child_session_id.clone();
+    let parent_session_id = request.parent_session_id.clone();
+    let label = request.label.clone();
+    runtime_handle.spawn(async move {
+        let spawn_failure = match AssertUnwindSafe(spawner.spawn(request)).catch_unwind().await {
+            Ok(Ok(())) => None,
+            Ok(Err(error)) => Some(error),
+            Err(panic_payload) => Some(format_async_delegate_spawn_panic(panic_payload)),
+        };
+        if let Some(error) = spawn_failure {
+            if let Err(finalize_error) = finalize_async_delegate_spawn_failure_with_recovery(
+                &memory_config,
+                &child_session_id,
+                &parent_session_id,
+                label,
+                error.clone(),
+            ) {
+                eprintln!(
+                    "error: async delegate spawn failure persistence failed for `{child_session_id}`: {finalize_error}; original spawn error: {error}"
+                );
+            }
+        }
+    });
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub async fn execute_delegate_async_with_config(
+    payload: Value,
+    current_session_id: &str,
+    memory_config: &crate::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &crate::config::ToolConfig,
+    spawner: Arc<dyn AsyncDelegateSpawner>,
+) -> Result<ToolCoreOutcome, String> {
+    if !tool_config.delegate.enabled {
+        return Err("app_tool_disabled: delegate is disabled by config".to_owned());
+    }
+
+    let delegate_request = parse_delegate_request_with_default_timeout(
+        &payload,
+        tool_config.delegate.timeout_seconds,
+    )?;
+    let runtime_handle = tokio::runtime::Handle::try_current()
+        .map_err(|error| format!("delegate_async_runtime_unavailable: {error}"))?;
+    let repo = crate::session::repository::SessionRepository::new(memory_config)?;
+    let current_depth = repo.session_lineage_depth(current_session_id)?;
+    let next_child_depth = current_depth.saturating_add(1);
+    if next_child_depth > tool_config.delegate.max_depth {
+        return Err(format!(
+            "delegate_depth_exceeded: next child depth {next_child_depth} exceeds configured max_depth {}",
+            tool_config.delegate.max_depth
+        ));
+    }
+
+    let child_session_id = next_delegate_session_id();
+    let child_label = delegate_request.label.clone();
+    repo.create_session_with_event(crate::session::repository::CreateSessionWithEventRequest {
+        session: crate::session::repository::NewSessionRecord {
+            session_id: child_session_id.clone(),
+            kind: crate::session::repository::SessionKind::DelegateChild,
+            parent_session_id: Some(current_session_id.to_owned()),
+            label: child_label.clone(),
+            state: crate::session::repository::SessionState::Ready,
+        },
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some(current_session_id.to_owned()),
+        event_payload_json: json!({
+            "task": delegate_request.task.clone(),
+            "label": child_label.clone(),
+            "timeout_seconds": delegate_request.timeout_seconds,
+        }),
+    })?;
+
+    let spawn_request = AsyncDelegateSpawnRequest {
+        child_session_id: child_session_id.clone(),
+        parent_session_id: current_session_id.to_owned(),
+        task: delegate_request.task,
+        label: child_label.clone(),
+        timeout_seconds: delegate_request.timeout_seconds,
+    };
+
+    spawn_async_delegate_detached(
+        runtime_handle,
+        memory_config.clone(),
+        Arc::clone(&spawner),
+        spawn_request,
+    );
+
+    Ok(delegate_async_queued_outcome(
+        child_session_id,
+        delegate_request.label,
+        delegate_request.timeout_seconds,
+    ))
 }
 
 fn required_payload_string(payload: &Value, field: &str) -> Result<String, String> {

--- a/crates/app/src/tools/delegate.rs
+++ b/crates/app/src/tools/delegate.rs
@@ -1,4 +1,6 @@
 use std::any::Any;
+#[cfg(feature = "memory-sqlite")]
+use std::io::{self, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -277,7 +279,9 @@ fn spawn_async_delegate_detached(
                 label,
                 error.clone(),
             ) {
-                eprintln!(
+                let mut stderr = io::stderr().lock();
+                let _ = writeln!(
+                    &mut stderr,
                     "error: async delegate spawn failure persistence failed for `{child_session_id}`: {finalize_error}; original spawn error: {error}"
                 );
             }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1,8 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
 use loongclaw_contracts::{Capability, ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{json, Value};
 
+use crate::config::{LoongClawConfig, ToolConfig};
+use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::KernelContext;
 
 mod catalog;
@@ -65,8 +68,8 @@ pub fn execute_app_tool(
 pub fn execute_app_tool_with_config(
     request: ToolCoreRequest,
     current_session_id: &str,
-    memory_config: &crate::memory::runtime_config::MemoryRuntimeConfig,
-    tool_config: &crate::config::ToolConfig,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let canonical_name = canonical_tool_name(request.tool_name.as_str());
     let request = ToolCoreRequest {
@@ -89,9 +92,89 @@ pub fn execute_app_tool_with_config(
             memory_config,
             tool_config,
         ),
-        "sessions_send" => Err("app_tool_not_implemented: sessions_send".to_owned()),
-        "session_wait" => Err("app_tool_not_implemented: session_wait".to_owned()),
-        "delegate" => Err("app_tool_not_implemented: delegate".to_owned()),
+        "sessions_send" => Err("app_tool_requires_runtime_support: sessions_send".to_owned()),
+        "session_wait" => Err("app_tool_requires_async_runtime_support: session_wait".to_owned()),
+        "delegate_async" => {
+            Err("app_tool_requires_async_runtime_support: delegate_async".to_owned())
+        }
+        "delegate" => Err("app_tool_requires_turn_loop_dispatch: delegate".to_owned()),
+        _ => Err(format!(
+            "app_tool_not_found: unknown tool `{}`",
+            request.tool_name
+        )),
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct AppToolRuntimeSupport<'a> {
+    pub app_config: Option<&'a LoongClawConfig>,
+    pub async_delegate_spawner: Option<Arc<dyn delegate::AsyncDelegateSpawner>>,
+}
+
+pub async fn execute_app_tool_with_runtime_support(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    runtime_support: AppToolRuntimeSupport<'_>,
+) -> Result<ToolCoreOutcome, String> {
+    let canonical_name = canonical_tool_name(request.tool_name.as_str());
+    let request = ToolCoreRequest {
+        tool_name: canonical_name.to_owned(),
+        payload: request.payload,
+    };
+    match canonical_name {
+        "sessions_list" | "sessions_history" | "session_status" | "session_events"
+        | "session_cancel" | "session_archive" | "session_recover" | "session_unarchive" => {
+            session::execute_session_tool_with_policies(
+                request,
+                current_session_id,
+                memory_config,
+                tool_config,
+            )
+        }
+        "memory_search" => memory::execute_memory_search_tool_with_policies(
+            request.payload,
+            current_session_id,
+            memory_config,
+            tool_config,
+        ),
+        "session_wait" => {
+            wait_for_session_with_config(
+                request.payload,
+                current_session_id,
+                memory_config,
+                tool_config,
+            )
+            .await
+        }
+        "sessions_send" => {
+            let app_config = runtime_support
+                .app_config
+                .ok_or_else(|| "sessions_send_not_configured".to_owned())?;
+            messaging::execute_sessions_send_with_config(
+                request.payload,
+                current_session_id,
+                memory_config,
+                tool_config,
+                app_config,
+            )
+            .await
+        }
+        "delegate_async" => {
+            let spawner = runtime_support
+                .async_delegate_spawner
+                .ok_or_else(|| "delegate_async_not_configured".to_owned())?;
+            delegate::execute_delegate_async_with_config(
+                request.payload,
+                current_session_id,
+                memory_config,
+                tool_config,
+                spawner,
+            )
+            .await
+        }
+        "delegate" => Err("app_tool_requires_turn_loop_dispatch: delegate".to_owned()),
         _ => Err(format!(
             "app_tool_not_found: unknown tool `{}`",
             request.tool_name
@@ -102,8 +185,8 @@ pub fn execute_app_tool_with_config(
 pub async fn wait_for_session_with_config(
     payload: Value,
     current_session_id: &str,
-    memory_config: &crate::memory::runtime_config::MemoryRuntimeConfig,
-    tool_config: &crate::config::ToolConfig,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     #[cfg(not(feature = "memory-sqlite"))]
     {
@@ -887,6 +970,120 @@ enabled = true
             .expect("sessions_send properties");
         assert!(properties.contains_key("session_id"));
         assert!(properties.contains_key("text"));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn isolated_memory_config(
+        test_name: &str,
+    ) -> crate::memory::runtime_config::MemoryRuntimeConfig {
+        let base = std::env::temp_dir().join(format!(
+            "loongclaw-tools-mod-{test_name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&base).expect("create tools test directory");
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(base.join("memory.sqlite3")),
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn execute_app_tool_runtime_support_routes_session_wait() {
+        let memory_config = isolated_memory_config("runtime-session-wait");
+        let repo =
+            crate::session::repository::SessionRepository::new(&memory_config).expect("repo");
+        repo.create_session(crate::session::repository::NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: crate::session::repository::SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: crate::session::repository::SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(crate::session::repository::NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: crate::session::repository::SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: crate::session::repository::SessionState::Ready,
+        })
+        .expect("create child");
+
+        let outcome = execute_app_tool_with_runtime_support(
+            ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 1
+                }),
+            },
+            "root-session",
+            &memory_config,
+            &crate::config::ToolConfig::default(),
+            AppToolRuntimeSupport::default(),
+        )
+        .await
+        .expect("session_wait outcome");
+
+        assert_eq!(outcome.status, "timeout");
+        assert_eq!(outcome.payload["session"]["session_id"], "child-session");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn execute_app_tool_runtime_support_reports_sessions_send_not_configured() {
+        let memory_config = isolated_memory_config("runtime-sessions-send");
+
+        let error = execute_app_tool_with_runtime_support(
+            ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:123",
+                    "text": "hello"
+                }),
+            },
+            "root-session",
+            &memory_config,
+            &crate::config::ToolConfig::default(),
+            AppToolRuntimeSupport::default(),
+        )
+        .await
+        .expect_err("missing app config should be rejected");
+
+        assert!(
+            error.contains("sessions_send_not_configured"),
+            "expected sessions_send_not_configured, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn execute_app_tool_runtime_support_rejects_delegate_without_turn_loop() {
+        let memory_config = isolated_memory_config("runtime-delegate");
+
+        let error = execute_app_tool_with_runtime_support(
+            ToolCoreRequest {
+                tool_name: "delegate".to_owned(),
+                payload: json!({
+                    "task": "research the runtime"
+                }),
+            },
+            "root-session",
+            &memory_config,
+            &crate::config::ToolConfig::default(),
+            AppToolRuntimeSupport::default(),
+        )
+        .await
+        .expect_err("delegate should require turn-loop dispatch");
+
+        assert!(
+            error.contains("app_tool_requires_turn_loop_dispatch: delegate"),
+            "expected delegate turn-loop error, got: {error}"
+        );
     }
 
     // --- Kernel-routed tool tests ---

--- a/docs/plans/2026-03-13-app-tool-runtime-unification-design.md
+++ b/docs/plans/2026-03-13-app-tool-runtime-unification-design.md
@@ -1,0 +1,97 @@
+# App Tool Runtime Unification Design
+
+## Context
+
+LoongClaw's app-tool surface has grown in two layers:
+
+- `crates/app/src/tools/mod.rs` exposes catalog, runtime tool view, and a synchronous
+  `execute_app_tool_with_config(...)` helper.
+- `crates/app/src/conversation/turn_engine.rs` owns the runtime dispatcher used by real
+  conversation turns.
+
+This was acceptable while app tools were synchronous session or transcript helpers. It became
+misleading once `session_wait`, `sessions_send`, and `delegate_async` landed:
+
+- they are advertised in the runtime tool surface
+- they are executable through the real dispatcher
+- but they are still split across dispatcher-local special cases instead of one authoritative
+  runtime execution boundary
+
+The result is internal truth drift. Runtime behavior is mostly correct, but the routing model is
+harder to reason about, test, and extend.
+
+## Root Cause
+
+The main issue is not that these tools are absent. The issue is that app-tool execution is
+fragmented:
+
+1. `execute_app_tool_with_config(...)` handles only the synchronous subset.
+2. `DefaultAppToolDispatcher` adds ad-hoc special cases for async-capable tools.
+3. `delegate` remains a separate turn-loop concern because it needs nested conversation execution.
+
+That means "what counts as an app tool" is defined in catalog/docs/provider schema, but "where app
+tools actually execute" is spread across multiple call sites.
+
+## Design Goals
+
+- Keep the public runtime tool surface truthful.
+- Centralize non-`delegate` app-tool execution behind one async helper.
+- Preserve the existing `delegate` special path, because it genuinely depends on turn-loop runtime
+  recursion and should not be faked as a normal direct app helper.
+- Reuse existing tool implementations instead of rewriting session, memory, or messaging logic.
+- Make unsupported execution modes explicit with precise errors instead of generic
+  `app_tool_not_implemented`.
+
+## Chosen Approach
+
+Introduce an authoritative async app-tool execution helper in `crates/app/src/tools/mod.rs` for
+all non-`delegate` app tools.
+
+This helper will:
+
+- route synchronous session and memory tools through existing helpers
+- route `session_wait` through the existing async wait helper
+- route `sessions_send` through the existing messaging helper when app config is present
+- route `delegate_async` through a shared delegate-async execution helper
+- reject `delegate` with an explicit "requires turn-loop dispatch" error
+
+To support this, move the reusable delegate-async runtime pieces out of
+`conversation/turn_engine.rs` into `crates/app/src/tools/delegate.rs`:
+
+- `AsyncDelegateSpawnRequest`
+- `AsyncDelegateSpawner`
+- async spawn failure persistence helpers
+- `execute_delegate_async_with_config(...)`
+
+`DefaultAppToolDispatcher` will then become thinner:
+
+- compute effective tool visibility and effective tool config
+- build runtime support inputs
+- call the centralized async app-tool executor
+
+`TurnLoopAppToolDispatcher` will still intercept `delegate` first and only fall back to the
+default dispatcher for the rest.
+
+## Why This Approach
+
+This is the smallest truthful refactor that improves architecture instead of papering over it.
+
+- It fixes the real layering problem without claiming `delegate` is a plain app helper.
+- It reuses existing tested behavior for `session_wait`, `sessions_send`, and session/memory
+  tools.
+- It makes the next tool slice easier, because new async app tools will have one clear runtime
+  entry point.
+
+## Non-Goals
+
+- Implementing browser, cron, or semantic memory features
+- Changing tool catalog visibility policy
+- Reworking the synchronous delegate flow in `turn_loop.rs`
+- Making every app tool executable through the old synchronous helper
+
+## Validation Strategy
+
+- Add direct tests for the new async app-tool runtime helper
+- Keep existing dispatcher behavior tests green
+- Re-run full `loongclaw-app` tests
+- Re-run `loongclaw-daemon --no-run` to verify no compile regressions on the daemon surface

--- a/docs/plans/2026-03-13-app-tool-runtime-unification-plan.md
+++ b/docs/plans/2026-03-13-app-tool-runtime-unification-plan.md
@@ -1,0 +1,182 @@
+# App Tool Runtime Unification Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Unify non-`delegate` app-tool execution behind one authoritative async runtime helper so the advertised tool surface and actual execution boundary stay aligned.
+
+**Architecture:** Keep `delegate` in the turn loop, but move reusable async delegate support into `tools::delegate` and introduce a central async app-tool executor in `tools::mod`. `DefaultAppToolDispatcher` becomes a thin visibility/config wrapper over that executor.
+
+**Tech Stack:** Rust, Tokio, serde_json, sqlite-backed session repository, existing conversation and tool test harnesses
+
+---
+
+### Task 1: Lock the target runtime behavior with failing tests
+
+**Files:**
+- Modify: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add async tests that expect:
+
+- a new async app-tool runtime helper can execute `session_wait`
+- the helper returns `sessions_send_not_configured` when `sessions_send` is requested without app config
+- the helper returns `app_tool_requires_turn_loop_dispatch: delegate` for `delegate`
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app execute_app_tool_runtime_ -- --nocapture --test-threads=1
+```
+
+Expected: fail because the helper or support plumbing does not exist yet.
+
+**Step 3: Commit**
+
+```bash
+git add crates/app/src/tools/mod.rs
+git commit -m "test(app): lock app tool runtime unification behavior"
+```
+
+### Task 2: Move reusable delegate-async runtime pieces into the tools layer
+
+**Files:**
+- Modify: `crates/app/src/tools/delegate.rs`
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+
+**Step 1: Add shared delegate-async runtime types and helpers**
+
+Move or re-home:
+
+- `AsyncDelegateSpawnRequest`
+- `AsyncDelegateSpawner`
+- async spawn failure persistence helpers
+- detached spawn execution helper
+- `execute_delegate_async_with_config(...)`
+
+Keep the subprocess spawner implementation in `turn_engine.rs`, but make it implement the moved
+trait from `tools::delegate`.
+
+**Step 2: Run focused tests**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app delegate_async_ -- --nocapture --test-threads=1
+```
+
+Expected: delegate-async behavior remains green.
+
+**Step 3: Commit**
+
+```bash
+git add crates/app/src/tools/delegate.rs crates/app/src/conversation/turn_engine.rs
+git commit -m "refactor(app): move delegate async runtime helpers into tools layer"
+```
+
+### Task 3: Add the authoritative async app-tool runtime executor
+
+**Files:**
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/messaging.rs`
+
+**Step 1: Implement the helper**
+
+Add:
+
+- a small runtime support struct for optional app config and async delegate spawner
+- `execute_app_tool_with_runtime_support(...)` as the async authoritative executor for all
+  non-`delegate` app tools
+
+Route:
+
+- session tools through the existing session helper
+- `memory_search` through the existing memory helper
+- `session_wait` through the existing async wait helper
+- `sessions_send` through messaging with explicit missing-config error
+- `delegate_async` through the shared delegate helper
+- `delegate` to `app_tool_requires_turn_loop_dispatch: delegate`
+
+**Step 2: Run focused tests**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app execute_app_tool_runtime_ -- --nocapture --test-threads=1
+```
+
+Expected: the new helper tests pass.
+
+**Step 3: Commit**
+
+```bash
+git add crates/app/src/tools/mod.rs crates/app/src/tools/messaging.rs
+git commit -m "feat(app): centralize async app tool execution"
+```
+
+### Task 4: Simplify the default app dispatcher to use the centralized helper
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+
+**Step 1: Replace dispatcher-local special cases**
+
+Have `DefaultAppToolDispatcher::execute_app_tool(...)`:
+
+- keep visibility enforcement
+- compute effective tool config
+- call the centralized async app-tool executor
+
+Retain `TurnLoopAppToolDispatcher` interception for `delegate`.
+
+**Step 2: Run focused dispatcher and conversation tests**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app sessions_send_ -- --nocapture --test-threads=1
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_wait_ -- --nocapture --test-threads=1
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app delegate_async_ -- --nocapture --test-threads=1
+```
+
+Expected: existing dispatcher behavior remains green.
+
+**Step 3: Commit**
+
+```bash
+git add crates/app/src/conversation/turn_engine.rs
+git commit -m "refactor(app): route default dispatcher through central app executor"
+```
+
+### Task 5: Verify the full slice and update any affected docs
+
+**Files:**
+- Modify only if needed after code review: `docs/product-specs/index.md`, `docs/roadmap.md`
+
+**Step 1: Run formatting and full verification**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --nocapture --test-threads=1
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-daemon --no-run
+```
+
+**Step 2: Inspect worktree cleanliness**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -8
+```
+
+**Step 3: Commit follow-up formatting or doc adjustments if needed**
+
+```bash
+git add <files>
+git commit -m "style(rust): format app tool runtime unification changes"
+```


### PR DESCRIPTION
## Summary

- centralize non-`delegate` app tool execution behind one authoritative async runtime helper
- move reusable `delegate_async` runtime support into the tools layer instead of dispatcher-local special cases
- keep `delegate` explicitly on the turn-loop path and add regression coverage for the new runtime boundary
- this change is needed so non-`delegate` app tools share one truthful execution path while `delegate` keeps its explicit turn-loop semantics

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

Scope note: this PR is intentionally stacked on top of `#92` so reviewers only see the app-tool runtime unification increment.

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

Risk note: the change is narrow, but it sits on the app-tool execution path and therefore includes focused runtime regression coverage.

## Validation

- [x] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional checks executed:

- [x] `<local-absolute-path> test -p loongclaw-app execute_app_tool_runtime_ -- --nocapture --test-threads=1`
- [x] `<local-absolute-path> test -p loongclaw-app session_wait_ -- --nocapture --test-threads=1`
- [x] `<local-absolute-path> test -p loongclaw-app sessions_send_ -- --nocapture --test-threads=1`
- [x] `<local-absolute-path> test -p loongclaw-app delegate_async_ -- --nocapture --test-threads=1`
- [x] `<local-absolute-path> test -p loongclaw-app -- --nocapture --test-threads=1`
- [x] `<local-absolute-path> test -p loongclaw-daemon --no-run`

## Stack Context

- Base branch: `feat/memory-search-pr-20260313`
- This PR is intentionally stacked on top of `#92` so reviewers only see the app-tool runtime unification increment. After the lower stack lands, this PR can be retargeted forward.

## Linked Issues

Closes #94