### PR TITLE
refactor(channel): expose operation requirement metadata

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -41,12 +41,13 @@ mod telegram;
 
 pub use registry::{
     ChannelCapability, ChannelCatalogEntry, ChannelCatalogImplementationStatus,
-    ChannelCatalogOperation, ChannelCatalogOperationAvailability, ChannelDoctorCheckSpec,
-    ChannelDoctorCheckTrigger, ChannelDoctorOperationSpec, ChannelInventory,
-    ChannelOperationHealth, ChannelOperationStatus, ChannelStatusSnapshot, ChannelSurface,
-    catalog_only_channel_entries, channel_inventory, channel_status_snapshots,
-    list_channel_catalog, normalize_channel_catalog_id, normalize_channel_platform,
-    resolve_channel_catalog_entry, resolve_channel_doctor_operation_spec,
+    ChannelCatalogOperation, ChannelCatalogOperationAvailability,
+    ChannelCatalogOperationRequirement, ChannelDoctorCheckSpec, ChannelDoctorCheckTrigger,
+    ChannelDoctorOperationSpec, ChannelInventory, ChannelOperationHealth, ChannelOperationStatus,
+    ChannelStatusSnapshot, ChannelSurface, catalog_only_channel_entries, channel_inventory,
+    channel_status_snapshots, list_channel_catalog, normalize_channel_catalog_id,
+    normalize_channel_platform, resolve_channel_catalog_entry,
+    resolve_channel_doctor_operation_spec,
 };
 pub use runtime_state::ChannelOperationRuntime;
 use runtime_state::ChannelOperationRuntimeTracker;

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -3,8 +3,9 @@ use std::{collections::BTreeSet, path::Path};
 use serde::Serialize;
 
 use crate::config::{
-    ChannelDefaultAccountSelectionSource, LoongClawConfig, ResolvedFeishuChannelConfig,
-    ResolvedTelegramChannelConfig,
+    ChannelDefaultAccountSelectionSource, FEISHU_APP_ID_ENV, FEISHU_APP_SECRET_ENV,
+    FEISHU_ENCRYPT_KEY_ENV, FEISHU_VERIFICATION_TOKEN_ENV, LoongClawConfig,
+    ResolvedFeishuChannelConfig, ResolvedTelegramChannelConfig, TELEGRAM_BOT_TOKEN_ENV,
 };
 
 use super::{ChannelOperationRuntime, ChannelPlatform, runtime_state};
@@ -16,6 +17,16 @@ pub struct ChannelCatalogOperation {
     pub command: &'static str,
     pub availability: ChannelCatalogOperationAvailability,
     pub tracks_runtime: bool,
+    pub requirements: &'static [ChannelCatalogOperationRequirement],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct ChannelCatalogOperationRequirement {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub config_paths: &'static [&'static str],
+    pub env_pointer_paths: &'static [&'static str],
+    pub default_env_var: Option<&'static str>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -208,7 +219,47 @@ const TELEGRAM_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperatio
     command: "telegram-serve",
     availability: ChannelCatalogOperationAvailability::Implemented,
     tracks_runtime: true,
+    requirements: TELEGRAM_SERVE_REQUIREMENTS,
 };
+
+const TELEGRAM_ENABLED_REQUIREMENT: ChannelCatalogOperationRequirement =
+    ChannelCatalogOperationRequirement {
+        id: "enabled",
+        label: "channel enabled",
+        config_paths: &["telegram.enabled", "telegram.accounts.<account>.enabled"],
+        env_pointer_paths: &[],
+        default_env_var: None,
+    };
+const TELEGRAM_BOT_TOKEN_REQUIREMENT: ChannelCatalogOperationRequirement =
+    ChannelCatalogOperationRequirement {
+        id: "bot_token",
+        label: "bot token",
+        config_paths: &[
+            "telegram.bot_token",
+            "telegram.accounts.<account>.bot_token",
+        ],
+        env_pointer_paths: &[
+            "telegram.bot_token_env",
+            "telegram.accounts.<account>.bot_token_env",
+        ],
+        default_env_var: Some(TELEGRAM_BOT_TOKEN_ENV),
+    };
+const TELEGRAM_ALLOWED_CHAT_IDS_REQUIREMENT: ChannelCatalogOperationRequirement =
+    ChannelCatalogOperationRequirement {
+        id: "allowed_chat_ids",
+        label: "allowed chat ids",
+        config_paths: &[
+            "telegram.allowed_chat_ids",
+            "telegram.accounts.<account>.allowed_chat_ids",
+        ],
+        env_pointer_paths: &[],
+        default_env_var: None,
+    };
+const TELEGRAM_SERVE_REQUIREMENTS: &[ChannelCatalogOperationRequirement] = &[
+    TELEGRAM_ENABLED_REQUIREMENT,
+    TELEGRAM_BOT_TOKEN_REQUIREMENT,
+    TELEGRAM_ALLOWED_CHAT_IDS_REQUIREMENT,
+];
 
 const TELEGRAM_SERVE_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[
     ChannelDoctorCheckSpec {
@@ -238,6 +289,7 @@ const FEISHU_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
     command: "feishu-send",
     availability: ChannelCatalogOperationAvailability::Implemented,
     tracks_runtime: false,
+    requirements: FEISHU_SEND_REQUIREMENTS,
 };
 
 const FEISHU_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
@@ -246,7 +298,88 @@ const FEISHU_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation 
     command: "feishu-serve",
     availability: ChannelCatalogOperationAvailability::Implemented,
     tracks_runtime: true,
+    requirements: FEISHU_SERVE_REQUIREMENTS,
 };
