### PR TITLE
refactor(channel): render channel surfaces in text output

### DIFF
--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -978,7 +978,7 @@ fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
 
     println!(
         "{}",
-        render_channel_snapshots_text(&resolved_path_display, &inventory)
+        render_channel_surfaces_text(&resolved_path_display, &inventory)
     );
     Ok(())
 }
@@ -1005,100 +1005,89 @@ fn build_channels_cli_json_payload(
     }
 }
 
-fn render_channel_snapshots_text(
+fn render_channel_surfaces_text(
     config_path: &str,
     inventory: &mvp::channel::ChannelInventory,
 ) -> String {
     let mut lines = vec![format!("config={config_path}")];
-    for snapshot in &inventory.channels {
-        let aliases = if snapshot.aliases.is_empty() {
-            "-".to_owned()
-        } else {
-            snapshot.aliases.join(",")
-        };
-        let api_base_url = snapshot.api_base_url.as_deref().unwrap_or("-");
-        lines.push(format!(
-            "{} [{}] configured_account={} default_account={} default_source={} compiled={} enabled={} aliases={} api_base_url={}",
-            snapshot.label,
-            snapshot.id,
-            snapshot.configured_account_id,
-            snapshot.is_default_account,
-            snapshot.default_account_source.as_str(),
-            snapshot.compiled,
-            snapshot.enabled,
-            aliases,
-            api_base_url
-        ));
-        lines.push(format!("  transport={}", snapshot.transport));
-        lines.push(format!(
-            "  configured_account_label={}",
-            snapshot.configured_account_label
-        ));
-        for note in &snapshot.notes {
-            lines.push(format!("  note: {note}"));
+    let mut catalog_only_surfaces = Vec::new();
+
+    for surface in &inventory.channel_surfaces {
+        if surface.catalog.implementation_status
+            == mvp::channel::ChannelCatalogImplementationStatus::Stub
+        {
+            catalog_only_surfaces.push(surface);
+            continue;
         }
-        for operation in &snapshot.operations {
+
+        push_channel_surface_header(&mut lines, surface);
+        for snapshot in &surface.configured_accounts {
+            let api_base_url = snapshot.api_base_url.as_deref().unwrap_or("-");
             lines.push(format!(
-                "  op {} ({}) {}: {}",
-                operation.id,
-                operation.command,
-                operation.health.as_str(),
-                operation.detail
+                "  account configured_account={} configured_account_label={} default_account={} default_source={} compiled={} enabled={} api_base_url={}",
+                snapshot.configured_account_id,
+                snapshot.configured_account_label,
+                snapshot.is_default_account,
+                snapshot.default_account_source.as_str(),
+                snapshot.compiled,
+                snapshot.enabled,
+                api_base_url
             ));
-            if let Some(runtime) = &operation.runtime {
-                lines.push(format!(
-                    "    runtime account={} account_id={} running={} stale={} busy={} active_runs={} instance_count={} running_instances={} stale_instances={} last_run_activity_at={} last_heartbeat_at={} pid={}",
-                    runtime
-                        .account_label
-                        .as_deref()
-                        .unwrap_or("-"),
-                    runtime
-                        .account_id
-                        .as_deref()
-                        .unwrap_or("-"),
-                    runtime.running,
-                    runtime.stale,
-                    runtime.busy,
-                    runtime.active_runs,
-                    runtime.instance_count,
-                    runtime.running_instances,
-                    runtime.stale_instances,
-                    runtime
-                        .last_run_activity_at
-                        .map(|value| value.to_string())
-                        .unwrap_or_else(|| "-".to_owned()),
-                    runtime
-                        .last_heartbeat_at
-                        .map(|value| value.to_string())
-                        .unwrap_or_else(|| "-".to_owned()),
-                    runtime
-                        .pid
-                        .map(|value| value.to_string())
-                        .unwrap_or_else(|| "-".to_owned())
-                ));
+            for note in &snapshot.notes {
+                lines.push(format!("    note: {note}"));
             }
-            for issue in &operation.issues {
-                lines.push(format!("    issue: {issue}"));
+            for operation in &snapshot.operations {
+                lines.push(format!(
+                    "    op {} ({}) {}: {}",
+                    operation.id,
+                    operation.command,
+                    operation.health.as_str(),
+                    operation.detail
+                ));
+                if let Some(runtime) = &operation.runtime {
+                    lines.push(format!(
+                        "      runtime account={} account_id={} running={} stale={} busy={} active_runs={} instance_count={} running_instances={} stale_instances={} last_run_activity_at={} last_heartbeat_at={} pid={}",
+                        runtime
+                            .account_label
+                            .as_deref()
+                            .unwrap_or("-"),
+                        runtime
+                            .account_id
+                            .as_deref()
+                            .unwrap_or("-"),
+                        runtime.running,
+                        runtime.stale,
+                        runtime.busy,
+                        runtime.active_runs,
+                        runtime.instance_count,
+                        runtime.running_instances,
+                        runtime.stale_instances,
+                        runtime
+                            .last_run_activity_at
+                            .map(|value| value.to_string())
+                            .unwrap_or_else(|| "-".to_owned()),
+                        runtime
+                            .last_heartbeat_at
+                            .map(|value| value.to_string())
+                            .unwrap_or_else(|| "-".to_owned()),
+                        runtime
+                            .pid
+                            .map(|value| value.to_string())
+                            .unwrap_or_else(|| "-".to_owned())
+                    ));
+                }
+                for issue in &operation.issues {
+                    lines.push(format!("      issue: {issue}"));
+                }
             }
         }
     }
-    if !inventory.catalog_only_channels.is_empty() {
+
+    if !catalog_only_surfaces.is_empty() {
         lines.push("catalog-only channels:".to_owned());
-        for entry in &inventory.catalog_only_channels {
-            let aliases = if entry.aliases.is_empty() {
-                "-".to_owned()
-            } else {
-                entry.aliases.join(",")
-            };
-            lines.push(format!(
-                "{} [{}] implementation_status={} aliases={} transport={}",
-                entry.label,
-                entry.id,
-                entry.implementation_status.as_str(),
-                aliases,
-                entry.transport
-            ));
-            for operation in &entry.operations {
+        for surface in catalog_only_surfaces {
+            push_channel_surface_header(&mut lines, surface);
+            for operation in &surface.catalog.operations {
                 lines.push(format!(
                     "  catalog op {} ({}) tracks_runtime={}",
                     operation.id, operation.command, operation.tracks_runtime
@@ -1107,6 +1096,27 @@ fn render_channel_snapshots_text(
         }
     }
     lines.join("\n")
+}
+
+fn push_channel_surface_header(lines: &mut Vec<String>, surface: &mvp::channel::ChannelSurface) {
+    let aliases = if surface.catalog.aliases.is_empty() {
+        "-".to_owned()
+    } else {
+        surface.catalog.aliases.join(",")
+    };
+    lines.push(format!(
+        "{} [{}] implementation_status={} aliases={} transport={} configured_accounts={} default_configured_account={}",
+        surface.catalog.label,
+        surface.catalog.id,
+        surface.catalog.implementation_status.as_str(),
+        aliases,
+        surface.catalog.transport,
+        surface.configured_accounts.len(),
+        surface
+            .default_configured_account_id
+            .as_deref()
+            .unwrap_or("-")
+    ));
 }
 
 fn run_list_context_engines_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -70,17 +70,19 @@ fn resolve_validate_output_rejects_conflicting_json_and_output_flags() {
 }
 
 #[test]
-fn render_channel_snapshots_text_reports_aliases_and_operation_health() {
+fn render_channel_surfaces_text_reports_aliases_and_operation_health() {
     let mut config = mvp::config::LoongClawConfig::default();
     config.feishu.enabled = true;
     config.feishu.app_id = Some("cli_a1b2c3".to_owned());
     config.feishu.app_secret = Some("app-secret".to_owned());
 
     let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &inventory);
+    let rendered = render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(rendered.contains("config=/tmp/loongclaw.toml"));
     assert!(rendered.contains("Feishu/Lark [feishu]"));
+    assert!(rendered.contains("implementation_status=runtime_backed"));
+    assert!(rendered.contains("configured_accounts=1"));
     assert!(rendered.contains("aliases=lark"));
     assert!(rendered.contains("account=feishu:cli_a1b2c3"));
     assert!(rendered.contains("op send (feishu-send) ready"));
@@ -89,7 +91,7 @@ fn render_channel_snapshots_text_reports_aliases_and_operation_health() {
 }
 
 #[test]
-fn render_channel_snapshots_text_reports_configured_accounts_for_multi_account_channels() {
+fn render_channel_surfaces_text_reports_configured_accounts_for_multi_account_channels() {
     let config: mvp::config::LoongClawConfig = serde_json::from_value(serde_json::json!({
         "telegram": {
             "enabled": true,
@@ -111,14 +113,16 @@ fn render_channel_snapshots_text_reports_configured_accounts_for_multi_account_c
     .expect("deserialize multi-account config");
 
     let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &inventory);
+    let rendered = render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
+    assert!(rendered.contains("configured_accounts=2"));
+    assert!(rendered.contains("default_configured_account=work-bot"));
     assert!(rendered.contains("configured_account=work-bot"));
     assert!(rendered.contains("configured_account=personal"));
 }
 
 #[test]
-fn render_channel_snapshots_text_reports_default_account_marker() {
+fn render_channel_surfaces_text_reports_default_account_marker() {
     let config: mvp::config::LoongClawConfig = serde_json::from_value(serde_json::json!({
         "telegram": {
             "enabled": true,
@@ -140,7 +144,7 @@ fn render_channel_snapshots_text_reports_default_account_marker() {
     .expect("deserialize multi-account config");
 
     let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &inventory);
+    let rendered = render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(rendered.contains("configured_account=work-bot"));
     assert!(rendered.contains("default_account=true"));
@@ -148,10 +152,10 @@ fn render_channel_snapshots_text_reports_default_account_marker() {
 }
 
 #[test]
-fn render_channel_snapshots_text_reports_catalog_only_channels() {
+fn render_channel_surfaces_text_reports_catalog_only_channels() {
     let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = render_channel_snapshots_text("/tmp/loongclaw.toml", &inventory);
+    let rendered = render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(rendered.contains("catalog-only channels:"));
     assert!(rendered.contains(


### PR DESCRIPTION
## Summary
- drive loongclaw channels text rendering from grouped channel_surfaces instead of flat channels
- surface platform-level metadata in text output while keeping per-account and runtime details nested underneath
- rename daemon text-render tests to match the grouped-surface model and cover grouped surface metadata

## Validation
- cargo test -p loongclaw-daemon doctor_cli --all-features --target-dir <local-absolute-path>
- cargo test -p loongclaw-daemon render_channel_surfaces_text --all-features --target-dir <local-absolute-path>
- cargo fmt --all --check
- git diff --check
- cargo clippy -p loongclaw-daemon --all-targets --all-features --target-dir <local-absolute-path> -- -D warnings
- cargo test --workspace --all-features --target-dir <local-absolute-path> -- --test-threads=1
- ./scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md