### PR TITLE
feat(channel): expose operation availability metadata

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -41,11 +41,11 @@ mod telegram;
 
 pub use registry::{
     ChannelCapability, ChannelCatalogEntry, ChannelCatalogImplementationStatus,
-    ChannelCatalogOperation, ChannelDoctorOperationSpec, ChannelInventory, ChannelOperationHealth,
-    ChannelOperationStatus, ChannelStatusSnapshot, ChannelSurface, catalog_only_channel_entries,
-    channel_inventory, channel_status_snapshots, list_channel_catalog,
-    normalize_channel_catalog_id, normalize_channel_platform, resolve_channel_catalog_entry,
-    resolve_channel_doctor_operation_spec,
+    ChannelCatalogOperation, ChannelCatalogOperationAvailability, ChannelDoctorOperationSpec,
+    ChannelInventory, ChannelOperationHealth, ChannelOperationStatus, ChannelStatusSnapshot,
+    ChannelSurface, catalog_only_channel_entries, channel_inventory, channel_status_snapshots,
+    list_channel_catalog, normalize_channel_catalog_id, normalize_channel_platform,
+    resolve_channel_catalog_entry, resolve_channel_doctor_operation_spec,
 };
 pub use runtime_state::ChannelOperationRuntime;
 use runtime_state::ChannelOperationRuntimeTracker;

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -14,7 +14,24 @@ pub struct ChannelCatalogOperation {
     pub id: &'static str,
     pub label: &'static str,
     pub command: &'static str,
+    pub availability: ChannelCatalogOperationAvailability,
     pub tracks_runtime: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelCatalogOperationAvailability {
+    Implemented,
+    Stub,
+}
+
+impl ChannelCatalogOperationAvailability {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Implemented => "implemented",
+            Self::Stub => "stub",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -180,6 +197,7 @@ const TELEGRAM_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperatio
     id: "serve",
     label: "reply loop",
     command: "telegram-serve",
+    availability: ChannelCatalogOperationAvailability::Implemented,
     tracks_runtime: true,
 };
 
@@ -201,6 +219,7 @@ const FEISHU_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
     id: "send",
     label: "direct send",
     command: "feishu-send",
+    availability: ChannelCatalogOperationAvailability::Implemented,
     tracks_runtime: false,
 };
 
@@ -208,6 +227,7 @@ const FEISHU_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation 
     id: "serve",
     label: "webhook reply server",
     command: "feishu-serve",
+    availability: ChannelCatalogOperationAvailability::Implemented,
     tracks_runtime: true,
 };
 
@@ -237,6 +257,7 @@ const DISCORD_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation 
     id: "send",
     label: "direct send",
     command: "discord-send",
+    availability: ChannelCatalogOperationAvailability::Stub,
     tracks_runtime: false,
 };
 
@@ -244,6 +265,7 @@ const DISCORD_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation
     id: "serve",
     label: "gateway reply loop",
     command: "discord-serve",
+    availability: ChannelCatalogOperationAvailability::Stub,
     tracks_runtime: true,
 };
 
@@ -260,6 +282,7 @@ const SLACK_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
     id: "send",
     label: "direct send",
     command: "slack-send",
+    availability: ChannelCatalogOperationAvailability::Stub,
     tracks_runtime: false,
 };
 
@@ -267,6 +290,7 @@ const SLACK_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
     id: "serve",
     label: "events reply loop",
     command: "slack-serve",
+    availability: ChannelCatalogOperationAvailability::Stub,
     tracks_runtime: true,
 };
 