+
+const FEISHU_ENABLED_REQUIREMENT: ChannelCatalogOperationRequirement =
+    ChannelCatalogOperationRequirement {
+        id: "enabled",
+        label: "channel enabled",
+        config_paths: &["feishu.enabled", "feishu.accounts.<account>.enabled"],
+        env_pointer_paths: &[],
+        default_env_var: None,
+    };
+const FEISHU_APP_ID_REQUIREMENT: ChannelCatalogOperationRequirement =
+    ChannelCatalogOperationRequirement {
+        id: "app_id",
+        label: "app id",
+        config_paths: &["feishu.app_id", "feishu.accounts.<account>.app_id"],
+        env_pointer_paths: &["feishu.app_id_env", "feishu.accounts.<account>.app_id_env"],
+        default_env_var: Some(FEISHU_APP_ID_ENV),
+    };
+const FEISHU_APP_SECRET_REQUIREMENT: ChannelCatalogOperationRequirement =
+    ChannelCatalogOperationRequirement {
+        id: "app_secret",
+        label: "app secret",
+        config_paths: &["feishu.app_secret", "feishu.accounts.<account>.app_secret"],
+        env_pointer_paths: &[
+            "feishu.app_secret_env",
+            "feishu.accounts.<account>.app_secret_env",
+        ],
+        default_env_var: Some(FEISHU_APP_SECRET_ENV),
+    };
+const FEISHU_ALLOWED_CHAT_IDS_REQUIREMENT: ChannelCatalogOperationRequirement =
+    ChannelCatalogOperationRequirement {
+        id: "allowed_chat_ids",
+        label: "allowed chat ids",
+        config_paths: &[
+            "feishu.allowed_chat_ids",
+            "feishu.accounts.<account>.allowed_chat_ids",
+        ],
+        env_pointer_paths: &[],
+        default_env_var: None,
+    };
+const FEISHU_VERIFICATION_TOKEN_REQUIREMENT: ChannelCatalogOperationRequirement =
+    ChannelCatalogOperationRequirement {
+        id: "verification_token",
+        label: "verification token",
+        config_paths: &[
+            "feishu.verification_token",
+            "feishu.accounts.<account>.verification_token",
+        ],
+        env_pointer_paths: &[
+            "feishu.verification_token_env",
+            "feishu.accounts.<account>.verification_token_env",
+        ],
+        default_env_var: Some(FEISHU_VERIFICATION_TOKEN_ENV),
+    };
+const FEISHU_ENCRYPT_KEY_REQUIREMENT: ChannelCatalogOperationRequirement =
+    ChannelCatalogOperationRequirement {
+        id: "encrypt_key",
+        label: "encrypt key",
+        config_paths: &[
+            "feishu.encrypt_key",
+            "feishu.accounts.<account>.encrypt_key",
+        ],
+        env_pointer_paths: &[
+            "feishu.encrypt_key_env",
+            "feishu.accounts.<account>.encrypt_key_env",
+        ],
+        default_env_var: Some(FEISHU_ENCRYPT_KEY_ENV),
+    };
+const FEISHU_SEND_REQUIREMENTS: &[ChannelCatalogOperationRequirement] = &[
+    FEISHU_ENABLED_REQUIREMENT,
+    FEISHU_APP_ID_REQUIREMENT,
+    FEISHU_APP_SECRET_REQUIREMENT,
+];
+const FEISHU_SERVE_REQUIREMENTS: &[ChannelCatalogOperationRequirement] = &[
+    FEISHU_ENABLED_REQUIREMENT,
+    FEISHU_APP_ID_REQUIREMENT,
+    FEISHU_APP_SECRET_REQUIREMENT,
+    FEISHU_ALLOWED_CHAT_IDS_REQUIREMENT,
+    FEISHU_VERIFICATION_TOKEN_REQUIREMENT,
+    FEISHU_ENCRYPT_KEY_REQUIREMENT,
+];
 
 const FEISHU_SEND_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorCheckSpec {
     name: "feishu channel",
@@ -286,6 +419,7 @@ const DISCORD_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation 
     command: "discord-send",
     availability: ChannelCatalogOperationAvailability::Stub,
     tracks_runtime: false,
+    requirements: &[],
 };
 
 const DISCORD_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
