### PR TITLE
feat(channel): expose grouped channel surfaces in inventory

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -42,7 +42,7 @@ mod telegram;
 pub use registry::{
     ChannelCatalogEntry, ChannelCatalogImplementationStatus, ChannelCatalogOperation,
     ChannelInventory, ChannelOperationHealth, ChannelOperationStatus, ChannelStatusSnapshot,
-    catalog_only_channel_entries, channel_inventory, channel_status_snapshots,
+    ChannelSurface, catalog_only_channel_entries, channel_inventory, channel_status_snapshots,
     list_channel_catalog, normalize_channel_catalog_id, normalize_channel_platform,
     resolve_channel_catalog_entry,
 };

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -108,6 +108,14 @@ pub struct ChannelInventory {
     pub channels: Vec<ChannelStatusSnapshot>,
     pub catalog_only_channels: Vec<ChannelCatalogEntry>,
     pub channel_catalog: Vec<ChannelCatalogEntry>,
+    pub channel_surfaces: Vec<ChannelSurface>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChannelSurface {
+    pub catalog: ChannelCatalogEntry,
+    pub configured_accounts: Vec<ChannelStatusSnapshot>,
+    pub default_configured_account_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -329,11 +337,38 @@ fn channel_inventory_with_now(
     let channel_catalog = list_channel_catalog();
     let channels = channel_status_snapshots_with_now(config, runtime_dir, now_ms);
     let catalog_only_channels = catalog_only_channel_entries_from(&channel_catalog, &channels);
+    let channel_surfaces = build_channel_surfaces(&channel_catalog, &channels);
     ChannelInventory {
         channels,
         catalog_only_channels,
         channel_catalog,
+        channel_surfaces,
     }
+}
+
+fn build_channel_surfaces(
+    channel_catalog: &[ChannelCatalogEntry],
+    channels: &[ChannelStatusSnapshot],
+) -> Vec<ChannelSurface> {
+    channel_catalog
+        .iter()
+        .map(|catalog| {
+            let configured_accounts = channels
+                .iter()
+                .filter(|snapshot| snapshot.id == catalog.id)
+                .cloned()
+                .collect::<Vec<_>>();
+            let default_configured_account_id = configured_accounts
+                .iter()
+                .find(|snapshot| snapshot.is_default_account)
+                .map(|snapshot| snapshot.configured_account_id.clone());
+            ChannelSurface {
+                catalog: catalog.clone(),
+                configured_accounts,
+                default_configured_account_id,
+            }
+        })
+        .collect()
 }
 
 fn channel_status_snapshots_with_now(
@@ -1026,6 +1061,45 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["telegram", "feishu", "discord", "slack"]
         );
+    }
+
+    #[test]
+    fn channel_inventory_exposes_grouped_channel_surfaces() {
+        let config = LoongClawConfig::default();
+        let inventory = channel_inventory(&config);
+
+        assert_eq!(
+            inventory
+                .channel_surfaces
+                .iter()
+                .map(|surface| surface.catalog.id)
+                .collect::<Vec<_>>(),
+            vec!["telegram", "feishu", "discord", "slack"]
+        );
+
+        let telegram = inventory
+            .channel_surfaces
+            .iter()
+            .find(|surface| surface.catalog.id == "telegram")
+            .expect("telegram surface");
+        assert_eq!(telegram.configured_accounts.len(), 1);
+        assert_eq!(
+            telegram.default_configured_account_id.as_deref(),
+            Some("default")
+        );
+        assert_eq!(telegram.configured_accounts[0].id, "telegram");
+
+        let discord = inventory
+            .channel_surfaces
+            .iter()
+            .find(|surface| surface.catalog.id == "discord")
+            .expect("discord surface");
+        assert_eq!(
+            discord.catalog.implementation_status,
+            ChannelCatalogImplementationStatus::Stub
+        );
+        assert!(discord.configured_accounts.is_empty());
+        assert_eq!(discord.default_configured_account_id, None);
     }
 
     #[test]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -989,6 +989,7 @@ struct ChannelsCliJsonPayload {
     channels: Vec<mvp::channel::ChannelStatusSnapshot>,
     catalog_only_channels: Vec<mvp::channel::ChannelCatalogEntry>,
     channel_catalog: Vec<mvp::channel::ChannelCatalogEntry>,
+    channel_surfaces: Vec<mvp::channel::ChannelSurface>,
 }
 
 fn build_channels_cli_json_payload(
@@ -1000,6 +1001,7 @@ fn build_channels_cli_json_payload(
         channels: inventory.channels.clone(),
         catalog_only_channels: inventory.catalog_only_channels.clone(),
         channel_catalog: inventory.channel_catalog.clone(),
+        channel_surfaces: inventory.channel_surfaces.clone(),
     }
 }
 

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -218,3 +218,53 @@ fn build_channels_cli_json_payload_includes_full_channel_catalog() {
             })
     );
 }
+
+#[test]
+fn build_channels_cli_json_payload_includes_grouped_channel_surfaces() {
+    let config = mvp::config::LoongClawConfig::default();
+    let inventory = mvp::channel::channel_inventory(&config);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
+    let encoded = serde_json::to_value(&payload).expect("serialize payload");
+
+    assert_eq!(
+        encoded
+            .get("channel_surfaces")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::len),
+        Some(4)
+    );
+
+    let surfaces = encoded["channel_surfaces"]
+        .as_array()
+        .expect("channel surfaces array");
+
+    assert!(surfaces.iter().any(|surface| {
+        surface
+            .get("catalog")
+            .and_then(|catalog| catalog.get("id"))
+            .and_then(serde_json::Value::as_str)
+            == Some("telegram")
+            && surface
+                .get("default_configured_account_id")
+                .and_then(serde_json::Value::as_str)
+                == Some("default")
+            && surface
+                .get("configured_accounts")
+                .and_then(serde_json::Value::as_array)
+                .map(Vec::len)
+                == Some(1)
+    }));
+
+    assert!(surfaces.iter().any(|surface| {
+        surface
+            .get("catalog")
+            .and_then(|catalog| catalog.get("id"))
+            .and_then(serde_json::Value::as_str)
+            == Some("discord")
+            && surface
+                .get("configured_accounts")
+                .and_then(serde_json::Value::as_array)
+                .map(Vec::len)
+                == Some(0)
+    }));
+}


### PR DESCRIPTION
## Summary
- add grouped `channel_surfaces` to the shared app-layer channel inventory
- model one stable surface per platform with nested configured account snapshots and default-account hinting
- expose grouped surfaces in `loongclaw channels --json` without changing existing text output

## Validation
- cargo fmt --all --check
- git diff --check
- cargo test -p loongclaw-app channel_inventory_exposes_grouped_channel_surfaces --all-features --target-dir <local-absolute-path>
- cargo test -p loongclaw-daemon build_channels_cli_json_payload_includes_grouped_channel_surfaces --all-features --target-dir <local-absolute-path>
- cargo test -p loongclaw-app channel::registry --all-features --target-dir <local-absolute-path>
- cargo test -p loongclaw-daemon render_channel_snapshots_text --all-features --target-dir <local-absolute-path>
- cargo clippy -p loongclaw-app -p loongclaw-daemon --all-targets --all-features --target-dir <local-absolute-path> -- -D warnings
- cargo test --workspace --all-features --target-dir <local-absolute-path> -- --test-threads=1
- ./scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md