### PR TITLE
refactor(channel): centralize inventory assembly in app

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -41,9 +41,10 @@ mod telegram;
 
 pub use registry::{
     ChannelCatalogEntry, ChannelCatalogImplementationStatus, ChannelCatalogOperation,
-    ChannelOperationHealth, ChannelOperationStatus, ChannelStatusSnapshot,
-    catalog_only_channel_entries, channel_status_snapshots, list_channel_catalog,
-    normalize_channel_catalog_id, normalize_channel_platform, resolve_channel_catalog_entry,
+    ChannelInventory, ChannelOperationHealth, ChannelOperationStatus, ChannelStatusSnapshot,
+    catalog_only_channel_entries, channel_inventory, channel_status_snapshots,
+    list_channel_catalog, normalize_channel_catalog_id, normalize_channel_platform,
+    resolve_channel_catalog_entry,
 };
 pub use runtime_state::ChannelOperationRuntime;
 use runtime_state::ChannelOperationRuntimeTracker;

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -103,6 +103,13 @@ impl ChannelStatusSnapshot {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChannelInventory {
+    pub channels: Vec<ChannelStatusSnapshot>,
+    pub catalog_only_channels: Vec<ChannelCatalogEntry>,
+    pub channel_catalog: Vec<ChannelCatalogEntry>,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ChannelRuntimeDescriptor {
     platform: ChannelPlatform,
@@ -298,12 +305,35 @@ pub fn normalize_channel_platform(raw: &str) -> Option<ChannelPlatform> {
         .and_then(|descriptor| descriptor.runtime.map(|runtime| runtime.platform))
 }
 
+pub fn channel_inventory(config: &LoongClawConfig) -> ChannelInventory {
+    channel_inventory_with_now(
+        config,
+        runtime_state::default_channel_runtime_state_dir().as_path(),
+        now_ms(),
+    )
+}
+
 pub fn channel_status_snapshots(config: &LoongClawConfig) -> Vec<ChannelStatusSnapshot> {
     channel_status_snapshots_with_now(
         config,
         runtime_state::default_channel_runtime_state_dir().as_path(),
         now_ms(),
     )
+}
+
+fn channel_inventory_with_now(
+    config: &LoongClawConfig,
+    runtime_dir: &Path,
+    now_ms: u64,
+) -> ChannelInventory {
+    let channel_catalog = list_channel_catalog();
+    let channels = channel_status_snapshots_with_now(config, runtime_dir, now_ms);
+    let catalog_only_channels = catalog_only_channel_entries_from(&channel_catalog, &channels);
+    ChannelInventory {
+        channels,
+        catalog_only_channels,
+        channel_catalog,
+    }
 }
 
 fn channel_status_snapshots_with_now(
@@ -965,6 +995,37 @@ mod tests {
         assert_eq!(catalog_only[0].operations[1].command, "discord-serve");
         assert_eq!(catalog_only[1].operations[0].command, "slack-send");
         assert_eq!(catalog_only[1].operations[1].command, "slack-serve");
+    }
+
+    #[test]
+    fn channel_inventory_combines_runtime_and_catalog_surfaces() {
+        let config = LoongClawConfig::default();
+        let inventory = channel_inventory(&config);
+
+        assert_eq!(
+            inventory
+                .channels
+                .iter()
+                .map(|snapshot| snapshot.id)
+                .collect::<Vec<_>>(),
+            vec!["telegram", "feishu"]
+        );
+        assert_eq!(
+            inventory
+                .catalog_only_channels
+                .iter()
+                .map(|entry| entry.id)
+                .collect::<Vec<_>>(),
+            vec!["discord", "slack"]
+        );
+        assert_eq!(
+            inventory
+                .channel_catalog
+                .iter()
+                .map(|entry| entry.id)
+                .collect::<Vec<_>>(),
+            vec!["telegram", "feishu", "discord", "slack"]
+        );
     }
 
     #[test]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -965,13 +965,11 @@ async fn run_list_models_cli(config_path: Option<&str>, as_json: bool) -> CliRes
 
 fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
     let (resolved_path, config) = mvp::config::load(config_path)?;
-    let snapshots = mvp::channel::channel_status_snapshots(&config);
-    let catalog_only = mvp::channel::catalog_only_channel_entries(&snapshots);
+    let inventory = mvp::channel::channel_inventory(&config);
     let resolved_path_display = resolved_path.display().to_string();
 
     if as_json {
-        let payload =
-            build_channels_cli_json_payload(&resolved_path_display, &snapshots, &catalog_only);
+        let payload = build_channels_cli_json_payload(&resolved_path_display, &inventory);
         let pretty = serde_json::to_string_pretty(&payload)
             .map_err(|error| format!("serialize channel status output failed: {error}"))?;
         println!("{pretty}");
@@ -980,7 +978,7 @@ fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
 
     println!(
         "{}",
-        render_channel_snapshots_text(&resolved_path_display, &snapshots, &catalog_only,)
+        render_channel_snapshots_text(&resolved_path_display, &inventory)
     );
     Ok(())
 }
@@ -995,24 +993,22 @@ struct ChannelsCliJsonPayload {
 
 fn build_channels_cli_json_payload(
     config_path: &str,
-    snapshots: &[mvp::channel::ChannelStatusSnapshot],
-    catalog_only: &[mvp::channel::ChannelCatalogEntry],
+    inventory: &mvp::channel::ChannelInventory,
 ) -> ChannelsCliJsonPayload {
     ChannelsCliJsonPayload {
         config: config_path.to_owned(),
-        channels: snapshots.to_vec(),
-        catalog_only_channels: catalog_only.to_vec(),
-        channel_catalog: mvp::channel::list_channel_catalog(),
+        channels: inventory.channels.clone(),
+        catalog_only_channels: inventory.catalog_only_channels.clone(),
+        channel_catalog: inventory.channel_catalog.clone(),
     }
 }
 
 fn render_channel_snapshots_text(
     config_path: &str,
-    snapshots: &[mvp::channel::ChannelStatusSnapshot],
-    catalog_only: &[mvp::channel::ChannelCatalogEntry],
+    inventory: &mvp::channel::ChannelInventory,
 ) -> String {
     let mut lines = vec![format!("config={config_path}")];
-    for snapshot in snapshots {
+    for snapshot in &inventory.channels {
         let aliases = if snapshot.aliases.is_empty() {
             "-".to_owned()
         } else {
@@ -1084,9 +1080,9 @@ fn render_channel_snapshots_text(
             }
         }
     }
-    if !catalog_only.is_empty() {
+    if !inventory.catalog_only_channels.is_empty() {
         lines.push("catalog-only channels:".to_owned());
-        for entry in catalog_only {
+        for entry in &inventory.catalog_only_channels {
             let aliases = if entry.aliases.is_empty() {
                 "-".to_owned()
             } else {

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -76,8 +76,8 @@ fn render_channel_snapshots_text_reports_aliases_and_operation_health() {
     config.feishu.app_id = Some("cli_a1b2c3".to_owned());
     config.feishu.app_secret = Some("app-secret".to_owned());
 
-    let snapshots = mvp::channel::channel_status_snapshots(&config);
-    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots, &[]);
+    let inventory = mvp::channel::channel_inventory(&config);
+    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(rendered.contains("config=/tmp/loongclaw.toml"));
     assert!(rendered.contains("Feishu/Lark [feishu]"));
@@ -110,8 +110,8 @@ fn render_channel_snapshots_text_reports_configured_accounts_for_multi_account_c
     }))
     .expect("deserialize multi-account config");
 
-    let snapshots = mvp::channel::channel_status_snapshots(&config);
-    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots, &[]);
+    let inventory = mvp::channel::channel_inventory(&config);
+    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(rendered.contains("configured_account=work-bot"));
     assert!(rendered.contains("configured_account=personal"));
@@ -139,8 +139,8 @@ fn render_channel_snapshots_text_reports_default_account_marker() {
     }))
     .expect("deserialize multi-account config");
 
-    let snapshots = mvp::channel::channel_status_snapshots(&config);
-    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots, &[]);
+    let inventory = mvp::channel::channel_inventory(&config);
+    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(rendered.contains("configured_account=work-bot"));
     assert!(rendered.contains("default_account=true"));
@@ -150,10 +150,8 @@ fn render_channel_snapshots_text_reports_default_account_marker() {
 #[test]
 fn render_channel_snapshots_text_reports_catalog_only_channels() {
     let config = mvp::config::LoongClawConfig::default();
-    let snapshots = mvp::channel::channel_status_snapshots(&config);
-    let catalog_only = mvp::channel::catalog_only_channel_entries(&snapshots);
-
-    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &snapshots, &catalog_only);
+    let inventory = mvp::channel::channel_inventory(&config);
+    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(rendered.contains("catalog-only channels:"));
     assert!(rendered.contains(
@@ -171,10 +169,8 @@ fn render_channel_snapshots_text_reports_catalog_only_channels() {
 #[test]
 fn build_channels_cli_json_payload_includes_full_channel_catalog() {
     let config = mvp::config::LoongClawConfig::default();
-    let snapshots = mvp::channel::channel_status_snapshots(&config);
-    let catalog_only = mvp::channel::catalog_only_channel_entries(&snapshots);
-
-    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &snapshots, &catalog_only);
+    let inventory = mvp::channel::channel_inventory(&config);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
     let encoded = serde_json::to_value(&payload).expect("serialize payload");
 
     assert_eq!(


### PR DESCRIPTION
## Summary
- add a shared `ChannelInventory` aggregate in `loongclaw_app::channel`
- move channel catalog/runtime/catalog-only assembly out of daemon CLI glue into the app registry layer
- switch daemon text/json channel surfaces to consume the shared inventory object

## Validation
- cargo fmt --all --check
- git diff --check
- cargo test -p loongclaw-app channel_inventory_combines_runtime_and_catalog_surfaces --all-features --target-dir <local-absolute-path>
- cargo test -p loongclaw-app channel::registry --all-features --target-dir <local-absolute-path>
- cargo test -p loongclaw-daemon build_channels_cli_json_payload_includes_full_channel_catalog --all-features --target-dir <local-absolute-path>
- cargo test -p loongclaw-daemon render_channel_snapshots_text --all-features --target-dir <local-absolute-path>
- cargo clippy -p loongclaw-app -p loongclaw-daemon --all-targets --all-features --target-dir <local-absolute-path> -- -D warnings
- cargo test --workspace --all-features --target-dir <local-absolute-path> -- --test-threads=1
- ./scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md