@@ -294,6 +428,7 @@ const DISCORD_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation
     command: "discord-serve",
     availability: ChannelCatalogOperationAvailability::Stub,
     tracks_runtime: true,
+    requirements: &[],
 };
 
 const DISCORD_OPERATIONS: &[ChannelRegistryOperationDescriptor] = &[
@@ -318,6 +453,7 @@ const SLACK_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
     command: "slack-send",
     availability: ChannelCatalogOperationAvailability::Stub,
     tracks_runtime: false,
+    requirements: &[],
 };
 
 const SLACK_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
@@ -326,6 +462,7 @@ const SLACK_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
     command: "slack-serve",
     availability: ChannelCatalogOperationAvailability::Stub,
     tracks_runtime: true,
+    requirements: &[],
 };
 
 const SLACK_OPERATIONS: &[ChannelRegistryOperationDescriptor] = &[
@@ -1325,6 +1462,82 @@ mod tests {
     }
 
     #[test]
+    fn channel_catalog_operations_expose_requirement_metadata() {
+        let catalog = list_channel_catalog();
+        let telegram = catalog
+            .iter()
+            .find(|entry| entry.id == "telegram")
+            .expect("telegram catalog entry");
+        let feishu = catalog
+            .iter()
+            .find(|entry| entry.id == "feishu")
+            .expect("feishu catalog entry");
+        let discord = catalog
+            .iter()
+            .find(|entry| entry.id == "discord")
+            .expect("discord catalog entry");
+
+        assert_eq!(
+            telegram.operations[0]
+                .requirements
+                .iter()
+                .map(|requirement| requirement.id)
+                .collect::<Vec<_>>(),
+            vec!["enabled", "bot_token", "allowed_chat_ids"]
+        );
+        assert_eq!(
+            telegram.operations[0].requirements[1].default_env_var,
+            Some("TELEGRAM_BOT_TOKEN")
+        );
+        assert_eq!(
+            telegram.operations[0].requirements[1].env_pointer_paths,
+            &[
+                "telegram.bot_token_env",
+                "telegram.accounts.<account>.bot_token_env",
+            ]
+        );
+
+        assert_eq!(
+            feishu.operations[0]
+                .requirements
+                .iter()
+                .map(|requirement| requirement.id)
+                .collect::<Vec<_>>(),
+            vec!["enabled", "app_id", "app_secret"]
+        );
+        assert_eq!(
+            feishu.operations[1]
+                .requirements
+                .iter()
+                .map(|requirement| requirement.id)
+                .collect::<Vec<_>>(),
+            vec![
+                "enabled",
+                "app_id",
+                "app_secret",
+                "allowed_chat_ids",
+                "verification_token",
+                "encrypt_key",
+            ]
+        );
+        assert_eq!(
+            feishu.operations[1].requirements[4].default_env_var,
+            Some("FEISHU_VERIFICATION_TOKEN")
+        );
+        assert_eq!(
+            feishu.operations[1].requirements[5].default_env_var,
+            Some("FEISHU_ENCRYPT_KEY")
+        );
+
+        assert!(
+            discord
+                .operations
+                .iter()
+                .all(|operation| operation.requirements.is_empty())
+        );
+    }
+
+    #[test]
     fn catalog_only_channel_entries_include_stub_surfaces_for_default_config() {
         let config = LoongClawConfig::default();
         let snapshots = channel_status_snapshots(&config);
@@ -1433,6 +1646,7 @@ mod tests {
                     command: "telegram-serve",
                     availability: ChannelCatalogOperationAvailability::Implemented,
                     tracks_runtime: true,
+                    requirements: &[],
                 }],
             },
             ChannelCatalogEntry {
@@ -1452,6 +1666,7 @@ mod tests {
                     command: "discord-send",
                     availability: ChannelCatalogOperationAvailability::Stub,
                     tracks_runtime: false,
+                    requirements: &[],
                 }],
             },
         ];

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -13,11 +13,11 @@ use super::shared::{
     read_secret_prefer_inline, validate_env_pointer_field,
 };
 
