### PR TITLE
feat(memory): land builtin-only system foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ LoongClaw is a layered Agentic OS kernel focused on stable kernel contracts, str
 - `setup` bootstraps a beginner-friendly TOML config and local SQLite memory.
 - `chat` provides an interactive CLI channel with sliding-window conversation memory.
 - Core tool runtime currently ships `shell.exec`, `file.read`, and `file.write`.
+- Memory-system selection is now a stable builtin-only seam:
+  - config: `[memory] system = "builtin"`
+  - env: `LOONGCLAW_MEMORY_SYSTEM=builtin`
+  - the runtime keeps LoongClaw-owned canonical history and reserves concrete external adapters for
+    later dedicated tracks
 - Conversation runtime now exposes a pluggable `context engine` seam with explicit lifecycle hooks
   (`bootstrap`, `ingest`, `assemble`, `after_turn`, `compact_context`) plus reserved subagent
   hooks for future multi-agent orchestration.
@@ -115,6 +120,7 @@ LoongClaw is a layered Agentic OS kernel focused on stable kernel contracts, str
   `activation_origin`, so operators can distinguish explicit ACP entry from automatic ACP routing.
 - The daemon now exposes operator-facing diagnostics for:
   - `list-context-engines`
+  - `list-memory-systems`
   - `list-acp-backends`
   - `list-acp-sessions`
   - `acp-doctor`
@@ -132,6 +138,7 @@ LoongClaw is a layered Agentic OS kernel focused on stable kernel contracts, str
 ```bash
 cargo run -p loongclaw-daemon --bin loongclawd -- list-models --json
 cargo run -p loongclaw-daemon --bin loongclawd -- list-context-engines --json
+cargo run -p loongclaw-daemon --bin loongclawd -- list-memory-systems --json
 cargo run -p loongclaw-daemon --bin loongclawd -- list-acp-backends --json
 cargo run -p loongclaw-daemon --bin loongclawd -- list-acp-sessions --json
 cargo run -p loongclaw-daemon --bin loongclawd -- acp-doctor --backend acpx --json
@@ -249,6 +256,26 @@ backend is SQLite, with three operator-selectable context injection modes:
 `profile_note` is the first migration-friendly durable memory lane. It is meant
 to carry imported claw identity, stable preferences, or long-lived operator
 tuning without forcing everything into the system prompt.
+
+## Memory Systems
+
+LoongClaw now treats `memory.system` as a stable selection seam, but the current
+runtime surface remains intentionally builtin-only:
+
+- `builtin` keeps canonical raw conversation history, typed canonical records,
+  and deterministic prompt hydration inside LoongClaw.
+- Future external memory systems are expected to plug in below final prompt
+  projection, not replace LoongClaw's context authority.
+- Memory-system failures are designed to fail open, preserving the baseline
+  recent-window chat experience instead of turning memory into a hidden
+  availability dependency.
+
+Use the runtime diagnostics command below to inspect the selected system,
+capability set, memory profile, ingest mode, and effective fail-open policy:
+
+```bash
+loongclaw list-memory-systems --json
+```
 
 ## Migration And Import
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -125,6 +125,25 @@ cargo install --path crates/daemon
 cargo test --workspace --all-features
 ```
 
+## 记忆配置与记忆系统
+
+LoongClaw 现在把 `memory.system` 作为稳定的选择缝预留出来，但当前 alpha-test
+运行面仍然刻意保持 builtin-only：
+
+- `builtin` 继续由 LoongClaw 自己掌管 canonical 原始会话历史、typed canonical
+  records 和确定性的 prompt hydration。
+- 未来接入外部记忆体系时，它们会落在派生/检索层，而不是直接接管最终 prompt
+  组装权。
+- 记忆系统异常默认按 fail-open 处理，优先保住最近窗口对话体验，而不是让记忆层
+  变成隐藏的单点依赖。
+
+可用下面的运行时诊断命令查看当前选中的 system、capabilities、memory profile、
+ingest mode 以及生效中的 fail-open policy：
+
+```bash
+loongclaw list-memory-systems --json
+```
+
 ## 迁移与导入
 
 LoongClaw 支持从旧 claw 工作区进行发现、规划、应用与回滚：

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -2027,12 +2027,29 @@ mod tests {
             ..LoongClawConfig::default()
         };
 
