### PR TITLE
refactor(spec): decouple app-native tool execution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,14 +12,12 @@ contracts (leaf -- zero internal deps)
 ├── kernel --> contracts
 ├── protocol (independent leaf)
 ├── app --> contracts, kernel
-├── spec --> contracts, kernel, protocol (+ app: known deviation, tracked as D1)
+├── spec --> contracts, kernel, protocol
 ├── bench --> contracts, kernel, spec
 └── daemon (binary) --> all of the above
 ```
 
 No dependency cycles. This is non-negotiable.
-Tracked deviation D1: `spec -> app` is currently allowed for transitional runtime coupling and
-must be removed in a follow-up architecture refactor.
 
 | Crate | Role |
 |-------|------|

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,7 +1336,6 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "futures-util",
- "loongclaw-app",
  "loongclaw-kernel",
  "loongclaw-protocol",
  "reqwest",

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -1067,6 +1067,11 @@ async fn run_spec_pressure_once(
     spec: &RunnerSpec,
     scenario: &ProgrammaticPressureScenario,
 ) -> CliResult<ScenarioRunSample> {
+    if spec_requires_native_tool_executor(spec) {
+        return Err(
+            "spec benchmark scenario requires a native tool executor; move this claw.import/claw-migration run to daemon composition root".to_owned(),
+        );
+    }
     let report = execute_spec(spec, false).await;
     let blocked = report.operation_kind == "blocked" || report.blocked_reason.is_some();
 
@@ -1105,6 +1110,19 @@ async fn run_spec_pressure_once(
     collect_spec_step_metrics(&report.outcome, &mut sample);
 
     Ok(sample)
+}
+
+fn spec_requires_native_tool_executor(spec: &RunnerSpec) -> bool {
+    match &spec.operation {
+        loongclaw_spec::OperationSpec::ToolCore { tool_name, .. } => matches!(
+            tool_name.as_str(),
+            "claw.import" | "claw_import" | "import_claw"
+        ),
+        loongclaw_spec::OperationSpec::ToolExtension { extension, .. } => {
+            extension == "claw-migration"
+        }
+        _ => false,
+    }
 }
 
 async fn run_circuit_half_open_pressure_once(
@@ -1959,6 +1977,7 @@ fn default_failures_before_open() -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kernel::{Capability, ExecutionRoute, HarnessKind, VerticalPackManifest};
     use serde_json::json;
 
     #[test]
@@ -2598,5 +2617,90 @@ mod tests {
         assert_eq!(normalized.max_ratio, 0.0);
         assert_eq!(normalized.min_ratio, 0.0);
         assert_eq!(normalized.latency_ms, 0.0);
+    }
+
+    #[tokio::test]
+    async fn run_spec_pressure_once_rejects_native_claw_import_scenarios() {
+        let spec = RunnerSpec {
+            pack: VerticalPackManifest {
+                pack_id: "bench-spec-native-claw-import".to_owned(),
+                domain: "ops".to_owned(),
+                version: "0.1.0".to_owned(),
+                default_route: ExecutionRoute {
+                    harness_kind: HarnessKind::EmbeddedPi,
+                    adapter: Some("pi-local".to_owned()),
+                },
+                allowed_connectors: BTreeSet::new(),
+                granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                metadata: BTreeMap::new(),
+            },
+            agent_id: "bench-agent-native-claw-import".to_owned(),
+            ttl_s: 60,
+            approval: None,
+            defaults: None,
+            self_awareness: None,
+            plugin_scan: None,
+            bridge_support: None,
+            bootstrap: None,
+            auto_provision: None,
+            hotfixes: Vec::new(),
+            operation: loongclaw_spec::OperationSpec::ToolCore {
+                tool_name: "claw.import".to_owned(),
+                required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                payload: json!({"mode": "plan"}),
+                core: None,
+            },
+        };
+        let scenario = ProgrammaticPressureScenario {
+            name: "native-claw-import".to_owned(),
+            description: None,
+            iterations: Some(1),
+            warmup_iterations: Some(0),
+            expected_operation_kind: "tool_core".to_owned(),
+            allow_blocked: false,
+            kind: ProgrammaticPressureScenarioKind::SpecRun { spec: spec.clone() },
+        };
+
+        let error = run_spec_pressure_once(&spec, &scenario)
+            .await
+            .expect_err("bench spec runs should reject native claw.import scenarios");
+        assert!(error.contains("native tool executor"));
+    }
+
+    #[test]
+    fn spec_requires_native_tool_executor_detects_claw_migration_extension() {
+        let spec = RunnerSpec {
+            pack: VerticalPackManifest {
+                pack_id: "bench-spec-claw-migration-extension".to_owned(),
+                domain: "ops".to_owned(),
+                version: "0.1.0".to_owned(),
+                default_route: ExecutionRoute {
+                    harness_kind: HarnessKind::EmbeddedPi,
+                    adapter: Some("pi-local".to_owned()),
+                },
+                allowed_connectors: BTreeSet::new(),
+                granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                metadata: BTreeMap::new(),
+            },
+            agent_id: "bench-agent-claw-migration-extension".to_owned(),
+            ttl_s: 60,
+            approval: None,
+            defaults: None,
+            self_awareness: None,
+            plugin_scan: None,
+            bridge_support: None,
+            bootstrap: None,
+            auto_provision: None,
+            hotfixes: Vec::new(),
+            operation: loongclaw_spec::OperationSpec::ToolExtension {
+                extension_action: "plan".to_owned(),
+                required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                payload: json!({"input_path": "/tmp/demo"}),
+                extension: "claw-migration".to_owned(),
+                core: None,
+            },
+        };
+
+        assert!(spec_requires_native_tool_executor(&spec));
     }
 }

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -1079,12 +1079,23 @@ async fn run_spec_pressure_once(
     scenario: &ProgrammaticPressureScenario,
     native_tool_executor: Option<NativeToolExecutor>,
 ) -> CliResult<ScenarioRunSample> {
-    if spec_requires_native_tool_executor(spec) && native_tool_executor.is_none() {
+    let requires_native_tool_executor = spec_requires_native_tool_executor(spec);
+    if requires_native_tool_executor && native_tool_executor.is_none() {
         return Err(
             "spec benchmark scenario requires a native tool executor; move this claw.import/claw-migration run to daemon composition root".to_owned(),
         );
     }
     let report = execute_spec_with_native_tool_executor(spec, false, native_tool_executor).await;
+    if requires_native_tool_executor
+        && report
+            .blocked_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("native tool executor"))
+    {
+        return Err(
+            "spec benchmark scenario requires a native tool executor that handles the requested native tool; move this claw.import/claw-migration run to daemon composition root".to_owned(),
+        );
+    }
     let blocked = report.operation_kind == "blocked" || report.blocked_reason.is_some();
 
     let mut sample = ScenarioRunSample {
@@ -2721,6 +2732,21 @@ mod tests {
         }))
     }
 
+    fn declining_native_tool_executor(
+        request: ToolCoreRequest,
+    ) -> Option<Result<ToolCoreOutcome, String>> {
+        if loongclaw_spec::tool_name_requires_native_tool_executor(request.tool_name.as_str()) {
+            return None;
+        }
+        Some(Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "native-tools",
+                "tool": request.tool_name,
+            }),
+        }))
+    }
+
     #[tokio::test]
     async fn run_spec_pressure_once_uses_native_executor_when_present() {
         let spec = RunnerSpec {
@@ -2769,5 +2795,54 @@ mod tests {
 
         assert!(sample.passed);
         assert!(!sample.blocked);
+    }
+
+    #[tokio::test]
+    async fn run_spec_pressure_once_errors_when_executor_declines_native_request() {
+        let spec = RunnerSpec {
+            pack: VerticalPackManifest {
+                pack_id: "bench-spec-native-claw-import-declined".to_owned(),
+                domain: "ops".to_owned(),
+                version: "0.1.0".to_owned(),
+                default_route: ExecutionRoute {
+                    harness_kind: HarnessKind::EmbeddedPi,
+                    adapter: Some("pi-local".to_owned()),
+                },
+                allowed_connectors: BTreeSet::new(),
+                granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                metadata: BTreeMap::new(),
+            },
+            agent_id: "bench-agent-native-claw-import-declined".to_owned(),
+            ttl_s: 60,
+            approval: None,
+            defaults: None,
+            self_awareness: None,
+            plugin_scan: None,
+            bridge_support: None,
+            bootstrap: None,
+            auto_provision: None,
+            hotfixes: Vec::new(),
+            operation: loongclaw_spec::OperationSpec::ToolCore {
+                tool_name: "claw.import".to_owned(),
+                required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                payload: json!({"mode": "plan"}),
+                core: None,
+            },
+        };
+        let scenario = ProgrammaticPressureScenario {
+            name: "native-claw-import-declined".to_owned(),
+            description: None,
+            iterations: Some(1),
+            warmup_iterations: Some(0),
+            expected_operation_kind: "tool_core".to_owned(),
+            allow_blocked: true,
+            kind: ProgrammaticPressureScenarioKind::SpecRun { spec: spec.clone() },
+        };
+
+        let error = run_spec_pressure_once(&spec, &scenario, Some(declining_native_tool_executor))
+            .await
+            .expect_err("bench spec runs should error when executor declines native requests");
+
+        assert!(error.contains("native tool executor"));
     }
 }

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -1121,7 +1121,16 @@ fn spec_requires_native_tool_executor(spec: &RunnerSpec) -> bool {
         loongclaw_spec::OperationSpec::ToolExtension { extension, .. } => {
             extension == "claw-migration"
         }
-        _ => false,
+        loongclaw_spec::OperationSpec::Task { .. }
+        | loongclaw_spec::OperationSpec::ConnectorLegacy { .. }
+        | loongclaw_spec::OperationSpec::ConnectorCore { .. }
+        | loongclaw_spec::OperationSpec::ConnectorExtension { .. }
+        | loongclaw_spec::OperationSpec::RuntimeCore { .. }
+        | loongclaw_spec::OperationSpec::RuntimeExtension { .. }
+        | loongclaw_spec::OperationSpec::MemoryCore { .. }
+        | loongclaw_spec::OperationSpec::MemoryExtension { .. }
+        | loongclaw_spec::OperationSpec::ToolSearch { .. }
+        | loongclaw_spec::OperationSpec::ProgrammaticToolCall { .. } => false,
     }
 }
 

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -18,8 +18,9 @@ use loongclaw_spec::programmatic::{
     acquire_programmatic_circuit_slot, record_programmatic_circuit_outcome,
 };
 use loongclaw_spec::{
-    BridgeRuntimePolicy, CliResult, ProgrammaticCircuitBreakerPolicy,
-    ProgrammaticCircuitRuntimeState, RunnerSpec, execute_spec, execute_wasm_component_bridge,
+    BridgeRuntimePolicy, CliResult, NativeToolExecutor, ProgrammaticCircuitBreakerPolicy,
+    ProgrammaticCircuitRuntimeState, RunnerSpec, execute_spec_with_native_tool_executor,
+    execute_wasm_component_bridge, spec_requires_native_tool_executor,
 };
 
 const DEFAULT_PRESSURE_ITERATIONS: usize = 12;
@@ -338,6 +339,7 @@ pub async fn run_programmatic_pressure_benchmark_cli(
     output_path: &str,
     enforce_gate: bool,
     preflight_fail_on_warnings: bool,
+    native_tool_executor: Option<NativeToolExecutor>,
 ) -> CliResult<()> {
     let matrix: ProgrammaticPressureMatrix = read_json_file(matrix_path)?;
 
@@ -382,6 +384,7 @@ pub async fn run_programmatic_pressure_benchmark_cli(
         baseline.as_ref(),
         preflight,
         enforce_gate,
+        native_tool_executor,
     )
     .await;
 
@@ -771,13 +774,19 @@ async fn run_programmatic_pressure_matrix(
     baseline: Option<&ProgrammaticPressureBaseline>,
     preflight: Option<ProgrammaticPressureBaselinePreflight>,
     enforce_gate: bool,
+    native_tool_executor: Option<NativeToolExecutor>,
 ) -> ProgrammaticPressureReport {
     let mut scenarios = Vec::new();
     for scenario in &matrix.scenarios {
         let baseline_thresholds = baseline.and_then(|value| value.scenarios.get(&scenario.name));
-        let report =
-            run_programmatic_pressure_scenario(matrix, scenario, baseline_thresholds, enforce_gate)
-                .await;
+        let report = run_programmatic_pressure_scenario(
+            matrix,
+            scenario,
+            baseline_thresholds,
+            enforce_gate,
+            native_tool_executor,
+        )
+        .await;
         scenarios.push(report);
     }
 
@@ -988,6 +997,7 @@ async fn run_programmatic_pressure_scenario(
     scenario: &ProgrammaticPressureScenario,
     thresholds: Option<&ProgrammaticPressureScenarioThresholds>,
     enforce_gate: bool,
+    native_tool_executor: Option<NativeToolExecutor>,
 ) -> ProgrammaticPressureScenarioReport {
     let iterations = scenario
         .iterations
@@ -998,13 +1008,13 @@ async fn run_programmatic_pressure_scenario(
         .unwrap_or(matrix.default_warmup_iterations);
 
     for _ in 0..warmup_iterations {
-        let _ = run_pressure_scenario_once(scenario).await;
+        let _ = run_pressure_scenario_once(scenario, native_tool_executor).await;
     }
 
     let mut samples = Vec::with_capacity(iterations);
     for _ in 0..iterations {
         let started = TokioInstant::now();
-        let run = run_pressure_scenario_once(scenario).await;
+        let run = run_pressure_scenario_once(scenario, native_tool_executor).await;
         let latency_ms = started.elapsed().as_secs_f64() * 1_000.0;
         samples.push(match run {
             Ok(mut sample) => {
@@ -1037,10 +1047,11 @@ async fn run_programmatic_pressure_scenario(
 
 async fn run_pressure_scenario_once(
     scenario: &ProgrammaticPressureScenario,
+    native_tool_executor: Option<NativeToolExecutor>,
 ) -> CliResult<ScenarioRunSample> {
     match &scenario.kind {
         ProgrammaticPressureScenarioKind::SpecRun { spec } => {
-            run_spec_pressure_once(spec, scenario).await
+            run_spec_pressure_once(spec, scenario, native_tool_executor).await
         }
         ProgrammaticPressureScenarioKind::CircuitHalfOpen {
             connector_name,
@@ -1066,13 +1077,14 @@ async fn run_pressure_scenario_once(
 async fn run_spec_pressure_once(
     spec: &RunnerSpec,
     scenario: &ProgrammaticPressureScenario,
+    native_tool_executor: Option<NativeToolExecutor>,
 ) -> CliResult<ScenarioRunSample> {
-    if spec_requires_native_tool_executor(spec) {
+    if spec_requires_native_tool_executor(spec) && native_tool_executor.is_none() {
         return Err(
             "spec benchmark scenario requires a native tool executor; move this claw.import/claw-migration run to daemon composition root".to_owned(),
         );
     }
-    let report = execute_spec(spec, false).await;
+    let report = execute_spec_with_native_tool_executor(spec, false, native_tool_executor).await;
     let blocked = report.operation_kind == "blocked" || report.blocked_reason.is_some();
 
     let mut sample = ScenarioRunSample {
@@ -1110,28 +1122,6 @@ async fn run_spec_pressure_once(
     collect_spec_step_metrics(&report.outcome, &mut sample);
 
     Ok(sample)
-}
-
-fn spec_requires_native_tool_executor(spec: &RunnerSpec) -> bool {
-    match &spec.operation {
-        loongclaw_spec::OperationSpec::ToolCore { tool_name, .. } => matches!(
-            tool_name.as_str(),
-            "claw.import" | "claw_import" | "import_claw"
-        ),
-        loongclaw_spec::OperationSpec::ToolExtension { extension, .. } => {
-            extension == "claw-migration"
-        }
-        loongclaw_spec::OperationSpec::Task { .. }
-        | loongclaw_spec::OperationSpec::ConnectorLegacy { .. }
-        | loongclaw_spec::OperationSpec::ConnectorCore { .. }
-        | loongclaw_spec::OperationSpec::ConnectorExtension { .. }
-        | loongclaw_spec::OperationSpec::RuntimeCore { .. }
-        | loongclaw_spec::OperationSpec::RuntimeExtension { .. }
-        | loongclaw_spec::OperationSpec::MemoryCore { .. }
-        | loongclaw_spec::OperationSpec::MemoryExtension { .. }
-        | loongclaw_spec::OperationSpec::ToolSearch { .. }
-        | loongclaw_spec::OperationSpec::ProgrammaticToolCall { .. } => false,
-    }
 }
 
 async fn run_circuit_half_open_pressure_once(
@@ -1986,7 +1976,10 @@ fn default_failures_before_open() -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kernel::{Capability, ExecutionRoute, HarnessKind, VerticalPackManifest};
+    use kernel::{
+        Capability, ExecutionRoute, HarnessKind, ToolCoreOutcome, ToolCoreRequest,
+        VerticalPackManifest,
+    };
     use serde_json::json;
 
     #[test]
@@ -2670,7 +2663,7 @@ mod tests {
             kind: ProgrammaticPressureScenarioKind::SpecRun { spec: spec.clone() },
         };
 
-        let error = run_spec_pressure_once(&spec, &scenario)
+        let error = run_spec_pressure_once(&spec, &scenario, None)
             .await
             .expect_err("bench spec runs should reject native claw.import scenarios");
         assert!(error.contains("native tool executor"));
@@ -2710,6 +2703,71 @@ mod tests {
             },
         };
 
-        assert!(spec_requires_native_tool_executor(&spec));
+        assert!(loongclaw_spec::spec_requires_native_tool_executor(&spec));
+    }
+
+    fn test_native_tool_executor(
+        request: ToolCoreRequest,
+    ) -> Option<Result<ToolCoreOutcome, String>> {
+        if !loongclaw_spec::tool_name_requires_native_tool_executor(request.tool_name.as_str()) {
+            return None;
+        }
+        Some(Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "native-tools",
+                "tool": request.tool_name,
+            }),
+        }))
+    }
+
+    #[tokio::test]
+    async fn run_spec_pressure_once_uses_native_executor_when_present() {
+        let spec = RunnerSpec {
+            pack: VerticalPackManifest {
+                pack_id: "bench-spec-native-claw-import-exec".to_owned(),
+                domain: "ops".to_owned(),
+                version: "0.1.0".to_owned(),
+                default_route: ExecutionRoute {
+                    harness_kind: HarnessKind::EmbeddedPi,
+                    adapter: Some("pi-local".to_owned()),
+                },
+                allowed_connectors: BTreeSet::new(),
+                granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                metadata: BTreeMap::new(),
+            },
+            agent_id: "bench-agent-native-claw-import-exec".to_owned(),
+            ttl_s: 60,
+            approval: None,
+            defaults: None,
+            self_awareness: None,
+            plugin_scan: None,
+            bridge_support: None,
+            bootstrap: None,
+            auto_provision: None,
+            hotfixes: Vec::new(),
+            operation: loongclaw_spec::OperationSpec::ToolCore {
+                tool_name: "claw.import".to_owned(),
+                required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                payload: json!({"mode": "plan"}),
+                core: None,
+            },
+        };
+        let scenario = ProgrammaticPressureScenario {
+            name: "native-claw-import-exec".to_owned(),
+            description: None,
+            iterations: Some(1),
+            warmup_iterations: Some(0),
+            expected_operation_kind: "tool_core".to_owned(),
+            allow_blocked: false,
+            kind: ProgrammaticPressureScenarioKind::SpecRun { spec: spec.clone() },
+        };
+
+        let sample = run_spec_pressure_once(&spec, &scenario, Some(test_native_tool_executor))
+            .await
+            .expect("bench spec runs should execute when a native executor is injected");
+
+        assert!(sample.passed);
+        assert!(!sample.blocked);
     }
 }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -17,7 +17,10 @@ use clap::CommandFactory;
 use clap::{Parser, Subcommand, ValueEnum};
 #[cfg(test)]
 use kernel::{AuditEventKind, ExecutionRoute, HarnessKind, PluginBridgeKind, VerticalPackManifest};
-use kernel::{Capability, ConnectorCommand, FixedClock, InMemoryAuditSink, TaskIntent};
+use kernel::{
+    Capability, ConnectorCommand, FixedClock, InMemoryAuditSink, TaskIntent, ToolCoreOutcome,
+    ToolCoreRequest,
+};
 use serde::Serialize;
 use serde_json::{Value, json};
 #[cfg(test)]
@@ -45,6 +48,13 @@ pub(crate) use loongclaw_spec::programmatic::{
 mod tests;
 
 const PUBLIC_GITHUB_REPO: &str = "loongclaw-ai/loongclaw";
+
+fn native_spec_tool_executor(request: ToolCoreRequest) -> Option<Result<ToolCoreOutcome, String>> {
+    if mvp::tools::canonical_tool_name(request.tool_name.as_str()) != "claw.import" {
+        return None;
+    }
+    Some(mvp::tools::execute_tool_core(request))
+}
 
 type ChannelCliCommandFuture<'a> = Pin<Box<dyn Future<Output = CliResult<()>> + Send + 'a>>;
 
@@ -930,7 +940,9 @@ fn init_spec_cli(output_path: &str) -> CliResult<()> {
 
 async fn run_spec_cli(spec_path: &str, print_audit: bool) -> CliResult<()> {
     let spec = read_spec_file(spec_path)?;
-    let report = execute_spec(&spec, print_audit).await;
+    let report =
+        execute_spec_with_native_tool_executor(&spec, print_audit, Some(native_spec_tool_executor))
+            .await;
     let pretty = serde_json::to_string_pretty(&report)
         .map_err(|error| format!("serialize spec run report failed: {error}"))?;
     println!("{pretty}");

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -495,6 +495,7 @@ async fn main() {
                 &output,
                 enforce_gate,
                 preflight_fail_on_warnings,
+                Some(native_spec_tool_executor),
             )
             .await
         }

--- a/crates/daemon/src/tests/spec_runtime.rs
+++ b/crates/daemon/src/tests/spec_runtime.rs
@@ -4481,7 +4481,8 @@ async fn execute_spec_tool_core_can_run_claw_import_plan_via_native_tool_runtime
         },
     };
 
-    let report = execute_spec(&spec, true).await;
+    let report =
+        execute_spec_with_native_tool_executor(&spec, true, Some(native_spec_tool_executor)).await;
     assert_eq!(report.operation_kind, "tool_core");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(report.outcome["outcome"]["payload"]["source"], "nanobot");
@@ -4566,7 +4567,8 @@ async fn execute_spec_tool_extension_can_hot_handle_claw_import_via_core_wrapper
         },
     };
 
-    let report = execute_spec(&spec, true).await;
+    let report =
+        execute_spec_with_native_tool_executor(&spec, true, Some(native_spec_tool_executor)).await;
     assert_eq!(report.operation_kind, "tool_extension");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -4667,7 +4669,8 @@ async fn execute_spec_tool_extension_can_discover_multiple_sources() {
         },
     };
 
-    let report = execute_spec(&spec, true).await;
+    let report =
+        execute_spec_with_native_tool_executor(&spec, true, Some(native_spec_tool_executor)).await;
     assert_eq!(report.operation_kind, "tool_extension");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(report.outcome["outcome"]["payload"]["action"], "discover");
@@ -4764,7 +4767,8 @@ async fn execute_spec_tool_extension_can_merge_profiles_without_merging_prompt_l
         },
     };
 
-    let report = execute_spec(&spec, true).await;
+    let report =
+        execute_spec_with_native_tool_executor(&spec, true, Some(native_spec_tool_executor)).await;
     assert_eq!(report.operation_kind, "tool_extension");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(
@@ -4870,7 +4874,8 @@ async fn execute_spec_tool_extension_apply_selected_safe_merge_keeps_native_prom
         },
     };
 
-    let report = execute_spec(&spec, true).await;
+    let report =
+        execute_spec_with_native_tool_executor(&spec, true, Some(native_spec_tool_executor)).await;
     assert_eq!(report.operation_kind, "tool_extension");
     assert_eq!(report.outcome["outcome"]["status"], "ok");
     assert_eq!(

--- a/crates/spec/Cargo.toml
+++ b/crates/spec/Cargo.toml
@@ -11,7 +11,6 @@ test-hooks = []
 [dependencies]
 async-trait.workspace = true
 kernel = { package = "loongclaw-kernel", path = "../kernel" }
-loongclaw-app = { path = "../app", default-features = false, features = ["config-toml"] }
 loongclaw-protocol = { path = "../protocol" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/spec/src/kernel_bootstrap.rs
+++ b/crates/spec/src/kernel_bootstrap.rs
@@ -22,6 +22,7 @@ use crate::spec_runtime::{
 pub struct KernelBuilder {
     clock: Option<Arc<dyn Clock>>,
     audit: Option<Arc<dyn AuditSink>>,
+    native_tool_executor: Option<crate::NativeToolExecutor>,
 }
 
 impl KernelBuilder {
@@ -37,9 +38,15 @@ impl KernelBuilder {
         self
     }
 
+    pub fn native_tool_executor(mut self, executor: crate::NativeToolExecutor) -> Self {
+        self.native_tool_executor = Some(executor);
+        self
+    }
+
     /// Build and return a fully configured kernel with all builtin adapters
     /// and the default pack manifest registered.
     pub fn build(self) -> LoongClawKernel<StaticPolicyEngine> {
+        let native_tool_executor = self.native_tool_executor;
         let mut kernel = match (self.clock, self.audit) {
             (Some(clock), Some(audit)) => {
                 LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit)
@@ -60,7 +67,7 @@ impl KernelBuilder {
                 Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
             ),
         };
-        register_builtin_adapters(&mut kernel);
+        register_builtin_adapters(&mut kernel, native_tool_executor);
         // The default pack manifest is hardcoded and always valid; ignore the
         // impossible error branch to avoid panicking in production.
         let _ = kernel.register_pack(default_pack_manifest());
@@ -68,7 +75,10 @@ impl KernelBuilder {
     }
 }
 
-fn register_builtin_adapters(kernel: &mut LoongClawKernel<StaticPolicyEngine>) {
+fn register_builtin_adapters(
+    kernel: &mut LoongClawKernel<StaticPolicyEngine>,
+    native_tool_executor: Option<crate::NativeToolExecutor>,
+) {
     kernel.register_harness_adapter(EmbeddedPiHarness {
         seen: Mutex::new(Vec::new()),
     });
@@ -81,7 +91,7 @@ fn register_builtin_adapters(kernel: &mut LoongClawKernel<StaticPolicyEngine>) {
     kernel.register_core_runtime_adapter(FallbackCoreRuntime);
     kernel.register_runtime_extension_adapter(AcpBridgeRuntimeExtension);
 
-    kernel.register_core_tool_adapter(CoreToolRuntime);
+    kernel.register_core_tool_adapter(CoreToolRuntime::new(native_tool_executor));
     kernel.register_tool_extension_adapter(ClawMigrationToolExtension);
     kernel.register_tool_extension_adapter(SqlAnalyticsToolExtension);
 

--- a/crates/spec/src/lib.rs
+++ b/crates/spec/src/lib.rs
@@ -2,6 +2,8 @@ use std::sync::OnceLock;
 #[cfg(any(test, feature = "test-hooks"))]
 use std::{collections::BTreeMap, sync::Mutex};
 
+use kernel::{ToolCoreOutcome, ToolCoreRequest};
+
 pub mod kernel_bootstrap;
 pub mod programmatic;
 pub mod spec_execution;
@@ -17,6 +19,7 @@ pub use spec_runtime::*;
 
 pub const DEFAULT_PACK_ID: &str = "dev-automation";
 pub const DEFAULT_AGENT_ID: &str = "agent-dev-01";
+pub type NativeToolExecutor = fn(ToolCoreRequest) -> Option<Result<ToolCoreOutcome, String>>;
 pub static BUNDLED_APPROVAL_RISK_PROFILE: OnceLock<ApprovalRiskProfile> = OnceLock::new();
 pub static BUNDLED_SECURITY_SCAN_PROFILE: OnceLock<SecurityScanProfile> = OnceLock::new();
 #[cfg(any(test, feature = "test-hooks"))]

--- a/crates/spec/src/lib.rs
+++ b/crates/spec/src/lib.rs
@@ -20,8 +20,118 @@ pub use spec_runtime::*;
 pub const DEFAULT_PACK_ID: &str = "dev-automation";
 pub const DEFAULT_AGENT_ID: &str = "agent-dev-01";
 pub type NativeToolExecutor = fn(ToolCoreRequest) -> Option<Result<ToolCoreOutcome, String>>;
+
+pub fn tool_name_requires_native_tool_executor(tool_name: &str) -> bool {
+    matches!(tool_name, "claw.import" | "claw_import" | "import_claw")
+}
+
+pub fn spec_requires_native_tool_executor(spec: &RunnerSpec) -> bool {
+    match &spec.operation {
+        OperationSpec::ToolCore { tool_name, .. } => {
+            tool_name_requires_native_tool_executor(tool_name)
+        }
+        OperationSpec::ToolExtension { extension, .. } => extension == "claw-migration",
+        OperationSpec::Task { .. }
+        | OperationSpec::ConnectorLegacy { .. }
+        | OperationSpec::ConnectorCore { .. }
+        | OperationSpec::ConnectorExtension { .. }
+        | OperationSpec::RuntimeCore { .. }
+        | OperationSpec::RuntimeExtension { .. }
+        | OperationSpec::MemoryCore { .. }
+        | OperationSpec::MemoryExtension { .. }
+        | OperationSpec::ToolSearch { .. }
+        | OperationSpec::ProgrammaticToolCall { .. } => false,
+    }
+}
+
 pub static BUNDLED_APPROVAL_RISK_PROFILE: OnceLock<ApprovalRiskProfile> = OnceLock::new();
 pub static BUNDLED_SECURITY_SCAN_PROFILE: OnceLock<SecurityScanProfile> = OnceLock::new();
 #[cfg(any(test, feature = "test-hooks"))]
 pub static WEBHOOK_TEST_RETRY_STATE: OnceLock<Mutex<BTreeMap<String, usize>>> = OnceLock::new();
 pub type CliResult<T> = Result<T, String>;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use kernel::{Capability, ExecutionRoute, HarnessKind, VerticalPackManifest};
+    use serde_json::json;
+
+    use super::{OperationSpec, RunnerSpec, execute_spec, spec_requires_native_tool_executor};
+
+    fn make_runner_spec(operation: OperationSpec) -> RunnerSpec {
+        RunnerSpec {
+            pack: VerticalPackManifest {
+                pack_id: "spec-native-tool-check".to_owned(),
+                domain: "ops".to_owned(),
+                version: "0.1.0".to_owned(),
+                default_route: ExecutionRoute {
+                    harness_kind: HarnessKind::EmbeddedPi,
+                    adapter: Some("pi-local".to_owned()),
+                },
+                allowed_connectors: BTreeSet::new(),
+                granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                metadata: BTreeMap::new(),
+            },
+            agent_id: "agent-native-tool-check".to_owned(),
+            ttl_s: 60,
+            approval: None,
+            defaults: None,
+            self_awareness: None,
+            plugin_scan: None,
+            bridge_support: None,
+            bootstrap: None,
+            auto_provision: None,
+            hotfixes: Vec::new(),
+            operation,
+        }
+    }
+
+    #[test]
+    fn spec_requires_native_tool_executor_detects_aliases_and_extension() {
+        let alias_spec = make_runner_spec(OperationSpec::ToolCore {
+            tool_name: "claw_import".to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            payload: json!({"mode": "plan"}),
+            core: None,
+        });
+        let extension_spec = make_runner_spec(OperationSpec::ToolExtension {
+            extension_action: "plan".to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            payload: json!({"input_path": "/tmp/demo"}),
+            extension: "claw-migration".to_owned(),
+            core: None,
+        });
+        let unrelated_spec = make_runner_spec(OperationSpec::ToolCore {
+            tool_name: "file.read".to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            payload: json!({"path": "/tmp/demo"}),
+            core: None,
+        });
+
+        assert!(spec_requires_native_tool_executor(&alias_spec));
+        assert!(spec_requires_native_tool_executor(&extension_spec));
+        assert!(!spec_requires_native_tool_executor(&unrelated_spec));
+    }
+
+    #[tokio::test]
+    async fn execute_spec_blocks_native_tool_without_executor() {
+        let spec = make_runner_spec(OperationSpec::ToolCore {
+            tool_name: "claw.import".to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            payload: json!({"mode": "plan"}),
+            core: None,
+        });
+
+        let report = execute_spec(&spec, false).await;
+
+        assert_eq!(report.operation_kind, "blocked");
+        assert!(
+            report
+                .blocked_reason
+                .as_deref()
+                .expect("blocked reason should exist")
+                .contains("native tool executor")
+        );
+    }
+}

--- a/crates/spec/src/spec_execution.rs
+++ b/crates/spec/src/spec_execution.rs
@@ -43,12 +43,23 @@ pub use bridge_support_policy::{
 pub use security_scan_policy::{load_security_scan_profile_from_path, security_scan_policy};
 
 pub async fn execute_spec(spec: &RunnerSpec, include_audit: bool) -> SpecRunReport {
+    execute_spec_with_native_tool_executor(spec, include_audit, None).await
+}
+
+pub async fn execute_spec_with_native_tool_executor(
+    spec: &RunnerSpec,
+    include_audit: bool,
+    native_tool_executor: Option<crate::NativeToolExecutor>,
+) -> SpecRunReport {
     let mut pack = spec.pack.clone();
     let audit_sink = Arc::new(InMemoryAuditSink::default());
-    let mut kernel = crate::kernel_bootstrap::KernelBuilder::default()
+    let mut builder = crate::kernel_bootstrap::KernelBuilder::default()
         .clock(Arc::new(SystemClock) as Arc<dyn Clock>)
-        .audit(audit_sink.clone())
-        .build();
+        .audit(audit_sink.clone());
+    if let Some(executor) = native_tool_executor {
+        builder = builder.native_tool_executor(executor);
+    }
+    let mut kernel = builder.build();
 
     let mut integration_catalog = default_integration_catalog();
     let mut blocked_reason = None;

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -2479,8 +2479,10 @@ fn maybe_execute_native_tool(
     request: &ToolCoreRequest,
     native_tool_executor: Option<crate::NativeToolExecutor>,
 ) -> Option<Result<ToolCoreOutcome, String>> {
-    if let Some(executor) = native_tool_executor {
-        return executor(request.clone());
+    if let Some(executor) = native_tool_executor
+        && let Some(result) = executor(request.clone())
+    {
+        return Some(result);
     }
     if crate::tool_name_requires_native_tool_executor(request.tool_name.as_str()) {
         return Some(Err(format!(
@@ -2986,5 +2988,33 @@ mod tests {
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["adapter"], "native-tools");
         assert_eq!(outcome.payload["tool"], "claw.import");
+    }
+
+    fn declining_native_tool_executor(
+        request: ToolCoreRequest,
+    ) -> Option<Result<ToolCoreOutcome, String>> {
+        if request.tool_name == "claw.import" {
+            return None;
+        }
+        Some(Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "native-tools",
+                "tool": request.tool_name,
+            }),
+        }))
+    }
+
+    #[tokio::test]
+    async fn core_tool_runtime_claw_import_fails_closed_when_executor_declines_request() {
+        let error = CoreToolRuntime::new(Some(declining_native_tool_executor))
+            .execute_core_tool(ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload: json!({"mode": "plan"}),
+            })
+            .await
+            .expect_err("native-only tool execution should fail closed when executor declines");
+
+        assert!(error.to_string().contains("native tool executor"));
     }
 }

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -2475,13 +2475,11 @@ fn stub_tool_core(request: ToolCoreRequest) -> Result<ToolCoreOutcome, String> {
     })
 }
 
-fn maybe_execute_native_app_tool(
+fn maybe_execute_native_tool(
     request: &ToolCoreRequest,
+    native_tool_executor: Option<crate::NativeToolExecutor>,
 ) -> Option<Result<ToolCoreOutcome, String>> {
-    if loongclaw_app::tools::canonical_tool_name(request.tool_name.as_str()) != "claw.import" {
-        return None;
-    }
-    Some(loongclaw_app::tools::execute_tool_core(request.clone()))
+    native_tool_executor.and_then(|executor| executor(request.clone()))
 }
 
 fn stub_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
@@ -2491,7 +2489,18 @@ fn stub_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, Str
     })
 }
 
-pub struct CoreToolRuntime;
+#[derive(Clone, Copy, Default)]
+pub struct CoreToolRuntime {
+    native_tool_executor: Option<crate::NativeToolExecutor>,
+}
+
+impl CoreToolRuntime {
+    pub const fn new(native_tool_executor: Option<crate::NativeToolExecutor>) -> Self {
+        Self {
+            native_tool_executor,
+        }
+    }
+}
 
 #[async_trait]
 impl CoreToolAdapter for CoreToolRuntime {
@@ -2503,7 +2512,7 @@ impl CoreToolAdapter for CoreToolRuntime {
         &self,
         request: ToolCoreRequest,
     ) -> Result<ToolCoreOutcome, kernel::ToolPlaneError> {
-        if let Some(result) = maybe_execute_native_app_tool(&request) {
+        if let Some(result) = maybe_execute_native_tool(&request, self.native_tool_executor) {
             return result.map_err(kernel::ToolPlaneError::Execution);
         }
         stub_tool_core(request).map_err(kernel::ToolPlaneError::Execution)
@@ -2660,9 +2669,11 @@ mod tests {
         parse_wasm_signals_based_traps,
     };
     use super::{
-        BridgeRuntimePolicy, WasmModuleCache, build_wasm_module_cache_key, compile_wasm_module,
-        normalize_sha256_pin, resolve_expected_wasm_sha256,
+        BridgeRuntimePolicy, CoreToolRuntime, WasmModuleCache, build_wasm_module_cache_key,
+        compile_wasm_module, normalize_sha256_pin, resolve_expected_wasm_sha256,
     };
+    use kernel::{CoreToolAdapter, ToolCoreOutcome, ToolCoreRequest};
+    use serde_json::json;
 
     const EMPTY_WASM_MODULE: [u8; 8] = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
 
@@ -2923,5 +2934,50 @@ mod tests {
 
         assert_ne!(identity_a, identity_b);
         let _ = fs::remove_dir_all(base);
+    }
+
+    #[tokio::test]
+    async fn core_tool_runtime_claw_import_without_native_executor_falls_back_to_stub() {
+        let outcome = CoreToolRuntime::default()
+            .execute_core_tool(ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload: json!({"mode": "plan"}),
+            })
+            .await
+            .expect("stub tool execution should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["adapter"], "core-tools");
+        assert_eq!(outcome.payload["tool"], "claw.import");
+    }
+
+    fn test_native_tool_executor(
+        request: ToolCoreRequest,
+    ) -> Option<Result<ToolCoreOutcome, String>> {
+        if request.tool_name != "claw.import" {
+            return None;
+        }
+        Some(Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "native-tools",
+                "tool": request.tool_name,
+            }),
+        }))
+    }
+
+    #[tokio::test]
+    async fn core_tool_runtime_uses_explicit_native_executor_when_present() {
+        let outcome = CoreToolRuntime::new(Some(test_native_tool_executor))
+            .execute_core_tool(ToolCoreRequest {
+                tool_name: "claw.import".to_owned(),
+                payload: json!({"mode": "plan"}),
+            })
+            .await
+            .expect("native tool execution should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["adapter"], "native-tools");
+        assert_eq!(outcome.payload["tool"], "claw.import");
     }
 }

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -2479,7 +2479,16 @@ fn maybe_execute_native_tool(
     request: &ToolCoreRequest,
     native_tool_executor: Option<crate::NativeToolExecutor>,
 ) -> Option<Result<ToolCoreOutcome, String>> {
-    native_tool_executor.and_then(|executor| executor(request.clone()))
+    if let Some(executor) = native_tool_executor {
+        return executor(request.clone());
+    }
+    if crate::tool_name_requires_native_tool_executor(request.tool_name.as_str()) {
+        return Some(Err(format!(
+            "native tool executor required for tool `{}`",
+            request.tool_name
+        )));
+    }
+    None
 }
 
 fn stub_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
@@ -2937,18 +2946,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn core_tool_runtime_claw_import_without_native_executor_falls_back_to_stub() {
-        let outcome = CoreToolRuntime::default()
+    async fn core_tool_runtime_claw_import_without_native_executor_fails_closed() {
+        let error = CoreToolRuntime::default()
             .execute_core_tool(ToolCoreRequest {
                 tool_name: "claw.import".to_owned(),
                 payload: json!({"mode": "plan"}),
             })
             .await
-            .expect("stub tool execution should succeed");
+            .expect_err("native-only tool execution should fail without an injected executor");
 
-        assert_eq!(outcome.status, "ok");
-        assert_eq!(outcome.payload["adapter"], "core-tools");
-        assert_eq!(outcome.payload["tool"], "claw.import");
+        assert!(error.to_string().contains("native tool executor"));
     }
 
     fn test_native_tool_executor(

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -24,7 +24,8 @@ Enforced by: CI (`verify` workflow). The optional `scripts/pre-commit` hook mirr
 
 1. **Complexity budgets are locally machine-checkable** — run `./scripts/check_architecture_boundaries.sh` or `task check:architecture` to inspect module line/function budgets for architecture hotspots (`spec_runtime`, `spec_execution`, `provider/mod`, `memory/mod`).
 2. **Memory operation literals are boundary-guarded** — memory core operation strings (`append_turn`, `window`, `clear_session`) must remain centralized in `crates/app/src/memory/*` and never spread into callsites.
-3. **Strict enforcement is an extended local gate** — use `task check:architecture:strict` (or set `LOONGCLAW_ARCH_STRICT=true`) to make architecture budget violations fail non-zero. This check is part of `task verify:full`, not the canonical CI-parity gate.
+3. **`spec` stays detached from `app`** — the architecture guardrails treat any direct `loongclaw-app` dependency in `crates/spec/Cargo.toml` as a boundary regression, and `./scripts/check_dep_graph.sh` must stay green.
+4. **Strict enforcement is an extended local gate** — use `task check:architecture:strict` (or set `LOONGCLAW_ARCH_STRICT=true`) to make architecture budget violations fail non-zero. This check is part of `task verify:full`, not the canonical CI-parity gate.
 
 ## Kernel Invariants
 

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-15T05:59:15Z
+- Generated at: 2026-03-15T06:09:02Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -11,7 +11,7 @@
 ## Hotspot Metrics
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
-| spec_runtime | `crates/spec/src/spec_runtime.rs` | 2990 | 3600 | 610 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
+| spec_runtime | `crates/spec/src/spec_runtime.rs` | 3020 | 3600 | 580 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1478 | 3700 | 2222 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 234 | 1000 | 766 | 5 | 20 | 15 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 620 | 650 | 30 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
@@ -38,7 +38,7 @@
 - [Release template](TEMPLATE.md)
 - [CI workflow](../../.github/workflows/ci.yml)
 
-<!-- arch-hotspot key=spec_runtime lines=2990 functions=47 -->
+<!-- arch-hotspot key=spec_runtime lines=3020 functions=47 -->
 <!-- arch-hotspot key=spec_execution lines=1478 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=234 functions=5 -->
 <!-- arch-hotspot key=memory_mod lines=620 functions=14 -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-15T05:41:57Z
+- Generated at: 2026-03-15T05:59:15Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -11,7 +11,7 @@
 ## Hotspot Metrics
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
-| spec_runtime | `crates/spec/src/spec_runtime.rs` | 2983 | 3600 | 617 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
+| spec_runtime | `crates/spec/src/spec_runtime.rs` | 2990 | 3600 | 610 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1478 | 3700 | 2222 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 234 | 1000 | 766 | 5 | 20 | 15 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 620 | 650 | 30 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
@@ -38,7 +38,7 @@
 - [Release template](TEMPLATE.md)
 - [CI workflow](../../.github/workflows/ci.yml)
 
-<!-- arch-hotspot key=spec_runtime lines=2983 functions=47 -->
+<!-- arch-hotspot key=spec_runtime lines=2990 functions=47 -->
 <!-- arch-hotspot key=spec_execution lines=1478 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=234 functions=5 -->
 <!-- arch-hotspot key=memory_mod lines=620 functions=14 -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,18 +1,18 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-14T07:50:08Z
+- Generated at: 2026-03-15T05:41:57Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
-- Boundary checks tracked: 2
+- Boundary checks tracked: 3
 - SLO status: PASS
 
 ## Hotspot Metrics
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
-| spec_runtime | `crates/spec/src/spec_runtime.rs` | 2927 | 3600 | 673 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
-| spec_execution | `crates/spec/src/spec_execution.rs` | 1467 | 3700 | 2233 | 22 | 80 | 58 | n/a | n/a | N/A | n/a |
+| spec_runtime | `crates/spec/src/spec_runtime.rs` | 2983 | 3600 | 617 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
+| spec_execution | `crates/spec/src/spec_execution.rs` | 1478 | 3700 | 2222 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 234 | 1000 | 766 | 5 | 20 | 15 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 620 | 650 | 30 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
@@ -21,6 +21,7 @@
 |---|---|---|---|
 | memory_literals | PASS | n/a | memory operation literals are centralized in crates/app/src/memory/* |
 | provider_mod_helper_definitions | PASS | n/a | provider/mod.rs keeps payload, parse, and recovery helper implementations outside the top-level module |
+| spec_app_dependency | PASS | n/a | spec crate remains detached from app crate at the Cargo dependency boundary |
 
 ## SLO Assessment
 - Hotspot growth SLO (>10% month-over-month): PASS
@@ -37,9 +38,10 @@
 - [Release template](TEMPLATE.md)
 - [CI workflow](../../.github/workflows/ci.yml)
 
-<!-- arch-hotspot key=spec_runtime lines=2927 functions=47 -->
-<!-- arch-hotspot key=spec_execution lines=1467 functions=22 -->
+<!-- arch-hotspot key=spec_runtime lines=2983 functions=47 -->
+<!-- arch-hotspot key=spec_execution lines=1478 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=234 functions=5 -->
 <!-- arch-hotspot key=memory_mod lines=620 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
+<!-- arch-boundary key=spec_app_dependency status=PASS -->

--- a/scripts/architecture_budget_lib.sh
+++ b/scripts/architecture_budget_lib.sh
@@ -86,6 +86,7 @@ architecture_boundary_check_keys() {
   cat <<'BOUNDARIES'
 memory_literals
 provider_mod_helper_definitions
+spec_app_dependency
 BOUNDARIES
 }
 
@@ -106,6 +107,15 @@ architecture_provider_mod_helper_definition_hits() {
   fi
 }
 
+architecture_spec_app_dependency_hits() {
+  local file="crates/spec/Cargo.toml"
+  if have_rg; then
+    rg -n '^loongclaw-app[[:space:]]*=' "$file" || true
+  else
+    grep -En '^loongclaw-app[[:space:]]*=' "$file" || true
+  fi
+}
+
 architecture_boundary_pass_summary() {
   case "$1" in
     memory_literals)
@@ -113,6 +123,9 @@ architecture_boundary_pass_summary() {
       ;;
     provider_mod_helper_definitions)
       echo "provider/mod.rs keeps payload, parse, and recovery helper implementations outside the top-level module"
+      ;;
+    spec_app_dependency)
+      echo "spec crate remains detached from app crate at the Cargo dependency boundary"
       ;;
     *)
       return 1
@@ -128,6 +141,9 @@ architecture_boundary_fail_summary() {
     provider_mod_helper_definitions)
       echo "provider/mod.rs still defines payload, parse, or recovery helpers directly"
       ;;
+    spec_app_dependency)
+      echo "spec crate depends on app crate directly"
+      ;;
     *)
       return 1
       ;;
@@ -141,6 +157,9 @@ architecture_boundary_hits() {
       ;;
     provider_mod_helper_definitions)
       architecture_provider_mod_helper_definition_hits
+      ;;
+    spec_app_dependency)
+      architecture_spec_app_dependency_hits
       ;;
     *)
       return 1

--- a/scripts/check_dep_graph.sh
+++ b/scripts/check_dep_graph.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #   ├── kernel → contracts
 #   ├── protocol (independent leaf)
 #   ├── app → contracts, kernel
-#   ├── spec → contracts, kernel, protocol (+ app: known deviation, tracked as D1)
+#   ├── spec → contracts, kernel, protocol
 #   ├── bench → contracts, kernel, spec
 #   └── daemon (binary) → all of the above
 
@@ -45,7 +45,6 @@ allowed=(
   "spec -> contracts"
   "spec -> kernel"
   "spec -> protocol"
-  "spec -> app"
   "bench -> contracts"
   "bench -> kernel"
   "bench -> spec"

--- a/scripts/test_architecture_budget_scripts.sh
+++ b/scripts/test_architecture_budget_scripts.sh
@@ -20,6 +20,7 @@ make_fixture_repo() {
   mkdir -p \
     "$fixture/scripts" \
     "$fixture/crates/spec/src" \
+    "$fixture/crates/spec" \
     "$fixture/crates/app/src/provider" \
     "$fixture/crates/app/src/memory"
 
@@ -33,6 +34,7 @@ make_fixture_repo() {
 
   cp "$REPO_ROOT/crates/spec/src/spec_runtime.rs" "$fixture/crates/spec/src/spec_runtime.rs"
   cp "$REPO_ROOT/crates/spec/src/spec_execution.rs" "$fixture/crates/spec/src/spec_execution.rs"
+  cp "$REPO_ROOT/crates/spec/Cargo.toml" "$fixture/crates/spec/Cargo.toml"
   cp "$REPO_ROOT/crates/app/src/provider/mod.rs" "$fixture/crates/app/src/provider/mod.rs"
   cp "$REPO_ROOT/crates/app/src/memory/mod.rs" "$fixture/crates/app/src/memory/mod.rs"
 

--- a/scripts/test_check_architecture_drift_freshness.sh
+++ b/scripts/test_check_architecture_drift_freshness.sh
@@ -21,6 +21,7 @@ make_fixture_repo() {
   mkdir -p \
     "$fixture/scripts" \
     "$fixture/crates/spec/src" \
+    "$fixture/crates/spec" \
     "$fixture/crates/app/src/provider" \
     "$fixture/crates/app/src/memory" \
     "$fixture/docs/releases"
@@ -35,6 +36,7 @@ make_fixture_repo() {
 
   cp "$REPO_ROOT/crates/spec/src/spec_runtime.rs" "$fixture/crates/spec/src/spec_runtime.rs"
   cp "$REPO_ROOT/crates/spec/src/spec_execution.rs" "$fixture/crates/spec/src/spec_execution.rs"
+  cp "$REPO_ROOT/crates/spec/Cargo.toml" "$fixture/crates/spec/Cargo.toml"
   cp "$REPO_ROOT/crates/app/src/provider/mod.rs" "$fixture/crates/app/src/provider/mod.rs"
   cp "$REPO_ROOT/crates/app/src/memory/mod.rs" "$fixture/crates/app/src/memory/mod.rs"
 
@@ -48,6 +50,7 @@ make_fixture_repo() {
       scripts/check_architecture_drift_freshness.sh \
       crates/spec/src/spec_runtime.rs \
       crates/spec/src/spec_execution.rs \
+      crates/spec/Cargo.toml \
       crates/app/src/provider/mod.rs \
       crates/app/src/memory/mod.rs
     git commit -qm "seed source inputs"

--- a/scripts/test_generate_architecture_drift_report.sh
+++ b/scripts/test_generate_architecture_drift_report.sh
@@ -35,6 +35,7 @@ run_no_baseline_test() {
   assert_contains "$output_file" "<!-- arch-hotspot key=spec_runtime"
   assert_contains "$output_file" "<!-- arch-boundary key=memory_literals status=PASS -->"
   assert_contains "$output_file" "<!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->"
+  assert_contains "$output_file" "<!-- arch-boundary key=spec_app_dependency status=PASS -->"
 }
 
 run_breach_baseline_test() {
@@ -47,6 +48,7 @@ run_breach_baseline_test() {
 <!-- arch-hotspot key=spec_runtime lines=1 functions=1 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
+<!-- arch-boundary key=spec_app_dependency status=PASS -->
 BASELINE
 
   local output_file="$tmp_dir/architecture-drift-2099-01.md"


### PR DESCRIPTION
## Summary

- remove the direct `spec -> app` dependency and inject native `claw.import` execution from the daemon composition root
- enforce the detached boundary in architecture docs, dependency checks, and architecture drift reporting
- reject native-only spec benchmark scenarios so bench runs cannot silently measure stubbed execution paths

## Scope

- [x] Small and focused
- [x] Includes docs and architecture guardrails
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional checks executed:
- [x] `cargo test -p loongclaw-spec`
- [x] `cargo test -p loongclaw-daemon spec_runtime -- --nocapture`
- [x] `cargo test -p loongclaw-bench`
- [x] `bash scripts/check_dep_graph.sh`
- [x] `bash scripts/check_architecture_boundaries.sh`
- [x] `bash scripts/test_architecture_budget_scripts.sh`
- [x] `bash scripts/test_generate_architecture_drift_report.sh`
- [x] `bash scripts/test_check_architecture_drift_freshness.sh`
- [x] `LOONGCLAW_ARCH_REPORT_MONTH=2026-03 bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md`

## Conflict Resolution

- synced the PR branch with the latest `alpha-test`
- resolved the remaining drift-report conflict by regenerating `docs/releases/architecture-drift-2026-03.md`
- fixed the follow-up bench Clippy failure by replacing a wildcard enum match arm with explicit `OperationSpec` variants

## Linked Issues

Closes #111
Related to #53