### PR TITLE
perf(default-cli): prune chrono from release binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,15 +35,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,17 +265,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,12 +334,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -565,6 +539,15 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -991,30 +974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,7 +1218,6 @@ dependencies = [
  "axum",
  "base64",
  "cbc",
- "chrono",
  "flate2",
  "loongclaw-contracts",
  "loongclaw-kernel",
@@ -1269,6 +1227,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tar",
+ "time",
  "tokio",
  "toml",
 ]
@@ -1300,7 +1259,6 @@ name = "loongclaw-daemon"
 version = "0.1.2"
 dependencies = [
  "base64",
- "chrono",
  "clap",
  "ed25519-dalek",
  "loongclaw-app",
@@ -1310,6 +1268,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "time",
  "tokio",
  "wat",
 ]
@@ -1424,12 +1383,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1516,6 +1490,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2190,6 +2170,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,63 +2835,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ authors = ["chumyin"]
 
 [workspace.dependencies]
 async-trait = "0.1"
-chrono = { version = "0.4.44", default-features = false, features = ["clock", "std"] }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.9"
 semver = "1"
 thiserror = "2"
+time = { version = "0.3.47", features = ["formatting", "local-offset", "macros", "parsing"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net", "io-util", "io-std", "process", "signal"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 futures-util = "0.3"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -30,7 +30,7 @@ flate2.workspace = true
 tar.workspace = true
 tokio.workspace = true
 base64.workspace = true
-chrono.workspace = true
+time.workspace = true
 rusqlite = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 aes = { version = "0.8", optional = true }

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -105,6 +105,8 @@ use profile_state_backend::{
     provider_profile_state_persistence_metrics_snapshot,
     record_provider_profile_state_persist_outcome,
 };
+#[cfg(any(test, feature = "memory-sqlite"))]
+use profile_state_store::current_unix_timestamp_ms;
 #[cfg(test)]
 use profile_state_store::{
     PROVIDER_PROFILE_STATE_SNAPSHOT_VERSION, ProviderProfileStateEntry,

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -105,8 +105,6 @@ use profile_state_backend::{
     provider_profile_state_persistence_metrics_snapshot,
     record_provider_profile_state_persist_outcome,
 };
-#[cfg(any(test, feature = "memory-sqlite"))]
-use profile_state_store::current_unix_timestamp_ms;
 #[cfg(test)]
 use profile_state_store::{
     PROVIDER_PROFILE_STATE_SNAPSHOT_VERSION, ProviderProfileStateEntry,

--- a/crates/app/src/provider/policy.rs
+++ b/crates/app/src/provider/policy.rs
@@ -1,6 +1,8 @@
 use crate::config::ProviderConfig;
-use chrono::{DateTime, Utc};
 use reqwest::header::{HeaderMap, RETRY_AFTER};
+use std::time::{Duration, SystemTime};
+use time::OffsetDateTime;
+use time::format_description::well_known::{Rfc2822, Rfc3339};
 
 const MIN_BACKOFF_MS: u64 = 50;
 
@@ -61,10 +63,10 @@ pub(super) fn next_backoff_ms(current: u64, max_backoff_ms: u64) -> u64 {
 }
 
 fn parse_retry_after_ms(response_headers: &HeaderMap) -> Option<u64> {
-    parse_retry_after_ms_at(response_headers, Utc::now())
+    parse_retry_after_ms_at(response_headers, SystemTime::now())
 }
 
-fn parse_retry_after_ms_at(response_headers: &HeaderMap, now: DateTime<Utc>) -> Option<u64> {
+fn parse_retry_after_ms_at(response_headers: &HeaderMap, now: SystemTime) -> Option<u64> {
     let raw = response_headers.get(RETRY_AFTER)?.to_str().ok()?.trim();
     if raw.is_empty() {
         return None;
@@ -74,19 +76,25 @@ fn parse_retry_after_ms_at(response_headers: &HeaderMap, now: DateTime<Utc>) -> 
         return Some(seconds.saturating_mul(1_000));
     }
 
-    let retry_at = DateTime::parse_from_rfc2822(raw)
-        .or_else(|_| DateTime::parse_from_rfc3339(raw))
+    let retry_at = OffsetDateTime::parse(raw, &Rfc2822)
+        .or_else(|_| OffsetDateTime::parse(raw, &Rfc3339))
         .ok()?
-        .with_timezone(&Utc);
-    let wait = retry_at.signed_duration_since(now);
-    if wait <= chrono::Duration::zero() {
-        return Some(0);
-    }
-    let wait_std = wait.to_std().ok()?;
-    match u64::try_from(wait_std.as_millis()) {
+        .to_offset(time::UtcOffset::UTC);
+    let retry_at = offset_date_time_to_system_time(retry_at)?;
+    let wait = match retry_at.duration_since(now) {
+        Ok(duration) => duration,
+        Err(_) => return Some(0),
+    };
+    match u64::try_from(wait.as_millis()) {
         Ok(ms) => Some(ms),
         Err(_) => Some(u64::MAX),
     }
+}
+
+fn offset_date_time_to_system_time(value: OffsetDateTime) -> Option<SystemTime> {
+    let seconds = u64::try_from(value.unix_timestamp()).ok()?;
+    let system_time = SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(seconds))?;
+    system_time.checked_add(Duration::from_nanos(u64::from(value.nanosecond())))
 }
 
 #[cfg(test)]
@@ -141,16 +149,44 @@ mod tests {
 
     #[test]
     fn retry_delay_uses_retry_after_http_date_hint_when_present() {
-        let now = DateTime::parse_from_rfc3339("2026-03-11T10:00:00Z")
-            .expect("valid test timestamp")
-            .with_timezone(&Utc);
-        let retry_at = (now + chrono::Duration::seconds(2)).to_rfc2822();
+        let now = time::macros::datetime!(2026-03-11 10:00:00 UTC);
+        let retry_at = (now + time::Duration::seconds(2))
+            .format(&Rfc2822)
+            .unwrap_or_else(|error| panic!("retry-after test date should format: {error}"));
         let mut headers = HeaderMap::new();
         headers.insert(
             RETRY_AFTER,
             HeaderValue::from_str(retry_at.as_str()).expect("valid retry-after header"),
         );
-        assert_eq!(parse_retry_after_ms_at(&headers, now), Some(2_000));
+        let now_system_time = match offset_date_time_to_system_time(now) {
+            Some(value) => value,
+            None => panic!("test timestamp should convert to SystemTime"),
+        };
+        assert_eq!(
+            parse_retry_after_ms_at(&headers, now_system_time),
+            Some(2_000)
+        );
+    }
+
+    #[test]
+    fn retry_delay_uses_retry_after_rfc3339_hint_when_present() {
+        let now = time::macros::datetime!(2026-03-11 10:00:00 UTC);
+        let retry_at = (now + time::Duration::seconds(2))
+            .format(&Rfc3339)
+            .unwrap_or_else(|error| panic!("retry-after test date should format: {error}"));
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            RETRY_AFTER,
+            HeaderValue::from_str(retry_at.as_str()).expect("valid retry-after header"),
+        );
+        let now_system_time = match offset_date_time_to_system_time(now) {
+            Some(value) => value,
+            None => panic!("test timestamp should convert to SystemTime"),
+        };
+        assert_eq!(
+            parse_retry_after_ms_at(&headers, now_system_time),
+            Some(2_000)
+        );
     }
 
     #[test]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -27,7 +27,7 @@ loongclaw-spec = { path = "../spec" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-chrono.workspace = true
+time.workspace = true
 
 [[bin]]
 name = "loongclaw"

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -4,10 +4,10 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use loongclaw_app as mvp;
+use loongclaw_spec::CliResult;
 use time::OffsetDateTime;
 use time::format_description::FormatItem;
 use time::macros::format_description;
-use loongclaw_spec::CliResult;
 
 const BACKUP_TIMESTAMP_FORMAT: &[FormatItem<'static>] =
     format_description!("[year][month][day]-[hour][minute][second]");

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -3,9 +3,14 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-use chrono::Local;
 use loongclaw_app as mvp;
+use time::OffsetDateTime;
+use time::format_description::FormatItem;
+use time::macros::format_description;
 use loongclaw_spec::CliResult;
+
+const BACKUP_TIMESTAMP_FORMAT: &[FormatItem<'static>] =
+    format_description!("[year][month][day]-[hour][minute][second]");
 
 #[derive(Debug, Clone)]
 pub(crate) struct OnboardCommandOptions {
@@ -1234,14 +1239,25 @@ fn resolve_force_write(output_path: &Path, options: &OnboardCommandOptions) -> C
 }
 
 fn resolve_backup_path(original: &Path) -> CliResult<PathBuf> {
+    let now = OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc());
+    resolve_backup_path_at(original, now)
+}
+
+fn resolve_backup_path_at(original: &Path, timestamp: OffsetDateTime) -> CliResult<PathBuf> {
     let parent = original.parent().unwrap_or(Path::new("."));
     let file_stem = original
         .file_stem()
         .map(|name| name.to_string_lossy().to_string())
         .unwrap_or_else(|| "config".to_owned());
 
-    let timestamp = Local::now().format("%Y%m%d-%H%M%S").to_string();
-    Ok(parent.join(format!("{}.toml.bak-{}", file_stem, timestamp)))
+    let formatted_timestamp = format_backup_timestamp_at(timestamp)?;
+    Ok(parent.join(format!("{}.toml.bak-{}", file_stem, formatted_timestamp)))
+}
+
+fn format_backup_timestamp_at(timestamp: OffsetDateTime) -> CliResult<String> {
+    timestamp
+        .format(BACKUP_TIMESTAMP_FORMAT)
+        .map_err(|error| format!("format backup timestamp failed: {error}"))
 }
 
 fn load_or_default_onboard_config(path: &Path) -> CliResult<mvp::config::LoongClawConfig> {
@@ -1251,4 +1267,37 @@ fn load_or_default_onboard_config(path: &Path) -> CliResult<mvp::config::LoongCl
     let path_string = path.display().to_string();
     let (_, config) = mvp::config::load(Some(&path_string))?;
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_backup_timestamp_at_matches_existing_filename_shape() {
+        let timestamp = time::macros::datetime!(2026-03-14 01:23:45 +08:00);
+
+        let formatted = match format_backup_timestamp_at(timestamp) {
+            Ok(value) => value,
+            Err(error) => panic!("formatting should succeed: {error}"),
+        };
+
+        assert_eq!(formatted, "20260314-012345");
+    }
+
+    #[test]
+    fn resolve_backup_path_at_uses_formatted_timestamp() {
+        let original = Path::new("/tmp/loongclaw.toml");
+        let timestamp = time::macros::datetime!(2026-03-14 01:23:45 +08:00);
+
+        let path = match resolve_backup_path_at(original, timestamp) {
+            Ok(value) => value,
+            Err(error) => panic!("backup path should resolve: {error}"),
+        };
+
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/loongclaw.toml.bak-20260314-012345")
+        );
+    }
 }

--- a/docs/plans/2026-03-14-default-cli-chrono-prune-evidence.md
+++ b/docs/plans/2026-03-14-default-cli-chrono-prune-evidence.md
@@ -1,0 +1,69 @@
+## Summary
+
+This note records the evidence behind pruning `chrono` from the default
+`loongclaw` CLI path.
+
+The change is intentionally narrow:
+
+- replace the remaining default-binary `chrono` usage in provider retry policy
+- replace the remaining default-binary `chrono` usage in onboarding backup
+  timestamp formatting
+- keep user-visible behavior intact
+
+## Behavioral Scope
+
+The retained behavior is:
+
+- numeric `Retry-After` values continue to parse as seconds
+- RFC 2822 HTTP-date `Retry-After` values continue to parse
+- RFC 3339 `Retry-After` values are covered explicitly
+- onboarding backup filenames retain the existing
+  `YYYYMMDD-HHMMSS` shape
+
+## Dependency Rationale
+
+Before this cleanup, the default CLI path still pulled `chrono` through narrow
+call sites in:
+
+- `crates/app/src/provider/policy.rs`
+- `crates/daemon/src/onboard_cli.rs`
+
+On macOS, that dependency had previously introduced a direct CoreFoundation
+link through the `chrono` -> `iana-time-zone` -> `core-foundation-sys` chain.
+
+The intended outcome of this change is therefore:
+
+- a smaller default release binary
+- a smaller default dependency surface
+- no claim of app-internal startup optimization unless benchmark data supports
+  it
+
+## Measurement Notes
+
+The detailed startup and binary-size study was executed in a dedicated
+performance analysis worktree rather than in this PR branch.
+
+That dedicated study found:
+
+- the stripped default binary shrank from `6,078,368` bytes to `6,009,968`
+  bytes
+- the direct dynamic dependency surface dropped the old CoreFoundation link
+- alternating startup reruns did not reproduce a stable regression
+- `main_entry_to_prompt_ms` stayed effectively unchanged, so any observed
+  startup improvement is more defensibly described as pre-`main()` residual
+  improvement rather than app-internal startup optimization
+
+This PR should therefore be described conservatively:
+
+- it is a dependency and footprint cleanup for the default CLI path
+- it is consistent with earlier measured pre-`main()` improvement
+- it should not be presented as proof of faster app-internal startup
+
+## PR-Branch Validation
+
+The code changes on this branch are validated with:
+
+- targeted onboarding backup-path tests
+- targeted provider retry-policy tests
+- the full `loongclaw-app` test suite
+- a fresh default release build for `loongclaw`

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-13T08:09:50Z
+- Generated at: 2026-03-13T23:54:20Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -11,8 +11,8 @@
 ## Hotspot Metrics
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
-| spec_runtime | `crates/spec/src/spec_runtime.rs` | 2913 | 3600 | 687 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
-| spec_execution | `crates/spec/src/spec_execution.rs` | 1466 | 3700 | 2234 | 22 | 80 | 58 | n/a | n/a | N/A | n/a |
+| spec_runtime | `crates/spec/src/spec_runtime.rs` | 2926 | 3600 | 674 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
+| spec_execution | `crates/spec/src/spec_execution.rs` | 1467 | 3700 | 2233 | 22 | 80 | 58 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 234 | 1000 | 766 | 5 | 20 | 15 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 620 | 650 | 30 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
@@ -37,8 +37,8 @@
 - [Release template](TEMPLATE.md)
 - [CI workflow](../../.github/workflows/ci.yml)
 
-<!-- arch-hotspot key=spec_runtime lines=2913 functions=47 -->
-<!-- arch-hotspot key=spec_execution lines=1466 functions=22 -->
+<!-- arch-hotspot key=spec_runtime lines=2926 functions=47 -->
+<!-- arch-hotspot key=spec_execution lines=1467 functions=22 -->
 <!-- arch-hotspot key=provider_mod lines=234 functions=5 -->
 <!-- arch-hotspot key=memory_mod lines=620 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
Closes #107

## Summary
- replace the remaining default CLI `chrono` call sites with `time`
- preserve retry-policy and onboarding backup timestamp behavior
- add a concise evidence note for the footprint and startup study

## Validation
- cargo fmt --all --check
- cargo test -p loongclaw-daemon onboard_cli::tests::
- cargo test -p loongclaw-app provider::policy::tests::
- cargo test -p loongclaw-app
- cargo build -p loongclaw-daemon --release --bin loongclaw
- cargo tree -p loongclaw-daemon -i core-foundation-sys
- otool -L target/release/loongclaw

## Notes
- earlier dedicated benchmarking found a smaller stripped default binary and a reduced macOS dynamic dependency surface after removing `chrono`
- the same study did not support a stable app-internal startup improvement claim, so this PR keeps the performance framing conservative