### PR TITLE
refactor(channel): move doctor specs into registry metadata

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -41,10 +41,11 @@ mod telegram;
 
 pub use registry::{
     ChannelCatalogEntry, ChannelCatalogImplementationStatus, ChannelCatalogOperation,
-    ChannelInventory, ChannelOperationHealth, ChannelOperationStatus, ChannelStatusSnapshot,
-    ChannelSurface, catalog_only_channel_entries, channel_inventory, channel_status_snapshots,
-    list_channel_catalog, normalize_channel_catalog_id, normalize_channel_platform,
-    resolve_channel_catalog_entry,
+    ChannelDoctorOperationSpec, ChannelInventory, ChannelOperationHealth, ChannelOperationStatus,
+    ChannelStatusSnapshot, ChannelSurface, catalog_only_channel_entries, channel_inventory,
+    channel_status_snapshots, list_channel_catalog, normalize_channel_catalog_id,
+    normalize_channel_platform, resolve_channel_catalog_entry,
+    resolve_channel_doctor_operation_spec,
 };
 pub use runtime_state::ChannelOperationRuntime;
 use runtime_state::ChannelOperationRuntimeTracker;

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -17,6 +17,12 @@ pub struct ChannelCatalogOperation {
     pub tracks_runtime: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChannelDoctorOperationSpec {
+    pub config_name: &'static str,
+    pub runtime_name: Option<&'static str>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChannelCatalogImplementationStatus {
@@ -124,6 +130,13 @@ struct ChannelRuntimeDescriptor {
     snapshot_builder: ChannelSnapshotBuilder,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ChannelRegistryDoctorOperationDescriptor {
+    operation_id: &'static str,
+    config_name: &'static str,
+    runtime_name: Option<&'static str>,
+}
+
 type ChannelSnapshotBuilder =
     fn(&ChannelRegistryDescriptor, &LoongClawConfig, &Path, u64) -> Vec<ChannelStatusSnapshot>;
 
@@ -136,6 +149,7 @@ struct ChannelRegistryDescriptor {
     aliases: &'static [&'static str],
     transport: &'static str,
     operations: &'static [ChannelCatalogOperation],
+    doctor_operations: &'static [ChannelRegistryDoctorOperationDescriptor],
 }
 
 const TELEGRAM_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
@@ -146,6 +160,12 @@ const TELEGRAM_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperatio
 };
 
 const TELEGRAM_OPERATIONS: &[ChannelCatalogOperation] = &[TELEGRAM_SERVE_OPERATION];
+const TELEGRAM_DOCTOR_OPERATIONS: &[ChannelRegistryDoctorOperationDescriptor] =
+    &[ChannelRegistryDoctorOperationDescriptor {
+        operation_id: "serve",
+        config_name: "telegram channel",
+        runtime_name: Some("telegram channel runtime"),
+    }];
 
 const FEISHU_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
     id: "send",
@@ -163,6 +183,18 @@ const FEISHU_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation 
 
 const FEISHU_OPERATIONS: &[ChannelCatalogOperation] =
     &[FEISHU_SEND_OPERATION, FEISHU_SERVE_OPERATION];
+const FEISHU_DOCTOR_OPERATIONS: &[ChannelRegistryDoctorOperationDescriptor] = &[
+    ChannelRegistryDoctorOperationDescriptor {
+        operation_id: "send",
+        config_name: "feishu channel",
+        runtime_name: None,
+    },
+    ChannelRegistryDoctorOperationDescriptor {
+        operation_id: "serve",
+        config_name: "feishu webhook verification",
+        runtime_name: Some("feishu webhook runtime"),
+    },
+];
 
 const DISCORD_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
     id: "send",
@@ -180,6 +212,7 @@ const DISCORD_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation
 
 const DISCORD_OPERATIONS: &[ChannelCatalogOperation] =
     &[DISCORD_SEND_OPERATION, DISCORD_SERVE_OPERATION];
+const DISCORD_DOCTOR_OPERATIONS: &[ChannelRegistryDoctorOperationDescriptor] = &[];
 
 const SLACK_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
     id: "send",
@@ -196,6 +229,7 @@ const SLACK_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
 };
 
 const SLACK_OPERATIONS: &[ChannelCatalogOperation] = &[SLACK_SEND_OPERATION, SLACK_SERVE_OPERATION];