-const TELEGRAM_BOT_TOKEN_ENV: &str = "TELEGRAM_BOT_TOKEN";
-const FEISHU_APP_ID_ENV: &str = "FEISHU_APP_ID";
-const FEISHU_APP_SECRET_ENV: &str = "FEISHU_APP_SECRET";
-const FEISHU_VERIFICATION_TOKEN_ENV: &str = "FEISHU_VERIFICATION_TOKEN";
-const FEISHU_ENCRYPT_KEY_ENV: &str = "FEISHU_ENCRYPT_KEY";
+pub(crate) const TELEGRAM_BOT_TOKEN_ENV: &str = "TELEGRAM_BOT_TOKEN";
+pub(crate) const FEISHU_APP_ID_ENV: &str = "FEISHU_APP_ID";
+pub(crate) const FEISHU_APP_SECRET_ENV: &str = "FEISHU_APP_SECRET";
+pub(crate) const FEISHU_VERIFICATION_TOKEN_ENV: &str = "FEISHU_VERIFICATION_TOKEN";
+pub(crate) const FEISHU_ENCRYPT_KEY_ENV: &str = "FEISHU_ENCRYPT_KEY";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CliChannelConfig {

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -12,6 +12,10 @@ pub use channels::{
     FeishuDomain, ResolvedFeishuChannelConfig, ResolvedTelegramChannelConfig,
     TelegramAccountConfig, TelegramChannelConfig,
 };
+pub(crate) use channels::{
+    FEISHU_APP_ID_ENV, FEISHU_APP_SECRET_ENV, FEISHU_ENCRYPT_KEY_ENV,
+    FEISHU_VERIFICATION_TOKEN_ENV, TELEGRAM_BOT_TOKEN_ENV,
+};
 #[allow(unused_imports)]
 pub use conversation::{ConversationConfig, ConversationTurnLoopConfig};
 #[allow(unused_imports)]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1055,12 +1055,22 @@ fn render_channel_surfaces_text(
                 lines.push(format!("    note: {note}"));
             }
             for operation in &snapshot.operations {
+                let requirement_ids = surface
+                    .catalog
+                    .operations
+                    .iter()
+                    .find(|catalog_operation| catalog_operation.id == operation.id)
+                    .map(|catalog_operation| {
+                        render_channel_operation_requirement_ids(catalog_operation.requirements)
+                    })
+                    .unwrap_or_else(|| "-".to_owned());
                 lines.push(format!(
-                    "    op {} ({}) {}: {}",
+                    "    op {} ({}) {}: {} requirements={}",
                     operation.id,
                     operation.command,
                     operation.health.as_str(),
-                    operation.detail
+                    operation.detail,
+                    requirement_ids,
                 ));
                 if let Some(runtime) = &operation.runtime {
                     lines.push(format!(
@@ -1107,16 +1117,30 @@ fn render_channel_surfaces_text(
             push_channel_surface_header(&mut lines, surface);
             for operation in &surface.catalog.operations {
                 lines.push(format!(
-                    "  catalog op {} ({}) availability={} tracks_runtime={}",
+                    "  catalog op {} ({}) availability={} tracks_runtime={} requirements={}",
                     operation.id,
                     operation.command,
                     operation.availability.as_str(),
-                    operation.tracks_runtime
+                    operation.tracks_runtime,
+                    render_channel_operation_requirement_ids(operation.requirements)
                 ));
             }
         }
     }
     lines.join("\n")
+}
+
+fn render_channel_operation_requirement_ids(
+    requirements: &[mvp::channel::ChannelCatalogOperationRequirement],
+) -> String {
+    if requirements.is_empty() {
+        return "-".to_owned();
+    }
+    requirements
+        .iter()
+        .map(|requirement| requirement.id)
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 fn push_channel_surface_header(lines: &mut Vec<String>, surface: &mvp::channel::ChannelSurface) {

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -88,8 +88,13 @@ fn render_channel_surfaces_text_reports_aliases_and_operation_health() {
     assert!(rendered.contains("configured_accounts=1"));
     assert!(rendered.contains("aliases=lark"));
     assert!(rendered.contains("account=feishu:cli_a1b2c3"));
-    assert!(rendered.contains("op send (feishu-send) ready"));
-    assert!(rendered.contains("op serve (feishu-serve) misconfigured"));
+    assert!(
+        rendered
+            .contains("op send (feishu-send) ready: ready requirements=enabled,app_id,app_secret")
+    );
+    assert!(rendered.contains(
+        "op serve (feishu-serve) misconfigured: allowed_chat_ids is empty; verification_token is missing; encrypt_key is missing requirements=enabled,app_id,app_secret,allowed_chat_ids,verification_token,encrypt_key"
+    ));
     assert!(rendered.contains("running=false"));
 }
 
@@ -164,21 +169,86 @@ fn render_channel_surfaces_text_reports_catalog_only_channels() {
     assert!(rendered.contains(
         "Discord [discord] implementation_status=stub capabilities=send,serve,runtime_tracking aliases=discord-bot transport=discord_gateway"
     ));
-    assert!(
-        rendered.contains("catalog op send (discord-send) availability=stub tracks_runtime=false")
-    );
-    assert!(
-        rendered.contains("catalog op serve (discord-serve) availability=stub tracks_runtime=true")
-    );
+    assert!(rendered.contains(
+        "catalog op send (discord-send) availability=stub tracks_runtime=false requirements=-"
+    ));
+    assert!(rendered.contains(
+        "catalog op serve (discord-serve) availability=stub tracks_runtime=true requirements=-"
+    ));
     assert!(rendered.contains(
         "Slack [slack] implementation_status=stub capabilities=send,serve,runtime_tracking aliases=slack-bot transport=slack_events_api"
     ));
+    assert!(rendered.contains(
+        "catalog op send (slack-send) availability=stub tracks_runtime=false requirements=-"
+    ));
+    assert!(rendered.contains(
+        "catalog op serve (slack-serve) availability=stub tracks_runtime=true requirements=-"
+    ));
+}
+
+#[test]
+fn build_channels_cli_json_payload_includes_operation_requirement_metadata() {
+    let config = mvp::config::LoongClawConfig::default();
+    let inventory = mvp::channel::channel_inventory(&config);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
+    let encoded = serde_json::to_value(&payload).expect("serialize payload");
+    let surfaces = encoded["channel_surfaces"]
+        .as_array()
+        .expect("channel surfaces array");
+
     assert!(
-        rendered.contains("catalog op send (slack-send) availability=stub tracks_runtime=false")
+        encoded["channel_catalog"]
+            .as_array()
+            .expect("channel catalog array")
+            .iter()
+            .any(|entry| {
+                entry.get("id").and_then(serde_json::Value::as_str) == Some("telegram")
+                    && entry
+                        .get("operations")
+                        .and_then(serde_json::Value::as_array)
+                        .and_then(|operations| operations.first())
+                        .and_then(|operation| operation.get("requirements"))
+                        .and_then(serde_json::Value::as_array)
+                        .map(|requirements| {
+                            requirements
+                                .iter()
+                                .filter_map(|item| item.get("id"))
+                                .filter_map(serde_json::Value::as_str)
+                                .collect::<Vec<_>>()
+                        })
+                        == Some(vec!["enabled", "bot_token", "allowed_chat_ids"])
+            })
     );
-    assert!(
-        rendered.contains("catalog op serve (slack-serve) availability=stub tracks_runtime=true")
-    );
+
+    assert!(surfaces.iter().any(|surface| {
+        surface
+            .get("catalog")
+            .and_then(|catalog| catalog.get("id"))
+            .and_then(serde_json::Value::as_str)
+            == Some("feishu")
+            && surface
+                .get("catalog")
+                .and_then(|catalog| catalog.get("operations"))
+                .and_then(serde_json::Value::as_array)
+                .and_then(|operations| operations.get(1))
+                .and_then(|operation| operation.get("requirements"))
+                .and_then(serde_json::Value::as_array)
+                .map(|requirements| {
+                    requirements
+                        .iter()
+                        .filter_map(|item| item.get("id"))
+                        .filter_map(serde_json::Value::as_str)
+                        .collect::<Vec<_>>()
+                })
+                == Some(vec![
+                    "enabled",
+                    "app_id",
+                    "app_secret",
+                    "allowed_chat_ids",
+                    "verification_token",
+                    "encrypt_key",
+                ])
+    }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add static requirement metadata to channel operation catalog descriptors
- expose requirement metadata through channel_catalog and channel_surfaces JSON views
- render compact requirement ids in channels text output without changing doctor behavior

## Testing
- cargo fmt --all --check
- git diff --check
- ./scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md
- <local-absolute-path> clippy -p loongclaw-daemon --all-targets --all-features --target-dir <local-absolute-path> -- -D warnings
- <local-absolute-path> test --workspace --all-features --target-dir <local-absolute-path> -- --test-threads=1