### PR TITLE
refactor(channel): annotate channels json schema views

### DIFF
--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -984,13 +984,25 @@ fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
 }
 
 #[derive(Debug, Clone, Serialize)]
+struct ChannelsCliJsonSchema {
+    version: u32,
+    primary_channel_view: &'static str,
+    catalog_view: &'static str,
+    legacy_channel_views: &'static [&'static str],
+}
+
+#[derive(Debug, Clone, Serialize)]
 struct ChannelsCliJsonPayload {
     config: String,
+    schema: ChannelsCliJsonSchema,
     channels: Vec<mvp::channel::ChannelStatusSnapshot>,
     catalog_only_channels: Vec<mvp::channel::ChannelCatalogEntry>,
     channel_catalog: Vec<mvp::channel::ChannelCatalogEntry>,
     channel_surfaces: Vec<mvp::channel::ChannelSurface>,
 }
+
+const CHANNELS_CLI_JSON_SCHEMA_VERSION: u32 = 1;
+const CHANNELS_CLI_JSON_LEGACY_VIEWS: &[&str] = &["channels", "catalog_only_channels"];
 
 fn build_channels_cli_json_payload(
     config_path: &str,
@@ -998,6 +1010,12 @@ fn build_channels_cli_json_payload(
 ) -> ChannelsCliJsonPayload {
     ChannelsCliJsonPayload {
         config: config_path.to_owned(),
+        schema: ChannelsCliJsonSchema {
+            version: CHANNELS_CLI_JSON_SCHEMA_VERSION,
+            primary_channel_view: "channel_surfaces",
+            catalog_view: "channel_catalog",
+            legacy_channel_views: CHANNELS_CLI_JSON_LEGACY_VIEWS,
+        },
         channels: inventory.channels.clone(),
         catalog_only_channels: inventory.catalog_only_channels.clone(),
         channel_catalog: inventory.channel_catalog.clone(),

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -183,6 +183,40 @@ fn build_channels_cli_json_payload_includes_full_channel_catalog() {
     );
     assert_eq!(
         encoded
+            .get("schema")
+            .and_then(|schema| schema.get("version"))
+            .and_then(serde_json::Value::as_u64),
+        Some(1)
+    );
+    assert_eq!(
+        encoded
+            .get("schema")
+            .and_then(|schema| schema.get("primary_channel_view"))
+            .and_then(serde_json::Value::as_str),
+        Some("channel_surfaces")
+    );
+    assert_eq!(
+        encoded
+            .get("schema")
+            .and_then(|schema| schema.get("catalog_view"))
+            .and_then(serde_json::Value::as_str),
+        Some("channel_catalog")
+    );
+    assert_eq!(
+        encoded
+            .get("schema")
+            .and_then(|schema| schema.get("legacy_channel_views"))
+            .and_then(serde_json::Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .collect::<Vec<_>>()
+            }),
+        Some(vec!["channels", "catalog_only_channels"])
+    );
+    assert_eq!(
+        encoded
             .get("channel_catalog")
             .and_then(serde_json::Value::as_array)
             .map(Vec::len),


### PR DESCRIPTION
## Summary
- add explicit schema metadata to `loongclaw channels --json`
- declare `channel_surfaces` as the primary machine-facing view and `channel_catalog` as the full catalog view
- preserve the flat `channels` and `catalog_only_channels` arrays as legacy compatibility views

## Validation
- cargo fmt --all --check
- git diff --check
- ./scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md
- cargo clippy -p loongclaw-daemon --all-targets --all-features --target-dir <local-absolute-path> -- -D warnings
- <local-absolute-path> test --workspace --all-features --target-dir <local-absolute-path> -- --test-threads=1