-        let report = backend
-            .doctor(&config)
-            .await
-            .expect("doctor should not fail")
-            .expect("doctor report");
-        assert!(report.healthy);
+        let mut last_report = None;
+        for attempt in 0..5 {
+            let report = backend
+                .doctor(&config)
+                .await
+                .expect("doctor should not fail")
+                .expect("doctor report");
+            if report.healthy {
+                last_report = Some(report);
+                break;
+            }
+            last_report = Some(report);
+            if attempt < 4 {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        }
+
+        let report = last_report.expect("doctor report");
+        assert!(
+            report.healthy,
+            "doctor should accept fake version command: {:?}",
+            report.diagnostics
+        );
         assert_eq!(
             report.diagnostics.get("command"),
             Some(&script_path.display().to_string())

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -1709,8 +1709,6 @@ fn now_ms() -> u64 {
 mod tests {
     use std::collections::BTreeMap;
     #[cfg(unix)]
-    use std::io::Write as _;
-    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     #[cfg(unix)]
     use std::path::{Path, PathBuf};

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -1709,6 +1709,8 @@ fn now_ms() -> u64 {
 mod tests {
     use std::collections::BTreeMap;
     #[cfg(unix)]
+    use std::io::Write as _;
+    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     #[cfg(unix)]
     use std::path::{Path, PathBuf};

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -39,7 +39,7 @@ pub use shared::expand_path;
 #[allow(unused_imports)]
 pub use tools_memory::{
     DEFAULT_SHELL_ALLOW, ExternalSkillsConfig, MemoryBackendKind, MemoryConfig, MemoryMode,
-    MemoryProfile, ToolConfig,
+    MemoryProfile, MemorySystemKind, ToolConfig,
 };
 
 #[cfg(test)]
@@ -1794,6 +1794,17 @@ context_engine = " Legacy "
             parsed.conversation.context_engine_id().as_deref(),
             Some("legacy")
         );
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn memory_system_field_parses_and_normalizes() {
+        let raw = r#"
+[memory]
+system = " Builtin "
+"#;
+        let parsed = toml::from_str::<LoongClawConfig>(raw).expect("parse memory.system");
+        assert_eq!(parsed.memory.resolved_system().as_str(), "builtin");
     }
 
     #[test]

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -1810,6 +1810,21 @@ system = " Builtin "
 
     #[test]
     #[cfg(feature = "config-toml")]
+    fn memory_system_field_rejects_unimplemented_future_variant() {
+        let raw = r#"
+[memory]
+system = " LuCid "
+"#;
+        let error =
+            toml::from_str::<LoongClawConfig>(raw).expect_err("lucid should stay unsupported");
+        assert!(
+            error.to_string().contains("available: builtin"),
+            "error should keep builtin-only surface: {error}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
     fn conversation_compaction_fields_parse_and_gate_compact_hook() {
         let raw = r#"
 [conversation]

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -38,9 +38,8 @@ pub(crate) use runtime::{normalize_dispatch_account_id, normalize_dispatch_chann
 pub use shared::expand_path;
 #[allow(unused_imports)]
 pub use tools_memory::{
-    DEFAULT_SHELL_ALLOW, ExternalSkillsConfig, MemoryBackendKind, MemoryConfig,
-    MemoryIngestMode, MemoryMode,
-    MemoryProfile, MemorySystemKind, ToolConfig,
+    DEFAULT_SHELL_ALLOW, ExternalSkillsConfig, MemoryBackendKind, MemoryConfig, MemoryIngestMode,
+    MemoryMode, MemoryProfile, MemorySystemKind, ToolConfig,
 };
 
 #[cfg(test)]

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -38,7 +38,8 @@ pub(crate) use runtime::{normalize_dispatch_account_id, normalize_dispatch_chann
 pub use shared::expand_path;
 #[allow(unused_imports)]
 pub use tools_memory::{
-    DEFAULT_SHELL_ALLOW, ExternalSkillsConfig, MemoryBackendKind, MemoryConfig, MemoryMode,
+    DEFAULT_SHELL_ALLOW, ExternalSkillsConfig, MemoryBackendKind, MemoryConfig,
+    MemoryIngestMode, MemoryMode,
     MemoryProfile, MemorySystemKind, ToolConfig,
 };
 

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -231,6 +231,16 @@ pub enum MemoryMode {
     ProfilePlusWindow,
 }
 
+impl MemoryMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::WindowOnly => "window_only",
+            Self::WindowPlusSummary => "window_plus_summary",
+            Self::ProfilePlusWindow => "profile_plus_window",
+        }
+    }
+}
+
 impl Default for ToolConfig {
     fn default() -> Self {
         Self {

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -332,6 +332,18 @@ impl MemoryConfig {
         self.profile.mode()
     }
 
+    pub const fn strict_mode_requested(&self) -> bool {
+        !self.fail_open
+    }
+
+    pub const fn strict_mode_active(&self) -> bool {
+        false
+    }
+
+    pub const fn effective_fail_open(&self) -> bool {
+        !self.strict_mode_active()
+    }
+
     pub fn summary_char_budget(&self) -> usize {
         self.summary_max_chars.max(256)
     }
@@ -407,7 +419,22 @@ mod tests {
     fn hydrated_memory_policy_defaults_are_fail_open_and_sync_minimal() {
         let config = MemoryConfig::default();
         assert!(config.fail_open);
+        assert!(config.effective_fail_open());
+        assert!(!config.strict_mode_requested());
+        assert!(!config.strict_mode_active());
         assert_eq!(config.ingest_mode, MemoryIngestMode::SyncMinimal);
+    }
+
+    #[test]
+    fn strict_mode_request_remains_reserved_and_disabled_by_default() {
+        let config = MemoryConfig {
+            fail_open: false,
+            ..MemoryConfig::default()
+        };
+
+        assert!(config.strict_mode_requested());
+        assert!(!config.strict_mode_active());
+        assert!(config.effective_fail_open());
     }
 
     #[test]

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -74,6 +74,10 @@ pub struct MemoryConfig {
     pub profile: MemoryProfile,
     #[serde(default)]
     pub system: MemorySystemKind,
+    #[serde(default = "default_true")]
+    pub fail_open: bool,
+    #[serde(default)]
+    pub ingest_mode: MemoryIngestMode,
     #[serde(default = "default_sqlite_path")]
     pub sqlite_path: String,
     #[serde(default = "default_sliding_window")]
@@ -116,6 +120,7 @@ pub enum MemoryProfile {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
 pub enum MemorySystemKind {
     #[default]
     Builtin,
@@ -145,6 +150,46 @@ impl<'de> Deserialize<'de> for MemorySystemKind {
         Self::parse_id(&raw).ok_or_else(|| {
             serde::de::Error::custom(format!(
                 "unsupported memory.system `{}` (available: builtin)",
+                raw.trim()
+            ))
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryIngestMode {
+    #[default]
+    SyncMinimal,
+    AsyncBackground,
+}
+
+impl MemoryIngestMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SyncMinimal => "sync_minimal",
+            Self::AsyncBackground => "async_background",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "sync_minimal" => Some(Self::SyncMinimal),
+            "async_background" => Some(Self::AsyncBackground),
+            _ => None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for MemoryIngestMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse_id(&raw).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "unsupported memory.ingest_mode `{}` (available: sync_minimal, async_background)",
                 raw.trim()
             ))
         })
@@ -243,6 +288,8 @@ impl Default for MemoryConfig {
             backend: MemoryBackendKind::default(),
             profile: MemoryProfile::default(),
             system: MemorySystemKind::default(),
+            fail_open: default_true(),
+            ingest_mode: MemoryIngestMode::default(),
             sqlite_path: default_sqlite_path(),
             sliding_window: default_sliding_window(),
             summary_max_chars: default_summary_max_chars(),
@@ -309,6 +356,10 @@ const fn default_require_download_approval() -> bool {
     true
 }
 
+const fn default_true() -> bool {
+    true
+}
+
 const fn default_auto_expose_installed() -> bool {
     true
 }
@@ -350,6 +401,13 @@ mod tests {
         assert_eq!(config.system, MemorySystemKind::Builtin);
         assert_eq!(config.resolved_system(), MemorySystemKind::Builtin);
         assert_eq!(config.resolved_system().as_str(), DEFAULT_MEMORY_SYSTEM_ID);
+    }
+
+    #[test]
+    fn hydrated_memory_policy_defaults_are_fail_open_and_sync_minimal() {
+        let config = MemoryConfig::default();
+        assert!(config.fail_open);
+        assert_eq!(config.ingest_mode, MemoryIngestMode::SyncMinimal);
     }
 
     #[test]

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, path::PathBuf};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use super::shared::{
     ConfigValidationIssue, DEFAULT_SQLITE_FILE, default_loongclaw_home, expand_path,
@@ -72,6 +72,8 @@ pub struct MemoryConfig {
     pub backend: MemoryBackendKind,
     #[serde(default)]
     pub profile: MemoryProfile,
+    #[serde(default)]
+    pub system: MemorySystemKind,
     #[serde(default = "default_sqlite_path")]
     pub sqlite_path: String,
     #[serde(default = "default_sliding_window")]
@@ -111,6 +113,42 @@ pub enum MemoryProfile {
     WindowOnly,
     WindowPlusSummary,
     ProfilePlusWindow,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
+pub enum MemorySystemKind {
+    #[default]
+    Builtin,
+}
+
+impl MemorySystemKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Builtin => "builtin",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "builtin" => Some(Self::Builtin),
+            _ => None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for MemorySystemKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse_id(&raw).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "unsupported memory.system `{}` (available: builtin)",
+                raw.trim()
+            ))
+        })
+    }
 }
 
 impl MemoryProfile {
@@ -204,6 +242,7 @@ impl Default for MemoryConfig {
         Self {
             backend: MemoryBackendKind::default(),
             profile: MemoryProfile::default(),
+            system: MemorySystemKind::default(),
             sqlite_path: default_sqlite_path(),
             sliding_window: default_sliding_window(),
             summary_max_chars: default_summary_max_chars(),
@@ -236,6 +275,10 @@ impl MemoryConfig {
 
     pub const fn resolved_profile(&self) -> MemoryProfile {
         self.profile
+    }
+
+    pub const fn resolved_system(&self) -> MemorySystemKind {
+        self.system
     }
 
     pub const fn resolved_mode(&self) -> MemoryMode {
@@ -291,6 +334,7 @@ const fn default_summary_max_chars() -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::memory::DEFAULT_MEMORY_SYSTEM_ID;
 
     #[test]
     fn memory_profile_defaults_to_window_only() {
@@ -298,6 +342,14 @@ mod tests {
         assert_eq!(config.backend, MemoryBackendKind::Sqlite);
         assert_eq!(config.profile, MemoryProfile::WindowOnly);
         assert_eq!(config.resolved_mode(), MemoryMode::WindowOnly);
+    }
+
+    #[test]
+    fn memory_system_defaults_to_builtin() {
+        let config = MemoryConfig::default();
+        assert_eq!(config.system, MemorySystemKind::Builtin);
+        assert_eq!(config.resolved_system(), MemorySystemKind::Builtin);
+        assert_eq!(config.resolved_system().as_str(), DEFAULT_MEMORY_SYSTEM_ID);
     }
 
     #[test]

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -416,6 +416,11 @@ mod tests {
     }
 
     #[test]
+    fn memory_system_rejects_unimplemented_future_variant_ids() {
+        assert_eq!(MemorySystemKind::parse_id("lucid"), None);
+    }
+
+    #[test]
     fn hydrated_memory_policy_defaults_are_fail_open_and_sync_minimal() {
         let config = MemoryConfig::default();
         assert!(config.fail_open);

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -318,6 +318,14 @@ impl ConversationContextEngine for DefaultContextEngine {
         include_system_prompt: bool,
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<Vec<Value>> {
+        if kernel_ctx.is_none() {
+            return crate::provider::build_messages_for_session(
+                config,
+                session_id,
+                include_system_prompt,
+            );
+        }
+
         #[cfg_attr(not(feature = "memory-sqlite"), allow(unused_mut))]
         let mut messages = crate::provider::build_base_messages(config, include_system_prompt);
 

--- a/crates/app/src/conversation/persistence.rs
+++ b/crates/app/src/conversation/persistence.rs
@@ -5,6 +5,9 @@ use crate::KernelContext;
 use crate::acp::{
     AcpTurnResult, PersistedAcpRuntimeEventContext, build_persisted_runtime_event_records,
 };
+use crate::memory::{
+    build_conversation_event_content, build_tool_decision_content, build_tool_outcome_content,
+};
 
 use super::runtime::ConversationRuntime;
 use super::turn_engine::{ToolDecision, ToolOutcome};
@@ -66,21 +69,12 @@ pub(super) async fn persist_tool_decision<R: ConversationRuntime + ?Sized>(
     decision: &ToolDecision,
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<()> {
-    let content = json!({
-        "type": "tool_decision",
-        "turn_id": turn_id,
-        "tool_call_id": tool_call_id,
-        "decision": serde_json::to_value(decision)
-            .map_err(|e| format!("serialize tool decision: {e}"))?,
-    });
-    persist_and_ingest_turn(
-        runtime,
-        session_id,
-        "assistant",
-        &content.to_string(),
-        kernel_ctx,
-    )
-    .await
+    let content = build_tool_decision_content(
+        turn_id,
+        tool_call_id,
+        serde_json::to_value(decision).map_err(|e| format!("serialize tool decision: {e}"))?,
+    );
+    persist_and_ingest_turn(runtime, session_id, "assistant", &content, kernel_ctx).await
 }
 
 /// Persist a tool outcome as a structured JSON assistant message.
@@ -97,21 +91,12 @@ pub(super) async fn persist_tool_outcome<R: ConversationRuntime + ?Sized>(
     outcome: &ToolOutcome,
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<()> {
-    let content = json!({
-        "type": "tool_outcome",
-        "turn_id": turn_id,
-        "tool_call_id": tool_call_id,
-        "outcome": serde_json::to_value(outcome)
-            .map_err(|e| format!("serialize tool outcome: {e}"))?,
-    });
-    persist_and_ingest_turn(
-        runtime,
-        session_id,
-        "assistant",
-        &content.to_string(),
-        kernel_ctx,
-    )
-    .await
+    let content = build_tool_outcome_content(
+        turn_id,
+        tool_call_id,
+        serde_json::to_value(outcome).map_err(|e| format!("serialize tool outcome: {e}"))?,
+    );
+    persist_and_ingest_turn(runtime, session_id, "assistant", &content, kernel_ctx).await
 }
 
 pub(super) async fn persist_error_turns<R: ConversationRuntime + ?Sized>(
@@ -221,13 +206,9 @@ pub(super) async fn persist_conversation_event<R: ConversationRuntime + ?Sized>(
     payload: Value,
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<()> {
-    let content = json!({
-        "type": "conversation_event",
-        "event": event_name,
-        "payload": payload,
-    });
+    let content = build_conversation_event_content(event_name, payload);
     runtime
-        .persist_turn(session_id, "assistant", &content.to_string(), kernel_ctx)
+        .persist_turn(session_id, "assistant", &content, kernel_ctx)
         .await
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -995,6 +995,60 @@ async fn default_runtime_build_context_explicit_builtin_system_preserves_profile
     let _ = std::fs::remove_file(sqlite_path);
 }
 
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_build_context_fail_open_memory_derivation_preserves_recent_window_projection()
+ {
+    let _faults = crate::memory::ScopedMemoryOrchestratorTestFaults::set(
+        crate::memory::MemoryOrchestratorTestFaults {
+            derivation_error: Some("simulated derivation failure".to_owned()),
+            ..crate::memory::MemoryOrchestratorTestFaults::default()
+        },
+    );
+    let runtime = DefaultConversationRuntime::default();
+    let session_id = unique_acp_test_id("default-runtime-context", "fail-open-memory");
+    let sqlite_path = unique_memory_sqlite_path("fail-open-memory");
+    let mut config = test_config();
+    config.memory.system = MemorySystemKind::Builtin;
+    config.memory.profile = MemoryProfile::WindowOnly;
+    config.memory.sliding_window = 2;
+    config.memory.sqlite_path = sqlite_path.clone();
+
+    let runtime_config =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    crate::memory::append_turn_direct(&session_id, "user", "turn 1", &runtime_config)
+        .expect("append turn 1 should succeed");
+    crate::memory::append_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
+        .expect("append turn 2 should succeed");
+    crate::memory::append_turn_direct(&session_id, "user", "turn 3", &runtime_config)
+        .expect("append turn 3 should succeed");
+
+    let assembled = runtime
+        .build_context(&config, &session_id, true, None)
+        .await
+        .expect("build context should stay available when memory derivation degrades");
+
+    let projected_turns = assembled
+        .messages
+        .iter()
+        .filter_map(|message| {
+            let role = message.get("role")?.as_str()?;
+            let content = message.get("content")?.as_str()?;
+            matches!(role, "user" | "assistant").then_some((role.to_owned(), content.to_owned()))
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        projected_turns,
+        vec![
+            ("assistant".to_owned(), "turn 2".to_owned()),
+            ("user".to_owned(), "turn 3".to_owned()),
+        ]
+    );
+
+    let _ = std::fs::remove_file(sqlite_path);
+}
+
 #[test]
 fn resolve_context_engine_selection_uses_default_when_unset() {
     let _env_lock = context_engine_env_lock().lock().expect("env lock");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -499,6 +499,21 @@ fn unique_memory_sqlite_path(suffix: &str) -> String {
         .to_string()
 }
 
+fn persisted_canonical_records(
+    persisted: &[(String, String, String)],
+) -> Vec<crate::memory::CanonicalMemoryRecord> {
+    persisted
+        .iter()
+        .map(|(session_id, role, content)| {
+            crate::memory::canonical_memory_record_from_persisted_turn(
+                session_id.as_str(),
+                role.as_str(),
+                content.as_str(),
+            )
+        })
+        .collect()
+}
+
 #[async_trait]
 impl AcpRuntimeBackend for RoutedAcpBackend {
     fn id(&self) -> &'static str {
@@ -1152,6 +1167,47 @@ async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
 }
 
 #[tokio::test]
+async fn persist_turn_provider_turns_expose_typed_canonical_records() {
+    let runtime = FakeRuntime::new(
+        vec![json!({"role": "system", "content": "sys"})],
+        Ok("assistant-reply".to_owned()),
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+    coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-canonical-provider",
+            "hello canonical memory",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("provider turn should succeed");
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let records = persisted_canonical_records(&persisted);
+
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].scope, crate::memory::MemoryScope::Session);
+    assert_eq!(
+        records[0].kind,
+        crate::memory::CanonicalMemoryKind::UserTurn
+    );
+    assert_eq!(records[0].role.as_deref(), Some("user"));
+    assert_eq!(records[0].content, "hello canonical memory");
+    assert_eq!(records[0].session_id, "session-canonical-provider");
+
+    assert_eq!(records[1].scope, crate::memory::MemoryScope::Session);
+    assert_eq!(
+        records[1].kind,
+        crate::memory::CanonicalMemoryKind::AssistantTurn
+    );
+    assert_eq!(records[1].role.as_deref(), Some("assistant"));
+    assert_eq!(records[1].content, "assistant-reply");
+}
+
+#[tokio::test]
 async fn handle_turn_with_runtime_keeps_provider_path_by_default_when_acp_enabled() {
     let (backend_id, shared) = register_routed_acp_backend("success", false);
     let runtime = FakeRuntime::new(
@@ -1313,6 +1369,83 @@ async fn handle_turn_with_runtime_routes_explicit_acp_turns_through_acp() {
             .get("loongclaw.acp.routing_origin")
             .map(String::as_str),
         Some("explicit_request")
+    );
+}
+
+#[tokio::test]
+async fn persist_turn_explicit_acp_routing_exposes_typed_canonical_records() {
+    let (backend_id, _shared) = register_routed_acp_backend_with_events(
+        "typed-explicit",
+        false,
+        vec![
+            json!({
+                "type": "text",
+                "content": "partial hello"
+            }),
+            json!({
+                "type": "done",
+                "stopReason": "completed"
+            }),
+        ],
+    );
+    let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
+    let orchestrator = ConversationOrchestrator::new();
+    let mut config = test_config();
+    config.acp.enabled = true;
+    config.acp.backend = Some(backend_id.to_owned());
+    config.acp.emit_runtime_events = true;
+    config.memory.sqlite_path = unique_acp_sqlite_path("typed-explicit");
+
+    let reply = orchestrator
+        .handle_turn_with_runtime_and_address_and_acp_options(
+            &config,
+            &ConversationSessionAddress::from_session_id("telegram:typed-explicit"),
+            "hello explicit canonical",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            &AcpConversationTurnOptions {
+                routing_intent: AcpRoutingIntent::Explicit,
+                ..AcpConversationTurnOptions::default()
+            },
+            None,
+        )
+        .await
+        .expect("explicit ACP turn should succeed");
+
+    assert_eq!(reply, "acp: hello explicit canonical");
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let records = persisted_canonical_records(&persisted);
+
+    assert!(
+        records
+            .iter()
+            .any(|record| record.kind == crate::memory::CanonicalMemoryKind::UserTurn)
+    );
+    assert!(
+        records
+            .iter()
+            .any(|record| record.kind == crate::memory::CanonicalMemoryKind::AssistantTurn)
+    );
+
+    let runtime_event = records
+        .iter()
+        .find(|record| record.kind == crate::memory::CanonicalMemoryKind::AcpRuntimeEvent)
+        .expect("expected ACP runtime event record");
+    assert_eq!(runtime_event.scope, crate::memory::MemoryScope::Session);
+    assert_eq!(runtime_event.metadata["event"], "acp_turn_event");
+    assert_eq!(
+        runtime_event.metadata["payload"]["routing_intent"],
+        "explicit"
+    );
+
+    let final_event = records
+        .iter()
+        .find(|record| record.kind == crate::memory::CanonicalMemoryKind::AcpFinalEvent)
+        .expect("expected ACP final event record");
+    assert_eq!(final_event.metadata["event"], "acp_turn_final");
+    assert_eq!(
+        final_event.metadata["payload"]["routing_intent"],
+        "explicit"
     );
 }
 
@@ -1720,6 +1853,157 @@ async fn handle_turn_with_runtime_routes_only_agent_prefixed_sessions_when_confi
             .map(String::as_str),
         Some("automatic_agent_prefixed")
     );
+}
+
+#[tokio::test]
+async fn persist_turn_automatic_acp_routing_exposes_typed_canonical_records() {
+    let (backend_id, _shared) = register_routed_acp_backend_with_events(
+        "typed-automatic",
+        false,
+        vec![
+            json!({
+                "type": "text",
+                "content": "partial hello"
+            }),
+            json!({
+                "type": "done",
+                "stopReason": "completed"
+            }),
+        ],
+    );
+    let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
+    let orchestrator = ConversationOrchestrator::new();
+    let mut config = test_config();
+    config.acp.enabled = true;
+    config.acp.backend = Some(backend_id.to_owned());
+    config.acp.emit_runtime_events = true;
+    config.acp.dispatch.conversation_routing =
+        crate::config::AcpConversationRoutingMode::AgentPrefixedOnly;
+    config.memory.sqlite_path = unique_acp_sqlite_path("typed-automatic");
+
+    let reply = orchestrator
+        .handle_turn_with_runtime(
+            &config,
+            "agent:codex:review-thread",
+            "hello automatic canonical",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("automatic ACP turn should succeed");
+
+    assert_eq!(reply, "acp: hello automatic canonical");
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let records = persisted_canonical_records(&persisted);
+
+    assert!(
+        records
+            .iter()
+            .any(|record| record.kind == crate::memory::CanonicalMemoryKind::UserTurn)
+    );
+    assert!(
+        records
+            .iter()
+            .any(|record| record.kind == crate::memory::CanonicalMemoryKind::AssistantTurn)
+    );
+
+    let runtime_event = records
+        .iter()
+        .find(|record| record.kind == crate::memory::CanonicalMemoryKind::AcpRuntimeEvent)
+        .expect("expected ACP runtime event record");
+    assert_eq!(runtime_event.metadata["event"], "acp_turn_event");
+    assert_eq!(
+        runtime_event.metadata["payload"]["routing_intent"],
+        "automatic"
+    );
+
+    let final_event = records
+        .iter()
+        .find(|record| record.kind == crate::memory::CanonicalMemoryKind::AcpFinalEvent)
+        .expect("expected ACP final event record");
+    assert_eq!(final_event.metadata["event"], "acp_turn_final");
+    assert_eq!(
+        final_event.metadata["payload"]["routing_intent"],
+        "automatic"
+    );
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_automatic_acp_routing_bypasses_context_engine_lifecycle_hooks() {
+    let (backend_id, shared) = register_routed_acp_backend("automatic-lifecycle-bypass", false);
+    let runtime = FakeRuntime::new(
+        vec![json!({"role": "system", "content": "sys"})],
+        Ok("provider-should-not-run".to_owned()),
+    );
+    let orchestrator = ConversationOrchestrator::new();
+    let mut config = test_config();
+    config.acp.enabled = true;
+    config.acp.backend = Some(backend_id.to_owned());
+    config.acp.dispatch.conversation_routing =
+        crate::config::AcpConversationRoutingMode::AgentPrefixedOnly;
+    config.memory.sqlite_path = unique_acp_sqlite_path("automatic-lifecycle-bypass");
+
+    let reply = orchestrator
+        .handle_turn_with_runtime(
+            &config,
+            "agent:codex:review-thread",
+            "route automatically through ACP",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("automatic ACP turn should succeed");
+
+    assert_eq!(reply, "acp: route automatically through ACP");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 0);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+    assert!(
+        runtime
+            .requested_messages
+            .lock()
+            .expect("requested messages lock")
+            .is_empty()
+    );
+    assert!(
+        runtime
+            .bootstrap_calls
+            .lock()
+            .expect("bootstrap lock")
+            .is_empty()
+    );
+    assert!(
+        runtime
+            .ingested_messages
+            .lock()
+            .expect("ingest lock")
+            .is_empty()
+    );
+    assert!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .is_empty()
+    );
+    assert!(
+        runtime
+            .compact_calls
+            .lock()
+            .expect("compact lock")
+            .is_empty()
+    );
+
+    let state = shared.lock().expect("ACP shared state");
+    assert_eq!(state.ensure_calls, 1);
+    assert_eq!(state.turn_calls, 1);
 }
 
 #[tokio::test]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -13,7 +13,8 @@ use sha2::{Digest, Sha256};
 
 use super::super::config::{
     CliChannelConfig, ConversationConfig, ExternalSkillsConfig, FeishuChannelConfig,
-    LoongClawConfig, MemoryConfig, ProviderConfig, TelegramChannelConfig, ToolConfig,
+    LoongClawConfig, MemoryConfig, MemoryProfile, MemorySystemKind, ProviderConfig,
+    TelegramChannelConfig, ToolConfig,
 };
 use super::persistence::format_provider_error_reply;
 use super::runtime::DefaultConversationRuntime;
@@ -488,6 +489,16 @@ fn test_turn_preparation_context_fingerprint(messages: &[Value]) -> String {
     format!("{:x}", Sha256::digest(serialized))
 }
 
+fn unique_memory_sqlite_path(suffix: &str) -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "{}.sqlite3",
+            unique_acp_test_id("conversation-memory", suffix)
+        ))
+        .display()
+        .to_string()
+}
+
 #[async_trait]
 impl AcpRuntimeBackend for RoutedAcpBackend {
     fn id(&self) -> &'static str {
@@ -878,6 +889,95 @@ async fn default_runtime_build_context_applies_system_prompt_addition() {
         merged, "runtime-policy-addition\n\nbase-system-prompt",
         "system prompt addition should be prepended"
     );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_build_context_matches_builtin_summary_projection() {
+    let runtime = DefaultConversationRuntime::default();
+    let session_id = unique_acp_test_id("default-runtime-context", "summary");
+    let sqlite_path = unique_memory_sqlite_path("summary");
+    let mut config = test_config();
+    config.memory.system = MemorySystemKind::Builtin;
+    config.memory.profile = MemoryProfile::WindowPlusSummary;
+    config.memory.sliding_window = 2;
+    config.memory.sqlite_path = sqlite_path.clone();
+
+    let runtime_config =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    crate::memory::append_turn_direct(&session_id, "user", "turn 1", &runtime_config)
+        .expect("append turn 1 should succeed");
+    crate::memory::append_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
+        .expect("append turn 2 should succeed");
+    crate::memory::append_turn_direct(&session_id, "user", "turn 3", &runtime_config)
+        .expect("append turn 3 should succeed");
+    crate::memory::append_turn_direct(&session_id, "assistant", "turn 4", &runtime_config)
+        .expect("append turn 4 should succeed");
+
+    let assembled = runtime
+        .build_context(&config, &session_id, true, None)
+        .await
+        .expect("build context from default runtime");
+    let provider_messages = crate::provider::build_messages_for_session(&config, &session_id, true)
+        .expect("build provider messages");
+
+    assert_eq!(
+        assembled.messages, provider_messages,
+        "default runtime should match provider projection for builtin summary hydration"
+    );
+    assert!(
+        assembled.messages.iter().any(|message| {
+            message["role"] == "system"
+                && message["content"]
+                    .as_str()
+                    .is_some_and(|content| content.contains("## Memory Summary"))
+        }),
+        "expected hydrated summary block in default runtime messages"
+    );
+
+    let _ = std::fs::remove_file(sqlite_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_build_context_explicit_builtin_system_preserves_profile_projection() {
+    let runtime = DefaultConversationRuntime::default();
+    let session_id = unique_acp_test_id("default-runtime-context", "profile");
+    let sqlite_path = unique_memory_sqlite_path("profile");
+    let mut config = test_config();
+    config.memory.system = MemorySystemKind::Builtin;
+    config.memory.profile = MemoryProfile::ProfilePlusWindow;
+    config.memory.profile_note = Some("Imported ZeroClaw preferences".to_owned());
+    config.memory.sliding_window = 2;
+    config.memory.sqlite_path = sqlite_path.clone();
+
+    let runtime_config =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    crate::memory::append_turn_direct(&session_id, "assistant", "turn 1", &runtime_config)
+        .expect("append turn should succeed");
+
+    let assembled = runtime
+        .build_context(&config, &session_id, true, None)
+        .await
+        .expect("build context from default runtime");
+    let provider_messages = crate::provider::build_messages_for_session(&config, &session_id, true)
+        .expect("build provider messages");
+
+    assert_eq!(
+        assembled.messages, provider_messages,
+        "explicit builtin memory system should not change prompt projection"
+    );
+    assert!(
+        assembled.messages.iter().any(|message| {
+            message["role"] == "system"
+                && message["content"]
+                    .as_str()
+                    .is_some_and(|content| content.contains("Imported ZeroClaw preferences"))
+        }),
+        "expected hydrated profile block in default runtime messages"
+    );
+
+    let _ = std::fs::remove_file(sqlite_path);
 }
 
 #[test]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1443,14 +1443,14 @@ async fn persist_turn_explicit_acp_routing_exposes_typed_canonical_records() {
         ],
     );
     let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.backend = Some(backend_id.to_owned());
     config.acp.emit_runtime_events = true;
     config.memory.sqlite_path = unique_acp_sqlite_path("typed-explicit");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:typed-explicit"),
@@ -1926,7 +1926,7 @@ async fn persist_turn_automatic_acp_routing_exposes_typed_canonical_records() {
         ],
     );
     let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.backend = Some(backend_id.to_owned());
@@ -1935,7 +1935,7 @@ async fn persist_turn_automatic_acp_routing_exposes_typed_canonical_records() {
         crate::config::AcpConversationRoutingMode::AgentPrefixedOnly;
     config.memory.sqlite_path = unique_acp_sqlite_path("typed-automatic");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime(
             &config,
             "agent:codex:review-thread",
@@ -1990,7 +1990,7 @@ async fn handle_turn_with_runtime_automatic_acp_routing_bypasses_context_engine_
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-should-not-run".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.backend = Some(backend_id.to_owned());
@@ -1998,7 +1998,7 @@ async fn handle_turn_with_runtime_automatic_acp_routing_bypasses_context_engine_
         crate::config::AcpConversationRoutingMode::AgentPrefixedOnly;
     config.memory.sqlite_path = unique_acp_sqlite_path("automatic-lifecycle-bypass");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime(
             &config,
             "agent:codex:review-thread",

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1240,7 +1240,7 @@ async fn persist_turn_provider_turns_expose_typed_canonical_records() {
         .expect("provider turn should succeed");
 
     let persisted = runtime.persisted.lock().expect("persisted lock").clone();
-    let records = persisted_canonical_records(&persisted);
+    let records = persisted_canonical_records(&persisted_visible_turns(&persisted));
 
     assert_eq!(records.len(), 2);
     assert_eq!(records[0].scope, crate::memory::MemoryScope::Session);

--- a/crates/app/src/memory/canonical.rs
+++ b/crates/app/src/memory/canonical.rs
@@ -1,0 +1,337 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+pub const CANONICAL_MEMORY_RECORD_TYPE: &str = "canonical_memory_record";
+pub const INTERNAL_PERSISTED_RECORD_MARKER: &str = "_loongclaw_internal";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryScope {
+    #[default]
+    Session,
+    User,
+    Agent,
+    Workspace,
+}
+
+impl MemoryScope {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Session => "session",
+            Self::User => "user",
+            Self::Agent => "agent",
+            Self::Workspace => "workspace",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "session" => Some(Self::Session),
+            "user" => Some(Self::User),
+            "agent" => Some(Self::Agent),
+            "workspace" => Some(Self::Workspace),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CanonicalMemoryKind {
+    UserTurn,
+    AssistantTurn,
+    ToolDecision,
+    ToolOutcome,
+    ImportedProfile,
+    ConversationEvent,
+    AcpRuntimeEvent,
+    AcpFinalEvent,
+}
+
+impl CanonicalMemoryKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UserTurn => "user_turn",
+            Self::AssistantTurn => "assistant_turn",
+            Self::ToolDecision => "tool_decision",
+            Self::ToolOutcome => "tool_outcome",
+            Self::ImportedProfile => "imported_profile",
+            Self::ConversationEvent => "conversation_event",
+            Self::AcpRuntimeEvent => "acp_runtime_event",
+            Self::AcpFinalEvent => "acp_final_event",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "user_turn" => Some(Self::UserTurn),
+            "assistant_turn" => Some(Self::AssistantTurn),
+            "tool_decision" => Some(Self::ToolDecision),
+            "tool_outcome" => Some(Self::ToolOutcome),
+            "imported_profile" => Some(Self::ImportedProfile),
+            "conversation_event" => Some(Self::ConversationEvent),
+            "acp_runtime_event" => Some(Self::AcpRuntimeEvent),
+            "acp_final_event" => Some(Self::AcpFinalEvent),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalMemoryRecord {
+    pub session_id: String,
+    pub scope: MemoryScope,
+    pub kind: CanonicalMemoryKind,
+    pub role: Option<String>,
+    pub content: String,
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CanonicalMemoryRecordEnvelope {
+    #[serde(default)]
+    scope: Option<String>,
+    kind: String,
+    #[serde(default)]
+    role: Option<String>,
+    content: String,
+    #[serde(default)]
+    metadata: Option<Value>,
+}
+
+pub fn build_tool_decision_content(turn_id: &str, tool_call_id: &str, decision: Value) -> String {
+    json!({
+        INTERNAL_PERSISTED_RECORD_MARKER: true,
+        "type": "tool_decision",
+        "turn_id": turn_id,
+        "tool_call_id": tool_call_id,
+        "decision": decision,
+    })
+    .to_string()
+}
+
+pub fn build_tool_outcome_content(turn_id: &str, tool_call_id: &str, outcome: Value) -> String {
+    json!({
+        INTERNAL_PERSISTED_RECORD_MARKER: true,
+        "type": "tool_outcome",
+        "turn_id": turn_id,
+        "tool_call_id": tool_call_id,
+        "outcome": outcome,
+    })
+    .to_string()
+}
+
+pub fn build_conversation_event_content(event_name: &str, payload: Value) -> String {
+    json!({
+        INTERNAL_PERSISTED_RECORD_MARKER: true,
+        "type": "conversation_event",
+        "event": event_name,
+        "payload": payload,
+    })
+    .to_string()
+}
+
+pub fn canonical_memory_record_from_persisted_turn(
+    session_id: &str,
+    role: &str,
+    content: &str,
+) -> CanonicalMemoryRecord {
+    let normalized_role = normalized_persisted_role(role);
+
+    if let Some(record) =
+        canonical_memory_record_from_structured_content(session_id, normalized_role, content)
+    {
+        return record;
+    }
+
+    CanonicalMemoryRecord {
+        session_id: session_id.to_owned(),
+        scope: MemoryScope::Session,
+        kind: canonical_kind_from_role(normalized_role),
+        role: Some(normalized_role.to_owned()),
+        content: content.to_owned(),
+        metadata: json!({}),
+    }
+}
+
+fn canonical_memory_record_from_structured_content(
+    session_id: &str,
+    role: &str,
+    content: &str,
+) -> Option<CanonicalMemoryRecord> {
+    if role != "assistant" {
+        return None;
+    }
+
+    let parsed = serde_json::from_str::<Value>(content).ok()?;
+    if parsed
+        .get(INTERNAL_PERSISTED_RECORD_MARKER)
+        .and_then(Value::as_bool)
+        != Some(true)
+    {
+        return None;
+    }
+    let type_id = parsed.get("type").and_then(Value::as_str)?;
+
+    if type_id == CANONICAL_MEMORY_RECORD_TYPE {
+        let envelope = serde_json::from_value::<CanonicalMemoryRecordEnvelope>(parsed).ok()?;
+        return Some(CanonicalMemoryRecord {
+            session_id: session_id.to_owned(),
+            scope: match envelope.scope.as_deref() {
+                Some(scope) => MemoryScope::parse_id(scope)?,
+                None => MemoryScope::default(),
+            },
+            kind: CanonicalMemoryKind::parse_id(envelope.kind.as_str())?,
+            role: envelope
+                .role
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned),
+            content: envelope.content,
+            metadata: envelope.metadata.unwrap_or_else(|| json!({})),
+        });
+    }
+
+    let kind = match type_id {
+        "tool_decision" => CanonicalMemoryKind::ToolDecision,
+        "tool_outcome" => CanonicalMemoryKind::ToolOutcome,
+        "conversation_event" => canonical_kind_from_event_name(
+            parsed
+                .get("event")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+        ),
+        _ => return None,
+    };
+
+    Some(CanonicalMemoryRecord {
+        session_id: session_id.to_owned(),
+        scope: MemoryScope::Session,
+        kind,
+        role: Some(role.to_owned()),
+        content: content.to_owned(),
+        metadata: parsed,
+    })
+}
+
+fn canonical_kind_from_role(role: &str) -> CanonicalMemoryKind {
+    match role {
+        "user" => CanonicalMemoryKind::UserTurn,
+        _ => CanonicalMemoryKind::AssistantTurn,
+    }
+}
+
+fn canonical_kind_from_event_name(event_name: &str) -> CanonicalMemoryKind {
+    match event_name {
+        "acp_turn_event" => CanonicalMemoryKind::AcpRuntimeEvent,
+        "acp_turn_final" => CanonicalMemoryKind::AcpFinalEvent,
+        _ => CanonicalMemoryKind::ConversationEvent,
+    }
+}
+
+fn normalized_persisted_role(role: &str) -> &str {
+    let trimmed = role.trim();
+    if trimmed.is_empty() {
+        "assistant"
+    } else {
+        trimmed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn canonical_memory_record_keeps_user_json_payloads_as_plain_user_turns() {
+        let content = json!({
+            "type": "conversation_event",
+            "event": "user_supplied",
+            "payload": {
+                "message": "hello"
+            },
+        })
+        .to_string();
+
+        let record = canonical_memory_record_from_persisted_turn("session-1", "user", &content);
+
+        assert_eq!(record.scope, MemoryScope::Session);
+        assert_eq!(record.kind, CanonicalMemoryKind::UserTurn);
+        assert_eq!(record.role.as_deref(), Some("user"));
+        assert_eq!(record.content, content);
+        assert_eq!(record.metadata, json!({}));
+    }
+
+    #[test]
+    fn canonical_memory_record_preserves_optional_role_in_envelopes() {
+        let content = json!({
+            "type": CANONICAL_MEMORY_RECORD_TYPE,
+            "_loongclaw_internal": true,
+            "scope": "workspace",
+            "kind": "imported_profile",
+            "content": "Imported profile note",
+            "metadata": {
+                "source": "import"
+            },
+        })
+        .to_string();
+
+        let record =
+            canonical_memory_record_from_persisted_turn("session-1", "assistant", &content);
+
+        assert_eq!(record.scope, MemoryScope::Workspace);
+        assert_eq!(record.kind, CanonicalMemoryKind::ImportedProfile);
+        assert_eq!(record.role, None);
+        assert_eq!(record.content, "Imported profile note");
+        assert_eq!(record.metadata["source"], "import");
+    }
+
+    #[test]
+    fn canonical_memory_record_rejects_unknown_envelope_scope() {
+        let content = json!({
+            "type": CANONICAL_MEMORY_RECORD_TYPE,
+            "_loongclaw_internal": true,
+            "scope": "tenant",
+            "kind": "conversation_event",
+            "content": "opaque canonical payload",
+            "metadata": {
+                "event": "lane_selected"
+            },
+        })
+        .to_string();
+
+        let record =
+            canonical_memory_record_from_persisted_turn("session-1", "assistant", &content);
+
+        assert_eq!(record.scope, MemoryScope::Session);
+        assert_eq!(record.kind, CanonicalMemoryKind::AssistantTurn);
+        assert_eq!(record.role.as_deref(), Some("assistant"));
+        assert_eq!(record.content, content);
+        assert_eq!(record.metadata, json!({}));
+    }
+
+    #[test]
+    fn canonical_memory_record_keeps_unmarked_assistant_json_payloads_as_plain_turns() {
+        let content = json!({
+            "type": "tool_outcome",
+            "turn_id": "turn-1",
+            "tool_call_id": "call-1",
+            "outcome": {
+                "status": "ok"
+            },
+        })
+        .to_string();
+
+        let record =
+            canonical_memory_record_from_persisted_turn("session-1", "assistant", &content);
+
+        assert_eq!(record.scope, MemoryScope::Session);
+        assert_eq!(record.kind, CanonicalMemoryKind::AssistantTurn);
+        assert_eq!(record.role.as_deref(), Some("assistant"));
+        assert_eq!(record.content, content);
+        assert_eq!(record.metadata, json!({}));
+    }
+}

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -2,11 +2,11 @@
 use std::path::PathBuf;
 
 use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
-use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::config::{MemoryBackendKind, MemoryMode};
 
+mod canonical;
 mod kernel_adapter;
 mod orchestrator;
 pub mod runtime_config;
@@ -15,6 +15,12 @@ mod sqlite;
 mod system;
 mod system_registry;
 
+pub use canonical::{
+    CANONICAL_MEMORY_RECORD_TYPE, CanonicalMemoryKind, CanonicalMemoryRecord,
+    INTERNAL_PERSISTED_RECORD_MARKER, MemoryScope, build_conversation_event_content,
+    build_tool_decision_content, build_tool_outcome_content,
+    canonical_memory_record_from_persisted_turn,
+};
 pub use kernel_adapter::MvpMemoryAdapter;
 pub use orchestrator::{
     BuiltinMemoryOrchestrator, HydratedMemoryContext, MemoryDiagnostics, hydrate_memory_context,
@@ -37,109 +43,12 @@ pub use system_registry::{
 pub const MEMORY_OP_APPEND_TURN: &str = "append_turn";
 pub const MEMORY_OP_WINDOW: &str = "window";
 pub const MEMORY_OP_CLEAR_SESSION: &str = "clear_session";
-pub const CANONICAL_MEMORY_RECORD_TYPE: &str = "canonical_memory_record";
-pub const INTERNAL_PERSISTED_RECORD_MARKER: &str = "_loongclaw_internal";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WindowTurn {
     pub role: String,
     pub content: String,
     pub ts: Option<i64>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum MemoryScope {
-    #[default]
-    Session,
-    User,
-    Agent,
-    Workspace,
-}
-
-impl MemoryScope {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Session => "session",
-            Self::User => "user",
-            Self::Agent => "agent",
-            Self::Workspace => "workspace",
-        }
-    }
-
-    pub fn parse_id(raw: &str) -> Option<Self> {
-        match raw.trim().to_ascii_lowercase().as_str() {
-            "session" => Some(Self::Session),
-            "user" => Some(Self::User),
-            "agent" => Some(Self::Agent),
-            "workspace" => Some(Self::Workspace),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CanonicalMemoryKind {
-    UserTurn,
-    AssistantTurn,
-    ToolDecision,
-    ToolOutcome,
-    ImportedProfile,
-    ConversationEvent,
-    AcpRuntimeEvent,
-    AcpFinalEvent,
-}
-
-impl CanonicalMemoryKind {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::UserTurn => "user_turn",
-            Self::AssistantTurn => "assistant_turn",
-            Self::ToolDecision => "tool_decision",
-            Self::ToolOutcome => "tool_outcome",
-            Self::ImportedProfile => "imported_profile",
-            Self::ConversationEvent => "conversation_event",
-            Self::AcpRuntimeEvent => "acp_runtime_event",
-            Self::AcpFinalEvent => "acp_final_event",
-        }
-    }
-
-    pub fn parse_id(raw: &str) -> Option<Self> {
-        match raw.trim().to_ascii_lowercase().as_str() {
-            "user_turn" => Some(Self::UserTurn),
-            "assistant_turn" => Some(Self::AssistantTurn),
-            "tool_decision" => Some(Self::ToolDecision),
-            "tool_outcome" => Some(Self::ToolOutcome),
-            "imported_profile" => Some(Self::ImportedProfile),
-            "conversation_event" => Some(Self::ConversationEvent),
-            "acp_runtime_event" => Some(Self::AcpRuntimeEvent),
-            "acp_final_event" => Some(Self::AcpFinalEvent),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CanonicalMemoryRecord {
-    pub session_id: String,
-    pub scope: MemoryScope,
-    pub kind: CanonicalMemoryKind,
-    pub role: Option<String>,
-    pub content: String,
-    pub metadata: Value,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct CanonicalMemoryRecordEnvelope {
-    #[serde(default)]
-    scope: Option<String>,
-    kind: String,
-    #[serde(default)]
-    role: Option<String>,
-    content: String,
-    #[serde(default)]
-    metadata: Option<Value>,
 }
 
 pub fn build_append_turn_request(session_id: &str, role: &str, content: &str) -> MemoryCoreRequest {
@@ -160,146 +69,6 @@ pub fn build_window_request(session_id: &str, limit: usize) -> MemoryCoreRequest
             "session_id": session_id,
             "limit": limit,
         }),
-    }
-}
-
-pub fn build_tool_decision_content(turn_id: &str, tool_call_id: &str, decision: Value) -> String {
-    json!({
-        INTERNAL_PERSISTED_RECORD_MARKER: true,
-        "type": "tool_decision",
-        "turn_id": turn_id,
-        "tool_call_id": tool_call_id,
-        "decision": decision,
-    })
-    .to_string()
-}
-
-pub fn build_tool_outcome_content(turn_id: &str, tool_call_id: &str, outcome: Value) -> String {
-    json!({
-        INTERNAL_PERSISTED_RECORD_MARKER: true,
-        "type": "tool_outcome",
-        "turn_id": turn_id,
-        "tool_call_id": tool_call_id,
-        "outcome": outcome,
-    })
-    .to_string()
-}
-
-pub fn build_conversation_event_content(event_name: &str, payload: Value) -> String {
-    json!({
-        INTERNAL_PERSISTED_RECORD_MARKER: true,
-        "type": "conversation_event",
-        "event": event_name,
-        "payload": payload,
-    })
-    .to_string()
-}
-
-pub fn canonical_memory_record_from_persisted_turn(
-    session_id: &str,
-    role: &str,
-    content: &str,
-) -> CanonicalMemoryRecord {
-    let normalized_role = normalized_persisted_role(role);
-
-    if let Some(record) =
-        canonical_memory_record_from_structured_content(session_id, normalized_role, content)
-    {
-        return record;
-    }
-
-    CanonicalMemoryRecord {
-        session_id: session_id.to_owned(),
-        scope: MemoryScope::Session,
-        kind: canonical_kind_from_role(normalized_role),
-        role: Some(normalized_role.to_owned()),
-        content: content.to_owned(),
-        metadata: json!({}),
-    }
-}
-
-fn canonical_memory_record_from_structured_content(
-    session_id: &str,
-    role: &str,
-    content: &str,
-) -> Option<CanonicalMemoryRecord> {
-    if role != "assistant" {
-        return None;
-    }
-
-    let parsed = serde_json::from_str::<Value>(content).ok()?;
-    if parsed
-        .get(INTERNAL_PERSISTED_RECORD_MARKER)
-        .and_then(Value::as_bool)
-        != Some(true)
-    {
-        return None;
-    }
-    let type_id = parsed.get("type").and_then(Value::as_str)?;
-
-    if type_id == CANONICAL_MEMORY_RECORD_TYPE {
-        let envelope = serde_json::from_value::<CanonicalMemoryRecordEnvelope>(parsed).ok()?;
-        return Some(CanonicalMemoryRecord {
-            session_id: session_id.to_owned(),
-            scope: match envelope.scope.as_deref() {
-                Some(scope) => MemoryScope::parse_id(scope)?,
-                None => MemoryScope::default(),
-            },
-            kind: CanonicalMemoryKind::parse_id(envelope.kind.as_str())?,
-            role: envelope
-                .role
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(ToOwned::to_owned),
-            content: envelope.content,
-            metadata: envelope.metadata.unwrap_or_else(|| json!({})),
-        });
-    }
-
-    let kind = match type_id {
-        "tool_decision" => CanonicalMemoryKind::ToolDecision,
-        "tool_outcome" => CanonicalMemoryKind::ToolOutcome,
-        "conversation_event" => canonical_kind_from_event_name(
-            parsed
-                .get("event")
-                .and_then(Value::as_str)
-                .unwrap_or_default(),
-        ),
-        _ => return None,
-    };
-
-    Some(CanonicalMemoryRecord {
-        session_id: session_id.to_owned(),
-        scope: MemoryScope::Session,
-        kind,
-        role: Some(role.to_owned()),
-        content: content.to_owned(),
-        metadata: parsed,
-    })
-}
-
-fn canonical_kind_from_role(role: &str) -> CanonicalMemoryKind {
-    match role {
-        "user" => CanonicalMemoryKind::UserTurn,
-        _ => CanonicalMemoryKind::AssistantTurn,
-    }
-}
-
-fn canonical_kind_from_event_name(event_name: &str) -> CanonicalMemoryKind {
-    match event_name {
-        "acp_turn_event" => CanonicalMemoryKind::AcpRuntimeEvent,
-        "acp_turn_final" => CanonicalMemoryKind::AcpFinalEvent,
-        _ => CanonicalMemoryKind::ConversationEvent,
-    }
-}
-
-fn normalized_persisted_role(role: &str) -> &str {
-    let trimmed = role.trim();
-    if trimmed.is_empty() {
-        "assistant"
-    } else {
-        trimmed
     }
 }
 
@@ -557,96 +326,6 @@ fn build_summary_block(turns: &[ConversationTurn], max_chars: usize) -> Option<S
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn canonical_memory_record_keeps_user_json_payloads_as_plain_user_turns() {
-        let content = json!({
-            "type": "conversation_event",
-            "event": "user_supplied",
-            "payload": {
-                "message": "hello"
-            },
-        })
-        .to_string();
-
-        let record = canonical_memory_record_from_persisted_turn("session-1", "user", &content);
-
-        assert_eq!(record.scope, MemoryScope::Session);
-        assert_eq!(record.kind, CanonicalMemoryKind::UserTurn);
-        assert_eq!(record.role.as_deref(), Some("user"));
-        assert_eq!(record.content, content);
-        assert_eq!(record.metadata, json!({}));
-    }
-
-    #[test]
-    fn canonical_memory_record_preserves_optional_role_in_envelopes() {
-        let content = json!({
-            "type": CANONICAL_MEMORY_RECORD_TYPE,
-            "_loongclaw_internal": true,
-            "scope": "workspace",
-            "kind": "imported_profile",
-            "content": "Imported profile note",
-            "metadata": {
-                "source": "import"
-            },
-        })
-        .to_string();
-
-        let record =
-            canonical_memory_record_from_persisted_turn("session-1", "assistant", &content);
-
-        assert_eq!(record.scope, MemoryScope::Workspace);
-        assert_eq!(record.kind, CanonicalMemoryKind::ImportedProfile);
-        assert_eq!(record.role, None);
-        assert_eq!(record.content, "Imported profile note");
-        assert_eq!(record.metadata["source"], "import");
-    }
-
-    #[test]
-    fn canonical_memory_record_rejects_unknown_envelope_scope() {
-        let content = json!({
-            "type": CANONICAL_MEMORY_RECORD_TYPE,
-            "_loongclaw_internal": true,
-            "scope": "tenant",
-            "kind": "conversation_event",
-            "content": "opaque canonical payload",
-            "metadata": {
-                "event": "lane_selected"
-            },
-        })
-        .to_string();
-
-        let record =
-            canonical_memory_record_from_persisted_turn("session-1", "assistant", &content);
-
-        assert_eq!(record.scope, MemoryScope::Session);
-        assert_eq!(record.kind, CanonicalMemoryKind::AssistantTurn);
-        assert_eq!(record.role.as_deref(), Some("assistant"));
-        assert_eq!(record.content, content);
-        assert_eq!(record.metadata, json!({}));
-    }
-
-    #[test]
-    fn canonical_memory_record_keeps_unmarked_assistant_json_payloads_as_plain_turns() {
-        let content = json!({
-            "type": "tool_outcome",
-            "turn_id": "turn-1",
-            "tool_call_id": "call-1",
-            "outcome": {
-                "status": "ok"
-            },
-        })
-        .to_string();
-
-        let record =
-            canonical_memory_record_from_persisted_turn("session-1", "assistant", &content);
-
-        assert_eq!(record.scope, MemoryScope::Session);
-        assert_eq!(record.kind, CanonicalMemoryKind::AssistantTurn);
-        assert_eq!(record.role.as_deref(), Some("assistant"));
-        assert_eq!(record.content, content);
-        assert_eq!(record.metadata, json!({}));
-    }
 
     #[test]
     fn fallback_memory_operation_stays_compatible() {

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -7,13 +7,19 @@ use serde_json::{Value, json};
 use crate::config::{MemoryBackendKind, MemoryMode};
 
 mod kernel_adapter;
+mod orchestrator;
 pub mod runtime_config;
-mod system;
-mod system_registry;
 #[cfg(feature = "memory-sqlite")]
 mod sqlite;
+mod system;
+mod system_registry;
 
 pub use kernel_adapter::MvpMemoryAdapter;
+pub use orchestrator::{
+    BuiltinMemoryOrchestrator, HydratedMemoryContext, MemoryDiagnostics, hydrate_memory_context,
+};
+#[cfg(feature = "memory-sqlite")]
+pub use sqlite::ConversationTurn;
 pub use system::{
     BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MEMORY_SYSTEM_API_VERSION, MemorySystem,
     MemorySystemCapability, MemorySystemMetadata,
@@ -24,8 +30,6 @@ pub use system_registry::{
     list_memory_system_ids, list_memory_system_metadata, memory_system_id_from_env,
     register_memory_system, resolve_memory_system, resolve_memory_system_selection,
 };
-#[cfg(feature = "memory-sqlite")]
-pub use sqlite::ConversationTurn;
 
 pub const MEMORY_OP_APPEND_TURN: &str = "append_turn";
 pub const MEMORY_OP_WINDOW: &str = "window";

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -2,6 +2,7 @@
 use std::path::PathBuf;
 
 use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::config::{MemoryBackendKind, MemoryMode};
@@ -34,12 +35,109 @@ pub use system_registry::{
 pub const MEMORY_OP_APPEND_TURN: &str = "append_turn";
 pub const MEMORY_OP_WINDOW: &str = "window";
 pub const MEMORY_OP_CLEAR_SESSION: &str = "clear_session";
+pub const CANONICAL_MEMORY_RECORD_TYPE: &str = "canonical_memory_record";
+pub const INTERNAL_PERSISTED_RECORD_MARKER: &str = "_loongclaw_internal";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WindowTurn {
     pub role: String,
     pub content: String,
     pub ts: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryScope {
+    #[default]
+    Session,
+    User,
+    Agent,
+    Workspace,
+}
+
+impl MemoryScope {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Session => "session",
+            Self::User => "user",
+            Self::Agent => "agent",
+            Self::Workspace => "workspace",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "session" => Some(Self::Session),
+            "user" => Some(Self::User),
+            "agent" => Some(Self::Agent),
+            "workspace" => Some(Self::Workspace),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CanonicalMemoryKind {
+    UserTurn,
+    AssistantTurn,
+    ToolDecision,
+    ToolOutcome,
+    ImportedProfile,
+    ConversationEvent,
+    AcpRuntimeEvent,
+    AcpFinalEvent,
+}
+
+impl CanonicalMemoryKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UserTurn => "user_turn",
+            Self::AssistantTurn => "assistant_turn",
+            Self::ToolDecision => "tool_decision",
+            Self::ToolOutcome => "tool_outcome",
+            Self::ImportedProfile => "imported_profile",
+            Self::ConversationEvent => "conversation_event",
+            Self::AcpRuntimeEvent => "acp_runtime_event",
+            Self::AcpFinalEvent => "acp_final_event",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "user_turn" => Some(Self::UserTurn),
+            "assistant_turn" => Some(Self::AssistantTurn),
+            "tool_decision" => Some(Self::ToolDecision),
+            "tool_outcome" => Some(Self::ToolOutcome),
+            "imported_profile" => Some(Self::ImportedProfile),
+            "conversation_event" => Some(Self::ConversationEvent),
+            "acp_runtime_event" => Some(Self::AcpRuntimeEvent),
+            "acp_final_event" => Some(Self::AcpFinalEvent),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalMemoryRecord {
+    pub session_id: String,
+    pub scope: MemoryScope,
+    pub kind: CanonicalMemoryKind,
+    pub role: Option<String>,
+    pub content: String,
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CanonicalMemoryRecordEnvelope {
+    #[serde(default)]
+    scope: Option<String>,
+    kind: String,
+    #[serde(default)]
+    role: Option<String>,
+    content: String,
+    #[serde(default)]
+    metadata: Option<Value>,
 }
 
 pub fn build_append_turn_request(session_id: &str, role: &str, content: &str) -> MemoryCoreRequest {
@@ -60,6 +158,146 @@ pub fn build_window_request(session_id: &str, limit: usize) -> MemoryCoreRequest
             "session_id": session_id,
             "limit": limit,
         }),
+    }
+}
+
+pub fn build_tool_decision_content(turn_id: &str, tool_call_id: &str, decision: Value) -> String {
+    json!({
+        INTERNAL_PERSISTED_RECORD_MARKER: true,
+        "type": "tool_decision",
+        "turn_id": turn_id,
+        "tool_call_id": tool_call_id,
+        "decision": decision,
+    })
+    .to_string()
+}
+
+pub fn build_tool_outcome_content(turn_id: &str, tool_call_id: &str, outcome: Value) -> String {
+    json!({
+        INTERNAL_PERSISTED_RECORD_MARKER: true,
+        "type": "tool_outcome",
+        "turn_id": turn_id,
+        "tool_call_id": tool_call_id,
+        "outcome": outcome,
+    })
+    .to_string()
+}
+
+pub fn build_conversation_event_content(event_name: &str, payload: Value) -> String {
+    json!({
+        INTERNAL_PERSISTED_RECORD_MARKER: true,
+        "type": "conversation_event",
+        "event": event_name,
+        "payload": payload,
+    })
+    .to_string()
+}
+
+pub fn canonical_memory_record_from_persisted_turn(
+    session_id: &str,
+    role: &str,
+    content: &str,
+) -> CanonicalMemoryRecord {
+    let normalized_role = normalized_persisted_role(role);
+
+    if let Some(record) =
+        canonical_memory_record_from_structured_content(session_id, normalized_role, content)
+    {
+        return record;
+    }
+
+    CanonicalMemoryRecord {
+        session_id: session_id.to_owned(),
+        scope: MemoryScope::Session,
+        kind: canonical_kind_from_role(normalized_role),
+        role: Some(normalized_role.to_owned()),
+        content: content.to_owned(),
+        metadata: json!({}),
+    }
+}
+
+fn canonical_memory_record_from_structured_content(
+    session_id: &str,
+    role: &str,
+    content: &str,
+) -> Option<CanonicalMemoryRecord> {
+    if role != "assistant" {
+        return None;
+    }
+
+    let parsed = serde_json::from_str::<Value>(content).ok()?;
+    if parsed
+        .get(INTERNAL_PERSISTED_RECORD_MARKER)
+        .and_then(Value::as_bool)
+        != Some(true)
+    {
+        return None;
+    }
+    let type_id = parsed.get("type").and_then(Value::as_str)?;
+
+    if type_id == CANONICAL_MEMORY_RECORD_TYPE {
+        let envelope = serde_json::from_value::<CanonicalMemoryRecordEnvelope>(parsed).ok()?;
+        return Some(CanonicalMemoryRecord {
+            session_id: session_id.to_owned(),
+            scope: match envelope.scope.as_deref() {
+                Some(scope) => MemoryScope::parse_id(scope)?,
+                None => MemoryScope::default(),
+            },
+            kind: CanonicalMemoryKind::parse_id(envelope.kind.as_str())?,
+            role: envelope
+                .role
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned),
+            content: envelope.content,
+            metadata: envelope.metadata.unwrap_or_else(|| json!({})),
+        });
+    }
+
+    let kind = match type_id {
+        "tool_decision" => CanonicalMemoryKind::ToolDecision,
+        "tool_outcome" => CanonicalMemoryKind::ToolOutcome,
+        "conversation_event" => canonical_kind_from_event_name(
+            parsed
+                .get("event")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+        ),
+        _ => return None,
+    };
+
+    Some(CanonicalMemoryRecord {
+        session_id: session_id.to_owned(),
+        scope: MemoryScope::Session,
+        kind,
+        role: Some(role.to_owned()),
+        content: content.to_owned(),
+        metadata: parsed,
+    })
+}
+
+fn canonical_kind_from_role(role: &str) -> CanonicalMemoryKind {
+    match role {
+        "user" => CanonicalMemoryKind::UserTurn,
+        _ => CanonicalMemoryKind::AssistantTurn,
+    }
+}
+
+fn canonical_kind_from_event_name(event_name: &str) -> CanonicalMemoryKind {
+    match event_name {
+        "acp_turn_event" => CanonicalMemoryKind::AcpRuntimeEvent,
+        "acp_turn_final" => CanonicalMemoryKind::AcpFinalEvent,
+        _ => CanonicalMemoryKind::ConversationEvent,
+    }
+}
+
+fn normalized_persisted_role(role: &str) -> &str {
+    let trimmed = role.trim();
+    if trimmed.is_empty() {
+        "assistant"
+    } else {
+        trimmed
     }
 }
 
@@ -317,6 +555,96 @@ fn build_summary_block(turns: &[ConversationTurn], max_chars: usize) -> Option<S
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonical_memory_record_keeps_user_json_payloads_as_plain_user_turns() {
+        let content = json!({
+            "type": "conversation_event",
+            "event": "user_supplied",
+            "payload": {
+                "message": "hello"
+            },
+        })
+        .to_string();
+
+        let record = canonical_memory_record_from_persisted_turn("session-1", "user", &content);
+
+        assert_eq!(record.scope, MemoryScope::Session);
+        assert_eq!(record.kind, CanonicalMemoryKind::UserTurn);
+        assert_eq!(record.role.as_deref(), Some("user"));
+        assert_eq!(record.content, content);
+        assert_eq!(record.metadata, json!({}));
+    }
+
+    #[test]
+    fn canonical_memory_record_preserves_optional_role_in_envelopes() {
+        let content = json!({
+            "type": CANONICAL_MEMORY_RECORD_TYPE,
+            "_loongclaw_internal": true,
+            "scope": "workspace",
+            "kind": "imported_profile",
+            "content": "Imported profile note",
+            "metadata": {
+                "source": "import"
+            },
+        })
+        .to_string();
+
+        let record =
+            canonical_memory_record_from_persisted_turn("session-1", "assistant", &content);
+
+        assert_eq!(record.scope, MemoryScope::Workspace);
+        assert_eq!(record.kind, CanonicalMemoryKind::ImportedProfile);
+        assert_eq!(record.role, None);
+        assert_eq!(record.content, "Imported profile note");
+        assert_eq!(record.metadata["source"], "import");
+    }
+
+    #[test]
+    fn canonical_memory_record_rejects_unknown_envelope_scope() {
+        let content = json!({
+            "type": CANONICAL_MEMORY_RECORD_TYPE,
+            "_loongclaw_internal": true,
+            "scope": "tenant",
+            "kind": "conversation_event",
+            "content": "opaque canonical payload",
+            "metadata": {
+                "event": "lane_selected"
+            },
+        })
+        .to_string();
+
+        let record =
+            canonical_memory_record_from_persisted_turn("session-1", "assistant", &content);
+
+        assert_eq!(record.scope, MemoryScope::Session);
+        assert_eq!(record.kind, CanonicalMemoryKind::AssistantTurn);
+        assert_eq!(record.role.as_deref(), Some("assistant"));
+        assert_eq!(record.content, content);
+        assert_eq!(record.metadata, json!({}));
+    }
+
+    #[test]
+    fn canonical_memory_record_keeps_unmarked_assistant_json_payloads_as_plain_turns() {
+        let content = json!({
+            "type": "tool_outcome",
+            "turn_id": "turn-1",
+            "tool_call_id": "call-1",
+            "outcome": {
+                "status": "ok"
+            },
+        })
+        .to_string();
+
+        let record =
+            canonical_memory_record_from_persisted_turn("session-1", "assistant", &content);
+
+        assert_eq!(record.scope, MemoryScope::Session);
+        assert_eq!(record.kind, CanonicalMemoryKind::AssistantTurn);
+        assert_eq!(record.role.as_deref(), Some("assistant"));
+        assert_eq!(record.content, content);
+        assert_eq!(record.metadata, json!({}));
+    }
 
     #[test]
     fn fallback_memory_operation_stays_compatible() {

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -34,10 +34,11 @@ pub use system::{
     MemorySystemCapability, MemorySystemMetadata,
 };
 pub use system_registry::{
-    MEMORY_SYSTEM_ENV, MemorySystemRuntimeSnapshot, MemorySystemSelection,
-    MemorySystemSelectionSource, collect_memory_system_runtime_snapshot, describe_memory_system,
-    list_memory_system_ids, list_memory_system_metadata, memory_system_id_from_env,
-    register_memory_system, resolve_memory_system, resolve_memory_system_selection,
+    MEMORY_SYSTEM_ENV, MemorySystemPolicySnapshot, MemorySystemRuntimeSnapshot,
+    MemorySystemSelection, MemorySystemSelectionSource, collect_memory_system_runtime_snapshot,
+    describe_memory_system, list_memory_system_ids, list_memory_system_metadata,
+    memory_system_id_from_env, register_memory_system, resolve_memory_system,
+    resolve_memory_system_selection,
 };
 
 pub const MEMORY_OP_APPEND_TURN: &str = "append_turn";

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -8,10 +8,22 @@ use crate::config::{MemoryBackendKind, MemoryMode};
 
 mod kernel_adapter;
 pub mod runtime_config;
+mod system;
+mod system_registry;
 #[cfg(feature = "memory-sqlite")]
 mod sqlite;
 
 pub use kernel_adapter::MvpMemoryAdapter;
+pub use system::{
+    BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MEMORY_SYSTEM_API_VERSION, MemorySystem,
+    MemorySystemCapability, MemorySystemMetadata,
+};
+pub use system_registry::{
+    MEMORY_SYSTEM_ENV, MemorySystemRuntimeSnapshot, MemorySystemSelection,
+    MemorySystemSelectionSource, collect_memory_system_runtime_snapshot, describe_memory_system,
+    list_memory_system_ids, list_memory_system_metadata, memory_system_id_from_env,
+    register_memory_system, resolve_memory_system, resolve_memory_system_selection,
+};
 #[cfg(feature = "memory-sqlite")]
 pub use sqlite::ConversationTurn;
 

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -19,6 +19,8 @@ pub use kernel_adapter::MvpMemoryAdapter;
 pub use orchestrator::{
     BuiltinMemoryOrchestrator, HydratedMemoryContext, MemoryDiagnostics, hydrate_memory_context,
 };
+#[cfg(test)]
+pub use orchestrator::{MemoryOrchestratorTestFaults, ScopedMemoryOrchestratorTestFaults};
 #[cfg(feature = "memory-sqlite")]
 pub use sqlite::ConversationTurn;
 pub use system::{

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -38,7 +38,7 @@ pub use system_registry::{
     MemorySystemSelection, MemorySystemSelectionSource, collect_memory_system_runtime_snapshot,
     describe_memory_system, list_memory_system_ids, list_memory_system_metadata,
     memory_system_id_from_env, register_memory_system, resolve_memory_system,
-    resolve_memory_system_selection,
+    resolve_memory_system_selection, supported_memory_system_kind_from_env,
 };
 
 pub const MEMORY_OP_APPEND_TURN: &str = "append_turn";

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -33,6 +33,7 @@ pub struct BuiltinMemoryOrchestrator;
 #[cfg(test)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MemoryOrchestratorTestFaults {
+    pub session_id: Option<String>,
     pub derivation_error: Option<String>,
     pub retrieval_error: Option<String>,
 }
@@ -59,6 +60,18 @@ fn active_memory_orchestrator_test_faults() -> Option<MemoryOrchestratorTestFaul
         .lock()
         .ok()
         .and_then(|guard| guard.clone())
+}
+
+#[cfg(test)]
+fn matching_memory_orchestrator_test_faults(
+    session_id: &str,
+) -> Option<MemoryOrchestratorTestFaults> {
+    active_memory_orchestrator_test_faults().filter(|faults| {
+        faults
+            .session_id
+            .as_deref()
+            .is_none_or(|expected| expected == session_id)
+    })
 }
 
 #[cfg(test)]
@@ -139,8 +152,8 @@ fn run_derivation_stage(
     _recent_window: &[WindowTurn],
 ) -> Result<Vec<MemoryContextEntry>, String> {
     #[cfg(test)]
-    if let Some(error) =
-        active_memory_orchestrator_test_faults().and_then(|faults| faults.derivation_error)
+    if let Some(error) = matching_memory_orchestrator_test_faults(_session_id)
+        .and_then(|faults| faults.derivation_error)
     {
         return Err(error);
     }
@@ -154,8 +167,8 @@ fn run_retrieval_stage(
     _recent_window: &[WindowTurn],
 ) -> Result<Vec<MemoryContextEntry>, String> {
     #[cfg(test)]
-    if let Some(error) =
-        active_memory_orchestrator_test_faults().and_then(|faults| faults.retrieval_error)
+    if let Some(error) = matching_memory_orchestrator_test_faults(_session_id)
+        .and_then(|faults| faults.retrieval_error)
     {
         return Err(error);
     }
@@ -360,7 +373,9 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     #[test]
     fn fail_open_memory_derivation_failure_keeps_recent_window_behavior() {
+        let session_id = "fail-open-derivation";
         let _faults = ScopedMemoryOrchestratorTestFaults::set(MemoryOrchestratorTestFaults {
+            session_id: Some(session_id.to_owned()),
             derivation_error: Some("simulated derivation failure".to_owned()),
             ..MemoryOrchestratorTestFaults::default()
         });
@@ -377,14 +392,14 @@ mod tests {
             ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
         };
 
-        append_turn_direct("fail-open-derivation", "user", "turn 1", &config)
+        append_turn_direct(session_id, "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
-        append_turn_direct("fail-open-derivation", "assistant", "turn 2", &config)
+        append_turn_direct(session_id, "assistant", "turn 2", &config)
             .expect("append turn 2 should succeed");
-        append_turn_direct("fail-open-derivation", "user", "turn 3", &config)
+        append_turn_direct(session_id, "user", "turn 3", &config)
             .expect("append turn 3 should succeed");
 
-        let hydrated = hydrate_memory_context("fail-open-derivation", &config)
+        let hydrated = hydrate_memory_context(session_id, &config)
             .expect("fail-open derivation should preserve hydration");
 
         let turn_entries = hydrated
@@ -409,7 +424,9 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     #[test]
     fn fail_open_memory_retrieval_failure_keeps_recent_window_behavior() {
+        let session_id = "fail-open-retrieval";
         let _faults = ScopedMemoryOrchestratorTestFaults::set(MemoryOrchestratorTestFaults {
+            session_id: Some(session_id.to_owned()),
             retrieval_error: Some("simulated retrieval failure".to_owned()),
             ..MemoryOrchestratorTestFaults::default()
         });
@@ -426,14 +443,14 @@ mod tests {
             ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
         };
 
-        append_turn_direct("fail-open-retrieval", "user", "turn 1", &config)
+        append_turn_direct(session_id, "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
-        append_turn_direct("fail-open-retrieval", "assistant", "turn 2", &config)
+        append_turn_direct(session_id, "assistant", "turn 2", &config)
             .expect("append turn 2 should succeed");
-        append_turn_direct("fail-open-retrieval", "user", "turn 3", &config)
+        append_turn_direct(session_id, "user", "turn 3", &config)
             .expect("append turn 3 should succeed");
 
-        let hydrated = hydrate_memory_context("fail-open-retrieval", &config)
+        let hydrated = hydrate_memory_context(session_id, &config)
             .expect("fail-open retrieval should preserve hydration");
 
         let turn_entries = hydrated
@@ -458,7 +475,9 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     #[test]
     fn fail_open_memory_strict_mode_remains_reserved_and_disabled_by_default() {
+        let session_id = "fail-open-strict-reserved";
         let _faults = ScopedMemoryOrchestratorTestFaults::set(MemoryOrchestratorTestFaults {
+            session_id: Some(session_id.to_owned()),
             derivation_error: Some("strict mode should stay disabled".to_owned()),
             ..MemoryOrchestratorTestFaults::default()
         });
@@ -476,10 +495,10 @@ mod tests {
         };
         config.fail_open = false;
 
-        append_turn_direct("fail-open-strict-reserved", "assistant", "turn 1", &config)
+        append_turn_direct(session_id, "assistant", "turn 1", &config)
             .expect("append turn should succeed");
 
-        let hydrated = hydrate_memory_context("fail-open-strict-reserved", &config)
+        let hydrated = hydrate_memory_context(session_id, &config)
             .expect("strict mode should remain reserved and disabled");
 
         assert!(hydrated.diagnostics.strict_mode_requested);

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
 use crate::config::MemorySystemKind;
 
 use super::{
@@ -15,6 +18,11 @@ pub struct HydratedMemoryContext {
 pub struct MemoryDiagnostics {
     pub system_id: &'static str,
     pub fail_open: bool,
+    pub strict_mode_requested: bool,
+    pub strict_mode_active: bool,
+    pub degraded: bool,
+    pub derivation_error: Option<String>,
+    pub retrieval_error: Option<String>,
     pub recent_window_count: usize,
     pub entry_count: usize,
 }
@@ -22,17 +30,97 @@ pub struct MemoryDiagnostics {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct BuiltinMemoryOrchestrator;
 
+#[cfg(test)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MemoryOrchestratorTestFaults {
+    pub derivation_error: Option<String>,
+    pub retrieval_error: Option<String>,
+}
+
+#[cfg(test)]
+static MEMORY_ORCHESTRATOR_TEST_FAULTS: OnceLock<Mutex<Option<MemoryOrchestratorTestFaults>>> =
+    OnceLock::new();
+#[cfg(test)]
+static MEMORY_ORCHESTRATOR_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[cfg(test)]
+fn memory_orchestrator_test_faults() -> &'static Mutex<Option<MemoryOrchestratorTestFaults>> {
+    MEMORY_ORCHESTRATOR_TEST_FAULTS.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(test)]
+fn memory_orchestrator_test_lock() -> &'static Mutex<()> {
+    MEMORY_ORCHESTRATOR_TEST_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(test)]
+fn active_memory_orchestrator_test_faults() -> Option<MemoryOrchestratorTestFaults> {
+    memory_orchestrator_test_faults()
+        .lock()
+        .ok()
+        .and_then(|guard| guard.clone())
+}
+
+#[cfg(test)]
+pub struct ScopedMemoryOrchestratorTestFaults {
+    _guard: MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl ScopedMemoryOrchestratorTestFaults {
+    pub fn set(faults: MemoryOrchestratorTestFaults) -> Self {
+        let guard = memory_orchestrator_test_lock()
+            .lock()
+            .expect("memory orchestrator test lock");
+        *memory_orchestrator_test_faults()
+            .lock()
+            .expect("memory orchestrator test faults lock") = Some(faults);
+        Self { _guard: guard }
+    }
+}
+
+#[cfg(test)]
+impl Drop for ScopedMemoryOrchestratorTestFaults {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = memory_orchestrator_test_faults().lock() {
+            *guard = None;
+        }
+    }
+}
+
 impl BuiltinMemoryOrchestrator {
     pub fn hydrate(
         &self,
         session_id: &str,
         config: &MemoryRuntimeConfig,
     ) -> Result<HydratedMemoryContext, String> {
-        let entries = load_prompt_context(session_id, config)?;
         let recent_window = recent_window_records(session_id, config)?;
+        let mut entries = load_prompt_context(session_id, config)?;
+        let mut derivation_error = None;
+        let mut retrieval_error = None;
+        let fail_open = config.effective_fail_open();
+
+        match run_derivation_stage(session_id, config, &recent_window) {
+            Ok(extra_entries) => entries.extend(extra_entries),
+            Err(error) if fail_open => derivation_error = Some(error),
+            Err(error) => return Err(format!("memory derivation stage failed: {error}")),
+        }
+
+        match run_retrieval_stage(session_id, config, &recent_window) {
+            Ok(extra_entries) => entries.extend(extra_entries),
+            Err(error) if fail_open => retrieval_error = Some(error),
+            Err(error) => return Err(format!("memory retrieval stage failed: {error}")),
+        }
+
+        let degraded = derivation_error.is_some() || retrieval_error.is_some();
         let diagnostics = MemoryDiagnostics {
             system_id: config.system.as_str(),
-            fail_open: config.fail_open,
+            fail_open,
+            strict_mode_requested: config.strict_mode_requested(),
+            strict_mode_active: config.strict_mode_active(),
+            degraded,
+            derivation_error,
+            retrieval_error,
             recent_window_count: recent_window.len(),
             entry_count: entries.len(),
         };
@@ -43,6 +131,36 @@ impl BuiltinMemoryOrchestrator {
             diagnostics,
         })
     }
+}
+
+fn run_derivation_stage(
+    _session_id: &str,
+    _config: &MemoryRuntimeConfig,
+    _recent_window: &[WindowTurn],
+) -> Result<Vec<MemoryContextEntry>, String> {
+    #[cfg(test)]
+    if let Some(error) =
+        active_memory_orchestrator_test_faults().and_then(|faults| faults.derivation_error)
+    {
+        return Err(error);
+    }
+
+    Ok(Vec::new())
+}
+
+fn run_retrieval_stage(
+    _session_id: &str,
+    _config: &MemoryRuntimeConfig,
+    _recent_window: &[WindowTurn],
+) -> Result<Vec<MemoryContextEntry>, String> {
+    #[cfg(test)]
+    if let Some(error) =
+        active_memory_orchestrator_test_faults().and_then(|faults| faults.retrieval_error)
+    {
+        return Err(error);
+    }
+
+    Ok(Vec::new())
 }
 
 pub fn hydrate_memory_context(
@@ -141,6 +259,11 @@ mod tests {
 
         assert_eq!(hydrated.diagnostics.system_id, "builtin");
         assert!(hydrated.diagnostics.fail_open);
+        assert!(!hydrated.diagnostics.strict_mode_requested);
+        assert!(!hydrated.diagnostics.strict_mode_active);
+        assert!(!hydrated.diagnostics.degraded);
+        assert_eq!(hydrated.diagnostics.derivation_error, None);
+        assert_eq!(hydrated.diagnostics.retrieval_error, None);
         assert_eq!(hydrated.diagnostics.recent_window_count, 0);
         assert_eq!(hydrated.diagnostics.entry_count, 0);
 
@@ -228,6 +351,143 @@ mod tests {
                 .iter()
                 .any(|entry| entry.content.contains("Imported ZeroClaw preferences")),
             "expected profile note content"
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn fail_open_memory_derivation_failure_keeps_recent_window_behavior() {
+        let _faults = ScopedMemoryOrchestratorTestFaults::set(MemoryOrchestratorTestFaults {
+            derivation_error: Some("simulated derivation failure".to_owned()),
+            ..MemoryOrchestratorTestFaults::default()
+        });
+        let tmp = hydrated_memory_temp_dir("loongclaw-fail-open-derivation");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("derivation.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct("fail-open-derivation", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("fail-open-derivation", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct("fail-open-derivation", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let hydrated = hydrate_memory_context("fail-open-derivation", &config)
+            .expect("fail-open derivation should preserve hydration");
+
+        let turn_entries = hydrated
+            .entries
+            .iter()
+            .filter(|entry| entry.kind == MemoryContextKind::Turn)
+            .collect::<Vec<_>>();
+        assert_eq!(turn_entries.len(), 2);
+        assert_eq!(turn_entries[0].content, "turn 2");
+        assert_eq!(turn_entries[1].content, "turn 3");
+        assert_eq!(
+            hydrated.diagnostics.derivation_error.as_deref(),
+            Some("simulated derivation failure")
+        );
+        assert!(hydrated.diagnostics.degraded);
+        assert!(hydrated.diagnostics.fail_open);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn fail_open_memory_retrieval_failure_keeps_recent_window_behavior() {
+        let _faults = ScopedMemoryOrchestratorTestFaults::set(MemoryOrchestratorTestFaults {
+            retrieval_error: Some("simulated retrieval failure".to_owned()),
+            ..MemoryOrchestratorTestFaults::default()
+        });
+        let tmp = hydrated_memory_temp_dir("loongclaw-fail-open-retrieval");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("retrieval.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct("fail-open-retrieval", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("fail-open-retrieval", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct("fail-open-retrieval", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let hydrated = hydrate_memory_context("fail-open-retrieval", &config)
+            .expect("fail-open retrieval should preserve hydration");
+
+        let turn_entries = hydrated
+            .entries
+            .iter()
+            .filter(|entry| entry.kind == MemoryContextKind::Turn)
+            .collect::<Vec<_>>();
+        assert_eq!(turn_entries.len(), 2);
+        assert_eq!(turn_entries[0].content, "turn 2");
+        assert_eq!(turn_entries[1].content, "turn 3");
+        assert_eq!(
+            hydrated.diagnostics.retrieval_error.as_deref(),
+            Some("simulated retrieval failure")
+        );
+        assert!(hydrated.diagnostics.degraded);
+        assert!(hydrated.diagnostics.fail_open);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn fail_open_memory_strict_mode_remains_reserved_and_disabled_by_default() {
+        let _faults = ScopedMemoryOrchestratorTestFaults::set(MemoryOrchestratorTestFaults {
+            derivation_error: Some("strict mode should stay disabled".to_owned()),
+            ..MemoryOrchestratorTestFaults::default()
+        });
+        let tmp = hydrated_memory_temp_dir("loongclaw-fail-open-strict-reserved");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("strict-reserved.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let mut config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        config.fail_open = false;
+
+        append_turn_direct("fail-open-strict-reserved", "assistant", "turn 1", &config)
+            .expect("append turn should succeed");
+
+        let hydrated = hydrate_memory_context("fail-open-strict-reserved", &config)
+            .expect("strict mode should remain reserved and disabled");
+
+        assert!(hydrated.diagnostics.strict_mode_requested);
+        assert!(!hydrated.diagnostics.strict_mode_active);
+        assert!(hydrated.diagnostics.fail_open);
+        assert_eq!(
+            hydrated.diagnostics.derivation_error.as_deref(),
+            Some("strict mode should stay disabled")
         );
 
         let _ = std::fs::remove_file(&db_path);

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -1,0 +1,236 @@
+use crate::config::MemorySystemKind;
+
+use super::{
+    MemoryContextEntry, WindowTurn, load_prompt_context, runtime_config::MemoryRuntimeConfig,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HydratedMemoryContext {
+    pub entries: Vec<MemoryContextEntry>,
+    pub recent_window: Vec<WindowTurn>,
+    pub diagnostics: MemoryDiagnostics,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryDiagnostics {
+    pub system_id: &'static str,
+    pub fail_open: bool,
+    pub recent_window_count: usize,
+    pub entry_count: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BuiltinMemoryOrchestrator;
+
+impl BuiltinMemoryOrchestrator {
+    pub fn hydrate(
+        &self,
+        session_id: &str,
+        config: &MemoryRuntimeConfig,
+    ) -> Result<HydratedMemoryContext, String> {
+        let entries = load_prompt_context(session_id, config)?;
+        let recent_window = recent_window_records(session_id, config)?;
+        let diagnostics = MemoryDiagnostics {
+            system_id: config.system.as_str(),
+            fail_open: config.fail_open,
+            recent_window_count: recent_window.len(),
+            entry_count: entries.len(),
+        };
+
+        Ok(HydratedMemoryContext {
+            entries,
+            recent_window,
+            diagnostics,
+        })
+    }
+}
+
+pub fn hydrate_memory_context(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<HydratedMemoryContext, String> {
+    match config.system {
+        MemorySystemKind::Builtin => BuiltinMemoryOrchestrator.hydrate(session_id, config),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn recent_window_records(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<WindowTurn>, String> {
+    let turns = super::window_direct(session_id, config.sliding_window, config)?;
+    Ok(turns
+        .into_iter()
+        .map(|turn| WindowTurn {
+            role: turn.role,
+            content: turn.content,
+            ts: Some(turn.ts),
+        })
+        .collect())
+}
+
+#[cfg(not(feature = "memory-sqlite"))]
+fn recent_window_records(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<WindowTurn>, String> {
+    let _ = (session_id, config);
+    Ok(Vec::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{MemoryMode, MemoryProfile};
+    use crate::memory::{MemoryContextKind, append_turn_direct};
+
+    fn hydrated_memory_temp_dir(prefix: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()))
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrated_memory_builtin_orchestrator_returns_recent_window_records() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-hydrated-window");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("window.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct("hydrated-window", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("hydrated-window", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct("hydrated-window", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let hydrated =
+            hydrate_memory_context("hydrated-window", &config).expect("hydrate memory context");
+
+        assert_eq!(hydrated.recent_window.len(), 2);
+        assert_eq!(hydrated.recent_window[0].content, "turn 2");
+        assert_eq!(hydrated.recent_window[1].content, "turn 3");
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrated_memory_builtin_orchestrator_reports_deterministic_diagnostics() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-hydrated-diagnostics");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("diagnostics.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        let hydrated = hydrate_memory_context("hydrated-diagnostics", &config)
+            .expect("hydrate memory context");
+
+        assert_eq!(hydrated.diagnostics.system_id, "builtin");
+        assert!(hydrated.diagnostics.fail_open);
+        assert_eq!(hydrated.diagnostics.recent_window_count, 0);
+        assert_eq!(hydrated.diagnostics.entry_count, 0);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrated_memory_builtin_orchestrator_preserves_summary_behavior() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-hydrated-summary");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("summary.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct("hydrated-summary", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("hydrated-summary", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct("hydrated-summary", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+        append_turn_direct("hydrated-summary", "assistant", "turn 4", &config)
+            .expect("append turn 4 should succeed");
+
+        let hydrated =
+            hydrate_memory_context("hydrated-summary", &config).expect("hydrate memory context");
+
+        assert!(
+            hydrated
+                .entries
+                .iter()
+                .any(|entry| entry.kind == MemoryContextKind::Summary),
+            "expected summary entry"
+        );
+        assert!(
+            hydrated
+                .entries
+                .iter()
+                .any(|entry| entry.content.contains("turn 1")),
+            "expected summary to mention older turns"
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrated_memory_builtin_orchestrator_preserves_profile_behavior() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-hydrated-profile");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("profile.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::ProfilePlusWindow,
+            mode: MemoryMode::ProfilePlusWindow,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            profile_note: Some("Imported ZeroClaw preferences".to_owned()),
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        let hydrated =
+            hydrate_memory_context("hydrated-profile", &config).expect("hydrate memory context");
+
+        assert!(
+            hydrated
+                .entries
+                .iter()
+                .any(|entry| entry.kind == MemoryContextKind::Profile),
+            "expected profile entry"
+        );
+        assert!(
+            hydrated
+                .entries
+                .iter()
+                .any(|entry| entry.content.contains("Imported ZeroClaw preferences")),
+            "expected profile note content"
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+}

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -76,10 +76,7 @@ impl MemoryRuntimeConfig {
             self.mode = profile.mode();
         }
 
-        if let Some(system) = crate::memory::memory_system_id_from_env()
-            .as_deref()
-            .and_then(MemorySystemKind::parse_id)
-        {
+        if let Some(system) = crate::memory::supported_memory_system_kind_from_env() {
             self.system = system;
         }
 
@@ -250,6 +247,7 @@ mod tests {
 
     #[test]
     fn runtime_config_from_memory_config_carries_profile_and_limits() {
+        let _env = ScopedEnv::new();
         let config = MemoryConfig {
             profile: MemoryProfile::WindowPlusSummary,
             summary_max_chars: 900,
@@ -266,6 +264,7 @@ mod tests {
 
     #[test]
     fn hydrated_memory_runtime_config_carries_system_policy() {
+        let _env = ScopedEnv::new();
         let config = MemoryConfig {
             system: crate::config::MemorySystemKind::Builtin,
             fail_open: false,

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -92,7 +92,9 @@ impl MemoryRuntimeConfig {
             self.ingest_mode = ingest_mode;
         }
 
-        if let Some(sqlite_path) = std::env::var("LOONGCLAW_SQLITE_PATH").ok().map(PathBuf::from)
+        if let Some(sqlite_path) = std::env::var("LOONGCLAW_SQLITE_PATH")
+            .ok()
+            .map(PathBuf::from)
         {
             self.sqlite_path = Some(sqlite_path);
         }
@@ -318,9 +320,6 @@ mod tests {
             runtime.sqlite_path,
             Some(PathBuf::from("/tmp/env-memory.sqlite3"))
         );
-        assert_eq!(
-            runtime.profile_note.as_deref(),
-            Some("env profile note")
-        );
+        assert_eq!(runtime.profile_note.as_deref(), Some("env profile note"));
     }
 }

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
-use crate::config::{MemoryBackendKind, MemoryConfig, MemoryMode, MemoryProfile};
+use crate::config::{
+    MemoryBackendKind, MemoryConfig, MemoryIngestMode, MemoryMode, MemoryProfile, MemorySystemKind,
+};
 
 /// Typed runtime configuration for the memory (SQLite) subsystem.
 ///
@@ -12,7 +14,10 @@ use crate::config::{MemoryBackendKind, MemoryConfig, MemoryMode, MemoryProfile};
 pub struct MemoryRuntimeConfig {
     pub backend: MemoryBackendKind,
     pub profile: MemoryProfile,
+    pub system: MemorySystemKind,
     pub mode: MemoryMode,
+    pub fail_open: bool,
+    pub ingest_mode: MemoryIngestMode,
     pub sqlite_path: Option<PathBuf>,
     pub sliding_window: usize,
     pub summary_max_chars: usize,
@@ -25,7 +30,10 @@ impl Default for MemoryRuntimeConfig {
         Self {
             backend: defaults.backend,
             profile: defaults.profile,
+            system: defaults.system,
             mode: defaults.resolved_mode(),
+            fail_open: defaults.fail_open,
+            ingest_mode: defaults.ingest_mode,
             sqlite_path: None,
             sliding_window: defaults.sliding_window,
             summary_max_chars: defaults.summary_char_budget(),
@@ -51,6 +59,17 @@ impl MemoryRuntimeConfig {
             .as_deref()
             .and_then(MemoryProfile::parse_id)
             .unwrap_or(defaults.profile);
+        let system = crate::memory::memory_system_id_from_env()
+            .as_deref()
+            .and_then(MemorySystemKind::parse_id)
+            .unwrap_or(defaults.system);
+        let fail_open = parse_bool(std::env::var("LOONGCLAW_MEMORY_FAIL_OPEN").ok())
+            .unwrap_or(defaults.fail_open);
+        let ingest_mode = std::env::var("LOONGCLAW_MEMORY_INGEST_MODE")
+            .ok()
+            .as_deref()
+            .and_then(MemoryIngestMode::parse_id)
+            .unwrap_or(defaults.ingest_mode);
         let sqlite_path = std::env::var("LOONGCLAW_SQLITE_PATH")
             .ok()
             .map(PathBuf::from);
@@ -68,7 +87,10 @@ impl MemoryRuntimeConfig {
         Self {
             backend,
             profile,
+            system,
             mode: profile.mode(),
+            fail_open,
+            ingest_mode,
             sqlite_path,
             sliding_window,
             summary_max_chars,
@@ -82,7 +104,10 @@ impl MemoryRuntimeConfig {
         Self {
             backend,
             profile,
+            system: config.resolved_system(),
             mode: config.resolved_mode(),
+            fail_open: config.fail_open,
+            ingest_mode: config.ingest_mode,
             sqlite_path: Some(config.resolved_sqlite_path()),
             sliding_window: config.sliding_window,
             summary_max_chars: config.summary_char_budget(),
@@ -94,6 +119,14 @@ impl MemoryRuntimeConfig {
 fn parse_positive_usize(raw: Option<String>) -> Option<usize> {
     raw.and_then(|value| value.parse::<usize>().ok())
         .filter(|value| *value > 0)
+}
+
+fn parse_bool(raw: Option<String>) -> Option<bool> {
+    raw.and_then(|value| match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    })
 }
 
 static MEMORY_RUNTIME_CONFIG: OnceLock<MemoryRuntimeConfig> = OnceLock::new();
@@ -139,6 +172,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_bool_accepts_common_true_false_forms() {
+        assert_eq!(parse_bool(Some("true".to_owned())), Some(true));
+        assert_eq!(parse_bool(Some("1".to_owned())), Some(true));
+        assert_eq!(parse_bool(Some("off".to_owned())), Some(false));
+        assert_eq!(parse_bool(Some("0".to_owned())), Some(false));
+    }
+
+    #[test]
+    fn parse_bool_rejects_unknown_values() {
+        assert_eq!(parse_bool(Some("maybe".to_owned())), None);
+        assert_eq!(parse_bool(None), None);
+    }
+
+    #[test]
     fn memory_runtime_config_default_has_no_path() {
         let config = MemoryRuntimeConfig::default();
         assert!(config.sqlite_path.is_none());
@@ -149,7 +196,10 @@ mod tests {
         let config = MemoryRuntimeConfig {
             backend: MemoryBackendKind::Sqlite,
             profile: MemoryProfile::WindowOnly,
+            system: MemorySystemKind::Builtin,
             mode: MemoryMode::WindowOnly,
+            fail_open: true,
+            ingest_mode: MemoryIngestMode::SyncMinimal,
             sqlite_path: Some(PathBuf::from("/tmp/test-memory.sqlite3")),
             sliding_window: 12,
             summary_max_chars: 1200,
@@ -175,5 +225,24 @@ mod tests {
         assert_eq!(runtime.profile, MemoryProfile::WindowPlusSummary);
         assert_eq!(runtime.mode, MemoryMode::WindowPlusSummary);
         assert_eq!(runtime.summary_max_chars, 900);
+    }
+
+    #[test]
+    fn hydrated_memory_runtime_config_carries_system_policy() {
+        let config = MemoryConfig {
+            system: crate::config::MemorySystemKind::Builtin,
+            fail_open: false,
+            ingest_mode: crate::config::MemoryIngestMode::AsyncBackground,
+            ..MemoryConfig::default()
+        };
+
+        let runtime = MemoryRuntimeConfig::from_memory_config(&config);
+
+        assert_eq!(runtime.system, crate::config::MemorySystemKind::Builtin);
+        assert!(!runtime.fail_open);
+        assert_eq!(
+            runtime.ingest_mode,
+            crate::config::MemoryIngestMode::AsyncBackground
+        );
     }
 }

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -114,6 +114,18 @@ impl MemoryRuntimeConfig {
             profile_note: config.trimmed_profile_note(),
         }
     }
+
+    pub const fn strict_mode_requested(&self) -> bool {
+        !self.fail_open
+    }
+
+    pub const fn strict_mode_active(&self) -> bool {
+        false
+    }
+
+    pub const fn effective_fail_open(&self) -> bool {
+        !self.strict_mode_active()
+    }
 }
 
 fn parse_positive_usize(raw: Option<String>) -> Option<usize> {
@@ -240,6 +252,9 @@ mod tests {
 
         assert_eq!(runtime.system, crate::config::MemorySystemKind::Builtin);
         assert!(!runtime.fail_open);
+        assert!(runtime.strict_mode_requested());
+        assert!(!runtime.strict_mode_active());
+        assert!(runtime.effective_fail_open());
         assert_eq!(
             runtime.ingest_mode,
             crate::config::MemoryIngestMode::AsyncBackground

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -43,67 +43,10 @@ impl Default for MemoryRuntimeConfig {
 }
 
 impl MemoryRuntimeConfig {
-    /// Build a config by reading the legacy environment variable.
-    ///
-    /// Keeps full backward compatibility for callers that still rely on
-    /// `LOONGCLAW_SQLITE_PATH`.
-    pub fn from_env() -> Self {
-        let defaults = MemoryConfig::default();
-        let backend = std::env::var("LOONGCLAW_MEMORY_BACKEND")
-            .ok()
-            .as_deref()
-            .and_then(MemoryBackendKind::parse_id)
-            .unwrap_or(defaults.backend);
-        let profile = std::env::var("LOONGCLAW_MEMORY_PROFILE")
-            .ok()
-            .as_deref()
-            .and_then(MemoryProfile::parse_id)
-            .unwrap_or(defaults.profile);
-        let system = crate::memory::memory_system_id_from_env()
-            .as_deref()
-            .and_then(MemorySystemKind::parse_id)
-            .unwrap_or(defaults.system);
-        let fail_open = parse_bool(std::env::var("LOONGCLAW_MEMORY_FAIL_OPEN").ok())
-            .unwrap_or(defaults.fail_open);
-        let ingest_mode = std::env::var("LOONGCLAW_MEMORY_INGEST_MODE")
-            .ok()
-            .as_deref()
-            .and_then(MemoryIngestMode::parse_id)
-            .unwrap_or(defaults.ingest_mode);
-        let sqlite_path = std::env::var("LOONGCLAW_SQLITE_PATH")
-            .ok()
-            .map(PathBuf::from);
-        let sliding_window = parse_positive_usize(std::env::var("LOONGCLAW_SLIDING_WINDOW").ok())
-            .unwrap_or(defaults.sliding_window);
-        let summary_max_chars =
-            parse_positive_usize(std::env::var("LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS").ok())
-                .unwrap_or(defaults.summary_char_budget());
-        let profile_note = std::env::var("LOONGCLAW_MEMORY_PROFILE_NOTE")
-            .ok()
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned);
+    fn from_memory_config_base(config: &MemoryConfig) -> Self {
         Self {
-            backend,
-            profile,
-            system,
-            mode: profile.mode(),
-            fail_open,
-            ingest_mode,
-            sqlite_path,
-            sliding_window,
-            summary_max_chars,
-            profile_note,
-        }
-    }
-
-    pub fn from_memory_config(config: &MemoryConfig) -> Self {
-        let backend = config.resolved_backend();
-        let profile = config.resolved_profile();
-        Self {
-            backend,
-            profile,
+            backend: config.resolved_backend(),
+            profile: config.resolved_profile(),
             system: config.resolved_system(),
             mode: config.resolved_mode(),
             fail_open: config.fail_open,
@@ -113,6 +56,87 @@ impl MemoryRuntimeConfig {
             summary_max_chars: config.summary_char_budget(),
             profile_note: config.trimmed_profile_note(),
         }
+    }
+
+    fn apply_env_overrides(&mut self) {
+        if let Some(backend) = std::env::var("LOONGCLAW_MEMORY_BACKEND")
+            .ok()
+            .as_deref()
+            .and_then(MemoryBackendKind::parse_id)
+        {
+            self.backend = backend;
+        }
+
+        if let Some(profile) = std::env::var("LOONGCLAW_MEMORY_PROFILE")
+            .ok()
+            .as_deref()
+            .and_then(MemoryProfile::parse_id)
+        {
+            self.profile = profile;
+            self.mode = profile.mode();
+        }
+
+        if let Some(system) = crate::memory::memory_system_id_from_env()
+            .as_deref()
+            .and_then(MemorySystemKind::parse_id)
+        {
+            self.system = system;
+        }
+
+        if let Some(fail_open) = parse_bool(std::env::var("LOONGCLAW_MEMORY_FAIL_OPEN").ok()) {
+            self.fail_open = fail_open;
+        }
+
+        if let Some(ingest_mode) = std::env::var("LOONGCLAW_MEMORY_INGEST_MODE")
+            .ok()
+            .as_deref()
+            .and_then(MemoryIngestMode::parse_id)
+        {
+            self.ingest_mode = ingest_mode;
+        }
+
+        if let Some(sqlite_path) = std::env::var("LOONGCLAW_SQLITE_PATH").ok().map(PathBuf::from)
+        {
+            self.sqlite_path = Some(sqlite_path);
+        }
+
+        if let Some(sliding_window) =
+            parse_positive_usize(std::env::var("LOONGCLAW_SLIDING_WINDOW").ok())
+        {
+            self.sliding_window = sliding_window;
+        }
+
+        if let Some(summary_max_chars) =
+            parse_positive_usize(std::env::var("LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS").ok())
+        {
+            self.summary_max_chars = summary_max_chars;
+        }
+
+        if let Ok(profile_note) = std::env::var("LOONGCLAW_MEMORY_PROFILE_NOTE") {
+            let trimmed = profile_note.trim();
+            self.profile_note = if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_owned())
+            };
+        }
+    }
+
+    /// Build a config by reading the legacy environment variable.
+    ///
+    /// Keeps full backward compatibility for callers that still rely on
+    /// `LOONGCLAW_SQLITE_PATH`.
+    pub fn from_env() -> Self {
+        let defaults = MemoryConfig::default();
+        let mut runtime = Self::from_memory_config_base(&defaults);
+        runtime.apply_env_overrides();
+        runtime
+    }
+
+    pub fn from_memory_config(config: &MemoryConfig) -> Self {
+        let mut runtime = Self::from_memory_config_base(config);
+        runtime.apply_env_overrides();
+        runtime
     }
 
     pub const fn strict_mode_requested(&self) -> bool {
@@ -165,6 +189,7 @@ pub fn get_memory_runtime_config() -> &'static MemoryRuntimeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::ScopedEnv;
 
     #[test]
     fn parse_sliding_window_accepts_positive_integer() {
@@ -258,6 +283,45 @@ mod tests {
         assert_eq!(
             runtime.ingest_mode,
             crate::config::MemoryIngestMode::AsyncBackground
+        );
+    }
+
+    #[test]
+    fn runtime_config_from_memory_config_applies_memory_env_overrides() {
+        let mut env = ScopedEnv::new();
+        env.set("LOONGCLAW_MEMORY_PROFILE", "profile_plus_window");
+        env.set("LOONGCLAW_MEMORY_FAIL_OPEN", "true");
+        env.set("LOONGCLAW_MEMORY_INGEST_MODE", "async_background");
+        env.set("LOONGCLAW_SLIDING_WINDOW", "24");
+        env.set("LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS", "2048");
+        env.set("LOONGCLAW_MEMORY_PROFILE_NOTE", "  env profile note  ");
+        env.set("LOONGCLAW_SQLITE_PATH", "/tmp/env-memory.sqlite3");
+
+        let config = MemoryConfig {
+            profile: MemoryProfile::WindowOnly,
+            fail_open: false,
+            ingest_mode: MemoryIngestMode::SyncMinimal,
+            sliding_window: 12,
+            summary_max_chars: 900,
+            profile_note: Some("config note".to_owned()),
+            ..MemoryConfig::default()
+        };
+
+        let runtime = MemoryRuntimeConfig::from_memory_config(&config);
+
+        assert_eq!(runtime.profile, MemoryProfile::ProfilePlusWindow);
+        assert_eq!(runtime.mode, MemoryMode::ProfilePlusWindow);
+        assert!(runtime.fail_open);
+        assert_eq!(runtime.ingest_mode, MemoryIngestMode::AsyncBackground);
+        assert_eq!(runtime.sliding_window, 24);
+        assert_eq!(runtime.summary_max_chars, 2048);
+        assert_eq!(
+            runtime.sqlite_path,
+            Some(PathBuf::from("/tmp/env-memory.sqlite3"))
+        );
+        assert_eq!(
+            runtime.profile_note.as_deref(),
+            Some("env profile note")
         );
     }
 }

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -1,0 +1,138 @@
+use std::collections::BTreeSet;
+
+pub const MEMORY_SYSTEM_API_VERSION: u16 = 1;
+pub const DEFAULT_MEMORY_SYSTEM_ID: &str = "builtin";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MemorySystemCapability {
+    CanonicalStore,
+    PromptHydration,
+    DeterministicSummary,
+    ProfileNoteProjection,
+}
+
+impl MemorySystemCapability {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CanonicalStore => "canonical_store",
+            Self::PromptHydration => "prompt_hydration",
+            Self::DeterministicSummary => "deterministic_summary",
+            Self::ProfileNoteProjection => "profile_note_projection",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemorySystemMetadata {
+    pub id: &'static str,
+    pub api_version: u16,
+    pub capabilities: BTreeSet<MemorySystemCapability>,
+    pub summary: &'static str,
+}
+
+impl MemorySystemMetadata {
+    pub fn new(
+        id: &'static str,
+        capabilities: impl IntoIterator<Item = MemorySystemCapability>,
+        summary: &'static str,
+    ) -> Self {
+        Self {
+            id,
+            api_version: MEMORY_SYSTEM_API_VERSION,
+            capabilities: capabilities.into_iter().collect(),
+            summary,
+        }
+    }
+
+    pub fn capability_names(&self) -> Vec<&'static str> {
+        let mut names = self
+            .capabilities
+            .iter()
+            .copied()
+            .map(MemorySystemCapability::as_str)
+            .collect::<Vec<_>>();
+        names.sort_unstable();
+        names
+    }
+}
+
+pub trait MemorySystem: Send + Sync {
+    fn id(&self) -> &'static str;
+
+    fn metadata(&self) -> MemorySystemMetadata;
+}
+
+impl<T> MemorySystem for Box<T>
+where
+    T: MemorySystem + ?Sized,
+{
+    fn id(&self) -> &'static str {
+        self.as_ref().id()
+    }
+
+    fn metadata(&self) -> MemorySystemMetadata {
+        self.as_ref().metadata()
+    }
+}
+
+#[derive(Default)]
+pub struct BuiltinMemorySystem;
+
+impl MemorySystem for BuiltinMemorySystem {
+    fn id(&self) -> &'static str {
+        DEFAULT_MEMORY_SYSTEM_ID
+    }
+
+    fn metadata(&self) -> MemorySystemMetadata {
+        MemorySystemMetadata::new(
+            DEFAULT_MEMORY_SYSTEM_ID,
+            [
+                MemorySystemCapability::CanonicalStore,
+                MemorySystemCapability::PromptHydration,
+                MemorySystemCapability::DeterministicSummary,
+                MemorySystemCapability::ProfileNoteProjection,
+            ],
+            "Built-in SQLite-backed canonical memory with deterministic prompt hydration.",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_memory_system_metadata_is_stable() {
+        let metadata = BuiltinMemorySystem.metadata();
+        assert_eq!(metadata.id, DEFAULT_MEMORY_SYSTEM_ID);
+        assert_eq!(metadata.api_version, MEMORY_SYSTEM_API_VERSION);
+        assert_eq!(
+            metadata.capability_names(),
+            vec![
+                "canonical_store",
+                "deterministic_summary",
+                "profile_note_projection",
+                "prompt_hydration",
+            ]
+        );
+    }
+
+    #[test]
+    fn memory_system_registry_includes_builtin_metadata() {
+        let metadata = crate::memory::list_memory_system_metadata().expect("list memory systems");
+        assert!(metadata.iter().any(|entry| entry.id == DEFAULT_MEMORY_SYSTEM_ID));
+    }
+
+    #[test]
+    fn memory_system_runtime_snapshot_defaults_to_builtin() {
+        let config = crate::config::LoongClawConfig::default();
+        let snapshot = crate::memory::collect_memory_system_runtime_snapshot(&config)
+            .expect("collect memory-system snapshot");
+        assert_eq!(snapshot.selected.id, DEFAULT_MEMORY_SYSTEM_ID);
+        assert_eq!(
+            snapshot.selected.source,
+            crate::memory::MemorySystemSelectionSource::Default
+        );
+        assert_eq!(snapshot.selected_metadata.id, DEFAULT_MEMORY_SYSTEM_ID);
+    }
+}

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -120,7 +120,11 @@ mod tests {
     #[test]
     fn memory_system_registry_includes_builtin_metadata() {
         let metadata = crate::memory::list_memory_system_metadata().expect("list memory systems");
-        assert!(metadata.iter().any(|entry| entry.id == DEFAULT_MEMORY_SYSTEM_ID));
+        assert!(
+            metadata
+                .iter()
+                .any(|entry| entry.id == DEFAULT_MEMORY_SYSTEM_ID)
+        );
     }
 
     #[test]

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -4,11 +4,15 @@ use std::sync::Mutex;
 use std::sync::{Arc, OnceLock, RwLock};
 
 use crate::CliResult;
-use crate::config::{LoongClawConfig, MemorySystemKind};
+use crate::config::{
+    LoongClawConfig, MemoryBackendKind, MemoryIngestMode, MemoryMode, MemoryProfile,
+    MemorySystemKind,
+};
 
 use super::system::{
     BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MemorySystem, MemorySystemMetadata,
 };
+use super::runtime_config::MemoryRuntimeConfig;
 
 pub const MEMORY_SYSTEM_ENV: &str = "LOONGCLAW_MEMORY_SYSTEM";
 
@@ -47,6 +51,34 @@ pub struct MemorySystemRuntimeSnapshot {
     pub selected: MemorySystemSelection,
     pub selected_metadata: MemorySystemMetadata,
     pub available: Vec<MemorySystemMetadata>,
+    pub policy: MemorySystemPolicySnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemorySystemPolicySnapshot {
+    pub backend: MemoryBackendKind,
+    pub profile: MemoryProfile,
+    pub mode: MemoryMode,
+    pub ingest_mode: MemoryIngestMode,
+    pub fail_open: bool,
+    pub strict_mode_requested: bool,
+    pub strict_mode_active: bool,
+    pub effective_fail_open: bool,
+}
+
+impl MemorySystemPolicySnapshot {
+    fn from_runtime_config(config: &MemoryRuntimeConfig) -> Self {
+        Self {
+            backend: config.backend,
+            profile: config.profile,
+            mode: config.mode,
+            ingest_mode: config.ingest_mode,
+            fail_open: config.fail_open,
+            strict_mode_requested: config.strict_mode_requested(),
+            strict_mode_active: config.strict_mode_active(),
+            effective_fail_open: config.effective_fail_open(),
+        }
+    }
 }
 
 fn registry() -> &'static RwLock<BTreeMap<String, MemorySystemFactory>> {
@@ -167,11 +199,14 @@ pub fn collect_memory_system_runtime_snapshot(
     let selected = resolve_memory_system_selection(config);
     let selected_metadata = describe_memory_system(Some(selected.id.as_str()))?;
     let available = list_memory_system_metadata()?;
+    let runtime = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let policy = MemorySystemPolicySnapshot::from_runtime_config(&runtime);
 
     Ok(MemorySystemRuntimeSnapshot {
         selected,
         selected_metadata,
         available,
+        policy,
     })
 }
 
@@ -195,6 +230,7 @@ pub(crate) fn clear_memory_system_env_override() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::ScopedEnv;
     use crate::memory::{MEMORY_SYSTEM_API_VERSION, MemorySystemCapability};
 
     struct TestRegistrySystem;
@@ -275,6 +311,78 @@ mod tests {
         assert!(
             !ids.iter().any(|id| id == "lucid"),
             "future adapter ids should not appear before the adapter actually lands"
+        );
+    }
+
+    #[test]
+    fn memory_system_runtime_snapshot_captures_runtime_policy() {
+        let config = LoongClawConfig {
+            memory: crate::config::MemoryConfig {
+                profile: crate::config::MemoryProfile::WindowPlusSummary,
+                fail_open: false,
+                ingest_mode: crate::config::MemoryIngestMode::AsyncBackground,
+                ..crate::config::MemoryConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot =
+            collect_memory_system_runtime_snapshot(&config).expect("collect runtime snapshot");
+
+        assert_eq!(snapshot.policy.backend, crate::config::MemoryBackendKind::Sqlite);
+        assert_eq!(
+            snapshot.policy.profile,
+            crate::config::MemoryProfile::WindowPlusSummary
+        );
+        assert_eq!(
+            snapshot.policy.mode,
+            crate::config::MemoryMode::WindowPlusSummary
+        );
+        assert_eq!(
+            snapshot.policy.ingest_mode,
+            crate::config::MemoryIngestMode::AsyncBackground
+        );
+        assert!(!snapshot.policy.fail_open);
+        assert!(snapshot.policy.strict_mode_requested);
+        assert!(!snapshot.policy.strict_mode_active);
+        assert!(snapshot.policy.effective_fail_open);
+    }
+
+    #[test]
+    fn memory_system_runtime_snapshot_uses_memory_env_policy_overrides() {
+        let mut env = ScopedEnv::new();
+        env.set(MEMORY_SYSTEM_ENV, "builtin");
+        env.set("LOONGCLAW_MEMORY_PROFILE", "profile_plus_window");
+        env.set("LOONGCLAW_MEMORY_FAIL_OPEN", "true");
+        env.set("LOONGCLAW_MEMORY_INGEST_MODE", "async_background");
+
+        let config = LoongClawConfig {
+            memory: crate::config::MemoryConfig {
+                profile: crate::config::MemoryProfile::WindowOnly,
+                fail_open: false,
+                ingest_mode: crate::config::MemoryIngestMode::SyncMinimal,
+                ..crate::config::MemoryConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot =
+            collect_memory_system_runtime_snapshot(&config).expect("collect runtime snapshot");
+
+        assert_eq!(snapshot.selected.id, DEFAULT_MEMORY_SYSTEM_ID);
+        assert_eq!(snapshot.selected.source, MemorySystemSelectionSource::Env);
+        assert_eq!(
+            snapshot.policy.profile,
+            crate::config::MemoryProfile::ProfilePlusWindow
+        );
+        assert_eq!(
+            snapshot.policy.mode,
+            crate::config::MemoryMode::ProfilePlusWindow
+        );
+        assert!(snapshot.policy.fail_open);
+        assert_eq!(
+            snapshot.policy.ingest_mode,
+            crate::config::MemoryIngestMode::AsyncBackground
         );
     }
 }

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -195,7 +195,7 @@ pub(crate) fn clear_memory_system_env_override() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::memory::{MemorySystemCapability, MEMORY_SYSTEM_API_VERSION};
+    use crate::memory::{MEMORY_SYSTEM_API_VERSION, MemorySystemCapability};
 
     struct TestRegistrySystem;
 

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -256,6 +256,18 @@ mod tests {
     use crate::memory::{MEMORY_SYSTEM_API_VERSION, MemorySystemCapability};
     use crate::test_support::ScopedEnv;
 
+    fn clear_memory_runtime_env_overrides(env: &mut ScopedEnv) {
+        env.remove(MEMORY_SYSTEM_ENV);
+        env.remove("LOONGCLAW_MEMORY_BACKEND");
+        env.remove("LOONGCLAW_MEMORY_PROFILE");
+        env.remove("LOONGCLAW_MEMORY_FAIL_OPEN");
+        env.remove("LOONGCLAW_MEMORY_INGEST_MODE");
+        env.remove("LOONGCLAW_SQLITE_PATH");
+        env.remove("LOONGCLAW_SLIDING_WINDOW");
+        env.remove("LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS");
+        env.remove("LOONGCLAW_MEMORY_PROFILE_NOTE");
+    }
+
     struct MatchingRegistrySystem;
 
     impl MemorySystem for MatchingRegistrySystem {
@@ -374,6 +386,9 @@ mod tests {
 
     #[test]
     fn memory_system_runtime_snapshot_captures_runtime_policy() {
+        let mut env = ScopedEnv::new();
+        clear_memory_runtime_env_overrides(&mut env);
+
         let config = LoongClawConfig {
             memory: crate::config::MemoryConfig {
                 profile: crate::config::MemoryProfile::WindowPlusSummary,
@@ -412,6 +427,7 @@ mod tests {
     #[test]
     fn memory_system_runtime_snapshot_uses_memory_env_policy_overrides() {
         let mut env = ScopedEnv::new();
+        clear_memory_runtime_env_overrides(&mut env);
         env.set(MEMORY_SYSTEM_ENV, "builtin");
         env.set("LOONGCLAW_MEMORY_PROFILE", "profile_plus_window");
         env.set("LOONGCLAW_MEMORY_FAIL_OPEN", "true");
@@ -450,6 +466,7 @@ mod tests {
     #[test]
     fn invalid_memory_system_env_is_ignored_so_snapshot_matches_runtime_behavior() {
         let mut env = ScopedEnv::new();
+        clear_memory_runtime_env_overrides(&mut env);
         env.set(MEMORY_SYSTEM_ENV, "lucid");
 
         let config = LoongClawConfig::default();

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -268,4 +268,13 @@ mod tests {
         assert_eq!(selection.source, MemorySystemSelectionSource::Env);
         clear_memory_system_env_override();
     }
+
+    #[test]
+    fn memory_system_registry_stays_builtin_only_until_adapter_lands() {
+        let ids = list_memory_system_ids().expect("list memory-system ids");
+        assert!(
+            !ids.iter().any(|id| id == "lucid"),
+            "future adapter ids should not appear before the adapter actually lands"
+        );
+    }
 }

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -109,6 +109,23 @@ where
     if normalized.is_empty() {
         return Err("memory system id must not be empty".to_owned());
     }
+    if normalized == DEFAULT_MEMORY_SYSTEM_ID {
+        return Err(format!(
+            "memory system `{DEFAULT_MEMORY_SYSTEM_ID}` is reserved and cannot be overridden"
+        ));
+    }
+
+    let system = factory();
+    let runtime_id = normalize_system_id(system.id());
+    let metadata = system.metadata();
+    let metadata_id = normalize_system_id(metadata.id);
+    if runtime_id != normalized || metadata_id != normalized {
+        return Err(format!(
+            "registered memory system id `{normalized}` must match system.id `{}` and metadata.id `{}`",
+            system.id(),
+            metadata.id
+        ));
+    }
 
     let mut guard = registry()
         .write()
@@ -172,10 +189,16 @@ pub fn memory_system_id_from_env() -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+pub fn supported_memory_system_kind_from_env() -> Option<MemorySystemKind> {
+    memory_system_id_from_env()
+        .as_deref()
+        .and_then(MemorySystemKind::parse_id)
+}
+
 pub fn resolve_memory_system_selection(config: &LoongClawConfig) -> MemorySystemSelection {
-    if let Some(id) = memory_system_id_from_env() {
+    if let Some(system) = supported_memory_system_kind_from_env() {
         return MemorySystemSelection {
-            id,
+            id: system.as_str().to_owned(),
             source: MemorySystemSelectionSource::Env,
         };
     }
@@ -233,18 +256,34 @@ mod tests {
     use crate::test_support::ScopedEnv;
     use crate::memory::{MEMORY_SYSTEM_API_VERSION, MemorySystemCapability};
 
-    struct TestRegistrySystem;
+    struct MatchingRegistrySystem;
 
-    impl MemorySystem for TestRegistrySystem {
+    impl MemorySystem for MatchingRegistrySystem {
         fn id(&self) -> &'static str {
-            "registry-test"
+            "registry-custom"
         }
 
         fn metadata(&self) -> MemorySystemMetadata {
             MemorySystemMetadata::new(
-                "registry-test",
+                "registry-custom",
                 [MemorySystemCapability::PromptHydration],
                 "Test registry system",
+            )
+        }
+    }
+
+    struct MismatchedRegistrySystem;
+
+    impl MemorySystem for MismatchedRegistrySystem {
+        fn id(&self) -> &'static str {
+            "registry-mismatch"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-mismatch",
+                [MemorySystemCapability::PromptHydration],
+                "Mismatched registry system",
             )
         }
     }
@@ -260,10 +299,28 @@ mod tests {
 
     #[test]
     fn registry_can_register_and_resolve_custom_system() {
-        register_memory_system("registry-custom", || Box::new(TestRegistrySystem))
+        register_memory_system("registry-custom", || Box::new(MatchingRegistrySystem))
             .expect("register custom system");
         let system = resolve_memory_system(Some("registry-custom")).expect("resolve custom system");
-        assert_eq!(system.id(), "registry-test");
+        assert_eq!(system.id(), "registry-custom");
+    }
+
+    #[test]
+    fn registry_rejects_builtin_override() {
+        let error = register_memory_system(DEFAULT_MEMORY_SYSTEM_ID, || {
+            Box::new(MatchingRegistrySystem)
+        })
+        .expect_err("builtin memory system should stay reserved");
+        assert!(error.contains("reserved"), "error: {error}");
+    }
+
+    #[test]
+    fn registry_rejects_registry_id_mismatches() {
+        let error = register_memory_system("registry-custom-alias", || {
+            Box::new(MismatchedRegistrySystem)
+        })
+        .expect_err("registry id mismatch should fail");
+        assert!(error.contains("must match"), "error: {error}");
     }
 
     #[test]
@@ -297,6 +354,7 @@ mod tests {
 
     #[test]
     fn memory_system_env_overrides_default_selection() {
+        let _env = ScopedEnv::new();
         set_memory_system_env_override(Some("builtin"));
         let config = LoongClawConfig::default();
         let selection = resolve_memory_system_selection(&config);
@@ -383,6 +441,22 @@ mod tests {
         assert_eq!(
             snapshot.policy.ingest_mode,
             crate::config::MemoryIngestMode::AsyncBackground
+        );
+    }
+
+    #[test]
+    fn invalid_memory_system_env_is_ignored_so_snapshot_matches_runtime_behavior() {
+        let mut env = ScopedEnv::new();
+        env.set(MEMORY_SYSTEM_ENV, "lucid");
+
+        let config = LoongClawConfig::default();
+        let snapshot =
+            collect_memory_system_runtime_snapshot(&config).expect("collect runtime snapshot");
+
+        assert_eq!(snapshot.selected.id, DEFAULT_MEMORY_SYSTEM_ID);
+        assert_eq!(
+            snapshot.selected.source,
+            MemorySystemSelectionSource::Default
         );
     }
 }

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -9,10 +9,10 @@ use crate::config::{
     MemorySystemKind,
 };
 
+use super::runtime_config::MemoryRuntimeConfig;
 use super::system::{
     BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MemorySystem, MemorySystemMetadata,
 };
-use super::runtime_config::MemoryRuntimeConfig;
 
 pub const MEMORY_SYSTEM_ENV: &str = "LOONGCLAW_MEMORY_SYSTEM";
 
@@ -253,8 +253,8 @@ pub(crate) fn clear_memory_system_env_override() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::ScopedEnv;
     use crate::memory::{MEMORY_SYSTEM_API_VERSION, MemorySystemCapability};
+    use crate::test_support::ScopedEnv;
 
     struct MatchingRegistrySystem;
 
@@ -387,7 +387,10 @@ mod tests {
         let snapshot =
             collect_memory_system_runtime_snapshot(&config).expect("collect runtime snapshot");
 
-        assert_eq!(snapshot.policy.backend, crate::config::MemoryBackendKind::Sqlite);
+        assert_eq!(
+            snapshot.policy.backend,
+            crate::config::MemoryBackendKind::Sqlite
+        );
         assert_eq!(
             snapshot.policy.profile,
             crate::config::MemoryProfile::WindowPlusSummary

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -1,0 +1,271 @@
+use std::collections::BTreeMap;
+#[cfg(test)]
+use std::sync::Mutex;
+use std::sync::{Arc, OnceLock, RwLock};
+
+use crate::CliResult;
+use crate::config::{LoongClawConfig, MemorySystemKind};
+
+use super::system::{
+    BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MemorySystem, MemorySystemMetadata,
+};
+
+pub const MEMORY_SYSTEM_ENV: &str = "LOONGCLAW_MEMORY_SYSTEM";
+
+type MemorySystemFactory = Arc<dyn Fn() -> Box<dyn MemorySystem> + Send + Sync>;
+
+static MEMORY_SYSTEM_REGISTRY: OnceLock<RwLock<BTreeMap<String, MemorySystemFactory>>> =
+    OnceLock::new();
+#[cfg(test)]
+static MEMORY_SYSTEM_ENV_OVERRIDE: OnceLock<Mutex<Option<Option<String>>>> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemorySystemSelectionSource {
+    Env,
+    Config,
+    Default,
+}
+
+impl MemorySystemSelectionSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Env => "env",
+            Self::Config => "config",
+            Self::Default => "default",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemorySystemSelection {
+    pub id: String,
+    pub source: MemorySystemSelectionSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemorySystemRuntimeSnapshot {
+    pub selected: MemorySystemSelection,
+    pub selected_metadata: MemorySystemMetadata,
+    pub available: Vec<MemorySystemMetadata>,
+}
+
+fn registry() -> &'static RwLock<BTreeMap<String, MemorySystemFactory>> {
+    MEMORY_SYSTEM_REGISTRY.get_or_init(|| {
+        let mut map: BTreeMap<String, MemorySystemFactory> = BTreeMap::new();
+        map.insert(
+            DEFAULT_MEMORY_SYSTEM_ID.to_owned(),
+            Arc::new(|| Box::new(BuiltinMemorySystem)),
+        );
+        RwLock::new(map)
+    })
+}
+
+fn normalize_system_id(raw: &str) -> String {
+    raw.trim().to_ascii_lowercase()
+}
+
+#[cfg(test)]
+fn env_override() -> &'static Mutex<Option<Option<String>>> {
+    MEMORY_SYSTEM_ENV_OVERRIDE.get_or_init(|| Mutex::new(None))
+}
+
+pub fn register_memory_system<F>(id: &str, factory: F) -> CliResult<()>
+where
+    F: Fn() -> Box<dyn MemorySystem> + Send + Sync + 'static,
+{
+    let normalized = normalize_system_id(id);
+    if normalized.is_empty() {
+        return Err("memory system id must not be empty".to_owned());
+    }
+
+    let mut guard = registry()
+        .write()
+        .map_err(|_error| "memory system registry lock poisoned".to_owned())?;
+    guard.insert(normalized, Arc::new(factory));
+    Ok(())
+}
+
+pub fn list_memory_system_ids() -> CliResult<Vec<String>> {
+    let guard = registry()
+        .read()
+        .map_err(|_error| "memory system registry lock poisoned".to_owned())?;
+    Ok(guard.keys().cloned().collect())
+}
+
+pub fn list_memory_system_metadata() -> CliResult<Vec<MemorySystemMetadata>> {
+    let guard = registry()
+        .read()
+        .map_err(|_error| "memory system registry lock poisoned".to_owned())?;
+    let mut metadata = guard
+        .values()
+        .map(|factory| factory().metadata())
+        .collect::<Vec<_>>();
+    metadata.sort_by_key(|entry| entry.id);
+    Ok(metadata)
+}
+
+pub fn resolve_memory_system(id: Option<&str>) -> CliResult<Box<dyn MemorySystem>> {
+    let normalized = id
+        .map(normalize_system_id)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| DEFAULT_MEMORY_SYSTEM_ID.to_owned());
+
+    let guard = registry()
+        .read()
+        .map_err(|_error| "memory system registry lock poisoned".to_owned())?;
+    let Some(factory) = guard.get(&normalized).cloned() else {
+        let available = guard.keys().cloned().collect::<Vec<_>>().join(", ");
+        return Err(format!(
+            "memory system `{normalized}` is not registered (available: {available})"
+        ));
+    };
+    Ok(factory())
+}
+
+pub fn describe_memory_system(id: Option<&str>) -> CliResult<MemorySystemMetadata> {
+    resolve_memory_system(id).map(|system| system.metadata())
+}
+
+pub fn memory_system_id_from_env() -> Option<String> {
+    #[cfg(test)]
+    {
+        if let Some(override_value) = env_override().lock().ok().and_then(|guard| guard.clone()) {
+            return override_value;
+        }
+    }
+
+    std::env::var(MEMORY_SYSTEM_ENV)
+        .ok()
+        .map(|value| normalize_system_id(value.as_str()))
+        .filter(|value| !value.is_empty())
+}
+
+pub fn resolve_memory_system_selection(config: &LoongClawConfig) -> MemorySystemSelection {
+    if let Some(id) = memory_system_id_from_env() {
+        return MemorySystemSelection {
+            id,
+            source: MemorySystemSelectionSource::Env,
+        };
+    }
+
+    if config.memory.resolved_system() != MemorySystemKind::default() {
+        return MemorySystemSelection {
+            id: config.memory.resolved_system().as_str().to_owned(),
+            source: MemorySystemSelectionSource::Config,
+        };
+    }
+
+    MemorySystemSelection {
+        id: DEFAULT_MEMORY_SYSTEM_ID.to_owned(),
+        source: MemorySystemSelectionSource::Default,
+    }
+}
+
+pub fn collect_memory_system_runtime_snapshot(
+    config: &LoongClawConfig,
+) -> CliResult<MemorySystemRuntimeSnapshot> {
+    let selected = resolve_memory_system_selection(config);
+    let selected_metadata = describe_memory_system(Some(selected.id.as_str()))?;
+    let available = list_memory_system_metadata()?;
+
+    Ok(MemorySystemRuntimeSnapshot {
+        selected,
+        selected_metadata,
+        available,
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn set_memory_system_env_override(value: Option<&str>) {
+    let normalized = value
+        .map(normalize_system_id)
+        .filter(|entry| !entry.is_empty());
+    if let Ok(mut guard) = env_override().lock() {
+        *guard = Some(normalized);
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn clear_memory_system_env_override() {
+    if let Ok(mut guard) = env_override().lock() {
+        *guard = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::{MemorySystemCapability, MEMORY_SYSTEM_API_VERSION};
+
+    struct TestRegistrySystem;
+
+    impl MemorySystem for TestRegistrySystem {
+        fn id(&self) -> &'static str {
+            "registry-test"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-test",
+                [MemorySystemCapability::PromptHydration],
+                "Test registry system",
+            )
+        }
+    }
+
+    #[test]
+    fn resolve_memory_system_includes_builtin() {
+        let ids = list_memory_system_ids().expect("list ids");
+        assert!(
+            ids.iter().any(|id| id == DEFAULT_MEMORY_SYSTEM_ID),
+            "builtin memory system should be registered"
+        );
+    }
+
+    #[test]
+    fn registry_can_register_and_resolve_custom_system() {
+        register_memory_system("registry-custom", || Box::new(TestRegistrySystem))
+            .expect("register custom system");
+        let system = resolve_memory_system(Some("registry-custom")).expect("resolve custom system");
+        assert_eq!(system.id(), "registry-test");
+    }
+
+    #[test]
+    fn resolve_memory_system_returns_error_for_unknown_id() {
+        let error = match resolve_memory_system(Some("not-registered")) {
+            Ok(system) => panic!("expected unknown id to fail, got {}", system.id()),
+            Err(error) => error,
+        };
+        assert!(error.contains("not registered"), "error: {error}");
+        assert!(
+            error.contains(DEFAULT_MEMORY_SYSTEM_ID),
+            "error should include available ids: {error}"
+        );
+    }
+
+    #[test]
+    fn list_memory_system_metadata_exposes_capabilities() {
+        let metadata = list_memory_system_metadata().expect("list metadata");
+        let builtin = metadata
+            .iter()
+            .find(|entry| entry.id == DEFAULT_MEMORY_SYSTEM_ID)
+            .expect("builtin metadata entry");
+        assert_eq!(builtin.api_version, MEMORY_SYSTEM_API_VERSION);
+        assert!(
+            builtin
+                .capabilities
+                .contains(&MemorySystemCapability::CanonicalStore),
+            "builtin metadata should include canonical-store capability"
+        );
+    }
+
+    #[test]
+    fn memory_system_env_overrides_default_selection() {
+        set_memory_system_env_override(Some("builtin"));
+        let config = LoongClawConfig::default();
+        let selection = resolve_memory_system_selection(&config);
+        assert_eq!(selection.id, DEFAULT_MEMORY_SYSTEM_ID);
+        assert_eq!(selection.source, MemorySystemSelectionSource::Env);
+        clear_memory_system_env_override();
+    }
+}

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -80,32 +80,36 @@ pub(super) fn load_memory_window_messages(
     {
         let mem_config =
             memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-        let memory_entries = memory::load_prompt_context(session_id, &mem_config)
-            .map_err(|error| format!("load prompt memory context failed: {error}"))?;
-        let mut messages = Vec::with_capacity(memory_entries.len());
-        for entry in memory_entries {
-            match entry.kind {
-                memory::MemoryContextKind::Profile | memory::MemoryContextKind::Summary => {
-                    messages.push(json!({
-                        "role": entry.role,
-                        "content": entry.content,
-                    }));
-                }
-                memory::MemoryContextKind::Turn => {
-                    push_history_message(
-                        &mut messages,
-                        entry.role.as_str(),
-                        entry.content.as_str(),
-                    );
-                }
-            }
-        }
+        let hydrated = memory::hydrate_memory_context(session_id, &mem_config)
+            .map_err(|error| format!("hydrate prompt memory context failed: {error}"))?;
+        let mut messages = Vec::with_capacity(hydrated.entries.len());
+        append_hydrated_memory_messages(&mut messages, &hydrated);
         Ok(messages)
     }
     #[cfg(not(feature = "memory-sqlite"))]
     {
         let _ = (config, session_id);
         Ok(Vec::new())
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn append_hydrated_memory_messages(
+    messages: &mut Vec<Value>,
+    hydrated: &memory::HydratedMemoryContext,
+) {
+    for entry in &hydrated.entries {
+        match entry.kind {
+            memory::MemoryContextKind::Profile | memory::MemoryContextKind::Summary => {
+                messages.push(json!({
+                    "role": entry.role,
+                    "content": entry.content,
+                }));
+            }
+            memory::MemoryContextKind::Turn => {
+                push_history_message(messages, entry.role.as_str(), entry.content.as_str());
+            }
+        }
     }
 }
 

--- a/crates/app/src/test_support.rs
+++ b/crates/app/src/test_support.rs
@@ -28,7 +28,7 @@ impl ScopedEnv {
         crate::process_env::set_var(key, value);
     }
 
-    #[allow(clippy::disallowed_methods)]
+    #[allow(dead_code, clippy::disallowed_methods)]
     pub(crate) fn remove(&mut self, key: &'static str) {
         self.capture_original(key);
         crate::process_env::remove_var(key);

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1400,43 +1400,18 @@ fn run_list_memory_systems_cli(config_path: Option<&str>, as_json: bool) -> CliR
     let snapshot = mvp::memory::collect_memory_system_runtime_snapshot(&config)?;
 
     if as_json {
-        let payload = json!({
-            "config": resolved_path.display().to_string(),
-            "selected": memory_system_metadata_json(
-                &snapshot.selected_metadata,
-                Some(snapshot.selected.source.as_str())
-            ),
-            "available": snapshot
-                .available
-                .iter()
-                .map(|metadata| memory_system_metadata_json(metadata, None))
-                .collect::<Vec<_>>(),
-        });
+        let payload =
+            build_memory_systems_cli_json_payload(&resolved_path.display().to_string(), &snapshot);
         let pretty = serde_json::to_string_pretty(&payload)
             .map_err(|error| format!("serialize memory-system output failed: {error}"))?;
         println!("{pretty}");
         return Ok(());
     }
 
-    println!("config={}", resolved_path.display());
     println!(
-        "selected={} source={} api_version={} capabilities={} summary={}",
-        snapshot.selected_metadata.id,
-        snapshot.selected.source.as_str(),
-        snapshot.selected_metadata.api_version,
-        format_capability_names(&snapshot.selected_metadata.capability_names()),
-        snapshot.selected_metadata.summary
+        "{}",
+        render_memory_system_snapshot_text(&resolved_path.display().to_string(), &snapshot)
     );
-    println!("available:");
-    for metadata in snapshot.available {
-        println!(
-            "- {} api_version={} capabilities={} summary={}",
-            metadata.id,
-            metadata.api_version,
-            format_capability_names(&metadata.capability_names()),
-            metadata.summary
-        );
-    }
     Ok(())
 }
 
@@ -2375,6 +2350,79 @@ fn memory_system_metadata_json(
         payload.insert("source".to_owned(), json!(source));
     }
     Value::Object(payload)
+}
+
+fn memory_system_policy_json(policy: &mvp::memory::MemorySystemPolicySnapshot) -> Value {
+    json!({
+        "backend": policy.backend.as_str(),
+        "profile": policy.profile.as_str(),
+        "mode": policy.mode.as_str(),
+        "ingest_mode": policy.ingest_mode.as_str(),
+        "fail_open": policy.fail_open,
+        "strict_mode_requested": policy.strict_mode_requested,
+        "strict_mode_active": policy.strict_mode_active,
+        "effective_fail_open": policy.effective_fail_open,
+    })
+}
+
+fn build_memory_systems_cli_json_payload(
+    config_path: &str,
+    snapshot: &mvp::memory::MemorySystemRuntimeSnapshot,
+) -> Value {
+    json!({
+        "config": config_path,
+        "selected": memory_system_metadata_json(
+            &snapshot.selected_metadata,
+            Some(snapshot.selected.source.as_str())
+        ),
+        "available": snapshot
+            .available
+            .iter()
+            .map(|metadata| memory_system_metadata_json(metadata, None))
+            .collect::<Vec<_>>(),
+        "policy": memory_system_policy_json(&snapshot.policy),
+    })
+}
+
+fn render_memory_system_snapshot_text(
+    config_path: &str,
+    snapshot: &mvp::memory::MemorySystemRuntimeSnapshot,
+) -> String {
+    let mut lines = vec![
+        format!("config={config_path}"),
+        format!(
+            "selected={} source={} api_version={} capabilities={} summary={}",
+            snapshot.selected_metadata.id,
+            snapshot.selected.source.as_str(),
+            snapshot.selected_metadata.api_version,
+            format_capability_names(&snapshot.selected_metadata.capability_names()),
+            snapshot.selected_metadata.summary
+        ),
+        format!(
+            "policy=backend:{} profile:{} mode:{} ingest_mode:{} fail_open:{} strict_mode_requested:{} strict_mode_active:{} effective_fail_open:{}",
+            snapshot.policy.backend.as_str(),
+            snapshot.policy.profile.as_str(),
+            snapshot.policy.mode.as_str(),
+            snapshot.policy.ingest_mode.as_str(),
+            snapshot.policy.fail_open,
+            snapshot.policy.strict_mode_requested,
+            snapshot.policy.strict_mode_active,
+            snapshot.policy.effective_fail_open,
+        ),
+        "available:".to_owned(),
+    ];
+
+    for metadata in &snapshot.available {
+        lines.push(format!(
+            "- {} api_version={} capabilities={} summary={}",
+            metadata.id,
+            metadata.api_version,
+            format_capability_names(&metadata.capability_names()),
+            metadata.summary
+        ));
+    }
+
+    lines.join("\n")
 }
 
 fn acp_backend_metadata_json(

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -308,6 +308,13 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
+    /// List available memory systems and selected runtime memory system
+    ListMemorySystems {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// List available ACP runtime backends and current control-plane selection
     ListAcpBackends {
         #[arg(long)]
@@ -611,6 +618,9 @@ async fn main() {
         Commands::ListModels { config, json } => run_list_models_cli(config.as_deref(), json).await,
         Commands::ListContextEngines { config, json } => {
             run_list_context_engines_cli(config.as_deref(), json)
+        }
+        Commands::ListMemorySystems { config, json } => {
+            run_list_memory_systems_cli(config.as_deref(), json)
         }
         Commands::ListAcpBackends { config, json } => {
             run_list_acp_backends_cli(config.as_deref(), json)
@@ -1380,6 +1390,51 @@ fn run_list_context_engines_cli(config_path: Option<&str>, as_json: bool) -> Cli
             metadata.id,
             metadata.api_version,
             format_capability_names(&metadata.capability_names())
+        );
+    }
+    Ok(())
+}
+
+fn run_list_memory_systems_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
+    let (resolved_path, config) = mvp::config::load(config_path)?;
+    let snapshot = mvp::memory::collect_memory_system_runtime_snapshot(&config)?;
+
+    if as_json {
+        let payload = json!({
+            "config": resolved_path.display().to_string(),
+            "selected": memory_system_metadata_json(
+                &snapshot.selected_metadata,
+                Some(snapshot.selected.source.as_str())
+            ),
+            "available": snapshot
+                .available
+                .iter()
+                .map(|metadata| memory_system_metadata_json(metadata, None))
+                .collect::<Vec<_>>(),
+        });
+        let pretty = serde_json::to_string_pretty(&payload)
+            .map_err(|error| format!("serialize memory-system output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("config={}", resolved_path.display());
+    println!(
+        "selected={} source={} api_version={} capabilities={} summary={}",
+        snapshot.selected_metadata.id,
+        snapshot.selected.source.as_str(),
+        snapshot.selected_metadata.api_version,
+        format_capability_names(&snapshot.selected_metadata.capability_names()),
+        snapshot.selected_metadata.summary
+    );
+    println!("available:");
+    for metadata in snapshot.available {
+        println!(
+            "- {} api_version={} capabilities={} summary={}",
+            metadata.id,
+            metadata.api_version,
+            format_capability_names(&metadata.capability_names()),
+            metadata.summary
         );
     }
     Ok(())
@@ -2304,6 +2359,24 @@ fn context_engine_metadata_json(
     Value::Object(payload)
 }
 
+fn memory_system_metadata_json(
+    metadata: &mvp::memory::MemorySystemMetadata,
+    source: Option<&str>,
+) -> Value {
+    let mut payload = serde_json::Map::new();
+    payload.insert("id".to_owned(), json!(metadata.id));
+    payload.insert("api_version".to_owned(), json!(metadata.api_version));
+    payload.insert(
+        "capabilities".to_owned(),
+        json!(metadata.capability_names()),
+    );
+    payload.insert("summary".to_owned(), json!(metadata.summary));
+    if let Some(source) = source {
+        payload.insert("source".to_owned(), json!(source));
+    }
+    Value::Object(payload)
+}
+
 fn acp_backend_metadata_json(
     metadata: &mvp::acp::AcpBackendMetadata,
     source: Option<&str>,
@@ -2718,6 +2791,20 @@ mod cli_tests {
         match cli.command {
             Some(Commands::Onboard { api_key, .. }) => {
                 assert_eq!(api_key.as_deref(), Some("OPENAI_API_KEY"));
+            }
+            other => panic!("unexpected command parsed: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn memory_systems_cli_parses() {
+        let cli = Cli::try_parse_from(["loongclaw", "list-memory-systems"])
+            .expect("`list-memory-systems` should parse");
+
+        match cli.command {
+            Some(Commands::ListMemorySystems { config, json }) => {
+                assert!(config.is_none());
+                assert!(!json);
             }
             other => panic!("unexpected command parsed: {other:?}"),
         }

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -245,6 +245,31 @@ fn render_channel_surfaces_text_reports_catalog_only_channels() {
 }
 
 #[test]
+fn memory_system_metadata_json_includes_summary_and_source() {
+    use mvp::memory::MemorySystem as _;
+
+    let metadata = mvp::memory::BuiltinMemorySystem.metadata();
+    let payload = memory_system_metadata_json(&metadata, Some("default"));
+
+    assert_eq!(payload["id"], "builtin");
+    assert_eq!(payload["api_version"], 1);
+    assert_eq!(payload["source"], "default");
+    assert!(
+        payload["summary"]
+            .as_str()
+            .expect("summary should be a string")
+            .contains("Built-in")
+    );
+    assert!(
+        payload["capabilities"]
+            .as_array()
+            .expect("capabilities should be an array")
+            .iter()
+            .any(|entry| entry == "canonical_store")
+    );
+}
+
+#[test]
 fn build_channels_cli_json_payload_includes_operation_requirement_metadata() {
     let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -270,6 +270,56 @@ fn memory_system_metadata_json_includes_summary_and_source() {
 }
 
 #[test]
+fn build_memory_systems_cli_json_payload_includes_runtime_policy() {
+    let config = mvp::config::LoongClawConfig {
+        memory: mvp::config::MemoryConfig {
+            profile: mvp::config::MemoryProfile::WindowPlusSummary,
+            fail_open: false,
+            ingest_mode: mvp::config::MemoryIngestMode::AsyncBackground,
+            ..mvp::config::MemoryConfig::default()
+        },
+        ..mvp::config::LoongClawConfig::default()
+    };
+    let snapshot =
+        mvp::memory::collect_memory_system_runtime_snapshot(&config).expect("runtime snapshot");
+
+    let payload = build_memory_systems_cli_json_payload("/tmp/loongclaw.toml", &snapshot);
+
+    assert_eq!(payload["config"], "/tmp/loongclaw.toml");
+    assert_eq!(payload["selected"]["id"], "builtin");
+    assert_eq!(payload["selected"]["source"], "default");
+    assert_eq!(payload["policy"]["backend"], "sqlite");
+    assert_eq!(payload["policy"]["profile"], "window_plus_summary");
+    assert_eq!(payload["policy"]["mode"], "window_plus_summary");
+    assert_eq!(payload["policy"]["ingest_mode"], "async_background");
+    assert_eq!(payload["policy"]["fail_open"], false);
+    assert_eq!(payload["policy"]["strict_mode_requested"], true);
+    assert_eq!(payload["policy"]["strict_mode_active"], false);
+    assert_eq!(payload["policy"]["effective_fail_open"], true);
+}
+
+#[test]
+fn render_memory_system_snapshot_text_reports_fail_open_policy() {
+    let config = mvp::config::LoongClawConfig {
+        memory: mvp::config::MemoryConfig {
+            profile: mvp::config::MemoryProfile::WindowPlusSummary,
+            fail_open: false,
+            ingest_mode: mvp::config::MemoryIngestMode::AsyncBackground,
+            ..mvp::config::MemoryConfig::default()
+        },
+        ..mvp::config::LoongClawConfig::default()
+    };
+    let snapshot =
+        mvp::memory::collect_memory_system_runtime_snapshot(&config).expect("runtime snapshot");
+
+    let rendered = render_memory_system_snapshot_text("/tmp/loongclaw.toml", &snapshot);
+
+    assert!(rendered.contains("config=/tmp/loongclaw.toml"));
+    assert!(rendered.contains("selected=builtin source=default api_version=1"));
+    assert!(rendered.contains("policy=backend:sqlite profile:window_plus_summary mode:window_plus_summary ingest_mode:async_background fail_open:false strict_mode_requested:true strict_mode_active:false effective_fail_open:true"));
+}
+
+#[test]
 fn build_channels_cli_json_payload_includes_operation_requirement_metadata() {
     let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # LoongClaw Roadmap
 
-Last updated: 2026-03-08
+Last updated: 2026-03-14
 
 This roadmap is execution-focused. Every stage has:
 
@@ -196,6 +196,11 @@ Delivered in current baseline:
 - active `http_json` runtime execution lane (no longer plan-only):
   - timeout-controlled request execution
   - structured runtime evidence (`status_code`, `response_json`)
+- builtin-only memory-system foundation for `alpha-test`:
+  - typed memory-system metadata and registry seam
+  - hydrated memory orchestration over LoongClaw-owned canonical history
+  - operator diagnostics for selected system, capability set, and effective
+    memory fail-open policy
 
 Planned deliverables:
 

--- a/docs/plans/2026-03-14-loongclaw-pluggable-memory-systems-design.md
+++ b/docs/plans/2026-03-14-loongclaw-pluggable-memory-systems-design.md
@@ -148,8 +148,11 @@ Add a single selector like:
 
 ```toml
 [memory]
-backend = "sqlite|lucid|mem0|cortex"
+backend = "sqlite|<future-system-id>"
 ```
+
+The example intentionally avoids naming concrete systems. The current runtime
+surface should remain builtin-only until a real integration is accepted.
 
 Pros:
 
@@ -427,16 +430,9 @@ system = "builtin"
 fail_open = true
 ingest_mode = "sync_minimal"
 
-[memory.systems.lucid]
+[memory.systems.<future_system_id>]
 enabled = true
-
-[memory.systems.mem0]
-enabled = true
-api_key_env = "MEM0_API_KEY"
-
-[memory.systems.cortex]
-enabled = true
-endpoint = "http://127.0.0.1:8085"
+# Adapter-specific fields stay nested here once a concrete system lands.
 ```
 
 The nested tables are intentionally adapter-specific. LoongClaw should not
@@ -458,15 +454,12 @@ Initial value:
 
 Which derivation and retrieval family is active?
 
-Initial value:
+Current runtime surface:
 
 - `builtin`
 
-Future examples:
-
-- `lucid`
-- `mem0`
-- `cortex`
+Future values should stay deferred until the first real integration lands.
+No non-builtin ids should be exposed only for planning convenience.
 
 ### 3. Memory Profile
 

--- a/docs/plans/2026-03-14-loongclaw-pluggable-memory-systems-design.md
+++ b/docs/plans/2026-03-14-loongclaw-pluggable-memory-systems-design.md
@@ -1,0 +1,661 @@
+# LoongClaw Pluggable Memory Systems Design
+
+Date: 2026-03-14
+Status: Approved for phased implementation planning
+
+## Summary
+
+The 2026-03-11 memory slice gave LoongClaw a profile-first memory surface
+(`window_only`, `window_plus_summary`, `profile_plus_window`) while keeping
+SQLite as the only concrete backend. That was the right first step, but it is
+not enough for the next product requirement: user-selectable memory systems.
+
+The system now needs to prepare for integrations that look more like:
+
+- a lightweight memory SDK or managed memory layer
+- a local-first cognitive retrieval engine
+- a full memory framework or external service
+
+These are not interchangeable storage backends. They sit at different layers of
+the memory stack and expose different operating models. The design in this
+document keeps LoongClaw in control of canonical history, policy, and context
+projection while making derivation and retrieval pluggable.
+
+The recommended direction is:
+
+- keep a LoongClaw-owned canonical fact layer
+- treat external memory systems as derivation and retrieval adapters
+- keep `ConversationContextEngine` as the prompt/context projection authority
+- let ACP and provider turns share the same canonical memory authority
+- introduce a typed memory-system selection surface that can remain stable while
+  adapters evolve
+
+## Why This Slice Exists
+
+The current memory architecture solved one problem well: users can choose memory
+behavior without thinking in storage-engine terms. It does not yet solve the
+next problem: allowing operators to choose a memory system style without
+fragmenting the runtime into separate memory authorities.
+
+Today, `alpha-test` already has the right raw ingredients:
+
+- a stable kernel memory plane
+- app-side memory helpers that centralize prompt hydration
+- a pluggable `ConversationContextEngine`
+- an ACP control plane intentionally separated from provider turns
+
+That means LoongClaw does not need a rewrite. It needs a stronger architectural
+boundary between:
+
+- canonical raw history
+- derived memories
+- memory retrieval
+- final prompt/context projection
+
+## Product Goals
+
+- Support user-selectable memory systems without making users think in raw
+  backend terms.
+- Preserve the local-first default and the current baseline interaction
+  experience.
+- Keep one canonical raw-history authority owned by LoongClaw.
+- Support both provider-routed and ACP-routed conversation output.
+- Allow external memory systems to vary in derivation and retrieval behavior
+  without rewriting the conversation runtime.
+- Make failure modes explicit and safe: external memory should enrich context,
+  not become a hidden single point of failure.
+
+## Non-Goals
+
+- No multi-provider federation in the first slice.
+- No mandatory external memory service dependency.
+- No rewrite of the current ACP/provider boundary.
+- No attempt to force all external memory systems into the same storage shape.
+- No handoff of final prompt shaping to an external memory product.
+- No requirement that the first external adapter be networked or hosted.
+
+## Current State
+
+The current `alpha-test` branch already draws an important boundary:
+
+- `ConversationContextEngine` is the context-lifecycle and context-projection
+  seam, not the storage authority.
+- The built-in `DefaultContextEngine` is intentionally light. It reads a memory
+  window and assembles prompt messages.
+- The `memory` module still behaves like a narrow canonical store and prompt
+  hydration layer. Its current public behavior is append-turn, recent-window,
+  clear-session, and deterministic prompt hydration.
+- The provider path persists user and assistant turns and participates in the
+  context-engine lifecycle.
+- The ACP path persists raw turns and structured ACP runtime events, but it does
+  not reuse the provider-side context-engine lifecycle hooks.
+
+This separation is good. The next step should preserve it.
+
+## External System Taxonomy
+
+The design must account for the fact that "memory system" can mean different
+things:
+
+### 1. Memory Layer / SDK
+
+Example shape: Mem0-like systems.
+
+Characteristics:
+
+- derive personalized memories from conversations
+- expose APIs like add, search, and user/session scoped retrieval
+- may be self-hosted or managed
+
+What LoongClaw should treat them as:
+
+- a derivation and retrieval adapter
+
+### 2. Local Cognitive Retrieval Engine
+
+Example shape: Lucid-like systems.
+
+Characteristics:
+
+- local-first storage and retrieval
+- low-latency coding-assistant oriented recall
+- stronger opinions about ranking, compression, episodic traces, and
+  association
+
+What LoongClaw should treat them as:
+
+- a local derivation and retrieval adapter
+
+### 3. Full Memory Framework / Service
+
+Example shape: Cortex-like systems.
+
+Characteristics:
+
+- its own hierarchy, indexing model, APIs, observability, or MCP surface
+- may manage session/user/agent/resource memory as a full subsystem
+
+What LoongClaw should treat them as:
+
+- an external memory subsystem adapter that still sits below LoongClaw's final
+  context projection
+
+## Approaches Considered
+
+### Approach 1: Treat Each Memory System As A Backend
+
+Add a single selector like:
+
+```toml
+[memory]
+backend = "sqlite|lucid|mem0|cortex"
+```
+
+Pros:
+
+- simple to describe initially
+- low short-term design overhead
+
+Cons:
+
+- conflates raw storage, derivation, retrieval, and projection
+- forces unrelated systems into a fake common denominator
+- makes future ACP/provider convergence harder
+- risks turning external vendors into the only memory authority
+
+### Approach 2: One Monolithic `MemoryProvider` Abstraction
+
+Expose a single app-layer trait that stores turns, derives memory, retrieves
+results, and shapes prompt input.
+
+Pros:
+
+- cleaner than backend-switching
+- one registry and one selection surface
+
+Cons:
+
+- still mixes authority, derivation, retrieval, and prompt shaping
+- hides important failure modes
+- makes it too easy for one adapter to take over prompt assembly
+- eventually becomes a "god trait" that blocks clean evolution
+
+### Approach 3: Layered Memory Stack With LoongClaw Canonical Authority
+
+Keep LoongClaw as the canonical raw-history authority. Introduce explicit layers
+for derivation and retrieval. Keep `ConversationContextEngine` as the final
+projection layer.
+
+Pros:
+
+- preserves LoongClaw control over truth, policy, and context assembly
+- supports local and hosted systems equally well
+- works for both provider and ACP-produced history
+- allows product-level memory-system choice without rewriting the runtime
+- gives a clean migration path from today's SQLite-first implementation
+
+Cons:
+
+- slightly more architecture to introduce up front
+- requires discipline to keep layers separate
+
+## Decision
+
+Adopt Approach 3.
+
+LoongClaw should not choose one memory product as its primary authority. It
+should own canonical facts and let memory systems compete and evolve at the
+derivation and retrieval layers.
+
+## Design Principles
+
+### 1. Canonical First
+
+LoongClaw keeps the canonical raw conversation and runtime-event stream. That
+stream is replayable, inspectable, and suitable for re-indexing.
+
+### 2. Profile First, System Second, Backend Last
+
+The user-facing choice remains about memory behavior and system style, not about
+raw storage engines. Storage remains an implementation detail as long as
+possible.
+
+### 3. Projection Stays In LoongClaw
+
+External memory systems may return retrieved records or hierarchical artifacts,
+but they do not directly author LoongClaw's final prompt.
+
+### 4. ACP And Provider Share One Fact Layer
+
+ACP should not grow into a separate long-term memory authority. ACP-generated
+turns and events should still feed the same canonical layer as provider turns.
+
+### 5. Degrade Gracefully
+
+External memory-system failure must fail open. Baseline interaction continues
+with built-in recent-context behavior.
+
+### 6. Typed Artifacts Over Opaque Prompt Blobs
+
+Memory derivation should produce typed records, not only preformatted text.
+Typed artifacts keep retrieval, ranking, auditing, and prompt projection under
+control.
+
+## Proposed Conceptual Architecture
+
+### Layer 1: Canonical Memory Store
+
+Responsibility:
+
+- persist raw conversation turns and runtime events
+- provide deterministic recent-window reads
+- provide replayable session history for reindexing and migration
+
+Initial authority:
+
+- the existing SQLite-backed LoongClaw memory plane
+
+Suggested conceptual operations:
+
+- `append_record`
+- `window`
+- `session_log`
+- `clear_session`
+
+Suggested conceptual record:
+
+```rust
+struct CanonicalMemoryRecord {
+    record_id: String,
+    session_id: String,
+    scope: MemoryScope,
+    kind: CanonicalMemoryKind,
+    role: Option<String>,
+    content: String,
+    ts: i64,
+    metadata: serde_json::Value,
+}
+```
+
+Initial `CanonicalMemoryKind` should be broad enough for:
+
+- user turn
+- assistant turn
+- tool result
+- imported profile
+- ACP runtime event
+- ACP final event
+
+### Layer 2: Memory Derivation
+
+Responsibility:
+
+- transform canonical records into durable higher-order memory artifacts
+- run synchronously in minimal mode or asynchronously in richer modes
+
+Derived artifact types may include:
+
+- summary
+- profile
+- fact
+- entity
+- episode
+- procedure
+- hierarchical abstract or overview records
+
+Suggested conceptual output:
+
+```rust
+struct DerivedMemoryRecord {
+    record_id: String,
+    source_record_ids: Vec<String>,
+    scope: MemoryScope,
+    kind: DerivedMemoryKind,
+    content: String,
+    metadata: serde_json::Value,
+}
+```
+
+Examples:
+
+- built-in mode: deterministic summary and profile-note projection
+- Lucid-like mode: local episodic and procedural traces
+- Mem0-like mode: personalized fact extraction and search index updates
+- Cortex-like mode: hierarchical L0/L1/L2 style artifacts
+
+### Layer 3: Memory Retrieval
+
+Responsibility:
+
+- answer context queries using derived memory under explicit policy and budget
+- return typed candidate records plus diagnostics
+
+Suggested conceptual request:
+
+```rust
+struct MemoryRetrievalRequest {
+    session_id: String,
+    query: Option<String>,
+    scopes: Vec<MemoryScope>,
+    budget_items: usize,
+    allowed_kinds: Vec<DerivedMemoryKind>,
+}
+```
+
+Important rule:
+
+- recent conversation window is not replaced by semantic retrieval
+- retrieval augments context; it does not become the only context source
+
+### Layer 4: Memory Orchestrator
+
+LoongClaw needs one app-layer orchestrator that composes canonical store,
+derivation, and retrieval behind a stable runtime API.
+
+Responsibilities:
+
+- persist canonical records
+- fan out to derivation
+- load recent window
+- query derived memory
+- produce a typed hydrated memory snapshot for context projection
+
+Suggested conceptual output:
+
+```rust
+struct HydratedMemoryContext {
+    recent_window: Vec<CanonicalMemoryRecord>,
+    retrieved: Vec<DerivedMemoryRecord>,
+    diagnostics: MemoryDiagnostics,
+}
+```
+
+This is the natural evolution of today's `load_prompt_context(...)`.
+
+### Layer 5: Context Projection
+
+`ConversationContextEngine` remains responsible for:
+
+- prompt ordering
+- system-prompt addition
+- token budgeting
+- compaction policy
+- subagent lifecycle hooks
+
+The context engine should consume a hydrated memory snapshot from the memory
+orchestrator rather than owning storage or derivation itself.
+
+## Proposed Runtime Surface
+
+The conceptual design should map to an initial runtime surface that is real but
+not over-engineered.
+
+### Stable User-Facing Surface
+
+Keep existing memory fields:
+
+- `memory.backend`
+- `memory.profile`
+- `memory.sqlite_path`
+- `memory.sliding_window`
+- `memory.summary_max_chars`
+- `memory.profile_note`
+
+Add:
+
+- `memory.system`
+- `memory.fail_open`
+- `memory.ingest_mode`
+
+Suggested meaning:
+
+- `backend`: canonical raw-store backend
+- `profile`: user-visible behavior contract
+- `system`: selected memory-system family
+- `ingest_mode`: whether derivation prefers synchronous minimal work or
+  asynchronous background work
+
+### Advanced Adapter Config
+
+Reserve nested adapter config for later:
+
+```toml
+[memory]
+backend = "sqlite"
+profile = "window_only"
+system = "builtin"
+fail_open = true
+ingest_mode = "sync_minimal"
+
+[memory.systems.lucid]
+enabled = true
+
+[memory.systems.mem0]
+enabled = true
+api_key_env = "MEM0_API_KEY"
+
+[memory.systems.cortex]
+enabled = true
+endpoint = "http://127.0.0.1:8085"
+```
+
+The nested tables are intentionally adapter-specific. LoongClaw should not
+pretend these systems have identical configuration models.
+
+## Proposed Selection Model
+
+This slice should separate three distinct selectors:
+
+### 1. Canonical Backend
+
+What stores raw canonical facts?
+
+Initial value:
+
+- `sqlite`
+
+### 2. Memory System
+
+Which derivation and retrieval family is active?
+
+Initial value:
+
+- `builtin`
+
+Future examples:
+
+- `lucid`
+- `mem0`
+- `cortex`
+
+### 3. Memory Profile
+
+What behavior contract should the user experience?
+
+Current values:
+
+- `window_only`
+- `window_plus_summary`
+- `profile_plus_window`
+
+Future values can remain independent from adapter brands.
+
+## Proposed Registry Strategy
+
+LoongClaw already has a successful pattern with `context_engine_registry`.
+Memory should follow the same spirit, but not necessarily the same exact
+granularity on day one.
+
+### Recommended Phase-1 Code Shape
+
+Introduce one selected memory-system facade:
+
+- `MemorySystem`
+- `MemorySystemMetadata`
+- `resolve_memory_system(...)`
+- `list_memory_systems(...)`
+
+Internally, the built-in memory system can still compose:
+
+- canonical store
+- derivation
+- retrieval
+
+This keeps the first implementation slice simple.
+
+### Future Split When Needed
+
+Only split into separate public registries for:
+
+- `CanonicalMemoryStore`
+- `MemoryDeriver`
+- `MemoryRetriever`
+
+after LoongClaw proves it truly needs mix-and-match composition rather than one
+selected stack per runtime.
+
+## Memory Scope Model
+
+The system should standardize scope names now so future adapters have a stable
+mapping target.
+
+Suggested scopes:
+
+- `session`
+- `user`
+- `agent`
+- `workspace`
+
+These are enough to cover the near-term product direction without overcommitting
+to more exotic shapes.
+
+## Provider And ACP Data Flow
+
+### Provider Path
+
+1. Persist canonical user turn.
+2. Perform minimal derivation work if configured.
+3. Build context through `ConversationContextEngine`, which reads hydrated
+   memory from the memory orchestrator.
+4. Request provider turn.
+5. Persist canonical assistant turn.
+6. Trigger post-turn derivation and retrieval maintenance.
+
+### ACP Path
+
+1. Route through ACP manager as today.
+2. Persist canonical raw user turn or runtime event before or during ACP
+   execution.
+3. Persist assistant final result and structured ACP runtime events.
+4. Feed those canonical records into derivation.
+5. Keep ACP separate from provider-only context-engine lifecycle hooks unless a
+   new explicit ACP-aware seam is added later.
+
+This preserves the existing ACP architecture while preventing memory split-brain.
+
+## Failure Policy
+
+### Canonical Store Failure
+
+Preserve current runtime semantics. Do not let new external memory features make
+canonical persistence less reliable.
+
+### Derivation Failure
+
+Fail open:
+
+- log diagnostics
+- keep recent-window behavior
+- avoid blocking the main conversation turn unless the operator explicitly
+  chooses strict mode in the future
+
+### Retrieval Failure
+
+Fail open:
+
+- skip external retrieval output
+- continue with built-in context projection
+
+## Migration Strategy
+
+### Phase 0: Document The Boundary
+
+- no behavior change
+- no user-visible config break
+
+### Phase 1: Introduce Memory-System Metadata And Selection
+
+- keep built-in system only
+- add registry, metadata, config selection, and diagnostics
+
+### Phase 2: Introduce The Memory Orchestrator
+
+- evolve `load_prompt_context(...)` into a richer hydrated-memory API
+- preserve current prompt behavior for `system = "builtin"`
+
+### Phase 3: Broaden Canonical Records
+
+- add typed canonical event persistence for ACP and future tool/runtime events
+- make replay and re-derivation explicit
+
+### Phase 4: Add One Experimental External Adapter
+
+Recommendation:
+
+- start with a local-first adapter before a hosted one
+
+Reason:
+
+- lowest operational risk
+- best fit for baseline UX preservation
+- easiest way to validate the abstractions without introducing service
+  dependency complexity
+
+### Phase 5: Reassess Public Registry Granularity
+
+- keep one memory-system facade if it remains sufficient
+- split component registries only if adapter reality demands it
+
+## Testing Strategy
+
+The architecture is only useful if it stays stable under current behavior.
+
+Required validation:
+
+- backward-compatibility tests for old memory config
+- selection tests for built-in memory system metadata and resolution
+- prompt-behavior regression tests for built-in recent-window flow
+- provider-path characterization tests
+- ACP-path characterization tests proving shared canonical persistence does not
+  imply shared provider lifecycle hooks
+- fail-open tests for derivation and retrieval failure
+
+## Consequences
+
+### Positive
+
+- supports future user-selectable memory systems without product lock-in
+- preserves LoongClaw control over truth and prompt assembly
+- lets ACP and provider share one fact layer without forcing one turn pipeline
+- makes future migration and reindexing possible
+
+### Negative
+
+- adds another layer of abstraction before the second real adapter lands
+- requires discipline to avoid leaking external-system prompt formatting into
+  core runtime logic
+
+## Final Recommendation
+
+LoongClaw should evolve toward a pluggable memory-stack architecture, but it
+should do so from a strong center:
+
+- canonical facts belong to LoongClaw
+- derivation and retrieval are pluggable
+- context projection remains a LoongClaw responsibility
+- user choice is expressed as profile plus selected memory system, not as raw
+  backend wiring
+
+That gives the project a clean foundation for Lucid-like, Mem0-like, and
+Cortex-like integrations without surrendering architecture control to any one of
+them.

--- a/docs/plans/2026-03-14-loongclaw-pluggable-memory-systems-implementation.md
+++ b/docs/plans/2026-03-14-loongclaw-pluggable-memory-systems-implementation.md
@@ -280,48 +280,59 @@ git add crates/app/src/memory/orchestrator.rs crates/app/src/config/tools_memory
 git commit -m "feat: add fail-open memory system policy"
 ```
 
-### Task 7: Land One Experimental External Adapter
+### Task 7: Keep Concrete External Adapters Deferred
 
 **Files:**
-- Create: `crates/app/src/memory/adapters/mod.rs`
-- Create: `crates/app/src/memory/adapters/<adapter>.rs`
-- Modify: `crates/app/src/memory/system_registry.rs`
+- Modify: `crates/app/src/config/mod.rs`
 - Modify: `crates/app/src/config/tools_memory.rs`
-- Test: `crates/app/src/memory/adapters/<adapter>.rs`
+- Modify: `crates/app/src/memory/mod.rs`
+- Modify: `crates/app/src/memory/orchestrator.rs`
+- Modify: `crates/app/src/memory/system_registry.rs`
+- Delete if present: `crates/app/src/memory/adapters/mod.rs`
+- Delete if present: `crates/app/src/memory/adapters/<adapter>.rs`
 
 **Step 1: Write the failing test**
 
 Add tests that assert:
 
-- the adapter registers cleanly
-- adapter metadata advertises the right capabilities
-- fallback to built-in behavior works when the adapter is unavailable
+- unsupported future ids remain rejected
+- the registry stays builtin-only
+- fail-open built-in hydration behavior remains intact
 
 **Step 2: Run test to verify it fails**
 
-Run: `cargo test -p loongclaw-app memory_adapters -- --nocapture`
+Run: `cargo test -p loongclaw-app config::tools_memory::tests::memory_system_rejects_unimplemented_future_variant_ids -- --exact --nocapture`
 
-Expected: FAIL because no adapter exists yet.
+Run: `cargo test -p loongclaw-app config::tests::memory_system_field_rejects_unimplemented_future_variant -- --exact --nocapture`
+
+Run: `cargo test -p loongclaw-app memory::system_registry::tests::memory_system_registry_stays_builtin_only_until_adapter_lands -- --exact --nocapture`
+
+Expected: FAIL because a concrete experimental adapter is still exposed.
 
 **Step 3: Write minimal implementation**
 
-Add the lowest-risk adapter first:
-
-- prefer a local-first experimental adapter
-- keep the canonical store in LoongClaw
-- wire only derivation and retrieval
+- remove concrete non-builtin ids from config and registry
+- keep the generic memory-system metadata and capability seam
+- keep fail-open diagnostics and session-scoped fault injection stability
+- defer the first real adapter to a later dedicated track
 
 **Step 4: Run test to verify it passes**
 
-Run: `cargo test -p loongclaw-app memory_adapters -- --nocapture`
+Run: `cargo test -p loongclaw-app config::tools_memory::tests::memory_system_rejects_unimplemented_future_variant_ids -- --exact --nocapture`
 
-Expected: PASS for registration and fallback contract tests.
+Run: `cargo test -p loongclaw-app config::tests::memory_system_field_rejects_unimplemented_future_variant -- --exact --nocapture`
+
+Run: `cargo test -p loongclaw-app memory::system_registry::tests::memory_system_registry_stays_builtin_only_until_adapter_lands -- --exact --nocapture`
+
+Run: `cargo test -p loongclaw-app fail_open_memory -- --nocapture`
+
+Expected: PASS for builtin-only surface and fail-open stability checks.
 
 **Step 5: Commit**
 
 ```bash
-git add crates/app/src/memory/adapters crates/app/src/memory/system_registry.rs crates/app/src/config/tools_memory.rs
-git commit -m "feat: add experimental external memory adapter"
+git add crates/app/src/config/mod.rs crates/app/src/config/tools_memory.rs crates/app/src/memory/mod.rs crates/app/src/memory/orchestrator.rs crates/app/src/memory/system_registry.rs
+git commit -m "refactor: keep memory architecture builtin-only for now"
 ```
 
 ### Task 8: Add Operator-Facing Docs And Runtime Diagnostics

--- a/docs/plans/2026-03-14-loongclaw-pluggable-memory-systems-implementation.md
+++ b/docs/plans/2026-03-14-loongclaw-pluggable-memory-systems-implementation.md
@@ -1,7 +1,5 @@
 # LoongClaw Pluggable Memory Systems Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Add a phased, backward-compatible architecture foundation for user-selectable memory systems while preserving LoongClaw-owned canonical history and the current built-in SQLite baseline.
 
 **Architecture:** Introduce a `MemorySystem` selection surface and metadata first, then evolve the current memory module into a richer memory orchestrator that separates canonical persistence, derivation, retrieval, and context projection. Keep `ConversationContextEngine` as the final prompt projection seam and keep ACP feeding the same canonical fact layer without reusing provider-only lifecycle hooks.

--- a/docs/plans/2026-03-14-loongclaw-pluggable-memory-systems-implementation.md
+++ b/docs/plans/2026-03-14-loongclaw-pluggable-memory-systems-implementation.md
@@ -1,0 +1,369 @@
+# LoongClaw Pluggable Memory Systems Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a phased, backward-compatible architecture foundation for user-selectable memory systems while preserving LoongClaw-owned canonical history and the current built-in SQLite baseline.
+
+**Architecture:** Introduce a `MemorySystem` selection surface and metadata first, then evolve the current memory module into a richer memory orchestrator that separates canonical persistence, derivation, retrieval, and context projection. Keep `ConversationContextEngine` as the final prompt projection seam and keep ACP feeding the same canonical fact layer without reusing provider-only lifecycle hooks.
+
+**Tech Stack:** Rust, serde/toml config, the existing `loongclaw-app` and `loongclaw-daemon` crates, SQLite-backed memory, async traits, registry patterns already used by `context_engine_registry`, and Rust unit/integration tests.
+
+---
+
+### Task 1: Add Memory-System Domain Types
+
+**Files:**
+- Create: `crates/app/src/memory/system.rs`
+- Modify: `crates/app/src/memory/mod.rs`
+- Modify: `crates/app/src/config/tools_memory.rs`
+- Test: `crates/app/src/memory/system.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+- built-in memory system metadata exists
+- memory-system ids normalize predictably
+- default config resolves to `system = "builtin"`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app memory_system -- --nocapture`
+
+Expected: FAIL because `MemorySystemMetadata` and related helpers do not exist.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- `MemorySystemSelection`
+- `MemorySystemMetadata`
+- `MemorySystemCapability`
+- config field `memory.system`
+- default built-in system id
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app memory_system -- --nocapture`
+
+Expected: PASS for the new metadata and config-resolution tests.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/memory/system.rs crates/app/src/memory/mod.rs crates/app/src/config/tools_memory.rs
+git commit -m "feat: add memory system metadata foundation"
+```
+
+### Task 2: Add Memory-System Registry And Diagnostics
+
+**Files:**
+- Create: `crates/app/src/memory/system_registry.rs`
+- Modify: `crates/app/src/memory/mod.rs`
+- Modify: `crates/app/src/lib.rs`
+- Modify: `crates/daemon/src/main.rs`
+- Test: `crates/app/src/memory/system_registry.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+- built-in system is always registered
+- unknown system ids fail with a useful error
+- metadata listing is stable and sorted
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app system_registry -- --nocapture`
+
+Expected: FAIL because the registry does not exist.
+
+**Step 3: Write minimal implementation**
+
+Mirror the existing context-engine registry pattern:
+
+- `register_memory_system`
+- `resolve_memory_system`
+- `list_memory_system_metadata`
+- `memory_system_id_from_env`
+
+Expose a daemon diagnostic such as `list-memory-systems`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app system_registry -- --nocapture`
+
+Run: `cargo test -p loongclaw-daemon list_memory_systems -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/memory/system_registry.rs crates/app/src/memory/mod.rs crates/app/src/lib.rs crates/daemon/src/main.rs
+git commit -m "feat: add memory system registry and diagnostics"
+```
+
+### Task 3: Introduce A Typed Hydrated-Memory Snapshot
+
+**Files:**
+- Create: `crates/app/src/memory/orchestrator.rs`
+- Modify: `crates/app/src/memory/mod.rs`
+- Modify: `crates/app/src/memory/runtime_config.rs`
+- Test: `crates/app/src/memory/orchestrator.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+- built-in orchestrator returns recent window records
+- built-in orchestrator returns deterministic diagnostics
+- built-in orchestrator preserves current summary/profile behavior
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app hydrated_memory -- --nocapture`
+
+Expected: FAIL because the typed orchestrator and snapshot do not exist.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- `HydratedMemoryContext`
+- `MemoryDiagnostics`
+- built-in orchestrator implementation that wraps current prompt hydration
+- runtime config plumbing for `memory.system`, `memory.fail_open`, and
+  `memory.ingest_mode`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app hydrated_memory -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/memory/orchestrator.rs crates/app/src/memory/mod.rs crates/app/src/memory/runtime_config.rs
+git commit -m "feat: add hydrated memory orchestrator foundation"
+```
+
+### Task 4: Route Context Assembly Through The Orchestrator
+
+**Files:**
+- Modify: `crates/app/src/conversation/context_engine.rs`
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/provider/request_message_runtime.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+- the default context engine builds context from the orchestrator snapshot
+- built-in behavior stays byte-for-byte equivalent for the existing memory
+  profiles
+- system selection does not change prompt output when `system = "builtin"`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app default_runtime_build_context -- --nocapture`
+
+Expected: FAIL because context assembly still depends on the older direct
+memory-window path.
+
+**Step 3: Write minimal implementation**
+
+Refactor `DefaultContextEngine` to consume the typed hydrated-memory snapshot,
+but preserve the current prompt ordering and existing profile behavior.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app default_runtime_build_context -- --nocapture`
+
+Run: `cargo test -p loongclaw-app provider:: -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/context_engine.rs crates/app/src/conversation/runtime.rs crates/app/src/provider/request_message_runtime.rs crates/app/src/conversation/tests.rs
+git commit -m "refactor: route context assembly through memory orchestrator"
+```
+
+### Task 5: Expand Canonical Persistence To Typed Records
+
+**Files:**
+- Modify: `crates/app/src/memory/mod.rs`
+- Modify: `crates/app/src/conversation/persistence.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+- provider turns persist typed canonical records
+- automatic and explicit ACP routing persist canonical records compatible with
+  later derivation
+- ACP still bypasses provider-only context-engine lifecycle hooks
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app handle_turn_with_runtime_automatic_acp_routing_bypasses_context_engine_lifecycle_hooks -- --exact`
+
+Run: `cargo test -p loongclaw-app persist_turn -- --nocapture`
+
+Expected: FAIL because typed canonical record persistence does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Extend the persistence path so canonical records can carry kind, scope, and
+metadata while remaining backward-compatible with the current SQLite baseline.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app handle_turn_with_runtime_automatic_acp_routing_bypasses_context_engine_lifecycle_hooks -- --exact`
+
+Run: `cargo test -p loongclaw-app persist_turn -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/memory/mod.rs crates/app/src/conversation/persistence.rs crates/app/src/conversation/turn_coordinator.rs crates/app/src/conversation/tests.rs
+git commit -m "feat: add typed canonical memory record persistence"
+```
+
+### Task 6: Add Fail-Open Behavior And Built-In Contract Tests
+
+**Files:**
+- Modify: `crates/app/src/memory/orchestrator.rs`
+- Modify: `crates/app/src/config/tools_memory.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+- Test: `crates/app/src/memory/orchestrator.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+- derivation failure falls back to built-in recent-window behavior
+- retrieval failure falls back to built-in recent-window behavior
+- strict-mode behavior remains reserved and disabled by default
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app fail_open_memory -- --nocapture`
+
+Expected: FAIL because fail-open policy is not wired into the orchestrator yet.
+
+**Step 3: Write minimal implementation**
+
+Add fail-open policy evaluation and diagnostics so external memory system
+problems do not break the baseline chat experience.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app fail_open_memory -- --nocapture`
+
+Run: `cargo test -p loongclaw-app conversation::tests:: -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/memory/orchestrator.rs crates/app/src/config/tools_memory.rs crates/app/src/conversation/tests.rs
+git commit -m "feat: add fail-open memory system policy"
+```
+
+### Task 7: Land One Experimental External Adapter
+
+**Files:**
+- Create: `crates/app/src/memory/adapters/mod.rs`
+- Create: `crates/app/src/memory/adapters/<adapter>.rs`
+- Modify: `crates/app/src/memory/system_registry.rs`
+- Modify: `crates/app/src/config/tools_memory.rs`
+- Test: `crates/app/src/memory/adapters/<adapter>.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+- the adapter registers cleanly
+- adapter metadata advertises the right capabilities
+- fallback to built-in behavior works when the adapter is unavailable
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app memory_adapters -- --nocapture`
+
+Expected: FAIL because no adapter exists yet.
+
+**Step 3: Write minimal implementation**
+
+Add the lowest-risk adapter first:
+
+- prefer a local-first experimental adapter
+- keep the canonical store in LoongClaw
+- wire only derivation and retrieval
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app memory_adapters -- --nocapture`
+
+Expected: PASS for registration and fallback contract tests.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/memory/adapters crates/app/src/memory/system_registry.rs crates/app/src/config/tools_memory.rs
+git commit -m "feat: add experimental external memory adapter"
+```
+
+### Task 8: Add Operator-Facing Docs And Runtime Diagnostics
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+- Modify: `docs/roadmap.md`
+- Modify: `crates/daemon/src/main.rs`
+
+**Step 1: Write the failing test**
+
+For CLI diagnostics, add tests that assert:
+
+- memory-system listing shows built-in metadata
+- diagnostics print selected system and fail-open policy
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon memory_systems -- --nocapture`
+
+Expected: FAIL because the diagnostics and docs are incomplete.
+
+**Step 3: Write minimal implementation**
+
+Document:
+
+- canonical store vs external memory-system boundary
+- supported systems and capability differences
+- failure policy and fallback behavior
+
+Expose operator diagnostics for selected memory system and capabilities.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon memory_systems -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add README.md README.zh-CN.md docs/roadmap.md crates/daemon/src/main.rs
+git commit -m "docs: describe pluggable memory system architecture"
+```

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -14,7 +14,7 @@
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3020 | 3600 | 580 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1478 | 3700 | 2222 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 260 | 1000 | 740 | 6 | 20 | 14 | n/a | n/a | N/A | n/a |
-| memory_mod | `crates/app/src/memory/mod.rs` | 620 | 650 | 30 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
+| memory_mod | `crates/app/src/memory/mod.rs` | 645 | 650 | 5 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
 | Check | Status | Previous Status | Detail |
@@ -41,7 +41,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3020 functions=47 -->
 <!-- arch-hotspot key=spec_execution lines=1478 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=260 functions=6 -->
-<!-- arch-hotspot key=memory_mod lines=620 functions=14 -->
+<!-- arch-hotspot key=memory_mod lines=645 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=spec_app_dependency status=PASS -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -14,7 +14,7 @@
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3020 | 3600 | 580 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1478 | 3700 | 2222 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 260 | 1000 | 740 | 6 | 20 | 14 | n/a | n/a | N/A | n/a |
-| memory_mod | `crates/app/src/memory/mod.rs` | 645 | 650 | 5 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
+| memory_mod | `crates/app/src/memory/mod.rs` | 646 | 650 | 4 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
 | Check | Status | Previous Status | Detail |
@@ -41,7 +41,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3020 functions=47 -->
 <!-- arch-hotspot key=spec_execution lines=1478 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=260 functions=6 -->
-<!-- arch-hotspot key=memory_mod lines=645 functions=14 -->
+<!-- arch-hotspot key=memory_mod lines=646 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=spec_app_dependency status=PASS -->


### PR DESCRIPTION
## Summary

- add the builtin-only memory system foundation, including registry metadata, hydrated orchestration, canonical memory persistence, and fail-open diagnostics
- keep the runtime surface builtin-only and add regression coverage so future adapter ids stay unavailable until a real integration lands
- neutralize planning docs so future adapters remain architectural examples instead of current product-surface configuration
- this change is needed to land the memory-system foundation on `alpha-test` without implying unsupported adapter variants are already productized

## Scope

- [ ] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

Scope note: this foundation slice touches config validation, memory orchestration, docs, and roadmap text across 23 files.

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

Risk note: this establishes the initial memory-system runtime contract and validation boundary that future adapters will build on.

## Validation

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional checks executed:

- [x] `<local-absolute-path> test -p loongclaw-app config::tools_memory::tests::memory_system_rejects_unimplemented_future_variant_ids --target-dir target/memory-foundation-pr-verify -- --exact --nocapture`
- [x] `<local-absolute-path> test -p loongclaw-app config::tests::memory_system_field_rejects_unimplemented_future_variant --target-dir target/memory-foundation-pr-verify -- --exact --nocapture`
- [x] `<local-absolute-path> test -p loongclaw-app memory::system_registry::tests::memory_system_registry_stays_builtin_only_until_adapter_lands --target-dir target/memory-foundation-pr-verify -- --exact --nocapture`
- [x] `<local-absolute-path> test -p loongclaw-app memory::orchestrator::tests::hydrated_memory_builtin_orchestrator_reports_deterministic_diagnostics --target-dir target/memory-foundation-pr-verify -- --exact --nocapture`
- [x] `<local-absolute-path> test -p loongclaw-app fail_open_memory --target-dir target/memory-foundation-pr-verify -- --nocapture`
- [x] `<local-absolute-path> test -p loongclaw-app --quiet --target-dir target/memory-foundation-pr-verify`

## Linked Issues

Closes #114