@@ -1055,6 +1079,7 @@ mod tests {
     #[test]
     fn resolve_channel_catalog_entry_returns_stub_metadata_for_alias_lookup() {
         let discord = resolve_channel_catalog_entry("discord-bot").expect("discord stub entry");
+        let encoded = serde_json::to_value(&discord).expect("serialize discord entry");
 
         assert_eq!(discord.id, "discord");
         assert_eq!(
@@ -1064,6 +1089,19 @@ mod tests {
         assert_eq!(discord.transport, "discord_gateway");
         assert_eq!(discord.operations[0].command, "discord-send");
         assert_eq!(discord.operations[1].command, "discord-serve");
+        assert_eq!(
+            encoded
+                .get("operations")
+                .and_then(serde_json::Value::as_array)
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(|item| item.get("availability"))
+                        .filter_map(serde_json::Value::as_str)
+                        .collect::<Vec<_>>()
+                }),
+            Some(vec!["stub", "stub"])
+        );
     }
 
     #[test]
@@ -1100,6 +1138,7 @@ mod tests {
             .iter()
             .find(|entry| entry.id == "feishu")
             .expect("feishu catalog entry");
+        let encoded = serde_json::to_value(feishu).expect("serialize feishu entry");
 
         assert_eq!(
             feishu.implementation_status,
@@ -1109,6 +1148,19 @@ mod tests {
         assert_eq!(feishu.operations.len(), 2);
         assert_eq!(feishu.operations[0].command, "feishu-send");
         assert_eq!(feishu.operations[1].command, "feishu-serve");
+        assert_eq!(
+            encoded
+                .get("operations")
+                .and_then(serde_json::Value::as_array)
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(|item| item.get("availability"))
+                        .filter_map(serde_json::Value::as_str)
+                        .collect::<Vec<_>>()
+                }),
+            Some(vec!["implemented", "implemented"])
+        );
     }
 
     #[test]
@@ -1299,6 +1351,7 @@ mod tests {
                     id: "serve",
                     label: "reply loop",
                     command: "telegram-serve",
+                    availability: ChannelCatalogOperationAvailability::Implemented,
                     tracks_runtime: true,
                 }],
             },
@@ -1317,6 +1370,7 @@ mod tests {
                     id: "send",
                     label: "direct send",
                     command: "discord-send",
+                    availability: ChannelCatalogOperationAvailability::Stub,
                     tracks_runtime: false,
                 }],
             },

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1107,8 +1107,11 @@ fn render_channel_surfaces_text(
             push_channel_surface_header(&mut lines, surface);
             for operation in &surface.catalog.operations {
                 lines.push(format!(
-                    "  catalog op {} ({}) tracks_runtime={}",
-                    operation.id, operation.command, operation.tracks_runtime
+                    "  catalog op {} ({}) availability={} tracks_runtime={}",
+                    operation.id,
+                    operation.command,
+                    operation.availability.as_str(),
+                    operation.tracks_runtime
                 ));
             }
         }

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -164,13 +164,21 @@ fn render_channel_surfaces_text_reports_catalog_only_channels() {
     assert!(rendered.contains(
         "Discord [discord] implementation_status=stub capabilities=send,serve,runtime_tracking aliases=discord-bot transport=discord_gateway"
     ));
-    assert!(rendered.contains("catalog op send (discord-send) tracks_runtime=false"));
-    assert!(rendered.contains("catalog op serve (discord-serve) tracks_runtime=true"));
+    assert!(
+        rendered.contains("catalog op send (discord-send) availability=stub tracks_runtime=false")
+    );
+    assert!(
+        rendered.contains("catalog op serve (discord-serve) availability=stub tracks_runtime=true")
+    );
     assert!(rendered.contains(
         "Slack [slack] implementation_status=stub capabilities=send,serve,runtime_tracking aliases=slack-bot transport=slack_events_api"
     ));
-    assert!(rendered.contains("catalog op send (slack-send) tracks_runtime=false"));
-    assert!(rendered.contains("catalog op serve (slack-serve) tracks_runtime=true"));
+    assert!(
+        rendered.contains("catalog op send (slack-send) availability=stub tracks_runtime=false")
+    );
+    assert!(
+        rendered.contains("catalog op serve (slack-serve) availability=stub tracks_runtime=true")
+    );
 }
 
 #[test]
@@ -256,6 +264,17 @@ fn build_channels_cli_json_payload_includes_full_channel_catalog() {
                         .get("implementation_status")
                         .and_then(serde_json::Value::as_str)
                         == Some("stub")
+                    && entry
+                        .get("operations")
+                        .and_then(serde_json::Value::as_array)
+                        .map(|items| {
+                            items
+                                .iter()
+                                .filter_map(|item| item.get("availability"))
+                                .filter_map(serde_json::Value::as_str)
+                                .collect::<Vec<_>>()
+                        })
+                        == Some(vec!["stub", "stub"])
             })
     );
 }


### PR DESCRIPTION
## Summary
- add explicit availability metadata to channel catalog operations
- expose whether each channel operation is implemented or still a stub through JSON and text channel surfaces
- avoid forcing consumers to infer operation readiness purely from channel-level implementation status

## Validation
- cargo fmt --all --check
- git diff --check
- ./scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md
- <local-absolute-path> clippy -p loongclaw-daemon --all-targets --all-features --target-dir <local-absolute-path> -- -D warnings
- <local-absolute-path> test --workspace --all-features --target-dir <local-absolute-path> -- --test-threads=1