### PR TITLE
refactor(channel): expose full catalog in channels json

### DIFF
--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -967,13 +967,11 @@ fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
     let (resolved_path, config) = mvp::config::load(config_path)?;
     let snapshots = mvp::channel::channel_status_snapshots(&config);
     let catalog_only = mvp::channel::catalog_only_channel_entries(&snapshots);
+    let resolved_path_display = resolved_path.display().to_string();
 
     if as_json {
-        let payload = json!({
-            "config": resolved_path.display().to_string(),
-            "channels": snapshots,
-            "catalog_only_channels": catalog_only,
-        });
+        let payload =
+            build_channels_cli_json_payload(&resolved_path_display, &snapshots, &catalog_only);
         let pretty = serde_json::to_string_pretty(&payload)
             .map_err(|error| format!("serialize channel status output failed: {error}"))?;
         println!("{pretty}");
@@ -982,13 +980,30 @@ fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
 
     println!(
         "{}",
-        render_channel_snapshots_text(
-            &resolved_path.display().to_string(),
-            &snapshots,
-            &catalog_only,
-        )
+        render_channel_snapshots_text(&resolved_path_display, &snapshots, &catalog_only,)
     );
     Ok(())
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ChannelsCliJsonPayload {
+    config: String,
+    channels: Vec<mvp::channel::ChannelStatusSnapshot>,
+    catalog_only_channels: Vec<mvp::channel::ChannelCatalogEntry>,
+    channel_catalog: Vec<mvp::channel::ChannelCatalogEntry>,
+}
+
+fn build_channels_cli_json_payload(
+    config_path: &str,
+    snapshots: &[mvp::channel::ChannelStatusSnapshot],
+    catalog_only: &[mvp::channel::ChannelCatalogEntry],
+) -> ChannelsCliJsonPayload {
+    ChannelsCliJsonPayload {
+        config: config_path.to_owned(),
+        channels: snapshots.to_vec(),
+        catalog_only_channels: catalog_only.to_vec(),
+        channel_catalog: mvp::channel::list_channel_catalog(),
+    }
 }
 
 fn render_channel_snapshots_text(

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -167,3 +167,58 @@ fn render_channel_snapshots_text_reports_catalog_only_channels() {
     assert!(rendered.contains("catalog op send (slack-send) tracks_runtime=false"));
     assert!(rendered.contains("catalog op serve (slack-serve) tracks_runtime=true"));
 }
+
+#[test]
+fn build_channels_cli_json_payload_includes_full_channel_catalog() {
+    let config = mvp::config::LoongClawConfig::default();
+    let snapshots = mvp::channel::channel_status_snapshots(&config);
+    let catalog_only = mvp::channel::catalog_only_channel_entries(&snapshots);
+
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &snapshots, &catalog_only);
+    let encoded = serde_json::to_value(&payload).expect("serialize payload");
+
+    assert_eq!(
+        encoded.get("config").and_then(serde_json::Value::as_str),
+        Some("/tmp/loongclaw.toml")
+    );
+    assert_eq!(
+        encoded
+            .get("channel_catalog")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::len),
+        Some(4)
+    );
+    assert_eq!(
+        encoded
+            .get("catalog_only_channels")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::len),
+        Some(2)
+    );
+    assert!(
+        encoded["channel_catalog"]
+            .as_array()
+            .expect("channel catalog array")
+            .iter()
+            .any(|entry| {
+                entry.get("id").and_then(serde_json::Value::as_str) == Some("telegram")
+                    && entry
+                        .get("implementation_status")
+                        .and_then(serde_json::Value::as_str)
+                        == Some("runtime_backed")
+            })
+    );
+    assert!(
+        encoded["channel_catalog"]
+            .as_array()
+            .expect("channel catalog array")
+            .iter()
+            .any(|entry| {
+                entry.get("id").and_then(serde_json::Value::as_str) == Some("discord")
+                    && entry
+                        .get("implementation_status")
+                        .and_then(serde_json::Value::as_str)
+                        == Some("stub")
+            })
+    );
+}


### PR DESCRIPTION
## Summary
- add a typed JSON payload builder for `loongclaw channels --json`
- expose `channel_catalog` alongside runtime-backed snapshots and catalog-only entries
- cover the JSON contract with a daemon CLI regression test

## Validation
- cargo fmt --all --check
- git diff --check
- cargo test -p loongclaw-daemon build_channels_cli_json_payload_includes_full_channel_catalog --all-features --target-dir <local-absolute-path>
- cargo test -p loongclaw-daemon render_channel_snapshots_text --all-features --target-dir <local-absolute-path>
- cargo clippy -p loongclaw-daemon --all-targets --all-features --target-dir <local-absolute-path> -- -D warnings
- cargo test --workspace --all-features --target-dir <local-absolute-path> -- --test-threads=1
- ./scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md