+const SLACK_DOCTOR_OPERATIONS: &[ChannelRegistryDoctorOperationDescriptor] = &[];
 
 const CHANNEL_REGISTRY: &[ChannelRegistryDescriptor] = &[
     ChannelRegistryDescriptor {
@@ -209,6 +243,7 @@ const CHANNEL_REGISTRY: &[ChannelRegistryDescriptor] = &[
         aliases: &[],
         transport: "telegram_bot_api_polling",
         operations: TELEGRAM_OPERATIONS,
+        doctor_operations: TELEGRAM_DOCTOR_OPERATIONS,
     },
     ChannelRegistryDescriptor {
         id: "feishu",
@@ -221,6 +256,7 @@ const CHANNEL_REGISTRY: &[ChannelRegistryDescriptor] = &[
         aliases: &["lark"],
         transport: "feishu_openapi_webhook",
         operations: FEISHU_OPERATIONS,
+        doctor_operations: FEISHU_DOCTOR_OPERATIONS,
     },
     ChannelRegistryDescriptor {
         id: "discord",
@@ -230,6 +266,7 @@ const CHANNEL_REGISTRY: &[ChannelRegistryDescriptor] = &[
         aliases: &["discord-bot"],
         transport: "discord_gateway",
         operations: DISCORD_OPERATIONS,
+        doctor_operations: DISCORD_DOCTOR_OPERATIONS,
     },
     ChannelRegistryDescriptor {
         id: "slack",
@@ -239,6 +276,7 @@ const CHANNEL_REGISTRY: &[ChannelRegistryDescriptor] = &[
         aliases: &["slack-bot"],
         transport: "slack_events_api",
         operations: SLACK_OPERATIONS,
+        doctor_operations: SLACK_DOCTOR_OPERATIONS,
     },
 ];
 
@@ -284,6 +322,20 @@ pub fn normalize_channel_catalog_id(raw: &str) -> Option<&'static str> {
 
 pub fn resolve_channel_catalog_entry(raw: &str) -> Option<ChannelCatalogEntry> {
     find_channel_registry_descriptor(raw).map(channel_catalog_entry_from_descriptor)
+}
+
+pub fn resolve_channel_doctor_operation_spec(
+    raw_channel_id: &str,
+    operation_id: &str,
+) -> Option<ChannelDoctorOperationSpec> {
+    find_channel_registry_descriptor(raw_channel_id)?
+        .doctor_operations
+        .iter()
+        .find(|descriptor| descriptor.operation_id == operation_id)
+        .map(|descriptor| ChannelDoctorOperationSpec {
+            config_name: descriptor.config_name,
+            runtime_name: descriptor.runtime_name,
+        })
 }
 
 pub fn catalog_only_channel_entries(
@@ -960,6 +1012,33 @@ mod tests {
         assert_eq!(discord.transport, "discord_gateway");
         assert_eq!(discord.operations[0].command, "discord-send");
         assert_eq!(discord.operations[1].command, "discord-serve");
+    }
+
+    #[test]
+    fn resolve_channel_doctor_operation_spec_uses_registry_metadata() {
+        let telegram =
+            resolve_channel_doctor_operation_spec("telegram", "serve").expect("telegram spec");
+        assert_eq!(telegram.config_name, "telegram channel");
+        assert_eq!(telegram.runtime_name, Some("telegram channel runtime"));
+
+        let feishu_send =
+            resolve_channel_doctor_operation_spec("feishu", "send").expect("feishu send spec");
+        assert_eq!(feishu_send.config_name, "feishu channel");
+        assert_eq!(feishu_send.runtime_name, None);
+
+        let lark_serve =
+            resolve_channel_doctor_operation_spec("lark", "serve").expect("lark serve spec");
+        assert_eq!(lark_serve.config_name, "feishu webhook verification");
+        assert_eq!(lark_serve.runtime_name, Some("feishu webhook runtime"));
+
+        assert_eq!(
+            resolve_channel_doctor_operation_spec("discord", "serve"),
+            None
+        );
+        assert_eq!(
+            resolve_channel_doctor_operation_spec("telegram", "send"),
+            None
+        );
     }
 
     #[test]

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -34,12 +34,6 @@ struct DoctorSummary {
     fail: usize,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct DoctorChannelCheckSpec {
-    config_name: &'static str,
-    runtime_name: Option<&'static str>,
-}
-
 pub(crate) async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
     let (config_path, mut config) = mvp::config::load(options.config.as_deref())?;
     let mut checks = Vec::new();
@@ -306,7 +300,10 @@ fn build_channel_surface_checks(
 
         for snapshot in &surface.configured_accounts {
             for operation in &snapshot.operations {
-                let Some(spec) = doctor_check_spec(surface.catalog.id, operation.id) else {
+                let Some(spec) = mvp::channel::resolve_channel_doctor_operation_spec(
+                    surface.catalog.id,
+                    operation.id,
+                ) else {
                     continue;
                 };
                 checks.push(DoctorCheck {
@@ -339,24 +336,6 @@ fn scoped_doctor_check_name(
         return base_name.to_owned();
     }
     format!("{base_name} [{}]", snapshot.configured_account_label)
-}
-
-fn doctor_check_spec(channel_id: &str, operation_id: &str) -> Option<DoctorChannelCheckSpec> {
-    match (channel_id, operation_id) {
-        ("telegram", "serve") => Some(DoctorChannelCheckSpec {
-            config_name: "telegram channel",
-            runtime_name: Some("telegram channel runtime"),
-        }),
-        ("feishu", "send") => Some(DoctorChannelCheckSpec {
-            config_name: "feishu channel",
-            runtime_name: None,
-        }),
-        ("feishu", "serve") => Some(DoctorChannelCheckSpec {
-            config_name: "feishu webhook verification",
-            runtime_name: Some("feishu webhook runtime"),
-        }),
-        _ => None,
-    }
 }
 
 fn doctor_check_level_for_health(health: mvp::channel::ChannelOperationHealth) -> DoctorCheckLevel {


### PR DESCRIPTION
## Summary
- move doctor operation naming metadata out of daemon-local matching and into the app-layer channel registry
- expose a registry-backed resolver so doctor consumers can stay metadata-driven while preserving the existing public channel catalog schema
- switch doctor_cli to consume registry metadata and cover alias resolution plus stub-channel no-op behavior in tests

## Research
- compared OpenClaw's channel dock / operator-metadata pattern via DeepWiki and applied the smallest incremental analogue here
- explicitly avoided importing ZeroClaw's heavier trait system; this change keeps LoongClaw on a descriptor-driven path

## Validation
- cargo test -p loongclaw-app resolve_channel_doctor_operation_spec_uses_registry_metadata --all-features --target-dir <local-absolute-path>
- cargo test -p loongclaw-daemon doctor_cli --all-features --target-dir <local-absolute-path>
- cargo fmt --all --check
- git diff --check
- cargo clippy -p loongclaw-app -p loongclaw-daemon --all-targets --all-features --target-dir <local-absolute-path> -- -D warnings
- cargo test --workspace --all-features --target-dir <local-absolute-path> -- --test-threads=1
- ./scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md