### PR TITLE
refactor(conversation): add typed turn phases and durable checkpoint semantics

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -15,13 +15,20 @@ use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context};
 
 use super::config::{self, ConversationConfig, LoongClawConfig};
 #[cfg(feature = "memory-sqlite")]
-use super::conversation::summarize_safe_lane_events;
+use super::conversation::load_safe_lane_event_summary;
 use super::conversation::{
     ConversationSessionAddress, ConversationTurnCoordinator, ProviderErrorMode,
     resolve_context_engine_selection,
 };
 #[cfg(any(test, feature = "memory-sqlite"))]
 use super::conversation::{SafeLaneEventSummary, SafeLaneFinalStatus};
+#[cfg(any(test, feature = "memory-sqlite"))]
+use super::conversation::{
+    TurnCheckpointDiagnostics, TurnCheckpointEventSummary, TurnCheckpointFailureStep,
+    TurnCheckpointProgressStatus, TurnCheckpointRecoveryAction, TurnCheckpointRecoveryAssessment,
+    TurnCheckpointSessionState, TurnCheckpointStage, TurnCheckpointTailRepairOutcome,
+    TurnCheckpointTailRepairReason, TurnCheckpointTailRepairRuntimeProbe,
+};
 #[cfg(feature = "memory-sqlite")]
 use super::memory;
 #[cfg(feature = "memory-sqlite")]
@@ -131,6 +138,27 @@ pub async fn run_cli_chat(
         );
     }
     let turn_coordinator = ConversationTurnCoordinator::new();
+
+    #[cfg(feature = "memory-sqlite")]
+    match turn_coordinator
+        .load_turn_checkpoint_diagnostics(&config, &session_id, Some(&kernel_ctx))
+        .await
+    {
+        Ok(diagnostics) => {
+            if let Some(health) = format_turn_checkpoint_startup_health(&session_id, &diagnostics) {
+                println!("{health}");
+                if let Some(probe) = diagnostics.runtime_probe() {
+                    println!(
+                        "{}",
+                        format_turn_checkpoint_runtime_probe(&session_id, probe)
+                    );
+                }
+            }
+        }
+        Err(error) => {
+            println!("turn_checkpoint_health session={session_id} state=unavailable error={error}");
+        }
+    }
     let session_address = ConversationSessionAddress::from_session_id(session_id.clone());
     let acp_event_printer = options
         .acp_event_stream
@@ -175,9 +203,60 @@ pub async fn run_cli_chat(
         }
         if let Some(limit) = parse_safe_lane_summary_limit(input, config.memory.sliding_window)? {
             #[cfg(feature = "memory-sqlite")]
-            print_safe_lane_summary(&session_id, limit, &config.conversation, &memory_config)?;
+            print_safe_lane_summary(
+                &session_id,
+                limit,
+                &config.conversation,
+                Some(&kernel_ctx),
+                &memory_config,
+            )
+            .await?;
             #[cfg(not(feature = "memory-sqlite"))]
-            print_safe_lane_summary(&session_id, limit, &config.conversation)?;
+            print_safe_lane_summary(&session_id, limit, &config.conversation, Some(&kernel_ctx))
+                .await?;
+            continue;
+        }
+        if let Some(limit) =
+            parse_turn_checkpoint_summary_limit(input, config.memory.sliding_window)?
+        {
+            #[cfg(feature = "memory-sqlite")]
+            print_turn_checkpoint_summary(
+                &turn_coordinator,
+                &config,
+                &session_id,
+                limit,
+                Some(&kernel_ctx),
+                &memory_config,
+            )
+            .await?;
+            #[cfg(not(feature = "memory-sqlite"))]
+            print_turn_checkpoint_summary(
+                &turn_coordinator,
+                &config,
+                &session_id,
+                limit,
+                Some(&kernel_ctx),
+            )
+            .await?;
+            continue;
+        }
+        if is_turn_checkpoint_repair_command(input)? {
+            #[cfg(feature = "memory-sqlite")]
+            print_turn_checkpoint_repair(
+                &turn_coordinator,
+                &config,
+                &session_id,
+                Some(&kernel_ctx),
+            )
+            .await?;
+            #[cfg(not(feature = "memory-sqlite"))]
+            print_turn_checkpoint_repair(
+                &turn_coordinator,
+                &config,
+                &session_id,
+                Some(&kernel_ctx),
+            )
+            .await?;
             continue;
         }
 
@@ -226,6 +305,8 @@ fn print_help() {
     println!("/help    show this help");
     println!("/history print current session sliding window");
     println!("/safe_lane_summary [limit]  summarize safe-lane runtime events");
+    println!("/turn_checkpoint_summary [limit]  summarize durable turn finalization state");
+    println!("/turn_checkpoint_repair  repair durable turn finalization tail when safe");
     println!("/exit    quit chat");
 }
 
@@ -323,22 +404,65 @@ fn parse_safe_lane_summary_limit(input: &str, default_window: usize) -> CliResul
     Ok(Some(limit))
 }
 
+fn parse_turn_checkpoint_summary_limit(
+    input: &str,
+    default_window: usize,
+) -> CliResult<Option<usize>> {
+    let mut tokens = input.split_whitespace();
+    let Some(command) = tokens.next() else {
+        return Ok(None);
+    };
+    if command != "/turn_checkpoint_summary" && command != "/turn-checkpoint-summary" {
+        return Ok(None);
+    }
+
+    let default_limit = default_window.saturating_mul(4).max(64);
+    let limit = match tokens.next() {
+        Some(raw) => raw.parse::<usize>().map_err(|error| {
+            format!(
+                "invalid /turn_checkpoint_summary limit `{raw}`: {error}; usage: /turn_checkpoint_summary [limit]"
+            )
+        })?,
+        None => default_limit,
+    };
+    if limit == 0 {
+        return Err(
+            "invalid /turn_checkpoint_summary limit `0`; usage: /turn_checkpoint_summary [limit]"
+                .to_owned(),
+        );
+    }
+    if tokens.next().is_some() {
+        return Err("usage: /turn_checkpoint_summary [limit]".to_owned());
+    }
+    Ok(Some(limit))
+}
+
+fn is_turn_checkpoint_repair_command(input: &str) -> CliResult<bool> {
+    let mut tokens = input.split_whitespace();
+    let Some(command) = tokens.next() else {
+        return Ok(false);
+    };
+    if command != "/turn_checkpoint_repair" && command != "/turn-checkpoint-repair" {
+        return Ok(false);
+    }
+    if tokens.next().is_some() {
+        return Err("usage: /turn_checkpoint_repair".to_owned());
+    }
+    Ok(true)
+}
+
 #[allow(clippy::print_stdout)] // CLI output
-fn print_safe_lane_summary(
+async fn print_safe_lane_summary(
     session_id: &str,
     limit: usize,
     conversation_config: &ConversationConfig,
+    kernel_ctx: Option<&crate::KernelContext>,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
-        let turns = memory::window_direct(session_id, limit, memory_config)
-            .map_err(|error| format!("load safe-lane summary failed: {error}"))?;
-        let summary = summarize_safe_lane_events(
-            turns
-                .iter()
-                .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.as_str())),
-        );
+        let summary =
+            load_safe_lane_event_summary(session_id, limit, kernel_ctx, memory_config).await?;
         println!(
             "{}",
             format_safe_lane_summary(session_id, limit, conversation_config, &summary)
@@ -348,8 +472,61 @@ fn print_safe_lane_summary(
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = (session_id, limit, conversation_config);
+        let _ = (session_id, limit, conversation_config, kernel_ctx);
         println!("safe-lane summary unavailable: memory-sqlite feature disabled");
+        Ok(())
+    }
+}
+
+#[allow(clippy::print_stdout)] // CLI output
+async fn print_turn_checkpoint_summary(
+    turn_coordinator: &ConversationTurnCoordinator,
+    config: &LoongClawConfig,
+    session_id: &str,
+    limit: usize,
+    kernel_ctx: Option<&crate::KernelContext>,
+    #[cfg(feature = "memory-sqlite")] _memory_config: &MemoryRuntimeConfig,
+) -> CliResult<()> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let diagnostics = turn_coordinator
+            .load_turn_checkpoint_diagnostics_with_limit(config, session_id, limit, kernel_ctx)
+            .await?;
+        println!(
+            "{}",
+            format_turn_checkpoint_summary_output(session_id, limit, &diagnostics)
+        );
+        Ok(())
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (turn_coordinator, config, session_id, limit, kernel_ctx);
+        println!("turn checkpoint summary unavailable: memory-sqlite feature disabled");
+        Ok(())
+    }
+}
+
+#[allow(clippy::print_stdout)] // CLI output
+async fn print_turn_checkpoint_repair(
+    turn_coordinator: &ConversationTurnCoordinator,
+    config: &LoongClawConfig,
+    session_id: &str,
+    kernel_ctx: Option<&crate::KernelContext>,
+) -> CliResult<()> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let outcome = turn_coordinator
+            .repair_turn_checkpoint_tail(config, session_id, kernel_ctx)
+            .await?;
+        println!("{}", format_turn_checkpoint_repair(session_id, &outcome));
+        Ok(())
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (turn_coordinator, config, session_id, kernel_ctx);
+        println!("turn checkpoint repair unavailable: memory-sqlite feature disabled");
         Ok(())
     }
 }
@@ -554,6 +731,305 @@ fn format_safe_lane_summary(
 }
 
 #[cfg(any(test, feature = "memory-sqlite"))]
+fn format_turn_checkpoint_stage(stage: Option<TurnCheckpointStage>) -> &'static str {
+    match stage {
+        Some(TurnCheckpointStage::PostPersist) => "post_persist",
+        Some(TurnCheckpointStage::Finalized) => "finalized",
+        Some(TurnCheckpointStage::FinalizationFailed) => "finalization_failed",
+        None => "-",
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_turn_checkpoint_progress(status: Option<TurnCheckpointProgressStatus>) -> &'static str {
+    match status {
+        Some(TurnCheckpointProgressStatus::Pending) => "pending",
+        Some(TurnCheckpointProgressStatus::Skipped) => "skipped",
+        Some(TurnCheckpointProgressStatus::Completed) => "completed",
+        Some(TurnCheckpointProgressStatus::Failed) => "failed",
+        Some(TurnCheckpointProgressStatus::FailedOpen) => "failed_open",
+        None => "-",
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_turn_checkpoint_failure_step(step: Option<TurnCheckpointFailureStep>) -> &'static str {
+    match step {
+        Some(TurnCheckpointFailureStep::AfterTurn) => "after_turn",
+        Some(TurnCheckpointFailureStep::Compaction) => "compaction",
+        None => "-",
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_turn_checkpoint_identity_presence(identity_present: Option<bool>) -> &'static str {
+    match identity_present {
+        Some(true) => "present",
+        Some(false) => "missing",
+        None => "-",
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_turn_checkpoint_session_state(state: TurnCheckpointSessionState) -> &'static str {
+    match state {
+        TurnCheckpointSessionState::NotDurable => "not_durable",
+        TurnCheckpointSessionState::PendingFinalization => "pending_finalization",
+        TurnCheckpointSessionState::Finalized => "finalized",
+        TurnCheckpointSessionState::FinalizationFailed => "finalization_failed",
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_turn_checkpoint_recovery_action(action: TurnCheckpointRecoveryAction) -> &'static str {
+    action.as_str()
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_turn_checkpoint_recovery_reason(
+    reason: Option<TurnCheckpointTailRepairReason>,
+) -> &'static str {
+    reason
+        .map(TurnCheckpointTailRepairReason::as_str)
+        .unwrap_or("-")
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TurnCheckpointRecoveryRenderLabels {
+    action: &'static str,
+    source: &'static str,
+    reason: &'static str,
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+impl TurnCheckpointRecoveryRenderLabels {
+    fn from_assessment(assessment: TurnCheckpointRecoveryAssessment) -> Self {
+        Self {
+            action: format_turn_checkpoint_recovery_action(assessment.action()),
+            source: assessment.source().as_str(),
+            reason: format_turn_checkpoint_recovery_reason(assessment.reason()),
+        }
+    }
+
+    fn from_outcome(outcome: &TurnCheckpointTailRepairOutcome) -> Self {
+        Self {
+            action: outcome.action().as_str(),
+            source: outcome.source().map(|value| value.as_str()).unwrap_or("-"),
+            reason: outcome.reason().as_str(),
+        }
+    }
+
+    fn from_probe(probe: &TurnCheckpointTailRepairRuntimeProbe) -> Self {
+        Self {
+            action: probe.action().as_str(),
+            source: probe.source().as_str(),
+            reason: probe.reason().as_str(),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TurnCheckpointSummaryRenderLabels<'a> {
+    session_state: &'static str,
+    stage: &'static str,
+    after_turn: &'static str,
+    compaction: &'static str,
+    lane: &'a str,
+    result_kind: &'a str,
+    persistence_mode: &'a str,
+    safe_lane_route_decision: &'static str,
+    safe_lane_route_reason: &'static str,
+    safe_lane_route_source: &'static str,
+    identity: &'static str,
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+impl<'a> TurnCheckpointSummaryRenderLabels<'a> {
+    fn from_summary(summary: &'a TurnCheckpointEventSummary) -> Self {
+        let (safe_lane_route_decision, safe_lane_route_reason, safe_lane_route_source) =
+            summary.latest_safe_lane_route_labels_or_default();
+        Self {
+            session_state: format_turn_checkpoint_session_state(summary.session_state),
+            stage: format_turn_checkpoint_stage(summary.latest_stage),
+            after_turn: format_turn_checkpoint_progress(summary.latest_after_turn),
+            compaction: format_turn_checkpoint_progress(summary.latest_compaction),
+            lane: summary.latest_lane.as_deref().unwrap_or("-"),
+            result_kind: summary.latest_result_kind.as_deref().unwrap_or("-"),
+            persistence_mode: summary.latest_persistence_mode.as_deref().unwrap_or("-"),
+            safe_lane_route_decision,
+            safe_lane_route_reason,
+            safe_lane_route_source,
+            identity: format_turn_checkpoint_identity_presence(summary.latest_identity_present),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TurnCheckpointDurabilityRenderLabels {
+    checkpoint_durable: u8,
+    reply_durable: u8,
+    durability: &'static str,
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+impl TurnCheckpointDurabilityRenderLabels {
+    fn from_summary(summary: &TurnCheckpointEventSummary) -> Self {
+        let checkpoint_durable = u8::from(summary.checkpoint_durable);
+        let reply_durable = u8::from(summary.reply_durable);
+        let durability = if checkpoint_durable == 0 {
+            "not_durable"
+        } else if reply_durable == 1 {
+            "reply"
+        } else {
+            "checkpoint_only"
+        };
+        Self {
+            checkpoint_durable,
+            reply_durable,
+            durability,
+        }
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_turn_checkpoint_summary(
+    session_id: &str,
+    limit: usize,
+    diagnostics: &TurnCheckpointDiagnostics,
+) -> String {
+    let summary = diagnostics.summary();
+    let render_labels = TurnCheckpointSummaryRenderLabels::from_summary(summary);
+    let durability_labels = TurnCheckpointDurabilityRenderLabels::from_summary(summary);
+    let recovery_labels =
+        TurnCheckpointRecoveryRenderLabels::from_assessment(diagnostics.recovery());
+    let failure_step = format_turn_checkpoint_failure_step(summary.latest_failure_step);
+    let requires_recovery = if summary.requires_recovery { 1 } else { 0 };
+    let failure_error = summary.latest_failure_error.as_deref().unwrap_or("-");
+
+    let mut lines = vec![format!(
+        "turn_checkpoint_summary session={session_id} limit={limit} checkpoints={} state={} durable={} checkpoint_durable={} durability={} requires_recovery={requires_recovery} recovery_action={} recovery_source={} recovery_reason={} stage={} after_turn={} compaction={} lane={} result_kind={} persistence_mode={} safe_lane_route_decision={} safe_lane_route_reason={} safe_lane_route_source={} identity={} failure_step={failure_step} failure_error={failure_error}",
+        summary.checkpoint_events,
+        render_labels.session_state,
+        durability_labels.reply_durable,
+        durability_labels.checkpoint_durable,
+        durability_labels.durability,
+        recovery_labels.action,
+        recovery_labels.source,
+        recovery_labels.reason,
+        render_labels.stage,
+        render_labels.after_turn,
+        render_labels.compaction,
+        render_labels.lane,
+        render_labels.result_kind,
+        render_labels.persistence_mode,
+        render_labels.safe_lane_route_decision,
+        render_labels.safe_lane_route_reason,
+        render_labels.safe_lane_route_source,
+        render_labels.identity,
+    )];
+    lines.push(format!(
+        "events post_persist={} finalized={} finalization_failed={}",
+        summary.post_persist_events, summary.finalized_events, summary.finalization_failed_events
+    ));
+    if !summary.stage_counts.is_empty() {
+        let stage_rollup = summary
+            .stage_counts
+            .iter()
+            .map(|(stage_name, count)| format!("{stage_name}:{count}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        lines.push(format!("rollup stages={stage_rollup}"));
+    }
+    lines.join("\n")
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_turn_checkpoint_summary_output(
+    session_id: &str,
+    limit: usize,
+    diagnostics: &TurnCheckpointDiagnostics,
+) -> String {
+    let mut rendered = format_turn_checkpoint_summary(session_id, limit, diagnostics);
+    if let Some(probe) = diagnostics.runtime_probe() {
+        rendered.push('\n');
+        rendered.push_str(&format_turn_checkpoint_runtime_probe(session_id, probe));
+    }
+    rendered
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_turn_checkpoint_startup_health(
+    session_id: &str,
+    diagnostics: &TurnCheckpointDiagnostics,
+) -> Option<String> {
+    let summary = diagnostics.summary();
+    if !summary.checkpoint_durable {
+        return None;
+    }
+
+    let render_labels = TurnCheckpointSummaryRenderLabels::from_summary(summary);
+    let durability_labels = TurnCheckpointDurabilityRenderLabels::from_summary(summary);
+    let recovery_labels =
+        TurnCheckpointRecoveryRenderLabels::from_assessment(diagnostics.recovery());
+    let recovery_needed = if summary.requires_recovery { 1 } else { 0 };
+
+    Some(format!(
+        "turn_checkpoint_health session={session_id} state={} reply_durable={} checkpoint_durable={} durability={} recovery_needed={recovery_needed} action={} source={} reason={} stage={} after_turn={} compaction={} lane={} result_kind={} persistence_mode={} safe_lane_route_decision={} safe_lane_route_reason={} safe_lane_route_source={} identity={}",
+        render_labels.session_state,
+        durability_labels.reply_durable,
+        durability_labels.checkpoint_durable,
+        durability_labels.durability,
+        recovery_labels.action,
+        recovery_labels.source,
+        recovery_labels.reason,
+        render_labels.stage,
+        render_labels.after_turn,
+        render_labels.compaction,
+        render_labels.lane,
+        render_labels.result_kind,
+        render_labels.persistence_mode,
+        render_labels.safe_lane_route_decision,
+        render_labels.safe_lane_route_reason,
+        render_labels.safe_lane_route_source,
+        render_labels.identity,
+    ))
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_turn_checkpoint_repair(
+    session_id: &str,
+    outcome: &TurnCheckpointTailRepairOutcome,
+) -> String {
+    let after_turn = outcome.after_turn_status().unwrap_or("-");
+    let compaction = outcome.compaction_status().unwrap_or("-");
+    let render_labels = TurnCheckpointRecoveryRenderLabels::from_outcome(outcome);
+    format!(
+        "turn_checkpoint_repair session={session_id} status={} action={} source={} reason={} state={} checkpoints={} after_turn={after_turn} compaction={compaction}",
+        outcome.status().as_str(),
+        render_labels.action,
+        render_labels.source,
+        render_labels.reason,
+        outcome.session_state().as_str(),
+        outcome.checkpoint_events(),
+    )
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_turn_checkpoint_runtime_probe(
+    session_id: &str,
+    probe: &TurnCheckpointTailRepairRuntimeProbe,
+) -> String {
+    let render_labels = TurnCheckpointRecoveryRenderLabels::from_probe(probe);
+    format!(
+        "turn_checkpoint_probe session={session_id} action={} source={} reason={}",
+        render_labels.action, render_labels.source, render_labels.reason,
+    )
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
 fn derive_safe_lane_health_signal(
     conversation_config: &ConversationConfig,
     summary: &SafeLaneEventSummary,
@@ -585,16 +1061,7 @@ fn derive_safe_lane_health_signal(
     if replan_rate >= replan_warn_threshold {
         flags.push(format!("replan_pressure({replan_rate:.3})"));
     }
-    let terminal_instability = matches!(summary.final_status, Some(SafeLaneFinalStatus::Failed))
-        && summary
-            .final_failure_code
-            .as_deref()
-            .map(|code| {
-                code.contains("verify_failed")
-                    || code.contains("backpressure")
-                    || code.contains("session_governor")
-            })
-            .unwrap_or(false);
+    let terminal_instability = summary.has_terminal_instability_final_failure();
     if terminal_instability {
         flags.push("terminal_instability".to_owned());
         has_critical = true;
@@ -732,6 +1199,400 @@ mod tests {
         let error = parse_safe_lane_summary_limit("/safe_lane_summary abc", 20)
             .expect_err("non-number limit should be rejected");
         assert!(error.contains("invalid"));
+    }
+
+    #[test]
+    fn parse_turn_checkpoint_summary_limit_accepts_default_and_explicit_limit() {
+        assert_eq!(
+            parse_turn_checkpoint_summary_limit("/turn_checkpoint_summary", 20).expect("parse"),
+            Some(80)
+        );
+        assert_eq!(
+            parse_turn_checkpoint_summary_limit("/turn-checkpoint-summary 96", 20).expect("parse"),
+            Some(96)
+        );
+    }
+
+    #[test]
+    fn parse_turn_checkpoint_summary_limit_rejects_invalid_input() {
+        let error = parse_turn_checkpoint_summary_limit("/turn_checkpoint_summary 0", 20)
+            .expect_err("zero limit should be rejected");
+        assert!(error.contains("usage"));
+
+        let error = parse_turn_checkpoint_summary_limit("/turn_checkpoint_summary nope", 20)
+            .expect_err("non-number limit should be rejected");
+        assert!(error.contains("invalid"));
+    }
+
+    #[test]
+    fn is_turn_checkpoint_repair_command_accepts_aliases_and_rejects_extra_args() {
+        assert!(is_turn_checkpoint_repair_command("/turn_checkpoint_repair").expect("parse"));
+        assert!(is_turn_checkpoint_repair_command("/turn-checkpoint-repair").expect("parse"));
+        assert!(!is_turn_checkpoint_repair_command("/turn_checkpoint_summary").expect("parse"));
+
+        let error = is_turn_checkpoint_repair_command("/turn_checkpoint_repair now")
+            .expect_err("extra args should be rejected");
+        assert!(error.contains("usage"));
+    }
+
+    fn test_turn_checkpoint_diagnostics(
+        summary: TurnCheckpointEventSummary,
+        runtime_probe: Option<TurnCheckpointTailRepairRuntimeProbe>,
+    ) -> crate::conversation::TurnCheckpointDiagnostics {
+        let recovery =
+            crate::conversation::TurnCheckpointRecoveryAssessment::from_summary(&summary);
+        crate::conversation::TurnCheckpointDiagnostics::new(summary, recovery, runtime_probe)
+    }
+
+    #[test]
+    fn format_turn_checkpoint_summary_reports_recovery_state_and_failure() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 2,
+            post_persist_events: 1,
+            finalization_failed_events: 1,
+            latest_stage: Some(TurnCheckpointStage::FinalizationFailed),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Completed),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Failed),
+            latest_failure_step: Some(TurnCheckpointFailureStep::Compaction),
+            latest_failure_error: Some("context compaction failed".to_owned()),
+            latest_lane: Some("safe".to_owned()),
+            latest_result_kind: Some("tool_call".to_owned()),
+            latest_persistence_mode: Some("error".to_owned()),
+            latest_safe_lane_terminal_route: Some(
+                crate::conversation::SafeLaneTerminalRouteSnapshot {
+                    decision: crate::conversation::SafeLaneFailureRouteDecision::Terminal,
+                    reason:
+                        crate::conversation::SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+                    source: crate::conversation::SafeLaneFailureRouteSource::SessionGovernor,
+                },
+            ),
+            latest_identity_present: Some(false),
+            latest_runs_after_turn: Some(true),
+            latest_attempts_context_compaction: Some(true),
+            session_state: TurnCheckpointSessionState::FinalizationFailed,
+            checkpoint_durable: true,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let diagnostics = test_turn_checkpoint_diagnostics(summary, None);
+        let formatted = format_turn_checkpoint_summary("session-checkpoint", 128, &diagnostics);
+
+        assert!(formatted.contains("turn_checkpoint_summary session=session-checkpoint limit=128"));
+        assert!(formatted.contains("state=finalization_failed"));
+        assert!(formatted.contains("durable=1"));
+        assert!(formatted.contains("requires_recovery=1"));
+        assert!(formatted.contains("stage=finalization_failed"));
+        assert!(formatted.contains("after_turn=completed"));
+        assert!(formatted.contains("compaction=failed"));
+        assert!(formatted.contains("lane=safe"));
+        assert!(formatted.contains("result_kind=tool_call"));
+        assert!(formatted.contains("persistence_mode=error"));
+        assert!(formatted.contains("safe_lane_route_decision=terminal"));
+        assert!(formatted.contains("safe_lane_route_reason=session_governor_no_replan"));
+        assert!(formatted.contains("safe_lane_route_source=session_governor"));
+        assert!(formatted.contains("identity=missing"));
+        assert!(formatted.contains("failure_step=compaction"));
+        assert!(formatted.contains("failure_error=context compaction failed"));
+        assert!(formatted.contains("recovery_action=inspect_manually"));
+        assert!(formatted.contains("recovery_source=summary"));
+        assert!(formatted.contains("recovery_reason=checkpoint_identity_missing"));
+    }
+
+    #[test]
+    fn format_turn_checkpoint_summary_marks_checkpoint_only_durability_for_return_error_sessions() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            finalized_events: 1,
+            latest_stage: Some(TurnCheckpointStage::Finalized),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_lane: None,
+            latest_result_kind: None,
+            latest_persistence_mode: None,
+            latest_identity_present: Some(false),
+            latest_runs_after_turn: Some(false),
+            latest_attempts_context_compaction: Some(false),
+            session_state: TurnCheckpointSessionState::Finalized,
+            checkpoint_durable: true,
+            requires_recovery: false,
+            reply_durable: false,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let diagnostics = test_turn_checkpoint_diagnostics(summary, None);
+        let formatted = format_turn_checkpoint_summary("session-checkpoint", 64, &diagnostics);
+
+        assert!(formatted.contains("durable=0"));
+        assert!(formatted.contains("checkpoint_durable=1"));
+        assert!(formatted.contains("durability=checkpoint_only"));
+        assert!(formatted.contains("state=finalized"));
+    }
+
+    #[test]
+    fn format_turn_checkpoint_summary_uses_typed_checkpoint_durability() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            latest_stage: Some(TurnCheckpointStage::Finalized),
+            session_state: TurnCheckpointSessionState::Finalized,
+            checkpoint_durable: false,
+            reply_durable: false,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let diagnostics = test_turn_checkpoint_diagnostics(summary, None);
+        let formatted = format_turn_checkpoint_summary("session-checkpoint", 32, &diagnostics);
+
+        assert!(formatted.contains("state=finalized"));
+        assert!(formatted.contains("checkpoint_durable=0"));
+        assert!(formatted.contains("durability=not_durable"));
+    }
+
+    #[test]
+    fn format_turn_checkpoint_startup_health_reports_recovery_action() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            post_persist_events: 1,
+            latest_stage: Some(TurnCheckpointStage::PostPersist),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Pending),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Pending),
+            latest_lane: Some("safe".to_owned()),
+            latest_result_kind: Some("tool_error".to_owned()),
+            latest_persistence_mode: Some("success".to_owned()),
+            latest_safe_lane_terminal_route: Some(
+                crate::conversation::SafeLaneTerminalRouteSnapshot {
+                    decision: crate::conversation::SafeLaneFailureRouteDecision::Terminal,
+                    reason: crate::conversation::SafeLaneFailureRouteReason::BackpressureAttemptsExhausted,
+                    source: crate::conversation::SafeLaneFailureRouteSource::BackpressureGuard,
+                },
+            ),
+            latest_identity_present: Some(true),
+            latest_runs_after_turn: Some(true),
+            latest_attempts_context_compaction: Some(true),
+            session_state: TurnCheckpointSessionState::PendingFinalization,
+            checkpoint_durable: true,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let diagnostics = test_turn_checkpoint_diagnostics(summary, None);
+        let formatted =
+            format_turn_checkpoint_startup_health("session-health", &diagnostics).expect("health");
+
+        assert!(formatted.contains("turn_checkpoint_health session=session-health"));
+        assert!(formatted.contains("state=pending_finalization"));
+        assert!(formatted.contains("recovery_needed=1"));
+        assert!(formatted.contains("action=run_after_turn_and_compaction"));
+        assert!(formatted.contains("source=summary"));
+        assert!(formatted.contains("reason=-"));
+        assert!(formatted.contains("lane=safe"));
+        assert!(formatted.contains("result_kind=tool_error"));
+        assert!(formatted.contains("safe_lane_route_decision=terminal"));
+        assert!(formatted.contains("safe_lane_route_reason=backpressure_attempts_exhausted"));
+        assert!(formatted.contains("safe_lane_route_source=backpressure_guard"));
+        assert!(formatted.contains("identity=present"));
+    }
+
+    #[test]
+    fn format_turn_checkpoint_startup_health_reports_route_aware_manual_reason() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            post_persist_events: 1,
+            latest_stage: Some(TurnCheckpointStage::PostPersist),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_lane: Some("safe".to_owned()),
+            latest_result_kind: Some("tool_error".to_owned()),
+            latest_persistence_mode: Some("success".to_owned()),
+            latest_safe_lane_terminal_route: Some(
+                crate::conversation::SafeLaneTerminalRouteSnapshot {
+                    decision: crate::conversation::SafeLaneFailureRouteDecision::Terminal,
+                    reason:
+                        crate::conversation::SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+                    source: crate::conversation::SafeLaneFailureRouteSource::SessionGovernor,
+                },
+            ),
+            latest_identity_present: Some(true),
+            latest_runs_after_turn: Some(false),
+            latest_attempts_context_compaction: Some(false),
+            session_state: TurnCheckpointSessionState::PendingFinalization,
+            checkpoint_durable: true,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let diagnostics = test_turn_checkpoint_diagnostics(summary, None);
+        let formatted =
+            format_turn_checkpoint_startup_health("session-health", &diagnostics).expect("health");
+
+        assert!(formatted.contains("turn_checkpoint_health session=session-health"));
+        assert!(formatted.contains("action=inspect_manually"));
+        assert!(formatted.contains("source=summary"));
+        assert!(
+            formatted
+                .contains("reason=safe_lane_session_governor_terminal_requires_manual_inspection")
+        );
+        assert!(formatted.contains("safe_lane_route_reason=session_governor_no_replan"));
+        assert!(formatted.contains("safe_lane_route_source=session_governor"));
+    }
+
+    #[test]
+    fn format_turn_checkpoint_startup_health_marks_checkpoint_only_durability() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            finalized_events: 1,
+            latest_stage: Some(TurnCheckpointStage::Finalized),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_identity_present: Some(false),
+            latest_runs_after_turn: Some(false),
+            latest_attempts_context_compaction: Some(false),
+            session_state: TurnCheckpointSessionState::Finalized,
+            checkpoint_durable: true,
+            requires_recovery: false,
+            reply_durable: false,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let diagnostics = test_turn_checkpoint_diagnostics(summary, None);
+        let formatted =
+            format_turn_checkpoint_startup_health("session-health", &diagnostics).expect("health");
+
+        assert!(formatted.contains("reply_durable=0"));
+        assert!(formatted.contains("checkpoint_durable=1"));
+        assert!(formatted.contains("durability=checkpoint_only"));
+    }
+
+    #[test]
+    fn format_turn_checkpoint_startup_health_uses_typed_checkpoint_durability_gate() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            latest_stage: Some(TurnCheckpointStage::Finalized),
+            session_state: TurnCheckpointSessionState::Finalized,
+            checkpoint_durable: false,
+            reply_durable: false,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let diagnostics = test_turn_checkpoint_diagnostics(summary, None);
+
+        assert!(format_turn_checkpoint_startup_health("session-health", &diagnostics).is_none());
+    }
+
+    #[test]
+    fn format_turn_checkpoint_startup_health_skips_non_durable_sessions() {
+        let diagnostics =
+            test_turn_checkpoint_diagnostics(TurnCheckpointEventSummary::default(), None);
+        assert!(format_turn_checkpoint_startup_health("session-empty", &diagnostics).is_none());
+    }
+
+    #[test]
+    fn format_turn_checkpoint_runtime_probe_reports_runtime_only_manual_reason() {
+        let probe = TurnCheckpointTailRepairRuntimeProbe::new(
+            TurnCheckpointRecoveryAction::InspectManually,
+            crate::conversation::TurnCheckpointTailRepairSource::Runtime,
+            crate::conversation::TurnCheckpointTailRepairReason::CheckpointPreparationFingerprintMismatch,
+        );
+
+        let formatted = format_turn_checkpoint_runtime_probe("session-probe", &probe);
+
+        assert!(formatted.contains("turn_checkpoint_probe session=session-probe"));
+        assert!(formatted.contains("action=inspect_manually"));
+        assert!(formatted.contains("source=runtime"));
+        assert!(formatted.contains("reason=checkpoint_preparation_fingerprint_mismatch"));
+    }
+
+    #[test]
+    fn format_turn_checkpoint_summary_output_appends_runtime_probe_line() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            post_persist_events: 1,
+            latest_stage: Some(TurnCheckpointStage::FinalizationFailed),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Completed),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Failed),
+            latest_lane: Some("fast".to_owned()),
+            latest_result_kind: Some("final_text".to_owned()),
+            latest_persistence_mode: Some("success".to_owned()),
+            latest_identity_present: Some(true),
+            latest_runs_after_turn: Some(true),
+            latest_attempts_context_compaction: Some(true),
+            session_state: TurnCheckpointSessionState::FinalizationFailed,
+            checkpoint_durable: true,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+        let probe = TurnCheckpointTailRepairRuntimeProbe::new(
+            TurnCheckpointRecoveryAction::InspectManually,
+            crate::conversation::TurnCheckpointTailRepairSource::Runtime,
+            crate::conversation::TurnCheckpointTailRepairReason::CheckpointPreparationFingerprintMismatch,
+        );
+
+        let diagnostics = test_turn_checkpoint_diagnostics(summary, Some(probe));
+        let formatted = format_turn_checkpoint_summary_output("session-summary", 64, &diagnostics);
+
+        assert!(formatted.contains("turn_checkpoint_summary session=session-summary limit=64"));
+        assert!(formatted.contains("turn_checkpoint_probe session=session-summary"));
+        assert!(formatted.contains("source=runtime"));
+        assert!(formatted.contains("reason=checkpoint_preparation_fingerprint_mismatch"));
+    }
+
+    #[test]
+    fn format_turn_checkpoint_repair_reports_summary_source() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            latest_stage: Some(TurnCheckpointStage::PostPersist),
+            session_state: TurnCheckpointSessionState::PendingFinalization,
+            checkpoint_durable: true,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+        let outcome = crate::conversation::TurnCheckpointTailRepairOutcome::from_summary(
+            crate::conversation::TurnCheckpointTailRepairStatus::ManualRequired,
+            TurnCheckpointRecoveryAction::InspectManually,
+            Some(crate::conversation::TurnCheckpointTailRepairSource::Summary),
+            crate::conversation::TurnCheckpointTailRepairReason::CheckpointIdentityMissing,
+            &summary,
+        );
+
+        let formatted = format_turn_checkpoint_repair("session-repair", &outcome);
+
+        assert!(formatted.contains("turn_checkpoint_repair session=session-repair"));
+        assert!(formatted.contains("status=manual_required"));
+        assert!(formatted.contains("source=summary"));
+        assert!(formatted.contains("reason=checkpoint_identity_missing"));
+    }
+
+    #[test]
+    fn format_turn_checkpoint_summary_output_omits_runtime_probe_line_without_probe() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            post_persist_events: 1,
+            latest_stage: Some(TurnCheckpointStage::PostPersist),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Pending),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Pending),
+            latest_lane: Some("fast".to_owned()),
+            latest_result_kind: Some("final_text".to_owned()),
+            latest_persistence_mode: Some("success".to_owned()),
+            latest_identity_present: Some(true),
+            latest_runs_after_turn: Some(true),
+            latest_attempts_context_compaction: Some(true),
+            session_state: TurnCheckpointSessionState::PendingFinalization,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let diagnostics = test_turn_checkpoint_diagnostics(summary, None);
+        let formatted = format_turn_checkpoint_summary_output("session-summary", 64, &diagnostics);
+
+        assert!(formatted.contains("turn_checkpoint_summary session=session-summary limit=64"));
+        assert!(!formatted.contains("turn_checkpoint_probe"));
+        assert!(!formatted.ends_with('\n'));
     }
 
     #[test]
@@ -908,5 +1769,19 @@ mod tests {
         assert!(formatted.contains("truncation_pressure(0.250)"));
         assert!(!formatted.contains("verify_failure_pressure"));
         assert!(!formatted.contains("replan_pressure"));
+    }
+
+    #[test]
+    fn format_safe_lane_summary_does_not_mark_unknown_failure_code_substrings_as_instability() {
+        let config = ConversationConfig::default();
+        let summary = SafeLaneEventSummary {
+            final_status: Some(SafeLaneFinalStatus::Failed),
+            final_failure_code: Some("unknown_session_governor_hint".to_owned()),
+            ..SafeLaneEventSummary::default()
+        };
+
+        let formatted = format_safe_lane_summary("session-unknown-code", 16, &config, &summary);
+        assert!(formatted.contains("health severity=ok"));
+        assert!(!formatted.contains("terminal_instability"));
     }
 }

--- a/crates/app/src/conversation/analytics.rs
+++ b/crates/app/src/conversation/analytics.rs
@@ -3,11 +3,27 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use super::safe_lane_failure::{
+    SafeLaneFailureCode, SafeLaneFailureRouteDecision, SafeLaneFailureRouteSource,
+    SafeLaneTerminalRouteSnapshot, is_safe_lane_backpressure_failure_code,
+    is_safe_lane_backpressure_route_reason,
+};
+use super::turn_budget::SafeLaneFailureRouteReason;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SafeLaneFinalStatus {
     Succeeded,
     Failed,
+}
+
+impl SafeLaneFinalStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -83,6 +99,293 @@ pub struct SafeLaneEventSummary {
     pub final_status_counts: BTreeMap<String, u32>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct SafeLaneHistoryProjection {
+    pub(crate) summary: SafeLaneEventSummary,
+    pub(crate) final_status_failed_samples: Vec<bool>,
+    pub(crate) backpressure_failure_samples: Vec<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SafeLaneFinalStatusSample {
+    failed: bool,
+    backpressure: bool,
+}
+
+impl SafeLaneEventSummary {
+    pub fn typed_final_failure_code(&self) -> Option<SafeLaneFailureCode> {
+        self.final_failure_code
+            .as_deref()
+            .and_then(SafeLaneFailureCode::parse)
+    }
+
+    pub fn typed_final_route_reason(&self) -> Option<SafeLaneFailureRouteReason> {
+        self.final_route_reason
+            .as_deref()
+            .and_then(SafeLaneFailureRouteReason::parse)
+    }
+
+    pub fn final_status_events_for(&self, status: SafeLaneFinalStatus) -> u32 {
+        self.final_status_counts
+            .get(status.as_str())
+            .copied()
+            .unwrap_or_default()
+    }
+
+    pub fn failed_final_status_events(&self) -> u32 {
+        self.final_status_events_for(SafeLaneFinalStatus::Failed)
+    }
+
+    pub fn backpressure_failure_events(&self) -> u32 {
+        self.failure_code_counts
+            .iter()
+            .filter_map(|(failure_code, count)| {
+                SafeLaneFailureCode::parse(failure_code)
+                    .filter(|code| code.is_backpressure())
+                    .map(|_| *count)
+            })
+            .sum()
+    }
+
+    pub fn backpressure_route_reason_events(&self) -> u32 {
+        self.route_reason_counts
+            .iter()
+            .filter_map(|(route_reason, count)| {
+                SafeLaneFailureRouteReason::parse(route_reason)
+                    .filter(|reason| reason.is_backpressure())
+                    .map(|_| *count)
+            })
+            .sum()
+    }
+
+    pub fn has_terminal_instability_final_failure(&self) -> bool {
+        matches!(self.final_status, Some(SafeLaneFinalStatus::Failed))
+            && self
+                .typed_final_failure_code()
+                .map(SafeLaneFailureCode::is_terminal_instability)
+                .unwrap_or(false)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnCheckpointStage {
+    PostPersist,
+    Finalized,
+    FinalizationFailed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnCheckpointProgressStatus {
+    Pending,
+    Skipped,
+    Completed,
+    Failed,
+    FailedOpen,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnCheckpointFailureStep {
+    AfterTurn,
+    Compaction,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnCheckpointSessionState {
+    #[default]
+    NotDurable,
+    PendingFinalization,
+    Finalized,
+    FinalizationFailed,
+}
+
+impl TurnCheckpointSessionState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NotDurable => "not_durable",
+            Self::PendingFinalization => "pending_finalization",
+            Self::Finalized => "finalized",
+            Self::FinalizationFailed => "finalization_failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnCheckpointRecoveryAction {
+    #[default]
+    None,
+    RunAfterTurn,
+    RunCompaction,
+    RunAfterTurnAndCompaction,
+    InspectManually,
+}
+
+impl TurnCheckpointRecoveryAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::RunAfterTurn => "run_after_turn",
+            Self::RunCompaction => "run_compaction",
+            Self::RunAfterTurnAndCompaction => "run_after_turn_and_compaction",
+            Self::InspectManually => "inspect_manually",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnCheckpointRepairManualReason {
+    CheckpointIdentityMissing,
+    SafeLaneBackpressureTerminalRequiresManualInspection,
+    SafeLaneSessionGovernorTerminalRequiresManualInspection,
+    CheckpointStateRequiresManualInspection,
+}
+
+impl TurnCheckpointRepairManualReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CheckpointIdentityMissing => "checkpoint_identity_missing",
+            Self::SafeLaneBackpressureTerminalRequiresManualInspection => {
+                "safe_lane_backpressure_terminal_requires_manual_inspection"
+            }
+            Self::SafeLaneSessionGovernorTerminalRequiresManualInspection => {
+                "safe_lane_session_governor_terminal_requires_manual_inspection"
+            }
+            Self::CheckpointStateRequiresManualInspection => {
+                "checkpoint_state_requires_manual_inspection"
+            }
+        }
+    }
+
+    pub fn from_safe_lane_terminal_route(route: SafeLaneTerminalRouteSnapshot) -> Option<Self> {
+        if route.is_backpressure_override_terminal() {
+            return Some(Self::SafeLaneBackpressureTerminalRequiresManualInspection);
+        }
+        if route.is_session_governor_override_terminal() {
+            return Some(Self::SafeLaneSessionGovernorTerminalRequiresManualInspection);
+        }
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TurnCheckpointRepairPlan {
+    action: TurnCheckpointRecoveryAction,
+    manual_reason: Option<TurnCheckpointRepairManualReason>,
+    after_turn_status: TurnCheckpointProgressStatus,
+    compaction_status: TurnCheckpointProgressStatus,
+}
+
+impl TurnCheckpointRepairPlan {
+    fn new(
+        action: TurnCheckpointRecoveryAction,
+        manual_reason: Option<TurnCheckpointRepairManualReason>,
+        after_turn_status: TurnCheckpointProgressStatus,
+        compaction_status: TurnCheckpointProgressStatus,
+    ) -> Self {
+        Self {
+            action,
+            manual_reason,
+            after_turn_status,
+            compaction_status,
+        }
+    }
+
+    pub fn action(self) -> TurnCheckpointRecoveryAction {
+        self.action
+    }
+
+    pub fn manual_reason(self) -> Option<TurnCheckpointRepairManualReason> {
+        self.manual_reason
+    }
+
+    pub fn should_run_after_turn(self) -> bool {
+        matches!(
+            self.action,
+            TurnCheckpointRecoveryAction::RunAfterTurn
+                | TurnCheckpointRecoveryAction::RunAfterTurnAndCompaction
+        )
+    }
+
+    pub fn should_run_compaction(self) -> bool {
+        matches!(
+            self.action,
+            TurnCheckpointRecoveryAction::RunCompaction
+                | TurnCheckpointRecoveryAction::RunAfterTurnAndCompaction
+        )
+    }
+
+    pub fn after_turn_status(self) -> TurnCheckpointProgressStatus {
+        self.after_turn_status
+    }
+
+    pub fn compaction_status(self) -> TurnCheckpointProgressStatus {
+        self.compaction_status
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnCheckpointEventSummary {
+    pub checkpoint_events: u32,
+    pub post_persist_events: u32,
+    pub finalized_events: u32,
+    pub finalization_failed_events: u32,
+    pub latest_schema_version: Option<u32>,
+    pub latest_stage: Option<TurnCheckpointStage>,
+    pub latest_after_turn: Option<TurnCheckpointProgressStatus>,
+    pub latest_compaction: Option<TurnCheckpointProgressStatus>,
+    pub latest_failure_step: Option<TurnCheckpointFailureStep>,
+    pub latest_failure_error: Option<String>,
+    pub latest_lane: Option<String>,
+    pub latest_result_kind: Option<String>,
+    pub latest_persistence_mode: Option<String>,
+    pub latest_safe_lane_terminal_route: Option<SafeLaneTerminalRouteSnapshot>,
+    pub latest_identity_present: Option<bool>,
+    pub latest_runs_after_turn: Option<bool>,
+    pub latest_attempts_context_compaction: Option<bool>,
+    pub stage_counts: BTreeMap<String, u32>,
+    pub session_state: TurnCheckpointSessionState,
+    pub checkpoint_durable: bool,
+    pub requires_recovery: bool,
+    pub reply_durable: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct TurnCheckpointHistoryProjection {
+    pub(crate) summary: TurnCheckpointEventSummary,
+    pub(crate) latest_checkpoint: Option<Value>,
+}
+
+impl TurnCheckpointEventSummary {
+    pub fn latest_safe_lane_route_decision_label(&self) -> Option<&'static str> {
+        self.latest_safe_lane_terminal_route
+            .map(SafeLaneTerminalRouteSnapshot::decision_label)
+    }
+
+    pub fn latest_safe_lane_route_reason_label(&self) -> Option<&'static str> {
+        self.latest_safe_lane_terminal_route
+            .map(SafeLaneTerminalRouteSnapshot::reason_label)
+    }
+
+    pub fn latest_safe_lane_route_source_label(&self) -> Option<&'static str> {
+        self.latest_safe_lane_terminal_route
+            .map(SafeLaneTerminalRouteSnapshot::source_label)
+    }
+
+    pub fn latest_safe_lane_route_labels_or_default(
+        &self,
+    ) -> (&'static str, &'static str, &'static str) {
+        (
+            self.latest_safe_lane_route_decision_label().unwrap_or("-"),
+            self.latest_safe_lane_route_reason_label().unwrap_or("-"),
+            self.latest_safe_lane_route_source_label().unwrap_or("-"),
+        )
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConversationEventRecord {
     pub event: String,
@@ -99,180 +402,496 @@ pub fn parse_conversation_event(content: &str) -> Option<ConversationEventRecord
     Some(ConversationEventRecord { event, payload })
 }
 
-pub fn summarize_safe_lane_events<'a, I>(contents: I) -> SafeLaneEventSummary
+pub(crate) fn summarize_safe_lane_history<'a, I>(contents: I) -> SafeLaneHistoryProjection
 where
     I: IntoIterator<Item = &'a str>,
 {
-    let mut summary = SafeLaneEventSummary::default();
+    let mut projection = SafeLaneHistoryProjection::default();
 
     for content in contents {
         let Some(record) = parse_conversation_event(content) else {
             continue;
         };
-        if !is_safe_lane_event_name(record.event.as_str()) {
-            continue;
-        }
-
-        let event_name = record.event.as_str();
-        let final_status_is_failed = event_name == "final_status"
-            && record
-                .payload
-                .get("status")
-                .and_then(Value::as_str)
-                .map(|status| status == "failed")
-                .unwrap_or(false);
-
-        match event_name {
-            "lane_selected" => {
-                summary.lane_selected_events = summary.lane_selected_events.saturating_add(1);
-            }
-            "plan_round_started" => {
-                summary.round_started_events = summary.round_started_events.saturating_add(1);
-            }
-            "plan_round_completed" => {
-                let is_succeeded = record
-                    .payload
-                    .get("status")
-                    .and_then(Value::as_str)
-                    .map(|status| status == "succeeded")
-                    .unwrap_or(false);
-                if is_succeeded {
-                    summary.round_completed_succeeded_events =
-                        summary.round_completed_succeeded_events.saturating_add(1);
-                } else {
-                    summary.round_completed_failed_events =
-                        summary.round_completed_failed_events.saturating_add(1);
-                }
-            }
-            "verify_failed" => {
-                summary.verify_failed_events = summary.verify_failed_events.saturating_add(1);
-            }
-            "verify_policy_adjusted" => {
-                summary.verify_policy_adjusted_events =
-                    summary.verify_policy_adjusted_events.saturating_add(1);
-            }
-            "replan_triggered" => {
-                summary.replan_triggered_events = summary.replan_triggered_events.saturating_add(1);
-            }
-            "final_status" => {
-                summary.final_status_events = summary.final_status_events.saturating_add(1);
-                match record.payload.get("status").and_then(Value::as_str) {
-                    Some("succeeded") => {
-                        summary.final_status = Some(SafeLaneFinalStatus::Succeeded);
-                        bump_count(&mut summary.final_status_counts, "succeeded");
-                    }
-                    Some("failed") => {
-                        summary.final_status = Some(SafeLaneFinalStatus::Failed);
-                        bump_count(&mut summary.final_status_counts, "failed");
-                    }
-                    _ => {}
-                }
-                summary.final_failure_code = record
-                    .payload
-                    .get("failure_code")
-                    .and_then(Value::as_str)
-                    .map(ToOwned::to_owned);
-                summary.final_route_decision = record
-                    .payload
-                    .get("route_decision")
-                    .and_then(Value::as_str)
-                    .map(ToOwned::to_owned);
-                summary.final_route_reason = record
-                    .payload
-                    .get("route_reason")
-                    .and_then(Value::as_str)
-                    .map(ToOwned::to_owned);
-            }
-            _ => {}
-        }
-
-        if let Some(route_decision) = record
-            .payload
-            .get("route_decision")
-            .and_then(Value::as_str)
-            .filter(|value| !value.trim().is_empty())
-        {
-            bump_count(&mut summary.route_decision_counts, route_decision);
-        }
-        if let Some(failure_code) = record
-            .payload
-            .get("failure_code")
-            .and_then(Value::as_str)
-            .filter(|value| !value.trim().is_empty())
-        {
-            bump_count(&mut summary.failure_code_counts, failure_code);
-        }
-        if let Some(route_reason) = record
-            .payload
-            .get("route_reason")
-            .and_then(Value::as_str)
-            .filter(|value| !value.trim().is_empty())
-        {
-            bump_count(&mut summary.route_reason_counts, route_reason);
-        }
-        fold_session_governor_summary(record.payload.get("session_governor"), &mut summary);
-
-        if let Some(metrics) = parse_metrics_snapshot(record.payload.get("metrics")) {
-            summary.metrics_snapshots_seen = summary.metrics_snapshots_seen.saturating_add(1);
-            summary.latest_metrics = Some(metrics);
-        }
-        if let Some(tool_output) =
-            parse_tool_output_snapshot(record.payload.get("tool_output_stats"))
-        {
-            summary.tool_output_snapshots_seen =
-                summary.tool_output_snapshots_seen.saturating_add(1);
-            if tool_output.any_truncated || tool_output.truncated_result_lines > 0 {
-                summary.tool_output_truncated_events =
-                    summary.tool_output_truncated_events.saturating_add(1);
-                if event_name == "verify_failed" {
-                    summary.tool_output_truncation_verify_failed_events = summary
-                        .tool_output_truncation_verify_failed_events
-                        .saturating_add(1);
-                }
-                if event_name == "replan_triggered" {
-                    summary.tool_output_truncation_replan_events = summary
-                        .tool_output_truncation_replan_events
-                        .saturating_add(1);
-                }
-                if final_status_is_failed {
-                    summary.tool_output_truncation_final_failure_events = summary
-                        .tool_output_truncation_final_failure_events
-                        .saturating_add(1);
-                }
-            }
-            summary.tool_output_result_lines_total = summary
-                .tool_output_result_lines_total
-                .saturating_add(tool_output.result_lines as u64);
-            summary.tool_output_truncated_result_lines_total = summary
-                .tool_output_truncated_result_lines_total
-                .saturating_add(tool_output.truncated_result_lines as u64);
-            summary.tool_output_aggregate_truncation_ratio_milli = compute_truncation_ratio_milli(
-                summary.tool_output_truncated_result_lines_total,
-                summary.tool_output_result_lines_total,
-            );
-            summary.latest_tool_output = Some(tool_output);
-        }
-        if let Some(health_signal) =
-            parse_health_signal_snapshot(record.payload.get("health_signal"))
-        {
-            summary.health_signal_snapshots_seen =
-                summary.health_signal_snapshots_seen.saturating_add(1);
-            match health_signal.severity.as_str() {
-                "warn" => {
-                    summary.health_signal_warn_events =
-                        summary.health_signal_warn_events.saturating_add(1);
-                }
-                "critical" => {
-                    summary.health_signal_critical_events =
-                        summary.health_signal_critical_events.saturating_add(1);
-                }
-                _ => {}
-            }
-            summary.latest_health_signal = Some(health_signal);
+        if let Some(sample) = fold_safe_lane_event_record(&record, &mut projection.summary) {
+            projection.final_status_failed_samples.push(sample.failed);
+            projection
+                .backpressure_failure_samples
+                .push(sample.backpressure);
         }
     }
 
-    summary
+    projection
+}
+
+pub fn summarize_safe_lane_events<'a, I>(contents: I) -> SafeLaneEventSummary
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    summarize_safe_lane_history(contents).summary
+}
+
+fn fold_safe_lane_event_record(
+    record: &ConversationEventRecord,
+    summary: &mut SafeLaneEventSummary,
+) -> Option<SafeLaneFinalStatusSample> {
+    if !is_safe_lane_event_name(record.event.as_str()) {
+        return None;
+    }
+
+    let event_name = record.event.as_str();
+    let final_status_sample = if event_name == "final_status" {
+        match record.payload.get("status").and_then(Value::as_str) {
+            Some("failed") => Some(SafeLaneFinalStatusSample {
+                failed: true,
+                backpressure: is_backpressure_safe_lane_final_status_payload(&record.payload),
+            }),
+            Some("succeeded") => Some(SafeLaneFinalStatusSample {
+                failed: false,
+                backpressure: false,
+            }),
+            _ => None,
+        }
+    } else {
+        None
+    };
+    let final_status_is_failed = final_status_sample
+        .map(|sample| sample.failed)
+        .unwrap_or(false);
+
+    match event_name {
+        "lane_selected" => {
+            summary.lane_selected_events = summary.lane_selected_events.saturating_add(1);
+        }
+        "plan_round_started" => {
+            summary.round_started_events = summary.round_started_events.saturating_add(1);
+        }
+        "plan_round_completed" => {
+            let is_succeeded = record
+                .payload
+                .get("status")
+                .and_then(Value::as_str)
+                .map(|status| status == "succeeded")
+                .unwrap_or(false);
+            if is_succeeded {
+                summary.round_completed_succeeded_events =
+                    summary.round_completed_succeeded_events.saturating_add(1);
+            } else {
+                summary.round_completed_failed_events =
+                    summary.round_completed_failed_events.saturating_add(1);
+            }
+        }
+        "verify_failed" => {
+            summary.verify_failed_events = summary.verify_failed_events.saturating_add(1);
+        }
+        "verify_policy_adjusted" => {
+            summary.verify_policy_adjusted_events =
+                summary.verify_policy_adjusted_events.saturating_add(1);
+        }
+        "replan_triggered" => {
+            summary.replan_triggered_events = summary.replan_triggered_events.saturating_add(1);
+        }
+        "final_status" => {
+            summary.final_status_events = summary.final_status_events.saturating_add(1);
+            match record.payload.get("status").and_then(Value::as_str) {
+                Some("succeeded") => {
+                    summary.final_status = Some(SafeLaneFinalStatus::Succeeded);
+                    bump_count(
+                        &mut summary.final_status_counts,
+                        SafeLaneFinalStatus::Succeeded.as_str(),
+                    );
+                }
+                Some("failed") => {
+                    summary.final_status = Some(SafeLaneFinalStatus::Failed);
+                    bump_count(
+                        &mut summary.final_status_counts,
+                        SafeLaneFinalStatus::Failed.as_str(),
+                    );
+                }
+                _ => {}
+            }
+            summary.final_failure_code = record
+                .payload
+                .get("failure_code")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            summary.final_route_decision = record
+                .payload
+                .get("route_decision")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            summary.final_route_reason = record
+                .payload
+                .get("route_reason")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+        }
+        _ => {}
+    }
+
+    if let Some(route_decision) = record
+        .payload
+        .get("route_decision")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        bump_count(&mut summary.route_decision_counts, route_decision);
+    }
+    if let Some(failure_code) = record
+        .payload
+        .get("failure_code")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        bump_count(&mut summary.failure_code_counts, failure_code);
+    }
+    if let Some(route_reason) = record
+        .payload
+        .get("route_reason")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        bump_count(&mut summary.route_reason_counts, route_reason);
+    }
+    fold_session_governor_summary(record.payload.get("session_governor"), summary);
+
+    if let Some(metrics) = parse_metrics_snapshot(record.payload.get("metrics")) {
+        summary.metrics_snapshots_seen = summary.metrics_snapshots_seen.saturating_add(1);
+        summary.latest_metrics = Some(metrics);
+    }
+    if let Some(tool_output) = parse_tool_output_snapshot(record.payload.get("tool_output_stats")) {
+        summary.tool_output_snapshots_seen = summary.tool_output_snapshots_seen.saturating_add(1);
+        if tool_output.any_truncated || tool_output.truncated_result_lines > 0 {
+            summary.tool_output_truncated_events =
+                summary.tool_output_truncated_events.saturating_add(1);
+            if event_name == "verify_failed" {
+                summary.tool_output_truncation_verify_failed_events = summary
+                    .tool_output_truncation_verify_failed_events
+                    .saturating_add(1);
+            }
+            if event_name == "replan_triggered" {
+                summary.tool_output_truncation_replan_events = summary
+                    .tool_output_truncation_replan_events
+                    .saturating_add(1);
+            }
+            if final_status_is_failed {
+                summary.tool_output_truncation_final_failure_events = summary
+                    .tool_output_truncation_final_failure_events
+                    .saturating_add(1);
+            }
+        }
+        summary.tool_output_result_lines_total = summary
+            .tool_output_result_lines_total
+            .saturating_add(tool_output.result_lines as u64);
+        summary.tool_output_truncated_result_lines_total = summary
+            .tool_output_truncated_result_lines_total
+            .saturating_add(tool_output.truncated_result_lines as u64);
+        summary.tool_output_aggregate_truncation_ratio_milli = compute_truncation_ratio_milli(
+            summary.tool_output_truncated_result_lines_total,
+            summary.tool_output_result_lines_total,
+        );
+        summary.latest_tool_output = Some(tool_output);
+    }
+    if let Some(health_signal) = parse_health_signal_snapshot(record.payload.get("health_signal")) {
+        summary.health_signal_snapshots_seen =
+            summary.health_signal_snapshots_seen.saturating_add(1);
+        match health_signal.severity.as_str() {
+            "warn" => {
+                summary.health_signal_warn_events =
+                    summary.health_signal_warn_events.saturating_add(1);
+            }
+            "critical" => {
+                summary.health_signal_critical_events =
+                    summary.health_signal_critical_events.saturating_add(1);
+            }
+            _ => {}
+        }
+        summary.latest_health_signal = Some(health_signal);
+    }
+
+    final_status_sample
+}
+
+pub(crate) fn summarize_turn_checkpoint_history<'a, I>(
+    contents: I,
+) -> TurnCheckpointHistoryProjection
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut projection = TurnCheckpointHistoryProjection::default();
+
+    for content in contents {
+        let Some(record) = parse_conversation_event(content) else {
+            continue;
+        };
+        if let Some(checkpoint) = fold_turn_checkpoint_event_record(record, &mut projection.summary)
+        {
+            projection.latest_checkpoint = Some(checkpoint);
+        }
+    }
+
+    projection.summary.session_state = classify_turn_checkpoint_session_state(
+        projection.summary.checkpoint_events,
+        projection.summary.latest_stage,
+    );
+    projection.summary.checkpoint_durable = projection.summary.checkpoint_events > 0;
+    projection.summary.reply_durable = projection.summary.latest_persistence_mode.is_some();
+    projection.summary.requires_recovery = matches!(
+        projection.summary.session_state,
+        TurnCheckpointSessionState::PendingFinalization
+            | TurnCheckpointSessionState::FinalizationFailed
+    );
+    projection
+}
+
+pub fn summarize_turn_checkpoint_events<'a, I>(contents: I) -> TurnCheckpointEventSummary
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    summarize_turn_checkpoint_history(contents).summary
+}
+
+fn fold_turn_checkpoint_event_record(
+    record: ConversationEventRecord,
+    summary: &mut TurnCheckpointEventSummary,
+) -> Option<Value> {
+    if record.event != "turn_checkpoint" {
+        return None;
+    }
+
+    summary.checkpoint_events = summary.checkpoint_events.saturating_add(1);
+    summary.latest_schema_version = record
+        .payload
+        .get("schema_version")
+        .and_then(Value::as_u64)
+        .map(|value| value.min(u32::MAX as u64) as u32);
+
+    let stage = record
+        .payload
+        .get("stage")
+        .and_then(Value::as_str)
+        .and_then(parse_turn_checkpoint_stage);
+    if let Some(raw_stage) = record.payload.get("stage").and_then(Value::as_str) {
+        bump_count(&mut summary.stage_counts, raw_stage);
+    }
+    match stage {
+        Some(TurnCheckpointStage::PostPersist) => {
+            summary.post_persist_events = summary.post_persist_events.saturating_add(1);
+        }
+        Some(TurnCheckpointStage::Finalized) => {
+            summary.finalized_events = summary.finalized_events.saturating_add(1);
+        }
+        Some(TurnCheckpointStage::FinalizationFailed) => {
+            summary.finalization_failed_events =
+                summary.finalization_failed_events.saturating_add(1);
+        }
+        None => {}
+    }
+    summary.latest_stage = stage;
+    summary.latest_after_turn = record
+        .payload
+        .get("finalization_progress")
+        .and_then(|progress| progress.get("after_turn"))
+        .and_then(Value::as_str)
+        .and_then(parse_turn_checkpoint_progress_status);
+    summary.latest_compaction = record
+        .payload
+        .get("finalization_progress")
+        .and_then(|progress| progress.get("compaction"))
+        .and_then(Value::as_str)
+        .and_then(parse_turn_checkpoint_progress_status);
+    summary.latest_failure_step = record
+        .payload
+        .get("failure")
+        .and_then(|failure| failure.get("step"))
+        .and_then(Value::as_str)
+        .and_then(parse_turn_checkpoint_failure_step);
+    summary.latest_failure_error = record
+        .payload
+        .get("failure")
+        .and_then(|failure| failure.get("error"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    summary.latest_lane = record
+        .payload
+        .get("checkpoint")
+        .and_then(|checkpoint| checkpoint.get("lane"))
+        .and_then(|lane| lane.get("lane"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    summary.latest_result_kind = record
+        .payload
+        .get("checkpoint")
+        .and_then(|checkpoint| checkpoint.get("lane"))
+        .and_then(|lane| lane.get("result_kind"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    summary.latest_safe_lane_terminal_route = parse_safe_lane_terminal_route_snapshot(
+        record
+            .payload
+            .get("checkpoint")
+            .and_then(|checkpoint| checkpoint.get("lane"))
+            .and_then(|lane| lane.get("safe_lane_terminal_route")),
+    );
+    let finalization = record
+        .payload
+        .get("checkpoint")
+        .and_then(|checkpoint| checkpoint.get("finalization"));
+    summary.latest_persistence_mode = finalization
+        .and_then(|finalization| finalization.get("persistence_mode"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    summary.latest_identity_present = record
+        .payload
+        .get("checkpoint")
+        .map(|checkpoint| checkpoint.get("identity").is_some());
+    let legacy_persist_reply = summary.latest_persistence_mode.is_some();
+    summary.latest_runs_after_turn = finalization
+        .and_then(|finalization| finalization.get("runs_after_turn"))
+        .and_then(Value::as_bool)
+        .or_else(|| legacy_persist_reply.then_some(true));
+    summary.latest_attempts_context_compaction = finalization
+        .and_then(|finalization| finalization.get("attempts_context_compaction"))
+        .and_then(Value::as_bool)
+        .or_else(|| legacy_persist_reply.then_some(true));
+
+    record.payload.get("checkpoint").cloned()
+}
+
+pub fn build_turn_checkpoint_repair_plan(
+    summary: &TurnCheckpointEventSummary,
+) -> TurnCheckpointRepairPlan {
+    let runs_after_turn = summary.latest_runs_after_turn.unwrap_or(false);
+    let attempts_context_compaction = summary.latest_attempts_context_compaction.unwrap_or(false);
+    let after_turn_status =
+        restore_turn_checkpoint_progress_status(summary.latest_after_turn, runs_after_turn);
+    let compaction_status = restore_turn_checkpoint_progress_status(
+        summary.latest_compaction,
+        attempts_context_compaction,
+    );
+
+    if !summary.requires_recovery {
+        return TurnCheckpointRepairPlan::new(
+            TurnCheckpointRecoveryAction::None,
+            None,
+            after_turn_status,
+            compaction_status,
+        );
+    }
+    if summary.latest_identity_present != Some(true) {
+        return TurnCheckpointRepairPlan::new(
+            TurnCheckpointRecoveryAction::InspectManually,
+            Some(TurnCheckpointRepairManualReason::CheckpointIdentityMissing),
+            after_turn_status,
+            compaction_status,
+        );
+    }
+
+    let run_after_turn = runs_after_turn
+        && matches!(
+            after_turn_status,
+            TurnCheckpointProgressStatus::Pending
+                | TurnCheckpointProgressStatus::Failed
+                | TurnCheckpointProgressStatus::FailedOpen
+        );
+    let run_compaction = attempts_context_compaction
+        && match compaction_status {
+            TurnCheckpointProgressStatus::Pending
+            | TurnCheckpointProgressStatus::Failed
+            | TurnCheckpointProgressStatus::FailedOpen => true,
+            TurnCheckpointProgressStatus::Skipped => run_after_turn,
+            TurnCheckpointProgressStatus::Completed => false,
+        };
+
+    match (run_after_turn, run_compaction) {
+        (false, false) => TurnCheckpointRepairPlan::new(
+            TurnCheckpointRecoveryAction::InspectManually,
+            Some(
+                summary
+                    .latest_safe_lane_terminal_route
+                    .and_then(TurnCheckpointRepairManualReason::from_safe_lane_terminal_route)
+                    .unwrap_or(
+                        TurnCheckpointRepairManualReason::CheckpointStateRequiresManualInspection,
+                    ),
+            ),
+            after_turn_status,
+            compaction_status,
+        ),
+        (true, false) => TurnCheckpointRepairPlan::new(
+            TurnCheckpointRecoveryAction::RunAfterTurn,
+            None,
+            after_turn_status,
+            compaction_status,
+        ),
+        (false, true) => TurnCheckpointRepairPlan::new(
+            TurnCheckpointRecoveryAction::RunCompaction,
+            None,
+            after_turn_status,
+            compaction_status,
+        ),
+        (true, true) => TurnCheckpointRepairPlan::new(
+            TurnCheckpointRecoveryAction::RunAfterTurnAndCompaction,
+            None,
+            after_turn_status,
+            compaction_status,
+        ),
+    }
+}
+
+pub fn plan_turn_checkpoint_recovery(
+    summary: &TurnCheckpointEventSummary,
+) -> TurnCheckpointRecoveryAction {
+    build_turn_checkpoint_repair_plan(summary).action()
+}
+
+fn restore_turn_checkpoint_progress_status(
+    status: Option<TurnCheckpointProgressStatus>,
+    expected: bool,
+) -> TurnCheckpointProgressStatus {
+    match status {
+        Some(TurnCheckpointProgressStatus::Pending) => TurnCheckpointProgressStatus::Pending,
+        Some(TurnCheckpointProgressStatus::Skipped) => TurnCheckpointProgressStatus::Skipped,
+        Some(TurnCheckpointProgressStatus::Completed) => TurnCheckpointProgressStatus::Completed,
+        Some(TurnCheckpointProgressStatus::Failed) => TurnCheckpointProgressStatus::Failed,
+        Some(TurnCheckpointProgressStatus::FailedOpen) => TurnCheckpointProgressStatus::FailedOpen,
+        None if expected => TurnCheckpointProgressStatus::Pending,
+        None => TurnCheckpointProgressStatus::Skipped,
+    }
+}
+
+fn is_backpressure_safe_lane_final_status_payload(payload: &Value) -> bool {
+    if payload
+        .get("failure_code")
+        .and_then(Value::as_str)
+        .map(is_safe_lane_backpressure_failure_code)
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    payload
+        .get("route_reason")
+        .and_then(Value::as_str)
+        .map(is_safe_lane_backpressure_route_reason)
+        .unwrap_or(false)
+}
+
+fn parse_safe_lane_terminal_route_snapshot(
+    value: Option<&Value>,
+) -> Option<SafeLaneTerminalRouteSnapshot> {
+    let route = value?;
+    Some(SafeLaneTerminalRouteSnapshot {
+        decision: route
+            .get("decision")
+            .and_then(Value::as_str)
+            .and_then(SafeLaneFailureRouteDecision::parse)?,
+        reason: route
+            .get("reason")
+            .and_then(Value::as_str)
+            .and_then(SafeLaneFailureRouteReason::parse)?,
+        source: route
+            .get("source")
+            .and_then(Value::as_str)
+            .and_then(SafeLaneFailureRouteSource::parse)?,
+    })
 }
 
 fn parse_metrics_snapshot(value: Option<&Value>) -> Option<SafeLaneMetricsSnapshot> {
@@ -388,6 +1007,51 @@ fn parse_health_signal_snapshot(value: Option<&Value>) -> Option<SafeLaneHealthS
         return None;
     }
     Some(SafeLaneHealthSignalSnapshot { severity, flags })
+}
+
+fn parse_turn_checkpoint_stage(value: &str) -> Option<TurnCheckpointStage> {
+    match value {
+        "post_persist" => Some(TurnCheckpointStage::PostPersist),
+        "finalized" => Some(TurnCheckpointStage::Finalized),
+        "finalization_failed" => Some(TurnCheckpointStage::FinalizationFailed),
+        _ => None,
+    }
+}
+
+fn parse_turn_checkpoint_progress_status(value: &str) -> Option<TurnCheckpointProgressStatus> {
+    match value {
+        "pending" => Some(TurnCheckpointProgressStatus::Pending),
+        "skipped" => Some(TurnCheckpointProgressStatus::Skipped),
+        "completed" => Some(TurnCheckpointProgressStatus::Completed),
+        "failed" => Some(TurnCheckpointProgressStatus::Failed),
+        "failed_open" => Some(TurnCheckpointProgressStatus::FailedOpen),
+        _ => None,
+    }
+}
+
+fn parse_turn_checkpoint_failure_step(value: &str) -> Option<TurnCheckpointFailureStep> {
+    match value {
+        "after_turn" => Some(TurnCheckpointFailureStep::AfterTurn),
+        "compaction" => Some(TurnCheckpointFailureStep::Compaction),
+        _ => None,
+    }
+}
+
+fn classify_turn_checkpoint_session_state(
+    checkpoint_events: u32,
+    latest_stage: Option<TurnCheckpointStage>,
+) -> TurnCheckpointSessionState {
+    if checkpoint_events == 0 {
+        return TurnCheckpointSessionState::NotDurable;
+    }
+    match latest_stage {
+        Some(TurnCheckpointStage::PostPersist) => TurnCheckpointSessionState::PendingFinalization,
+        Some(TurnCheckpointStage::Finalized) => TurnCheckpointSessionState::Finalized,
+        Some(TurnCheckpointStage::FinalizationFailed) => {
+            TurnCheckpointSessionState::FinalizationFailed
+        }
+        None => TurnCheckpointSessionState::PendingFinalization,
+    }
 }
 
 fn is_safe_lane_event_name(event_name: &str) -> bool {
@@ -513,6 +1177,8 @@ fn read_f64_milli_opt(value: &Value, key: &str) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::conversation::SafeLaneFailureCode;
+    use crate::conversation::turn_budget::SafeLaneFailureRouteReason;
     use serde_json::json;
 
     #[test]
@@ -670,6 +1336,73 @@ mod tests {
             summary.final_route_reason.as_deref(),
             Some("session_governor_no_replan")
         );
+    }
+
+    #[test]
+    fn safe_lane_event_summary_typed_rollups_track_known_failure_and_route_vocab() {
+        let payloads = [
+            json!({
+                "type": "conversation_event",
+                "event": "verify_failed",
+                "payload": {
+                    "failure_code": "safe_lane_plan_backpressure_guard",
+                    "route_reason": "backpressure_attempts_exhausted"
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "final_status",
+                "payload": {
+                    "status": "failed",
+                    "failure_code": "safe_lane_plan_verify_failed_session_governor",
+                    "route_reason": "session_governor_no_replan"
+                }
+            })
+            .to_string(),
+        ];
+
+        let summary = summarize_safe_lane_events(payloads.iter().map(String::as_str));
+        assert_eq!(
+            summary.typed_final_failure_code(),
+            Some(SafeLaneFailureCode::VerifyFailedSessionGovernor)
+        );
+        assert_eq!(
+            summary.typed_final_route_reason(),
+            Some(SafeLaneFailureRouteReason::SessionGovernorNoReplan)
+        );
+        assert_eq!(summary.backpressure_failure_events(), 1);
+        assert_eq!(summary.backpressure_route_reason_events(), 1);
+        assert!(summary.has_terminal_instability_final_failure());
+        assert_eq!(summary.failed_final_status_events(), 1);
+    }
+
+    #[test]
+    fn safe_lane_event_summary_typed_rollups_ignore_unknown_lookalikes() {
+        let mut summary = SafeLaneEventSummary {
+            final_status: Some(SafeLaneFinalStatus::Failed),
+            final_failure_code: Some("unknown_session_governor_hint".to_owned()),
+            final_route_reason: Some("backpressure_noise".to_owned()),
+            ..SafeLaneEventSummary::default()
+        };
+        summary
+            .failure_code_counts
+            .insert("safe_lane_plan_backpressure_guard".to_owned(), 2);
+        summary
+            .failure_code_counts
+            .insert("unknown_backpressure_hint".to_owned(), 99);
+        summary
+            .route_reason_counts
+            .insert("backpressure_replans_exhausted".to_owned(), 3);
+        summary
+            .route_reason_counts
+            .insert("backpressure_noise".to_owned(), 88);
+
+        assert_eq!(summary.typed_final_failure_code(), None);
+        assert_eq!(summary.typed_final_route_reason(), None);
+        assert_eq!(summary.backpressure_failure_events(), 2);
+        assert_eq!(summary.backpressure_route_reason_events(), 3);
+        assert!(!summary.has_terminal_instability_final_failure());
     }
 
     #[test]
@@ -922,6 +1655,629 @@ mod tests {
                 severity: "critical".to_owned(),
                 flags: vec!["terminal_instability".to_owned()],
             })
+        );
+    }
+
+    #[test]
+    fn summarize_safe_lane_history_tracks_governor_samples_with_summary() {
+        let payloads = [
+            json!({
+                "type": "conversation_event",
+                "event": "lane_selected",
+                "payload": {
+                    "lane": "safe"
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "final_status",
+                "payload": {
+                    "status": "failed",
+                    "failure_code": "safe_lane_plan_backpressure_guard",
+                    "route_reason": "backpressure_attempts_exhausted",
+                    "route_decision": "terminal"
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "final_status",
+                "payload": {
+                    "status": "succeeded"
+                }
+            })
+            .to_string(),
+        ];
+
+        let projection = summarize_safe_lane_history(payloads.iter().map(String::as_str));
+
+        assert_eq!(projection.summary.lane_selected_events, 1);
+        assert_eq!(projection.summary.final_status_events, 2);
+        assert_eq!(projection.summary.failed_final_status_events(), 1);
+        assert_eq!(
+            projection.summary.final_status,
+            Some(SafeLaneFinalStatus::Succeeded)
+        );
+        assert_eq!(projection.summary.final_failure_code, None);
+        assert_eq!(projection.final_status_failed_samples, vec![true, false]);
+        assert_eq!(projection.backpressure_failure_samples, vec![true, false]);
+    }
+
+    #[test]
+    fn summarize_turn_checkpoint_events_tracks_latest_finalized_state() {
+        let payloads = [
+            json!({
+                "type": "conversation_event",
+                "event": "turn_checkpoint",
+                "payload": {
+                    "schema_version": 1,
+                    "stage": "post_persist",
+                    "checkpoint": {
+                        "identity": {
+                            "user_input_sha256": "u1",
+                            "assistant_reply_sha256": "a1",
+                            "user_input_chars": 5,
+                            "assistant_reply_chars": 6
+                        },
+                        "lane": {
+                            "lane": "safe",
+                            "result_kind": "tool_error"
+                        },
+                        "finalization": {
+                            "persistence_mode": "success"
+                        }
+                    },
+                    "finalization_progress": {
+                        "after_turn": "pending",
+                        "compaction": "pending"
+                    },
+                    "failure": null
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "turn_checkpoint",
+                "payload": {
+                    "schema_version": 1,
+                    "stage": "finalized",
+                    "checkpoint": {
+                        "identity": {
+                            "user_input_sha256": "u2",
+                            "assistant_reply_sha256": "a2",
+                            "user_input_chars": 7,
+                            "assistant_reply_chars": 8
+                        },
+                        "lane": {
+                            "lane": "safe",
+                            "result_kind": "tool_error",
+                            "safe_lane_terminal_route": {
+                                "decision": "terminal",
+                                "reason": "session_governor_no_replan",
+                                "source": "session_governor"
+                            }
+                        },
+                        "finalization": {
+                            "persistence_mode": "success"
+                        }
+                    },
+                    "finalization_progress": {
+                        "after_turn": "completed",
+                        "compaction": "failed_open"
+                    },
+                    "failure": null
+                }
+            })
+            .to_string(),
+        ];
+
+        let summary = summarize_turn_checkpoint_events(payloads.iter().map(String::as_str));
+        assert_eq!(summary.checkpoint_events, 2);
+        assert_eq!(summary.post_persist_events, 1);
+        assert_eq!(summary.finalized_events, 1);
+        assert_eq!(summary.finalization_failed_events, 0);
+        assert_eq!(summary.latest_schema_version, Some(1));
+        assert_eq!(summary.latest_stage, Some(TurnCheckpointStage::Finalized));
+        assert_eq!(
+            summary.latest_after_turn,
+            Some(TurnCheckpointProgressStatus::Completed)
+        );
+        assert_eq!(
+            summary.latest_compaction,
+            Some(TurnCheckpointProgressStatus::FailedOpen)
+        );
+        assert_eq!(summary.latest_lane.as_deref(), Some("safe"));
+        assert_eq!(summary.latest_result_kind.as_deref(), Some("tool_error"));
+        assert_eq!(summary.latest_persistence_mode.as_deref(), Some("success"));
+        assert_eq!(
+            summary.latest_safe_lane_terminal_route,
+            Some(SafeLaneTerminalRouteSnapshot {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+                source: SafeLaneFailureRouteSource::SessionGovernor,
+            })
+        );
+        assert_eq!(summary.latest_identity_present, Some(true));
+        assert_eq!(summary.latest_runs_after_turn, Some(true));
+        assert_eq!(summary.latest_attempts_context_compaction, Some(true));
+        assert_eq!(summary.session_state, TurnCheckpointSessionState::Finalized);
+        assert_eq!(
+            plan_turn_checkpoint_recovery(&summary),
+            TurnCheckpointRecoveryAction::None
+        );
+        assert!(summary.checkpoint_durable);
+        assert!(summary.reply_durable);
+        assert!(!summary.requires_recovery);
+        assert_eq!(summary.stage_counts.get("post_persist").copied(), Some(1));
+        assert_eq!(summary.stage_counts.get("finalized").copied(), Some(1));
+    }
+
+    #[test]
+    fn summarize_turn_checkpoint_events_flags_failed_finalization_for_recovery() {
+        let payloads = [json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalization_failed",
+                "checkpoint": {
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "inline_provider_error"
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "failed"
+                },
+                "failure": {
+                    "step": "compaction",
+                    "error": "compact failure"
+                }
+            }
+        })
+        .to_string()];
+
+        let summary = summarize_turn_checkpoint_events(payloads.iter().map(String::as_str));
+        assert_eq!(summary.checkpoint_events, 1);
+        assert_eq!(
+            summary.latest_stage,
+            Some(TurnCheckpointStage::FinalizationFailed)
+        );
+        assert_eq!(
+            summary.latest_after_turn,
+            Some(TurnCheckpointProgressStatus::Completed)
+        );
+        assert_eq!(
+            summary.latest_compaction,
+            Some(TurnCheckpointProgressStatus::Failed)
+        );
+        assert_eq!(
+            summary.latest_failure_step,
+            Some(TurnCheckpointFailureStep::Compaction)
+        );
+        assert_eq!(
+            summary.latest_failure_error.as_deref(),
+            Some("compact failure")
+        );
+        assert_eq!(
+            summary.latest_persistence_mode.as_deref(),
+            Some("inline_provider_error")
+        );
+        assert_eq!(summary.latest_identity_present, Some(false));
+        assert_eq!(summary.latest_runs_after_turn, Some(true));
+        assert_eq!(summary.latest_attempts_context_compaction, Some(true));
+        assert_eq!(
+            summary.session_state,
+            TurnCheckpointSessionState::FinalizationFailed
+        );
+        assert_eq!(
+            plan_turn_checkpoint_recovery(&summary),
+            TurnCheckpointRecoveryAction::InspectManually
+        );
+        assert!(summary.checkpoint_durable);
+        assert!(summary.reply_durable);
+        assert!(summary.requires_recovery);
+    }
+
+    #[test]
+    fn summarize_turn_checkpoint_events_keeps_return_error_finalized_without_reply_durability() {
+        let payloads = [json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalized",
+                "checkpoint": {
+                    "request": {
+                        "kind": "return_error"
+                    },
+                    "finalization": {
+                        "kind": "return_error"
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "skipped",
+                    "compaction": "skipped"
+                },
+                "failure": null
+            }
+        })
+        .to_string()];
+
+        let summary = summarize_turn_checkpoint_events(payloads.iter().map(String::as_str));
+
+        assert_eq!(summary.checkpoint_events, 1);
+        assert_eq!(summary.latest_stage, Some(TurnCheckpointStage::Finalized));
+        assert_eq!(summary.session_state, TurnCheckpointSessionState::Finalized);
+        assert_eq!(
+            plan_turn_checkpoint_recovery(&summary),
+            TurnCheckpointRecoveryAction::None
+        );
+        assert!(summary.checkpoint_durable);
+        assert!(!summary.reply_durable);
+        assert!(!summary.requires_recovery);
+        assert_eq!(summary.latest_persistence_mode, None);
+        assert_eq!(summary.latest_identity_present, Some(false));
+    }
+
+    #[test]
+    fn summarize_turn_checkpoint_history_tracks_latest_checkpoint_payload_with_summary() {
+        let payloads = [
+            json!({
+                "type": "conversation_event",
+                "event": "turn_checkpoint",
+                "payload": {
+                    "schema_version": 1,
+                    "stage": "post_persist",
+                    "checkpoint": {
+                        "identity": {
+                            "user_input_sha256": "u1",
+                            "assistant_reply_sha256": "a1",
+                            "user_input_chars": 5,
+                            "assistant_reply_chars": 6
+                        },
+                        "lane": {
+                            "lane": "safe",
+                            "result_kind": "tool_call"
+                        },
+                        "finalization": {
+                            "persistence_mode": "success"
+                        }
+                    },
+                    "finalization_progress": {
+                        "after_turn": "pending",
+                        "compaction": "pending"
+                    },
+                    "failure": null
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "turn_checkpoint",
+                "payload": {
+                    "schema_version": 1,
+                    "stage": "finalization_failed",
+                    "checkpoint": {
+                        "identity": {
+                            "user_input_sha256": "u2",
+                            "assistant_reply_sha256": "a2",
+                            "user_input_chars": 7,
+                            "assistant_reply_chars": 8
+                        },
+                        "lane": {
+                            "lane": "fast",
+                            "result_kind": "final_text"
+                        },
+                        "finalization": {
+                            "persistence_mode": "success",
+                            "runs_after_turn": true,
+                            "attempts_context_compaction": true
+                        }
+                    },
+                    "finalization_progress": {
+                        "after_turn": "completed",
+                        "compaction": "failed"
+                    },
+                    "failure": {
+                        "step": "compaction",
+                        "error": "compact failure"
+                    }
+                }
+            })
+            .to_string(),
+        ];
+
+        let projection = summarize_turn_checkpoint_history(payloads.iter().map(String::as_str));
+
+        assert_eq!(projection.summary.checkpoint_events, 2);
+        assert_eq!(
+            projection.summary.latest_stage,
+            Some(TurnCheckpointStage::FinalizationFailed)
+        );
+        assert_eq!(
+            projection.summary.latest_after_turn,
+            Some(TurnCheckpointProgressStatus::Completed)
+        );
+        assert_eq!(
+            projection.summary.latest_compaction,
+            Some(TurnCheckpointProgressStatus::Failed)
+        );
+        assert_eq!(
+            projection.summary.latest_failure_step,
+            Some(TurnCheckpointFailureStep::Compaction)
+        );
+        assert_eq!(projection.summary.latest_lane.as_deref(), Some("fast"));
+        assert_eq!(
+            projection.summary.latest_result_kind.as_deref(),
+            Some("final_text")
+        );
+        assert!(projection.summary.requires_recovery);
+        assert!(projection.summary.checkpoint_durable);
+        assert_eq!(
+            projection
+                .latest_checkpoint
+                .as_ref()
+                .and_then(|checkpoint| checkpoint.get("lane"))
+                .and_then(|lane| lane.get("lane"))
+                .and_then(Value::as_str),
+            Some("fast")
+        );
+        assert_eq!(
+            projection
+                .latest_checkpoint
+                .as_ref()
+                .and_then(|checkpoint| checkpoint.get("finalization"))
+                .and_then(|finalization| finalization.get("attempts_context_compaction"))
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn plan_turn_checkpoint_recovery_restarts_after_turn_and_compaction_when_needed() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            latest_stage: Some(TurnCheckpointStage::FinalizationFailed),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Failed),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_failure_step: Some(TurnCheckpointFailureStep::AfterTurn),
+            latest_identity_present: Some(true),
+            latest_runs_after_turn: Some(true),
+            latest_attempts_context_compaction: Some(true),
+            session_state: TurnCheckpointSessionState::FinalizationFailed,
+            checkpoint_durable: true,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        assert_eq!(
+            plan_turn_checkpoint_recovery(&summary),
+            TurnCheckpointRecoveryAction::RunAfterTurnAndCompaction
+        );
+    }
+
+    #[test]
+    fn plan_turn_checkpoint_recovery_requires_manual_inspection_without_identity() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            latest_stage: Some(TurnCheckpointStage::PostPersist),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Pending),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Pending),
+            latest_identity_present: Some(false),
+            latest_runs_after_turn: Some(true),
+            latest_attempts_context_compaction: Some(true),
+            session_state: TurnCheckpointSessionState::PendingFinalization,
+            checkpoint_durable: true,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        assert_eq!(
+            plan_turn_checkpoint_recovery(&summary),
+            TurnCheckpointRecoveryAction::InspectManually
+        );
+    }
+
+    #[test]
+    fn build_turn_checkpoint_repair_plan_marks_missing_identity_as_manual_reason() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            latest_stage: Some(TurnCheckpointStage::PostPersist),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Pending),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Pending),
+            latest_identity_present: Some(false),
+            latest_runs_after_turn: Some(true),
+            latest_attempts_context_compaction: Some(true),
+            session_state: TurnCheckpointSessionState::PendingFinalization,
+            checkpoint_durable: true,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let plan = build_turn_checkpoint_repair_plan(&summary);
+
+        assert_eq!(plan.action(), TurnCheckpointRecoveryAction::InspectManually);
+        assert_eq!(
+            plan.manual_reason(),
+            Some(TurnCheckpointRepairManualReason::CheckpointIdentityMissing)
+        );
+        assert!(!plan.should_run_after_turn());
+        assert!(!plan.should_run_compaction());
+        assert_eq!(
+            plan.after_turn_status(),
+            TurnCheckpointProgressStatus::Pending
+        );
+        assert_eq!(
+            plan.compaction_status(),
+            TurnCheckpointProgressStatus::Pending
+        );
+    }
+
+    #[test]
+    fn build_turn_checkpoint_repair_plan_restores_tail_progress_and_remaining_steps() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            latest_stage: Some(TurnCheckpointStage::FinalizationFailed),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Completed),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Failed),
+            latest_failure_step: Some(TurnCheckpointFailureStep::Compaction),
+            latest_identity_present: Some(true),
+            latest_runs_after_turn: Some(true),
+            latest_attempts_context_compaction: Some(true),
+            session_state: TurnCheckpointSessionState::FinalizationFailed,
+            checkpoint_durable: true,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let plan = build_turn_checkpoint_repair_plan(&summary);
+
+        assert_eq!(plan.action(), TurnCheckpointRecoveryAction::RunCompaction);
+        assert_eq!(plan.manual_reason(), None);
+        assert!(!plan.should_run_after_turn());
+        assert!(plan.should_run_compaction());
+        assert_eq!(
+            plan.after_turn_status(),
+            TurnCheckpointProgressStatus::Completed
+        );
+        assert_eq!(
+            plan.compaction_status(),
+            TurnCheckpointProgressStatus::Failed
+        );
+    }
+
+    #[test]
+    fn build_turn_checkpoint_repair_plan_preserves_safe_lane_override_route_in_manual_reason() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            latest_stage: Some(TurnCheckpointStage::PostPersist),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_safe_lane_terminal_route: Some(SafeLaneTerminalRouteSnapshot {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: SafeLaneFailureRouteReason::BackpressureAttemptsExhausted,
+                source: SafeLaneFailureRouteSource::BackpressureGuard,
+            }),
+            latest_identity_present: Some(true),
+            latest_runs_after_turn: Some(false),
+            latest_attempts_context_compaction: Some(false),
+            session_state: TurnCheckpointSessionState::PendingFinalization,
+            checkpoint_durable: true,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let plan = build_turn_checkpoint_repair_plan(&summary);
+
+        assert_eq!(plan.action(), TurnCheckpointRecoveryAction::InspectManually);
+        assert_eq!(
+            plan.manual_reason()
+                .map(TurnCheckpointRepairManualReason::as_str),
+            Some("safe_lane_backpressure_terminal_requires_manual_inspection")
+        );
+        assert!(!plan.should_run_after_turn());
+        assert!(!plan.should_run_compaction());
+    }
+
+    #[test]
+    fn build_turn_checkpoint_repair_plan_keeps_replan_routes_out_of_manual_override_reason() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            latest_stage: Some(TurnCheckpointStage::PostPersist),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_safe_lane_terminal_route: Some(SafeLaneTerminalRouteSnapshot {
+                decision: SafeLaneFailureRouteDecision::Replan,
+                reason: SafeLaneFailureRouteReason::RetryableFailure,
+                source: SafeLaneFailureRouteSource::BackpressureGuard,
+            }),
+            latest_identity_present: Some(true),
+            latest_runs_after_turn: Some(false),
+            latest_attempts_context_compaction: Some(false),
+            session_state: TurnCheckpointSessionState::PendingFinalization,
+            checkpoint_durable: true,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let plan = build_turn_checkpoint_repair_plan(&summary);
+
+        assert_eq!(plan.action(), TurnCheckpointRecoveryAction::InspectManually);
+        assert_eq!(
+            plan.manual_reason()
+                .map(TurnCheckpointRepairManualReason::as_str),
+            Some("checkpoint_state_requires_manual_inspection")
+        );
+    }
+
+    #[test]
+    fn build_turn_checkpoint_repair_plan_ignores_inconsistent_override_route_pairs() {
+        let summary = TurnCheckpointEventSummary {
+            checkpoint_events: 1,
+            latest_stage: Some(TurnCheckpointStage::PostPersist),
+            latest_after_turn: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_compaction: Some(TurnCheckpointProgressStatus::Skipped),
+            latest_safe_lane_terminal_route: Some(SafeLaneTerminalRouteSnapshot {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: SafeLaneFailureRouteReason::RetryableFailure,
+                source: SafeLaneFailureRouteSource::BackpressureGuard,
+            }),
+            latest_identity_present: Some(true),
+            latest_runs_after_turn: Some(false),
+            latest_attempts_context_compaction: Some(false),
+            session_state: TurnCheckpointSessionState::PendingFinalization,
+            checkpoint_durable: true,
+            requires_recovery: true,
+            reply_durable: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        let plan = build_turn_checkpoint_repair_plan(&summary);
+
+        assert_eq!(plan.action(), TurnCheckpointRecoveryAction::InspectManually);
+        assert_eq!(
+            plan.manual_reason()
+                .map(TurnCheckpointRepairManualReason::as_str),
+            Some("checkpoint_state_requires_manual_inspection")
+        );
+    }
+
+    #[test]
+    fn turn_checkpoint_event_summary_route_labels_default_to_dash_without_snapshot() {
+        let summary = TurnCheckpointEventSummary::default();
+
+        assert_eq!(
+            summary.latest_safe_lane_route_labels_or_default(),
+            ("-", "-", "-")
+        );
+    }
+
+    #[test]
+    fn turn_checkpoint_event_summary_route_labels_project_typed_snapshot() {
+        let summary = TurnCheckpointEventSummary {
+            latest_safe_lane_terminal_route: Some(SafeLaneTerminalRouteSnapshot {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+                source: SafeLaneFailureRouteSource::SessionGovernor,
+            }),
+            ..TurnCheckpointEventSummary::default()
+        };
+
+        assert_eq!(
+            summary.latest_safe_lane_route_labels_or_default(),
+            ("terminal", "session_governor_no_replan", "session_governor")
         );
     }
 }

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -7,7 +7,10 @@ pub mod plan_executor;
 pub mod plan_ir;
 pub mod plan_verifier;
 mod runtime;
+mod safe_lane_failure;
 mod session_address;
+mod session_history;
+mod turn_budget;
 mod turn_coordinator;
 pub mod turn_engine;
 mod turn_loop;
@@ -16,7 +19,11 @@ mod turn_shared;
 pub use analytics::{
     ConversationEventRecord, SafeLaneEventSummary, SafeLaneFinalStatus,
     SafeLaneHealthSignalSnapshot, SafeLaneMetricsSnapshot, SafeLaneToolOutputSnapshot,
-    parse_conversation_event, summarize_safe_lane_events,
+    TurnCheckpointEventSummary, TurnCheckpointFailureStep, TurnCheckpointProgressStatus,
+    TurnCheckpointRecoveryAction, TurnCheckpointRepairManualReason, TurnCheckpointRepairPlan,
+    TurnCheckpointSessionState, TurnCheckpointStage, build_turn_checkpoint_repair_plan,
+    parse_conversation_event, plan_turn_checkpoint_recovery, summarize_safe_lane_events,
+    summarize_turn_checkpoint_events,
 };
 pub use context_engine::{
     AssembledConversationContext, CONTEXT_ENGINE_API_VERSION, ContextEngineBootstrapResult,
@@ -35,9 +42,22 @@ pub use runtime::{
     ContextEngineSelectionSource, ConversationRuntime, DefaultConversationRuntime,
     collect_context_engine_runtime_snapshot, resolve_context_engine_selection,
 };
+pub use safe_lane_failure::{
+    SafeLaneFailureCode, SafeLaneFailureRouteDecision, SafeLaneFailureRouteSource,
+    SafeLaneTerminalRouteSnapshot, classify_safe_lane_plan_failure,
+    is_safe_lane_backpressure_failure_code, is_safe_lane_backpressure_route_reason,
+    is_safe_lane_terminal_instability_failure_code,
+};
 pub use session_address::ConversationSessionAddress;
+pub use session_history::{load_safe_lane_event_summary, load_turn_checkpoint_event_summary};
+pub use turn_budget::SafeLaneFailureRouteReason;
 pub use turn_coordinator::ConversationTurnCoordinator;
-pub type ConversationOrchestrator = ConversationTurnCoordinator;
+pub(crate) use turn_coordinator::{TurnCheckpointDiagnostics, TurnCheckpointRecoveryAssessment};
+pub use turn_coordinator::{
+    TurnCheckpointTailRepairOutcome, TurnCheckpointTailRepairReason,
+    TurnCheckpointTailRepairRuntimeProbe, TurnCheckpointTailRepairSource,
+    TurnCheckpointTailRepairStatus,
+};
 pub use turn_engine::{
     ProviderTurn, ToolDecision, ToolIntent, ToolOutcome, TurnEngine, TurnFailure, TurnFailureKind,
     TurnResult,

--- a/crates/app/src/conversation/persistence.rs
+++ b/crates/app/src/conversation/persistence.rs
@@ -8,6 +8,7 @@ use crate::acp::{
 
 use super::runtime::ConversationRuntime;
 use super::turn_engine::{ToolDecision, ToolOutcome};
+use super::turn_shared::ReplyPersistenceMode;
 
 pub(super) fn format_provider_error_reply(error: &str) -> String {
     format!("[provider_error] {error}")
@@ -30,6 +31,25 @@ pub(super) async fn persist_success_turns<R: ConversationRuntime + ?Sized>(
     )
     .await?;
     Ok(())
+}
+
+pub(super) async fn persist_reply_turns_with_mode<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    user_input: &str,
+    assistant_reply: &str,
+    persistence_mode: ReplyPersistenceMode,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<()> {
+    match persistence_mode {
+        ReplyPersistenceMode::Success => {
+            persist_success_turns(runtime, session_id, user_input, assistant_reply, kernel_ctx)
+                .await
+        }
+        ReplyPersistenceMode::InlineProviderError => {
+            persist_error_turns(runtime, session_id, user_input, assistant_reply, kernel_ctx).await
+        }
+    }
 }
 
 /// Persist a tool decision as a structured JSON assistant message.
@@ -130,6 +150,26 @@ pub(super) async fn persist_success_turns_raw<R: ConversationRuntime + ?Sized>(
     )
     .await?;
     Ok(())
+}
+
+pub(super) async fn persist_reply_turns_raw_with_mode<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    user_input: &str,
+    assistant_reply: &str,
+    persistence_mode: ReplyPersistenceMode,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<()> {
+    match persistence_mode {
+        ReplyPersistenceMode::Success => {
+            persist_success_turns_raw(runtime, session_id, user_input, assistant_reply, kernel_ctx)
+                .await
+        }
+        ReplyPersistenceMode::InlineProviderError => {
+            persist_error_turns_raw(runtime, session_id, user_input, assistant_reply, kernel_ctx)
+                .await
+        }
+    }
 }
 
 pub(super) async fn persist_error_turns_raw<R: ConversationRuntime + ?Sized>(

--- a/crates/app/src/conversation/safe_lane_failure.rs
+++ b/crates/app/src/conversation/safe_lane_failure.rs
@@ -1,0 +1,414 @@
+use serde::{Deserialize, Serialize};
+
+use super::plan_executor::{PlanNodeErrorKind, PlanRunFailure};
+use super::turn_budget::SafeLaneFailureRouteReason;
+use super::turn_engine::{TurnFailure, TurnFailureKind};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SafeLaneFailureRouteDecision {
+    Replan,
+    Terminal,
+}
+
+impl SafeLaneFailureRouteDecision {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Replan => "replan",
+            Self::Terminal => "terminal",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "replan" => Some(Self::Replan),
+            "terminal" => Some(Self::Terminal),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SafeLaneFailureRouteSource {
+    BaseRouting,
+    BackpressureGuard,
+    SessionGovernor,
+}
+
+impl SafeLaneFailureRouteSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::BaseRouting => "base_routing",
+            Self::BackpressureGuard => "backpressure_guard",
+            Self::SessionGovernor => "session_governor",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "base_routing" => Some(Self::BaseRouting),
+            "backpressure_guard" => Some(Self::BackpressureGuard),
+            "session_governor" => Some(Self::SessionGovernor),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SafeLaneTerminalRouteSnapshot {
+    pub decision: SafeLaneFailureRouteDecision,
+    pub reason: SafeLaneFailureRouteReason,
+    pub source: SafeLaneFailureRouteSource,
+}
+
+impl SafeLaneTerminalRouteSnapshot {
+    pub fn is_terminal(self) -> bool {
+        self.decision == SafeLaneFailureRouteDecision::Terminal
+    }
+
+    pub fn is_backpressure_override_terminal(self) -> bool {
+        self.is_terminal()
+            && self.source == SafeLaneFailureRouteSource::BackpressureGuard
+            && self.reason.is_backpressure()
+    }
+
+    pub fn is_session_governor_override_terminal(self) -> bool {
+        self.is_terminal()
+            && self.source == SafeLaneFailureRouteSource::SessionGovernor
+            && self.reason == SafeLaneFailureRouteReason::SessionGovernorNoReplan
+    }
+
+    pub fn decision_label(self) -> &'static str {
+        self.decision.as_str()
+    }
+
+    pub fn reason_label(self) -> &'static str {
+        self.reason.as_str()
+    }
+
+    pub fn source_label(self) -> &'static str {
+        self.source.as_str()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SafeLaneFailureCode {
+    PlanValidationFailed,
+    PlanTopologyResolutionFailed,
+    PlanBudgetExceeded,
+    PlanWallTimeExceeded,
+    PlanNodePolicyDenied,
+    PlanNodeRetryableError,
+    PlanNodeNonRetryableError,
+    VerifyFailed,
+    VerifyFailedBackpressureGuard,
+    VerifyFailedSessionGovernor,
+    VerifyFailedBudgetExhausted,
+    PlanBackpressureGuard,
+    PlanSessionGovernorNoReplan,
+}
+
+impl SafeLaneFailureCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PlanValidationFailed => "safe_lane_plan_validation_failed",
+            Self::PlanTopologyResolutionFailed => "safe_lane_plan_topology_resolution_failed",
+            Self::PlanBudgetExceeded => "safe_lane_plan_budget_exceeded",
+            Self::PlanWallTimeExceeded => "safe_lane_plan_wall_time_exceeded",
+            Self::PlanNodePolicyDenied => "safe_lane_plan_node_policy_denied",
+            Self::PlanNodeRetryableError => "safe_lane_plan_node_retryable_error",
+            Self::PlanNodeNonRetryableError => "safe_lane_plan_node_non_retryable_error",
+            Self::VerifyFailed => "safe_lane_plan_verify_failed",
+            Self::VerifyFailedBackpressureGuard => {
+                "safe_lane_plan_verify_failed_backpressure_guard"
+            }
+            Self::VerifyFailedSessionGovernor => "safe_lane_plan_verify_failed_session_governor",
+            Self::VerifyFailedBudgetExhausted => "safe_lane_plan_verify_failed_budget_exhausted",
+            Self::PlanBackpressureGuard => "safe_lane_plan_backpressure_guard",
+            Self::PlanSessionGovernorNoReplan => "safe_lane_plan_session_governor_no_replan",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "safe_lane_plan_validation_failed" => Some(Self::PlanValidationFailed),
+            "safe_lane_plan_topology_resolution_failed" => Some(Self::PlanTopologyResolutionFailed),
+            "safe_lane_plan_budget_exceeded" => Some(Self::PlanBudgetExceeded),
+            "safe_lane_plan_wall_time_exceeded" => Some(Self::PlanWallTimeExceeded),
+            "safe_lane_plan_node_policy_denied" => Some(Self::PlanNodePolicyDenied),
+            "safe_lane_plan_node_retryable_error" => Some(Self::PlanNodeRetryableError),
+            "safe_lane_plan_node_non_retryable_error" => Some(Self::PlanNodeNonRetryableError),
+            "safe_lane_plan_verify_failed" => Some(Self::VerifyFailed),
+            "safe_lane_plan_verify_failed_backpressure_guard" => {
+                Some(Self::VerifyFailedBackpressureGuard)
+            }
+            "safe_lane_plan_verify_failed_session_governor" => {
+                Some(Self::VerifyFailedSessionGovernor)
+            }
+            "safe_lane_plan_verify_failed_budget_exhausted" => {
+                Some(Self::VerifyFailedBudgetExhausted)
+            }
+            "safe_lane_plan_backpressure_guard" => Some(Self::PlanBackpressureGuard),
+            "safe_lane_plan_session_governor_no_replan" => Some(Self::PlanSessionGovernorNoReplan),
+            _ => None,
+        }
+    }
+
+    pub fn is_backpressure(self) -> bool {
+        matches!(
+            self,
+            Self::VerifyFailedBackpressureGuard | Self::PlanBackpressureGuard
+        )
+    }
+
+    pub fn is_terminal_instability(self) -> bool {
+        matches!(
+            self,
+            Self::VerifyFailed
+                | Self::VerifyFailedBackpressureGuard
+                | Self::VerifyFailedSessionGovernor
+                | Self::VerifyFailedBudgetExhausted
+                | Self::PlanBackpressureGuard
+                | Self::PlanSessionGovernorNoReplan
+        )
+    }
+
+    pub fn into_turn_failure(
+        self,
+        kind: TurnFailureKind,
+        reason: impl Into<String>,
+    ) -> TurnFailure {
+        match kind {
+            TurnFailureKind::ApprovalRequired => {
+                TurnFailure::approval_required(self.as_str(), reason)
+            }
+            TurnFailureKind::PolicyDenied => TurnFailure::policy_denied(self.as_str(), reason),
+            TurnFailureKind::Retryable => TurnFailure::retryable(self.as_str(), reason),
+            TurnFailureKind::NonRetryable => TurnFailure::non_retryable(self.as_str(), reason),
+            TurnFailureKind::Provider => TurnFailure::provider(self.as_str(), reason),
+        }
+    }
+}
+
+pub fn classify_safe_lane_plan_failure(
+    failure: &PlanRunFailure,
+) -> (SafeLaneFailureCode, TurnFailureKind) {
+    match failure {
+        PlanRunFailure::ValidationFailed(_) => (
+            SafeLaneFailureCode::PlanValidationFailed,
+            TurnFailureKind::NonRetryable,
+        ),
+        PlanRunFailure::TopologyResolutionFailed => (
+            SafeLaneFailureCode::PlanTopologyResolutionFailed,
+            TurnFailureKind::NonRetryable,
+        ),
+        PlanRunFailure::BudgetExceeded { .. } => (
+            SafeLaneFailureCode::PlanBudgetExceeded,
+            TurnFailureKind::NonRetryable,
+        ),
+        PlanRunFailure::WallTimeExceeded { .. } => (
+            SafeLaneFailureCode::PlanWallTimeExceeded,
+            TurnFailureKind::NonRetryable,
+        ),
+        PlanRunFailure::NodeFailed {
+            last_error_kind, ..
+        } => match last_error_kind {
+            PlanNodeErrorKind::PolicyDenied => (
+                SafeLaneFailureCode::PlanNodePolicyDenied,
+                TurnFailureKind::PolicyDenied,
+            ),
+            PlanNodeErrorKind::Retryable => (
+                SafeLaneFailureCode::PlanNodeRetryableError,
+                TurnFailureKind::Retryable,
+            ),
+            PlanNodeErrorKind::NonRetryable => (
+                SafeLaneFailureCode::PlanNodeNonRetryableError,
+                TurnFailureKind::NonRetryable,
+            ),
+        },
+    }
+}
+
+pub fn is_safe_lane_backpressure_failure_code(value: &str) -> bool {
+    SafeLaneFailureCode::parse(value)
+        .map(SafeLaneFailureCode::is_backpressure)
+        .unwrap_or(false)
+}
+
+pub fn is_safe_lane_terminal_instability_failure_code(value: Option<&str>) -> bool {
+    value
+        .and_then(SafeLaneFailureCode::parse)
+        .map(SafeLaneFailureCode::is_terminal_instability)
+        .unwrap_or(false)
+}
+
+pub fn is_safe_lane_backpressure_route_reason(value: &str) -> bool {
+    SafeLaneFailureRouteReason::parse(value)
+        .map(SafeLaneFailureRouteReason::is_backpressure)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        SafeLaneFailureCode, SafeLaneFailureRouteDecision, SafeLaneFailureRouteSource,
+        SafeLaneTerminalRouteSnapshot, classify_safe_lane_plan_failure,
+        is_safe_lane_backpressure_failure_code, is_safe_lane_backpressure_route_reason,
+        is_safe_lane_terminal_instability_failure_code,
+    };
+    use crate::conversation::plan_executor::{PlanNodeErrorKind, PlanRunFailure};
+    use crate::conversation::turn_budget::SafeLaneFailureRouteReason;
+    use crate::conversation::turn_engine::TurnFailureKind;
+
+    #[test]
+    fn parse_safe_lane_failure_code_accepts_known_codes_only() {
+        assert_eq!(
+            SafeLaneFailureCode::parse("safe_lane_plan_verify_failed_session_governor"),
+            Some(SafeLaneFailureCode::VerifyFailedSessionGovernor)
+        );
+        assert_eq!(
+            SafeLaneFailureCode::parse("safe_lane_plan_backpressure_guard"),
+            Some(SafeLaneFailureCode::PlanBackpressureGuard)
+        );
+        assert_eq!(
+            SafeLaneFailureCode::parse("unknown_session_governor_hint"),
+            None
+        );
+    }
+
+    #[test]
+    fn safe_lane_failure_code_classifiers_match_known_terminal_semantics() {
+        assert!(is_safe_lane_terminal_instability_failure_code(Some(
+            "safe_lane_plan_verify_failed"
+        )));
+        assert!(is_safe_lane_terminal_instability_failure_code(Some(
+            "safe_lane_plan_session_governor_no_replan"
+        )));
+        assert!(!is_safe_lane_terminal_instability_failure_code(Some(
+            "safe_lane_plan_node_policy_denied"
+        )));
+        assert!(!is_safe_lane_terminal_instability_failure_code(Some(
+            "unknown_verify_failed_hint"
+        )));
+    }
+
+    #[test]
+    fn safe_lane_backpressure_classifiers_ignore_unknown_lookalikes() {
+        assert!(is_safe_lane_backpressure_failure_code(
+            "safe_lane_plan_backpressure_guard"
+        ));
+        assert!(!is_safe_lane_backpressure_failure_code(
+            "unknown_backpressure_hint"
+        ));
+        assert!(is_safe_lane_backpressure_route_reason(
+            "backpressure_attempts_exhausted"
+        ));
+        assert!(!is_safe_lane_backpressure_route_reason(
+            "backpressure_noise"
+        ));
+    }
+
+    #[test]
+    fn safe_lane_route_vocabulary_parses_known_labels_only() {
+        assert_eq!(
+            SafeLaneFailureRouteDecision::parse("terminal"),
+            Some(SafeLaneFailureRouteDecision::Terminal)
+        );
+        assert_eq!(
+            SafeLaneFailureRouteSource::parse("session_governor"),
+            Some(SafeLaneFailureRouteSource::SessionGovernor)
+        );
+        assert_eq!(SafeLaneFailureRouteDecision::parse("terminalish"), None);
+        assert_eq!(
+            SafeLaneFailureRouteSource::parse("route_source_noise"),
+            None
+        );
+    }
+
+    #[test]
+    fn safe_lane_terminal_route_snapshot_reports_labels_from_typed_fields() {
+        let snapshot = SafeLaneTerminalRouteSnapshot {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+            source: SafeLaneFailureRouteSource::SessionGovernor,
+        };
+
+        assert_eq!(snapshot.decision_label(), "terminal");
+        assert_eq!(snapshot.reason_label(), "session_governor_no_replan");
+        assert_eq!(snapshot.source_label(), "session_governor");
+    }
+
+    #[test]
+    fn safe_lane_terminal_route_snapshot_terminality_depends_on_decision() {
+        let terminal = SafeLaneTerminalRouteSnapshot {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+            source: SafeLaneFailureRouteSource::SessionGovernor,
+        };
+        let replan = SafeLaneTerminalRouteSnapshot {
+            decision: SafeLaneFailureRouteDecision::Replan,
+            reason: SafeLaneFailureRouteReason::RetryableFailure,
+            source: SafeLaneFailureRouteSource::BaseRouting,
+        };
+
+        assert!(terminal.is_terminal());
+        assert!(!replan.is_terminal());
+    }
+
+    #[test]
+    fn safe_lane_terminal_route_snapshot_override_classifiers_require_consistent_pairs() {
+        let backpressure_terminal = SafeLaneTerminalRouteSnapshot {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: SafeLaneFailureRouteReason::BackpressureAttemptsExhausted,
+            source: SafeLaneFailureRouteSource::BackpressureGuard,
+        };
+        let malformed_backpressure = SafeLaneTerminalRouteSnapshot {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: SafeLaneFailureRouteReason::RetryableFailure,
+            source: SafeLaneFailureRouteSource::BackpressureGuard,
+        };
+        let governor_terminal = SafeLaneTerminalRouteSnapshot {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+            source: SafeLaneFailureRouteSource::SessionGovernor,
+        };
+        let malformed_governor = SafeLaneTerminalRouteSnapshot {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: SafeLaneFailureRouteReason::NonRetryableFailure,
+            source: SafeLaneFailureRouteSource::SessionGovernor,
+        };
+
+        assert!(backpressure_terminal.is_backpressure_override_terminal());
+        assert!(!malformed_backpressure.is_backpressure_override_terminal());
+        assert!(governor_terminal.is_session_governor_override_terminal());
+        assert!(!malformed_governor.is_session_governor_override_terminal());
+    }
+
+    #[test]
+    fn classify_safe_lane_plan_failure_maps_node_and_static_failures() {
+        let retryable_node = PlanRunFailure::NodeFailed {
+            node_id: "tool-1".to_owned(),
+            attempts_used: 1,
+            last_error_kind: PlanNodeErrorKind::Retryable,
+            last_error: "transient".to_owned(),
+        };
+        assert_eq!(
+            classify_safe_lane_plan_failure(&retryable_node),
+            (
+                SafeLaneFailureCode::PlanNodeRetryableError,
+                TurnFailureKind::Retryable
+            )
+        );
+
+        let validation = PlanRunFailure::ValidationFailed("invalid".to_owned());
+        assert_eq!(
+            classify_safe_lane_plan_failure(&validation),
+            (
+                SafeLaneFailureCode::PlanValidationFailed,
+                TurnFailureKind::NonRetryable
+            )
+        );
+    }
+}

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -1,0 +1,218 @@
+#[cfg(feature = "memory-sqlite")]
+use std::collections::BTreeSet;
+
+#[cfg(feature = "memory-sqlite")]
+use loongclaw_contracts::{Capability, MemoryCoreRequest};
+#[cfg(feature = "memory-sqlite")]
+use serde_json::{Value, json};
+
+use crate::CliResult;
+use crate::KernelContext;
+#[cfg(feature = "memory-sqlite")]
+use crate::memory;
+#[cfg(feature = "memory-sqlite")]
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+
+use super::analytics::{
+    SafeLaneEventSummary, TurnCheckpointEventSummary, summarize_safe_lane_events,
+    summarize_turn_checkpoint_history,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TurnCheckpointLatestEntry {
+    pub summary: TurnCheckpointEventSummary,
+    pub checkpoint: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TurnCheckpointHistorySnapshot {
+    summary: TurnCheckpointEventSummary,
+    latest_checkpoint: Option<Value>,
+}
+
+impl TurnCheckpointHistorySnapshot {
+    pub(crate) fn into_summary(self) -> TurnCheckpointEventSummary {
+        self.summary
+    }
+
+    pub(crate) fn into_latest_entry(self) -> Option<TurnCheckpointLatestEntry> {
+        self.latest_checkpoint
+            .map(|checkpoint| TurnCheckpointLatestEntry {
+                summary: self.summary,
+                checkpoint,
+            })
+    }
+
+    pub(crate) fn into_summary_and_latest_entry(
+        self,
+    ) -> (
+        TurnCheckpointEventSummary,
+        Option<TurnCheckpointLatestEntry>,
+    ) {
+        let summary = self.summary;
+        let latest_entry = self
+            .latest_checkpoint
+            .map(|checkpoint| TurnCheckpointLatestEntry {
+                summary: summary.clone(),
+                checkpoint,
+            });
+        (summary, latest_entry)
+    }
+}
+
+pub async fn load_turn_checkpoint_event_summary(
+    session_id: &str,
+    limit: usize,
+    kernel_ctx: Option<&KernelContext>,
+    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+) -> CliResult<TurnCheckpointEventSummary> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        Ok(
+            load_turn_checkpoint_history_snapshot(session_id, limit, kernel_ctx, memory_config)
+                .await?
+                .into_summary(),
+        )
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (session_id, limit, kernel_ctx);
+        Err("turn checkpoint summary unavailable: memory-sqlite feature disabled".to_owned())
+    }
+}
+
+pub async fn load_safe_lane_event_summary(
+    session_id: &str,
+    limit: usize,
+    kernel_ctx: Option<&KernelContext>,
+    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+) -> CliResult<SafeLaneEventSummary> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let assistant_contents = load_assistant_contents_from_session_window(
+            session_id,
+            limit,
+            kernel_ctx,
+            memory_config,
+        )
+        .await?;
+        Ok(summarize_safe_lane_events(
+            assistant_contents.iter().map(String::as_str),
+        ))
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (session_id, limit, kernel_ctx);
+        Err("safe-lane summary unavailable: memory-sqlite feature disabled".to_owned())
+    }
+}
+
+pub(crate) async fn load_latest_turn_checkpoint_entry(
+    session_id: &str,
+    limit: usize,
+    kernel_ctx: Option<&KernelContext>,
+    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+) -> CliResult<Option<TurnCheckpointLatestEntry>> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        Ok(
+            load_turn_checkpoint_history_snapshot(session_id, limit, kernel_ctx, memory_config)
+                .await?
+                .into_latest_entry(),
+        )
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (session_id, limit, kernel_ctx);
+        Err("turn checkpoint entry unavailable: memory-sqlite feature disabled".to_owned())
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) async fn load_turn_checkpoint_history_snapshot(
+    session_id: &str,
+    limit: usize,
+    kernel_ctx: Option<&KernelContext>,
+    memory_config: &MemoryRuntimeConfig,
+) -> CliResult<TurnCheckpointHistorySnapshot> {
+    let assistant_contents =
+        load_assistant_contents_from_session_window(session_id, limit, kernel_ctx, memory_config)
+            .await?;
+    Ok(build_turn_checkpoint_history_snapshot(&assistant_contents))
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) async fn load_assistant_contents_from_session_window(
+    session_id: &str,
+    limit: usize,
+    kernel_ctx: Option<&KernelContext>,
+    memory_config: &MemoryRuntimeConfig,
+) -> CliResult<Vec<String>> {
+    if let Some(ctx) = kernel_ctx {
+        let request = MemoryCoreRequest {
+            operation: memory::MEMORY_OP_WINDOW.to_owned(),
+            payload: json!({
+                "session_id": session_id,
+                "limit": limit,
+                "allow_extended_limit": true,
+            }),
+        };
+        let caps = BTreeSet::from([Capability::MemoryRead]);
+        let outcome = ctx
+            .kernel
+            .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
+            .await;
+        if let Ok(outcome) = outcome
+            && outcome.status == "ok"
+        {
+            return Ok(collect_assistant_contents_from_memory_window_payload(
+                outcome.payload.get("turns"),
+            ));
+        }
+    }
+
+    let turns = memory::window_direct(session_id, limit, memory_config)
+        .map_err(|error| format!("load turn checkpoint summary failed: {error}"))?;
+    Ok(turns
+        .iter()
+        .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.clone()))
+        .collect())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_turn_checkpoint_history_snapshot(
+    assistant_contents: &[String],
+) -> TurnCheckpointHistorySnapshot {
+    let projection =
+        summarize_turn_checkpoint_history(assistant_contents.iter().map(String::as_str));
+    TurnCheckpointHistorySnapshot {
+        summary: projection.summary,
+        latest_checkpoint: projection.latest_checkpoint,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn collect_assistant_contents_from_memory_window_payload(
+    turns_payload: Option<&Value>,
+) -> Vec<String> {
+    turns_payload
+        .and_then(Value::as_array)
+        .map(|turns| {
+            turns
+                .iter()
+                .filter_map(|turn| {
+                    (turn.get("role").and_then(Value::as_str) == Some("assistant"))
+                        .then(|| {
+                            turn.get("content")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default()
+                        })
+                        .map(ToOwned::to_owned)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -9,6 +9,7 @@ use loongclaw_kernel::{
     MemoryCoreRequest, StaticPolicyEngine, VerticalPackManifest,
 };
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 
 use super::super::config::{
     CliChannelConfig, ConversationConfig, ExternalSkillsConfig, FeishuChannelConfig,
@@ -27,18 +28,26 @@ use crate::acp::{
     AcpTurnRequest, AcpTurnResult, AcpTurnStopReason, register_acp_backend,
 };
 use crate::memory::MEMORY_OP_WINDOW;
+#[cfg(feature = "memory-sqlite")]
+use crate::memory::runtime_config::MemoryRuntimeConfig;
 
 struct FakeRuntime {
     seed_messages: Vec<Value>,
+    assembled_context_with_system_prompt: Option<AssembledConversationContext>,
+    assembled_context_without_system_prompt: Option<AssembledConversationContext>,
     completion_responses: Mutex<VecDeque<Result<String, String>>>,
     turn_responses: Mutex<VecDeque<Result<ProviderTurn, String>>>,
+    after_turn_result: Result<(), String>,
     compact_result: Result<(), String>,
+    #[cfg(feature = "memory-sqlite")]
+    durable_memory_config: Option<MemoryRuntimeConfig>,
     persisted: Mutex<Vec<(String, String, String)>>,
     bootstrap_calls: Mutex<Vec<String>>,
     ingested_messages: Mutex<Vec<(String, Value)>>,
     requested_messages: Mutex<Vec<Value>>,
     turn_requested_messages: Mutex<Vec<Vec<Value>>>,
     completion_requested_messages: Mutex<Vec<Vec<Value>>>,
+    build_context_calls: Mutex<Vec<(String, bool)>>,
     completion_calls: Mutex<usize>,
     turn_calls: Mutex<usize>,
     after_turn_calls: Mutex<Vec<(String, String, String, usize)>>,
@@ -311,20 +320,58 @@ impl FakeRuntime {
     ) -> Self {
         Self {
             seed_messages,
+            assembled_context_with_system_prompt: None,
+            assembled_context_without_system_prompt: None,
             completion_responses: Mutex::new(VecDeque::from(completions)),
             turn_responses: Mutex::new(VecDeque::from(turns)),
+            after_turn_result: Ok(()),
             compact_result: Ok(()),
+            #[cfg(feature = "memory-sqlite")]
+            durable_memory_config: None,
             persisted: Mutex::new(Vec::new()),
             bootstrap_calls: Mutex::new(Vec::new()),
             ingested_messages: Mutex::new(Vec::new()),
             requested_messages: Mutex::new(Vec::new()),
             turn_requested_messages: Mutex::new(Vec::new()),
             completion_requested_messages: Mutex::new(Vec::new()),
+            build_context_calls: Mutex::new(Vec::new()),
             completion_calls: Mutex::new(0),
             turn_calls: Mutex::new(0),
             after_turn_calls: Mutex::new(Vec::new()),
             compact_calls: Mutex::new(Vec::new()),
         }
+    }
+
+    fn with_assembled_context(mut self, assembled_context: AssembledConversationContext) -> Self {
+        self.assembled_context_with_system_prompt = Some(assembled_context.clone());
+        self.assembled_context_without_system_prompt = Some(assembled_context);
+        self
+    }
+
+    fn with_assembled_context_variants(
+        mut self,
+        with_system_prompt: AssembledConversationContext,
+        without_system_prompt: AssembledConversationContext,
+    ) -> Self {
+        self.assembled_context_with_system_prompt = Some(with_system_prompt);
+        self.assembled_context_without_system_prompt = Some(without_system_prompt);
+        self
+    }
+
+    fn with_after_turn_result(mut self, result: Result<(), String>) -> Self {
+        self.after_turn_result = result;
+        self
+    }
+
+    fn with_compact_result(mut self, result: Result<(), String>) -> Self {
+        self.compact_result = result;
+        self
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn with_durable_memory_config(mut self, config: MemoryRuntimeConfig) -> Self {
+        self.durable_memory_config = Some(config);
+        self
     }
 }
 
@@ -376,6 +423,69 @@ fn unique_acp_sqlite_path(suffix: &str) -> String {
         ))
         .display()
         .to_string()
+}
+
+fn persisted_conversation_event_payloads_by_name(
+    persisted: &[(String, String, String)],
+    event_name: &str,
+) -> Vec<Value> {
+    persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            (parsed.get("event")?.as_str()? == event_name)
+                .then(|| parsed.get("payload").cloned().unwrap_or(Value::Null))
+        })
+        .collect()
+}
+
+fn is_internal_assistant_record(content: &str) -> bool {
+    serde_json::from_str::<Value>(content)
+        .ok()
+        .and_then(|parsed| {
+            parsed
+                .get("type")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+        .map(|event_type| {
+            matches!(
+                event_type.as_str(),
+                "conversation_event" | "tool_decision" | "tool_outcome"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn persisted_visible_turns(
+    persisted: &[(String, String, String)],
+) -> Vec<(String, String, String)> {
+    persisted
+        .iter()
+        .filter(|(_, role, content)| *role != "assistant" || !is_internal_assistant_record(content))
+        .cloned()
+        .collect()
+}
+
+fn test_turn_checkpoint_identity(user_input: &str, assistant_reply: &str) -> Value {
+    json!({
+        "user_input_sha256": format!("{:x}", Sha256::digest(user_input.as_bytes())),
+        "assistant_reply_sha256": format!("{:x}", Sha256::digest(assistant_reply.as_bytes())),
+        "user_input_chars": user_input.chars().count(),
+        "assistant_reply_chars": assistant_reply.chars().count(),
+    })
+}
+
+fn test_turn_preparation_context_fingerprint(messages: &[Value]) -> String {
+    let serialized =
+        serde_json::to_vec(messages).expect("serializing test preparation messages should work");
+    format!("{:x}", Sha256::digest(serialized))
 }
 
 #[async_trait]
@@ -483,10 +593,38 @@ impl ConversationRuntime for FakeRuntime {
         &self,
         _config: &LoongClawConfig,
         _session_id: &str,
-        _include_system_prompt: bool,
+        include_system_prompt: bool,
         _kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<Vec<Value>> {
-        Ok(self.seed_messages.clone())
+        let assembled = if include_system_prompt {
+            self.assembled_context_with_system_prompt.as_ref()
+        } else {
+            self.assembled_context_without_system_prompt.as_ref()
+        };
+        Ok(assembled
+            .map(|context| context.messages.clone())
+            .unwrap_or_else(|| self.seed_messages.clone()))
+    }
+
+    async fn build_context(
+        &self,
+        _config: &LoongClawConfig,
+        session_id: &str,
+        include_system_prompt: bool,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<AssembledConversationContext> {
+        self.build_context_calls
+            .lock()
+            .expect("build context lock")
+            .push((session_id.to_owned(), include_system_prompt));
+        let assembled = if include_system_prompt {
+            self.assembled_context_with_system_prompt.clone()
+        } else {
+            self.assembled_context_without_system_prompt.clone()
+        };
+        Ok(assembled.unwrap_or_else(|| {
+            AssembledConversationContext::from_messages(self.seed_messages.clone())
+        }))
     }
 
     async fn request_completion(
@@ -538,6 +676,11 @@ impl ConversationRuntime for FakeRuntime {
         content: &str,
         _kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<()> {
+        #[cfg(feature = "memory-sqlite")]
+        if let Some(config) = self.durable_memory_config.as_ref() {
+            crate::memory::append_turn_direct(session_id, role, content, config)
+                .map_err(|error| format!("persist {role} turn failed: {error}"))?;
+        }
         self.persisted.lock().expect("persist lock").push((
             session_id.to_owned(),
             role.to_owned(),
@@ -563,7 +706,7 @@ impl ConversationRuntime for FakeRuntime {
                 assistant_reply.to_owned(),
                 messages.len(),
             ));
-        Ok(())
+        self.after_turn_result.clone()
     }
 
     async fn compact_context(
@@ -858,10 +1001,11 @@ async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
     assert_eq!(requested[1]["role"], "user");
     assert_eq!(requested[1]["content"], "hello");
 
-    let persisted = runtime.persisted.lock().expect("persisted lock");
-    assert_eq!(persisted.len(), 2);
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let visible_turns = persisted_visible_turns(&persisted);
+    assert_eq!(visible_turns.len(), 2);
     assert_eq!(
-        persisted[0],
+        visible_turns[0],
         (
             "session-1".to_owned(),
             "user".to_owned(),
@@ -869,7 +1013,7 @@ async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
         )
     );
     assert_eq!(
-        persisted[1],
+        visible_turns[1],
         (
             "session-1".to_owned(),
             "assistant".to_owned(),
@@ -914,7 +1058,7 @@ async fn handle_turn_with_runtime_keeps_provider_path_by_default_when_acp_enable
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-normal-path".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.default_agent = Some("claude".to_owned());
@@ -925,7 +1069,7 @@ async fn handle_turn_with_runtime_keeps_provider_path_by_default_when_acp_enable
         vec![" Filesystem ".to_owned(), "filesystem".to_owned()];
     config.memory.sqlite_path = unique_acp_sqlite_path("success");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime(
             &config,
             "telegram:42",
@@ -949,7 +1093,7 @@ async fn handle_turn_with_runtime_routes_explicit_acp_turns_through_acp() {
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-should-not-run".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.default_agent = Some("claude".to_owned());
@@ -960,7 +1104,7 @@ async fn handle_turn_with_runtime_routes_explicit_acp_turns_through_acp() {
         vec![" Filesystem ".to_owned(), "filesystem".to_owned()];
     config.memory.sqlite_path = unique_acp_sqlite_path("success-explicit");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:42"),
@@ -1079,7 +1223,7 @@ async fn handle_turn_with_runtime_merges_additional_acp_bootstrap_mcp_servers_fr
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-should-not-run".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.default_agent = Some("claude".to_owned());
@@ -1093,7 +1237,7 @@ async fn handle_turn_with_runtime_merges_additional_acp_bootstrap_mcp_servers_fr
         " Search ".to_owned(),
     ];
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:4242"),
@@ -1129,7 +1273,7 @@ async fn handle_turn_with_runtime_applies_acp_turn_provenance_metadata() {
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-should-not-run".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.default_agent = Some("claude".to_owned());
@@ -1137,7 +1281,7 @@ async fn handle_turn_with_runtime_applies_acp_turn_provenance_metadata() {
     config.acp.backend = Some(backend_id.to_owned());
     config.memory.sqlite_path = unique_acp_sqlite_path("turn-provenance");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:4242"),
@@ -1201,7 +1345,7 @@ async fn handle_turn_with_runtime_applies_acp_working_directory_from_options() {
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-should-not-run".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.default_agent = Some("claude".to_owned());
@@ -1210,7 +1354,7 @@ async fn handle_turn_with_runtime_applies_acp_working_directory_from_options() {
     config.memory.sqlite_path = unique_acp_sqlite_path("turn-working-directory");
     let working_directory = PathBuf::from("/workspace/project");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:4242"),
@@ -1254,7 +1398,7 @@ async fn handle_turn_with_runtime_falls_back_to_dispatch_acp_working_directory()
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-should-not-run".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.default_agent = Some("claude".to_owned());
@@ -1263,7 +1407,7 @@ async fn handle_turn_with_runtime_falls_back_to_dispatch_acp_working_directory()
     config.acp.dispatch.working_directory = Some(" /workspace/dispatch ".to_owned());
     config.memory.sqlite_path = unique_acp_sqlite_path("dispatch-working-directory");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:4343"),
@@ -1306,14 +1450,14 @@ async fn handle_turn_with_runtime_uses_provider_path_when_acp_dispatch_is_disabl
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-path-reply".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.backend = Some(backend_id.to_owned());
     config.acp.dispatch.enabled = false;
     config.memory.sqlite_path = unique_acp_sqlite_path("dispatch-disabled");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime(
             &config,
             "telegram:424242",
@@ -1349,14 +1493,14 @@ async fn handle_turn_with_runtime_explicit_acp_request_bypasses_dispatch_gate() 
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-should-not-run".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.backend = Some(backend_id.to_owned());
     config.acp.dispatch.enabled = false;
     config.memory.sqlite_path = unique_acp_sqlite_path("dispatch-disabled-explicit");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:424242"),
@@ -1383,11 +1527,11 @@ async fn handle_turn_with_runtime_explicit_acp_request_fails_closed_when_acp_is_
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-should-not-run".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = false;
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:424242"),
@@ -1417,7 +1561,7 @@ async fn handle_turn_with_runtime_routes_only_agent_prefixed_sessions_when_confi
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-fallback".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.backend = Some(backend_id.to_owned());
@@ -1425,7 +1569,7 @@ async fn handle_turn_with_runtime_routes_only_agent_prefixed_sessions_when_confi
         crate::config::AcpConversationRoutingMode::AgentPrefixedOnly;
     config.memory.sqlite_path = unique_acp_sqlite_path("prefixed-only");
 
-    let non_prefixed = orchestrator
+    let non_prefixed = coordinator
         .handle_turn_with_runtime(
             &config,
             "telegram:600",
@@ -1438,7 +1582,7 @@ async fn handle_turn_with_runtime_routes_only_agent_prefixed_sessions_when_confi
         .expect("non-prefixed session should stay on provider path");
     assert_eq!(non_prefixed, "provider-fallback");
 
-    let prefixed = orchestrator
+    let prefixed = coordinator
         .handle_turn_with_runtime(
             &config,
             "agent:codex:review-thread",
@@ -1485,7 +1629,7 @@ async fn handle_turn_with_runtime_routes_only_allowed_channels_into_acp() {
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-feishu-reply".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.backend = Some(backend_id.to_owned());
@@ -1493,7 +1637,7 @@ async fn handle_turn_with_runtime_routes_only_allowed_channels_into_acp() {
     config.acp.dispatch.allowed_channels = vec!["telegram".to_owned()];
     config.memory.sqlite_path = unique_acp_sqlite_path("channel-allowlist");
 
-    let telegram = orchestrator
+    let telegram = coordinator
         .handle_turn_with_runtime(
             &config,
             "telegram:100",
@@ -1532,7 +1676,7 @@ async fn handle_turn_with_runtime_routes_only_allowed_channels_into_acp() {
         );
     }
 
-    let feishu = orchestrator
+    let feishu = coordinator
         .handle_turn_with_runtime(
             &config,
             "feishu:oc_123",
@@ -1561,7 +1705,7 @@ async fn handle_turn_with_runtime_and_address_routes_structured_channel_scope_in
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-reply".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.backend = Some(backend_id.to_owned());
@@ -1571,7 +1715,7 @@ async fn handle_turn_with_runtime_and_address_routes_structured_channel_scope_in
     let address = ConversationSessionAddress::from_session_id("opaque-session")
         .with_channel_scope("telegram", "100");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address(
             &config,
             &address,
@@ -1631,7 +1775,7 @@ async fn handle_turn_with_runtime_and_address_enforces_account_and_thread_dispat
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-reply".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.backend = Some(backend_id.to_owned());
@@ -1649,7 +1793,7 @@ async fn handle_turn_with_runtime_and_address_enforces_account_and_thread_dispat
         .with_channel_scope("feishu", "oc_123")
         .with_account_id("lark-prod");
 
-    let allowed_reply = orchestrator
+    let allowed_reply = coordinator
         .handle_turn_with_runtime_and_address(
             &config,
             &allowed,
@@ -1662,7 +1806,7 @@ async fn handle_turn_with_runtime_and_address_enforces_account_and_thread_dispat
         .expect("thread-bound allowed address should route through ACP");
     assert_eq!(allowed_reply, "acp: hello allowed");
 
-    let blocked_reply = orchestrator
+    let blocked_reply = coordinator
         .handle_turn_with_runtime_and_address(
             &config,
             &blocked,
@@ -1711,13 +1855,13 @@ async fn handle_turn_with_runtime_formats_acp_errors_inline_when_requested() {
         vec![json!({"role": "system", "content": "sys"})],
         Ok("provider-should-not-run".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.backend = Some(backend_id.to_owned());
     config.memory.sqlite_path = unique_acp_sqlite_path("inline-error");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("feishu:oc_123"),
@@ -1756,13 +1900,13 @@ async fn handle_turn_with_runtime_formats_acp_errors_inline_when_requested() {
 async fn handle_turn_with_runtime_reuses_shared_acp_session_between_turns() {
     let (backend_id, shared) = register_routed_acp_backend("reuse", false);
     let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.backend = Some(backend_id.to_owned());
     config.memory.sqlite_path = unique_acp_sqlite_path("reuse");
 
-    let first = orchestrator
+    let first = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:4242"),
@@ -1777,7 +1921,7 @@ async fn handle_turn_with_runtime_reuses_shared_acp_session_between_turns() {
         )
         .await
         .expect("first ACP-routed turn");
-    let second = orchestrator
+    let second = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:4242"),
@@ -1820,14 +1964,14 @@ async fn handle_turn_with_runtime_persists_acp_runtime_events_when_enabled() {
         ],
     );
     let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let mut config = test_config();
     config.acp.enabled = true;
     config.acp.backend = Some(backend_id.to_owned());
     config.acp.emit_runtime_events = true;
     config.memory.sqlite_path = unique_acp_sqlite_path("runtime-events");
 
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:777"),
@@ -1927,7 +2071,7 @@ async fn handle_turn_with_runtime_streams_acp_runtime_events_to_external_sink_wi
         ],
     );
     let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let sink = RecordingAcpEventSink::default();
     let mut config = test_config();
     config.acp.enabled = true;
@@ -1936,7 +2080,7 @@ async fn handle_turn_with_runtime_streams_acp_runtime_events_to_external_sink_wi
     config.memory.sqlite_path = unique_acp_sqlite_path("external-runtime-events");
 
     let acp_options = AcpConversationTurnOptions::from_event_sink(Some(&sink));
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:778"),
@@ -1996,7 +2140,7 @@ async fn handle_turn_with_runtime_streams_and_persists_acp_runtime_events_when_b
         ],
     );
     let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
-    let orchestrator = ConversationOrchestrator::new();
+    let coordinator = ConversationTurnCoordinator::new();
     let sink = RecordingAcpEventSink::default();
     let mut config = test_config();
     config.acp.enabled = true;
@@ -2005,7 +2149,7 @@ async fn handle_turn_with_runtime_streams_and_persists_acp_runtime_events_when_b
     config.memory.sqlite_path = unique_acp_sqlite_path("external-and-persisted-runtime-events");
 
     let acp_options = AcpConversationTurnOptions::from_event_sink(Some(&sink));
-    let reply = orchestrator
+    let reply = coordinator
         .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &ConversationSessionAddress::from_session_id("telegram:779"),
@@ -2059,8 +2203,8 @@ async fn handle_turn_with_runtime_skips_compaction_when_disabled() {
     let mut config = test_config();
     config.conversation.compact_enabled = false;
 
-    let orchestrator = ConversationOrchestrator::new();
-    let reply = orchestrator
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
         .handle_turn_with_runtime(
             &config,
             "session-no-compact",
@@ -2091,8 +2235,8 @@ async fn handle_turn_with_runtime_skips_compaction_below_min_messages() {
     let mut config = test_config();
     config.conversation.compact_min_messages = Some(10);
 
-    let orchestrator = ConversationOrchestrator::new();
-    let reply = orchestrator
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
         .handle_turn_with_runtime(
             &config,
             "session-no-compact-threshold",
@@ -2124,8 +2268,8 @@ async fn handle_turn_with_runtime_skips_compaction_below_token_threshold() {
     config.conversation.compact_min_messages = None;
     config.conversation.compact_trigger_estimated_tokens = Some(100_000);
 
-    let orchestrator = ConversationOrchestrator::new();
-    let reply = orchestrator
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
         .handle_turn_with_runtime(
             &config,
             "session-no-compact-token-threshold",
@@ -2157,8 +2301,8 @@ async fn handle_turn_with_runtime_compacts_when_token_threshold_reached() {
     config.conversation.compact_min_messages = Some(999);
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
-    let orchestrator = ConversationOrchestrator::new();
-    let reply = orchestrator
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
         .handle_turn_with_runtime(
             &config,
             "session-compact-token-threshold",
@@ -2186,8 +2330,8 @@ async fn handle_turn_with_runtime_compaction_error_is_ignored_when_fail_open() {
     let mut config = test_config();
     config.conversation.compact_fail_open = true;
 
-    let orchestrator = ConversationOrchestrator::new();
-    let reply = orchestrator
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
         .handle_turn_with_runtime(
             &config,
             "session-compact-fail-open",
@@ -2214,8 +2358,8 @@ async fn handle_turn_with_runtime_compaction_error_propagates_when_fail_closed()
     let mut config = test_config();
     config.conversation.compact_fail_open = false;
 
-    let orchestrator = ConversationOrchestrator::new();
-    let error = orchestrator
+    let coordinator = ConversationTurnCoordinator::new();
+    let error = coordinator
         .handle_turn_with_runtime(
             &config,
             "session-compact-fail-closed",
@@ -2234,7 +2378,221 @@ async fn handle_turn_with_runtime_compaction_error_propagates_when_fail_closed()
 }
 
 #[tokio::test]
-async fn handle_turn_with_runtime_propagates_error_without_persisting() {
+async fn handle_turn_with_runtime_persists_turn_checkpoint_events_for_successful_provider_turn() {
+    let runtime = FakeRuntime::new(
+        vec![json!({"role": "system", "content": "sys"})],
+        Ok("assistant-reply".to_owned()),
+    );
+    let mut config = test_config();
+    config.conversation.compact_enabled = false;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-turn-checkpoint-success",
+            "hello",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("success path should persist checkpoint events");
+
+    assert_eq!(reply, "assistant-reply");
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(payloads.len(), 2, "expected two checkpoint events");
+
+    assert_eq!(payloads[0]["schema_version"], 1);
+    assert_eq!(payloads[0]["stage"], "post_persist");
+    assert_eq!(payloads[0]["checkpoint"]["request"]["kind"], "continue");
+    assert_eq!(
+        payloads[0]["checkpoint"]["identity"],
+        test_turn_checkpoint_identity("hello", "assistant-reply")
+    );
+    assert_eq!(
+        payloads[0]["checkpoint"]["preparation"]["context_fingerprint_sha256"],
+        test_turn_preparation_context_fingerprint(&[
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+        ])
+    );
+    assert_eq!(payloads[0]["checkpoint"]["lane"]["lane"], "fast");
+    assert_eq!(
+        payloads[0]["checkpoint"]["lane"]["result_kind"],
+        "final_text"
+    );
+    assert_eq!(payloads[0]["checkpoint"]["reply"]["decision"], "direct");
+    assert_eq!(
+        payloads[0]["checkpoint"]["finalization"]["persistence_mode"],
+        "success"
+    );
+    assert_eq!(
+        payloads[0]["finalization_progress"]["after_turn"],
+        "pending"
+    );
+    assert_eq!(
+        payloads[0]["finalization_progress"]["compaction"],
+        "pending"
+    );
+
+    assert_eq!(payloads[1]["schema_version"], 1);
+    assert_eq!(payloads[1]["stage"], "finalized");
+    assert_eq!(
+        payloads[1]["finalization_progress"]["after_turn"],
+        "completed"
+    );
+    assert_eq!(
+        payloads[1]["finalization_progress"]["compaction"],
+        "skipped"
+    );
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_persists_turn_checkpoint_events_for_inline_provider_error() {
+    let runtime = FakeRuntime::new(vec![], Err("timeout".to_owned()));
+    let mut config = test_config();
+    config.conversation.compact_enabled = false;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-turn-checkpoint-inline-error",
+            "hello",
+            ProviderErrorMode::InlineMessage,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("inline provider error should persist checkpoint events");
+
+    assert_eq!(reply, "[provider_error] timeout");
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(payloads.len(), 2, "expected two checkpoint events");
+
+    assert_eq!(payloads[0]["stage"], "post_persist");
+    assert_eq!(
+        payloads[0]["checkpoint"]["request"]["kind"],
+        "finalize_inline_provider_error"
+    );
+    assert_eq!(
+        payloads[0]["checkpoint"]["identity"],
+        test_turn_checkpoint_identity("hello", "[provider_error] timeout")
+    );
+    assert!(payloads[0]["checkpoint"]["lane"].is_null());
+    assert!(payloads[0]["checkpoint"]["reply"].is_null());
+    assert_eq!(
+        payloads[0]["checkpoint"]["finalization"]["persistence_mode"],
+        "inline_provider_error"
+    );
+
+    assert_eq!(payloads[1]["stage"], "finalized");
+    assert_eq!(
+        payloads[1]["finalization_progress"]["after_turn"],
+        "completed"
+    );
+    assert_eq!(
+        payloads[1]["finalization_progress"]["compaction"],
+        "skipped"
+    );
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_persists_turn_checkpoint_event_for_propagated_provider_error() {
+    let runtime = FakeRuntime::new(vec![], Err("timeout".to_owned()));
+    let mut config = test_config();
+    config.conversation.compact_enabled = false;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let error = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-turn-checkpoint-propagated-error",
+            "hello",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect_err("propagated provider error should still persist checkpoint event");
+
+    assert_eq!(error, "timeout");
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(payloads.len(), 1, "expected one finalized checkpoint event");
+
+    assert_eq!(payloads[0]["stage"], "finalized");
+    assert_eq!(payloads[0]["checkpoint"]["request"]["kind"], "return_error");
+    assert!(payloads[0]["checkpoint"]["identity"].is_null());
+    assert!(payloads[0]["checkpoint"]["lane"].is_null());
+    assert!(payloads[0]["checkpoint"]["reply"].is_null());
+    assert_eq!(
+        payloads[0]["checkpoint"]["finalization"]["kind"],
+        "return_error"
+    );
+    assert_eq!(
+        payloads[0]["finalization_progress"]["after_turn"],
+        "skipped"
+    );
+    assert_eq!(
+        payloads[0]["finalization_progress"]["compaction"],
+        "skipped"
+    );
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_persists_failed_turn_checkpoint_when_compaction_fails_closed() {
+    let mut runtime = FakeRuntime::new(
+        vec![json!({"role": "system", "content": "sys"})],
+        Ok("assistant-reply".to_owned()),
+    );
+    runtime.compact_result = Err("compact failure".to_owned());
+    let mut config = test_config();
+    config.conversation.compact_fail_open = false;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let error = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-turn-checkpoint-compaction-failure",
+            "hello",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect_err("compaction failure should still persist failed checkpoint event");
+
+    assert!(
+        error.contains("compact failure"),
+        "unexpected error: {error}"
+    );
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(
+        payloads.len(),
+        2,
+        "expected pre-failure and failure checkpoints"
+    );
+
+    assert_eq!(payloads[0]["stage"], "post_persist");
+    assert_eq!(payloads[1]["stage"], "finalization_failed");
+    assert_eq!(
+        payloads[1]["finalization_progress"]["after_turn"],
+        "completed"
+    );
+    assert_eq!(payloads[1]["finalization_progress"]["compaction"], "failed");
+    assert_eq!(payloads[1]["failure"]["step"], "compaction");
+    assert_eq!(payloads[1]["failure"]["error"], "compact failure");
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_propagates_error_without_persisting_reply_turns() {
     let runtime = FakeRuntime::new(vec![], Err("timeout".to_owned()));
     let coordinator = ConversationTurnCoordinator::new();
     let error = coordinator
@@ -2258,7 +2616,11 @@ async fn handle_turn_with_runtime_propagates_error_without_persisting() {
             .as_slice(),
         ["session-2"]
     );
-    assert!(runtime.persisted.lock().expect("persisted lock").is_empty());
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(payloads.len(), 1);
+    assert_eq!(payloads[0]["stage"], "finalized");
+    assert_eq!(payloads[0]["checkpoint"]["request"]["kind"], "return_error");
     assert!(
         runtime
             .ingested_messages
@@ -2308,10 +2670,11 @@ async fn handle_turn_with_runtime_inline_mode_returns_synthetic_reply_and_persis
         ["session-3"]
     );
 
-    let persisted = runtime.persisted.lock().expect("persisted lock");
-    assert_eq!(persisted.len(), 2);
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let visible_turns = persisted_visible_turns(&persisted);
+    assert_eq!(visible_turns.len(), 2);
     assert_eq!(
-        persisted[0],
+        visible_turns[0],
         (
             "session-3".to_owned(),
             "user".to_owned(),
@@ -2319,7 +2682,7 @@ async fn handle_turn_with_runtime_inline_mode_returns_synthetic_reply_and_persis
         )
     );
     assert_eq!(
-        persisted[1],
+        visible_turns[1],
         (
             "session-3".to_owned(),
             "assistant".to_owned(),
@@ -2410,11 +2773,12 @@ async fn handle_turn_with_runtime_tool_turn_uses_natural_language_completion_by_
     );
     assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
 
-    let persisted = runtime.persisted.lock().expect("persisted lock");
-    assert_eq!(persisted.len(), 2);
-    assert_eq!(persisted[0].1, "user");
-    assert_eq!(persisted[1].1, "assistant");
-    assert_eq!(persisted[1].2, reply);
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let visible_turns = persisted_visible_turns(&persisted);
+    assert_eq!(visible_turns.len(), 2);
+    assert_eq!(visible_turns[0].1, "user");
+    assert_eq!(visible_turns[1].1, "assistant");
+    assert_eq!(visible_turns[1].2, reply);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2899,7 +3263,10 @@ async fn handle_turn_with_runtime_safe_lane_plan_skips_runtime_events_when_disab
                 return None;
             }
             let parsed = serde_json::from_str::<Value>(content).ok()?;
-            (parsed.get("type")?.as_str()? == "conversation_event").then_some(())
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            (parsed.get("event")?.as_str()? != "turn_checkpoint").then_some(())
         })
         .count();
     assert_eq!(event_count, 0, "unexpected runtime events: {persisted:?}");
@@ -4001,6 +4368,199 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_requests_extended_h
     assert_eq!(window_request.payload["allow_extended_limit"], true);
 }
 
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_safe_lane_session_governor_falls_back_to_configured_sqlite_history_when_kernel_window_is_non_ok()
+ {
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
+    use loongclaw_kernel::{CoreMemoryAdapter, CoreToolAdapter};
+
+    struct FlakyAlwaysRetryableAdapter {
+        calls: Arc<Mutex<usize>>,
+    }
+
+    #[async_trait]
+    impl CoreToolAdapter for FlakyAlwaysRetryableAdapter {
+        fn name(&self) -> &str {
+            "flaky-governor-fallback-tools"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            _request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            {
+                let mut calls = self.calls.lock().expect("flaky calls lock");
+                *calls = calls.saturating_add(1);
+            }
+            Err(ToolPlaneError::Execution(
+                "transient tool failure".to_owned(),
+            ))
+        }
+    }
+
+    struct NonOkWindowMemoryAdapter;
+
+    #[async_trait]
+    impl CoreMemoryAdapter for NonOkWindowMemoryAdapter {
+        fn name(&self) -> &str {
+            "non-ok-governor-memory"
+        }
+
+        async fn execute_core_memory(
+            &self,
+            request: MemoryCoreRequest,
+        ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
+            if request.operation == MEMORY_OP_WINDOW {
+                return Ok(MemoryCoreOutcome {
+                    status: "error".to_owned(),
+                    payload: json!({
+                        "reason": "kernel memory window unavailable"
+                    }),
+                });
+            }
+            Ok(MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({}),
+            })
+        }
+    }
+
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-safe-lane-governor", "sqlite-fallback")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let call_counter = Arc::new(Mutex::new(0usize));
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::MemoryRead]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_memory_adapter(NonOkWindowMemoryAdapter);
+    kernel
+        .set_default_core_memory_adapter("non-ok-governor-memory")
+        .expect("set default core memory adapter");
+    kernel.register_core_tool_adapter(FlakyAlwaysRetryableAdapter {
+        calls: call_counter.clone(),
+    });
+    kernel
+        .set_default_core_tool_adapter("flaky-governor-fallback-tools")
+        .expect("set default core tool adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+    config.conversation.safe_lane_node_max_attempts = 1;
+    config.conversation.safe_lane_replan_max_rounds = 3;
+    config.conversation.safe_lane_replan_max_node_attempts = 4;
+    config.conversation.safe_lane_session_governor_enabled = true;
+    config
+        .conversation
+        .safe_lane_session_governor_failed_final_status_threshold = 1;
+    config
+        .conversation
+        .safe_lane_session_governor_backpressure_failure_threshold = 9;
+    config
+        .conversation
+        .safe_lane_session_governor_force_no_replan = true;
+    config
+        .conversation
+        .safe_lane_session_governor_force_node_max_attempts = 1;
+
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    crate::memory::append_turn_direct(
+        "session-safe-governor-fallback",
+        "assistant",
+        r#"{"type":"conversation_event","event":"final_status","payload":{"status":"failed","failure_code":"safe_lane_plan_node_retryable_error","route_decision":"terminal"}} "#.trim(),
+        &mem_config,
+    )
+    .expect("persist governor history into configured sqlite db");
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Running checks.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe-governor-fallback".to_owned(),
+                turn_id: "turn-safe-governor-fallback".to_owned(),
+                tool_call_id: "call-safe-governor-fallback-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let _reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-governor-fallback",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&ctx),
+        )
+        .await
+        .expect("safe lane should use sqlite governor fallback history");
+
+    let calls = *call_counter.lock().expect("call counter lock");
+    assert_eq!(
+        calls, 1,
+        "governor should suppress replans when configured sqlite history shows chronic failure"
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let lane_selected_payload = persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            if parsed.get("event")?.as_str()? != "lane_selected" {
+                return None;
+            }
+            parsed.get("payload").cloned()
+        })
+        .next_back()
+        .expect("lane_selected payload");
+    assert_eq!(lane_selected_payload["session_governor"]["engaged"], true);
+    assert_eq!(
+        lane_selected_payload["session_governor"]["failed_threshold_triggered"],
+        true
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn handle_turn_with_runtime_safe_lane_replans_failed_subgraph_only() {
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
@@ -4205,9 +4765,10 @@ async fn handle_turn_with_runtime_tool_denial_returns_inline_reply_even_in_propa
         "tool-denied fallback should run a completion pass for language-aware output"
     );
 
-    let persisted = runtime.persisted.lock().expect("persisted lock");
-    assert_eq!(persisted.len(), 2);
-    assert_eq!(persisted[1].2, reply);
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let visible_turns = persisted_visible_turns(&persisted);
+    assert_eq!(visible_turns.len(), 2);
+    assert_eq!(visible_turns[1].2, reply);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4264,9 +4825,10 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
         "tool-error fallback should run a completion pass for language-aware output"
     );
 
-    let persisted = runtime.persisted.lock().expect("persisted lock");
-    assert_eq!(persisted.len(), 2);
-    assert_eq!(persisted[1].2, reply);
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let visible_turns = persisted_visible_turns(&persisted);
+    assert_eq!(visible_turns.len(), 2);
+    assert_eq!(visible_turns[1].2, reply);
 }
 
 #[tokio::test]
@@ -5170,6 +5732,22 @@ async fn turn_engine_persists_tool_lifecycle_events() {
 fn build_kernel_context(
     audit: Arc<InMemoryAuditSink>,
 ) -> (KernelContext, Arc<Mutex<Vec<MemoryCoreRequest>>>) {
+    build_kernel_context_with_window_turns(
+        audit,
+        json!([
+            {
+                "role": "assistant",
+                "content": "kernel-memory-window",
+                "ts": 1
+            }
+        ]),
+    )
+}
+
+fn build_kernel_context_with_window_turns(
+    audit: Arc<InMemoryAuditSink>,
+    window_turns: Value,
+) -> (KernelContext, Arc<Mutex<Vec<MemoryCoreRequest>>>) {
     let clock = Arc::new(FixedClock::new(1_700_000_000));
     let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
 
@@ -5190,6 +5768,7 @@ fn build_kernel_context(
     let invocations = Arc::new(Mutex::new(Vec::new()));
     let adapter = SharedTestMemoryAdapter {
         invocations: invocations.clone(),
+        window_turns,
     };
     kernel.register_core_memory_adapter(adapter);
     kernel
@@ -5208,8 +5787,52 @@ fn build_kernel_context(
     (ctx, invocations)
 }
 
+fn build_kernel_context_with_window_turn_sequence(
+    audit: Arc<InMemoryAuditSink>,
+    window_turn_sequence: Vec<Value>,
+) -> (KernelContext, Arc<Mutex<Vec<MemoryCoreRequest>>>) {
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::MemoryWrite, Capability::MemoryRead]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+
+    let invocations = Arc::new(Mutex::new(Vec::new()));
+    let adapter = SequencedTestMemoryAdapter {
+        invocations: invocations.clone(),
+        window_turns: Mutex::new(VecDeque::from(window_turn_sequence)),
+    };
+    kernel.register_core_memory_adapter(adapter);
+    kernel
+        .set_default_core_memory_adapter("test-memory-sequenced")
+        .expect("set default memory adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    (ctx, invocations)
+}
+
 struct SharedTestMemoryAdapter {
     invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
+    window_turns: Value,
 }
 
 #[async_trait]
@@ -5224,13 +5847,44 @@ impl CoreMemoryAdapter for SharedTestMemoryAdapter {
     ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
         let payload = if request.operation == crate::memory::MEMORY_OP_WINDOW {
             json!({
-                "turns": [
-                    {
-                        "role": "assistant",
-                        "content": "kernel-memory-window",
-                        "ts": 1
-                    }
-                ]
+                "turns": self.window_turns.clone()
+            })
+        } else {
+            json!({})
+        };
+        self.invocations
+            .lock()
+            .expect("invocations lock")
+            .push(request);
+        Ok(MemoryCoreOutcome {
+            status: "ok".to_owned(),
+            payload,
+        })
+    }
+}
+
+struct SequencedTestMemoryAdapter {
+    invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
+    window_turns: Mutex<VecDeque<Value>>,
+}
+
+#[async_trait]
+impl CoreMemoryAdapter for SequencedTestMemoryAdapter {
+    fn name(&self) -> &str {
+        "test-memory-sequenced"
+    }
+
+    async fn execute_core_memory(
+        &self,
+        request: MemoryCoreRequest,
+    ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
+        let payload = if request.operation == crate::memory::MEMORY_OP_WINDOW {
+            let turns = {
+                let mut queued_turns = self.window_turns.lock().expect("window turns lock");
+                queued_turns.pop_front().unwrap_or_else(|| json!([]))
+            };
+            json!({
+                "turns": turns
             })
         } else {
             json!({})
@@ -5330,6 +5984,104 @@ async fn build_messages_routes_memory_window_through_kernel_when_context_provide
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_turn_checkpoint_event_summary_prefers_kernel_memory_window_when_context_provided() {
+    let checkpoint_turns = json!([
+        {
+            "role": "assistant",
+            "content": json!({
+                "type": "conversation_event",
+                "event": "turn_checkpoint",
+                "payload": {
+                    "schema_version": 1,
+                    "stage": "post_persist",
+                    "checkpoint": {
+                        "lane": {
+                            "lane": "safe",
+                            "result_kind": "tool_call"
+                        },
+                        "finalization": {
+                            "persistence_mode": "success"
+                        }
+                    },
+                    "finalization_progress": {
+                        "after_turn": "pending",
+                        "compaction": "pending"
+                    },
+                    "failure": null
+                }
+            })
+            .to_string(),
+            "ts": 1
+        },
+        {
+            "role": "assistant",
+            "content": json!({
+                "type": "conversation_event",
+                "event": "turn_checkpoint",
+                "payload": {
+                    "schema_version": 1,
+                    "stage": "finalized",
+                    "checkpoint": {
+                        "lane": {
+                            "lane": "safe",
+                            "result_kind": "tool_call"
+                        },
+                        "finalization": {
+                            "persistence_mode": "success"
+                        }
+                    },
+                    "finalization_progress": {
+                        "after_turn": "completed",
+                        "compaction": "skipped"
+                    },
+                    "failure": null
+                }
+            })
+            .to_string(),
+            "ts": 2
+        }
+    ]);
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (ctx, invocations) = build_kernel_context_with_window_turns(audit, checkpoint_turns);
+    let config = test_config();
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    let summary = load_turn_checkpoint_event_summary(
+        "session-k-turn-checkpoint",
+        96,
+        Some(&ctx),
+        &mem_config,
+    )
+    .await
+    .expect("load checkpoint summary via kernel");
+
+    assert_eq!(summary.checkpoint_events, 2);
+    assert_eq!(summary.session_state, TurnCheckpointSessionState::Finalized);
+    assert!(summary.checkpoint_durable);
+    assert_eq!(summary.latest_stage, Some(TurnCheckpointStage::Finalized));
+    assert_eq!(
+        summary.latest_after_turn,
+        Some(TurnCheckpointProgressStatus::Completed)
+    );
+    assert_eq!(
+        summary.latest_compaction,
+        Some(TurnCheckpointProgressStatus::Skipped)
+    );
+    assert!(!summary.requires_recovery);
+    assert!(summary.reply_durable);
+
+    let captured = invocations.lock().expect("invocations lock");
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
+    assert_eq!(
+        captured[0].payload["session_id"],
+        "session-k-turn-checkpoint"
+    );
+    assert_eq!(captured[0].payload["limit"], json!(96));
+    assert_eq!(captured[0].payload["allow_extended_limit"], json!(true));
+}
+
 #[cfg(not(feature = "memory-sqlite"))]
 #[tokio::test]
 async fn persist_turn_without_memory_sqlite_is_noop_with_kernel_context() {
@@ -5340,4 +6092,2581 @@ async fn persist_turn_without_memory_sqlite_is_noop_with_kernel_context() {
         .persist_turn("session-k0", "user", "no-memory", Some(&ctx))
         .await
         .expect("persist should be no-op when memory-sqlite is disabled");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn persisted_turn_checkpoint_events_survive_reload_without_polluting_prompt_history() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "reload")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 16;
+
+    let runtime = DefaultConversationRuntime::default();
+    let session_id = "session-turn-checkpoint-reload";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "post_persist",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success"
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "pending",
+                    "compaction": "pending"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist post_persist checkpoint");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalized",
+                "checkpoint": {
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success"
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "skipped"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist finalized checkpoint");
+
+    let messages = runtime
+        .build_messages(&config, session_id, true, None)
+        .await
+        .expect("reload prompt history");
+    assert!(
+        messages.iter().any(
+            |message| message["role"] == "assistant" && message["content"] == "assistant-reply"
+        ),
+        "assistant reply should survive reload: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|message| {
+            message["content"]
+                .as_str()
+                .map(|content| content.contains("\"event\":\"turn_checkpoint\""))
+                .unwrap_or(false)
+        }),
+        "checkpoint events must not pollute provider prompt history: {messages:?}"
+    );
+
+    let turns = crate::memory::window_direct(session_id, 16, &mem_config)
+        .expect("load raw turns from sqlite");
+    let assistant_contents = turns
+        .iter()
+        .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.as_str()))
+        .collect::<Vec<_>>();
+    let summary = summarize_turn_checkpoint_events(assistant_contents.iter().copied());
+    assert_eq!(summary.checkpoint_events, 2);
+    assert_eq!(summary.latest_stage, Some(TurnCheckpointStage::Finalized));
+    assert_eq!(
+        summary.latest_after_turn,
+        Some(TurnCheckpointProgressStatus::Completed)
+    );
+    assert_eq!(
+        summary.latest_compaction,
+        Some(TurnCheckpointProgressStatus::Skipped)
+    );
+    assert_eq!(summary.latest_lane.as_deref(), Some("fast"));
+    assert_eq!(summary.latest_result_kind.as_deref(), Some("final_text"));
+    assert_eq!(summary.session_state, TurnCheckpointSessionState::Finalized);
+    assert!(summary.checkpoint_durable);
+    assert!(summary.reply_durable);
+    assert!(!summary.requires_recovery);
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[tokio::test]
+async fn load_turn_checkpoint_event_summary_reads_recovery_state_from_sqlite_history() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "reader")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 8;
+
+    let session_id = "session-turn-checkpoint-reader";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "post_persist",
+                "checkpoint": {
+                    "lane": {
+                        "lane": "safe",
+                        "result_kind": "tool_call"
+                    },
+                    "finalization": {
+                        "persistence_mode": "error"
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "pending"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist post_persist checkpoint");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalization_failed",
+                "checkpoint": {
+                    "lane": {
+                        "lane": "safe",
+                        "result_kind": "tool_call"
+                    },
+                    "finalization": {
+                        "persistence_mode": "error"
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "failed"
+                },
+                "failure": {
+                    "step": "compaction",
+                    "error": "context compaction failed"
+                }
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist failed checkpoint");
+
+    let summary = load_turn_checkpoint_event_summary(session_id, 32, None, &mem_config)
+        .await
+        .expect("load checkpoint event summary");
+
+    assert_eq!(summary.checkpoint_events, 2);
+    assert_eq!(
+        summary.session_state,
+        TurnCheckpointSessionState::FinalizationFailed
+    );
+    assert!(summary.checkpoint_durable);
+    assert_eq!(
+        summary.latest_stage,
+        Some(TurnCheckpointStage::FinalizationFailed)
+    );
+    assert_eq!(
+        summary.latest_after_turn,
+        Some(TurnCheckpointProgressStatus::Completed)
+    );
+    assert_eq!(
+        summary.latest_compaction,
+        Some(TurnCheckpointProgressStatus::Failed)
+    );
+    assert_eq!(
+        summary.latest_failure_step,
+        Some(TurnCheckpointFailureStep::Compaction)
+    );
+    assert_eq!(
+        summary.latest_failure_error.as_deref(),
+        Some("context compaction failed")
+    );
+    assert_eq!(summary.latest_lane.as_deref(), Some("safe"));
+    assert_eq!(summary.latest_result_kind.as_deref(), Some("tool_call"));
+    assert_eq!(summary.latest_persistence_mode.as_deref(), Some("error"));
+    assert!(summary.reply_durable);
+    assert!(summary.requires_recovery);
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_with_runtime_finalizes_pending_checkpoint() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "repair-pending")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+    config.conversation.compact_fail_open = false;
+
+    let session_id = "session-turn-checkpoint-repair-pending";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "post_persist",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "pending",
+                    "compaction": "pending"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist post_persist checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let outcome = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("repair pending checkpoint");
+
+    assert_eq!(outcome.status().as_str(), "repaired");
+    assert_eq!(
+        outcome.source().map(|source| source.as_str()),
+        Some("runtime")
+    );
+    assert_eq!(outcome.action().as_str(), "run_after_turn_and_compaction");
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        1
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 1);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(payloads.len(), 1, "expected one repair checkpoint event");
+    assert_eq!(payloads[0]["stage"], "finalized");
+    assert_eq!(
+        payloads[0]["finalization_progress"]["after_turn"],
+        "completed"
+    );
+    assert_eq!(
+        payloads[0]["finalization_progress"]["compaction"],
+        "completed"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_with_runtime_requires_manual_repair_without_identity() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "repair-missing-identity")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let session_id = "session-turn-checkpoint-repair-missing-identity";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "post_persist",
+                "checkpoint": {
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "pending",
+                    "compaction": "pending"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist post_persist checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let outcome = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("repair should fail closed when identity is missing");
+
+    assert_eq!(outcome.status().as_str(), "manual_required");
+    assert_eq!(
+        outcome.source().map(|source| source.as_str()),
+        Some("summary")
+    );
+    assert_eq!(outcome.action().as_str(), "inspect_manually");
+    assert_eq!(
+        outcome.reason(),
+        TurnCheckpointTailRepairReason::CheckpointIdentityMissing
+    );
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 0);
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert!(
+        payloads.is_empty(),
+        "manual downgrade should not persist a new checkpoint event"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_with_runtime_preserves_safe_lane_override_reason_when_tail_is_not_runnable()
+ {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id(
+            "conversation-turn-checkpoint",
+            "repair-safe-lane-override-manual-reason"
+        )
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+
+    let session_id = "session-turn-checkpoint-repair-safe-lane-override-manual-reason";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "post_persist",
+                "checkpoint": {
+                    "identity": {
+                        "user_input_sha256": "u1",
+                        "assistant_reply_sha256": "a1",
+                        "user_input_chars": 5,
+                        "assistant_reply_chars": 15
+                    },
+                    "lane": {
+                        "lane": "safe",
+                        "result_kind": "tool_error",
+                        "safe_lane_terminal_route": {
+                            "decision": "terminal",
+                            "reason": "backpressure_attempts_exhausted",
+                            "source": "backpressure_guard"
+                        }
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": false,
+                        "attempts_context_compaction": false
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "skipped",
+                    "compaction": "skipped"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist post_persist checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let outcome = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("repair should downgrade to manual inspection");
+
+    assert_eq!(outcome.status().as_str(), "manual_required");
+    assert_eq!(outcome.action().as_str(), "inspect_manually");
+    assert_eq!(
+        outcome.reason().as_str(),
+        "safe_lane_backpressure_terminal_requires_manual_inspection"
+    );
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 0);
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_with_runtime_requires_manual_repair_on_identity_mismatch() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "repair-identity-mismatch")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let session_id = "session-turn-checkpoint-repair-identity-mismatch";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "post_persist",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "pending",
+                    "compaction": "pending"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist post_persist checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply-mutated"}),
+        ],
+        vec![],
+        vec![],
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let outcome = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("repair should fail closed on mismatched visible tail");
+
+    assert_eq!(outcome.status().as_str(), "manual_required");
+    assert_eq!(outcome.action().as_str(), "inspect_manually");
+    assert_eq!(
+        outcome.reason(),
+        TurnCheckpointTailRepairReason::CheckpointIdentityMismatch
+    );
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 0);
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert!(
+        payloads.is_empty(),
+        "mismatch downgrade should not persist a new checkpoint event"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_with_runtime_retries_failed_compaction_only() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "repair-compaction")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let session_id = "session-turn-checkpoint-repair-compaction";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalization_failed",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "failed"
+                },
+                "failure": {
+                    "step": "compaction",
+                    "error": "compact failed"
+                }
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist failed checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let outcome = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("repair failed compaction checkpoint");
+
+    assert_eq!(outcome.status().as_str(), "repaired");
+    assert_eq!(outcome.action().as_str(), "run_compaction");
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 1);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(payloads.len(), 1, "expected one repair checkpoint event");
+    assert_eq!(payloads[0]["stage"], "finalized");
+    assert_eq!(
+        payloads[0]["finalization_progress"]["after_turn"],
+        "completed"
+    );
+    assert_eq!(
+        payloads[0]["finalization_progress"]["compaction"],
+        "completed"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_rebuilds_original_finalization_context_for_compaction_retry() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "repair-compaction-context")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(3);
+    config.conversation.compact_trigger_estimated_tokens = None;
+
+    let session_id = "session-turn-checkpoint-repair-compaction-context";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalization_failed",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "failed"
+                },
+                "failure": {
+                    "step": "compaction",
+                    "error": "compact failed"
+                }
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist failed checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(vec![], vec![], vec![])
+        .with_assembled_context_variants(
+            AssembledConversationContext {
+                messages: vec![
+                    json!({"role": "system", "content": "sys"}),
+                    json!({"role": "user", "content": "hello"}),
+                    json!({"role": "assistant", "content": "assistant-reply"}),
+                ],
+                estimated_tokens: Some(3),
+                system_prompt_addition: None,
+            },
+            AssembledConversationContext {
+                messages: vec![
+                    json!({"role": "user", "content": "hello"}),
+                    json!({"role": "assistant", "content": "assistant-reply"}),
+                ],
+                estimated_tokens: Some(2),
+                system_prompt_addition: None,
+            },
+        );
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let outcome = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("repair should replay compaction against original finalization context");
+
+    assert_eq!(outcome.status().as_str(), "repaired");
+    assert_eq!(outcome.action().as_str(), "run_compaction");
+    assert_eq!(
+        runtime
+            .build_context_calls
+            .lock()
+            .expect("build context lock")
+            .clone(),
+        vec![(session_id.to_owned(), true)]
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 1);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(payloads.len(), 1, "expected one repair checkpoint event");
+    assert_eq!(payloads[0]["stage"], "finalized");
+    assert_eq!(
+        payloads[0]["finalization_progress"]["compaction"],
+        "completed"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_prefers_checkpoint_estimate_for_compaction_retry() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "repair-compaction-estimate")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(999);
+    config.conversation.compact_trigger_estimated_tokens = Some(50);
+
+    let session_id = "session-turn-checkpoint-repair-compaction-estimate";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalization_failed",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "preparation": {
+                        "estimated_tokens": 60
+                    },
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "failed"
+                },
+                "failure": {
+                    "step": "compaction",
+                    "error": "compact failed"
+                }
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist failed checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(vec![], vec![], vec![])
+        .with_assembled_context(AssembledConversationContext {
+            messages: vec![
+                json!({"role": "system", "content": "sys"}),
+                json!({"role": "user", "content": "hello"}),
+                json!({"role": "assistant", "content": "assistant-reply"}),
+            ],
+            estimated_tokens: Some(1),
+            system_prompt_addition: None,
+        });
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let outcome = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("repair should reuse checkpoint estimate for compaction retry");
+
+    assert_eq!(outcome.status().as_str(), "repaired");
+    assert_eq!(outcome.action().as_str(), "run_compaction");
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 1);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(payloads.len(), 1, "expected one repair checkpoint event");
+    assert_eq!(payloads[0]["stage"], "finalized");
+    assert_eq!(
+        payloads[0]["finalization_progress"]["compaction"],
+        "completed"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn probe_turn_checkpoint_tail_runtime_gate_reports_preparation_content_mismatch() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id(
+            "conversation-turn-checkpoint",
+            "probe-context-fingerprint-mismatch"
+        )
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let session_id = "session-turn-checkpoint-probe-context-fingerprint-mismatch";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalization_failed",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "preparation": {
+                        "context_message_count": 2,
+                        "context_fingerprint_sha256": test_turn_preparation_context_fingerprint(&[
+                            json!({"role": "system", "content": "sys"}),
+                            json!({"role": "user", "content": "hello"}),
+                        ]),
+                        "estimated_tokens": 16
+                    },
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "failed"
+                },
+                "failure": {
+                    "step": "compaction",
+                    "error": "compact failed"
+                }
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist failed checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(vec![], vec![], vec![])
+        .with_assembled_context(AssembledConversationContext {
+            messages: vec![
+                json!({"role": "system", "content": "summary drift"}),
+                json!({"role": "user", "content": "hello"}),
+                json!({"role": "assistant", "content": "assistant-reply"}),
+            ],
+            estimated_tokens: Some(99),
+            system_prompt_addition: None,
+        });
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let probe = coordinator
+        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("runtime probe should succeed")
+        .expect("fingerprint drift should produce a runtime probe");
+
+    assert_eq!(probe.action().as_str(), "inspect_manually");
+    assert_eq!(probe.source().as_str(), "runtime");
+    assert_eq!(
+        probe.reason().as_str(),
+        "checkpoint_preparation_fingerprint_mismatch"
+    );
+    assert_eq!(
+        runtime
+            .build_context_calls
+            .lock()
+            .expect("build context lock")
+            .as_slice(),
+        &[(session_id.to_owned(), true)]
+    );
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 0);
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn probe_turn_checkpoint_tail_runtime_gate_returns_none_when_repair_not_needed() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "probe-not-needed")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+
+    let session_id = "session-turn-checkpoint-probe-not-needed";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalized",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "completed"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist finalized checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let probe = coordinator
+        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("not-needed probe should succeed");
+
+    assert!(probe.is_none());
+    assert!(
+        runtime
+            .build_context_calls
+            .lock()
+            .expect("build context lock")
+            .is_empty()
+    );
+    assert!(runtime.persisted.lock().expect("persisted lock").is_empty());
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 0);
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn probe_turn_checkpoint_tail_runtime_gate_returns_none_for_summary_manual_repair() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "probe-summary-manual")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+
+    let session_id = "session-turn-checkpoint-probe-summary-manual";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "post_persist",
+                "checkpoint": {
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "pending",
+                    "compaction": "pending"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist summary-manual checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let probe = coordinator
+        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("summary-manual probe should succeed");
+
+    assert!(probe.is_none());
+    assert!(
+        runtime
+            .build_context_calls
+            .lock()
+            .expect("build context lock")
+            .is_empty(),
+        "summary-derived manual downgrade must stop before runtime context assembly"
+    );
+    assert!(runtime.persisted.lock().expect("persisted lock").is_empty());
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 0);
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn probe_turn_checkpoint_tail_runtime_gate_returns_none_for_runnable_repair() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "probe-runnable")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+
+    let session_id = "session-turn-checkpoint-probe-runnable";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "post_persist",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "pending",
+                    "compaction": "pending"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist runnable checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let probe = coordinator
+        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("runnable probe should succeed");
+
+    assert!(probe.is_none());
+    assert_eq!(
+        runtime
+            .build_context_calls
+            .lock()
+            .expect("build context lock")
+            .as_slice(),
+        &[(session_id.to_owned(), true)],
+        "runnable repair should validate runtime context but remain read-only"
+    );
+    assert!(runtime.persisted.lock().expect("persisted lock").is_empty());
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 0);
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn load_turn_checkpoint_diagnostics_with_runtime_preserves_summary_manual_assessment() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "diagnostics-summary-manual")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+
+    let session_id = "session-turn-checkpoint-diagnostics-summary-manual";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "post_persist",
+                "checkpoint": {
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "pending",
+                    "compaction": "pending"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist summary-manual checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let diagnostics = coordinator
+        .load_turn_checkpoint_diagnostics_with_runtime_and_limit(
+            &config, session_id, 12, &runtime, None,
+        )
+        .await
+        .expect("diagnostics should load");
+
+    assert_eq!(
+        diagnostics.summary().session_state,
+        TurnCheckpointSessionState::PendingFinalization
+    );
+    assert_eq!(
+        diagnostics.recovery().action(),
+        TurnCheckpointRecoveryAction::InspectManually
+    );
+    assert_eq!(
+        diagnostics.recovery().source(),
+        TurnCheckpointTailRepairSource::Summary
+    );
+    assert_eq!(
+        diagnostics.recovery().reason(),
+        Some(TurnCheckpointTailRepairReason::CheckpointIdentityMissing)
+    );
+    assert!(diagnostics.runtime_probe().is_none());
+    assert!(
+        runtime
+            .build_context_calls
+            .lock()
+            .expect("build context lock")
+            .is_empty(),
+        "summary-derived manual assessment must not assemble runtime context"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn load_turn_checkpoint_diagnostics_with_runtime_preserves_summary_assessment_and_runtime_probe()
+ {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "diagnostics-runtime-drift")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let session_id = "session-turn-checkpoint-diagnostics-runtime-drift";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalization_failed",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "preparation": {
+                        "context_message_count": 2,
+                        "context_fingerprint_sha256": test_turn_preparation_context_fingerprint(&[
+                            json!({"role": "system", "content": "sys"}),
+                            json!({"role": "user", "content": "hello"}),
+                        ]),
+                        "estimated_tokens": 16
+                    },
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "failed"
+                },
+                "failure": {
+                    "step": "compaction",
+                    "error": "compact failed"
+                }
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist failed checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(vec![], vec![], vec![])
+        .with_assembled_context(AssembledConversationContext {
+            messages: vec![
+                json!({"role": "system", "content": "summary drift"}),
+                json!({"role": "user", "content": "hello"}),
+                json!({"role": "assistant", "content": "assistant-reply"}),
+            ],
+            estimated_tokens: Some(99),
+            system_prompt_addition: None,
+        });
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let diagnostics = coordinator
+        .load_turn_checkpoint_diagnostics_with_runtime_and_limit(
+            &config, session_id, 12, &runtime, None,
+        )
+        .await
+        .expect("diagnostics should load");
+
+    assert_eq!(
+        diagnostics.summary().session_state,
+        TurnCheckpointSessionState::FinalizationFailed
+    );
+    assert_eq!(
+        diagnostics.recovery().action(),
+        TurnCheckpointRecoveryAction::RunCompaction
+    );
+    assert_eq!(
+        diagnostics.recovery().source(),
+        TurnCheckpointTailRepairSource::Summary
+    );
+    assert_eq!(diagnostics.recovery().reason(), None);
+
+    let runtime_probe = diagnostics
+        .runtime_probe()
+        .expect("runtime drift should surface a probe");
+    assert_eq!(runtime_probe.action().as_str(), "inspect_manually");
+    assert_eq!(runtime_probe.source().as_str(), "runtime");
+    assert_eq!(
+        runtime_probe.reason(),
+        TurnCheckpointTailRepairReason::CheckpointPreparationFingerprintMismatch
+    );
+    assert_eq!(
+        runtime
+            .build_context_calls
+            .lock()
+            .expect("build context lock")
+            .as_slice(),
+        &[(session_id.to_owned(), true)]
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_turn_checkpoint_diagnostics_uses_single_kernel_window_snapshot_for_summary_and_runtime_probe()
+ {
+    let first_window_turns = json!([
+        {
+            "role": "assistant",
+            "content": json!({
+                "type": "conversation_event",
+                "event": "turn_checkpoint",
+                "payload": {
+                    "schema_version": 1,
+                    "stage": "finalization_failed",
+                    "checkpoint": {
+                        "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                        "preparation": {
+                            "context_message_count": 2,
+                            "context_fingerprint_sha256": test_turn_preparation_context_fingerprint(&[
+                                json!({"role": "system", "content": "different-system"}),
+                                json!({"role": "user", "content": "hello"}),
+                            ]),
+                            "estimated_tokens": 16
+                        },
+                        "lane": {
+                            "lane": "fast",
+                            "result_kind": "final_text"
+                        },
+                        "finalization": {
+                            "persistence_mode": "success",
+                            "runs_after_turn": true,
+                            "attempts_context_compaction": true
+                        }
+                    },
+                    "finalization_progress": {
+                        "after_turn": "completed",
+                        "compaction": "failed"
+                    },
+                    "failure": {
+                        "step": "compaction",
+                        "error": "compact failed"
+                    }
+                }
+            })
+            .to_string(),
+            "ts": 1
+        }
+    ]);
+    let second_window_turns = json!([
+        {
+            "role": "assistant",
+            "content": "stale-drift-without-checkpoint",
+            "ts": 2
+        }
+    ]);
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (ctx, invocations) = build_kernel_context_with_window_turn_sequence(
+        audit,
+        vec![first_window_turns, second_window_turns],
+    );
+
+    let mut config = test_config();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let session_id = "session-turn-checkpoint-diagnostics-kernel-single-window";
+    let runtime = FakeRuntime::with_turns_and_completions(vec![], vec![], vec![])
+        .with_assembled_context(AssembledConversationContext {
+            messages: vec![
+                json!({"role": "system", "content": "summary drift"}),
+                json!({"role": "user", "content": "hello"}),
+                json!({"role": "assistant", "content": "assistant-reply"}),
+            ],
+            estimated_tokens: Some(99),
+            system_prompt_addition: None,
+        });
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let diagnostics = coordinator
+        .load_turn_checkpoint_diagnostics_with_runtime_and_limit(
+            &config,
+            session_id,
+            12,
+            &runtime,
+            Some(&ctx),
+        )
+        .await
+        .expect("diagnostics should load from one kernel window snapshot");
+
+    assert_eq!(
+        diagnostics.summary().session_state,
+        TurnCheckpointSessionState::FinalizationFailed
+    );
+    assert_eq!(
+        diagnostics.recovery().action(),
+        TurnCheckpointRecoveryAction::RunCompaction
+    );
+    assert_eq!(
+        diagnostics.recovery().source(),
+        TurnCheckpointTailRepairSource::Summary
+    );
+    assert_eq!(diagnostics.recovery().reason(), None);
+
+    let runtime_probe = diagnostics
+        .runtime_probe()
+        .expect("runtime probe should use the same checkpoint snapshot");
+    assert_eq!(runtime_probe.action().as_str(), "inspect_manually");
+    assert_eq!(runtime_probe.source().as_str(), "runtime");
+    assert_eq!(
+        runtime_probe.reason(),
+        TurnCheckpointTailRepairReason::CheckpointPreparationFingerprintMismatch
+    );
+
+    let captured = invocations.lock().expect("invocations lock");
+    let window_calls = captured
+        .iter()
+        .filter(|request| request.operation == MEMORY_OP_WINDOW)
+        .count();
+    assert_eq!(
+        window_calls, 1,
+        "diagnostics should reuse one kernel window snapshot for summary and runtime probe"
+    );
+    assert_eq!(
+        runtime
+            .build_context_calls
+            .lock()
+            .expect("build context lock")
+            .as_slice(),
+        &[(session_id.to_owned(), true)]
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_requires_manual_repair_on_preparation_context_mismatch() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "repair-context-mismatch")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let session_id = "session-turn-checkpoint-repair-context-mismatch";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalization_failed",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "preparation": {
+                        "context_message_count": 2,
+                        "estimated_tokens": 16
+                    },
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "failed"
+                },
+                "failure": {
+                    "step": "compaction",
+                    "error": "compact failed"
+                }
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist failed checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(vec![], vec![], vec![])
+        .with_assembled_context(AssembledConversationContext {
+            messages: vec![
+                json!({"role": "system", "content": "sys"}),
+                json!({"role": "system", "content": "summary drift"}),
+                json!({"role": "user", "content": "hello"}),
+                json!({"role": "assistant", "content": "assistant-reply"}),
+            ],
+            estimated_tokens: Some(99),
+            system_prompt_addition: None,
+        });
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let outcome = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("context drift should downgrade to manual repair");
+
+    assert_eq!(outcome.status().as_str(), "manual_required");
+    assert_eq!(outcome.action().as_str(), "inspect_manually");
+    assert_eq!(
+        outcome.reason(),
+        TurnCheckpointTailRepairReason::CheckpointPreparationMismatch
+    );
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 0);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert!(
+        payloads.is_empty(),
+        "preparation mismatch downgrade should not persist a new checkpoint event"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_requires_manual_repair_on_preparation_content_mismatch() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id(
+            "conversation-turn-checkpoint",
+            "repair-context-fingerprint-mismatch"
+        )
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let session_id = "session-turn-checkpoint-repair-context-fingerprint-mismatch";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalization_failed",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "preparation": {
+                        "context_message_count": 2,
+                        "context_fingerprint_sha256": test_turn_preparation_context_fingerprint(&[
+                            json!({"role": "system", "content": "sys"}),
+                            json!({"role": "user", "content": "hello"}),
+                        ]),
+                        "estimated_tokens": 16
+                    },
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "failed"
+                },
+                "failure": {
+                    "step": "compaction",
+                    "error": "compact failed"
+                }
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist failed checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(vec![], vec![], vec![])
+        .with_assembled_context(AssembledConversationContext {
+            messages: vec![
+                json!({"role": "system", "content": "summary drift"}),
+                json!({"role": "user", "content": "hello"}),
+                json!({"role": "assistant", "content": "assistant-reply"}),
+            ],
+            estimated_tokens: Some(99),
+            system_prompt_addition: None,
+        });
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let outcome = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("content drift should downgrade to manual repair");
+
+    assert_eq!(outcome.status().as_str(), "manual_required");
+    assert_eq!(
+        outcome.source().map(|source| source.as_str()),
+        Some("runtime")
+    );
+    assert_eq!(outcome.action().as_str(), "inspect_manually");
+    assert_eq!(
+        outcome.reason().as_str(),
+        "checkpoint_preparation_fingerprint_mismatch"
+    );
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 0);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert!(
+        payloads.is_empty(),
+        "preparation fingerprint mismatch downgrade should not persist a new checkpoint event"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_requires_manual_repair_on_malformed_preparation_snapshot() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id(
+            "conversation-turn-checkpoint",
+            "repair-preparation-malformed"
+        )
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let session_id = "session-turn-checkpoint-repair-preparation-malformed";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalization_failed",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "preparation": {
+                        "context_message_count": "two",
+                        "estimated_tokens": 16
+                    },
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "failed"
+                },
+                "failure": {
+                    "step": "compaction",
+                    "error": "compact failed"
+                }
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist failed checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(vec![], vec![], vec![])
+        .with_assembled_context(AssembledConversationContext {
+            messages: vec![
+                json!({"role": "system", "content": "sys"}),
+                json!({"role": "user", "content": "hello"}),
+                json!({"role": "assistant", "content": "assistant-reply"}),
+            ],
+            estimated_tokens: Some(99),
+            system_prompt_addition: None,
+        });
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let outcome = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("malformed preparation should downgrade to manual repair");
+
+    assert_eq!(outcome.status().as_str(), "manual_required");
+    assert_eq!(outcome.action().as_str(), "inspect_manually");
+    assert_eq!(
+        outcome.reason(),
+        TurnCheckpointTailRepairReason::CheckpointPreparationMalformed
+    );
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 0);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert!(
+        payloads.is_empty(),
+        "malformed preparation downgrade should not persist a new checkpoint event"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_with_runtime_persists_failed_after_turn_repair() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "repair-after-turn-fail")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let session_id = "session-turn-checkpoint-repair-after-turn-fail";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "post_persist",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "pending",
+                    "compaction": "pending"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist post_persist checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    )
+    .with_after_turn_result(Err("repair after_turn failed".to_owned()));
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let error = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect_err("after_turn repair should fail closed");
+    assert!(error.contains("repair after_turn failed"));
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        1
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 0);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(
+        payloads.len(),
+        1,
+        "expected one failed repair checkpoint event"
+    );
+    assert_eq!(payloads[0]["stage"], "finalization_failed");
+    assert_eq!(payloads[0]["finalization_progress"]["after_turn"], "failed");
+    assert_eq!(
+        payloads[0]["finalization_progress"]["compaction"],
+        "skipped"
+    );
+    assert_eq!(payloads[0]["failure"]["step"], "after_turn");
+    assert_eq!(payloads[0]["failure"]["error"], "repair after_turn failed");
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_with_runtime_persists_failed_compaction_repair() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "repair-compaction-fail")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 12;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+    config.conversation.compact_fail_open = false;
+
+    let session_id = "session-turn-checkpoint-repair-compaction-fail";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalization_failed",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "failed"
+                },
+                "failure": {
+                    "step": "compaction",
+                    "error": "compact failed"
+                }
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist failed checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    )
+    .with_compact_result(Err("repair compaction failed".to_owned()));
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let error = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect_err("compaction repair should fail closed");
+    assert!(error.contains("repair compaction failed"));
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 1);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(
+        payloads.len(),
+        1,
+        "expected one failed repair checkpoint event"
+    );
+    assert_eq!(payloads[0]["stage"], "finalization_failed");
+    assert_eq!(
+        payloads[0]["finalization_progress"]["after_turn"],
+        "completed"
+    );
+    assert_eq!(payloads[0]["finalization_progress"]["compaction"], "failed");
+    assert_eq!(payloads[0]["failure"]["step"], "compaction");
+    assert_eq!(payloads[0]["failure"]["error"], "repair compaction failed");
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn durable_turn_checkpoint_repair_persists_finalized_checkpoint_and_repeated_repair_is_noop()
+{
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "durable-repair-idempotent")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 16;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+    config.conversation.compact_fail_open = false;
+
+    let session_id = "session-turn-checkpoint-durable-repair-idempotent";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "post_persist",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "pending",
+                    "compaction": "pending"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist pending checkpoint");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    )
+    .with_durable_memory_config(mem_config.clone());
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let first = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("first durable repair should succeed");
+    assert_eq!(first.status().as_str(), "repaired");
+    assert_eq!(first.action().as_str(), "run_after_turn_and_compaction");
+    assert_eq!(first.reason(), TurnCheckpointTailRepairReason::Repaired);
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        1
+    );
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 1);
+
+    let summary_after_first = load_turn_checkpoint_event_summary(session_id, 32, None, &mem_config)
+        .await
+        .expect("load summary after first durable repair");
+    assert_eq!(summary_after_first.checkpoint_events, 2);
+    assert_eq!(
+        summary_after_first.latest_stage,
+        Some(TurnCheckpointStage::Finalized)
+    );
+    assert_eq!(
+        summary_after_first.latest_after_turn,
+        Some(TurnCheckpointProgressStatus::Completed)
+    );
+    assert_eq!(
+        summary_after_first.latest_compaction,
+        Some(TurnCheckpointProgressStatus::Completed)
+    );
+    assert_eq!(summary_after_first.latest_identity_present, Some(true));
+    assert!(!summary_after_first.requires_recovery);
+
+    let second = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .await
+        .expect("second durable repair should be a noop");
+    assert_eq!(second.status().as_str(), "not_needed");
+    assert_eq!(second.action().as_str(), "none");
+    assert_eq!(second.reason(), TurnCheckpointTailRepairReason::NotNeeded);
+    assert_eq!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        1,
+        "repeated repair must not rerun after_turn"
+    );
+    assert_eq!(
+        runtime.compact_calls.lock().expect("compact lock").len(),
+        1,
+        "repeated repair must not rerun compaction"
+    );
+
+    let summary_after_second =
+        load_turn_checkpoint_event_summary(session_id, 32, None, &mem_config)
+            .await
+            .expect("load summary after second durable repair");
+    assert_eq!(summary_after_second.checkpoint_events, 2);
+    assert_eq!(
+        summary_after_second.latest_stage,
+        Some(TurnCheckpointStage::Finalized)
+    );
+    assert!(!summary_after_second.requires_recovery);
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn durable_turn_checkpoint_repair_persists_failed_terminal_checkpoint_then_recovers_on_retry()
+{
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "durable-repair-retry")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 16;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+    config.conversation.compact_fail_open = false;
+
+    let session_id = "session-turn-checkpoint-durable-repair-retry";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+    crate::memory::append_turn_direct(
+        session_id,
+        "assistant",
+        &json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "post_persist",
+                "checkpoint": {
+                    "identity": test_turn_checkpoint_identity("hello", "assistant-reply"),
+                    "lane": {
+                        "lane": "fast",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success",
+                        "runs_after_turn": true,
+                        "attempts_context_compaction": true
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "pending",
+                    "compaction": "pending"
+                },
+                "failure": null
+            }
+        })
+        .to_string(),
+        &mem_config,
+    )
+    .expect("persist pending checkpoint");
+
+    let failing_runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    )
+    .with_durable_memory_config(mem_config.clone())
+    .with_compact_result(Err("durable repair compaction failed".to_owned()));
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let error = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &failing_runtime, None)
+        .await
+        .expect_err("first durable repair should persist failure and return error");
+    assert!(error.contains("durable repair compaction failed"));
+    assert_eq!(
+        failing_runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        1
+    );
+    assert_eq!(
+        failing_runtime
+            .compact_calls
+            .lock()
+            .expect("compact lock")
+            .len(),
+        1
+    );
+
+    let summary_after_failure =
+        load_turn_checkpoint_event_summary(session_id, 32, None, &mem_config)
+            .await
+            .expect("load summary after durable failure");
+    assert_eq!(summary_after_failure.checkpoint_events, 2);
+    assert_eq!(
+        summary_after_failure.latest_stage,
+        Some(TurnCheckpointStage::FinalizationFailed)
+    );
+    assert_eq!(
+        summary_after_failure.latest_after_turn,
+        Some(TurnCheckpointProgressStatus::Completed)
+    );
+    assert_eq!(
+        summary_after_failure.latest_compaction,
+        Some(TurnCheckpointProgressStatus::Failed)
+    );
+    assert_eq!(summary_after_failure.latest_identity_present, Some(true));
+    assert!(summary_after_failure.requires_recovery);
+    assert_eq!(
+        plan_turn_checkpoint_recovery(&summary_after_failure),
+        TurnCheckpointRecoveryAction::RunCompaction
+    );
+
+    let retry_runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![],
+        vec![],
+    )
+    .with_durable_memory_config(mem_config.clone());
+
+    let retry = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &retry_runtime, None)
+        .await
+        .expect("second durable repair should recover");
+    assert_eq!(retry.status().as_str(), "repaired");
+    assert_eq!(retry.action().as_str(), "run_compaction");
+    assert_eq!(retry.reason(), TurnCheckpointTailRepairReason::Repaired);
+    assert_eq!(
+        retry_runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0,
+        "compaction-only retry must not rerun after_turn"
+    );
+    assert_eq!(
+        retry_runtime
+            .compact_calls
+            .lock()
+            .expect("compact lock")
+            .len(),
+        1
+    );
+
+    let summary_after_retry = load_turn_checkpoint_event_summary(session_id, 32, None, &mem_config)
+        .await
+        .expect("load summary after durable retry");
+    assert_eq!(summary_after_retry.checkpoint_events, 3);
+    assert_eq!(
+        summary_after_retry.latest_stage,
+        Some(TurnCheckpointStage::Finalized)
+    );
+    assert_eq!(
+        summary_after_retry.latest_after_turn,
+        Some(TurnCheckpointProgressStatus::Completed)
+    );
+    assert_eq!(
+        summary_after_retry.latest_compaction,
+        Some(TurnCheckpointProgressStatus::Completed)
+    );
+    assert_eq!(summary_after_retry.latest_identity_present, Some(true));
+    assert!(!summary_after_retry.requires_recovery);
+
+    let third = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &retry_runtime, None)
+        .await
+        .expect("finalized durable repair should stay noop");
+    assert_eq!(third.status().as_str(), "not_needed");
+    assert_eq!(third.reason(), TurnCheckpointTailRepairReason::NotNeeded);
+    assert_eq!(
+        retry_runtime
+            .compact_calls
+            .lock()
+            .expect("compact lock")
+            .len(),
+        1,
+        "finalized durable checkpoint must not trigger another compaction"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
 }

--- a/crates/app/src/conversation/turn_budget.rs
+++ b/crates/app/src/conversation/turn_budget.rs
@@ -1,0 +1,266 @@
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnRoundBudgetDecision {
+    ContinueWithFollowup,
+    FinalizeWithCompletionPass,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TurnRoundBudget {
+    round_index: usize,
+    max_rounds: usize,
+}
+
+impl TurnRoundBudget {
+    pub fn for_round_index(round_index: usize, max_rounds: usize) -> Self {
+        Self {
+            round_index,
+            max_rounds: max_rounds.max(1),
+        }
+    }
+
+    pub fn followup_decision(self) -> TurnRoundBudgetDecision {
+        if self.round_index.saturating_add(1) < self.max_rounds {
+            TurnRoundBudgetDecision::ContinueWithFollowup
+        } else {
+            TurnRoundBudgetDecision::FinalizeWithCompletionPass
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SafeLaneReplanBudget {
+    current_round: u8,
+    max_replans: u8,
+}
+
+impl SafeLaneReplanBudget {
+    pub fn new(max_replans: u8) -> Self {
+        Self {
+            current_round: 0,
+            max_replans,
+        }
+    }
+
+    pub fn current_round(self) -> u8 {
+        self.current_round
+    }
+
+    pub fn max_replans(self) -> u8 {
+        self.max_replans
+    }
+
+    pub fn continuation_decision(self) -> SafeLaneContinuationBudgetDecision {
+        if self.current_round < self.max_replans {
+            SafeLaneContinuationBudgetDecision::Continue
+        } else {
+            SafeLaneContinuationBudgetDecision::Terminal {
+                reason: SafeLaneFailureRouteReason::RoundBudgetExhausted,
+            }
+        }
+    }
+
+    pub fn after_replan(self) -> Self {
+        Self {
+            current_round: self.current_round.saturating_add(1),
+            max_replans: self.max_replans,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EscalatingAttemptBudget {
+    current_limit: u8,
+    max_limit: u8,
+}
+
+impl EscalatingAttemptBudget {
+    pub fn new(initial_limit: u8, max_limit: u8) -> Self {
+        let current_limit = initial_limit.max(1);
+        let max_limit = max_limit.max(current_limit).max(1);
+        Self {
+            current_limit: current_limit.min(max_limit),
+            max_limit,
+        }
+    }
+
+    pub fn current_limit(self) -> u8 {
+        self.current_limit
+    }
+
+    pub fn max_limit(self) -> u8 {
+        self.max_limit
+    }
+
+    pub fn after_retry(self) -> Self {
+        Self {
+            current_limit: self
+                .current_limit
+                .saturating_add(1)
+                .min(self.max_limit)
+                .max(1),
+            max_limit: self.max_limit,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SafeLaneBackpressureBudget {
+    max_total_attempts: u64,
+    max_replans: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SafeLaneContinuationBudgetDecision {
+    Continue,
+    Terminal { reason: SafeLaneFailureRouteReason },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SafeLaneFailureRouteReason {
+    RetryableFailure,
+    RoundBudgetExhausted,
+    PolicyDenied,
+    NonRetryableFailure,
+    RetryableFlagFalse,
+    ApprovalRequired,
+    ProviderFailure,
+    BackpressureAttemptsExhausted,
+    BackpressureReplansExhausted,
+    SessionGovernorNoReplan,
+}
+
+impl SafeLaneFailureRouteReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RetryableFailure => "retryable_failure",
+            Self::RoundBudgetExhausted => "round_budget_exhausted",
+            Self::PolicyDenied => "policy_denied",
+            Self::NonRetryableFailure => "non_retryable_failure",
+            Self::RetryableFlagFalse => "retryable_flag_false",
+            Self::ApprovalRequired => "approval_required",
+            Self::ProviderFailure => "provider_failure",
+            Self::BackpressureAttemptsExhausted => "backpressure_attempts_exhausted",
+            Self::BackpressureReplansExhausted => "backpressure_replans_exhausted",
+            Self::SessionGovernorNoReplan => "session_governor_no_replan",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "retryable_failure" => Some(Self::RetryableFailure),
+            "round_budget_exhausted" => Some(Self::RoundBudgetExhausted),
+            "policy_denied" => Some(Self::PolicyDenied),
+            "non_retryable_failure" => Some(Self::NonRetryableFailure),
+            "retryable_flag_false" => Some(Self::RetryableFlagFalse),
+            "approval_required" => Some(Self::ApprovalRequired),
+            "provider_failure" => Some(Self::ProviderFailure),
+            "backpressure_attempts_exhausted" => Some(Self::BackpressureAttemptsExhausted),
+            "backpressure_replans_exhausted" => Some(Self::BackpressureReplansExhausted),
+            "session_governor_no_replan" => Some(Self::SessionGovernorNoReplan),
+            _ => None,
+        }
+    }
+
+    pub fn is_backpressure(self) -> bool {
+        matches!(
+            self,
+            Self::BackpressureAttemptsExhausted | Self::BackpressureReplansExhausted
+        )
+    }
+}
+
+impl FromStr for SafeLaneFailureRouteReason {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value).ok_or(())
+    }
+}
+
+impl SafeLaneBackpressureBudget {
+    pub fn new(max_total_attempts: u64, max_replans: u32) -> Self {
+        Self {
+            max_total_attempts: max_total_attempts.max(1),
+            max_replans: max_replans.max(1),
+        }
+    }
+
+    pub fn continuation_decision(
+        self,
+        total_attempts_used: u64,
+        replans_triggered: u32,
+    ) -> SafeLaneContinuationBudgetDecision {
+        if total_attempts_used >= self.max_total_attempts {
+            return SafeLaneContinuationBudgetDecision::Terminal {
+                reason: SafeLaneFailureRouteReason::BackpressureAttemptsExhausted,
+            };
+        }
+        if replans_triggered >= self.max_replans {
+            return SafeLaneContinuationBudgetDecision::Terminal {
+                reason: SafeLaneFailureRouteReason::BackpressureReplansExhausted,
+            };
+        }
+        SafeLaneContinuationBudgetDecision::Continue
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        SafeLaneBackpressureBudget, SafeLaneContinuationBudgetDecision, SafeLaneFailureRouteReason,
+        SafeLaneReplanBudget, TurnRoundBudget, TurnRoundBudgetDecision,
+    };
+
+    #[test]
+    fn turn_round_budget_followup_decision_reports_remaining_capacity() {
+        let budget = TurnRoundBudget::for_round_index(0, 2);
+        assert_eq!(
+            budget.followup_decision(),
+            TurnRoundBudgetDecision::ContinueWithFollowup
+        );
+    }
+
+    #[test]
+    fn turn_round_budget_followup_decision_reports_round_limit_reached() {
+        let budget = TurnRoundBudget::for_round_index(1, 2);
+        assert_eq!(
+            budget.followup_decision(),
+            TurnRoundBudgetDecision::FinalizeWithCompletionPass
+        );
+    }
+
+    #[test]
+    fn safe_lane_replan_budget_continuation_decision_reports_budget_exhaustion() {
+        let budget = SafeLaneReplanBudget::new(1).after_replan();
+        assert_eq!(
+            budget.continuation_decision(),
+            SafeLaneContinuationBudgetDecision::Terminal {
+                reason: SafeLaneFailureRouteReason::RoundBudgetExhausted,
+            }
+        );
+    }
+
+    #[test]
+    fn safe_lane_backpressure_budget_continuation_decision_reports_attempt_exhaustion() {
+        let budget = SafeLaneBackpressureBudget::new(2, 10);
+        assert_eq!(
+            budget.continuation_decision(2, 0),
+            SafeLaneContinuationBudgetDecision::Terminal {
+                reason: SafeLaneFailureRouteReason::BackpressureAttemptsExhausted,
+            }
+        );
+    }
+
+    #[test]
+    fn safe_lane_backpressure_budget_continuation_decision_reports_continue_below_limits() {
+        let budget = SafeLaneBackpressureBudget::new(3, 2);
+        assert_eq!(
+            budget.continuation_decision(1, 0),
+            SafeLaneContinuationBudgetDecision::Continue
+        );
+    }
+}

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeSet;
 
 use async_trait::async_trait;
-use loongclaw_contracts::{
-    AuditEventKind, Capability, ExecutionPlane, MemoryCoreRequest, PlaneTier, ToolCoreRequest,
-};
+use loongclaw_contracts::{AuditEventKind, Capability, ExecutionPlane, PlaneTier, ToolCoreRequest};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 
 use crate::CliResult;
@@ -14,20 +14,26 @@ use crate::acp::{
     AcpConversationTurnOptions, AcpTurnEventSink, evaluate_acp_conversation_turn_entry_for_address,
     execute_acp_conversation_turn_for_address,
 };
+#[cfg(feature = "memory-sqlite")]
+use crate::memory::runtime_config::MemoryRuntimeConfig;
 
 use super::super::config::LoongClawConfig;
 use super::ConversationSessionAddress;
 use super::ProviderErrorMode;
 use super::analytics::{
-    SafeLaneEventSummary, parse_conversation_event, summarize_safe_lane_events,
+    SafeLaneEventSummary, TurnCheckpointProgressStatus as AnalyticsTurnCheckpointProgressStatus,
+    TurnCheckpointRecoveryAction, TurnCheckpointRepairManualReason, TurnCheckpointRepairPlan,
+    TurnCheckpointSessionState, build_turn_checkpoint_repair_plan, summarize_safe_lane_history,
 };
+use super::context_engine::AssembledConversationContext;
 use super::lane_arbiter::{ExecutionLane, LaneArbiterPolicy, LaneDecision};
 use super::persistence::{
     format_provider_error_reply, persist_acp_runtime_events, persist_conversation_event,
-    persist_error_turns, persist_error_turns_raw, persist_success_turns, persist_success_turns_raw,
+    persist_reply_turns_raw_with_mode, persist_reply_turns_with_mode,
 };
 use super::plan_executor::{
-    PlanExecutor, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor, PlanRunFailure, PlanRunStatus,
+    PlanExecutor, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor, PlanRunFailure,
+    PlanRunReport, PlanRunStatus,
 };
 use super::plan_ir::{
     PLAN_GRAPH_VERSION, PlanBudget, PlanEdge, PlanGraph, PlanNode, PlanNodeKind, RiskTier,
@@ -37,19 +43,335 @@ use super::plan_verifier::{
     PlanVerificationReport, verify_output,
 };
 use super::runtime::{ConversationRuntime, DefaultConversationRuntime};
+use super::safe_lane_failure::{
+    SafeLaneFailureCode, SafeLaneFailureRouteDecision, SafeLaneFailureRouteSource,
+    classify_safe_lane_plan_failure,
+};
+#[cfg(feature = "memory-sqlite")]
+use super::session_history::{
+    load_assistant_contents_from_session_window, load_latest_turn_checkpoint_entry,
+    load_turn_checkpoint_history_snapshot,
+};
+use super::turn_budget::{
+    EscalatingAttemptBudget, SafeLaneBackpressureBudget, SafeLaneContinuationBudgetDecision,
+    SafeLaneFailureRouteReason, SafeLaneReplanBudget,
+};
 use super::turn_engine::{
     KernelFailureClass, ProviderTurn, ToolIntent, TurnEngine, TurnFailure, TurnFailureKind,
     TurnResult, classify_kernel_error,
 };
 use super::turn_shared::{
-    build_tool_followup_user_prompt, compose_assistant_reply, join_non_empty_lines,
-    tool_result_contains_truncation_signal, user_requested_raw_tool_output,
+    ProviderTurnRequestAction, ReplyPersistenceMode, ReplyResolutionMode, ToolDrivenFollowupKind,
+    ToolDrivenFollowupPayload, ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase,
+    build_tool_driven_followup_tail, decide_provider_turn_request_action,
+    request_completion_with_raw_fallback, tool_result_contains_truncation_signal,
+    user_requested_raw_tool_output,
 };
 
 #[derive(Default)]
 pub struct ConversationTurnCoordinator;
 
-const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "A managed external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnCheckpointTailRepairStatus {
+    NoCheckpoint,
+    NotNeeded,
+    Repaired,
+    ManualRequired,
+}
+
+impl TurnCheckpointTailRepairStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NoCheckpoint => "no_checkpoint",
+            Self::NotNeeded => "not_needed",
+            Self::Repaired => "repaired",
+            Self::ManualRequired => "manual_required",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnCheckpointTailRepairReason {
+    NoCheckpoint,
+    NotNeeded,
+    Repaired,
+    CheckpointIdentityMissing,
+    SafeLaneBackpressureTerminalRequiresManualInspection,
+    SafeLaneSessionGovernorTerminalRequiresManualInspection,
+    CheckpointPreparationMalformed,
+    CheckpointPreparationMismatch,
+    CheckpointPreparationFingerprintMismatch,
+    CheckpointStateRequiresManualInspection,
+    VisibleTurnPairMissing,
+    CheckpointIdentityMismatch,
+}
+
+impl TurnCheckpointTailRepairReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NoCheckpoint => "no_checkpoint",
+            Self::NotNeeded => "not_needed",
+            Self::Repaired => "repaired",
+            Self::CheckpointIdentityMissing => "checkpoint_identity_missing",
+            Self::SafeLaneBackpressureTerminalRequiresManualInspection => {
+                "safe_lane_backpressure_terminal_requires_manual_inspection"
+            }
+            Self::SafeLaneSessionGovernorTerminalRequiresManualInspection => {
+                "safe_lane_session_governor_terminal_requires_manual_inspection"
+            }
+            Self::CheckpointPreparationMalformed => "checkpoint_preparation_malformed",
+            Self::CheckpointPreparationMismatch => "checkpoint_preparation_mismatch",
+            Self::CheckpointPreparationFingerprintMismatch => {
+                "checkpoint_preparation_fingerprint_mismatch"
+            }
+            Self::CheckpointStateRequiresManualInspection => {
+                "checkpoint_state_requires_manual_inspection"
+            }
+            Self::VisibleTurnPairMissing => "visible_turn_pair_missing",
+            Self::CheckpointIdentityMismatch => "checkpoint_identity_mismatch",
+        }
+    }
+}
+
+impl From<TurnCheckpointRepairManualReason> for TurnCheckpointTailRepairReason {
+    fn from(reason: TurnCheckpointRepairManualReason) -> Self {
+        match reason {
+            TurnCheckpointRepairManualReason::CheckpointIdentityMissing => {
+                Self::CheckpointIdentityMissing
+            }
+            TurnCheckpointRepairManualReason::SafeLaneBackpressureTerminalRequiresManualInspection => {
+                Self::SafeLaneBackpressureTerminalRequiresManualInspection
+            }
+            TurnCheckpointRepairManualReason::SafeLaneSessionGovernorTerminalRequiresManualInspection => {
+                Self::SafeLaneSessionGovernorTerminalRequiresManualInspection
+            }
+            TurnCheckpointRepairManualReason::CheckpointStateRequiresManualInspection => {
+                Self::CheckpointStateRequiresManualInspection
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnCheckpointTailRepairOutcome {
+    status: TurnCheckpointTailRepairStatus,
+    action: TurnCheckpointRecoveryAction,
+    source: Option<TurnCheckpointTailRepairSource>,
+    reason: TurnCheckpointTailRepairReason,
+    session_state: TurnCheckpointSessionState,
+    checkpoint_events: u32,
+    after_turn_status: Option<&'static str>,
+    compaction_status: Option<&'static str>,
+}
+
+impl TurnCheckpointTailRepairOutcome {
+    fn no_checkpoint() -> Self {
+        Self {
+            status: TurnCheckpointTailRepairStatus::NoCheckpoint,
+            action: TurnCheckpointRecoveryAction::None,
+            source: None,
+            reason: TurnCheckpointTailRepairReason::NoCheckpoint,
+            session_state: TurnCheckpointSessionState::NotDurable,
+            checkpoint_events: 0,
+            after_turn_status: None,
+            compaction_status: None,
+        }
+    }
+
+    pub(crate) fn from_summary(
+        status: TurnCheckpointTailRepairStatus,
+        action: TurnCheckpointRecoveryAction,
+        source: Option<TurnCheckpointTailRepairSource>,
+        reason: TurnCheckpointTailRepairReason,
+        summary: &super::analytics::TurnCheckpointEventSummary,
+    ) -> Self {
+        Self {
+            status,
+            action,
+            source,
+            reason,
+            session_state: summary.session_state,
+            checkpoint_events: summary.checkpoint_events,
+            after_turn_status: summary
+                .latest_after_turn
+                .map(format_analytics_turn_checkpoint_progress_status),
+            compaction_status: summary
+                .latest_compaction
+                .map(format_analytics_turn_checkpoint_progress_status),
+        }
+    }
+
+    fn repaired(
+        action: TurnCheckpointRecoveryAction,
+        summary: &super::analytics::TurnCheckpointEventSummary,
+        after_turn_status: TurnCheckpointProgressStatus,
+        compaction_status: TurnCheckpointProgressStatus,
+    ) -> Self {
+        Self {
+            status: TurnCheckpointTailRepairStatus::Repaired,
+            action,
+            source: Some(TurnCheckpointTailRepairSource::Runtime),
+            reason: TurnCheckpointTailRepairReason::Repaired,
+            session_state: summary.session_state,
+            checkpoint_events: summary.checkpoint_events,
+            after_turn_status: Some(format_turn_checkpoint_progress_status(after_turn_status)),
+            compaction_status: Some(format_turn_checkpoint_progress_status(compaction_status)),
+        }
+    }
+
+    pub fn status(&self) -> TurnCheckpointTailRepairStatus {
+        self.status
+    }
+
+    pub fn action(&self) -> TurnCheckpointRecoveryAction {
+        self.action
+    }
+
+    pub fn source(&self) -> Option<TurnCheckpointTailRepairSource> {
+        self.source
+    }
+
+    pub fn reason(&self) -> TurnCheckpointTailRepairReason {
+        self.reason
+    }
+
+    pub fn session_state(&self) -> TurnCheckpointSessionState {
+        self.session_state
+    }
+
+    pub fn checkpoint_events(&self) -> u32 {
+        self.checkpoint_events
+    }
+
+    pub fn after_turn_status(&self) -> Option<&'static str> {
+        self.after_turn_status
+    }
+
+    pub fn compaction_status(&self) -> Option<&'static str> {
+        self.compaction_status
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnCheckpointTailRepairSource {
+    Summary,
+    Runtime,
+}
+
+impl TurnCheckpointTailRepairSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Summary => "summary",
+            Self::Runtime => "runtime",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TurnCheckpointTailRepairRuntimeProbe {
+    action: TurnCheckpointRecoveryAction,
+    source: TurnCheckpointTailRepairSource,
+    reason: TurnCheckpointTailRepairReason,
+}
+
+impl TurnCheckpointTailRepairRuntimeProbe {
+    pub(crate) fn new(
+        action: TurnCheckpointRecoveryAction,
+        source: TurnCheckpointTailRepairSource,
+        reason: TurnCheckpointTailRepairReason,
+    ) -> Self {
+        Self {
+            action,
+            source,
+            reason,
+        }
+    }
+
+    pub fn action(&self) -> TurnCheckpointRecoveryAction {
+        self.action
+    }
+
+    pub fn source(&self) -> TurnCheckpointTailRepairSource {
+        self.source
+    }
+
+    pub fn reason(&self) -> TurnCheckpointTailRepairReason {
+        self.reason
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TurnCheckpointRecoveryAssessment {
+    action: TurnCheckpointRecoveryAction,
+    source: TurnCheckpointTailRepairSource,
+    reason: Option<TurnCheckpointTailRepairReason>,
+}
+
+impl TurnCheckpointRecoveryAssessment {
+    pub(crate) fn from_summary(summary: &super::analytics::TurnCheckpointEventSummary) -> Self {
+        let repair_plan = build_turn_checkpoint_repair_plan(summary);
+        let reason = matches!(
+            repair_plan.action(),
+            TurnCheckpointRecoveryAction::InspectManually
+        )
+        .then(|| {
+            repair_plan
+                .manual_reason()
+                .map(TurnCheckpointTailRepairReason::from)
+                .unwrap_or(TurnCheckpointTailRepairReason::CheckpointStateRequiresManualInspection)
+        });
+        Self {
+            action: repair_plan.action(),
+            source: TurnCheckpointTailRepairSource::Summary,
+            reason,
+        }
+    }
+
+    pub fn action(self) -> TurnCheckpointRecoveryAction {
+        self.action
+    }
+
+    pub fn source(self) -> TurnCheckpointTailRepairSource {
+        self.source
+    }
+
+    pub fn reason(self) -> Option<TurnCheckpointTailRepairReason> {
+        self.reason
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TurnCheckpointDiagnostics {
+    summary: super::analytics::TurnCheckpointEventSummary,
+    recovery: TurnCheckpointRecoveryAssessment,
+    runtime_probe: Option<TurnCheckpointTailRepairRuntimeProbe>,
+}
+
+impl TurnCheckpointDiagnostics {
+    pub(crate) fn new(
+        summary: super::analytics::TurnCheckpointEventSummary,
+        recovery: TurnCheckpointRecoveryAssessment,
+        runtime_probe: Option<TurnCheckpointTailRepairRuntimeProbe>,
+    ) -> Self {
+        Self {
+            summary,
+            recovery,
+            runtime_probe,
+        }
+    }
+
+    pub fn summary(&self) -> &super::analytics::TurnCheckpointEventSummary {
+        &self.summary
+    }
+
+    pub fn recovery(&self) -> TurnCheckpointRecoveryAssessment {
+        self.recovery
+    }
+
+    pub fn runtime_probe(&self) -> Option<&TurnCheckpointTailRepairRuntimeProbe> {
+        self.runtime_probe.as_ref()
+    }
+}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct SafeLaneExecutionMetrics {
@@ -212,6 +534,761 @@ struct SafeLaneGovernorHistorySignals {
     backpressure_failure_samples: Vec<bool>,
 }
 
+#[derive(Debug, Clone)]
+struct SafeLanePlanLoopState {
+    governor: SafeLaneSessionGovernorDecision,
+    replan_budget: SafeLaneReplanBudget,
+    tool_node_attempt_budget: EscalatingAttemptBudget,
+    plan_start_tool_index: usize,
+    seed_tool_outputs: Vec<String>,
+    metrics: SafeLaneExecutionMetrics,
+    adaptive_verify_policy: SafeLaneAdaptiveVerifyPolicyState,
+}
+
+impl SafeLanePlanLoopState {
+    fn new(config: &LoongClawConfig, governor: SafeLaneSessionGovernorDecision) -> Self {
+        let mut tool_node_max_attempts = config.conversation.safe_lane_node_max_attempts.max(1);
+        if let Some(forced_node_max_attempts) = governor.forced_node_max_attempts {
+            tool_node_max_attempts = tool_node_max_attempts.min(forced_node_max_attempts.max(1));
+        }
+        let mut max_node_attempts = config
+            .conversation
+            .safe_lane_replan_max_node_attempts
+            .max(tool_node_max_attempts);
+        if let Some(forced_node_max_attempts) = governor.forced_node_max_attempts {
+            max_node_attempts = max_node_attempts.min(forced_node_max_attempts.max(1));
+        }
+
+        Self {
+            governor,
+            replan_budget: SafeLaneReplanBudget::new(if governor.force_no_replan {
+                0
+            } else {
+                config.conversation.safe_lane_replan_max_rounds
+            }),
+            tool_node_attempt_budget: EscalatingAttemptBudget::new(
+                tool_node_max_attempts,
+                max_node_attempts,
+            ),
+            plan_start_tool_index: 0,
+            seed_tool_outputs: Vec::new(),
+            metrics: SafeLaneExecutionMetrics::default(),
+            adaptive_verify_policy: SafeLaneAdaptiveVerifyPolicyState::default(),
+        }
+    }
+
+    fn refresh_verify_policy(&mut self, config: &LoongClawConfig) -> Option<usize> {
+        let next_min_anchor_matches =
+            compute_safe_lane_verify_min_anchor_matches(config, self.metrics.verify_failures);
+        if next_min_anchor_matches == self.adaptive_verify_policy.min_anchor_matches {
+            return None;
+        }
+        self.adaptive_verify_policy.min_anchor_matches = next_min_anchor_matches;
+        (next_min_anchor_matches > 0).then_some(next_min_anchor_matches)
+    }
+
+    fn note_round_started(&mut self) {
+        self.metrics.rounds_started = self.metrics.rounds_started.saturating_add(1);
+    }
+
+    fn record_round_execution(&mut self, report: &PlanRunReport, stats: SafeLaneToolOutputStats) {
+        self.metrics.total_attempts_used = self
+            .metrics
+            .total_attempts_used
+            .saturating_add(report.attempts_used as u64);
+        self.metrics.record_tool_output_stats(stats);
+    }
+
+    fn note_round_succeeded(&mut self) {
+        self.metrics.rounds_succeeded = self.metrics.rounds_succeeded.saturating_add(1);
+    }
+
+    fn note_round_failed(&mut self) {
+        self.metrics.rounds_failed = self.metrics.rounds_failed.saturating_add(1);
+    }
+
+    fn note_verify_failure(&mut self) {
+        self.metrics.verify_failures = self.metrics.verify_failures.saturating_add(1);
+    }
+
+    fn note_replan(
+        &mut self,
+        next_plan_start_tool_index: usize,
+        next_seed_tool_outputs: Vec<String>,
+    ) {
+        self.plan_start_tool_index = next_plan_start_tool_index;
+        self.seed_tool_outputs = next_seed_tool_outputs;
+        self.metrics.replans_triggered = self.metrics.replans_triggered.saturating_add(1);
+    }
+
+    fn advance_round(&mut self) {
+        self.replan_budget = self.replan_budget.after_replan();
+        self.tool_node_attempt_budget = self.tool_node_attempt_budget.after_retry();
+    }
+
+    fn round(&self) -> u8 {
+        self.replan_budget.current_round()
+    }
+
+    fn max_rounds(&self) -> u8 {
+        self.replan_budget.max_replans()
+    }
+
+    fn tool_node_max_attempts(&self) -> u8 {
+        self.tool_node_attempt_budget.current_limit()
+    }
+
+    fn max_node_attempts(&self) -> u8 {
+        self.tool_node_attempt_budget.max_limit()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SafeLaneRoundExecution {
+    report: PlanRunReport,
+    tool_outputs: Vec<String>,
+    tool_output_stats: SafeLaneToolOutputStats,
+}
+
+#[derive(Debug, Clone)]
+struct ProviderTurnSessionState {
+    messages: Vec<Value>,
+    estimated_tokens: Option<usize>,
+}
+
+impl ProviderTurnSessionState {
+    fn from_assembled_context(
+        assembled_context: AssembledConversationContext,
+        user_input: &str,
+    ) -> Self {
+        let mut messages = assembled_context.messages;
+        messages.push(json!({
+            "role": "user",
+            "content": user_input,
+        }));
+        Self {
+            messages,
+            estimated_tokens: assembled_context.estimated_tokens,
+        }
+    }
+
+    fn after_turn_messages(&self, reply: &str) -> Vec<Value> {
+        let mut messages = self.messages.clone();
+        messages.push(json!({
+            "role": "assistant",
+            "content": reply,
+        }));
+        messages
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ProviderTurnReplyTailPhase {
+    reply: String,
+    after_turn_messages: Vec<Value>,
+    estimated_tokens: Option<usize>,
+}
+
+impl ProviderTurnReplyTailPhase {
+    fn from_session(session: &ProviderTurnSessionState, reply: &str) -> Self {
+        Self {
+            reply: reply.to_owned(),
+            after_turn_messages: session.after_turn_messages(reply),
+            estimated_tokens: session.estimated_tokens,
+        }
+    }
+
+    fn reply(&self) -> &str {
+        self.reply.as_str()
+    }
+
+    fn after_turn_messages(&self) -> &[Value] {
+        &self.after_turn_messages
+    }
+
+    fn estimated_tokens(&self) -> Option<usize> {
+        self.estimated_tokens
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ProviderTurnPreparation {
+    session: ProviderTurnSessionState,
+    lane_plan: ProviderTurnLanePlan,
+    raw_tool_output_requested: bool,
+}
+
+impl ProviderTurnPreparation {
+    fn from_assembled_context(
+        config: &LoongClawConfig,
+        assembled_context: AssembledConversationContext,
+        user_input: &str,
+    ) -> Self {
+        Self {
+            session: ProviderTurnSessionState::from_assembled_context(
+                assembled_context,
+                user_input,
+            ),
+            lane_plan: ProviderTurnLanePlan::from_user_input(config, user_input),
+            raw_tool_output_requested: user_requested_raw_tool_output(user_input),
+        }
+    }
+
+    fn checkpoint(&self) -> TurnPreparationSnapshot {
+        TurnPreparationSnapshot {
+            lane: self.lane_plan.decision.lane,
+            max_tool_steps: self.lane_plan.max_tool_steps,
+            raw_tool_output_requested: self.raw_tool_output_requested,
+            context_message_count: self.session.messages.len(),
+            context_fingerprint_sha256: checkpoint_context_fingerprint_sha256(
+                &self.session.messages,
+            ),
+            estimated_tokens: self.session.estimated_tokens,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ProviderTurnLanePlan {
+    decision: LaneDecision,
+    max_tool_steps: usize,
+}
+
+impl ProviderTurnLanePlan {
+    fn from_user_input(config: &LoongClawConfig, user_input: &str) -> Self {
+        let decision = if config.conversation.hybrid_lane_enabled {
+            lane_policy_from_config(config).decide(user_input)
+        } else {
+            disabled_lane_decision(user_input)
+        };
+        let max_tool_steps = match decision.lane {
+            ExecutionLane::Fast => config.conversation.fast_lane_max_tool_steps(),
+            ExecutionLane::Safe => config.conversation.safe_lane_max_tool_steps(),
+        };
+
+        Self {
+            decision,
+            max_tool_steps,
+        }
+    }
+
+    fn should_use_safe_lane_plan_path(
+        &self,
+        config: &LoongClawConfig,
+        turn: &ProviderTurn,
+    ) -> bool {
+        config.conversation.safe_lane_plan_execution_enabled
+            && matches!(self.decision.lane, ExecutionLane::Safe)
+            && !turn.tool_intents.is_empty()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ProviderTurnLaneExecution {
+    lane: ExecutionLane,
+    assistant_preface: String,
+    had_tool_intents: bool,
+    raw_tool_output_requested: bool,
+    turn_result: TurnResult,
+    safe_lane_terminal_route: Option<SafeLaneFailureRoute>,
+}
+
+impl ProviderTurnLaneExecution {
+    fn checkpoint(&self) -> TurnLaneExecutionSnapshot {
+        TurnLaneExecutionSnapshot {
+            lane: self.lane,
+            had_tool_intents: self.had_tool_intents,
+            raw_tool_output_requested: self.raw_tool_output_requested,
+            result_kind: turn_checkpoint_result_kind(&self.turn_result),
+            safe_lane_terminal_route: self.safe_lane_terminal_route,
+        }
+    }
+
+    fn reply_phase(&self) -> ToolDrivenReplyPhase {
+        ToolDrivenReplyPhase::new(
+            self.assistant_preface.as_str(),
+            self.had_tool_intents,
+            self.raw_tool_output_requested,
+            &self.turn_result,
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ProviderTurnContinuePhase {
+    request: TurnCheckpointRequest,
+    lane_execution: ProviderTurnLaneExecution,
+    reply_phase: ToolDrivenReplyPhase,
+}
+
+impl ProviderTurnContinuePhase {
+    fn new(tool_intents: usize, lane_execution: ProviderTurnLaneExecution) -> Self {
+        let reply_phase = lane_execution.reply_phase();
+        Self {
+            request: TurnCheckpointRequest::Continue { tool_intents },
+            lane_execution,
+            reply_phase,
+        }
+    }
+
+    fn checkpoint(
+        &self,
+        preparation: &ProviderTurnPreparation,
+        user_input: &str,
+        reply: &str,
+    ) -> TurnCheckpointSnapshot {
+        build_resolved_provider_checkpoint(
+            preparation,
+            user_input,
+            Some(reply),
+            self.request.clone(),
+            Some(self.lane_execution.checkpoint()),
+            Some(turn_reply_checkpoint(&self.reply_phase)),
+            TurnFinalizationCheckpoint::persist_reply(ReplyPersistenceMode::Success),
+        )
+    }
+
+    async fn resolve_reply<R: ConversationRuntime + ?Sized>(
+        &self,
+        runtime: &R,
+        config: &LoongClawConfig,
+        preparation: &ProviderTurnPreparation,
+        user_input: &str,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> String {
+        resolve_provider_turn_reply(
+            runtime,
+            config,
+            preparation,
+            &self.lane_execution,
+            &self.reply_phase,
+            user_input,
+            kernel_ctx,
+        )
+        .await
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TurnCheckpointSnapshot {
+    identity: Option<TurnCheckpointIdentity>,
+    preparation: TurnPreparationSnapshot,
+    request: TurnCheckpointRequest,
+    lane: Option<TurnLaneExecutionSnapshot>,
+    reply: Option<TurnReplyCheckpoint>,
+    finalization: TurnFinalizationCheckpoint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TurnCheckpointIdentity {
+    user_input_sha256: String,
+    assistant_reply_sha256: String,
+    user_input_chars: usize,
+    assistant_reply_chars: usize,
+}
+
+impl TurnCheckpointIdentity {
+    fn from_turn(user_input: &str, assistant_reply: &str) -> Self {
+        Self {
+            user_input_sha256: sha256_hex(user_input),
+            assistant_reply_sha256: sha256_hex(assistant_reply),
+            user_input_chars: user_input.chars().count(),
+            assistant_reply_chars: assistant_reply.chars().count(),
+        }
+    }
+
+    fn matches_turn(&self, user_input: &str, assistant_reply: &str) -> bool {
+        self.user_input_chars == user_input.chars().count()
+            && self.assistant_reply_chars == assistant_reply.chars().count()
+            && self.user_input_sha256 == sha256_hex(user_input)
+            && self.assistant_reply_sha256 == sha256_hex(assistant_reply)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TurnPreparationSnapshot {
+    lane: ExecutionLane,
+    max_tool_steps: usize,
+    raw_tool_output_requested: bool,
+    context_message_count: usize,
+    context_fingerprint_sha256: String,
+    estimated_tokens: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum TurnCheckpointRequest {
+    Continue { tool_intents: usize },
+    FinalizeInlineProviderError,
+    ReturnError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TurnLaneExecutionSnapshot {
+    lane: ExecutionLane,
+    had_tool_intents: bool,
+    raw_tool_output_requested: bool,
+    result_kind: TurnCheckpointResultKind,
+    safe_lane_terminal_route: Option<SafeLaneFailureRoute>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TurnCheckpointResultKind {
+    FinalText,
+    ToolDenied,
+    ToolError,
+    NeedsApproval,
+    ProviderError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TurnReplyCheckpoint {
+    decision: ReplyResolutionMode,
+    followup_kind: Option<ToolDrivenFollowupKind>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum TurnFinalizationCheckpoint {
+    PersistReply {
+        persistence_mode: ReplyPersistenceMode,
+        runs_after_turn: bool,
+        attempts_context_compaction: bool,
+    },
+    ReturnError,
+}
+
+impl TurnFinalizationCheckpoint {
+    fn persist_reply(persistence_mode: ReplyPersistenceMode) -> Self {
+        Self::PersistReply {
+            persistence_mode,
+            runs_after_turn: true,
+            attempts_context_compaction: true,
+        }
+    }
+
+    fn persistence_mode(self) -> Option<ReplyPersistenceMode> {
+        match self {
+            Self::PersistReply {
+                persistence_mode, ..
+            } => Some(persistence_mode),
+            Self::ReturnError => None,
+        }
+    }
+
+    fn runs_after_turn(self) -> bool {
+        match self {
+            Self::PersistReply {
+                runs_after_turn, ..
+            } => runs_after_turn,
+            Self::ReturnError => false,
+        }
+    }
+
+    fn attempts_context_compaction(self) -> bool {
+        match self {
+            Self::PersistReply {
+                attempts_context_compaction,
+                ..
+            } => attempts_context_compaction,
+            Self::ReturnError => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TurnCheckpointStage {
+    PostPersist,
+    Finalized,
+    FinalizationFailed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TurnCheckpointProgressStatus {
+    Pending,
+    Skipped,
+    Completed,
+    Failed,
+    FailedOpen,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+struct TurnCheckpointFinalizationProgress {
+    after_turn: TurnCheckpointProgressStatus,
+    compaction: TurnCheckpointProgressStatus,
+}
+
+impl TurnCheckpointFinalizationProgress {
+    fn pending(checkpoint: &TurnCheckpointSnapshot) -> Self {
+        Self {
+            after_turn: if checkpoint.finalization.runs_after_turn() {
+                TurnCheckpointProgressStatus::Pending
+            } else {
+                TurnCheckpointProgressStatus::Skipped
+            },
+            compaction: if checkpoint.finalization.attempts_context_compaction() {
+                TurnCheckpointProgressStatus::Pending
+            } else {
+                TurnCheckpointProgressStatus::Skipped
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContextCompactionOutcome {
+    Skipped,
+    Completed,
+    FailedOpen,
+}
+
+impl ContextCompactionOutcome {
+    fn checkpoint_status(self) -> TurnCheckpointProgressStatus {
+        match self {
+            Self::Skipped => TurnCheckpointProgressStatus::Skipped,
+            Self::Completed => TurnCheckpointProgressStatus::Completed,
+            Self::FailedOpen => TurnCheckpointProgressStatus::FailedOpen,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TurnCheckpointFailureStep {
+    AfterTurn,
+    Compaction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TurnCheckpointFailure {
+    step: TurnCheckpointFailureStep,
+    error: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ResolvedProviderTurn {
+    PersistReply(ResolvedProviderReply),
+    ReturnError(ResolvedProviderError),
+}
+
+impl ResolvedProviderTurn {
+    fn persist_reply(reply: String, checkpoint: TurnCheckpointSnapshot) -> Self {
+        Self::PersistReply(ResolvedProviderReply { reply, checkpoint })
+    }
+
+    fn return_error(error: String, checkpoint: TurnCheckpointSnapshot) -> Self {
+        Self::ReturnError(ResolvedProviderError { error, checkpoint })
+    }
+
+    #[cfg(test)]
+    fn checkpoint(&self) -> &TurnCheckpointSnapshot {
+        match self {
+            Self::PersistReply(reply) => &reply.checkpoint,
+            Self::ReturnError(error) => &error.checkpoint,
+        }
+    }
+
+    fn terminal_phase<'a>(
+        &'a self,
+        session: &ProviderTurnSessionState,
+    ) -> ProviderTurnTerminalPhase<'a> {
+        match self {
+            Self::PersistReply(reply) => {
+                ProviderTurnTerminalPhase::PersistReply(ProviderTurnPersistReplyPhase {
+                    checkpoint: &reply.checkpoint,
+                    tail_phase: ProviderTurnReplyTailPhase::from_session(
+                        session,
+                        reply.reply.as_str(),
+                    ),
+                })
+            }
+            Self::ReturnError(error) => {
+                ProviderTurnTerminalPhase::ReturnError(ProviderTurnReturnErrorPhase {
+                    checkpoint: &error.checkpoint,
+                    error: error.error.as_str(),
+                })
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn reply_text(&self) -> Option<&str> {
+        match self {
+            Self::PersistReply(reply) => Some(reply.reply.as_str()),
+            Self::ReturnError(_) => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedProviderReply {
+    reply: String,
+    checkpoint: TurnCheckpointSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedProviderError {
+    error: String,
+    checkpoint: TurnCheckpointSnapshot,
+}
+
+#[derive(Debug)]
+enum ProviderTurnTerminalPhase<'a> {
+    PersistReply(ProviderTurnPersistReplyPhase<'a>),
+    ReturnError(ProviderTurnReturnErrorPhase<'a>),
+}
+
+impl<'a> ProviderTurnTerminalPhase<'a> {
+    async fn apply<R: ConversationRuntime + ?Sized>(
+        self,
+        config: &LoongClawConfig,
+        runtime: &R,
+        session_id: &str,
+        user_input: &str,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<String> {
+        match self {
+            Self::PersistReply(phase) => {
+                finalize_provider_turn_reply(
+                    config,
+                    runtime,
+                    session_id,
+                    user_input,
+                    &phase.tail_phase,
+                    phase.checkpoint,
+                    kernel_ctx,
+                )
+                .await
+            }
+            Self::ReturnError(phase) => {
+                persist_resolved_provider_error_checkpoint(
+                    runtime,
+                    session_id,
+                    phase.checkpoint,
+                    kernel_ctx,
+                )
+                .await?;
+                Err(phase.error.to_owned())
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ProviderTurnPersistReplyPhase<'a> {
+    checkpoint: &'a TurnCheckpointSnapshot,
+    tail_phase: ProviderTurnReplyTailPhase,
+}
+
+#[derive(Debug)]
+struct ProviderTurnReturnErrorPhase<'a> {
+    checkpoint: &'a TurnCheckpointSnapshot,
+    error: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ProviderTurnRequestTerminalPhase {
+    PersistInlineProviderError { reply: String },
+    ReturnError { error: String },
+}
+
+impl ProviderTurnRequestTerminalPhase {
+    fn persist_inline_provider_error(reply: String) -> Self {
+        Self::PersistInlineProviderError { reply }
+    }
+
+    fn return_error(error: String) -> Self {
+        Self::ReturnError { error }
+    }
+
+    fn resolve(
+        self,
+        preparation: &ProviderTurnPreparation,
+        user_input: &str,
+    ) -> ResolvedProviderTurn {
+        match self {
+            Self::PersistInlineProviderError { reply } => {
+                let checkpoint = build_resolved_provider_checkpoint(
+                    preparation,
+                    user_input,
+                    Some(reply.as_str()),
+                    TurnCheckpointRequest::FinalizeInlineProviderError,
+                    None,
+                    None,
+                    TurnFinalizationCheckpoint::persist_reply(
+                        ReplyPersistenceMode::InlineProviderError,
+                    ),
+                );
+                ResolvedProviderTurn::persist_reply(reply, checkpoint)
+            }
+            Self::ReturnError { error } => {
+                let checkpoint = build_resolved_provider_checkpoint(
+                    preparation,
+                    user_input,
+                    None,
+                    TurnCheckpointRequest::ReturnError,
+                    None,
+                    None,
+                    TurnFinalizationCheckpoint::ReturnError,
+                );
+                ResolvedProviderTurn::return_error(error, checkpoint)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SafeLaneTurnOutcome {
+    result: TurnResult,
+    terminal_route: Option<SafeLaneFailureRoute>,
+}
+
+impl SafeLaneTurnOutcome {
+    fn without_terminal_route(result: TurnResult) -> Self {
+        Self {
+            result,
+            terminal_route: None,
+        }
+    }
+
+    fn with_terminal_route(result: TurnResult, terminal_route: SafeLaneFailureRoute) -> Self {
+        Self {
+            result,
+            terminal_route: Some(terminal_route),
+        }
+    }
+}
+
+fn turn_reply_checkpoint(phase: &ToolDrivenReplyPhase) -> TurnReplyCheckpoint {
+    TurnReplyCheckpoint {
+        decision: phase.resolution_mode(),
+        followup_kind: phase.followup_kind(),
+    }
+}
+
+fn build_resolved_provider_checkpoint(
+    preparation: &ProviderTurnPreparation,
+    user_input: &str,
+    reply_text: Option<&str>,
+    request: TurnCheckpointRequest,
+    lane: Option<TurnLaneExecutionSnapshot>,
+    reply: Option<TurnReplyCheckpoint>,
+    finalization: TurnFinalizationCheckpoint,
+) -> TurnCheckpointSnapshot {
+    TurnCheckpointSnapshot {
+        identity: reply_text
+            .map(|assistant_reply| TurnCheckpointIdentity::from_turn(user_input, assistant_reply)),
+        preparation: preparation.checkpoint(),
+        request,
+        lane,
+        reply,
+        finalization,
+    }
+}
+
 impl ConversationTurnCoordinator {
     pub fn new() -> Self {
         Self
@@ -254,6 +1331,79 @@ impl ConversationTurnCoordinator {
             error_mode,
             acp_options,
             kernel_ctx,
+        )
+        .await
+    }
+
+    pub async fn repair_turn_checkpoint_tail(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<TurnCheckpointTailRepairOutcome> {
+        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        self.repair_turn_checkpoint_tail_with_runtime(config, session_id, &runtime, kernel_ctx)
+            .await
+    }
+
+    pub(crate) async fn load_turn_checkpoint_diagnostics(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<TurnCheckpointDiagnostics> {
+        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
+            config,
+            session_id,
+            config.memory.sliding_window,
+            &runtime,
+            kernel_ctx,
+        )
+        .await
+    }
+
+    pub(crate) async fn load_turn_checkpoint_diagnostics_with_limit(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        limit: usize,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<TurnCheckpointDiagnostics> {
+        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
+            config, session_id, limit, &runtime, kernel_ctx,
+        )
+        .await
+    }
+
+    pub async fn probe_turn_checkpoint_tail_runtime_gate(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
+        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
+            config,
+            session_id,
+            config.memory.sliding_window,
+            &runtime,
+            kernel_ctx,
+        )
+        .await
+    }
+
+    pub async fn probe_turn_checkpoint_tail_runtime_gate_with_limit(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        limit: usize,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
+        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
+            config, session_id, limit, &runtime, kernel_ctx,
         )
         .await
     }
@@ -364,6 +1514,140 @@ impl ConversationTurnCoordinator {
         .await
     }
 
+    pub async fn repair_turn_checkpoint_tail_with_runtime<R: ConversationRuntime + ?Sized>(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        runtime: &R,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<TurnCheckpointTailRepairOutcome> {
+        #[cfg(feature = "memory-sqlite")]
+        {
+            let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+            let Some(entry) = load_latest_turn_checkpoint_entry(
+                session_id,
+                config.memory.sliding_window,
+                kernel_ctx,
+                &memory_config,
+            )
+            .await?
+            else {
+                return Ok(TurnCheckpointTailRepairOutcome::no_checkpoint());
+            };
+
+            repair_turn_checkpoint_tail_entry(config, runtime, session_id, &entry, kernel_ctx).await
+        }
+
+        #[cfg(not(feature = "memory-sqlite"))]
+        {
+            let _ = (config, session_id, runtime, kernel_ctx);
+            Err("turn checkpoint repair unavailable: memory-sqlite feature disabled".to_owned())
+        }
+    }
+
+    pub(crate) async fn load_turn_checkpoint_diagnostics_with_runtime_and_limit<
+        R: ConversationRuntime + ?Sized,
+    >(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        limit: usize,
+        runtime: &R,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<TurnCheckpointDiagnostics> {
+        #[cfg(feature = "memory-sqlite")]
+        {
+            let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+            let (summary, latest_entry) = load_turn_checkpoint_history_snapshot(
+                session_id,
+                limit,
+                kernel_ctx,
+                &memory_config,
+            )
+            .await?
+            .into_summary_and_latest_entry();
+            let recovery = TurnCheckpointRecoveryAssessment::from_summary(&summary);
+            let runtime_probe = match recovery.action() {
+                TurnCheckpointRecoveryAction::None
+                | TurnCheckpointRecoveryAction::InspectManually => None,
+                TurnCheckpointRecoveryAction::RunAfterTurn
+                | TurnCheckpointRecoveryAction::RunCompaction
+                | TurnCheckpointRecoveryAction::RunAfterTurnAndCompaction => {
+                    match latest_entry.as_ref() {
+                        Some(entry) => {
+                            probe_turn_checkpoint_tail_runtime_gate_entry(
+                                config, runtime, session_id, entry, kernel_ctx,
+                            )
+                            .await?
+                        }
+                        None => None,
+                    }
+                }
+            };
+            Ok(TurnCheckpointDiagnostics::new(
+                summary,
+                recovery,
+                runtime_probe,
+            ))
+        }
+
+        #[cfg(not(feature = "memory-sqlite"))]
+        {
+            let _ = (config, session_id, limit, runtime, kernel_ctx);
+            Err(
+                "turn checkpoint diagnostics unavailable: memory-sqlite feature disabled"
+                    .to_owned(),
+            )
+        }
+    }
+
+    pub async fn probe_turn_checkpoint_tail_runtime_gate_with_runtime<
+        R: ConversationRuntime + ?Sized,
+    >(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        runtime: &R,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
+        self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
+            config,
+            session_id,
+            config.memory.sliding_window,
+            runtime,
+            kernel_ctx,
+        )
+        .await
+    }
+
+    pub async fn probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit<
+        R: ConversationRuntime + ?Sized,
+    >(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        limit: usize,
+        runtime: &R,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
+        #[cfg(feature = "memory-sqlite")]
+        {
+            probe_turn_checkpoint_tail_runtime_gate_entry_with_limit(
+                config, runtime, session_id, limit, kernel_ctx,
+            )
+            .await
+        }
+
+        #[cfg(not(feature = "memory-sqlite"))]
+        {
+            let _ = (config, session_id, runtime, kernel_ctx);
+            Err(
+                "turn checkpoint runtime probe unavailable: memory-sqlite feature disabled"
+                    .to_owned(),
+            )
+        }
+    }
+
     pub async fn handle_turn_with_runtime_and_acp_options<R: ConversationRuntime + ?Sized>(
         &self,
         config: &LoongClawConfig,
@@ -452,8 +1736,13 @@ impl ConversationTurnCoordinator {
                     ProviderErrorMode::Propagate => Err(error),
                     ProviderErrorMode::InlineMessage => {
                         let synthetic = format_provider_error_reply(&error);
-                        persist_error_turns_raw(
-                            runtime, session_id, user_input, &synthetic, kernel_ctx,
+                        persist_reply_turns_raw_with_mode(
+                            runtime,
+                            session_id,
+                            user_input,
+                            &synthetic,
+                            ReplyPersistenceMode::InlineProviderError,
+                            kernel_ctx,
                         )
                         .await?;
                         Ok(synthetic)
@@ -477,205 +1766,37 @@ impl ConversationTurnCoordinator {
         }
 
         runtime.bootstrap(config, session_id, kernel_ctx).await?;
-        let assembled_context = runtime
-            .build_context(config, session_id, true, kernel_ctx)
-            .await?;
-        let mut messages = assembled_context.messages;
-        messages.push(json!({
-            "role": "user",
-            "content": user_input,
-        }));
-        let lane_policy = lane_policy_from_config(config);
-        let lane_decision = if config.conversation.hybrid_lane_enabled {
-            lane_policy.decide(user_input)
-        } else {
-            disabled_lane_decision(user_input)
-        };
-        let max_tool_steps = match lane_decision.lane {
-            ExecutionLane::Fast => config.conversation.fast_lane_max_tool_steps(),
-            ExecutionLane::Safe => config.conversation.safe_lane_max_tool_steps(),
-        };
+        let preparation = ProviderTurnPreparation::from_assembled_context(
+            config,
+            runtime
+                .build_context(config, session_id, true, kernel_ctx)
+                .await?,
+            user_input,
+        );
+        let resolved_turn = resolve_provider_turn(
+            config,
+            runtime,
+            session_id,
+            user_input,
+            &preparation,
+            runtime
+                .request_turn(config, &preparation.session.messages, kernel_ctx)
+                .await,
+            error_mode,
+            kernel_ctx,
+        )
+        .await;
 
-        let provider_result = runtime.request_turn(config, &messages, kernel_ctx).await;
-        match provider_result {
-            Ok(turn) => {
-                let had_tool_intents = !turn.tool_intents.is_empty();
-                let raw_tool_output_requested = user_requested_raw_tool_output(user_input);
-                let turn_result = if should_use_safe_lane_plan_path(config, &lane_decision, &turn) {
-                    execute_turn_with_safe_lane_plan(
-                        config,
-                        runtime,
-                        session_id,
-                        &lane_decision,
-                        &turn,
-                        kernel_ctx,
-                    )
-                    .await
-                } else {
-                    TurnEngine::with_tool_result_payload_summary_limit(
-                        max_tool_steps,
-                        config
-                            .conversation
-                            .tool_result_payload_summary_limit_chars(),
-                    )
-                    .execute_turn(&turn, kernel_ctx)
-                    .await
-                };
-                #[allow(clippy::wildcard_enum_match_arm)]
-                let reply = match turn_result {
-                    TurnResult::FinalText(tool_text) if had_tool_intents => {
-                        let raw_reply = join_non_empty_lines(&[
-                            turn.assistant_text.as_str(),
-                            tool_text.as_str(),
-                        ]);
-                        if raw_tool_output_requested {
-                            raw_reply
-                        } else {
-                            let follow_up_messages = build_tool_followup_messages(
-                                &messages,
-                                turn.assistant_text.as_str(),
-                                tool_text.as_str(),
-                                user_input,
-                            );
-                            match runtime
-                                .request_completion(config, &follow_up_messages, kernel_ctx)
-                                .await
-                            {
-                                Ok(final_reply) => {
-                                    let trimmed = final_reply.trim();
-                                    if trimmed.is_empty() {
-                                        raw_reply
-                                    } else {
-                                        trimmed.to_owned()
-                                    }
-                                }
-                                Err(_) => raw_reply,
-                            }
-                        }
-                    }
-                    TurnResult::ToolDenied(failure)
-                        if had_tool_intents && !raw_tool_output_requested =>
-                    {
-                        let raw_reply = compose_assistant_reply(
-                            turn.assistant_text.as_str(),
-                            had_tool_intents,
-                            TurnResult::ToolDenied(failure.clone()),
-                        );
-                        let follow_up_messages = build_tool_failure_followup_messages(
-                            &messages,
-                            turn.assistant_text.as_str(),
-                            failure.reason.as_str(),
-                            user_input,
-                        );
-                        match runtime
-                            .request_completion(config, &follow_up_messages, kernel_ctx)
-                            .await
-                        {
-                            Ok(final_reply) => {
-                                let trimmed = final_reply.trim();
-                                if trimmed.is_empty() {
-                                    raw_reply
-                                } else {
-                                    trimmed.to_owned()
-                                }
-                            }
-                            Err(_) => raw_reply,
-                        }
-                    }
-                    TurnResult::ToolError(failure)
-                        if had_tool_intents && !raw_tool_output_requested =>
-                    {
-                        let raw_reply = compose_assistant_reply(
-                            turn.assistant_text.as_str(),
-                            had_tool_intents,
-                            TurnResult::ToolError(failure.clone()),
-                        );
-                        let follow_up_messages = build_tool_failure_followup_messages(
-                            &messages,
-                            turn.assistant_text.as_str(),
-                            failure.reason.as_str(),
-                            user_input,
-                        );
-                        match runtime
-                            .request_completion(config, &follow_up_messages, kernel_ctx)
-                            .await
-                        {
-                            Ok(final_reply) => {
-                                let trimmed = final_reply.trim();
-                                if trimmed.is_empty() {
-                                    raw_reply
-                                } else {
-                                    trimmed.to_owned()
-                                }
-                            }
-                            Err(_) => raw_reply,
-                        }
-                    }
-                    other => compose_assistant_reply(
-                        turn.assistant_text.as_str(),
-                        had_tool_intents,
-                        other,
-                    ),
-                };
-                persist_success_turns(runtime, session_id, user_input, &reply, kernel_ctx).await?;
-                let mut after_turn_messages = messages.clone();
-                after_turn_messages.push(json!({
-                    "role": "assistant",
-                    "content": reply,
-                }));
-                runtime
-                    .after_turn(
-                        session_id,
-                        user_input,
-                        &reply,
-                        &after_turn_messages,
-                        kernel_ctx,
-                    )
-                    .await?;
-                maybe_compact_context(
-                    config,
-                    runtime,
-                    session_id,
-                    &after_turn_messages,
-                    assembled_context.estimated_tokens,
-                    kernel_ctx,
-                )
-                .await?;
-                Ok(reply)
-            }
-            Err(error) => match error_mode {
-                ProviderErrorMode::Propagate => Err(error),
-                ProviderErrorMode::InlineMessage => {
-                    let synthetic = format_provider_error_reply(&error);
-                    persist_error_turns(runtime, session_id, user_input, &synthetic, kernel_ctx)
-                        .await?;
-                    let mut after_turn_messages = messages.clone();
-                    after_turn_messages.push(json!({
-                        "role": "assistant",
-                        "content": synthetic,
-                    }));
-                    runtime
-                        .after_turn(
-                            session_id,
-                            user_input,
-                            &synthetic,
-                            &after_turn_messages,
-                            kernel_ctx,
-                        )
-                        .await?;
-                    maybe_compact_context(
-                        config,
-                        runtime,
-                        session_id,
-                        &after_turn_messages,
-                        assembled_context.estimated_tokens,
-                        kernel_ctx,
-                    )
-                    .await?;
-                    Ok(synthetic)
-                }
-            },
-        }
+        apply_resolved_provider_turn(
+            config,
+            runtime,
+            session_id,
+            user_input,
+            &preparation,
+            &resolved_turn,
+            kernel_ctx,
+        )
+        .await
     }
 
     pub async fn handle_turn_with_runtime_and_address_and_acp_event_sink<
@@ -722,8 +1843,15 @@ impl ConversationTurnCoordinator {
         match executed.outcome {
             AcpConversationTurnExecutionOutcome::Succeeded(success) => {
                 let reply = success.result.output_text.clone();
-                persist_success_turns_raw(runtime, session_id, user_input, &reply, kernel_ctx)
-                    .await?;
+                persist_reply_turns_raw_with_mode(
+                    runtime,
+                    session_id,
+                    user_input,
+                    &reply,
+                    ReplyPersistenceMode::Success,
+                    kernel_ctx,
+                )
+                .await?;
                 if config.acp.emit_runtime_events {
                     let _ = persist_acp_runtime_events(
                         runtime,
@@ -755,8 +1883,13 @@ impl ConversationTurnCoordinator {
                     ProviderErrorMode::Propagate => Err(failure.error),
                     ProviderErrorMode::InlineMessage => {
                         let synthetic = format_provider_error_reply(&failure.error);
-                        persist_error_turns_raw(
-                            runtime, session_id, user_input, &synthetic, kernel_ctx,
+                        persist_reply_turns_raw_with_mode(
+                            runtime,
+                            session_id,
+                            user_input,
+                            &synthetic,
+                            ReplyPersistenceMode::InlineProviderError,
+                            kernel_ctx,
                         )
                         .await?;
                         Ok(synthetic)
@@ -774,21 +1907,23 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
     messages: &[Value],
     estimated_tokens: Option<usize>,
     kernel_ctx: Option<&KernelContext>,
-) -> CliResult<()> {
+) -> CliResult<ContextCompactionOutcome> {
     let estimated_tokens = estimated_tokens.or_else(|| estimate_tokens(messages));
     if !config
         .conversation
         .should_compact_with_estimate(messages.len(), estimated_tokens)
     {
-        return Ok(());
+        return Ok(ContextCompactionOutcome::Skipped);
     }
 
     match runtime
         .compact_context(config, session_id, messages, kernel_ctx)
         .await
     {
-        Ok(()) => Ok(()),
-        Err(_error) if config.conversation.compaction_fail_open() => Ok(()),
+        Ok(()) => Ok(ContextCompactionOutcome::Completed),
+        Err(_error) if config.conversation.compaction_fail_open() => {
+            Ok(ContextCompactionOutcome::FailedOpen)
+        }
         Err(error) => Err(error),
     }
 }
@@ -840,14 +1975,776 @@ fn disabled_lane_decision(user_input: &str) -> LaneDecision {
     }
 }
 
-fn should_use_safe_lane_plan_path(
+async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
     config: &LoongClawConfig,
-    lane_decision: &LaneDecision,
-    turn: &ProviderTurn,
-) -> bool {
-    config.conversation.safe_lane_plan_execution_enabled
-        && matches!(lane_decision.lane, ExecutionLane::Safe)
-        && !turn.tool_intents.is_empty()
+    runtime: &R,
+    session_id: &str,
+    user_input: &str,
+    preparation: &ProviderTurnPreparation,
+    result: CliResult<ProviderTurn>,
+    error_mode: ProviderErrorMode,
+    kernel_ctx: Option<&KernelContext>,
+) -> ResolvedProviderTurn {
+    match decide_provider_turn_request_action(result, error_mode) {
+        ProviderTurnRequestAction::Continue { turn } => {
+            let continue_phase = prepare_provider_turn_continue_phase(
+                config,
+                runtime,
+                session_id,
+                preparation,
+                turn,
+                kernel_ctx,
+            )
+            .await;
+            let reply = continue_phase
+                .resolve_reply(runtime, config, preparation, user_input, kernel_ctx)
+                .await;
+            let checkpoint = continue_phase.checkpoint(preparation, user_input, reply.as_str());
+            ResolvedProviderTurn::persist_reply(reply, checkpoint)
+        }
+        ProviderTurnRequestAction::FinalizeInlineProviderError { reply } => {
+            ProviderTurnRequestTerminalPhase::persist_inline_provider_error(reply)
+                .resolve(preparation, user_input)
+        }
+        ProviderTurnRequestAction::ReturnError { error } => {
+            ProviderTurnRequestTerminalPhase::return_error(error).resolve(preparation, user_input)
+        }
+    }
+}
+
+async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    preparation: &ProviderTurnPreparation,
+    turn: ProviderTurn,
+    kernel_ctx: Option<&KernelContext>,
+) -> ProviderTurnContinuePhase {
+    let tool_intents = turn.tool_intents.len();
+    let lane_execution =
+        execute_provider_turn_lane(config, runtime, session_id, preparation, turn, kernel_ctx)
+            .await;
+    ProviderTurnContinuePhase::new(tool_intents, lane_execution)
+}
+
+async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    config: &LoongClawConfig,
+    preparation: &ProviderTurnPreparation,
+    lane_execution: &ProviderTurnLaneExecution,
+    phase: &ToolDrivenReplyPhase,
+    user_input: &str,
+    kernel_ctx: Option<&KernelContext>,
+) -> String {
+    match phase.decision() {
+        ToolDrivenReplyBaseDecision::FinalizeDirect { reply } => reply.clone(),
+        ToolDrivenReplyBaseDecision::RequireFollowup {
+            raw_reply,
+            payload: followup,
+        } => {
+            let follow_up_messages = build_turn_reply_followup_messages(
+                &preparation.session.messages,
+                lane_execution.assistant_preface.as_str(),
+                followup.clone(),
+                user_input,
+            );
+            request_completion_with_raw_fallback(
+                runtime,
+                config,
+                &follow_up_messages,
+                kernel_ctx,
+                raw_reply.as_str(),
+            )
+            .await
+        }
+    }
+}
+
+fn turn_checkpoint_result_kind(result: &TurnResult) -> TurnCheckpointResultKind {
+    match result {
+        TurnResult::FinalText(_) => TurnCheckpointResultKind::FinalText,
+        TurnResult::ToolDenied(_) => TurnCheckpointResultKind::ToolDenied,
+        TurnResult::ToolError(_) => TurnCheckpointResultKind::ToolError,
+        TurnResult::NeedsApproval(_) => TurnCheckpointResultKind::NeedsApproval,
+        TurnResult::ProviderError(_) => TurnCheckpointResultKind::ProviderError,
+    }
+}
+
+fn format_turn_checkpoint_progress_status(status: TurnCheckpointProgressStatus) -> &'static str {
+    match status {
+        TurnCheckpointProgressStatus::Pending => "pending",
+        TurnCheckpointProgressStatus::Skipped => "skipped",
+        TurnCheckpointProgressStatus::Completed => "completed",
+        TurnCheckpointProgressStatus::Failed => "failed",
+        TurnCheckpointProgressStatus::FailedOpen => "failed_open",
+    }
+}
+
+fn format_analytics_turn_checkpoint_progress_status(
+    status: AnalyticsTurnCheckpointProgressStatus,
+) -> &'static str {
+    match status {
+        AnalyticsTurnCheckpointProgressStatus::Pending => "pending",
+        AnalyticsTurnCheckpointProgressStatus::Skipped => "skipped",
+        AnalyticsTurnCheckpointProgressStatus::Completed => "completed",
+        AnalyticsTurnCheckpointProgressStatus::Failed => "failed",
+        AnalyticsTurnCheckpointProgressStatus::FailedOpen => "failed_open",
+    }
+}
+
+fn build_turn_reply_followup_messages(
+    base_messages: &[Value],
+    assistant_preface: &str,
+    followup: ToolDrivenFollowupPayload,
+    user_input: &str,
+) -> Vec<Value> {
+    let mut messages = base_messages.to_vec();
+    messages.extend(build_tool_driven_followup_tail(
+        assistant_preface,
+        &followup,
+        user_input,
+        None,
+        |_, text| text.to_owned(),
+    ));
+    messages
+}
+
+async fn persist_turn_checkpoint_event<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    checkpoint: &TurnCheckpointSnapshot,
+    stage: TurnCheckpointStage,
+    progress: TurnCheckpointFinalizationProgress,
+    failure: Option<TurnCheckpointFailure>,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<()> {
+    let checkpoint = serde_json::to_value(checkpoint)
+        .map_err(|error| format!("serialize turn checkpoint failed: {error}"))?;
+    persist_turn_checkpoint_event_value(
+        runtime,
+        session_id,
+        &checkpoint,
+        stage,
+        progress,
+        failure,
+        kernel_ctx,
+    )
+    .await
+}
+
+async fn persist_turn_checkpoint_event_value<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    checkpoint: &Value,
+    stage: TurnCheckpointStage,
+    progress: TurnCheckpointFinalizationProgress,
+    failure: Option<TurnCheckpointFailure>,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<()> {
+    persist_conversation_event(
+        runtime,
+        session_id,
+        "turn_checkpoint",
+        json!({
+            "schema_version": 1,
+            "stage": stage,
+            "checkpoint": checkpoint,
+            "finalization_progress": progress,
+            "failure": failure,
+        }),
+        kernel_ctx,
+    )
+    .await
+}
+
+fn recover_latest_turn_pair(messages: &[Value]) -> Option<(String, String)> {
+    let assistant_index = messages.iter().rposition(|message| {
+        message.get("role").and_then(Value::as_str) == Some("assistant")
+            && message.get("content").and_then(Value::as_str).is_some()
+    })?;
+    let assistant_reply = messages
+        .get(assistant_index)?
+        .get("content")
+        .and_then(Value::as_str)?
+        .to_owned();
+    let user_input = messages
+        .get(..assistant_index)?
+        .iter()
+        .rposition(|message| {
+            message.get("role").and_then(Value::as_str) == Some("user")
+                && message.get("content").and_then(Value::as_str).is_some()
+        })
+        .and_then(|index| {
+            messages
+                .get(index)
+                .and_then(|message| message.get("content"))
+                .and_then(Value::as_str)
+        })
+        .map(ToOwned::to_owned)?;
+    Some((user_input, assistant_reply))
+}
+
+fn load_turn_checkpoint_identity(checkpoint: &Value) -> Option<TurnCheckpointIdentity> {
+    checkpoint
+        .get("identity")
+        .cloned()
+        .and_then(|identity| serde_json::from_value(identity).ok())
+}
+
+fn sha256_hex(input: &str) -> String {
+    format!("{:x}", Sha256::digest(input.as_bytes()))
+}
+
+fn checkpoint_context_fingerprint_sha256(messages: &[Value]) -> String {
+    let serialized = Value::Array(messages.to_vec()).to_string();
+    format!("{:x}", Sha256::digest(serialized.as_bytes()))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+struct TurnCheckpointRepairPreparation {
+    #[serde(default)]
+    context_message_count: Option<usize>,
+    #[serde(default)]
+    context_fingerprint_sha256: Option<String>,
+    #[serde(default)]
+    estimated_tokens: Option<usize>,
+}
+
+fn load_turn_checkpoint_repair_preparation(
+    checkpoint: &Value,
+) -> Result<Option<TurnCheckpointRepairPreparation>, TurnCheckpointTailRepairReason> {
+    let Some(preparation) = checkpoint.get("preparation") else {
+        return Ok(None);
+    };
+    serde_json::from_value(preparation.clone())
+        .map(Some)
+        .map_err(|_error| TurnCheckpointTailRepairReason::CheckpointPreparationMalformed)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TurnCheckpointRepairResumeInput {
+    user_input: String,
+    assistant_reply: String,
+    messages: Vec<Value>,
+    estimated_tokens: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TurnCheckpointTailRuntimeEligibility {
+    NotNeeded {
+        action: TurnCheckpointRecoveryAction,
+        reason: TurnCheckpointTailRepairReason,
+    },
+    Manual {
+        action: TurnCheckpointRecoveryAction,
+        reason: TurnCheckpointTailRepairReason,
+        source: TurnCheckpointTailRepairSource,
+    },
+    Runnable {
+        action: TurnCheckpointRecoveryAction,
+        plan: TurnCheckpointRepairPlan,
+        resume_input: TurnCheckpointRepairResumeInput,
+    },
+}
+
+impl TurnCheckpointRepairResumeInput {
+    fn from_assembled_context(
+        assembled: AssembledConversationContext,
+        checkpoint: &Value,
+    ) -> Result<Self, TurnCheckpointTailRepairReason> {
+        let repair_preparation = load_turn_checkpoint_repair_preparation(checkpoint)?;
+        let messages = assembled.messages;
+        let Some((user_input, assistant_reply)) = recover_latest_turn_pair(&messages) else {
+            return Err(TurnCheckpointTailRepairReason::VisibleTurnPairMissing);
+        };
+        let Some((_, pre_assistant_messages)) = messages.split_last() else {
+            return Err(TurnCheckpointTailRepairReason::VisibleTurnPairMissing);
+        };
+        let Some(identity) = load_turn_checkpoint_identity(checkpoint) else {
+            return Err(TurnCheckpointTailRepairReason::CheckpointIdentityMissing);
+        };
+        if !identity.matches_turn(&user_input, &assistant_reply) {
+            return Err(TurnCheckpointTailRepairReason::CheckpointIdentityMismatch);
+        }
+        if let Some(expected_context_message_count) = repair_preparation
+            .as_ref()
+            .and_then(|preparation| preparation.context_message_count)
+            && pre_assistant_messages.len() != expected_context_message_count
+        {
+            return Err(TurnCheckpointTailRepairReason::CheckpointPreparationMismatch);
+        }
+        if let Some(expected_context_fingerprint_sha256) = repair_preparation
+            .as_ref()
+            .and_then(|preparation| preparation.context_fingerprint_sha256.as_deref())
+            && checkpoint_context_fingerprint_sha256(pre_assistant_messages)
+                != expected_context_fingerprint_sha256
+        {
+            return Err(TurnCheckpointTailRepairReason::CheckpointPreparationFingerprintMismatch);
+        }
+
+        Ok(Self {
+            user_input,
+            assistant_reply,
+            messages,
+            estimated_tokens: repair_preparation
+                .and_then(|preparation| preparation.estimated_tokens)
+                .or(assembled.estimated_tokens),
+        })
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    entry: &super::session_history::TurnCheckpointLatestEntry,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<TurnCheckpointTailRepairOutcome> {
+    let summary = &entry.summary;
+    let (action, repair_plan, resume_input) = match load_turn_checkpoint_tail_runtime_eligibility(
+        config, runtime, session_id, entry, kernel_ctx,
+    )
+    .await?
+    {
+        TurnCheckpointTailRuntimeEligibility::NotNeeded { action, reason } => {
+            return Ok(TurnCheckpointTailRepairOutcome::from_summary(
+                TurnCheckpointTailRepairStatus::NotNeeded,
+                action,
+                Some(TurnCheckpointTailRepairSource::Summary),
+                reason,
+                summary,
+            ));
+        }
+        TurnCheckpointTailRuntimeEligibility::Manual {
+            action,
+            reason,
+            source,
+        } => {
+            return Ok(TurnCheckpointTailRepairOutcome::from_summary(
+                TurnCheckpointTailRepairStatus::ManualRequired,
+                action,
+                Some(source),
+                reason,
+                summary,
+            ));
+        }
+        TurnCheckpointTailRuntimeEligibility::Runnable {
+            action,
+            plan,
+            resume_input,
+        } => (action, plan, resume_input),
+    };
+
+    let mut after_turn_status =
+        restore_analytics_turn_checkpoint_progress_status(repair_plan.after_turn_status());
+    let mut compaction_status =
+        restore_analytics_turn_checkpoint_progress_status(repair_plan.compaction_status());
+
+    if repair_plan.should_run_after_turn() {
+        match runtime
+            .after_turn(
+                session_id,
+                &resume_input.user_input,
+                &resume_input.assistant_reply,
+                &resume_input.messages,
+                kernel_ctx,
+            )
+            .await
+        {
+            Ok(()) => {
+                after_turn_status = TurnCheckpointProgressStatus::Completed;
+            }
+            Err(error) => {
+                persist_turn_checkpoint_event_value(
+                    runtime,
+                    session_id,
+                    &entry.checkpoint,
+                    TurnCheckpointStage::FinalizationFailed,
+                    TurnCheckpointFinalizationProgress {
+                        after_turn: TurnCheckpointProgressStatus::Failed,
+                        compaction: if repair_plan.should_run_compaction() {
+                            TurnCheckpointProgressStatus::Skipped
+                        } else {
+                            compaction_status
+                        },
+                    },
+                    Some(TurnCheckpointFailure {
+                        step: TurnCheckpointFailureStep::AfterTurn,
+                        error: error.clone(),
+                    }),
+                    kernel_ctx,
+                )
+                .await?;
+                return Err(error);
+            }
+        }
+    }
+
+    if repair_plan.should_run_compaction() {
+        match maybe_compact_context(
+            config,
+            runtime,
+            session_id,
+            &resume_input.messages,
+            resume_input.estimated_tokens,
+            kernel_ctx,
+        )
+        .await
+        {
+            Ok(outcome) => {
+                compaction_status = outcome.checkpoint_status();
+            }
+            Err(error) => {
+                persist_turn_checkpoint_event_value(
+                    runtime,
+                    session_id,
+                    &entry.checkpoint,
+                    TurnCheckpointStage::FinalizationFailed,
+                    TurnCheckpointFinalizationProgress {
+                        after_turn: after_turn_status,
+                        compaction: TurnCheckpointProgressStatus::Failed,
+                    },
+                    Some(TurnCheckpointFailure {
+                        step: TurnCheckpointFailureStep::Compaction,
+                        error: error.clone(),
+                    }),
+                    kernel_ctx,
+                )
+                .await?;
+                return Err(error);
+            }
+        }
+    }
+
+    persist_turn_checkpoint_event_value(
+        runtime,
+        session_id,
+        &entry.checkpoint,
+        TurnCheckpointStage::Finalized,
+        TurnCheckpointFinalizationProgress {
+            after_turn: after_turn_status,
+            compaction: compaction_status,
+        },
+        None,
+        kernel_ctx,
+    )
+    .await?;
+
+    Ok(TurnCheckpointTailRepairOutcome::repaired(
+        action,
+        summary,
+        after_turn_status,
+        compaction_status,
+    ))
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn probe_turn_checkpoint_tail_runtime_gate_entry<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    entry: &super::session_history::TurnCheckpointLatestEntry,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
+    match load_turn_checkpoint_tail_runtime_eligibility(
+        config, runtime, session_id, entry, kernel_ctx,
+    )
+    .await?
+    {
+        TurnCheckpointTailRuntimeEligibility::Manual {
+            action,
+            reason,
+            source: TurnCheckpointTailRepairSource::Runtime,
+        } => Ok(Some(TurnCheckpointTailRepairRuntimeProbe::new(
+            action,
+            TurnCheckpointTailRepairSource::Runtime,
+            reason,
+        ))),
+        TurnCheckpointTailRuntimeEligibility::NotNeeded { .. }
+        | TurnCheckpointTailRuntimeEligibility::Manual { .. }
+        | TurnCheckpointTailRuntimeEligibility::Runnable { .. } => Ok(None),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn load_turn_checkpoint_tail_runtime_eligibility<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    entry: &super::session_history::TurnCheckpointLatestEntry,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<TurnCheckpointTailRuntimeEligibility> {
+    let summary = &entry.summary;
+    let recovery = TurnCheckpointRecoveryAssessment::from_summary(summary);
+    let action = recovery.action();
+    if matches!(action, TurnCheckpointRecoveryAction::None) {
+        return Ok(TurnCheckpointTailRuntimeEligibility::NotNeeded {
+            action,
+            reason: TurnCheckpointTailRepairReason::NotNeeded,
+        });
+    }
+    if matches!(action, TurnCheckpointRecoveryAction::InspectManually) {
+        return Ok(TurnCheckpointTailRuntimeEligibility::Manual {
+            action,
+            reason: recovery
+                .reason()
+                .unwrap_or(TurnCheckpointTailRepairReason::CheckpointStateRequiresManualInspection),
+            source: recovery.source(),
+        });
+    }
+
+    let repair_plan = build_turn_checkpoint_repair_plan(summary);
+    let assembled = runtime
+        .build_context(config, session_id, true, kernel_ctx)
+        .await?;
+    match TurnCheckpointRepairResumeInput::from_assembled_context(assembled, &entry.checkpoint) {
+        Ok(resume_input) => Ok(TurnCheckpointTailRuntimeEligibility::Runnable {
+            action,
+            plan: repair_plan,
+            resume_input,
+        }),
+        Err(reason) => Ok(TurnCheckpointTailRuntimeEligibility::Manual {
+            action: TurnCheckpointRecoveryAction::InspectManually,
+            reason,
+            source: TurnCheckpointTailRepairSource::Runtime,
+        }),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn probe_turn_checkpoint_tail_runtime_gate_entry_with_limit<
+    R: ConversationRuntime + ?Sized,
+>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    limit: usize,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let Some(entry) =
+        load_latest_turn_checkpoint_entry(session_id, limit, kernel_ctx, &memory_config).await?
+    else {
+        return Ok(None);
+    };
+    probe_turn_checkpoint_tail_runtime_gate_entry(config, runtime, session_id, &entry, kernel_ctx)
+        .await
+}
+
+fn restore_analytics_turn_checkpoint_progress_status(
+    status: AnalyticsTurnCheckpointProgressStatus,
+) -> TurnCheckpointProgressStatus {
+    match status {
+        AnalyticsTurnCheckpointProgressStatus::Pending => TurnCheckpointProgressStatus::Pending,
+        AnalyticsTurnCheckpointProgressStatus::Skipped => TurnCheckpointProgressStatus::Skipped,
+        AnalyticsTurnCheckpointProgressStatus::Completed => TurnCheckpointProgressStatus::Completed,
+        AnalyticsTurnCheckpointProgressStatus::Failed => TurnCheckpointProgressStatus::Failed,
+        AnalyticsTurnCheckpointProgressStatus::FailedOpen => {
+            TurnCheckpointProgressStatus::FailedOpen
+        }
+    }
+}
+
+async fn finalize_provider_turn_reply<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    user_input: &str,
+    tail_phase: &ProviderTurnReplyTailPhase,
+    checkpoint: &TurnCheckpointSnapshot,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<String> {
+    let Some(persistence_mode) = checkpoint.finalization.persistence_mode() else {
+        return Ok(tail_phase.reply().to_owned());
+    };
+    persist_reply_turns_with_mode(
+        runtime,
+        session_id,
+        user_input,
+        tail_phase.reply(),
+        persistence_mode,
+        kernel_ctx,
+    )
+    .await?;
+
+    persist_turn_checkpoint_event(
+        runtime,
+        session_id,
+        checkpoint,
+        TurnCheckpointStage::PostPersist,
+        TurnCheckpointFinalizationProgress::pending(checkpoint),
+        None,
+        kernel_ctx,
+    )
+    .await?;
+
+    let after_turn_status = if checkpoint.finalization.runs_after_turn() {
+        match runtime
+            .after_turn(
+                session_id,
+                user_input,
+                tail_phase.reply(),
+                tail_phase.after_turn_messages(),
+                kernel_ctx,
+            )
+            .await
+        {
+            Ok(()) => TurnCheckpointProgressStatus::Completed,
+            Err(error) => {
+                persist_turn_checkpoint_event(
+                    runtime,
+                    session_id,
+                    checkpoint,
+                    TurnCheckpointStage::FinalizationFailed,
+                    TurnCheckpointFinalizationProgress {
+                        after_turn: TurnCheckpointProgressStatus::Failed,
+                        compaction: TurnCheckpointProgressStatus::Skipped,
+                    },
+                    Some(TurnCheckpointFailure {
+                        step: TurnCheckpointFailureStep::AfterTurn,
+                        error: error.clone(),
+                    }),
+                    kernel_ctx,
+                )
+                .await?;
+                return Err(error);
+            }
+        }
+    } else {
+        TurnCheckpointProgressStatus::Skipped
+    };
+    let compaction_status = if checkpoint.finalization.attempts_context_compaction() {
+        match maybe_compact_context(
+            config,
+            runtime,
+            session_id,
+            tail_phase.after_turn_messages(),
+            tail_phase.estimated_tokens(),
+            kernel_ctx,
+        )
+        .await
+        {
+            Ok(outcome) => outcome.checkpoint_status(),
+            Err(error) => {
+                persist_turn_checkpoint_event(
+                    runtime,
+                    session_id,
+                    checkpoint,
+                    TurnCheckpointStage::FinalizationFailed,
+                    TurnCheckpointFinalizationProgress {
+                        after_turn: after_turn_status,
+                        compaction: TurnCheckpointProgressStatus::Failed,
+                    },
+                    Some(TurnCheckpointFailure {
+                        step: TurnCheckpointFailureStep::Compaction,
+                        error: error.clone(),
+                    }),
+                    kernel_ctx,
+                )
+                .await?;
+                return Err(error);
+            }
+        }
+    } else {
+        TurnCheckpointProgressStatus::Skipped
+    };
+    persist_turn_checkpoint_event(
+        runtime,
+        session_id,
+        checkpoint,
+        TurnCheckpointStage::Finalized,
+        TurnCheckpointFinalizationProgress {
+            after_turn: after_turn_status,
+            compaction: compaction_status,
+        },
+        None,
+        kernel_ctx,
+    )
+    .await?;
+    Ok(tail_phase.reply().to_owned())
+}
+
+async fn persist_resolved_provider_error_checkpoint<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    checkpoint: &TurnCheckpointSnapshot,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<()> {
+    persist_turn_checkpoint_event(
+        runtime,
+        session_id,
+        checkpoint,
+        TurnCheckpointStage::Finalized,
+        TurnCheckpointFinalizationProgress::pending(checkpoint),
+        None,
+        kernel_ctx,
+    )
+    .await
+}
+
+async fn apply_resolved_provider_turn<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    user_input: &str,
+    preparation: &ProviderTurnPreparation,
+    resolved: &ResolvedProviderTurn,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<String> {
+    resolved
+        .terminal_phase(&preparation.session)
+        .apply(config, runtime, session_id, user_input, kernel_ctx)
+        .await
+}
+
+async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    preparation: &ProviderTurnPreparation,
+    turn: ProviderTurn,
+    kernel_ctx: Option<&KernelContext>,
+) -> ProviderTurnLaneExecution {
+    let had_tool_intents = !turn.tool_intents.is_empty();
+    let assistant_preface = turn.assistant_text.clone();
+    let lane = preparation.lane_plan.decision.lane;
+    let (turn_result, safe_lane_terminal_route) = if preparation
+        .lane_plan
+        .should_use_safe_lane_plan_path(config, &turn)
+    {
+        let outcome = execute_turn_with_safe_lane_plan(
+            config,
+            runtime,
+            session_id,
+            &preparation.lane_plan.decision,
+            &turn,
+            kernel_ctx,
+        )
+        .await;
+        (outcome.result, outcome.terminal_route)
+    } else {
+        (
+            TurnEngine::with_tool_result_payload_summary_limit(
+                preparation.lane_plan.max_tool_steps,
+                config
+                    .conversation
+                    .tool_result_payload_summary_limit_chars(),
+            )
+            .execute_turn(&turn, kernel_ctx)
+            .await,
+            None,
+        )
+    };
+
+    ProviderTurnLaneExecution {
+        lane,
+        assistant_preface,
+        had_tool_intents,
+        raw_tool_output_requested: preparation.raw_tool_output_requested,
+        turn_result,
+        safe_lane_terminal_route,
+    }
 }
 
 async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
@@ -857,7 +2754,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
     lane_decision: &LaneDecision,
     turn: &ProviderTurn,
     kernel_ctx: Option<&KernelContext>,
-) -> TurnResult {
+) -> SafeLaneTurnOutcome {
     let governor_history_signals =
         load_safe_lane_history_signals_for_governor(config, session_id, kernel_ctx).await;
     let governor = decide_safe_lane_session_governor(config, &governor_history_signals);
@@ -879,267 +2776,229 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
     )
     .await;
 
-    let mut round = 0u8;
-    let max_rounds = if governor.force_no_replan {
-        0
-    } else {
-        config.conversation.safe_lane_replan_max_rounds
-    };
-    let mut tool_node_max_attempts = config.conversation.safe_lane_node_max_attempts.max(1);
-    if let Some(forced_node_max_attempts) = governor.forced_node_max_attempts {
-        tool_node_max_attempts = tool_node_max_attempts.min(forced_node_max_attempts.max(1));
-    }
-    let mut max_node_attempts = config
-        .conversation
-        .safe_lane_replan_max_node_attempts
-        .max(tool_node_max_attempts);
-    if let Some(forced_node_max_attempts) = governor.forced_node_max_attempts {
-        max_node_attempts = max_node_attempts.min(forced_node_max_attempts.max(1));
-    }
-    let mut plan_start_tool_index = 0usize;
-    let mut seed_tool_outputs = Vec::new();
-    let mut metrics = SafeLaneExecutionMetrics::default();
-    let mut adaptive_verify_policy = SafeLaneAdaptiveVerifyPolicyState::default();
+    let mut state = SafeLanePlanLoopState::new(config, governor);
 
     loop {
-        let next_min_anchor_matches =
-            compute_safe_lane_verify_min_anchor_matches(config, metrics.verify_failures);
-        if next_min_anchor_matches != adaptive_verify_policy.min_anchor_matches {
-            adaptive_verify_policy.min_anchor_matches = next_min_anchor_matches;
-            if adaptive_verify_policy.min_anchor_matches > 0 {
-                emit_safe_lane_event(
-                    config,
-                    runtime,
-                    session_id,
-                    "verify_policy_adjusted",
-                    json!({
-                        "round": round,
-                        "policy": "adaptive_anchor_escalation",
-                        "min_anchor_matches": adaptive_verify_policy.min_anchor_matches,
-                        "verify_failures": metrics.verify_failures,
-                        "escalation_after_failures": config
-                            .conversation
-                            .safe_lane_verify_anchor_escalation_after_failures(),
-                        "metrics": metrics.as_json(),
-                    }),
-                    kernel_ctx,
-                )
-                .await;
-            }
+        if let Some(min_anchor_matches) = state.refresh_verify_policy(config) {
+            emit_safe_lane_event(
+                config,
+                runtime,
+                session_id,
+                "verify_policy_adjusted",
+                json!({
+                    "round": state.round(),
+                    "policy": "adaptive_anchor_escalation",
+                    "min_anchor_matches": min_anchor_matches,
+                    "verify_failures": state.metrics.verify_failures,
+                    "escalation_after_failures": config
+                        .conversation
+                        .safe_lane_verify_anchor_escalation_after_failures(),
+                    "metrics": state.metrics.as_json(),
+                }),
+                kernel_ctx,
+            )
+            .await;
         }
 
-        metrics.rounds_started = metrics.rounds_started.saturating_add(1);
+        state.note_round_started();
         emit_safe_lane_event(
             config,
             runtime,
             session_id,
             "plan_round_started",
             json!({
-                "round": round,
-                "start_tool_index": plan_start_tool_index,
-                "tool_node_max_attempts": tool_node_max_attempts,
-                "effective_max_rounds": max_rounds,
-                "effective_max_node_attempts": max_node_attempts,
-                "verify_min_anchor_matches": adaptive_verify_policy.min_anchor_matches,
-                "session_governor": governor.as_json(),
-                "metrics": metrics.as_json(),
+                "round": state.round(),
+                "start_tool_index": state.plan_start_tool_index,
+                "tool_node_max_attempts": state.tool_node_max_attempts(),
+                "effective_max_rounds": state.max_rounds(),
+                "effective_max_node_attempts": state.max_node_attempts(),
+                "verify_min_anchor_matches": state.adaptive_verify_policy.min_anchor_matches,
+                "session_governor": state.governor.as_json(),
+                "metrics": state.metrics.as_json(),
             }),
             kernel_ctx,
         )
         .await;
 
-        let plan = build_safe_lane_plan_graph(
-            config,
-            lane_decision,
-            turn,
-            tool_node_max_attempts,
-            plan_start_tool_index,
-        );
-        let executor = SafeLanePlanNodeExecutor::new(
-            turn.tool_intents.as_slice(),
-            kernel_ctx,
-            config.conversation.safe_lane_verify_output_non_empty,
-            seed_tool_outputs.clone(),
-            config
-                .conversation
-                .tool_result_payload_summary_limit_chars(),
-        );
-        let report = PlanExecutor::execute(&plan, &executor).await;
-        metrics.total_attempts_used = metrics
-            .total_attempts_used
-            .saturating_add(report.attempts_used as u64);
-        let round_tool_outputs = executor.tool_outputs_snapshot().await;
-        let round_tool_output_stats =
-            summarize_safe_lane_tool_output_stats(round_tool_outputs.as_slice());
-        metrics.record_tool_output_stats(round_tool_output_stats);
+        let round_execution =
+            evaluate_safe_lane_round(config, lane_decision, turn, kernel_ctx, &state).await;
+        state.record_round_execution(&round_execution.report, round_execution.tool_output_stats);
 
-        match report.status {
+        match round_execution.report.status.clone() {
             PlanRunStatus::Succeeded => {
-                metrics.rounds_succeeded = metrics.rounds_succeeded.saturating_add(1);
+                state.note_round_succeeded();
                 emit_safe_lane_event(
                     config,
                     runtime,
                     session_id,
                     "plan_round_completed",
                     json!({
-                        "round": round,
+                        "round": state.round(),
                         "status": "succeeded",
-                        "attempts_used": report.attempts_used,
-                        "elapsed_ms": report.elapsed_ms,
-                        "tool_output_stats": round_tool_output_stats.as_json(),
+                        "attempts_used": round_execution.report.attempts_used,
+                        "elapsed_ms": round_execution.report.elapsed_ms,
+                        "tool_output_stats": round_execution.tool_output_stats.as_json(),
                         "health_signal": derive_safe_lane_runtime_health_signal(
                             config,
-                            metrics,
+                            state.metrics,
                             false,
                             None,
                         )
                         .as_json(),
-                        "metrics": metrics.as_json(),
+                        "metrics": state.metrics.as_json(),
                     }),
                     kernel_ctx,
                 )
                 .await;
-                let tool_output = round_tool_outputs.join("\n");
+                let tool_output = round_execution.tool_outputs.join("\n");
                 let verify_report = verify_safe_lane_final_output(
                     config,
                     tool_output.as_str(),
                     turn.tool_intents.as_slice(),
-                    adaptive_verify_policy,
+                    state.adaptive_verify_policy,
                 );
                 if verify_report.passed {
-                    {
+                    emit_safe_lane_event(
+                        config,
+                        runtime,
+                        session_id,
+                        "final_status",
+                        json!({
+                            "status": "succeeded",
+                            "round": state.round(),
+                            "tool_output_stats": round_execution.tool_output_stats.as_json(),
+                            "health_signal": derive_safe_lane_runtime_health_signal(
+                                config,
+                                state.metrics,
+                                false,
+                                None,
+                            )
+                            .as_json(),
+                            "metrics": state.metrics.as_json(),
+                        }),
+                        kernel_ctx,
+                    )
+                    .await;
+                    return SafeLaneTurnOutcome::without_terminal_route(TurnResult::FinalText(
+                        tool_output,
+                    ));
+                }
+
+                let verify_error = verify_report.failure_reasons.join(",");
+                let failure_codes = verify_report
+                    .failure_codes
+                    .iter()
+                    .map(format_verification_failure_code)
+                    .collect::<Vec<_>>();
+                let retryable_verify_failure =
+                    should_replan_for_verification_failure(&verify_report);
+                let verify_failure = turn_failure_from_verify_failure(
+                    verify_error.as_str(),
+                    retryable_verify_failure,
+                );
+                state.note_verify_failure();
+                let verify_route = decide_safe_lane_failure_route(
+                    config,
+                    &verify_failure,
+                    state.replan_budget,
+                    state.metrics,
+                    state.governor,
+                );
+                emit_safe_lane_event(
+                    config,
+                    runtime,
+                    session_id,
+                    "verify_failed",
+                    json!({
+                        "round": state.round(),
+                        "error": verify_error.clone(),
+                        "failure_codes": failure_codes,
+                        "retryable": retryable_verify_failure,
+                        "failure_kind": format_turn_failure_kind(verify_failure.kind),
+                        "failure_code": verify_failure.code.clone(),
+                        "failure_retryable": verify_failure.retryable,
+                        "route_decision": verify_route.decision_label(),
+                        "route_reason": verify_route.reason.as_str(),
+                        "route_source": verify_route.source_label(),
+                        "tool_output_stats": round_execution.tool_output_stats.as_json(),
+                        "health_signal": derive_safe_lane_runtime_health_signal(
+                            config,
+                            state.metrics,
+                            false,
+                            None,
+                        )
+                        .as_json(),
+                        "metrics": state.metrics.as_json(),
+                    }),
+                    kernel_ctx,
+                )
+                .await;
+
+                match decide_safe_lane_verify_failure_action(
+                    verify_error.as_str(),
+                    retryable_verify_failure,
+                    verify_route,
+                ) {
+                    SafeLaneRoundDecision::Finalize { result } => {
+                        let failure_meta = result.failure();
                         emit_safe_lane_event(
                             config,
                             runtime,
                             session_id,
                             "final_status",
                             json!({
-                                "status": "succeeded",
-                                "round": round,
-                                "tool_output_stats": round_tool_output_stats.as_json(),
+                                "status": "failed",
+                                "round": state.round(),
+                                "failure": verify_route.verify_terminal_summary_label(),
+                                "failure_kind": failure_meta
+                                    .map(|failure| format_turn_failure_kind(failure.kind)),
+                                "failure_code": failure_meta.map(|failure| failure.code.clone()),
+                                "failure_retryable": failure_meta.map(|failure| failure.retryable),
+                                "route_decision": verify_route.decision_label(),
+                                "route_reason": verify_route.reason.as_str(),
+                                "route_source": verify_route.source_label(),
+                                "tool_output_stats": round_execution.tool_output_stats.as_json(),
                                 "health_signal": derive_safe_lane_runtime_health_signal(
                                     config,
-                                    metrics,
-                                    false,
-                                    None,
+                                    state.metrics,
+                                    true,
+                                    failure_meta.map(|failure| failure.code.as_str()),
                                 )
                                 .as_json(),
-                                "metrics": metrics.as_json(),
+                                "metrics": state.metrics.as_json(),
                             }),
                             kernel_ctx,
                         )
                         .await;
-                        return TurnResult::FinalText(tool_output);
+                        return SafeLaneTurnOutcome::with_terminal_route(result, verify_route);
                     }
-                } else {
-                    let verify_error = verify_report.failure_reasons.join(",");
-                    let failure_codes = verify_report
-                        .failure_codes
-                        .iter()
-                        .map(format_verification_failure_code)
-                        .collect::<Vec<_>>();
-                    let retryable_verify_failure =
-                        should_replan_for_verification_failure(&verify_report);
-                    let verify_failure = turn_failure_from_verify_failure(
-                        verify_error.as_str(),
-                        retryable_verify_failure,
-                    );
-                    metrics.verify_failures = metrics.verify_failures.saturating_add(1);
-                    let verify_route = apply_safe_lane_backpressure_guard(
-                        config,
-                        route_safe_lane_failure(&verify_failure, round, max_rounds),
-                        metrics,
-                    );
-                    let verify_route =
-                        apply_safe_lane_session_governor_route_override(verify_route, governor);
-                    {
-                        emit_safe_lane_event(
-                            config,
-                            runtime,
-                            session_id,
-                            "verify_failed",
-                            json!({
-                                "round": round,
-                                "error": verify_error.clone(),
-                                "failure_codes": failure_codes,
-                                "retryable": retryable_verify_failure,
-                                "failure_kind": format_turn_failure_kind(verify_failure.kind),
-                                "failure_code": verify_failure.code.clone(),
-                                "failure_retryable": verify_failure.retryable,
-                                "route_decision": format_safe_lane_route_decision(verify_route.decision),
-                                "route_reason": verify_route.reason,
-                                "tool_output_stats": round_tool_output_stats.as_json(),
-                                "health_signal": derive_safe_lane_runtime_health_signal(
-                                    config,
-                                    metrics,
-                                    false,
-                                    None,
-                                )
-                                .as_json(),
-                                "metrics": metrics.as_json(),
-                            }),
-                            kernel_ctx,
-                        )
-                        .await;
-                        if matches!(
-                            verify_route.decision,
-                            SafeLaneFailureRouteDecision::Terminal
-                        ) {
-                            let terminal_failure = terminal_turn_failure_from_verify_failure(
-                                verify_error.as_str(),
-                                retryable_verify_failure,
-                                verify_route.reason,
-                            );
-                            emit_safe_lane_event(
-                                config,
-                                runtime,
-                                session_id,
-                                "final_status",
-                                json!({
-                                    "status": "failed",
-                                    "round": round,
-                                    "failure": summarize_verify_terminal_reason(verify_route.reason),
-                                    "failure_kind": format_turn_failure_kind(terminal_failure.kind),
-                                    "failure_code": terminal_failure.code.clone(),
-                                    "failure_retryable": terminal_failure.retryable,
-                                    "route_decision": format_safe_lane_route_decision(verify_route.decision),
-                                    "route_reason": verify_route.reason,
-                                    "tool_output_stats": round_tool_output_stats.as_json(),
-                                    "health_signal": derive_safe_lane_runtime_health_signal(
-                                        config,
-                                        metrics,
-                                        true,
-                                        Some(terminal_failure.code.as_str()),
-                                    )
-                                    .as_json(),
-                                    "metrics": metrics.as_json(),
-                                }),
-                                kernel_ctx,
-                            )
-                            .await;
-                            return TurnResult::ToolError(terminal_failure);
-                        }
-                        metrics.replans_triggered = metrics.replans_triggered.saturating_add(1);
+                    SafeLaneRoundDecision::Replan {
+                        reason,
+                        next_plan_start_tool_index,
+                        next_seed_tool_outputs,
+                    } => {
+                        state.note_replan(next_plan_start_tool_index, next_seed_tool_outputs);
                         emit_safe_lane_event(
                             config,
                             runtime,
                             session_id,
                             "replan_triggered",
                             json!({
-                                "round": round,
-                                "reason": "verify_failed",
+                                "round": state.round(),
+                                "reason": reason,
                                 "detail": verify_error,
-                                "route_decision": format_safe_lane_route_decision(verify_route.decision),
-                                "route_reason": verify_route.reason,
-                                "tool_output_stats": round_tool_output_stats.as_json(),
+                                "route_decision": verify_route.decision_label(),
+                                "route_reason": verify_route.reason.as_str(),
+                                "route_source": verify_route.source_label(),
+                                "tool_output_stats": round_execution.tool_output_stats.as_json(),
                                 "health_signal": derive_safe_lane_runtime_health_signal(
                                     config,
-                                    metrics,
+                                    state.metrics,
                                     false,
                                     None,
                                 )
                                 .as_json(),
-                                "metrics": metrics.as_json(),
+                                "metrics": state.metrics.as_json(),
                             }),
                             kernel_ctx,
                         )
@@ -1148,116 +3007,168 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                 }
             }
             PlanRunStatus::Failed(failure) => {
-                metrics.rounds_failed = metrics.rounds_failed.saturating_add(1);
+                state.note_round_failed();
                 let round_failure_meta = turn_failure_from_plan_failure(&failure);
-                let route = apply_safe_lane_backpressure_guard(
+                let route = decide_safe_lane_failure_route(
                     config,
-                    route_safe_lane_failure(&round_failure_meta, round, max_rounds),
-                    metrics,
+                    &round_failure_meta,
+                    state.replan_budget,
+                    state.metrics,
+                    state.governor,
                 );
-                let route = apply_safe_lane_session_governor_route_override(route, governor);
+                let failure_summary = summarize_plan_failure(&failure);
                 emit_safe_lane_event(
                     config,
                     runtime,
                     session_id,
                     "plan_round_completed",
                     json!({
-                        "round": round,
+                        "round": state.round(),
                         "status": "failed",
-                        "attempts_used": report.attempts_used,
-                        "elapsed_ms": report.elapsed_ms,
-                        "failure": summarize_plan_failure(&failure),
+                        "attempts_used": round_execution.report.attempts_used,
+                        "elapsed_ms": round_execution.report.elapsed_ms,
+                        "failure": failure_summary.clone(),
                         "failure_kind": format_turn_failure_kind(round_failure_meta.kind),
                         "failure_code": round_failure_meta.code.clone(),
                         "failure_retryable": round_failure_meta.retryable,
-                        "route_decision": format_safe_lane_route_decision(route.decision),
-                        "route_reason": route.reason,
-                        "tool_output_stats": round_tool_output_stats.as_json(),
+                        "route_decision": route.decision_label(),
+                        "route_reason": route.reason.as_str(),
+                        "route_source": route.source_label(),
+                        "tool_output_stats": round_execution.tool_output_stats.as_json(),
                         "health_signal": derive_safe_lane_runtime_health_signal(
                             config,
-                            metrics,
+                            state.metrics,
                             false,
                             None,
                         )
                         .as_json(),
-                        "metrics": metrics.as_json(),
+                        "metrics": state.metrics.as_json(),
                     }),
                     kernel_ctx,
                 )
                 .await;
-                if matches!(route.decision, SafeLaneFailureRouteDecision::Replan) {
-                    let (next_start_tool_index, next_seed_outputs) =
-                        derive_replan_cursor(&failure, &executor, turn.tool_intents.len()).await;
-                    plan_start_tool_index = next_start_tool_index;
-                    seed_tool_outputs = next_seed_outputs;
-                    metrics.replans_triggered = metrics.replans_triggered.saturating_add(1);
-                    emit_safe_lane_event(
-                        config,
-                        runtime,
-                        session_id,
-                        "replan_triggered",
-                        json!({
-                            "round": round,
-                            "reason": summarize_plan_failure(&failure),
-                            "restart_tool_index": plan_start_tool_index,
-                            "seeded_outputs": seed_tool_outputs.len(),
-                            "route_decision": format_safe_lane_route_decision(route.decision),
-                            "route_reason": route.reason,
-                            "tool_output_stats": round_tool_output_stats.as_json(),
-                            "health_signal": derive_safe_lane_runtime_health_signal(
-                                config,
-                                metrics,
-                                false,
-                                None,
-                            )
-                            .as_json(),
-                            "metrics": metrics.as_json(),
-                        }),
-                        kernel_ctx,
-                    )
-                    .await;
+                let (next_start_tool_index, next_seed_outputs) = if route.should_replan() {
+                    let (next_start_tool_index, next_seed_outputs) = derive_replan_cursor(
+                        &failure,
+                        round_execution.tool_outputs.as_slice(),
+                        turn.tool_intents.len(),
+                    );
+                    (next_start_tool_index, next_seed_outputs)
                 } else {
-                    let terminal_result =
-                        terminal_turn_result_from_plan_failure_with_route(failure.clone(), route);
-                    let failure_meta = terminal_result.failure();
-                    emit_safe_lane_event(
-                        config,
-                        runtime,
-                        session_id,
-                        "final_status",
-                        json!({
-                            "status": "failed",
-                            "round": round,
-                            "failure": summarize_plan_failure(&failure),
-                            "failure_kind": failure_meta
-                                .map(|failure| format_turn_failure_kind(failure.kind)),
-                            "failure_code": failure_meta.map(|failure| failure.code.clone()),
-                            "failure_retryable": failure_meta.map(|failure| failure.retryable),
-                            "route_decision": format_safe_lane_route_decision(route.decision),
-                            "route_reason": route.reason,
-                            "tool_output_stats": round_tool_output_stats.as_json(),
-                            "health_signal": derive_safe_lane_runtime_health_signal(
-                                config,
-                                metrics,
-                                true,
-                                failure_meta.map(|failure| failure.code.as_str()),
-                            )
-                            .as_json(),
-                            "metrics": metrics.as_json(),
-                        }),
-                        kernel_ctx,
-                    )
-                    .await;
-                    return terminal_result;
+                    (0, Vec::new())
+                };
+                match decide_safe_lane_plan_failure_action(
+                    failure.clone(),
+                    route,
+                    next_start_tool_index,
+                    next_seed_outputs,
+                ) {
+                    SafeLaneRoundDecision::Finalize { result } => {
+                        let failure_meta = result.failure();
+                        emit_safe_lane_event(
+                            config,
+                            runtime,
+                            session_id,
+                            "final_status",
+                            json!({
+                                "status": "failed",
+                                "round": state.round(),
+                                "failure": failure_summary,
+                                "failure_kind": failure_meta
+                                    .map(|failure| format_turn_failure_kind(failure.kind)),
+                                "failure_code": failure_meta.map(|failure| failure.code.clone()),
+                                "failure_retryable": failure_meta.map(|failure| failure.retryable),
+                                "route_decision": route.decision_label(),
+                                "route_reason": route.reason.as_str(),
+                                "route_source": route.source_label(),
+                                "tool_output_stats": round_execution.tool_output_stats.as_json(),
+                                "health_signal": derive_safe_lane_runtime_health_signal(
+                                    config,
+                                    state.metrics,
+                                    true,
+                                    failure_meta.map(|failure| failure.code.as_str()),
+                                )
+                                .as_json(),
+                                "metrics": state.metrics.as_json(),
+                            }),
+                            kernel_ctx,
+                        )
+                        .await;
+                        return SafeLaneTurnOutcome::with_terminal_route(result, route);
+                    }
+                    SafeLaneRoundDecision::Replan {
+                        reason,
+                        next_plan_start_tool_index,
+                        next_seed_tool_outputs,
+                    } => {
+                        let seeded_outputs_count = next_seed_tool_outputs.len();
+                        state.note_replan(next_plan_start_tool_index, next_seed_tool_outputs);
+                        emit_safe_lane_event(
+                            config,
+                            runtime,
+                            session_id,
+                            "replan_triggered",
+                            json!({
+                                "round": state.round(),
+                                "reason": reason,
+                                "restart_tool_index": state.plan_start_tool_index,
+                                "seeded_outputs": seeded_outputs_count,
+                                "route_decision": route.decision_label(),
+                                "route_reason": route.reason.as_str(),
+                                "route_source": route.source_label(),
+                                "tool_output_stats": round_execution.tool_output_stats.as_json(),
+                                "health_signal": derive_safe_lane_runtime_health_signal(
+                                    config,
+                                    state.metrics,
+                                    false,
+                                    None,
+                                )
+                                .as_json(),
+                                "metrics": state.metrics.as_json(),
+                            }),
+                            kernel_ctx,
+                        )
+                        .await;
+                    }
                 }
             }
         }
 
-        round = round.saturating_add(1);
-        tool_node_max_attempts = tool_node_max_attempts
-            .saturating_add(1)
-            .min(max_node_attempts)
-            .max(1);
+        state.advance_round();
+    }
+}
+
+async fn evaluate_safe_lane_round(
+    config: &LoongClawConfig,
+    lane_decision: &LaneDecision,
+    turn: &ProviderTurn,
+    kernel_ctx: Option<&KernelContext>,
+    state: &SafeLanePlanLoopState,
+) -> SafeLaneRoundExecution {
+    let plan = build_safe_lane_plan_graph(
+        config,
+        lane_decision,
+        turn,
+        state.tool_node_max_attempts(),
+        state.plan_start_tool_index,
+    );
+    let executor = SafeLanePlanNodeExecutor::new(
+        turn.tool_intents.as_slice(),
+        kernel_ctx,
+        config.conversation.safe_lane_verify_output_non_empty,
+        state.seed_tool_outputs.clone(),
+        config
+            .conversation
+            .tool_result_payload_summary_limit_chars(),
+    );
+    let report = PlanExecutor::execute(&plan, &executor).await;
+    let tool_outputs = executor.tool_outputs_snapshot().await;
+    let tool_output_stats = summarize_safe_lane_tool_output_stats(tool_outputs.as_slice());
+
+    SafeLaneRoundExecution {
+        report,
+        tool_outputs,
+        tool_output_stats,
     }
 }
 
@@ -1638,12 +3549,8 @@ fn decide_safe_lane_session_governor(
     let history_window_turns = config
         .conversation
         .safe_lane_session_governor_window_turns();
-    let failed_final_status_events = summary
-        .final_status_counts
-        .get("failed")
-        .copied()
-        .unwrap_or_default();
-    let backpressure_failure_events = count_safe_lane_backpressure_failures(summary);
+    let failed_final_status_events = summary.failed_final_status_events();
+    let backpressure_failure_events = summary.backpressure_failure_events();
     let failed_final_status_threshold = config
         .conversation
         .safe_lane_session_governor_failed_final_status_threshold();
@@ -1766,37 +3673,20 @@ async fn load_safe_lane_history_signals_for_governor(
     let window_turns = config
         .conversation
         .safe_lane_session_governor_window_turns();
-    if let Some(ctx) = kernel_ctx {
-        let request = MemoryCoreRequest {
-            operation: crate::memory::MEMORY_OP_WINDOW.to_owned(),
-            payload: json!({
-                "session_id": session_id,
-                "limit": window_turns,
-                "allow_extended_limit": true,
-            }),
-        };
-        let caps = BTreeSet::from([Capability::MemoryRead]);
-        if let Ok(outcome) = ctx
-            .kernel
-            .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
-            .await
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        if let Ok(assistant_contents) = load_assistant_contents_from_session_window(
+            session_id,
+            window_turns,
+            kernel_ctx,
+            &memory_config,
+        )
+        .await
         {
-            let assistant_contents =
-                collect_assistant_contents_from_memory_window_payload(outcome.payload.get("turns"));
             return summarize_governor_history_signals(
                 assistant_contents.iter().map(String::as_str),
             );
-        }
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    {
-        if let Ok(turns) = crate::memory::window_direct_extended(session_id, window_turns) {
-            let assistant_contents = turns
-                .iter()
-                .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.as_str()))
-                .collect::<Vec<_>>();
-            return summarize_governor_history_signals(assistant_contents);
         }
     }
 
@@ -1809,93 +3699,12 @@ fn summarize_governor_history_signals<'a, I>(
 where
     I: IntoIterator<Item = &'a str>,
 {
-    let mut retained_contents = Vec::new();
-    let mut final_status_failed_samples = Vec::new();
-    let mut backpressure_failure_samples = Vec::new();
-
-    for content in assistant_contents {
-        retained_contents.push(content.to_owned());
-        let Some(record) = parse_conversation_event(content) else {
-            continue;
-        };
-        if record.event != "final_status" {
-            continue;
-        }
-        match record.payload.get("status").and_then(Value::as_str) {
-            Some("failed") => {
-                final_status_failed_samples.push(true);
-                backpressure_failure_samples
-                    .push(is_backpressure_final_status_payload(&record.payload));
-            }
-            Some("succeeded") => {
-                final_status_failed_samples.push(false);
-                backpressure_failure_samples.push(false);
-            }
-            _ => {}
-        }
-    }
-
+    let projection = summarize_safe_lane_history(assistant_contents);
     SafeLaneGovernorHistorySignals {
-        summary: summarize_safe_lane_events(retained_contents.iter().map(String::as_str)),
-        final_status_failed_samples,
-        backpressure_failure_samples,
+        summary: projection.summary,
+        final_status_failed_samples: projection.final_status_failed_samples,
+        backpressure_failure_samples: projection.backpressure_failure_samples,
     }
-}
-
-fn collect_assistant_contents_from_memory_window_payload(
-    turns_payload: Option<&Value>,
-) -> Vec<String> {
-    turns_payload
-        .and_then(Value::as_array)
-        .map(|turns| {
-            turns
-                .iter()
-                .filter_map(|turn| {
-                    (turn.get("role").and_then(Value::as_str) == Some("assistant"))
-                        .then_some(turn.get("content").and_then(Value::as_str))
-                        .flatten()
-                        .map(ToOwned::to_owned)
-                })
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn count_safe_lane_backpressure_failures(summary: &SafeLaneEventSummary) -> u32 {
-    summary
-        .failure_code_counts
-        .get("safe_lane_plan_backpressure_guard")
-        .copied()
-        .unwrap_or_default()
-        .saturating_add(
-            summary
-                .failure_code_counts
-                .get("safe_lane_plan_verify_failed_backpressure_guard")
-                .copied()
-                .unwrap_or_default(),
-        )
-}
-
-fn is_backpressure_final_status_payload(payload: &Value) -> bool {
-    if payload
-        .get("failure_code")
-        .and_then(Value::as_str)
-        .map(|code| {
-            matches!(
-                code,
-                "safe_lane_plan_backpressure_guard"
-                    | "safe_lane_plan_verify_failed_backpressure_guard"
-            )
-        })
-        .unwrap_or(false)
-    {
-        return true;
-    }
-    payload
-        .get("route_reason")
-        .and_then(Value::as_str)
-        .map(|reason| reason.starts_with("backpressure_"))
-        .unwrap_or(false)
 }
 
 fn compute_ewma_bool(samples: &[bool], alpha: f64) -> Option<f64> {
@@ -1920,173 +3729,275 @@ fn trailing_success_streak(failed_samples: &[bool]) -> u32 {
     streak
 }
 
-fn apply_safe_lane_session_governor_route_override(
-    route: SafeLaneFailureRoute,
-    governor: SafeLaneSessionGovernorDecision,
-) -> SafeLaneFailureRoute {
-    if governor.force_no_replan && route.reason == "round_budget_exhausted" {
-        return SafeLaneFailureRoute {
-            decision: SafeLaneFailureRouteDecision::Terminal,
-            reason: "session_governor_no_replan",
-        };
-    }
-    route
+fn safe_lane_backpressure_budget(config: &LoongClawConfig) -> Option<SafeLaneBackpressureBudget> {
+    config
+        .conversation
+        .safe_lane_backpressure_guard_enabled
+        .then(|| {
+            SafeLaneBackpressureBudget::new(
+                config
+                    .conversation
+                    .safe_lane_backpressure_max_total_attempts(),
+                config.conversation.safe_lane_backpressure_max_replans(),
+            )
+        })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SafeLaneFailureRouteDecision {
-    Replan,
-    Terminal,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 struct SafeLaneFailureRoute {
     decision: SafeLaneFailureRouteDecision,
-    reason: &'static str,
+    reason: SafeLaneFailureRouteReason,
+    source: SafeLaneFailureRouteSource,
 }
 
-fn route_safe_lane_failure(
-    failure: &TurnFailure,
-    round: u8,
-    max_rounds: u8,
-) -> SafeLaneFailureRoute {
-    if round >= max_rounds {
-        return SafeLaneFailureRoute {
-            decision: SafeLaneFailureRouteDecision::Terminal,
-            reason: "round_budget_exhausted",
-        };
+impl SafeLaneFailureRoute {
+    fn from_failure(failure: &TurnFailure, replan_budget: SafeLaneReplanBudget) -> Self {
+        if let SafeLaneContinuationBudgetDecision::Terminal { reason } =
+            replan_budget.continuation_decision()
+        {
+            return Self::terminal(reason);
+        }
+
+        match failure.code.as_str() {
+            "kernel_policy_denied"
+            | "tool_not_found"
+            | "max_tool_steps_exceeded"
+            | "no_kernel_context" => {
+                return Self::terminal(SafeLaneFailureRouteReason::PolicyDenied);
+            }
+            "tool_execution_failed" => {
+                if failure.retryable {
+                    return Self::replan(SafeLaneFailureRouteReason::RetryableFailure);
+                }
+                return Self::terminal(SafeLaneFailureRouteReason::RetryableFlagFalse);
+            }
+            "kernel_execution_failed" => {
+                return Self::terminal(SafeLaneFailureRouteReason::NonRetryableFailure);
+            }
+            _ => {}
+        }
+
+        if let Some(code) = SafeLaneFailureCode::parse(failure.code.as_str()) {
+            match code {
+                SafeLaneFailureCode::PlanNodePolicyDenied => {
+                    return Self::terminal(SafeLaneFailureRouteReason::PolicyDenied);
+                }
+                SafeLaneFailureCode::VerifyFailed => {
+                    if failure.retryable {
+                        return Self::replan(SafeLaneFailureRouteReason::RetryableFailure);
+                    }
+                    return Self::terminal(SafeLaneFailureRouteReason::NonRetryableFailure);
+                }
+                SafeLaneFailureCode::PlanNodeRetryableError => {
+                    if failure.retryable {
+                        return Self::replan(SafeLaneFailureRouteReason::RetryableFailure);
+                    }
+                    return Self::terminal(SafeLaneFailureRouteReason::RetryableFlagFalse);
+                }
+                SafeLaneFailureCode::VerifyFailedBudgetExhausted => {
+                    return Self::terminal(SafeLaneFailureRouteReason::RoundBudgetExhausted);
+                }
+                SafeLaneFailureCode::PlanValidationFailed
+                | SafeLaneFailureCode::PlanTopologyResolutionFailed
+                | SafeLaneFailureCode::PlanBudgetExceeded
+                | SafeLaneFailureCode::PlanWallTimeExceeded
+                | SafeLaneFailureCode::PlanNodeNonRetryableError
+                | SafeLaneFailureCode::VerifyFailedBackpressureGuard
+                | SafeLaneFailureCode::VerifyFailedSessionGovernor
+                | SafeLaneFailureCode::PlanBackpressureGuard
+                | SafeLaneFailureCode::PlanSessionGovernorNoReplan => {
+                    return Self::terminal(SafeLaneFailureRouteReason::NonRetryableFailure);
+                }
+            }
+        }
+
+        match failure.kind {
+            TurnFailureKind::Retryable if failure.retryable => {
+                Self::replan(SafeLaneFailureRouteReason::RetryableFailure)
+            }
+            TurnFailureKind::Retryable => {
+                Self::terminal(SafeLaneFailureRouteReason::RetryableFlagFalse)
+            }
+            TurnFailureKind::PolicyDenied => {
+                Self::terminal(SafeLaneFailureRouteReason::PolicyDenied)
+            }
+            TurnFailureKind::NonRetryable => {
+                Self::terminal(SafeLaneFailureRouteReason::NonRetryableFailure)
+            }
+            TurnFailureKind::ApprovalRequired => {
+                Self::terminal(SafeLaneFailureRouteReason::ApprovalRequired)
+            }
+            TurnFailureKind::Provider => {
+                Self::terminal(SafeLaneFailureRouteReason::ProviderFailure)
+            }
+        }
     }
 
-    match failure.code.as_str() {
-        "safe_lane_plan_node_policy_denied"
-        | "kernel_policy_denied"
-        | "tool_not_found"
-        | "max_tool_steps_exceeded"
-        | "no_kernel_context" => {
-            return SafeLaneFailureRoute {
-                decision: SafeLaneFailureRouteDecision::Terminal,
-                reason: "policy_denied",
-            };
-        }
-        "safe_lane_plan_verify_failed" => {
-            if failure.retryable {
-                return SafeLaneFailureRoute {
-                    decision: SafeLaneFailureRouteDecision::Replan,
-                    reason: "retryable_failure",
-                };
-            }
-            return SafeLaneFailureRoute {
-                decision: SafeLaneFailureRouteDecision::Terminal,
-                reason: "non_retryable_failure",
-            };
-        }
-        "safe_lane_plan_node_retryable_error" | "tool_execution_failed" => {
-            if failure.retryable {
-                return SafeLaneFailureRoute {
-                    decision: SafeLaneFailureRouteDecision::Replan,
-                    reason: "retryable_failure",
-                };
-            }
-            return SafeLaneFailureRoute {
-                decision: SafeLaneFailureRouteDecision::Terminal,
-                reason: "retryable_flag_false",
-            };
-        }
-        "safe_lane_plan_verify_failed_budget_exhausted" => {
-            return SafeLaneFailureRoute {
-                decision: SafeLaneFailureRouteDecision::Terminal,
-                reason: "round_budget_exhausted",
-            };
-        }
-        "safe_lane_plan_validation_failed"
-        | "safe_lane_plan_topology_resolution_failed"
-        | "safe_lane_plan_budget_exceeded"
-        | "safe_lane_plan_wall_time_exceeded"
-        | "safe_lane_plan_node_non_retryable_error"
-        | "kernel_execution_failed" => {
-            return SafeLaneFailureRoute {
-                decision: SafeLaneFailureRouteDecision::Terminal,
-                reason: "non_retryable_failure",
-            };
-        }
-        _ => {}
-    }
-
-    match failure.kind {
-        TurnFailureKind::Retryable if failure.retryable => SafeLaneFailureRoute {
+    fn replan(reason: SafeLaneFailureRouteReason) -> Self {
+        Self {
             decision: SafeLaneFailureRouteDecision::Replan,
-            reason: "retryable_failure",
-        },
-        TurnFailureKind::Retryable => SafeLaneFailureRoute {
-            decision: SafeLaneFailureRouteDecision::Terminal,
-            reason: "retryable_flag_false",
-        },
-        TurnFailureKind::PolicyDenied => SafeLaneFailureRoute {
-            decision: SafeLaneFailureRouteDecision::Terminal,
-            reason: "policy_denied",
-        },
-        TurnFailureKind::NonRetryable => SafeLaneFailureRoute {
-            decision: SafeLaneFailureRouteDecision::Terminal,
-            reason: "non_retryable_failure",
-        },
-        TurnFailureKind::ApprovalRequired => SafeLaneFailureRoute {
-            decision: SafeLaneFailureRouteDecision::Terminal,
-            reason: "approval_required",
-        },
-        TurnFailureKind::Provider => SafeLaneFailureRoute {
-            decision: SafeLaneFailureRouteDecision::Terminal,
-            reason: "provider_failure",
-        },
-    }
-}
-
-fn apply_safe_lane_backpressure_guard(
-    config: &LoongClawConfig,
-    route: SafeLaneFailureRoute,
-    metrics: SafeLaneExecutionMetrics,
-) -> SafeLaneFailureRoute {
-    if !config.conversation.safe_lane_backpressure_guard_enabled
-        || !matches!(route.decision, SafeLaneFailureRouteDecision::Replan)
-    {
-        return route;
-    }
-
-    if metrics.total_attempts_used
-        >= config
-            .conversation
-            .safe_lane_backpressure_max_total_attempts()
-    {
-        return SafeLaneFailureRoute {
-            decision: SafeLaneFailureRouteDecision::Terminal,
-            reason: "backpressure_attempts_exhausted",
-        };
-    }
-
-    if metrics.replans_triggered >= config.conversation.safe_lane_backpressure_max_replans() {
-        return SafeLaneFailureRoute {
-            decision: SafeLaneFailureRouteDecision::Terminal,
-            reason: "backpressure_replans_exhausted",
-        };
-    }
-
-    route
-}
-
-fn format_safe_lane_route_decision(decision: SafeLaneFailureRouteDecision) -> &'static str {
-    match decision {
-        SafeLaneFailureRouteDecision::Replan => "replan",
-        SafeLaneFailureRouteDecision::Terminal => "terminal",
-    }
-}
-
-fn summarize_verify_terminal_reason(route_reason: &str) -> &'static str {
-    match route_reason {
-        "round_budget_exhausted" => "verify_failed_budget_exhausted",
-        "backpressure_attempts_exhausted" | "backpressure_replans_exhausted" => {
-            "verify_failed_backpressure_guard"
+            reason,
+            source: SafeLaneFailureRouteSource::BaseRouting,
         }
-        "session_governor_no_replan" => "verify_failed_session_governor",
-        _ => "verify_failed_non_retryable",
+    }
+
+    fn terminal(reason: SafeLaneFailureRouteReason) -> Self {
+        Self {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason,
+            source: SafeLaneFailureRouteSource::BaseRouting,
+        }
+    }
+
+    fn terminal_with_source(
+        reason: SafeLaneFailureRouteReason,
+        source: SafeLaneFailureRouteSource,
+    ) -> Self {
+        Self {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason,
+            source,
+        }
+    }
+
+    fn is_base_round_budget_terminal(self) -> bool {
+        self.decision == SafeLaneFailureRouteDecision::Terminal
+            && self.source == SafeLaneFailureRouteSource::BaseRouting
+            && self.reason == SafeLaneFailureRouteReason::RoundBudgetExhausted
+    }
+
+    fn should_replan(self) -> bool {
+        self.decision == SafeLaneFailureRouteDecision::Replan
+    }
+
+    fn decision_label(self) -> &'static str {
+        self.decision.as_str()
+    }
+
+    fn source_label(self) -> &'static str {
+        self.source.as_str()
+    }
+
+    fn verify_terminal_summary_label(self) -> &'static str {
+        match (self.source, self.reason) {
+            (SafeLaneFailureRouteSource::BackpressureGuard, _) => {
+                "verify_failed_backpressure_guard"
+            }
+            (SafeLaneFailureRouteSource::SessionGovernor, _) => "verify_failed_session_governor",
+            (
+                SafeLaneFailureRouteSource::BaseRouting,
+                SafeLaneFailureRouteReason::RoundBudgetExhausted,
+            ) => "verify_failed_budget_exhausted",
+            (SafeLaneFailureRouteSource::BaseRouting, _) => "verify_failed_non_retryable",
+        }
+    }
+
+    fn terminal_verify_failure_code(self, retryable_signal: bool) -> SafeLaneFailureCode {
+        match (self.source, self.reason, retryable_signal) {
+            (SafeLaneFailureRouteSource::BackpressureGuard, _, _) => {
+                SafeLaneFailureCode::VerifyFailedBackpressureGuard
+            }
+            (SafeLaneFailureRouteSource::SessionGovernor, _, _) => {
+                SafeLaneFailureCode::VerifyFailedSessionGovernor
+            }
+            (
+                SafeLaneFailureRouteSource::BaseRouting,
+                SafeLaneFailureRouteReason::RoundBudgetExhausted,
+                true,
+            ) => SafeLaneFailureCode::VerifyFailedBudgetExhausted,
+            (SafeLaneFailureRouteSource::BaseRouting, _, _) => SafeLaneFailureCode::VerifyFailed,
+        }
+    }
+
+    fn terminal_plan_failure_code(self) -> Option<SafeLaneFailureCode> {
+        match self.source {
+            SafeLaneFailureRouteSource::BackpressureGuard => {
+                Some(SafeLaneFailureCode::PlanBackpressureGuard)
+            }
+            SafeLaneFailureRouteSource::SessionGovernor => {
+                Some(SafeLaneFailureCode::PlanSessionGovernorNoReplan)
+            }
+            SafeLaneFailureRouteSource::BaseRouting => None,
+        }
+    }
+
+    fn with_backpressure_guard(
+        self,
+        backpressure_budget: Option<SafeLaneBackpressureBudget>,
+        metrics: SafeLaneExecutionMetrics,
+    ) -> Self {
+        if !self.should_replan() {
+            return self;
+        }
+
+        let Some(reason) = backpressure_budget.and_then(|budget| {
+            match budget
+                .continuation_decision(metrics.total_attempts_used, metrics.replans_triggered)
+            {
+                SafeLaneContinuationBudgetDecision::Continue => None,
+                SafeLaneContinuationBudgetDecision::Terminal { reason } => Some(reason),
+            }
+        }) else {
+            return self;
+        };
+
+        Self::terminal_with_source(reason, SafeLaneFailureRouteSource::BackpressureGuard)
+    }
+
+    fn with_session_governor_override(self, governor: SafeLaneSessionGovernorDecision) -> Self {
+        if governor.force_no_replan && self.is_base_round_budget_terminal() {
+            return Self::terminal_with_source(
+                SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+                SafeLaneFailureRouteSource::SessionGovernor,
+            );
+        }
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+enum SafeLaneRoundDecision {
+    Finalize {
+        result: TurnResult,
+    },
+    Replan {
+        reason: String,
+        next_plan_start_tool_index: usize,
+        next_seed_tool_outputs: Vec<String>,
+    },
+}
+
+fn decide_safe_lane_failure_route(
+    config: &LoongClawConfig,
+    failure: &TurnFailure,
+    replan_budget: SafeLaneReplanBudget,
+    metrics: SafeLaneExecutionMetrics,
+    governor: SafeLaneSessionGovernorDecision,
+) -> SafeLaneFailureRoute {
+    SafeLaneFailureRoute::from_failure(failure, replan_budget)
+        .with_backpressure_guard(safe_lane_backpressure_budget(config), metrics)
+        .with_session_governor_override(governor)
+}
+
+fn decide_safe_lane_verify_failure_action(
+    verify_error: &str,
+    retryable_signal: bool,
+    route: SafeLaneFailureRoute,
+) -> SafeLaneRoundDecision {
+    if !route.should_replan() {
+        return SafeLaneRoundDecision::Finalize {
+            result: TurnResult::ToolError(terminal_turn_failure_from_verify_failure(
+                verify_error,
+                retryable_signal,
+                route,
+            )),
+        };
+    }
+
+    SafeLaneRoundDecision::Replan {
+        reason: "verify_failed".to_owned(),
+        next_plan_start_tool_index: 0,
+        next_seed_tool_outputs: Vec::new(),
     }
 }
 
@@ -2199,9 +4110,9 @@ fn push_anchor_candidate(text: &str, anchors: &mut BTreeSet<String>) {
     }
 }
 
-async fn derive_replan_cursor(
+fn derive_replan_cursor(
     failure: &PlanRunFailure,
-    executor: &SafeLanePlanNodeExecutor<'_>,
+    round_tool_outputs: &[String],
     tool_count: usize,
 ) -> (usize, Vec<String>) {
     #[allow(clippy::wildcard_enum_match_arm)]
@@ -2210,7 +4121,7 @@ async fn derive_replan_cursor(
             if let Ok(index) = parse_tool_node_index(node_id.as_str())
                 && index < tool_count
             {
-                return (index, executor.tool_outputs_snapshot().await);
+                return (index, round_tool_outputs.to_vec());
             }
             (0, Vec::new())
         }
@@ -2258,78 +4169,66 @@ fn format_turn_failure_kind(kind: TurnFailureKind) -> &'static str {
 }
 
 fn turn_failure_from_plan_failure(failure: &PlanRunFailure) -> TurnFailure {
+    let (code, kind) = classify_safe_lane_plan_failure(failure);
     match failure {
-        PlanRunFailure::ValidationFailed(error) => TurnFailure::non_retryable(
-            "safe_lane_plan_validation_failed",
-            format!("safe_lane_plan_validation_failed: {error}"),
-        ),
-        PlanRunFailure::TopologyResolutionFailed => TurnFailure::non_retryable(
-            "safe_lane_plan_topology_resolution_failed",
-            "safe_lane_plan_topology_resolution_failed",
-        ),
+        PlanRunFailure::ValidationFailed(error) => {
+            code.into_turn_failure(kind, format!("{}: {error}", code.as_str()))
+        }
+        PlanRunFailure::TopologyResolutionFailed => code.into_turn_failure(kind, code.as_str()),
         PlanRunFailure::BudgetExceeded {
             attempts_used,
             limit,
-        } => TurnFailure::non_retryable(
-            "safe_lane_plan_budget_exceeded",
-            format!("safe_lane_plan_budget_exceeded attempts_used={attempts_used} limit={limit}"),
+        } => code.into_turn_failure(
+            kind,
+            format!(
+                "{} attempts_used={attempts_used} limit={limit}",
+                code.as_str()
+            ),
         ),
         PlanRunFailure::WallTimeExceeded {
             elapsed_ms,
             limit_ms,
-        } => TurnFailure::non_retryable(
-            "safe_lane_plan_wall_time_exceeded",
+        } => code.into_turn_failure(
+            kind,
             format!(
-                "safe_lane_plan_wall_time_exceeded elapsed_ms={elapsed_ms} limit_ms={limit_ms}"
+                "{} elapsed_ms={elapsed_ms} limit_ms={limit_ms}",
+                code.as_str()
             ),
         ),
-        PlanRunFailure::NodeFailed {
-            last_error,
-            last_error_kind,
-            ..
-        } => match last_error_kind {
-            PlanNodeErrorKind::PolicyDenied => {
-                TurnFailure::policy_denied("safe_lane_plan_node_policy_denied", last_error.clone())
-            }
-            PlanNodeErrorKind::Retryable => {
-                TurnFailure::retryable("safe_lane_plan_node_retryable_error", last_error.clone())
-            }
-            PlanNodeErrorKind::NonRetryable => TurnFailure::non_retryable(
-                "safe_lane_plan_node_non_retryable_error",
-                last_error.clone(),
-            ),
-        },
+        PlanRunFailure::NodeFailed { last_error, .. } => {
+            code.into_turn_failure(kind, last_error.clone())
+        }
     }
 }
 
 fn turn_failure_from_verify_failure(verify_error: &str, retryable: bool) -> TurnFailure {
-    let reason = format!("safe_lane_plan_verify_failed: {verify_error}");
-    if retryable {
-        TurnFailure::retryable("safe_lane_plan_verify_failed", reason)
-    } else {
-        TurnFailure::non_retryable("safe_lane_plan_verify_failed", reason)
-    }
+    SafeLaneFailureCode::VerifyFailed.into_turn_failure(
+        if retryable {
+            TurnFailureKind::Retryable
+        } else {
+            TurnFailureKind::NonRetryable
+        },
+        format!(
+            "{}: {verify_error}",
+            SafeLaneFailureCode::VerifyFailed.as_str()
+        ),
+    )
 }
 
 fn terminal_turn_failure_from_verify_failure(
     verify_error: &str,
     retryable_signal: bool,
-    route_reason: &str,
+    route: SafeLaneFailureRoute,
 ) -> TurnFailure {
-    let reason = format!("safe_lane_plan_verify_failed: {verify_error}");
-    match route_reason {
-        "round_budget_exhausted" if retryable_signal => {
-            // Retryable at signal layer, but terminal after exhausting rounds.
-            TurnFailure::non_retryable("safe_lane_plan_verify_failed_budget_exhausted", reason)
-        }
-        "backpressure_attempts_exhausted" | "backpressure_replans_exhausted" => {
-            TurnFailure::non_retryable("safe_lane_plan_verify_failed_backpressure_guard", reason)
-        }
-        "session_governor_no_replan" => {
-            TurnFailure::non_retryable("safe_lane_plan_verify_failed_session_governor", reason)
-        }
-        _ => TurnFailure::non_retryable("safe_lane_plan_verify_failed", reason),
-    }
+    route
+        .terminal_verify_failure_code(retryable_signal)
+        .into_turn_failure(
+            TurnFailureKind::NonRetryable,
+            format!(
+                "{}: {verify_error}",
+                SafeLaneFailureCode::VerifyFailed.as_str()
+            ),
+        )
 }
 
 fn turn_result_from_plan_failure(failure: PlanRunFailure) -> TurnResult {
@@ -2345,24 +4244,33 @@ fn terminal_turn_result_from_plan_failure_with_route(
     failure: PlanRunFailure,
     route: SafeLaneFailureRoute,
 ) -> TurnResult {
-    if matches!(
-        route.reason,
-        "backpressure_attempts_exhausted" | "backpressure_replans_exhausted"
-    ) {
+    if let Some(code) = route.terminal_plan_failure_code() {
         let summary = summarize_plan_failure(&failure);
-        return TurnResult::ToolError(TurnFailure::non_retryable(
-            "safe_lane_plan_backpressure_guard",
-            format!("safe_lane_plan_backpressure_guard: {summary}"),
-        ));
-    }
-    if route.reason == "session_governor_no_replan" {
-        let summary = summarize_plan_failure(&failure);
-        return TurnResult::ToolError(TurnFailure::non_retryable(
-            "safe_lane_plan_session_governor_no_replan",
-            format!("safe_lane_plan_session_governor_no_replan: {summary}"),
+        return TurnResult::ToolError(code.into_turn_failure(
+            TurnFailureKind::NonRetryable,
+            format!("{}: {summary}", code.as_str()),
         ));
     }
     turn_result_from_plan_failure(failure)
+}
+
+fn decide_safe_lane_plan_failure_action(
+    failure: PlanRunFailure,
+    route: SafeLaneFailureRoute,
+    next_plan_start_tool_index: usize,
+    next_seed_tool_outputs: Vec<String>,
+) -> SafeLaneRoundDecision {
+    if route.should_replan() {
+        return SafeLaneRoundDecision::Replan {
+            reason: summarize_plan_failure(&failure),
+            next_plan_start_tool_index,
+            next_seed_tool_outputs,
+        };
+    }
+
+    SafeLaneRoundDecision::Finalize {
+        result: terminal_turn_result_from_plan_failure_with_route(failure, route),
+    }
 }
 
 struct SafeLanePlanNodeExecutor<'a> {
@@ -2488,152 +4396,21 @@ async fn execute_single_tool_intent(
     ))
 }
 
-fn build_tool_followup_messages(
-    base_messages: &[Value],
-    assistant_preface: &str,
-    tool_result_text: &str,
-    user_input: &str,
-) -> Vec<Value> {
-    let mut messages = base_messages.to_vec();
-    let preface = assistant_preface.trim();
-    if !preface.is_empty() {
-        messages.push(json!({
-            "role": "assistant",
-            "content": preface,
-        }));
-    }
-    if let Some(skill_context) = parse_external_skill_invoke_context(tool_result_text) {
-        messages.push(json!({
-            "role": "system",
-            "content": build_external_skill_system_message(&skill_context),
-        }));
-        messages.push(json!({
-            "role": "user",
-            "content": build_external_skill_followup_user_prompt(user_input, &skill_context),
-        }));
-        return messages;
-    }
-    messages.push(json!({
-        "role": "assistant",
-        "content": format!("[tool_result]\n{tool_result_text}"),
-    }));
-    messages.push(json!({
-        "role": "user",
-        "content": build_tool_followup_user_prompt(user_input, None, Some(tool_result_text)),
-    }));
-    messages
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ExternalSkillInvokeContext {
-    skill_id: String,
-    display_name: String,
-    instructions: String,
-}
-
-fn parse_external_skill_invoke_context(
-    tool_result_text: &str,
-) -> Option<ExternalSkillInvokeContext> {
-    let trimmed = tool_result_text.trim();
-    let mut lines = trimmed.lines().filter(|line| !line.trim().is_empty());
-    let line = lines.next()?;
-    if lines.next().is_some() {
-        return None;
-    }
-    let payload = line.strip_prefix("[ok] ")?;
-    let envelope: Value = serde_json::from_str(payload).ok()?;
-    if envelope.get("tool")?.as_str()? != "external_skills.invoke" {
-        return None;
-    }
-    let payload_summary = envelope.get("payload_summary")?.as_str()?;
-    let payload_json: Value = serde_json::from_str(payload_summary).ok()?;
-    let instructions = payload_json
-        .get("instructions")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())?
-        .to_owned();
-    let skill_id = payload_json
-        .get("skill_id")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("external-skill")
-        .to_owned();
-    let display_name = payload_json
-        .get("display_name")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(skill_id.as_str())
-        .to_owned();
-    Some(ExternalSkillInvokeContext {
-        skill_id,
-        display_name,
-        instructions,
-    })
-}
-
-fn build_external_skill_system_message(skill_context: &ExternalSkillInvokeContext) -> String {
-    format!(
-        "Managed external skill `{}` ({}) is now active for this task. Treat the following `SKILL.md` content as trusted runtime guidance until superseded.\n\n{}",
-        skill_context.skill_id, skill_context.display_name, skill_context.instructions
-    )
-}
-
-fn build_external_skill_followup_user_prompt(
-    user_input: &str,
-    skill_context: &ExternalSkillInvokeContext,
-) -> String {
-    [
-        EXTERNAL_SKILL_FOLLOWUP_PROMPT.to_owned(),
-        format!(
-            "Loaded managed external skill:\n- id: {}\n- name: {}",
-            skill_context.skill_id, skill_context.display_name
-        ),
-        format!("Original request:\n{user_input}"),
-    ]
-    .join("\n\n")
-}
-
-fn build_tool_failure_followup_messages(
-    base_messages: &[Value],
-    assistant_preface: &str,
-    tool_failure_reason: &str,
-    user_input: &str,
-) -> Vec<Value> {
-    let mut messages = base_messages.to_vec();
-    let preface = assistant_preface.trim();
-    if !preface.is_empty() {
-        messages.push(json!({
-            "role": "assistant",
-            "content": preface,
-        }));
-    }
-    messages.push(json!({
-        "role": "assistant",
-        "content": format!("[tool_failure]\n{tool_failure_reason}"),
-    }));
-    messages.push(json!({
-        "role": "user",
-        "content": build_tool_followup_user_prompt(user_input, None, None),
-    }));
-    messages
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn build_tool_followup_messages_include_truncation_hint_for_truncated_tool_results() {
-        let messages = build_tool_followup_messages(
+    fn build_turn_reply_followup_messages_include_truncation_hint_for_truncated_tool_results() {
+        let messages = build_turn_reply_followup_messages(
             &[serde_json::json!({
                 "role": "system",
                 "content": "sys"
             })],
             "preface",
-            r#"[ok] {"payload_truncated":true,"payload_summary":"..."}"#,
+            ToolDrivenFollowupPayload::ToolResult {
+                text: r#"[ok] {"payload_truncated":true,"payload_summary":"..."}"#.to_owned(),
+            },
             "summarize note.md",
         );
 
@@ -2649,14 +4426,16 @@ mod tests {
     }
 
     #[test]
-    fn build_tool_failure_followup_messages_do_not_include_truncation_hint() {
-        let messages = build_tool_failure_followup_messages(
+    fn build_turn_reply_followup_messages_do_not_include_truncation_hint_for_failure() {
+        let messages = build_turn_reply_followup_messages(
             &[serde_json::json!({
                 "role": "system",
                 "content": "sys"
             })],
             "preface",
-            "tool_timeout ...(truncated 200 chars)",
+            ToolDrivenFollowupPayload::ToolFailure {
+                reason: "tool_timeout ...(truncated 200 chars)".to_owned(),
+            },
             "summarize note.md",
         );
 
@@ -2671,14 +4450,16 @@ mod tests {
     }
 
     #[test]
-    fn build_tool_followup_messages_promotes_external_skill_invoke_to_system_context() {
-        let messages = build_tool_followup_messages(
+    fn build_turn_reply_followup_messages_promotes_external_skill_invoke_to_system_context() {
+        let messages = build_turn_reply_followup_messages(
             &[serde_json::json!({
                 "role": "system",
                 "content": "sys"
             })],
             "preface",
-            r#"[ok] {"status":"ok","tool":"external_skills.invoke","tool_call_id":"call-1","payload_summary":"{\"skill_id\":\"demo-skill\",\"display_name\":\"Demo Skill\",\"instructions\":\"Follow the managed skill instruction before answering.\"}","payload_chars":180,"payload_truncated":false}"#,
+            ToolDrivenFollowupPayload::ToolResult {
+                text: r#"[ok] {"status":"ok","tool":"external_skills.invoke","tool_call_id":"call-1","payload_summary":"{\"skill_id\":\"demo-skill\",\"display_name\":\"Demo Skill\",\"instructions\":\"Follow the managed skill instruction before answering.\"}","payload_chars":180,"payload_truncated":false}"#.to_owned(),
+            },
             "summarize note.md",
         );
 
@@ -2706,39 +4487,832 @@ mod tests {
     }
 
     #[test]
+    fn build_turn_reply_followup_messages_rejects_truncated_external_skill_invoke_payload() {
+        let messages = build_turn_reply_followup_messages(
+            &[serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })],
+            "preface",
+            ToolDrivenFollowupPayload::ToolResult {
+                text: r#"[ok] {"status":"ok","tool":"external_skills.invoke","tool_call_id":"call-1","payload_summary":"{\"skill_id\":\"demo-skill\",\"display_name\":\"Demo Skill\",\"instructions\":\"Follow the managed skill instruction before answering.\"}","payload_chars":180,"payload_truncated":true}"#.to_owned(),
+            },
+            "summarize note.md",
+        );
+
+        assert!(
+            !messages.iter().any(|message| message.get("role")
+                == Some(&Value::String("system".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| content
+                        .contains("Follow the managed skill instruction before answering."))
+                    .unwrap_or(false)),
+            "truncated invoke payload must not activate managed skill system context: {messages:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .filter(
+                    |message| message.get("role") == Some(&Value::String("assistant".to_owned()))
+                )
+                .filter_map(|message| message.get("content").and_then(Value::as_str))
+                .any(|content| content.contains("[tool_result]\n[ok]")),
+            "truncated invoke payload should stay as ordinary assistant tool_result content: {messages:?}"
+        );
+    }
+
+    #[test]
+    fn provider_turn_session_state_appends_user_input_and_keeps_estimate() {
+        let session = ProviderTurnSessionState::from_assembled_context(
+            AssembledConversationContext {
+                messages: vec![serde_json::json!({
+                    "role": "system",
+                    "content": "sys"
+                })],
+                estimated_tokens: Some(42),
+                system_prompt_addition: None,
+            },
+            "hello world",
+        );
+
+        assert_eq!(session.estimated_tokens, Some(42));
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[1]["role"], "user");
+        assert_eq!(session.messages[1]["content"], "hello world");
+    }
+
+    #[test]
+    fn provider_turn_session_state_after_turn_messages_appends_reply() {
+        let session = ProviderTurnSessionState::from_assembled_context(
+            AssembledConversationContext::from_messages(vec![serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })]),
+            "hello world",
+        );
+
+        let messages = session.after_turn_messages("done");
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[2]["role"], "assistant");
+        assert_eq!(messages[2]["content"], "done");
+    }
+
+    #[test]
+    fn provider_turn_reply_tail_phase_captures_reply_and_after_turn_context() {
+        let session = ProviderTurnSessionState::from_assembled_context(
+            AssembledConversationContext {
+                messages: vec![serde_json::json!({
+                    "role": "system",
+                    "content": "sys"
+                })],
+                estimated_tokens: Some(42),
+                system_prompt_addition: None,
+            },
+            "hello world",
+        );
+
+        let phase = ProviderTurnReplyTailPhase::from_session(&session, "done");
+
+        assert_eq!(phase.reply(), "done");
+        assert_eq!(phase.estimated_tokens(), Some(42));
+        assert_eq!(phase.after_turn_messages().len(), 3);
+        assert_eq!(phase.after_turn_messages()[2]["role"], "assistant");
+        assert_eq!(phase.after_turn_messages()[2]["content"], "done");
+    }
+
+    #[test]
+    fn provider_turn_lane_plan_hybrid_disabled_forces_fast_lane_limits() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.hybrid_lane_enabled = false;
+        config.conversation.fast_lane_max_tool_steps_per_turn = 3;
+        config.conversation.safe_lane_max_tool_steps_per_turn = 7;
+
+        let plan = ProviderTurnLanePlan::from_user_input(&config, "deploy to production");
+
+        assert_eq!(plan.decision.lane, ExecutionLane::Fast);
+        assert_eq!(plan.max_tool_steps, 3);
+        assert!(
+            plan.decision
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("hybrid_lane_disabled"))
+        );
+    }
+
+    #[test]
+    fn provider_turn_preparation_derives_lane_plan_and_raw_mode() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.fast_lane_max_tool_steps_per_turn = 2;
+        config.conversation.safe_lane_max_tool_steps_per_turn = 5;
+
+        let preparation = ProviderTurnPreparation::from_assembled_context(
+            &config,
+            AssembledConversationContext::from_messages(vec![serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })]),
+            "deploy to production and show raw tool output",
+        );
+
+        assert_eq!(preparation.session.messages.len(), 2);
+        assert_eq!(preparation.session.messages[1]["role"], "user");
+        assert_eq!(
+            preparation.session.messages[1]["content"],
+            "deploy to production and show raw tool output"
+        );
+        assert!(preparation.raw_tool_output_requested);
+        assert_eq!(preparation.lane_plan.decision.lane, ExecutionLane::Safe);
+        assert_eq!(preparation.lane_plan.max_tool_steps, 5);
+    }
+
+    #[test]
+    fn provider_turn_lane_plan_safe_plan_path_requires_safe_lane_and_tool_intents() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_plan_execution_enabled = true;
+
+        let safe_plan = ProviderTurnLanePlan::from_user_input(
+            &config,
+            "deploy to production and rotate the token",
+        );
+        let tool_turn = ProviderTurn {
+            assistant_text: "preface".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "shell.exec".to_owned(),
+                args_json: json!({"command": "echo hi"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe".to_owned(),
+                turn_id: "turn-safe".to_owned(),
+                tool_call_id: "call-safe".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        };
+
+        assert_eq!(safe_plan.decision.lane, ExecutionLane::Safe);
+        assert!(safe_plan.should_use_safe_lane_plan_path(&config, &tool_turn));
+        assert!(!safe_plan.should_use_safe_lane_plan_path(
+            &config,
+            &ProviderTurn {
+                tool_intents: Vec::new(),
+                ..tool_turn.clone()
+            }
+        ));
+
+        let fast_plan = ProviderTurnLanePlan::from_user_input(&config, "say hello");
+        assert_eq!(fast_plan.decision.lane, ExecutionLane::Fast);
+        assert!(!fast_plan.should_use_safe_lane_plan_path(&config, &tool_turn));
+    }
+
+    #[test]
+    fn provider_turn_continue_phase_checkpoint_captures_continue_branch_kernel_shape() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_max_tool_steps_per_turn = 5;
+        let preparation = ProviderTurnPreparation::from_assembled_context(
+            &config,
+            AssembledConversationContext::from_messages(vec![serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })]),
+            "deploy to production",
+        );
+        let phase = ProviderTurnContinuePhase::new(
+            2,
+            ProviderTurnLaneExecution {
+                lane: ExecutionLane::Safe,
+                assistant_preface: "preface".to_owned(),
+                had_tool_intents: true,
+                raw_tool_output_requested: false,
+                turn_result: TurnResult::ToolError(TurnFailure::retryable(
+                    "safe_lane_plan_node_retryable_error",
+                    "transient",
+                )),
+                safe_lane_terminal_route: Some(SafeLaneFailureRoute {
+                    decision: SafeLaneFailureRouteDecision::Terminal,
+                    reason: SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+                    source: SafeLaneFailureRouteSource::SessionGovernor,
+                }),
+            },
+        );
+
+        let checkpoint =
+            phase.checkpoint(&preparation, "deploy to production", "preface\ntransient");
+
+        assert_eq!(
+            checkpoint.request,
+            TurnCheckpointRequest::Continue { tool_intents: 2 }
+        );
+        assert_eq!(
+            checkpoint
+                .lane
+                .as_ref()
+                .expect("lane snapshot should be present")
+                .result_kind,
+            TurnCheckpointResultKind::ToolError
+        );
+        assert_eq!(
+            checkpoint
+                .lane
+                .as_ref()
+                .and_then(|lane| lane.safe_lane_terminal_route)
+                .expect("safe-lane route should be present")
+                .source,
+            SafeLaneFailureRouteSource::SessionGovernor
+        );
+        assert_eq!(
+            checkpoint
+                .reply
+                .as_ref()
+                .expect("reply checkpoint should be present")
+                .decision,
+            ReplyResolutionMode::CompletionPass
+        );
+        assert_eq!(
+            checkpoint
+                .reply
+                .as_ref()
+                .and_then(|reply| reply.followup_kind),
+            Some(ToolDrivenFollowupKind::ToolFailure)
+        );
+        assert_eq!(
+            checkpoint.finalization,
+            TurnFinalizationCheckpoint::PersistReply {
+                persistence_mode: ReplyPersistenceMode::Success,
+                runs_after_turn: true,
+                attempts_context_compaction: true,
+            }
+        );
+        assert_eq!(
+            checkpoint
+                .identity
+                .as_ref()
+                .expect("identity should be present")
+                .assistant_reply_chars,
+            "preface\ntransient".chars().count()
+        );
+    }
+
+    #[test]
+    fn provider_turn_continue_phase_checkpoint_keeps_direct_reply_without_followup() {
+        let preparation = ProviderTurnPreparation::from_assembled_context(
+            &LoongClawConfig::default(),
+            AssembledConversationContext::from_messages(vec![serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })]),
+            "say hello",
+        );
+        let phase = ProviderTurnContinuePhase::new(
+            0,
+            ProviderTurnLaneExecution {
+                lane: ExecutionLane::Fast,
+                assistant_preface: "preface".to_owned(),
+                had_tool_intents: false,
+                raw_tool_output_requested: false,
+                turn_result: TurnResult::FinalText("hello there".to_owned()),
+                safe_lane_terminal_route: None,
+            },
+        );
+
+        let checkpoint = phase.checkpoint(&preparation, "say hello", "hello there");
+
+        assert_eq!(
+            checkpoint.request,
+            TurnCheckpointRequest::Continue { tool_intents: 0 }
+        );
+        assert_eq!(
+            checkpoint
+                .lane
+                .as_ref()
+                .expect("lane snapshot should be present")
+                .result_kind,
+            TurnCheckpointResultKind::FinalText
+        );
+        assert_eq!(
+            checkpoint
+                .reply
+                .as_ref()
+                .expect("reply checkpoint should be present")
+                .decision,
+            ReplyResolutionMode::Direct
+        );
+        assert_eq!(
+            checkpoint
+                .reply
+                .as_ref()
+                .and_then(|reply| reply.followup_kind),
+            None
+        );
+        assert_eq!(
+            checkpoint
+                .identity
+                .as_ref()
+                .expect("identity should be present")
+                .assistant_reply_chars,
+            "hello there".chars().count()
+        );
+    }
+
+    #[test]
+    fn resolved_provider_turn_checkpoint_preserves_safe_lane_route_provenance() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_max_tool_steps_per_turn = 5;
+
+        let resolved = ResolvedProviderTurn::PersistReply(ResolvedProviderReply {
+            reply: "preface\nsafe lane terminal".to_owned(),
+            checkpoint: TurnCheckpointSnapshot {
+                identity: Some(TurnCheckpointIdentity::from_turn(
+                    "deploy to production",
+                    "preface\nsafe lane terminal",
+                )),
+                preparation: ProviderTurnPreparation::from_assembled_context(
+                    &config,
+                    AssembledConversationContext::from_messages(vec![serde_json::json!({
+                        "role": "system",
+                        "content": "sys"
+                    })]),
+                    "deploy to production",
+                )
+                .checkpoint(),
+                request: TurnCheckpointRequest::Continue { tool_intents: 1 },
+                lane: Some(TurnLaneExecutionSnapshot {
+                    lane: ExecutionLane::Safe,
+                    had_tool_intents: true,
+                    raw_tool_output_requested: false,
+                    result_kind: TurnCheckpointResultKind::ToolError,
+                    safe_lane_terminal_route: Some(SafeLaneFailureRoute {
+                        decision: SafeLaneFailureRouteDecision::Terminal,
+                        reason: SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+                        source: SafeLaneFailureRouteSource::SessionGovernor,
+                    }),
+                }),
+                reply: Some(TurnReplyCheckpoint {
+                    decision: ReplyResolutionMode::CompletionPass,
+                    followup_kind: Some(ToolDrivenFollowupKind::ToolFailure),
+                }),
+                finalization: TurnFinalizationCheckpoint::PersistReply {
+                    persistence_mode: ReplyPersistenceMode::Success,
+                    runs_after_turn: true,
+                    attempts_context_compaction: true,
+                },
+            },
+        });
+        let snapshot = resolved.checkpoint();
+
+        assert_eq!(snapshot.preparation.lane, ExecutionLane::Safe);
+        assert_eq!(snapshot.preparation.context_message_count, 2);
+        assert_eq!(
+            snapshot.preparation.context_fingerprint_sha256,
+            checkpoint_context_fingerprint_sha256(&[
+                serde_json::json!({
+                    "role": "system",
+                    "content": "sys"
+                }),
+                serde_json::json!({
+                    "role": "user",
+                    "content": "deploy to production"
+                }),
+            ])
+        );
+        assert_eq!(
+            snapshot.request,
+            TurnCheckpointRequest::Continue { tool_intents: 1 }
+        );
+        assert_eq!(
+            snapshot.lane.as_ref().expect("lane snapshot").result_kind,
+            TurnCheckpointResultKind::ToolError
+        );
+        assert_eq!(
+            snapshot
+                .lane
+                .as_ref()
+                .and_then(|lane| lane.safe_lane_terminal_route)
+                .expect("safe-lane route")
+                .source,
+            SafeLaneFailureRouteSource::SessionGovernor
+        );
+        assert_eq!(
+            snapshot.reply.as_ref().expect("reply checkpoint").decision,
+            ReplyResolutionMode::CompletionPass
+        );
+        assert_eq!(
+            snapshot
+                .reply
+                .as_ref()
+                .and_then(|reply| reply.followup_kind),
+            Some(ToolDrivenFollowupKind::ToolFailure)
+        );
+        assert_eq!(
+            snapshot.finalization,
+            TurnFinalizationCheckpoint::PersistReply {
+                persistence_mode: ReplyPersistenceMode::Success,
+                runs_after_turn: true,
+                attempts_context_compaction: true,
+            }
+        );
+        assert_eq!(
+            snapshot
+                .identity
+                .as_ref()
+                .expect("identity should be present")
+                .user_input_chars,
+            "deploy to production".chars().count()
+        );
+        assert_eq!(resolved.reply_text(), Some("preface\nsafe lane terminal"));
+    }
+
+    #[test]
+    fn resolved_provider_turn_checkpoint_keeps_inline_provider_error_terminal_shape() {
+        let resolved = ResolvedProviderTurn::PersistReply(ResolvedProviderReply {
+            reply: "provider unavailable".to_owned(),
+            checkpoint: TurnCheckpointSnapshot {
+                identity: Some(TurnCheckpointIdentity::from_turn(
+                    "say hello",
+                    "provider unavailable",
+                )),
+                preparation: ProviderTurnPreparation::from_assembled_context(
+                    &LoongClawConfig::default(),
+                    AssembledConversationContext::from_messages(vec![serde_json::json!({
+                        "role": "system",
+                        "content": "sys"
+                    })]),
+                    "say hello",
+                )
+                .checkpoint(),
+                request: TurnCheckpointRequest::FinalizeInlineProviderError,
+                lane: None,
+                reply: None,
+                finalization: TurnFinalizationCheckpoint::PersistReply {
+                    persistence_mode: ReplyPersistenceMode::InlineProviderError,
+                    runs_after_turn: true,
+                    attempts_context_compaction: true,
+                },
+            },
+        });
+        let snapshot = resolved.checkpoint();
+
+        assert_eq!(
+            snapshot.request,
+            TurnCheckpointRequest::FinalizeInlineProviderError
+        );
+        assert!(snapshot.lane.is_none());
+        assert!(snapshot.reply.is_none());
+        assert!(snapshot.identity.is_some());
+        assert_eq!(
+            snapshot.finalization,
+            TurnFinalizationCheckpoint::PersistReply {
+                persistence_mode: ReplyPersistenceMode::InlineProviderError,
+                runs_after_turn: true,
+                attempts_context_compaction: true,
+            }
+        );
+        assert_eq!(resolved.reply_text(), Some("provider unavailable"));
+    }
+
+    #[test]
+    fn resolved_provider_turn_checkpoint_marks_return_error_finalization() {
+        let resolved = ResolvedProviderTurn::ReturnError(ResolvedProviderError {
+            error: "provider unavailable".to_owned(),
+            checkpoint: TurnCheckpointSnapshot {
+                identity: None,
+                preparation: ProviderTurnPreparation::from_assembled_context(
+                    &LoongClawConfig::default(),
+                    AssembledConversationContext::from_messages(vec![serde_json::json!({
+                        "role": "system",
+                        "content": "sys"
+                    })]),
+                    "say hello",
+                )
+                .checkpoint(),
+                request: TurnCheckpointRequest::ReturnError,
+                lane: None,
+                reply: None,
+                finalization: TurnFinalizationCheckpoint::ReturnError,
+            },
+        });
+        let snapshot = resolved.checkpoint();
+
+        assert_eq!(snapshot.request, TurnCheckpointRequest::ReturnError);
+        assert!(snapshot.identity.is_none());
+        assert!(snapshot.lane.is_none());
+        assert!(snapshot.reply.is_none());
+        assert_eq!(
+            snapshot.finalization,
+            TurnFinalizationCheckpoint::ReturnError
+        );
+        assert_eq!(resolved.reply_text(), None);
+    }
+
+    #[test]
+    fn resolved_provider_turn_terminal_phase_builds_reply_tail_and_checkpoint() {
+        let session = ProviderTurnSessionState::from_assembled_context(
+            AssembledConversationContext {
+                messages: vec![serde_json::json!({
+                    "role": "system",
+                    "content": "sys"
+                })],
+                estimated_tokens: Some(42),
+                system_prompt_addition: None,
+            },
+            "say hello",
+        );
+        let resolved = ResolvedProviderTurn::PersistReply(ResolvedProviderReply {
+            reply: "done".to_owned(),
+            checkpoint: TurnCheckpointSnapshot {
+                identity: Some(TurnCheckpointIdentity::from_turn("say hello", "done")),
+                preparation: ProviderTurnPreparation::from_assembled_context(
+                    &LoongClawConfig::default(),
+                    AssembledConversationContext::from_messages(vec![serde_json::json!({
+                        "role": "system",
+                        "content": "sys"
+                    })]),
+                    "say hello",
+                )
+                .checkpoint(),
+                request: TurnCheckpointRequest::Continue { tool_intents: 0 },
+                lane: Some(TurnLaneExecutionSnapshot {
+                    lane: ExecutionLane::Fast,
+                    had_tool_intents: false,
+                    raw_tool_output_requested: false,
+                    result_kind: TurnCheckpointResultKind::FinalText,
+                    safe_lane_terminal_route: None,
+                }),
+                reply: Some(TurnReplyCheckpoint {
+                    decision: ReplyResolutionMode::Direct,
+                    followup_kind: None,
+                }),
+                finalization: TurnFinalizationCheckpoint::persist_reply(
+                    ReplyPersistenceMode::Success,
+                ),
+            },
+        });
+
+        let phase = resolved.terminal_phase(&session);
+
+        match phase {
+            ProviderTurnTerminalPhase::PersistReply(phase) => {
+                assert_eq!(
+                    phase.checkpoint.request,
+                    TurnCheckpointRequest::Continue { tool_intents: 0 }
+                );
+                assert_eq!(phase.tail_phase.reply(), "done");
+                assert_eq!(phase.tail_phase.estimated_tokens(), Some(42));
+                assert_eq!(phase.tail_phase.after_turn_messages().len(), 3);
+                assert_eq!(phase.tail_phase.after_turn_messages()[2]["content"], "done");
+            }
+            ProviderTurnTerminalPhase::ReturnError(_) => {
+                panic!("persist reply should build persist terminal phase")
+            }
+        }
+    }
+
+    #[test]
+    fn resolved_provider_turn_terminal_phase_preserves_return_error_checkpoint() {
+        let session = ProviderTurnSessionState::from_assembled_context(
+            AssembledConversationContext::from_messages(vec![serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })]),
+            "say hello",
+        );
+        let resolved = ResolvedProviderTurn::ReturnError(ResolvedProviderError {
+            error: "provider unavailable".to_owned(),
+            checkpoint: TurnCheckpointSnapshot {
+                identity: None,
+                preparation: ProviderTurnPreparation::from_assembled_context(
+                    &LoongClawConfig::default(),
+                    AssembledConversationContext::from_messages(vec![serde_json::json!({
+                        "role": "system",
+                        "content": "sys"
+                    })]),
+                    "say hello",
+                )
+                .checkpoint(),
+                request: TurnCheckpointRequest::ReturnError,
+                lane: None,
+                reply: None,
+                finalization: TurnFinalizationCheckpoint::ReturnError,
+            },
+        });
+
+        let phase = resolved.terminal_phase(&session);
+
+        match phase {
+            ProviderTurnTerminalPhase::ReturnError(phase) => {
+                assert_eq!(phase.checkpoint.request, TurnCheckpointRequest::ReturnError);
+                assert_eq!(phase.error, "provider unavailable");
+            }
+            ProviderTurnTerminalPhase::PersistReply(_) => {
+                panic!("return error should build return-error terminal phase")
+            }
+        }
+    }
+
+    #[test]
+    fn provider_turn_request_terminal_phase_builds_inline_provider_error_reply() {
+        let preparation = ProviderTurnPreparation::from_assembled_context(
+            &LoongClawConfig::default(),
+            AssembledConversationContext::from_messages(vec![serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })]),
+            "say hello",
+        );
+
+        let resolved = ProviderTurnRequestTerminalPhase::persist_inline_provider_error(
+            "provider unavailable".to_owned(),
+        )
+        .resolve(&preparation, "say hello");
+
+        match resolved {
+            ResolvedProviderTurn::PersistReply(reply) => {
+                assert_eq!(reply.reply, "provider unavailable");
+                assert_eq!(
+                    reply.checkpoint.request,
+                    TurnCheckpointRequest::FinalizeInlineProviderError
+                );
+                assert!(reply.checkpoint.lane.is_none());
+                assert!(reply.checkpoint.reply.is_none());
+                assert_eq!(
+                    reply.checkpoint.finalization,
+                    TurnFinalizationCheckpoint::persist_reply(
+                        ReplyPersistenceMode::InlineProviderError,
+                    )
+                );
+                assert!(reply.checkpoint.identity.is_some());
+            }
+            ResolvedProviderTurn::ReturnError(_) => {
+                panic!("inline provider error should resolve to persisted reply")
+            }
+        }
+    }
+
+    #[test]
+    fn provider_turn_request_terminal_phase_builds_return_error_without_reply_identity() {
+        let preparation = ProviderTurnPreparation::from_assembled_context(
+            &LoongClawConfig::default(),
+            AssembledConversationContext::from_messages(vec![serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })]),
+            "say hello",
+        );
+
+        let resolved =
+            ProviderTurnRequestTerminalPhase::return_error("provider unavailable".to_owned())
+                .resolve(&preparation, "say hello");
+
+        match resolved {
+            ResolvedProviderTurn::ReturnError(error) => {
+                assert_eq!(error.error, "provider unavailable");
+                assert_eq!(error.checkpoint.request, TurnCheckpointRequest::ReturnError);
+                assert!(error.checkpoint.identity.is_none());
+                assert!(error.checkpoint.lane.is_none());
+                assert!(error.checkpoint.reply.is_none());
+                assert_eq!(
+                    error.checkpoint.finalization,
+                    TurnFinalizationCheckpoint::ReturnError
+                );
+            }
+            ResolvedProviderTurn::PersistReply(_) => {
+                panic!("propagated provider error should resolve to return-error outcome")
+            }
+        }
+    }
+
+    #[test]
+    fn safe_lane_replan_budget_allows_one_retry_then_exhausts() {
+        let initial = SafeLaneReplanBudget::new(1);
+
+        assert_eq!(
+            initial.continuation_decision(),
+            SafeLaneContinuationBudgetDecision::Continue
+        );
+        assert_eq!(initial.current_round(), 0);
+
+        let exhausted = initial.after_replan();
+        assert_eq!(
+            exhausted.continuation_decision(),
+            SafeLaneContinuationBudgetDecision::Terminal {
+                reason: SafeLaneFailureRouteReason::RoundBudgetExhausted,
+            }
+        );
+        assert_eq!(exhausted.current_round(), 1);
+    }
+
+    #[test]
+    fn escalating_attempt_budget_caps_growth_at_maximum() {
+        let budget = EscalatingAttemptBudget::new(2, 4);
+
+        assert_eq!(budget.current_limit(), 2);
+        assert_eq!(budget.after_retry().current_limit(), 3);
+        assert_eq!(budget.after_retry().after_retry().current_limit(), 4);
+        assert_eq!(
+            budget
+                .after_retry()
+                .after_retry()
+                .after_retry()
+                .current_limit(),
+            4
+        );
+    }
+
+    #[test]
+    fn decide_provider_request_action_continues_on_success() {
+        let decision = decide_provider_turn_request_action(
+            Ok(ProviderTurn {
+                assistant_text: "preface".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+            ProviderErrorMode::Propagate,
+        );
+
+        if let ProviderTurnRequestAction::Continue { turn } = decision {
+            assert_eq!(turn.assistant_text, "preface");
+            assert!(turn.tool_intents.is_empty());
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
+    }
+
+    #[test]
+    fn decide_provider_request_action_inlines_synthetic_reply_when_requested() {
+        let decision = decide_provider_turn_request_action(
+            Err("provider unavailable".to_owned()),
+            ProviderErrorMode::InlineMessage,
+        );
+
+        if let ProviderTurnRequestAction::FinalizeInlineProviderError { reply } = decision {
+            assert!(reply.contains("provider unavailable"));
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
+    }
+
+    #[test]
+    fn decide_provider_request_action_returns_error_in_propagate_mode() {
+        let decision = decide_provider_turn_request_action(
+            Err("provider unavailable".to_owned()),
+            ProviderErrorMode::Propagate,
+        );
+
+        if let ProviderTurnRequestAction::ReturnError { error } = decision {
+            assert_eq!(error, "provider unavailable");
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
+    }
+
+    #[test]
     fn safe_lane_route_retryable_failure_replans_with_remaining_budget() {
         let failure = TurnFailure::retryable("safe_lane_plan_node_retryable_error", "transient");
-        let route = route_safe_lane_failure(&failure, 0, 1);
+        let route = SafeLaneFailureRoute::from_failure(&failure, SafeLaneReplanBudget::new(1));
 
         assert_eq!(route.decision, SafeLaneFailureRouteDecision::Replan);
-        assert_eq!(route.reason, "retryable_failure");
+        assert_eq!(route.reason, SafeLaneFailureRouteReason::RetryableFailure);
+        assert_eq!(route.source, SafeLaneFailureRouteSource::BaseRouting);
+        assert_eq!(route.reason.as_str(), "retryable_failure");
     }
 
     #[test]
     fn safe_lane_route_retryable_failure_becomes_terminal_after_budget_exhaustion() {
         let failure = TurnFailure::retryable("safe_lane_plan_node_retryable_error", "transient");
-        let route = route_safe_lane_failure(&failure, 1, 1);
+        let route = SafeLaneFailureRoute::from_failure(
+            &failure,
+            SafeLaneReplanBudget::new(1).after_replan(),
+        );
 
         assert_eq!(route.decision, SafeLaneFailureRouteDecision::Terminal);
-        assert_eq!(route.reason, "round_budget_exhausted");
+        assert_eq!(
+            route.reason,
+            SafeLaneFailureRouteReason::RoundBudgetExhausted
+        );
+        assert_eq!(route.source, SafeLaneFailureRouteSource::BaseRouting);
+        assert!(route.is_base_round_budget_terminal());
     }
 
     #[test]
     fn safe_lane_route_policy_denied_failure_is_terminal() {
         let failure = TurnFailure::policy_denied("safe_lane_plan_node_policy_denied", "denied");
-        let route = route_safe_lane_failure(&failure, 0, 3);
+        let route = SafeLaneFailureRoute::from_failure(&failure, SafeLaneReplanBudget::new(3));
 
         assert_eq!(route.decision, SafeLaneFailureRouteDecision::Terminal);
-        assert_eq!(route.reason, "policy_denied");
+        assert_eq!(route.reason, SafeLaneFailureRouteReason::PolicyDenied);
+        assert_eq!(route.source, SafeLaneFailureRouteSource::BaseRouting);
     }
 
     #[test]
     fn safe_lane_route_non_retryable_failure_is_terminal() {
         let failure = TurnFailure::non_retryable("safe_lane_plan_node_non_retryable_error", "bad");
-        let route = route_safe_lane_failure(&failure, 0, 3);
+        let route = SafeLaneFailureRoute::from_failure(&failure, SafeLaneReplanBudget::new(3));
 
         assert_eq!(route.decision, SafeLaneFailureRouteDecision::Terminal);
-        assert_eq!(route.reason, "non_retryable_failure");
+        assert_eq!(
+            route.reason,
+            SafeLaneFailureRouteReason::NonRetryableFailure
+        );
+        assert_eq!(route.source, SafeLaneFailureRouteSource::BaseRouting);
     }
 
     #[test]
@@ -3068,15 +5642,24 @@ mod tests {
 
         let route = SafeLaneFailureRoute {
             decision: SafeLaneFailureRouteDecision::Replan,
-            reason: "retryable_failure",
+            reason: SafeLaneFailureRouteReason::RetryableFailure,
+            source: SafeLaneFailureRouteSource::BaseRouting,
         };
         let metrics = SafeLaneExecutionMetrics {
             total_attempts_used: 2,
             ..SafeLaneExecutionMetrics::default()
         };
-        let guarded = apply_safe_lane_backpressure_guard(&config, route, metrics);
+        let guarded =
+            route.with_backpressure_guard(safe_lane_backpressure_budget(&config), metrics);
         assert_eq!(guarded.decision, SafeLaneFailureRouteDecision::Terminal);
-        assert_eq!(guarded.reason, "backpressure_attempts_exhausted");
+        assert_eq!(
+            guarded.reason,
+            SafeLaneFailureRouteReason::BackpressureAttemptsExhausted
+        );
+        assert_eq!(
+            guarded.source,
+            SafeLaneFailureRouteSource::BackpressureGuard
+        );
     }
 
     #[test]
@@ -3090,15 +5673,24 @@ mod tests {
 
         let route = SafeLaneFailureRoute {
             decision: SafeLaneFailureRouteDecision::Replan,
-            reason: "retryable_failure",
+            reason: SafeLaneFailureRouteReason::RetryableFailure,
+            source: SafeLaneFailureRouteSource::BaseRouting,
         };
         let metrics = SafeLaneExecutionMetrics {
             replans_triggered: 1,
             ..SafeLaneExecutionMetrics::default()
         };
-        let guarded = apply_safe_lane_backpressure_guard(&config, route, metrics);
+        let guarded =
+            route.with_backpressure_guard(safe_lane_backpressure_budget(&config), metrics);
         assert_eq!(guarded.decision, SafeLaneFailureRouteDecision::Terminal);
-        assert_eq!(guarded.reason, "backpressure_replans_exhausted");
+        assert_eq!(
+            guarded.reason,
+            SafeLaneFailureRouteReason::BackpressureReplansExhausted
+        );
+        assert_eq!(
+            guarded.source,
+            SafeLaneFailureRouteSource::BackpressureGuard
+        );
     }
 
     fn governor_history_with_summary(
@@ -3108,6 +5700,72 @@ mod tests {
             summary,
             ..SafeLaneGovernorHistorySignals::default()
         }
+    }
+
+    #[test]
+    fn safe_lane_backpressure_budget_detects_attempt_exhaustion() {
+        let budget = SafeLaneBackpressureBudget::new(2, 10);
+        let metrics = SafeLaneExecutionMetrics {
+            total_attempts_used: 2,
+            ..SafeLaneExecutionMetrics::default()
+        };
+
+        assert_eq!(
+            budget.continuation_decision(metrics.total_attempts_used, metrics.replans_triggered),
+            SafeLaneContinuationBudgetDecision::Terminal {
+                reason: SafeLaneFailureRouteReason::BackpressureAttemptsExhausted,
+            }
+        );
+    }
+
+    #[test]
+    fn decide_safe_lane_failure_route_applies_backpressure_after_retryable_base_route() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.safe_lane_backpressure_guard_enabled = true;
+        config
+            .conversation
+            .safe_lane_backpressure_max_total_attempts = 2;
+        config.conversation.safe_lane_backpressure_max_replans = 10;
+
+        let route = decide_safe_lane_failure_route(
+            &config,
+            &TurnFailure::retryable("safe_lane_plan_node_retryable_error", "transient"),
+            SafeLaneReplanBudget::new(3),
+            SafeLaneExecutionMetrics {
+                total_attempts_used: 2,
+                ..SafeLaneExecutionMetrics::default()
+            },
+            SafeLaneSessionGovernorDecision::default(),
+        );
+
+        assert_eq!(route.decision, SafeLaneFailureRouteDecision::Terminal);
+        assert_eq!(
+            route.reason,
+            SafeLaneFailureRouteReason::BackpressureAttemptsExhausted
+        );
+        assert_eq!(route.source, SafeLaneFailureRouteSource::BackpressureGuard);
+    }
+
+    #[test]
+    fn decide_safe_lane_failure_route_applies_session_governor_override_to_exhausted_budget() {
+        let config = LoongClawConfig::default();
+        let route = decide_safe_lane_failure_route(
+            &config,
+            &TurnFailure::retryable("safe_lane_plan_node_retryable_error", "transient"),
+            SafeLaneReplanBudget::new(1).after_replan(),
+            SafeLaneExecutionMetrics::default(),
+            SafeLaneSessionGovernorDecision {
+                force_no_replan: true,
+                ..SafeLaneSessionGovernorDecision::default()
+            },
+        );
+
+        assert_eq!(route.decision, SafeLaneFailureRouteDecision::Terminal);
+        assert_eq!(
+            route.reason,
+            SafeLaneFailureRouteReason::SessionGovernorNoReplan
+        );
+        assert_eq!(route.source, SafeLaneFailureRouteSource::SessionGovernor);
     }
 
     #[test]
@@ -3128,6 +5786,17 @@ mod tests {
                 .copied(),
             Some(1)
         );
+    }
+
+    #[test]
+    fn summarize_governor_history_signals_ignores_unknown_backpressure_like_strings() {
+        let contents = [
+            r#"{"type":"conversation_event","event":"final_status","payload":{"status":"failed","failure_code":"unknown_backpressure_hint","route_reason":"backpressure_noise"}}"#,
+        ];
+
+        let signals = summarize_governor_history_signals(contents.iter().copied());
+        assert_eq!(signals.final_status_failed_samples, vec![true]);
+        assert_eq!(signals.backpressure_failure_samples, vec![false]);
     }
 
     #[test]
@@ -3310,14 +5979,22 @@ mod tests {
     fn session_governor_route_override_marks_no_replan_terminal_reason() {
         let route = SafeLaneFailureRoute {
             decision: SafeLaneFailureRouteDecision::Terminal,
-            reason: "round_budget_exhausted",
+            reason: SafeLaneFailureRouteReason::RoundBudgetExhausted,
+            source: SafeLaneFailureRouteSource::BaseRouting,
         };
         let governor = SafeLaneSessionGovernorDecision {
             force_no_replan: true,
             ..SafeLaneSessionGovernorDecision::default()
         };
-        let overridden = apply_safe_lane_session_governor_route_override(route, governor);
-        assert_eq!(overridden.reason, "session_governor_no_replan");
+        let overridden = route.with_session_governor_override(governor);
+        assert_eq!(
+            overridden.reason,
+            SafeLaneFailureRouteReason::SessionGovernorNoReplan
+        );
+        assert_eq!(
+            overridden.source,
+            SafeLaneFailureRouteSource::SessionGovernor
+        );
     }
 
     #[test]
@@ -3325,7 +6002,11 @@ mod tests {
         let failure = terminal_turn_failure_from_verify_failure(
             "retryable verify failure",
             true,
-            "backpressure_attempts_exhausted",
+            SafeLaneFailureRoute {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: SafeLaneFailureRouteReason::BackpressureAttemptsExhausted,
+                source: SafeLaneFailureRouteSource::BackpressureGuard,
+            },
         );
         assert_eq!(
             failure.code,
@@ -3335,11 +6016,89 @@ mod tests {
     }
 
     #[test]
+    fn safe_lane_terminal_verify_failure_code_prefers_budget_exhaustion_for_retryable_base_route() {
+        let code = SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: SafeLaneFailureRouteReason::RoundBudgetExhausted,
+            source: SafeLaneFailureRouteSource::BaseRouting,
+        }
+        .terminal_verify_failure_code(true);
+        assert_eq!(code, SafeLaneFailureCode::VerifyFailedBudgetExhausted);
+    }
+
+    #[test]
+    fn safe_lane_route_verify_summary_label_marks_backpressure_guard() {
+        let label = SafeLaneFailureRoute {
+            decision: SafeLaneFailureRouteDecision::Terminal,
+            reason: SafeLaneFailureRouteReason::BackpressureAttemptsExhausted,
+            source: SafeLaneFailureRouteSource::BackpressureGuard,
+        }
+        .verify_terminal_summary_label();
+        assert_eq!(label, "verify_failed_backpressure_guard");
+    }
+
+    #[test]
+    fn safe_lane_route_profile_methods_encode_decision_and_source_labels() {
+        let route = SafeLaneFailureRoute::replan(SafeLaneFailureRouteReason::RetryableFailure);
+        assert!(route.should_replan());
+        assert_eq!(route.decision_label(), "replan");
+        assert_eq!(route.source_label(), "base_routing");
+
+        let terminal = SafeLaneFailureRoute::terminal_with_source(
+            SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+            SafeLaneFailureRouteSource::SessionGovernor,
+        );
+        assert!(!terminal.should_replan());
+        assert_eq!(terminal.decision_label(), "terminal");
+        assert_eq!(terminal.source_label(), "session_governor");
+    }
+
+    #[test]
+    fn safe_lane_route_backpressure_transition_is_localized_on_route() {
+        let route = SafeLaneFailureRoute::replan(SafeLaneFailureRouteReason::RetryableFailure)
+            .with_backpressure_guard(
+                Some(SafeLaneBackpressureBudget::new(2, 10)),
+                SafeLaneExecutionMetrics {
+                    total_attempts_used: 2,
+                    ..SafeLaneExecutionMetrics::default()
+                },
+            );
+        assert!(!route.should_replan());
+        assert_eq!(
+            route.reason,
+            SafeLaneFailureRouteReason::BackpressureAttemptsExhausted
+        );
+        assert_eq!(route.source, SafeLaneFailureRouteSource::BackpressureGuard);
+    }
+
+    #[test]
+    fn terminal_verify_failure_uses_budget_exhaustion_error_code() {
+        let failure = terminal_turn_failure_from_verify_failure(
+            "retryable verify failure",
+            true,
+            SafeLaneFailureRoute {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: SafeLaneFailureRouteReason::RoundBudgetExhausted,
+                source: SafeLaneFailureRouteSource::BaseRouting,
+            },
+        );
+        assert_eq!(
+            failure.code,
+            "safe_lane_plan_verify_failed_budget_exhausted"
+        );
+        assert_eq!(failure.kind, TurnFailureKind::NonRetryable);
+    }
+
+    #[test]
     fn terminal_verify_failure_uses_session_governor_error_code() {
         let failure = terminal_turn_failure_from_verify_failure(
             "retryable verify failure",
             true,
-            "session_governor_no_replan",
+            SafeLaneFailureRoute {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+                source: SafeLaneFailureRouteSource::SessionGovernor,
+            },
         );
         assert_eq!(
             failure.code,
@@ -3358,11 +6117,133 @@ mod tests {
         };
         let route = SafeLaneFailureRoute {
             decision: SafeLaneFailureRouteDecision::Terminal,
-            reason: "session_governor_no_replan",
+            reason: SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+            source: SafeLaneFailureRouteSource::SessionGovernor,
         };
+        assert_eq!(
+            route.terminal_plan_failure_code(),
+            Some(SafeLaneFailureCode::PlanSessionGovernorNoReplan)
+        );
         let result = terminal_turn_result_from_plan_failure_with_route(failure, route);
         let meta = result.failure().expect("failure metadata");
         assert_eq!(meta.code, "safe_lane_plan_session_governor_no_replan");
         assert_eq!(meta.kind, TurnFailureKind::NonRetryable);
+    }
+
+    #[test]
+    fn decide_safe_lane_verify_failure_action_replans_with_remaining_budget() {
+        let decision = decide_safe_lane_verify_failure_action(
+            "missing anchors",
+            true,
+            SafeLaneFailureRoute {
+                decision: SafeLaneFailureRouteDecision::Replan,
+                reason: SafeLaneFailureRouteReason::RetryableFailure,
+                source: SafeLaneFailureRouteSource::BaseRouting,
+            },
+        );
+
+        if let SafeLaneRoundDecision::Replan {
+            reason,
+            next_plan_start_tool_index,
+            next_seed_tool_outputs,
+        } = decision
+        {
+            assert_eq!(reason, "verify_failed");
+            assert_eq!(next_plan_start_tool_index, 0);
+            assert!(next_seed_tool_outputs.is_empty());
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
+    }
+
+    #[test]
+    fn decide_safe_lane_verify_failure_action_terminalizes_with_governor_code() {
+        let decision = decide_safe_lane_verify_failure_action(
+            "missing anchors",
+            true,
+            SafeLaneFailureRoute {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: SafeLaneFailureRouteReason::SessionGovernorNoReplan,
+                source: SafeLaneFailureRouteSource::SessionGovernor,
+            },
+        );
+
+        if let SafeLaneRoundDecision::Finalize {
+            result: TurnResult::ToolError(failure),
+        } = decision
+        {
+            assert_eq!(
+                failure.code,
+                "safe_lane_plan_verify_failed_session_governor"
+            );
+            assert_eq!(failure.kind, TurnFailureKind::NonRetryable);
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
+    }
+
+    #[test]
+    fn decide_safe_lane_plan_failure_action_replans_with_failed_subgraph_cursor() {
+        let decision = decide_safe_lane_plan_failure_action(
+            PlanRunFailure::NodeFailed {
+                node_id: "tool-2".to_owned(),
+                attempts_used: 1,
+                last_error_kind: PlanNodeErrorKind::Retryable,
+                last_error: "transient".to_owned(),
+            },
+            SafeLaneFailureRoute {
+                decision: SafeLaneFailureRouteDecision::Replan,
+                reason: SafeLaneFailureRouteReason::RetryableFailure,
+                source: SafeLaneFailureRouteSource::BaseRouting,
+            },
+            1,
+            vec!["[ok] {\"path\":\"note.md\"}".to_owned()],
+        );
+
+        if let SafeLaneRoundDecision::Replan {
+            reason,
+            next_plan_start_tool_index,
+            next_seed_tool_outputs,
+        } = decision
+        {
+            assert_eq!(
+                reason,
+                "node_failed node=tool-2 error_kind=Retryable reason=transient"
+            );
+            assert_eq!(next_plan_start_tool_index, 1);
+            assert_eq!(next_seed_tool_outputs.len(), 1);
+            assert!(next_seed_tool_outputs[0].contains("note.md"));
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
+    }
+
+    #[test]
+    fn decide_safe_lane_plan_failure_action_terminalizes_with_backpressure_code() {
+        let decision = decide_safe_lane_plan_failure_action(
+            PlanRunFailure::NodeFailed {
+                node_id: "tool-1".to_owned(),
+                attempts_used: 2,
+                last_error_kind: PlanNodeErrorKind::Retryable,
+                last_error: "transient".to_owned(),
+            },
+            SafeLaneFailureRoute {
+                decision: SafeLaneFailureRouteDecision::Terminal,
+                reason: SafeLaneFailureRouteReason::BackpressureAttemptsExhausted,
+                source: SafeLaneFailureRouteSource::BackpressureGuard,
+            },
+            0,
+            Vec::new(),
+        );
+
+        if let SafeLaneRoundDecision::Finalize {
+            result: TurnResult::ToolError(failure),
+        } = decision
+        {
+            assert_eq!(failure.code, "safe_lane_plan_backpressure_guard");
+            assert_eq!(failure.kind, TurnFailureKind::NonRetryable);
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
     }
 }

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -8,19 +8,73 @@ use crate::KernelContext;
 
 use super::super::config::LoongClawConfig;
 use super::ProviderErrorMode;
-use super::persistence::{format_provider_error_reply, persist_error_turns, persist_success_turns};
+use super::persistence::persist_reply_turns_with_mode;
 use super::runtime::{ConversationRuntime, DefaultConversationRuntime};
+use super::turn_budget::{TurnRoundBudget, TurnRoundBudgetDecision};
 use super::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
 use super::turn_shared::{
-    build_external_skill_followup_user_prompt, build_external_skill_system_message,
-    build_tool_followup_user_prompt, compose_assistant_reply, join_non_empty_lines,
-    parse_external_skill_invoke_context, user_requested_raw_tool_output,
+    ProviderTurnRequestAction, ReplyPersistenceMode, ToolDrivenFollowupPayload,
+    ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase, build_tool_driven_followup_tail,
+    build_tool_loop_guard_tail, decide_provider_turn_request_action,
+    request_completion_with_raw_fallback, user_requested_raw_tool_output,
 };
 
 #[derive(Default)]
 pub struct ConversationTurnLoop;
 
-const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
+#[derive(Debug, Clone)]
+struct TurnLoopSessionState {
+    messages: Vec<Value>,
+    raw_tool_output_requested: bool,
+    last_raw_reply: String,
+    loop_supervisor: ToolLoopSupervisor,
+    followup_payload_budget: FollowupPayloadBudget,
+}
+
+#[derive(Debug, Clone)]
+struct RoundKernelEvaluation {
+    assistant_preface: String,
+    had_tool_intents: bool,
+    turn_result: TurnResult,
+    loop_verdict: Option<ToolLoopSupervisorVerdict>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RoundKernelDecision {
+    ContinueWithFollowup(RoundFollowup),
+    FinalizeDirect {
+        reply: String,
+    },
+    FinalizeWithCompletionPass {
+        raw_reply: String,
+        followup: RoundFollowup,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TurnLoopTerminalAction {
+    PersistReply {
+        reply: String,
+        persistence_mode: ReplyPersistenceMode,
+    },
+    ReturnError {
+        error: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RoundFollowup {
+    Tool {
+        assistant_preface: String,
+        payload: ToolDrivenFollowupPayload,
+        loop_warning_reason: Option<String>,
+    },
+    Guard {
+        assistant_preface: String,
+        reason: String,
+        latest_tool_payload: Option<ToolDrivenFollowupPayload>,
+    },
+}
 
 impl ConversationTurnLoop {
     pub fn new() -> Self {
@@ -51,364 +105,358 @@ impl ConversationTurnLoop {
         runtime: &R,
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<String> {
-        let mut messages = runtime
-            .build_messages(config, session_id, true, kernel_ctx)
-            .await?;
-        messages.push(json!({
-            "role": "user",
-            "content": user_input,
-        }));
-        let raw_tool_output_requested = user_requested_raw_tool_output(user_input);
-        let mut last_raw_reply = String::new();
         let policy = TurnLoopPolicy::from_config(config);
-        let mut loop_supervisor = ToolLoopSupervisor::default();
-        let mut followup_payload_budget = FollowupPayloadBudget::new(
-            policy.max_followup_tool_payload_chars,
-            policy.max_followup_tool_payload_chars_total,
+        let mut session = initialize_turn_loop_session(
+            runtime
+                .build_messages(config, session_id, true, kernel_ctx)
+                .await?,
+            user_input,
+            &policy,
         );
 
         for round_index in 0..policy.max_rounds {
-            let turn = match runtime.request_turn(config, &messages, kernel_ctx).await {
-                Ok(turn) => turn,
-                Err(error) => {
-                    return match error_mode {
-                        ProviderErrorMode::Propagate => Err(error),
-                        ProviderErrorMode::InlineMessage => {
-                            let synthetic = format_provider_error_reply(&error);
-                            persist_error_turns(
-                                runtime, session_id, user_input, &synthetic, kernel_ctx,
-                            )
-                            .await?;
-                            Ok(synthetic)
-                        }
-                    };
-                }
-            };
-
-            let had_tool_intents = !turn.tool_intents.is_empty();
-            let current_tool_signature =
-                had_tool_intents.then(|| tool_intent_signature_for_turn(&turn));
-            let current_tool_name_signature =
-                had_tool_intents.then(|| tool_name_signature(&turn.tool_intents));
-
-            let turn_result = TurnEngine::with_tool_result_payload_summary_limit(
-                policy.max_tool_steps_per_round,
-                config
-                    .conversation
-                    .tool_result_payload_summary_limit_chars(),
-            )
-            .execute_turn(&turn, kernel_ctx)
-            .await;
-            let loop_supervisor_verdict = if let (Some(signature), Some(name_signature)) = (
-                current_tool_signature.as_deref(),
-                current_tool_name_signature.as_deref(),
+            let turn = match decide_provider_turn_request_action(
+                runtime
+                    .request_turn(config, &session.messages, kernel_ctx)
+                    .await,
+                error_mode,
             ) {
-                tool_round_outcome(&turn_result).map(|outcome| {
-                    loop_supervisor.observe_round(
-                        &policy,
-                        signature,
-                        name_signature,
-                        outcome.fingerprint.as_str(),
-                        outcome.failed,
+                ProviderTurnRequestAction::Continue { turn } => turn,
+                ProviderTurnRequestAction::FinalizeInlineProviderError { reply } => {
+                    return apply_turn_loop_terminal_action(
+                        runtime,
+                        session_id,
+                        user_input,
+                        TurnLoopTerminalAction::PersistReply {
+                            reply,
+                            persistence_mode: ReplyPersistenceMode::InlineProviderError,
+                        },
+                        kernel_ctx,
                     )
-                })
-            } else {
-                None
+                    .await;
+                }
+                ProviderTurnRequestAction::ReturnError { error } => {
+                    return apply_turn_loop_terminal_action(
+                        runtime,
+                        session_id,
+                        user_input,
+                        TurnLoopTerminalAction::ReturnError { error },
+                        kernel_ctx,
+                    )
+                    .await;
+                }
             };
 
-            #[allow(clippy::wildcard_enum_match_arm)]
-            let reply = match turn_result {
-                TurnResult::FinalText(tool_text) if had_tool_intents => {
-                    let raw_reply =
-                        join_non_empty_lines(&[turn.assistant_text.as_str(), tool_text.as_str()]);
-                    last_raw_reply = raw_reply.clone();
-                    if let Some(ToolLoopSupervisorVerdict::HardStop { reason }) =
-                        loop_supervisor_verdict.as_ref()
-                    {
-                        if raw_tool_output_requested {
-                            raw_reply
-                        } else {
-                            append_repeated_tool_guard_followup_messages(
-                                &mut messages,
-                                turn.assistant_text.as_str(),
-                                reason.as_str(),
-                                user_input,
-                                Some(("tool_result", tool_text.as_str())),
-                                &mut followup_payload_budget,
-                            );
-                            request_completion_with_raw_fallback(
-                                runtime,
-                                config,
-                                &messages,
-                                kernel_ctx,
-                                raw_reply.as_str(),
-                            )
-                            .await
-                        }
-                    } else {
-                        let loop_warning_reason = match loop_supervisor_verdict.as_ref() {
-                            Some(ToolLoopSupervisorVerdict::InjectWarning { reason }) => {
-                                Some(reason.as_str())
-                            }
-                            _ => None,
-                        };
-                        if raw_tool_output_requested {
-                            raw_reply
-                        } else {
-                            append_tool_followup_messages(
-                                &mut messages,
-                                turn.assistant_text.as_str(),
-                                tool_text.as_str(),
-                                user_input,
-                                &mut followup_payload_budget,
-                                loop_warning_reason,
-                            );
-                            if round_index + 1 < policy.max_rounds {
-                                continue;
-                            }
-                            request_completion_with_raw_fallback(
-                                runtime,
-                                config,
-                                &messages,
-                                kernel_ctx,
-                                raw_reply.as_str(),
-                            )
-                            .await
-                        }
-                    }
-                }
-                TurnResult::ToolDenied(reason) if had_tool_intents => {
-                    let raw_reply = compose_assistant_reply(
-                        turn.assistant_text.as_str(),
-                        had_tool_intents,
-                        TurnResult::ToolDenied(reason.clone()),
-                    );
-                    last_raw_reply = raw_reply.clone();
-                    if let Some(ToolLoopSupervisorVerdict::HardStop {
-                        reason: loop_reason,
-                    }) = loop_supervisor_verdict.as_ref()
-                    {
-                        if raw_tool_output_requested {
-                            raw_reply
-                        } else {
-                            append_repeated_tool_guard_followup_messages(
-                                &mut messages,
-                                turn.assistant_text.as_str(),
-                                loop_reason.as_str(),
-                                user_input,
-                                Some(("tool_failure", reason.as_str())),
-                                &mut followup_payload_budget,
-                            );
-                            request_completion_with_raw_fallback(
-                                runtime,
-                                config,
-                                &messages,
-                                kernel_ctx,
-                                raw_reply.as_str(),
-                            )
-                            .await
-                        }
-                    } else {
-                        let loop_warning_reason = match loop_supervisor_verdict.as_ref() {
-                            Some(ToolLoopSupervisorVerdict::InjectWarning { reason }) => {
-                                Some(reason.as_str())
-                            }
-                            _ => None,
-                        };
-                        if raw_tool_output_requested {
-                            raw_reply
-                        } else {
-                            append_tool_failure_followup_messages(
-                                &mut messages,
-                                turn.assistant_text.as_str(),
-                                reason.as_str(),
-                                user_input,
-                                &mut followup_payload_budget,
-                                loop_warning_reason,
-                            );
-                            if round_index + 1 < policy.max_rounds {
-                                continue;
-                            }
-                            request_completion_with_raw_fallback(
-                                runtime,
-                                config,
-                                &messages,
-                                kernel_ctx,
-                                raw_reply.as_str(),
-                            )
-                            .await
-                        }
-                    }
-                }
-                TurnResult::ToolError(reason) if had_tool_intents => {
-                    let raw_reply = compose_assistant_reply(
-                        turn.assistant_text.as_str(),
-                        had_tool_intents,
-                        TurnResult::ToolError(reason.clone()),
-                    );
-                    last_raw_reply = raw_reply.clone();
-                    if let Some(ToolLoopSupervisorVerdict::HardStop {
-                        reason: loop_reason,
-                    }) = loop_supervisor_verdict.as_ref()
-                    {
-                        if raw_tool_output_requested {
-                            raw_reply
-                        } else {
-                            append_repeated_tool_guard_followup_messages(
-                                &mut messages,
-                                turn.assistant_text.as_str(),
-                                loop_reason.as_str(),
-                                user_input,
-                                Some(("tool_failure", reason.as_str())),
-                                &mut followup_payload_budget,
-                            );
-                            request_completion_with_raw_fallback(
-                                runtime,
-                                config,
-                                &messages,
-                                kernel_ctx,
-                                raw_reply.as_str(),
-                            )
-                            .await
-                        }
-                    } else {
-                        let loop_warning_reason = match loop_supervisor_verdict.as_ref() {
-                            Some(ToolLoopSupervisorVerdict::InjectWarning { reason }) => {
-                                Some(reason.as_str())
-                            }
-                            _ => None,
-                        };
-                        if raw_tool_output_requested {
-                            raw_reply
-                        } else {
-                            append_tool_failure_followup_messages(
-                                &mut messages,
-                                turn.assistant_text.as_str(),
-                                reason.as_str(),
-                                user_input,
-                                &mut followup_payload_budget,
-                                loop_warning_reason,
-                            );
-                            if round_index + 1 < policy.max_rounds {
-                                continue;
-                            }
-                            request_completion_with_raw_fallback(
-                                runtime,
-                                config,
-                                &messages,
-                                kernel_ctx,
-                                raw_reply.as_str(),
-                            )
-                            .await
-                        }
-                    }
-                }
-                other => {
-                    compose_assistant_reply(turn.assistant_text.as_str(), had_tool_intents, other)
-                }
-            };
-            persist_success_turns(runtime, session_id, user_input, &reply, kernel_ctx).await?;
-            return Ok(reply);
+            let evaluation = evaluate_round_kernel(
+                config,
+                &policy,
+                &turn,
+                kernel_ctx,
+                &mut session.loop_supervisor,
+            )
+            .await;
+            let reply_phase = evaluation.reply_phase(session.raw_tool_output_requested);
+            if let Some(raw_reply) = reply_phase.raw_reply() {
+                session.last_raw_reply = raw_reply.to_owned();
+            }
+            let decision = decide_round_kernel_action(
+                TurnRoundBudget::for_round_index(round_index, policy.max_rounds),
+                evaluation,
+                reply_phase,
+            );
+
+            if let Some(action) = resolve_round_kernel_terminal_action(
+                runtime,
+                config,
+                &mut session,
+                user_input,
+                decision,
+                kernel_ctx,
+            )
+            .await?
+            {
+                return apply_turn_loop_terminal_action(
+                    runtime, session_id, user_input, action, kernel_ctx,
+                )
+                .await;
+            }
         }
 
-        let reply = if last_raw_reply.is_empty() {
+        apply_turn_loop_terminal_action(
+            runtime,
+            session_id,
+            user_input,
+            build_round_limit_terminal_action(session.last_raw_reply.as_str()),
+            kernel_ctx,
+        )
+        .await
+    }
+}
+
+fn build_round_limit_terminal_action(last_raw_reply: &str) -> TurnLoopTerminalAction {
+    TurnLoopTerminalAction::PersistReply {
+        persistence_mode: ReplyPersistenceMode::Success,
+        reply: if last_raw_reply.is_empty() {
             "agent_loop_round_limit_reached".to_owned()
         } else {
-            last_raw_reply
-        };
-        persist_success_turns(runtime, session_id, user_input, &reply, kernel_ctx).await?;
-        Ok(reply)
+            last_raw_reply.to_owned()
+        },
     }
 }
 
-fn append_tool_followup_messages(
-    messages: &mut Vec<Value>,
-    assistant_preface: &str,
-    tool_result_text: &str,
+async fn resolve_round_kernel_terminal_action<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    config: &LoongClawConfig,
+    session: &mut TurnLoopSessionState,
     user_input: &str,
-    followup_payload_budget: &mut FollowupPayloadBudget,
-    loop_warning_reason: Option<&str>,
-) {
-    let preface = assistant_preface.trim();
-    if !preface.is_empty() {
-        messages.push(json!({
-            "role": "assistant",
-            "content": preface,
-        }));
-    }
-    if let Some(skill_context) = parse_external_skill_invoke_context(tool_result_text) {
-        messages.push(json!({
-            "role": "system",
-            "content": build_external_skill_system_message(&skill_context),
-        }));
-        if let Some(reason) = loop_warning_reason {
-            messages.push(json!({
-                "role": "assistant",
-                "content": format!("[tool_loop_warning]\n{reason}"),
-            }));
+    decision: RoundKernelDecision,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<Option<TurnLoopTerminalAction>> {
+    match decision {
+        RoundKernelDecision::ContinueWithFollowup(followup) => {
+            append_round_followup_messages(session, user_input, followup);
+            Ok(None)
         }
-        messages.push(json!({
-            "role": "user",
-            "content": build_external_skill_followup_user_prompt(
-                user_input,
-                loop_warning_reason,
-                &skill_context,
-            ),
-        }));
-        return;
+        RoundKernelDecision::FinalizeDirect { reply } => {
+            Ok(Some(TurnLoopTerminalAction::PersistReply {
+                reply,
+                persistence_mode: ReplyPersistenceMode::Success,
+            }))
+        }
+        RoundKernelDecision::FinalizeWithCompletionPass {
+            raw_reply,
+            followup,
+        } => {
+            append_round_followup_messages(session, user_input, followup);
+            let reply = request_completion_with_raw_fallback(
+                runtime,
+                config,
+                &session.messages,
+                kernel_ctx,
+                raw_reply.as_str(),
+            )
+            .await;
+            Ok(Some(TurnLoopTerminalAction::PersistReply {
+                reply,
+                persistence_mode: ReplyPersistenceMode::Success,
+            }))
+        }
     }
-    let bounded_result = followup_payload_budget.truncate_payload("tool_result", tool_result_text);
-    messages.push(json!({
-        "role": "assistant",
-        "content": format!("[tool_result]\n{bounded_result}"),
-    }));
-    if let Some(reason) = loop_warning_reason {
-        messages.push(json!({
-            "role": "assistant",
-            "content": format!("[tool_loop_warning]\n{reason}"),
-        }));
-    }
-    messages.push(json!({
-        "role": "user",
-        "content": build_tool_followup_user_prompt(
-            user_input,
-            loop_warning_reason,
-            Some(tool_result_text),
-        ),
-    }));
 }
 
-fn append_tool_failure_followup_messages(
+async fn apply_turn_loop_terminal_action<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    user_input: &str,
+    action: TurnLoopTerminalAction,
+    kernel_ctx: Option<&KernelContext>,
+) -> CliResult<String> {
+    match action {
+        TurnLoopTerminalAction::PersistReply {
+            reply,
+            persistence_mode,
+        } => {
+            persist_reply_turns_with_mode(
+                runtime,
+                session_id,
+                user_input,
+                &reply,
+                persistence_mode,
+                kernel_ctx,
+            )
+            .await?;
+            Ok(reply)
+        }
+        TurnLoopTerminalAction::ReturnError { error } => Err(error),
+    }
+}
+
+fn initialize_turn_loop_session(
+    mut messages: Vec<Value>,
+    user_input: &str,
+    policy: &TurnLoopPolicy,
+) -> TurnLoopSessionState {
+    messages.push(json!({
+        "role": "user",
+        "content": user_input,
+    }));
+    TurnLoopSessionState {
+        messages,
+        raw_tool_output_requested: user_requested_raw_tool_output(user_input),
+        last_raw_reply: String::new(),
+        loop_supervisor: ToolLoopSupervisor::default(),
+        followup_payload_budget: FollowupPayloadBudget::new(
+            policy.max_followup_tool_payload_chars,
+            policy.max_followup_tool_payload_chars_total,
+        ),
+    }
+}
+
+async fn evaluate_round_kernel(
+    config: &LoongClawConfig,
+    policy: &TurnLoopPolicy,
+    turn: &ProviderTurn,
+    kernel_ctx: Option<&KernelContext>,
+    loop_supervisor: &mut ToolLoopSupervisor,
+) -> RoundKernelEvaluation {
+    let had_tool_intents = !turn.tool_intents.is_empty();
+    let current_tool_signature = had_tool_intents.then(|| tool_intent_signature_for_turn(turn));
+    let current_tool_name_signature =
+        had_tool_intents.then(|| tool_name_signature(&turn.tool_intents));
+
+    let turn_result = TurnEngine::with_tool_result_payload_summary_limit(
+        policy.max_tool_steps_per_round,
+        config
+            .conversation
+            .tool_result_payload_summary_limit_chars(),
+    )
+    .execute_turn(turn, kernel_ctx)
+    .await;
+    let loop_verdict = if let (Some(signature), Some(name_signature)) = (
+        current_tool_signature.as_deref(),
+        current_tool_name_signature.as_deref(),
+    ) {
+        tool_round_outcome(&turn_result).map(|outcome| {
+            loop_supervisor.observe_round(
+                policy,
+                signature,
+                name_signature,
+                outcome.fingerprint.as_str(),
+                outcome.failed,
+            )
+        })
+    } else {
+        None
+    };
+
+    RoundKernelEvaluation {
+        assistant_preface: turn.assistant_text.clone(),
+        had_tool_intents,
+        turn_result,
+        loop_verdict,
+    }
+}
+
+impl RoundKernelEvaluation {
+    fn reply_phase(&self, raw_tool_output_requested: bool) -> ToolDrivenReplyPhase {
+        ToolDrivenReplyPhase::new(
+            self.assistant_preface.as_str(),
+            self.had_tool_intents,
+            raw_tool_output_requested,
+            &self.turn_result,
+        )
+    }
+
+    fn loop_warning_reason(&self) -> Option<String> {
+        match self.loop_verdict.as_ref() {
+            Some(ToolLoopSupervisorVerdict::InjectWarning { reason }) => Some(reason.clone()),
+            _ => None,
+        }
+    }
+
+    fn hard_stop_reason(&self) -> Option<String> {
+        match self.loop_verdict.as_ref() {
+            Some(ToolLoopSupervisorVerdict::HardStop { reason }) => Some(reason.clone()),
+            _ => None,
+        }
+    }
+}
+
+fn decide_round_kernel_action(
+    round_budget: TurnRoundBudget,
+    evaluation: RoundKernelEvaluation,
+    reply_phase: ToolDrivenReplyPhase,
+) -> RoundKernelDecision {
+    let (raw_reply, tool_payload) = match reply_phase.into_decision() {
+        ToolDrivenReplyBaseDecision::FinalizeDirect { reply } => {
+            return RoundKernelDecision::FinalizeDirect { reply };
+        }
+        ToolDrivenReplyBaseDecision::RequireFollowup { raw_reply, payload } => (raw_reply, payload),
+    };
+
+    if let Some(reason) = evaluation.hard_stop_reason() {
+        return RoundKernelDecision::FinalizeWithCompletionPass {
+            raw_reply,
+            followup: RoundFollowup::Guard {
+                assistant_preface: evaluation.assistant_preface,
+                reason,
+                latest_tool_payload: Some(tool_payload),
+            },
+        };
+    }
+
+    let loop_warning_reason = evaluation.loop_warning_reason();
+    let followup = RoundFollowup::Tool {
+        assistant_preface: evaluation.assistant_preface,
+        payload: tool_payload,
+        loop_warning_reason,
+    };
+
+    match round_budget.followup_decision() {
+        TurnRoundBudgetDecision::ContinueWithFollowup => {
+            RoundKernelDecision::ContinueWithFollowup(followup)
+        }
+        TurnRoundBudgetDecision::FinalizeWithCompletionPass => {
+            RoundKernelDecision::FinalizeWithCompletionPass {
+                raw_reply,
+                followup,
+            }
+        }
+    }
+}
+
+fn append_round_followup_messages(
+    session: &mut TurnLoopSessionState,
+    user_input: &str,
+    followup: RoundFollowup,
+) {
+    match followup {
+        RoundFollowup::Tool {
+            assistant_preface,
+            payload,
+            loop_warning_reason,
+        } => append_tool_driven_followup_messages(
+            &mut session.messages,
+            assistant_preface.as_str(),
+            &payload,
+            user_input,
+            &mut session.followup_payload_budget,
+            loop_warning_reason.as_deref(),
+        ),
+        RoundFollowup::Guard {
+            assistant_preface,
+            reason,
+            latest_tool_payload,
+        } => append_repeated_tool_guard_followup_messages(
+            &mut session.messages,
+            assistant_preface.as_str(),
+            reason.as_str(),
+            user_input,
+            latest_tool_payload.as_ref().map(round_tool_payload_context),
+            &mut session.followup_payload_budget,
+        ),
+    }
+}
+
+fn round_tool_payload_context(payload: &ToolDrivenFollowupPayload) -> (&'static str, &str) {
+    payload.message_context()
+}
+
+fn append_tool_driven_followup_messages(
     messages: &mut Vec<Value>,
     assistant_preface: &str,
-    tool_failure_reason: &str,
+    payload: &ToolDrivenFollowupPayload,
     user_input: &str,
     followup_payload_budget: &mut FollowupPayloadBudget,
     loop_warning_reason: Option<&str>,
 ) {
-    let preface = assistant_preface.trim();
-    if !preface.is_empty() {
-        messages.push(json!({
-            "role": "assistant",
-            "content": preface,
-        }));
-    }
-    let bounded_failure =
-        followup_payload_budget.truncate_payload("tool_failure", tool_failure_reason);
-    messages.push(json!({
-        "role": "assistant",
-        "content": format!("[tool_failure]\n{bounded_failure}"),
-    }));
-    if let Some(reason) = loop_warning_reason {
-        messages.push(json!({
-            "role": "assistant",
-            "content": format!("[tool_loop_warning]\n{reason}"),
-        }));
-    }
-    messages.push(json!({
-        "role": "user",
-        "content": build_tool_followup_user_prompt(user_input, loop_warning_reason, None),
-    }));
+    messages.extend(build_tool_driven_followup_tail(
+        assistant_preface,
+        payload,
+        user_input,
+        loop_warning_reason,
+        |label, text| followup_payload_budget.truncate_payload(label, text),
+    ));
 }
 
 fn append_repeated_tool_guard_followup_messages(
@@ -419,57 +467,13 @@ fn append_repeated_tool_guard_followup_messages(
     latest_tool_context: Option<(&str, &str)>,
     followup_payload_budget: &mut FollowupPayloadBudget,
 ) {
-    let preface = assistant_preface.trim();
-    if !preface.is_empty() {
-        messages.push(json!({
-            "role": "assistant",
-            "content": preface,
-        }));
-    }
-    if let Some((label, text)) = latest_tool_context {
-        let bounded = followup_payload_budget.truncate_payload(label, text);
-        messages.push(json!({
-            "role": "assistant",
-            "content": format!("[{label}]\n{bounded}"),
-        }));
-    }
-    messages.push(json!({
-        "role": "assistant",
-        "content": format!("[tool_loop_guard]\n{reason}"),
-    }));
-    messages.push(json!({
-        "role": "user",
-        "content": build_tool_loop_guard_prompt(user_input, reason),
-    }));
-}
-
-fn build_tool_loop_guard_prompt(user_input: &str, reason: &str) -> String {
-    format!(
-        "{TOOL_LOOP_GUARD_PROMPT}\n\nLoop guard reason:\n{reason}\n\nOriginal request:\n{user_input}"
-    )
-}
-
-async fn request_completion_with_raw_fallback<R: ConversationRuntime + ?Sized>(
-    runtime: &R,
-    config: &LoongClawConfig,
-    messages: &[Value],
-    kernel_ctx: Option<&KernelContext>,
-    raw_reply: &str,
-) -> String {
-    match runtime
-        .request_completion(config, messages, kernel_ctx)
-        .await
-    {
-        Ok(final_reply) => {
-            let trimmed = final_reply.trim();
-            if trimmed.is_empty() {
-                raw_reply.to_owned()
-            } else {
-                trimmed.to_owned()
-            }
-        }
-        Err(_) => raw_reply.to_owned(),
-    }
+    messages.extend(build_tool_loop_guard_tail(
+        assistant_preface,
+        reason,
+        user_input,
+        latest_tool_context,
+        |label, text| followup_payload_budget.truncate_payload(label, text),
+    ));
 }
 
 fn truncate_followup_tool_payload(label: &str, text: &str, max_chars: usize) -> String {
@@ -775,16 +779,19 @@ impl ToolLoopSupervisor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::conversation::turn_engine::TurnFailure;
 
     #[test]
-    fn append_tool_followup_messages_adds_truncation_hint_to_user_prompt() {
+    fn append_tool_driven_followup_messages_adds_truncation_hint_to_user_prompt() {
         let mut messages = Vec::new();
         let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
 
-        append_tool_followup_messages(
+        append_tool_driven_followup_messages(
             &mut messages,
             "preface",
-            r#"[ok] {"payload_truncated":true,"payload_summary":"..."}"#,
+            &ToolDrivenFollowupPayload::ToolResult {
+                text: r#"[ok] {"payload_truncated":true,"payload_summary":"..."}"#.to_owned(),
+            },
             "summarize note.md",
             &mut budget,
             None,
@@ -801,14 +808,16 @@ mod tests {
     }
 
     #[test]
-    fn append_tool_failure_followup_messages_omits_truncation_hint_in_user_prompt() {
+    fn append_tool_driven_followup_messages_omits_truncation_hint_in_user_prompt() {
         let mut messages = Vec::new();
         let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
 
-        append_tool_failure_followup_messages(
+        append_tool_driven_followup_messages(
             &mut messages,
             "preface",
-            "tool_timeout ...(truncated 200 chars)",
+            &ToolDrivenFollowupPayload::ToolFailure {
+                reason: "tool_timeout ...(truncated 200 chars)".to_owned(),
+            },
             "summarize note.md",
             &mut budget,
             None,
@@ -825,14 +834,16 @@ mod tests {
     }
 
     #[test]
-    fn append_tool_followup_messages_promotes_external_skill_invoke_into_system_context() {
+    fn append_tool_driven_followup_messages_promotes_external_skill_invoke_into_system_context() {
         let mut messages = Vec::new();
         let mut budget = FollowupPayloadBudget::new(64, 64);
 
-        append_tool_followup_messages(
+        append_tool_driven_followup_messages(
             &mut messages,
             "preface",
-            r#"[ok] {"status":"ok","tool":"external_skills.invoke","tool_call_id":"call-1","payload_summary":"{\"skill_id\":\"demo-skill\",\"display_name\":\"Demo Skill\",\"instructions\":\"Follow the managed skill instruction before answering.\"}","payload_chars":180,"payload_truncated":false}"#,
+            &ToolDrivenFollowupPayload::ToolResult {
+                text: r#"[ok] {"status":"ok","tool":"external_skills.invoke","tool_call_id":"call-1","payload_summary":"{\"skill_id\":\"demo-skill\",\"display_name\":\"Demo Skill\",\"instructions\":\"Follow the managed skill instruction before answering.\"}","payload_chars":180,"payload_truncated":false}"#.to_owned(),
+            },
             "summarize note.md",
             &mut budget,
             None,
@@ -858,7 +869,7 @@ mod tests {
     }
 
     #[test]
-    fn append_tool_followup_messages_keeps_large_external_skill_instructions_intact() {
+    fn append_tool_driven_followup_messages_keeps_large_external_skill_instructions_intact() {
         let mut messages = Vec::new();
         let mut budget = FollowupPayloadBudget::new(32, 32);
         let instructions = format!("prefix {}\nsuffix-marker", "x".repeat(512));
@@ -880,10 +891,10 @@ mod tests {
             })
         );
 
-        append_tool_followup_messages(
+        append_tool_driven_followup_messages(
             &mut messages,
             "",
-            tool_result.as_str(),
+            &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
             "apply the skill",
             &mut budget,
             None,
@@ -896,5 +907,258 @@ mod tests {
             system_content.contains("suffix-marker"),
             "system context should preserve the tail of large invoke instructions"
         );
+    }
+
+    #[test]
+    fn decide_round_kernel_action_continues_tool_result_with_warning_before_round_limit() {
+        let evaluation = RoundKernelEvaluation {
+            assistant_preface: "preface".to_owned(),
+            had_tool_intents: true,
+            turn_result: TurnResult::FinalText("tool output".to_owned()),
+            loop_verdict: Some(ToolLoopSupervisorVerdict::InjectWarning {
+                reason: "warning".to_owned(),
+            }),
+        };
+
+        let reply_phase = evaluation.reply_phase(false);
+        let decision = decide_round_kernel_action(
+            TurnRoundBudget::for_round_index(0, 3),
+            evaluation,
+            reply_phase,
+        );
+
+        if let RoundKernelDecision::ContinueWithFollowup(RoundFollowup::Tool {
+            assistant_preface,
+            payload: ToolDrivenFollowupPayload::ToolResult { text },
+            loop_warning_reason,
+        }) = decision
+        {
+            assert_eq!(assistant_preface, "preface");
+            assert_eq!(text, "tool output");
+            assert_eq!(loop_warning_reason.as_deref(), Some("warning"));
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
+    }
+
+    #[test]
+    fn decide_round_kernel_action_hard_stop_tool_result_uses_completion_pass() {
+        let evaluation = RoundKernelEvaluation {
+            assistant_preface: "preface".to_owned(),
+            had_tool_intents: true,
+            turn_result: TurnResult::FinalText("tool output".to_owned()),
+            loop_verdict: Some(ToolLoopSupervisorVerdict::HardStop {
+                reason: "stop".to_owned(),
+            }),
+        };
+
+        let reply_phase = evaluation.reply_phase(false);
+        let decision = decide_round_kernel_action(
+            TurnRoundBudget::for_round_index(0, 3),
+            evaluation,
+            reply_phase,
+        );
+
+        if let RoundKernelDecision::FinalizeWithCompletionPass {
+            raw_reply,
+            followup:
+                RoundFollowup::Guard {
+                    assistant_preface,
+                    reason,
+                    latest_tool_payload: Some(ToolDrivenFollowupPayload::ToolResult { text }),
+                },
+        } = decision
+        {
+            assert_eq!(raw_reply, "preface\ntool output");
+            assert_eq!(assistant_preface, "preface");
+            assert_eq!(reason, "stop");
+            assert_eq!(text, "tool output");
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
+    }
+
+    #[test]
+    fn decide_round_kernel_action_hard_stop_tool_failure_uses_completion_pass() {
+        let evaluation = RoundKernelEvaluation {
+            assistant_preface: "preface".to_owned(),
+            had_tool_intents: true,
+            turn_result: TurnResult::ToolError(TurnFailure::retryable(
+                "tool_failed",
+                "tool failure",
+            )),
+            loop_verdict: Some(ToolLoopSupervisorVerdict::HardStop {
+                reason: "stop".to_owned(),
+            }),
+        };
+
+        let reply_phase = evaluation.reply_phase(false);
+        let decision = decide_round_kernel_action(
+            TurnRoundBudget::for_round_index(0, 3),
+            evaluation,
+            reply_phase,
+        );
+
+        if let RoundKernelDecision::FinalizeWithCompletionPass {
+            raw_reply,
+            followup:
+                RoundFollowup::Guard {
+                    assistant_preface,
+                    reason,
+                    latest_tool_payload:
+                        Some(ToolDrivenFollowupPayload::ToolFailure {
+                            reason: tool_reason,
+                        }),
+                },
+        } = decision
+        {
+            assert_eq!(raw_reply, "preface\ntool failure");
+            assert_eq!(assistant_preface, "preface");
+            assert_eq!(reason, "stop");
+            assert_eq!(tool_reason, "tool failure");
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
+    }
+
+    #[test]
+    fn decide_round_kernel_action_raw_mode_finalizes_tool_result_directly() {
+        let evaluation = RoundKernelEvaluation {
+            assistant_preface: "preface".to_owned(),
+            had_tool_intents: true,
+            turn_result: TurnResult::FinalText("tool output".to_owned()),
+            loop_verdict: Some(ToolLoopSupervisorVerdict::InjectWarning {
+                reason: "warning".to_owned(),
+            }),
+        };
+
+        let reply_phase = evaluation.reply_phase(true);
+        let decision = decide_round_kernel_action(
+            TurnRoundBudget::for_round_index(0, 3),
+            evaluation,
+            reply_phase,
+        );
+
+        if let RoundKernelDecision::FinalizeDirect { reply } = decision {
+            assert_eq!(reply, "preface\ntool output");
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
+    }
+
+    #[test]
+    fn turn_round_budget_detects_followup_capacity() {
+        let first_round = TurnRoundBudget::for_round_index(0, 3);
+        let last_round = TurnRoundBudget::for_round_index(2, 3);
+
+        assert_eq!(
+            first_round.followup_decision(),
+            TurnRoundBudgetDecision::ContinueWithFollowup
+        );
+        assert_eq!(
+            last_round.followup_decision(),
+            TurnRoundBudgetDecision::FinalizeWithCompletionPass
+        );
+    }
+
+    #[test]
+    fn decide_provider_turn_request_action_continues_successful_turns() {
+        let action = decide_provider_turn_request_action(
+            Ok(ProviderTurn {
+                assistant_text: "preface".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+            ProviderErrorMode::Propagate,
+        );
+
+        match action {
+            ProviderTurnRequestAction::Continue { turn } => {
+                assert_eq!(turn.assistant_text, "preface");
+                assert!(turn.tool_intents.is_empty());
+            }
+            ProviderTurnRequestAction::FinalizeInlineProviderError { reply } => {
+                panic!("unexpected inline error action: {reply}");
+            }
+            ProviderTurnRequestAction::ReturnError { error } => {
+                panic!("unexpected propagated error action: {error}");
+            }
+        }
+    }
+
+    #[test]
+    fn decide_provider_turn_request_action_formats_inline_provider_errors() {
+        let action = decide_provider_turn_request_action(
+            Err("timeout".to_owned()),
+            ProviderErrorMode::InlineMessage,
+        );
+
+        match action {
+            ProviderTurnRequestAction::FinalizeInlineProviderError { reply } => {
+                assert_eq!(reply, "[provider_error] timeout");
+            }
+            ProviderTurnRequestAction::Continue { turn } => {
+                panic!("unexpected continue action: {turn:?}");
+            }
+            ProviderTurnRequestAction::ReturnError { error } => {
+                panic!("unexpected propagated error action: {error}");
+            }
+        }
+    }
+
+    #[test]
+    fn decide_provider_turn_request_action_propagates_provider_errors() {
+        let action = decide_provider_turn_request_action(
+            Err("timeout".to_owned()),
+            ProviderErrorMode::Propagate,
+        );
+
+        match action {
+            ProviderTurnRequestAction::ReturnError { error } => {
+                assert_eq!(error, "timeout");
+            }
+            ProviderTurnRequestAction::Continue { turn } => {
+                panic!("unexpected continue action: {turn:?}");
+            }
+            ProviderTurnRequestAction::FinalizeInlineProviderError { reply } => {
+                panic!("unexpected inline error action: {reply}");
+            }
+        }
+    }
+
+    #[test]
+    fn build_round_limit_terminal_action_prefers_last_raw_reply() {
+        let action = build_round_limit_terminal_action("last raw reply");
+
+        match action {
+            TurnLoopTerminalAction::PersistReply {
+                reply,
+                persistence_mode,
+            } => {
+                assert_eq!(reply, "last raw reply");
+                assert_eq!(persistence_mode, ReplyPersistenceMode::Success);
+            }
+            TurnLoopTerminalAction::ReturnError { error } => {
+                panic!("unexpected propagated error terminal action: {error}");
+            }
+        }
+    }
+
+    #[test]
+    fn build_round_limit_terminal_action_uses_synthetic_reply_when_raw_reply_missing() {
+        let action = build_round_limit_terminal_action("");
+
+        match action {
+            TurnLoopTerminalAction::PersistReply {
+                reply,
+                persistence_mode,
+            } => {
+                assert_eq!(reply, "agent_loop_round_limit_reached");
+                assert_eq!(persistence_mode, ReplyPersistenceMode::Success);
+            }
+            TurnLoopTerminalAction::ReturnError { error } => {
+                panic!("unexpected propagated error terminal action: {error}");
+            }
+        }
     }
 }

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -1,16 +1,239 @@
+use super::super::config::LoongClawConfig;
+use super::ProviderErrorMode;
 use super::persistence::format_provider_error_reply;
-use super::turn_engine::TurnResult;
+use super::runtime::ConversationRuntime;
+use super::turn_engine::{ProviderTurn, TurnResult};
+use serde::Serialize;
 use serde_json::Value;
+
+use crate::CliResult;
+use crate::KernelContext;
 
 pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
 pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
 pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "A managed external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
+pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolDrivenFollowupPayload {
+    ToolResult { text: String },
+    ToolFailure { reason: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolDrivenFollowupKind {
+    ToolResult,
+    ToolFailure,
+}
+
+impl ToolDrivenFollowupPayload {
+    pub fn kind(&self) -> ToolDrivenFollowupKind {
+        match self {
+            Self::ToolResult { .. } => ToolDrivenFollowupKind::ToolResult,
+            Self::ToolFailure { .. } => ToolDrivenFollowupKind::ToolFailure,
+        }
+    }
+
+    pub fn message_context(&self) -> (&'static str, &str) {
+        match self {
+            Self::ToolResult { text } => ("tool_result", text.as_str()),
+            Self::ToolFailure { reason } => ("tool_failure", reason.as_str()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolDrivenReplyBaseDecision {
+    FinalizeDirect {
+        reply: String,
+    },
+    RequireFollowup {
+        raw_reply: String,
+        payload: ToolDrivenFollowupPayload,
+    },
+}
+
+impl ToolDrivenReplyBaseDecision {
+    pub fn resolution_mode(&self) -> ReplyResolutionMode {
+        match self {
+            Self::FinalizeDirect { .. } => ReplyResolutionMode::Direct,
+            Self::RequireFollowup { .. } => ReplyResolutionMode::CompletionPass,
+        }
+    }
+
+    pub fn followup_kind(&self) -> Option<ToolDrivenFollowupKind> {
+        match self {
+            Self::FinalizeDirect { .. } => None,
+            Self::RequireFollowup { payload, .. } => Some(payload.kind()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolDrivenReplyPhase {
+    raw_reply: Option<String>,
+    decision: ToolDrivenReplyBaseDecision,
+}
+
+impl ToolDrivenReplyPhase {
+    pub fn new(
+        assistant_preface: &str,
+        had_tool_intents: bool,
+        raw_tool_output_requested: bool,
+        turn_result: &TurnResult,
+    ) -> Self {
+        let kernel = ToolDrivenReplyKernel::new(assistant_preface, had_tool_intents, turn_result);
+        Self {
+            raw_reply: kernel.raw_reply(),
+            decision: kernel.base_decision(raw_tool_output_requested),
+        }
+    }
+
+    pub fn raw_reply(&self) -> Option<&str> {
+        self.raw_reply.as_deref()
+    }
+
+    pub fn decision(&self) -> &ToolDrivenReplyBaseDecision {
+        &self.decision
+    }
+
+    pub fn into_decision(self) -> ToolDrivenReplyBaseDecision {
+        self.decision
+    }
+
+    pub fn resolution_mode(&self) -> ReplyResolutionMode {
+        self.decision.resolution_mode()
+    }
+
+    pub fn followup_kind(&self) -> Option<ToolDrivenFollowupKind> {
+        self.decision.followup_kind()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplyPersistenceMode {
+    Success,
+    InlineProviderError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplyResolutionMode {
+    Direct,
+    CompletionPass,
+}
+
+#[derive(Debug, Clone)]
+pub enum ProviderTurnRequestAction {
+    Continue { turn: ProviderTurn },
+    FinalizeInlineProviderError { reply: String },
+    ReturnError { error: String },
+}
+
+pub fn decide_provider_turn_request_action(
+    result: CliResult<ProviderTurn>,
+    error_mode: ProviderErrorMode,
+) -> ProviderTurnRequestAction {
+    match result {
+        Ok(turn) => ProviderTurnRequestAction::Continue { turn },
+        Err(error) => match error_mode {
+            ProviderErrorMode::Propagate => ProviderTurnRequestAction::ReturnError { error },
+            ProviderErrorMode::InlineMessage => {
+                ProviderTurnRequestAction::FinalizeInlineProviderError {
+                    reply: format_provider_error_reply(&error),
+                }
+            }
+        },
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExternalSkillInvokeContext {
     pub skill_id: String,
     pub display_name: String,
     pub instructions: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ToolDrivenReplyKernel<'a> {
+    assistant_preface: &'a str,
+    had_tool_intents: bool,
+    turn_result: &'a TurnResult,
+}
+
+impl<'a> ToolDrivenReplyKernel<'a> {
+    pub fn new(
+        assistant_preface: &'a str,
+        had_tool_intents: bool,
+        turn_result: &'a TurnResult,
+    ) -> Self {
+        Self {
+            assistant_preface,
+            had_tool_intents,
+            turn_result,
+        }
+    }
+
+    pub fn fallback_reply(&self) -> String {
+        compose_assistant_reply(
+            self.assistant_preface,
+            self.had_tool_intents,
+            self.turn_result.clone(),
+        )
+    }
+
+    pub fn raw_reply(&self) -> Option<String> {
+        if !self.had_tool_intents {
+            return None;
+        }
+        match self.turn_result {
+            TurnResult::FinalText(text) => Some(join_non_empty_lines(&[
+                self.assistant_preface,
+                text.as_str(),
+            ])),
+            TurnResult::ToolDenied(failure) | TurnResult::ToolError(failure) => {
+                Some(join_non_empty_lines(&[
+                    self.assistant_preface,
+                    failure.reason.as_str(),
+                ]))
+            }
+            TurnResult::NeedsApproval(_) | TurnResult::ProviderError(_) => None,
+        }
+    }
+
+    pub fn followup_payload(&self) -> Option<ToolDrivenFollowupPayload> {
+        if !self.had_tool_intents {
+            return None;
+        }
+        match self.turn_result {
+            TurnResult::FinalText(text) => {
+                Some(ToolDrivenFollowupPayload::ToolResult { text: text.clone() })
+            }
+            TurnResult::ToolDenied(failure) | TurnResult::ToolError(failure) => {
+                Some(ToolDrivenFollowupPayload::ToolFailure {
+                    reason: failure.reason.clone(),
+                })
+            }
+            TurnResult::NeedsApproval(_) | TurnResult::ProviderError(_) => None,
+        }
+    }
+
+    pub fn base_decision(&self, raw_tool_output_requested: bool) -> ToolDrivenReplyBaseDecision {
+        let fallback_reply = self.fallback_reply();
+        let Some(payload) = self.followup_payload() else {
+            return ToolDrivenReplyBaseDecision::FinalizeDirect {
+                reply: fallback_reply,
+            };
+        };
+        let raw_reply = self.raw_reply().unwrap_or_else(|| fallback_reply.clone());
+        if raw_tool_output_requested {
+            ToolDrivenReplyBaseDecision::FinalizeDirect { reply: raw_reply }
+        } else {
+            ToolDrivenReplyBaseDecision::RequireFollowup { raw_reply, payload }
+        }
+    }
 }
 
 pub fn user_requested_raw_tool_output(user_input: &str) -> bool {
@@ -154,6 +377,158 @@ pub fn build_external_skill_followup_user_prompt(
     sections.join("\n\n")
 }
 
+pub fn build_tool_result_followup_tail<F>(
+    assistant_preface: &str,
+    tool_result_text: &str,
+    user_input: &str,
+    loop_warning_reason: Option<&str>,
+    mut payload_mapper: F,
+) -> Vec<Value>
+where
+    F: FnMut(&str, &str) -> String,
+{
+    let mut messages = Vec::new();
+    append_followup_preface(&mut messages, assistant_preface);
+    if let Some(skill_context) = parse_external_skill_invoke_context(tool_result_text) {
+        messages.push(serde_json::json!({
+            "role": "system",
+            "content": build_external_skill_system_message(&skill_context),
+        }));
+        append_followup_warning(&mut messages, loop_warning_reason);
+        messages.push(serde_json::json!({
+            "role": "user",
+            "content": build_external_skill_followup_user_prompt(
+                user_input,
+                loop_warning_reason,
+                &skill_context,
+            ),
+        }));
+        return messages;
+    }
+
+    let bounded_result = payload_mapper("tool_result", tool_result_text);
+    messages.push(serde_json::json!({
+        "role": "assistant",
+        "content": format!("[tool_result]\n{bounded_result}"),
+    }));
+    append_followup_warning(&mut messages, loop_warning_reason);
+    messages.push(serde_json::json!({
+        "role": "user",
+        "content": build_tool_followup_user_prompt(
+            user_input,
+            loop_warning_reason,
+            Some(tool_result_text),
+        ),
+    }));
+    messages
+}
+
+pub fn build_tool_failure_followup_tail<F>(
+    assistant_preface: &str,
+    tool_failure_reason: &str,
+    user_input: &str,
+    loop_warning_reason: Option<&str>,
+    mut payload_mapper: F,
+) -> Vec<Value>
+where
+    F: FnMut(&str, &str) -> String,
+{
+    let mut messages = Vec::new();
+    append_followup_preface(&mut messages, assistant_preface);
+    let bounded_failure = payload_mapper("tool_failure", tool_failure_reason);
+    messages.push(serde_json::json!({
+        "role": "assistant",
+        "content": format!("[tool_failure]\n{bounded_failure}"),
+    }));
+    append_followup_warning(&mut messages, loop_warning_reason);
+    messages.push(serde_json::json!({
+        "role": "user",
+        "content": build_tool_followup_user_prompt(user_input, loop_warning_reason, None),
+    }));
+    messages
+}
+
+pub fn build_tool_driven_followup_tail<F>(
+    assistant_preface: &str,
+    payload: &ToolDrivenFollowupPayload,
+    user_input: &str,
+    loop_warning_reason: Option<&str>,
+    payload_mapper: F,
+) -> Vec<Value>
+where
+    F: FnMut(&str, &str) -> String,
+{
+    match payload {
+        ToolDrivenFollowupPayload::ToolResult { text } => build_tool_result_followup_tail(
+            assistant_preface,
+            text.as_str(),
+            user_input,
+            loop_warning_reason,
+            payload_mapper,
+        ),
+        ToolDrivenFollowupPayload::ToolFailure { reason } => build_tool_failure_followup_tail(
+            assistant_preface,
+            reason.as_str(),
+            user_input,
+            loop_warning_reason,
+            payload_mapper,
+        ),
+    }
+}
+
+pub fn build_tool_loop_guard_tail<F>(
+    assistant_preface: &str,
+    reason: &str,
+    user_input: &str,
+    latest_tool_context: Option<(&str, &str)>,
+    mut payload_mapper: F,
+) -> Vec<Value>
+where
+    F: FnMut(&str, &str) -> String,
+{
+    let mut messages = Vec::new();
+    append_followup_preface(&mut messages, assistant_preface);
+    if let Some((label, text)) = latest_tool_context {
+        let bounded = payload_mapper(label, text);
+        messages.push(serde_json::json!({
+            "role": "assistant",
+            "content": format!("[{label}]\n{bounded}"),
+        }));
+    }
+    messages.push(serde_json::json!({
+        "role": "assistant",
+        "content": format!("[tool_loop_guard]\n{reason}"),
+    }));
+    messages.push(serde_json::json!({
+        "role": "user",
+        "content": build_tool_loop_guard_prompt(user_input, reason),
+    }));
+    messages
+}
+
+pub async fn request_completion_with_raw_fallback<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    config: &LoongClawConfig,
+    messages: &[Value],
+    kernel_ctx: Option<&KernelContext>,
+    raw_reply: &str,
+) -> String {
+    match runtime
+        .request_completion(config, messages, kernel_ctx)
+        .await
+    {
+        Ok(final_reply) => {
+            let trimmed = final_reply.trim();
+            if trimmed.is_empty() {
+                raw_reply.to_owned()
+            } else {
+                trimmed.to_owned()
+            }
+        }
+        Err(_) => raw_reply.to_owned(),
+    }
+}
+
 pub fn join_non_empty_lines(parts: &[&str]) -> String {
     parts
         .iter()
@@ -161,6 +536,31 @@ pub fn join_non_empty_lines(parts: &[&str]) -> String {
         .filter(|part| !part.is_empty())
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn append_followup_preface(messages: &mut Vec<Value>, assistant_preface: &str) {
+    let preface = assistant_preface.trim();
+    if !preface.is_empty() {
+        messages.push(serde_json::json!({
+            "role": "assistant",
+            "content": preface,
+        }));
+    }
+}
+
+fn append_followup_warning(messages: &mut Vec<Value>, loop_warning_reason: Option<&str>) {
+    if let Some(reason) = loop_warning_reason {
+        messages.push(serde_json::json!({
+            "role": "assistant",
+            "content": format!("[tool_loop_warning]\n{reason}"),
+        }));
+    }
+}
+
+fn build_tool_loop_guard_prompt(user_input: &str, reason: &str) -> String {
+    format!(
+        "{TOOL_LOOP_GUARD_PROMPT}\n\nLoop guard reason:\n{reason}\n\nOriginal request:\n{user_input}"
+    )
 }
 
 fn parse_external_skill_invoke_context_line(line: &str) -> Option<ExternalSkillInvokeContext> {
@@ -235,6 +635,471 @@ mod tests {
     }
 
     #[test]
+    fn tool_driven_reply_kernel_extracts_raw_reply_and_result_followup() {
+        let result = TurnResult::FinalText("tool output".to_owned());
+        let kernel = ToolDrivenReplyKernel::new("preface", true, &result);
+
+        assert_eq!(kernel.fallback_reply(), "preface\ntool output");
+        assert_eq!(kernel.raw_reply(), Some("preface\ntool output".to_owned()));
+        assert_eq!(
+            kernel.followup_payload(),
+            Some(ToolDrivenFollowupPayload::ToolResult {
+                text: "tool output".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn tool_driven_reply_kernel_extracts_raw_reply_and_failure_followup() {
+        let result =
+            TurnResult::ToolError(TurnFailure::retryable("tool_error", "temporary failure"));
+        let kernel = ToolDrivenReplyKernel::new("preface", true, &result);
+
+        assert_eq!(kernel.fallback_reply(), "preface\ntemporary failure");
+        assert_eq!(
+            kernel.raw_reply(),
+            Some("preface\ntemporary failure".to_owned())
+        );
+        assert_eq!(
+            kernel.followup_payload(),
+            Some(ToolDrivenFollowupPayload::ToolFailure {
+                reason: "temporary failure".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn tool_driven_reply_kernel_rejects_non_tool_followup_paths() {
+        let provider_error = TurnResult::ProviderError(TurnFailure::provider(
+            "provider_error",
+            "provider unavailable",
+        ));
+        let kernel = ToolDrivenReplyKernel::new("preface", true, &provider_error);
+        assert_eq!(kernel.raw_reply(), None);
+        assert_eq!(kernel.followup_payload(), None);
+
+        let plain_text = TurnResult::FinalText("plain reply".to_owned());
+        let non_tool_kernel = ToolDrivenReplyKernel::new("preface", false, &plain_text);
+        assert_eq!(non_tool_kernel.raw_reply(), None);
+        assert_eq!(non_tool_kernel.followup_payload(), None);
+        assert_eq!(non_tool_kernel.fallback_reply(), "plain reply");
+    }
+
+    #[test]
+    fn tool_driven_followup_payload_reports_result_kind_and_context() {
+        let payload = ToolDrivenFollowupPayload::ToolResult {
+            text: "tool output".to_owned(),
+        };
+
+        assert_eq!(payload.kind(), ToolDrivenFollowupKind::ToolResult);
+        assert_eq!(payload.message_context(), ("tool_result", "tool output"));
+    }
+
+    #[test]
+    fn tool_driven_followup_payload_reports_failure_kind_and_context() {
+        let payload = ToolDrivenFollowupPayload::ToolFailure {
+            reason: "tool failed".to_owned(),
+        };
+
+        assert_eq!(payload.kind(), ToolDrivenFollowupKind::ToolFailure);
+        assert_eq!(payload.message_context(), ("tool_failure", "tool failed"));
+    }
+
+    #[test]
+    fn tool_driven_followup_kind_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_value(ToolDrivenFollowupKind::ToolResult).expect("serialize kind"),
+            Value::String("tool_result".to_owned())
+        );
+        assert_eq!(
+            serde_json::to_value(ToolDrivenFollowupKind::ToolFailure).expect("serialize kind"),
+            Value::String("tool_failure".to_owned())
+        );
+    }
+
+    #[test]
+    fn reply_resolution_mode_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_value(ReplyResolutionMode::Direct).expect("serialize mode"),
+            Value::String("direct".to_owned())
+        );
+        assert_eq!(
+            serde_json::to_value(ReplyResolutionMode::CompletionPass).expect("serialize mode"),
+            Value::String("completion_pass".to_owned())
+        );
+    }
+
+    #[test]
+    fn tool_driven_reply_kernel_base_decision_finalizes_non_tool_reply_directly() {
+        let result = TurnResult::FinalText("plain reply".to_owned());
+        let kernel = ToolDrivenReplyKernel::new("preface", false, &result);
+
+        assert_eq!(
+            kernel.base_decision(false),
+            ToolDrivenReplyBaseDecision::FinalizeDirect {
+                reply: "plain reply".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn tool_driven_reply_kernel_base_decision_honors_raw_tool_output_mode() {
+        let result = TurnResult::FinalText("tool output".to_owned());
+        let kernel = ToolDrivenReplyKernel::new("preface", true, &result);
+
+        assert_eq!(
+            kernel.base_decision(true),
+            ToolDrivenReplyBaseDecision::FinalizeDirect {
+                reply: "preface\ntool output".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn tool_driven_reply_kernel_base_decision_requires_followup_for_tool_failure() {
+        let result =
+            TurnResult::ToolError(TurnFailure::retryable("tool_error", "temporary failure"));
+        let kernel = ToolDrivenReplyKernel::new("preface", true, &result);
+
+        assert_eq!(
+            kernel.base_decision(false),
+            ToolDrivenReplyBaseDecision::RequireFollowup {
+                raw_reply: "preface\ntemporary failure".to_owned(),
+                payload: ToolDrivenFollowupPayload::ToolFailure {
+                    reason: "temporary failure".to_owned(),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn tool_driven_reply_base_decision_reports_followup_kind_only_for_followup_paths() {
+        let direct = ToolDrivenReplyBaseDecision::FinalizeDirect {
+            reply: "reply".to_owned(),
+        };
+        let followup = ToolDrivenReplyBaseDecision::RequireFollowup {
+            raw_reply: "raw".to_owned(),
+            payload: ToolDrivenFollowupPayload::ToolResult {
+                text: "tool output".to_owned(),
+            },
+        };
+
+        assert_eq!(direct.resolution_mode(), ReplyResolutionMode::Direct);
+        assert_eq!(
+            followup.resolution_mode(),
+            ReplyResolutionMode::CompletionPass
+        );
+        assert_eq!(direct.followup_kind(), None);
+        assert_eq!(
+            followup.followup_kind(),
+            Some(ToolDrivenFollowupKind::ToolResult)
+        );
+    }
+
+    #[test]
+    fn tool_driven_reply_phase_finalizes_non_tool_reply_directly() {
+        let result = TurnResult::FinalText("plain reply".to_owned());
+        let phase = ToolDrivenReplyPhase::new("preface", false, false, &result);
+
+        assert_eq!(phase.resolution_mode(), ReplyResolutionMode::Direct);
+        assert_eq!(phase.followup_kind(), None);
+        assert_eq!(
+            phase.decision(),
+            &ToolDrivenReplyBaseDecision::FinalizeDirect {
+                reply: "plain reply".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn tool_driven_reply_phase_requires_followup_for_tool_success() {
+        let result = TurnResult::FinalText("tool output".to_owned());
+        let phase = ToolDrivenReplyPhase::new("preface", true, false, &result);
+
+        assert_eq!(phase.resolution_mode(), ReplyResolutionMode::CompletionPass);
+        assert_eq!(
+            phase.followup_kind(),
+            Some(ToolDrivenFollowupKind::ToolResult)
+        );
+        assert_eq!(
+            phase.decision(),
+            &ToolDrivenReplyBaseDecision::RequireFollowup {
+                raw_reply: "preface\ntool output".to_owned(),
+                payload: ToolDrivenFollowupPayload::ToolResult {
+                    text: "tool output".to_owned(),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn tool_driven_reply_phase_requires_followup_for_tool_failure() {
+        let result =
+            TurnResult::ToolError(TurnFailure::retryable("tool_error", "temporary failure"));
+        let phase = ToolDrivenReplyPhase::new("preface", true, false, &result);
+
+        assert_eq!(phase.resolution_mode(), ReplyResolutionMode::CompletionPass);
+        assert_eq!(
+            phase.followup_kind(),
+            Some(ToolDrivenFollowupKind::ToolFailure)
+        );
+        assert_eq!(
+            phase.decision(),
+            &ToolDrivenReplyBaseDecision::RequireFollowup {
+                raw_reply: "preface\ntemporary failure".to_owned(),
+                payload: ToolDrivenFollowupPayload::ToolFailure {
+                    reason: "temporary failure".to_owned(),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn tool_driven_reply_phase_exposes_raw_reply_for_tool_success() {
+        let result = TurnResult::FinalText("tool output".to_owned());
+        let phase = ToolDrivenReplyPhase::new("preface", true, false, &result);
+
+        assert_eq!(phase.raw_reply(), Some("preface\ntool output"));
+    }
+
+    #[test]
+    fn tool_driven_reply_phase_exposes_raw_reply_for_tool_failure() {
+        let result =
+            TurnResult::ToolError(TurnFailure::retryable("tool_error", "temporary failure"));
+        let phase = ToolDrivenReplyPhase::new("preface", true, false, &result);
+
+        assert_eq!(phase.raw_reply(), Some("preface\ntemporary failure"));
+    }
+
+    #[test]
+    fn tool_driven_reply_phase_omits_raw_reply_for_non_tool_paths() {
+        let result = TurnResult::FinalText("plain reply".to_owned());
+        let phase = ToolDrivenReplyPhase::new("preface", false, false, &result);
+
+        assert_eq!(phase.raw_reply(), None);
+    }
+
+    #[test]
+    fn tool_driven_reply_phase_raw_mode_bypasses_completion_pass() {
+        let result = TurnResult::FinalText("tool output".to_owned());
+        let phase = ToolDrivenReplyPhase::new("preface", true, true, &result);
+
+        assert_eq!(phase.resolution_mode(), ReplyResolutionMode::Direct);
+        assert_eq!(phase.followup_kind(), None);
+        assert_eq!(
+            phase.decision(),
+            &ToolDrivenReplyBaseDecision::FinalizeDirect {
+                reply: "preface\ntool output".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn tool_result_followup_tail_promotes_external_skill_without_payload_mapping() {
+        let tail = build_tool_result_followup_tail(
+            "preface",
+            r#"[ok] {"status":"ok","tool":"external_skills.invoke","tool_call_id":"call-1","payload_summary":"{\"skill_id\":\"demo-skill\",\"display_name\":\"Demo Skill\",\"instructions\":\"Follow the managed skill instruction before answering.\"}","payload_chars":180,"payload_truncated":false}"#,
+            "summarize note.md",
+            Some("warning"),
+            |_, _| panic!("external skill payload should bypass payload mapper"),
+        );
+
+        assert!(tail.iter().any(|message| {
+            message.get("role") == Some(&Value::String("system".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| {
+                        content.contains("Follow the managed skill instruction before answering.")
+                    })
+                    .unwrap_or(false)
+        }));
+        assert!(tail.iter().any(|message| {
+            message.get("role") == Some(&Value::String("assistant".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| content.contains("[tool_loop_warning]\nwarning"))
+                    .unwrap_or(false)
+        }));
+        assert!(
+            tail.iter()
+                .filter_map(|message| message.get("content").and_then(Value::as_str))
+                .all(|content| !content.contains("[tool_result]\n[ok]"))
+        );
+    }
+
+    #[test]
+    fn tool_result_followup_tail_uses_payload_mapper_and_keeps_truncation_hint() {
+        let tail = build_tool_result_followup_tail(
+            "preface",
+            r#"[ok] {"payload_truncated":true}"#,
+            "summarize note.md",
+            Some("warning"),
+            |_, _| "bounded-result".to_owned(),
+        );
+
+        assert!(tail.iter().any(|message| {
+            message.get("role") == Some(&Value::String("assistant".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| content == "[tool_result]\nbounded-result")
+                    .unwrap_or(false)
+        }));
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+        assert!(user_prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
+        assert!(user_prompt.contains("Loop warning:\nwarning"));
+    }
+
+    #[test]
+    fn tool_failure_followup_tail_uses_payload_mapper_without_truncation_hint() {
+        let tail = build_tool_failure_followup_tail(
+            "preface",
+            "tool_timeout ...(truncated 200 chars)",
+            "summarize note.md",
+            Some("warning"),
+            |_, _| "bounded-failure".to_owned(),
+        );
+
+        assert!(tail.iter().any(|message| {
+            message.get("role") == Some(&Value::String("assistant".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| content == "[tool_failure]\nbounded-failure")
+                    .unwrap_or(false)
+        }));
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+        assert!(!user_prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
+        assert!(user_prompt.contains("Loop warning:\nwarning"));
+    }
+
+    #[test]
+    fn tool_driven_followup_tail_dispatches_result_payload() {
+        let payload = ToolDrivenFollowupPayload::ToolResult {
+            text: r#"[ok] {"payload_truncated":true}"#.to_owned(),
+        };
+        let tail = build_tool_driven_followup_tail(
+            "preface",
+            &payload,
+            "summarize note.md",
+            Some("warning"),
+            |_, _| "bounded-result".to_owned(),
+        );
+
+        assert!(tail.iter().any(|message| {
+            message.get("role") == Some(&Value::String("assistant".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| content == "[tool_result]\nbounded-result")
+                    .unwrap_or(false)
+        }));
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+        assert!(user_prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
+        assert!(user_prompt.contains("Loop warning:\nwarning"));
+    }
+
+    #[test]
+    fn tool_driven_followup_tail_dispatches_failure_payload() {
+        let payload = ToolDrivenFollowupPayload::ToolFailure {
+            reason: "tool_timeout ...(truncated 200 chars)".to_owned(),
+        };
+        let tail = build_tool_driven_followup_tail(
+            "preface",
+            &payload,
+            "summarize note.md",
+            Some("warning"),
+            |_, _| "bounded-failure".to_owned(),
+        );
+
+        assert!(tail.iter().any(|message| {
+            message.get("role") == Some(&Value::String("assistant".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| content == "[tool_failure]\nbounded-failure")
+                    .unwrap_or(false)
+        }));
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+        assert!(!user_prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
+        assert!(user_prompt.contains("Loop warning:\nwarning"));
+    }
+
+    #[test]
+    fn tool_loop_guard_tail_uses_payload_mapper_and_builds_guard_prompt() {
+        let tail = build_tool_loop_guard_tail(
+            "preface",
+            "stop",
+            "summarize note.md",
+            Some(("tool_result", "tool output")),
+            |_, _| "bounded-result".to_owned(),
+        );
+
+        assert!(tail.iter().any(|message| {
+            message.get("role") == Some(&Value::String("assistant".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| content == "preface")
+                    .unwrap_or(false)
+        }));
+        assert!(tail.iter().any(|message| {
+            message.get("role") == Some(&Value::String("assistant".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| content == "[tool_result]\nbounded-result")
+                    .unwrap_or(false)
+        }));
+        assert!(tail.iter().any(|message| {
+            message.get("role") == Some(&Value::String("assistant".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| content == "[tool_loop_guard]\nstop")
+                    .unwrap_or(false)
+        }));
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+        assert!(user_prompt.contains(TOOL_LOOP_GUARD_PROMPT));
+        assert!(user_prompt.contains("Loop guard reason:\nstop"));
+        assert!(user_prompt.contains("Original request:\nsummarize note.md"));
+    }
+
+    #[test]
+    fn tool_loop_guard_tail_skips_latest_tool_context_without_payload_mapping() {
+        let tail = build_tool_loop_guard_tail("", "stop", "summarize note.md", None, |_, _| {
+            panic!("missing latest tool context should bypass payload mapper")
+        });
+
+        assert_eq!(tail.len(), 2);
+        assert_eq!(tail[0]["role"], "assistant");
+        assert_eq!(tail[0]["content"], "[tool_loop_guard]\nstop");
+        assert_eq!(tail[1]["role"], "user");
+    }
+
+    #[test]
     fn truncation_signal_detection_matches_structured_tool_result() {
         assert!(tool_result_contains_truncation_signal(
             r#"[ok] {"payload_truncated":true}"#
@@ -298,5 +1163,30 @@ mod tests {
         assert_eq!(parsed.skill_id, "demo-skill");
         assert_eq!(parsed.display_name, "Demo Skill");
         assert!(parsed.instructions.contains("suffix-marker"));
+    }
+
+    #[test]
+    fn parse_external_skill_invoke_context_rejects_truncated_payload() {
+        let payload = json!({
+            "skill_id": "demo-skill",
+            "display_name": "Demo Skill",
+            "instructions": "Follow the managed skill instruction before answering.",
+        });
+        let line = format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "tool": "external_skills.invoke",
+                "tool_call_id": "call-1",
+                "payload_summary": serde_json::to_string(&payload).expect("encode payload"),
+                "payload_chars": 512,
+                "payload_truncated": true
+            })
+        );
+
+        assert!(
+            parse_external_skill_invoke_context(line.as_str()).is_none(),
+            "truncated external skill payload should not activate managed skill context"
+        );
     }
 }

--- a/docs/design-docs/acp-acpx-preembed.md
+++ b/docs/design-docs/acp-acpx-preembed.md
@@ -254,7 +254,7 @@ This creates an operator-facing validation path before full ACPX runtime executi
 
 ### 9. Channel / CLI turns now route through ACP via explicit dispatch policy
 
-`ConversationOrchestrator` now treats ACP as a first-class runtime path:
+`ConversationTurnCoordinator` now treats ACP as a first-class runtime path:
 
 - when `acp.enabled = false`, turns continue down the existing provider path
 - when `acp.enabled = true`, normal turns still stay on the existing provider/context-engine path
@@ -404,7 +404,7 @@ The new pieces are:
 
 - `AcpSessionManager::run_turn_with_sink(...)` as the formal manager seam for streamed ACP turn
   events
-- `ConversationTurnCoordinator::*acp_event_sink(...)` entrypoints as the conversation/orchestrator
+- `ConversationTurnCoordinator::*acp_event_sink(...)` entrypoints as the conversation turn-coordinator
   seam for live ACP runtime event subscribers, so callers can observe ACP runtime events directly
   without reaching into manager/backend internals
 - conversation-path persistence of structured `acp_turn_event` and `acp_turn_final` records into
@@ -464,7 +464,7 @@ OpenClaw's documented ACP agent-management direction.
 
 ### 15. ACP-owned turn options now front-load per-turn extensibility without API sprawl
 
-One remaining pre-embed risk was API shape drift in the conversation/orchestrator layer.
+One remaining pre-embed risk was API shape drift in the conversation turn-coordinator layer.
 
 After adding the public ACP live event sink, the next obvious trap would have been to keep growing
  `ConversationTurnCoordinator` with one more variant per new ACP concern:
@@ -531,7 +531,7 @@ This matters for architecture more than for operator ergonomics:
   dispatch baseline without mutating global config or leaking ACPX-specific config into top-level
   `[acp]`
 - it gives LoongClaw a first operator-facing ACP turn override surface that is still routed through
-  the conversation/orchestrator abstraction, not around it
+  the conversation turn-coordinator abstraction, not around it
 
 This is still intentionally smaller than OpenClaw's broader ACP bridge/runtime surfaces, but it
 removes two future refactor cliffs:
@@ -578,7 +578,7 @@ Current scope is deliberately narrow:
   path
 
 That means channel-specific ACP bootstrap policy now lives above ACPX backend config, but below the
-conversation/orchestrator seam, which is exactly where future per-channel workflow policy belongs.
+conversation turn-coordinator seam, which is exactly where future per-channel workflow policy belongs.
 
 ### 18. Channel status snapshots now expose ACP bootstrap MCP presets for operator visibility
 
@@ -665,7 +665,7 @@ There was one more hidden refactor cliff in the ACP path:
 - `AcpSessionBootstrap` already had `working_directory`
 - `AcpTurnRequest` already had `working_directory`
 - `acpx` backend already knew how to honor it
-- but the conversation/orchestrator path still hard-coded both to `None`
+- but the conversation turn-coordinator path still hard-coded both to `None`
 
 That meant any future requirement for:
 
@@ -690,7 +690,7 @@ and wires it through:
 This is the correct ownership boundary:
 
 - channel/account/workflow layers choose the runtime workspace hint
-- conversation/orchestrator carries it as a per-turn ACP concern
+- conversation turn-coordinator carries it as a per-turn ACP concern
 - ACP control-plane transports it
 - ACPX consumes it as one backend implementation detail
 
@@ -757,7 +757,7 @@ One smaller but important ownership leak still remained after the earlier ACP ev
 That is now tightened further:
 
 - `acp::BufferedAcpTurnEventSink` and `acp::CompositeAcpTurnEventSink` are the shared ACP-owned
-  sink utilities used by both the ACP manager and conversation/orchestrator path
+  sink utilities used by both the ACP manager and conversation turn-coordinator path
 - `acp::analytics::build_persisted_runtime_event_records(...)` owns the persisted
   `acp_turn_event` / `acp_turn_final` record shape
 - `conversation::persistence::persist_acp_runtime_events(...)` now acts only as storage transport
@@ -931,7 +931,7 @@ These items are still outstanding and should remain separate workstreams:
 ## Recommended next implementation order
 
 1. Add a public live event stream surface on top of the persisted runtime-event shape so
-   daemon/channel/orchestrator callers can choose direct streaming instead of summary-only
+   daemon/channel/conversation callers can choose direct streaming instead of summary-only
    observation; the ACP-owned JSONL sink is now the minimal base seam, but richer transport/API
    surfaces are still separate work.
 2. Expand user-facing ACP bootstrap surfaces beyond `acp.dispatch.bootstrap_mcp_servers`, so

--- a/docs/plans/2026-03-11-hybrid-runtime-design.md
+++ b/docs/plans/2026-03-11-hybrid-runtime-design.md
@@ -120,7 +120,7 @@ Delivered:
 Files:
 
 - `crates/app/src/conversation/turn_coordinator.rs`
-- `crates/app/src/conversation/orchestrator.rs` (compat alias)
+- no separate conversation alias module; `turn_coordinator.rs` is the canonical runtime entrypoint
 
 Delivered:
 
@@ -254,7 +254,7 @@ Delivered:
       - non-retryable verify failures fail fast without wasting replan rounds
 - naming aligned with actual responsibility:
   - canonical type: `ConversationTurnCoordinator`
-  - `ConversationOrchestrator` retained as backward-compatible alias
+  - removed the old `ConversationOrchestrator` alias so the type name matches the actual responsibility
 - failure taxonomy unification across fast/safe execution surfaces:
   - `TurnResult` failure variants now carry structured `TurnFailure` metadata
   - shared fields: `kind`, `code`, `reason`, `retryable`

--- a/docs/plans/2026-03-13-hybrid-turn-kernel-convergence-design.md
+++ b/docs/plans/2026-03-13-hybrid-turn-kernel-convergence-design.md
@@ -1,0 +1,465 @@
+# Hybrid Turn Kernel Convergence Design
+
+Date: 2026-03-13
+Branch: `feat/turn-loop-kernelization-20260313`
+Scope: research-calibrated convergence path after fast-lane and safe-lane kernelization
+Status: working design note
+
+## Why this note exists
+
+Fast-lane turn-loop kernelization and safe-lane plan-loop kernelization are now in place, but the
+outer hybrid turn path still determines whether the architecture can evolve into a stronger runtime
+without reintroducing implicit state transitions.
+
+The next problem is no longer "can the loop run?". The next problem is "where is the shared turn
+contract between lanes, reply finalization, retries, and persisted state?"
+
+## External calibration
+
+This note is based on the following primary-source references:
+
+1. LangGraph overview: https://docs.langchain.com/oss/python/langgraph/overview
+2. LangGraph Graph API overview: https://docs.langchain.com/oss/javascript/langgraph/graph-api
+3. LangGraph persistence: https://docs.langchain.com/oss/python/langgraph/persistence
+4. Semantic Kernel Agent Architecture: https://learn.microsoft.com/en-us/semantic-kernel/frameworks/agent/agent-architecture
+5. Temporal Continue-As-New: https://docs.temporal.io/develop/typescript/continue-as-new
+
+## What the references agree on
+
+### 1. Execution needs an explicit state model
+
+LangGraph treats execution as graph/state transitions instead of ad hoc loop mutation.
+Semantic Kernel separates agents, threads, orchestration patterns, and plugins.
+Temporal treats workflow state and activity execution as separate concerns.
+
+Implication for loongclaw:
+Current lane internals are getting healthier, but the hybrid turn boundary still needs a more
+explicit shared state/decision contract.
+
+### 2. Retry boundaries must be explicit and auditable
+
+LangGraph exposes retry policy at runtime boundaries.
+Temporal emphasizes retry classes, idempotent activities, and terminal vs retryable failures.
+
+Implication for loongclaw:
+`safe_lane` already has route/backpressure/governor logic, but the architecture should keep retry
+and finalization decisions as explicit typed transitions instead of repeated inline match logic.
+
+### 3. Reply finalization is a real kernel boundary
+
+Across these systems, the runtime separates execution output from the commit/update step that turns
+execution results into durable state, user-visible output, or the next control transition.
+
+Implication for loongclaw:
+The provider/lane execution result should not directly inline the reply-finalization policy in each
+caller. A shared reply-finalization kernel is the correct convergence seam.
+
+### 4. Structured contracts are safer than repeated local conventions
+
+LangGraph relies on shared state schema and control-flow primitives.
+Semantic Kernel relies on explicit orchestration patterns and thread/message contracts.
+Temporal relies on deterministic workflow/activity contracts.
+
+Implication for loongclaw:
+Duplicated follow-up semantics, external-skill activation parsing, and raw-fallback behavior should
+move into shared helpers or shared decision types before more policy is added.
+
+### 5. Long-running execution needs a compact checkpoint seam
+
+LangGraph persistence is thread-scoped and records checkpoints at explicit super-step boundaries.
+Semantic Kernel keeps thread state separate from orchestration patterns and plugin execution.
+Temporal uses Continue-As-New as a deliberate carry-forward boundary when a workflow grows too long.
+
+Implication for loongclaw:
+The eventual durable turn checkpoint boundary should snapshot a compact typed turn state, not replay
+opaque emitted events until control flow becomes reconstructable by accident.
+
+## Current loongclaw position
+
+### What is already good
+
+1. `ConversationTurnLoop` now has explicit per-turn session state, round evaluation, and round
+   decision types.
+2. `execute_turn_with_safe_lane_plan(...)` now has explicit safe-lane loop state, round execution,
+   and failure decision helpers.
+3. Safe-lane replan cursor derivation already depends on round outputs instead of executor internals.
+
+### What still needs convergence
+
+1. `ConversationTurnCoordinator` still owns a large outer hybrid turn path.
+2. Reply finalization policy is shared conceptually across lanes but was historically implemented as
+   repeated local logic.
+3. External-skill activation and completion-with-raw-fallback semantics can drift if duplicated.
+4. Durable per-turn checkpointing across lane boundaries is still event-centric, not kernel-centric.
+
+## Immediate convergence target
+
+The next narrow, high-value step is not a giant shared orchestrator. It is a smaller and more exact
+boundary:
+
+1. shared reply-finalization decision vocabulary
+2. shared external-skill follow-up activation rules
+3. shared completion-with-raw-fallback helper
+
+This keeps naming honest and keeps the architecture aligned with the real control seam.
+
+## What this branch now implements toward that target
+
+1. `turn_shared.rs` owns external-skill activation parsing and rejects truncated invoke payloads.
+2. `turn_shared.rs` owns completion-with-raw-fallback behavior.
+3. `ConversationTurnCoordinator` now derives an explicit `TurnReplyDecision` before persistence and
+   after-turn side effects.
+4. `ConversationTurnCoordinator` now uses an explicit provider-turn session state and a single
+   provider-turn commit/finalization boundary for success and inline-provider-error paths.
+5. `ConversationTurnCoordinator` now derives an explicit provider-request decision and an explicit
+   provider-lane-execution result before reply finalization.
+6. `ConversationTurnCoordinator` now derives a `ProviderTurnPreparation` and
+   `ProviderTurnLanePlan` so lane selection, raw-output mode, and tool-step limits enter the outer
+   provider path as a typed preparation stage instead of anonymous locals.
+7. Fast-lane and safe-lane now share a narrow budget vocabulary:
+   `TurnRoundBudget`, `SafeLaneReplanBudget`, and `EscalatingAttemptBudget`.
+   This keeps round-followup, replan exhaustion, and attempt-escalation logic out of anonymous
+   integer comparisons.
+8. Safe-lane failure routing now carries explicit route provenance
+   (`base_routing`, `backpressure_guard`, `session_governor`) so verify/plan finalization and
+   runtime audit paths do not need to infer override origin from `reason` strings alone.
+9. Safe-lane route reasons now share a typed vocabulary
+   (`SafeLaneFailureRouteReason`) across base routing, backpressure terminalization, governor
+   override, verify terminalization, checkpoint provenance, and event emission. The runtime still
+   emits stable snake_case strings outward, but the kernel no longer branches on ad hoc literals.
+10. Safe-lane failure codes now also have an explicit classifier boundary for durable consumers.
+    Health derivation, governor-history recovery, and other event-driven readers can distinguish
+    known verify/backpressure/governor failure families without relying on substring or prefix
+    heuristics over persisted strings. Generation paths are converging on the same vocabulary, so
+    write-side terminalization and read-side durability logic no longer drift independently.
+11. The provider-path turn boundary now has a compact typed checkpoint seam spanning preparation,
+   provider request outcome, lane execution summary, reply decision summary, and finalization
+   summary. This is still in-memory/internal only, but it turns the outer turn path into a
+   snapshot-friendly kernel without committing to event-schema churn.
+12. Session-history reads are converging on a shared assistant-window seam that is explicitly bound
+    to the active memory configuration. Checkpoint summaries, safe-lane summaries, and
+    governor-history recovery now share the same kernel-first, durable-fallback read boundary
+    instead of silently drifting across duplicate window-loading helpers.
+13. Safe-lane analytics now has an internal typed-rollup seam on top of the durable event summary.
+    Persisted payloads and outward summary fields remain stable string-based schema for backward
+    compatibility, but health/governor readers can now consume typed final failure codes, typed
+    route reasons, typed backpressure counters, and typed final-status rollups without rebuilding
+    classifiers ad hoc at each read site.
+14. The outer provider-path turn now also converges on a narrow resolved-outcome seam before
+    persistence/finalization. Provider request handling, lane execution, reply resolution, and
+    finalization mode selection still happen in stages, but they now collapse into one typed
+    resolved turn contract before checkpoints and post-turn durability are applied.
+15. Provider-path and turn-loop reply finalization now share a smaller tool-driven reply seam.
+    Raw-reply derivation, tool-result/tool-failure followup payload extraction, and non-tool
+    fallthrough semantics no longer live in two drifting local evaluators; they are derived from
+    one shared helper in `turn_shared`.
+16. Provider-path and turn-loop followup tail construction now also converges on a shared helper
+    seam in `turn_shared`. Assistant preface carry-forward, external-skill invoke promotion,
+    loop-warning insertion, truncation-hint prompting, and tool_result/tool_failure assistant
+    payload shapes no longer drift across duplicated local builders. The remaining intentional
+    difference is budget policy: the turn loop maps payloads through bounded truncation, while the
+    provider-path coordinator keeps unbounded followup payload text.
+17. Turn-loop hard-stop guard followup construction now also sits on the shared kernel side.
+    The guard marker, user prompt shape, and optional carry-forward of the latest tool payload are
+    no longer private `turn_loop` string assembly rules. The only turn-loop-local behavior left on
+    that path is the truncation budget mapper applied to the carried tool payload before the shared
+    guard tail is emitted.
+18. The remaining thin local followup payload wrappers have now been removed as well. Both
+    `turn_loop` and the provider-path coordinator consume `ToolDrivenFollowupPayload` directly, and
+    checkpoint followup-kind derivation now depends on a shared typed kind helper rather than local
+    `ToolResult`/`ToolFailure` mirror enums drifting separately in each runtime path.
+19. The repeated pre-decision transition logic now also converges on a shared base decision seam.
+    Non-tool direct finalization, raw-tool-output short-circuiting, and followup-candidate
+    derivation (`raw_reply` plus shared followup payload) are no longer duplicated across
+    `turn_loop` and the provider-path coordinator. Local paths now only apply their own
+    post-decision policy: round budget / loop hard-stop shaping on one side, direct
+    completion-pass resolution on the other.
+20. Provider-path reply checkpoints now also reuse the shared followup kind type directly.
+    The durable `followup_kind` field no longer depends on a coordinator-local mirror enum with the
+    same `tool_result` / `tool_failure` vocabulary. Shared payload kind, reply decision, and
+    checkpoint summary are now aligned on one serialized type boundary.
+21. The provider-path reply decision shell has also been removed. The coordinator now consumes
+    `ToolDrivenReplyBaseDecision` directly for decision, checkpoint summary derivation, and
+    completion-pass resolution instead of wrapping that same shared shape in a local
+    `TurnReplyDecision` enum first.
+22. Tool-driven followup dispatch now also converges on a shared payload router in `turn_shared`.
+    Provider-path and turn-loop callers no longer keep separate result-vs-failure match shells just
+    to select the same shared tail builders. The remaining intentional divergence is still local:
+    provider-path prepends base messages unchanged, while the turn loop applies followup-payload
+    truncation and keeps the loop-guard branch private.
+23. Durable turn-checkpoint repair now also consumes a shared typed recovery plan instead of only
+    a flat recovery action. Summary surfaces and the repair executor converge on the same kernel
+    contract for: whether repair is needed, whether repair is manual-only, which tail steps remain
+    runnable, and which existing per-step statuses should be carried forward before rerunning the
+    tail. Runtime-only downgrade reasons such as visible-tail mismatch remain local, but
+    summary-derived repair semantics no longer drift across analytics, CLI reporting, and the
+    repair executor.
+24. Tail-repair outcomes now also expose a typed reason vocabulary instead of returning raw
+    string literals from the coordinator path. Shared summary-derived manual reasons and
+    runtime-only downgrade reasons now sit behind one enum boundary, so CLI reporting, tests, and
+    future harness code do not need to rely on ad hoc string comparisons when evaluating repair
+    results.
+25. Repair execution now runs against a typed resume input instead of ad hoc `build_context`
+    output. That resume seam restores the original finalization envelope by rebuilding context with
+    the provider-path system layer included and by preferring checkpoint-carried estimated-token
+    metadata when deciding whether compaction should rerun. The repair path therefore converges on
+    the same finalization inputs normal provider turns used, instead of drifting based on whatever
+    a later context reassembly happens to estimate.
+26. The repair resume seam now also refuses context-shape drift when the checkpoint still carries
+    a preparation snapshot. If the rebuilt visible envelope no longer matches the original
+    `context_message_count` boundary, repair downgrades to manual inspection instead of replaying
+    tail hooks against a widened or narrowed history window. This keeps constrained tail recovery
+    aligned with the original provider turn instead of silently absorbing later summary/profile
+    reshaping.
+27. Repair preparation intake is now typed as well. The repair path no longer cherry-picks raw
+    JSON fields for `estimated_tokens` and `context_message_count`; it parses a minimal typed
+    preparation view and treats malformed checkpoint preparation payloads as manual-only recovery.
+    That keeps corrupted durable state from silently degrading into best-effort tail replay.
+28. Repair admissibility now also rejects content drift, not only envelope-shape drift. New
+    checkpoints persist a preparation-context fingerprint over the original pre-assistant
+    finalization envelope, and repair compares that fingerprint against the rebuilt visible
+    pre-assistant envelope before rerunning any tail hooks. If the count still matches but the
+    actual context content has drifted, repair downgrades to manual inspection instead of
+    replaying compaction or after-turn hooks against a different conversation state.
+29. Runtime-only repair downgrades are now observable without executing repair. The coordinator
+    exposes a narrow runtime-gate probe that rebuilds the typed resume input, checks the same
+    admissibility rules, and reports a manual-only downgrade reason when current session context
+    has drifted beyond what durable summary state can prove. CLI startup health can therefore show
+    fingerprint/context mismatches before any tail hook rerun is attempted, without turning the
+    repair path into a replay-first "try it and see" flow.
+30. Runtime admissibility is now routed through one local typed seam instead of being re-derived
+    separately by repair execution and runtime probe paths. The coordinator now evaluates one
+    narrow eligibility result that distinguishes summary-derived terminal states, runtime-only
+    manual downgrades, and truly runnable tail repair inputs. The same seam also lets
+    `/turn_checkpoint_summary` surface a probe line for the same requested window, so summary and
+    runtime probe no longer disagree just because they sampled different history ranges.
+31. The runtime-gate seam is now also covered as an explicit four-state matrix instead of only a
+    single positive probe example. Tests now prove that probe output is suppressed for
+    `NotNeeded`, summary-derived `InspectManually`, and fully runnable repair states, while the
+    runtime-only manual downgrade remains the only case that emits a probe line. This keeps
+    observability tight: the CLI only warns when runtime context drift adds new information beyond
+    durable summary state, not for already-known or safely recoverable conditions.
+32. Provider-turn request normalization now also converges on one shared typed seam. Fast-lane
+    `turn_loop` and the provider-path coordinator no longer keep separate local mappings from
+    `CliResult<ProviderTurn>` plus `ProviderErrorMode` into continue / inline-provider-error /
+    propagate-error branches. The shared seam ends exactly there: downstream persistence,
+    checkpoint shaping, and completion/finalization side effects still stay local to each path.
+    This is the intended convergence boundary because the three-way request outcome is genuinely
+    shared semantics, while the consequences of that outcome are not.
+33. Reply persistence class is now also shared, but only at the exact point where semantics are
+    truly identical. Fast-lane finalization, provider-path finalization, and ACP/raw fallbacks now
+    all route normal replies versus inline provider-error replies through one typed
+    `ReplyPersistenceMode` vocabulary and one persistence selector. The convergence still stops
+    before checkpoint emission, after-turn execution, and context compaction, because those later
+    lifecycle stages remain materially different between the fast path and the provider-path
+    coordinator.
+34. Reply resolution mode is now also shared at the base-decision layer. The direct-versus-
+    completion-pass distinction no longer lives only as coordinator-local checkpoint naming;
+    `ToolDrivenReplyBaseDecision` now exposes one shared `ReplyResolutionMode`, and the
+    coordinator checkpoint simply records that mode. This keeps the shared seam aligned with the
+    already-shared base decision instead of re-encoding the same branch locally under a second
+    enum.
+35. Budget decisions are now slightly more typed and less boolean-driven. Fast-lane
+    `TurnRoundBudget` now exposes an explicit follow-up decision instead of forcing callers to
+    branch on raw index math, while safe-lane replan budget and backpressure budget now both
+    expose a shared continuation decision that either allows progress or returns a typed terminal
+    reason. This keeps budget terminalization closer to the same decision-first style already used
+    for request normalization, reply resolution, and reply persistence.
+36. Safe-lane terminal route profiling is now also more local and less stringly-derived. The
+    route itself now owns its verify summary label and terminal code mappings for verify and plan
+    failure paths, instead of forcing multiple free functions to re-match the same
+    `source/reason` tuple. This keeps terminalization semantics attached to the typed route object
+    that already carries provenance.
+37. Safe-lane route transition shaping is now also localized onto the route type instead of being
+    spread across separate coordinator helpers. Base failure classification, backpressure
+    terminalization, session-governor override, and event-facing route labels now all live on
+    `SafeLaneFailureRoute` itself, while the coordinator only composes those typed transitions.
+    This preserves the existing event schema and lifecycle boundaries without re-inflating a new
+    runtime-level abstraction.
+38. Durable checkpoint observability now also consumes the typed safe-lane terminal route that was
+    already being persisted in lane snapshots. Turn-checkpoint analytics and chat summary/health
+    output now surface that stored route decision/reason/source directly instead of dropping the
+    provenance after persistence. This improves recovery-time diagnosis without changing the
+    checkpoint schema or turning repair into a replay-first reconstruction path.
+39. The durable checkpoint plane now also reuses the shared route-decision / route-source
+    vocabulary instead of maintaining a second raw-string-only representation in analytics. This
+    keeps runtime routing, persisted lane snapshots, and operator-facing checkpoint summaries on
+    one narrow typed contract while still leaving execution lifecycle control local to the
+    coordinator.
+40. Checkpoint repair and startup-health reporting now also preserve override-driven terminal route
+    provenance when recovery downgrades to manual inspection. The repair action still stays
+    local to the checkpoint tail state, but the manual reason can now distinguish safe-lane
+    backpressure and session-governor terminals from generic state inspection. This keeps durable
+    recovery hints typed and specific without conflating route provenance with replay-oriented
+    reconstruction logic.
+41. Route-aware checkpoint recovery hints are now explicitly terminal-only, and checkpoint route
+    label projection is centralized on the event summary instead of being re-expanded in each chat
+    formatter. This avoids accidental reuse of non-terminal route snapshots for manual-repair
+    diagnosis and trims another small repetition seam without widening the public architecture.
+42. Durable repair hint classification now also validates override-pair consistency instead of
+    trusting persisted route source alone. Backpressure-specific and session-governor-specific
+    manual reasons are emitted only when the persisted terminal route carries a source/reason pair
+    that is internally coherent, so malformed or mixed snapshots degrade back to generic manual
+    inspection instead of overstating what the runtime previously decided.
+43. Runtime tail-repair probes now also expose their diagnostic source explicitly instead of
+    flattening everything into action/reason only. This keeps operator-facing probe output aligned
+    with the already-typed internal eligibility source and prevents runtime-gate findings from
+    looking indistinguishable from summary-derived manual repair conclusions.
+44. Tail-repair outcomes now also preserve summary-versus-runtime source on the terminal operator
+    surface instead of discarding that distinction after probe time. This keeps `turn_checkpoint_
+    repair` aligned with probe diagnostics and makes manual-required outcomes auditable without
+    inferring provenance from reason strings alone.
+45. Turn-checkpoint operator diagnostics now also converge on a narrow local render seam instead
+    of re-projecting summary, repair, and probe labels separately in each formatter. Startup
+    health, summary output, runtime probe, and repair output still keep their existing outward
+    roles, but they now share the same typed label projection for recovery action/reason/source
+    and for summary-derived state labels. That keeps future checkpoint observability expansion
+    from drifting across multiple string assembly sites while avoiding any new runtime-wide
+    "orchestrator" abstraction.
+46. Turn-checkpoint diagnostics are now also assembled from a coordinator-owned typed report
+    instead of making the chat layer pair summary loading with a separate runtime-probe call.
+    Summary-derived recovery assessment and optional runtime-gate findings still remain narrow and
+    read-only, but they now cross the coordinator/chat boundary as one typed diagnostic contract.
+    That reduces another summary-versus-runtime drift seam without widening repair execution into a
+    general replay subsystem.
+47. Turn-checkpoint diagnostics now also consume a single session-history snapshot instead of
+    reloading the memory window once for summary state and again for runtime-gate eligibility.
+    Summary recovery assessment and latest checkpoint payload are derived from the same assistant
+    window snapshot, so operator diagnostics no longer admit cross-read drift when kernel-routed
+    memory changes between calls. This keeps the seam local to session history and coordinator
+    logic rather than introducing a broader caching or replay layer.
+48. The turn-checkpoint session-history seam now also folds assistant checkpoint events into
+    summary state and latest-checkpoint payload in one parse pass instead of first building
+    summary state and then reparsing the same snapshot to recover the latest checkpoint body.
+    This keeps the kernelized diagnostics path narrow and deterministic while reducing repeated
+    JSON decoding inside the same history snapshot boundary.
+49. Safe-lane governor history now also consumes a single safe-lane history projection instead of
+    parsing assistant event content once for governor failure samples and then reparsing the same
+    history again for safe-lane summary rollups. The summary surface and the governor sample
+    surface stay separate, but they now share one local fold seam, which removes another small
+    consistency and overhead leak without introducing a broader runtime cache layer.
+50. Provider-path and turn-loop reply entry now also share an explicit `ToolDrivenReplyPhase`
+    contract instead of leaving the coordinator with a private `TurnReplyEvaluation ->
+    decide_turn_reply_action` shell while the turn loop talked directly to `ToolDrivenReplyKernel`.
+    The shared phase stays narrow on purpose: it only owns the reply-entry projection from
+    assistant preface, tool-intent presence, raw-output mode, and turn result into one
+    typed base decision plus resolution metadata. Checkpoint persistence, round-budget policy,
+    and completion-pass execution remain local to their callers.
+51. `ToolDrivenReplyPhase` now also carries the projected raw-reply view used by the turn loop's
+    round-limit fallback path. The fast path no longer asks one helper for `raw_reply` and another
+    helper for the base decision over the same turn result. That removes a small but real drift and
+    recomputation seam while keeping the phase boundary local to reply-entry projection rather than
+    widening it into a broader lane or persistence abstraction.
+52. Provider-path resolved outcomes now also own their final `TurnCheckpointSnapshot` at resolve
+    time instead of reconstructing that snapshot later during apply/finalization from
+    `preparation + user_input + scattered resolved fields`. This makes the resolved outcome seam
+    more self-contained and snapshot-friendly: request classification, lane summary, reply summary,
+    and finalization summary now cross the resolve/apply boundary as one compact object rather than
+    being re-derived from parallel inputs.
+53. Propagated provider errors now also participate in the durable checkpoint seam instead of
+    silently skipping it. A `return_error` outcome now persists a single `finalized` checkpoint
+    event with skipped finalization progress, and analytics no longer equates "checkpoint durable"
+    with "reply durable" for that path. This closes an auditability hole without pretending that a
+    provider error produced a persisted assistant reply.
+54. The provider-path `Continue` branch now also crosses a narrower local phase seam before reply
+    resolution. Request shaping, lane execution summary, and tool-driven reply projection are
+    carried together as one `ProviderTurnContinuePhase` instead of being re-derived as parallel
+    locals inside `resolve_provider_turn(...)`. The seam stays intentionally coordinator-local:
+    it reduces hybrid-turn glue without widening a new cross-runtime abstraction.
+55. Provider-path reply finalization now also enters the tail through a compact local phase input
+    instead of reassembling `reply + after_turn_messages + estimated_tokens` as unrelated locals at
+    the call site. `ProviderTurnReplyTailPhase` keeps the finalization boundary explicit without
+    inflating resolved outcomes with full session payloads, so the durable tail remains typed and
+    local rather than drifting back into ad hoc apply-side plumbing.
+56. Resolved provider outcomes now also cross into apply/finalization through a typed terminal
+    phase instead of making `apply_resolved_provider_turn(...)` re-branch over raw resolved data.
+    Persisted replies and propagated provider errors still terminate differently, but that
+    difference now sits behind one local `ProviderTurnTerminalPhase` seam. This keeps
+    resolve/apply/tail ownership explicit without turning provider-path finalization into a new
+    runtime-wide orchestration layer.
+57. Operator-facing turn-checkpoint diagnostics now also distinguish reply durability from
+    checkpoint durability explicitly. Sessions that only persisted a terminal checkpoint (for
+    example propagated provider errors) no longer show up as a vague `durable=0` state without
+    context; chat summary and startup health now surface `checkpoint_durable=1` with
+    `durability=checkpoint_only`, which keeps the internal checkpoint semantics auditable at the
+    same precision the kernel now maintains internally.
+58. `checkpoint_durable` now also lives on `TurnCheckpointEventSummary` itself instead of being
+    re-inferred inside chat from `session_state != not_durable`. That keeps operator surfaces
+    honest about where durability semantics come from: analytics owns the fact that a checkpoint
+    event was durably observed, and chat just renders the typed summary. This is a small change,
+    but it closes one more inference seam between the checkpoint kernel and its operator-facing
+    diagnostics.
+
+This is still behavior-preserving for normal paths, but it hardens one previously duplicated unsafe
+edge: truncated external-skill invoke payloads no longer activate managed skill context in the
+coordinator path.
+
+## Next phases after this note
+
+### Phase 1: shared hybrid turn transition contract
+
+Introduce a narrow typed contract for the outer hybrid turn path:
+
+1. provider turn obtained
+2. lane execution completed
+3. reply finalization decision derived
+4. persistence/after-turn/context-compaction applied
+
+### Phase 2: typed retry budget kernel
+
+Unify the notion of round budget, retry budget, and terminalization budget so fast-lane and
+safe-lane stop encoding retry ceilings in unrelated local primitives.
+
+This phase should stay narrow:
+
+1. fast-lane follow-up continuation should depend on a typed round budget, not direct index math
+2. safe-lane replan exhaustion should depend on a typed retry budget, not raw `round/max_rounds`
+3. safe-lane node-attempt growth should depend on a typed escalating attempt budget, not manual
+   increment/min logic
+4. safe-lane failure routing should carry typed provenance for terminalization overrides so verify
+   and plan failure finalization can consume a route object instead of stringly-typed reason
+   plumbing
+5. total-attempt backpressure and terminalization can remain separate until a later slice proves a
+   stronger merged budget contract is actually needed
+
+### Phase 3: durable turn checkpoint boundary
+
+Persist a compact typed turn snapshot around lane execution and finalization so interrupted or
+partially failed turns can be resumed or audited without reconstructing everything from emitted
+assistant events. The right model is closer to LangGraph thread checkpoints / super-step snapshots
+and Temporal carry-forward execution state than to a flat append-only event replay.
+That checkpoint should preserve typed route provenance when terminalization is override-driven,
+because backpressure/governor exits are runtime-state facts, not just presentation strings.
+
+Current convergence slice:
+
+1. `TurnCheckpointSnapshot` exists as a narrow provider-path seam and is now persisted through a
+   versioned `turn_checkpoint` conversation event.
+2. That durable payload is stage-aware (`post_persist`, `finalized`, `finalization_failed`) so the
+   runtime can distinguish reply durability from later finalization progress.
+3. Safe-lane terminal route provenance is carried into the outer lane execution summary instead of
+   being re-inferred from terminal error codes.
+4. The commit/finalization boundary consumes typed finalization summary rather than a raw
+   persistence mode argument and now records post-turn progress explicitly.
+5. Context compaction durability is explicit at the checkpoint layer:
+   `skipped`, `completed`, `failed_open`, and fail-closed `failed` are no longer implicit runtime
+   side effects.
+6. Replay/time-travel concerns remain separate from base turn-state reconstruction. The checkpoint
+   is a compact kernel contract, not a second full-fidelity assistant-reply store.
+
+## Non-goals
+
+1. No giant "orchestrator" abstraction.
+2. No premature shared code between fast-lane and safe-lane execution engines.
+3. No policy retuning mixed into basic kernel convergence work.
+4. No event-schema churn unless a later phase proves it is necessary.
+
+## Acceptance signal for the current stage
+
+The architecture is moving in the right direction when:
+
+1. duplicated turn-finalization semantics are removed or minimized
+2. retry/finalization branches become typed and unit-testable
+3. external-skill activation safety is consistent across lanes
+4. new policy work can be implemented by editing typed decision helpers rather than expanding large
+   monolithic turn handlers

--- a/docs/plans/2026-03-13-safe-lane-plan-kernelization-design.md
+++ b/docs/plans/2026-03-13-safe-lane-plan-kernelization-design.md
@@ -1,0 +1,157 @@
+# Safe-Lane Plan Loop Kernelization Design
+
+Date: 2026-03-13
+Branch: `feat/turn-loop-kernelization-20260313`
+Scope: behavior-preserving kernelization of the safe-lane plan execution loop in
+`crates/app/src/conversation/turn_coordinator.rs`
+Status: Approved for implementation
+
+## Problem
+
+`execute_turn_with_safe_lane_plan(...)` has become the control hotspot of the hybrid runtime.
+The function currently interleaves:
+
+1. governor bootstrap and effective budget derivation
+2. adaptive verify policy escalation
+3. round-start event emission
+4. plan build + plan execution
+5. tool-output stats and metric aggregation
+6. verify-failure routing
+7. plan-failure routing
+8. terminal result construction
+9. replan cursor mutation
+10. round advancement and retry ceiling mutation
+
+The runtime behavior is strong, but the control flow is now hard to reason about. This increases
+review cost and makes future safe-lane evolution risky because side effects and routing logic are
+mixed inside a single loop body.
+
+## Goals
+
+1. Keep safe-lane external behavior unchanged in this slice.
+2. Introduce explicit typed loop state for safe-lane plan execution.
+3. Introduce explicit typed round outcome and next-step decision boundaries.
+4. Separate pure routing / terminalization logic from side effects such as event persistence.
+5. Make later hybrid-runtime upgrades safer by reducing hidden state transitions.
+
+## Non-Goals
+
+1. No config schema changes.
+2. No new runtime event names or payload semantics.
+3. No governor policy tuning changes.
+4. No verifier policy behavior changes.
+5. No ACP or fast-lane behavior changes.
+
+## Approaches Considered
+
+### A. Helper extraction only
+
+Extract a few helper functions but keep the current implicit loop shape.
+
+Pros:
+- smallest patch
+- low local risk
+
+Cons:
+- leaves mutation order implicit
+- does not create a durable state-machine seam
+- future changes still need to reason about the whole loop body
+
+### B. Behavior-preserving safe-lane loop kernel
+
+Introduce explicit internal state, explicit round outcome types, and explicit next-step decisions
+while preserving current behavior.
+
+Pros:
+- creates a durable kernel boundary
+- keeps reviewable scope inside one function family
+- prepares safe lane for later convergence with fast-lane kernel concepts
+
+Cons:
+- larger patch than pure helper extraction
+- requires new kernel-level tests
+
+### C. Kernelization plus policy cleanup
+
+Kernelize the loop and also change routing / governor / verifier semantics in the same patch.
+
+Pros:
+- potentially cleaner end state immediately
+
+Cons:
+- too much semantic risk in one slice
+- harder to attribute regressions
+- harder to review
+
+## Decision
+
+Implement Approach B.
+
+The next correct step is not new safe-lane features. It is to make the existing safe-lane plan
+loop explicit and testable so future policy work sits on a stable execution kernel.
+
+## Target Design
+
+### 1. Explicit safe-lane session state
+
+Add a local state container that owns:
+
+1. governor decision
+2. current round index
+3. effective round / node retry ceilings
+4. replan cursor (`plan_start_tool_index`)
+5. seeded tool outputs
+6. aggregated runtime metrics
+7. adaptive verify policy state
+
+This makes cross-round mutation visible and auditable.
+
+### 2. Explicit round outcome
+
+Represent a safe-lane round as a typed outcome that captures:
+
+1. plan execution report
+2. tool outputs for the round
+3. summarized tool-output stats
+4. derived failure metadata when present
+5. verify report when the plan succeeded
+
+This separates “what happened in the round” from “what should happen next.”
+
+### 3. Explicit next-step decision
+
+Introduce a typed decision enum for the loop:
+
+1. finalize success
+2. finalize terminal verify failure
+3. finalize terminal plan failure
+4. replan after verify failure
+5. replan after plan failure
+
+The outer loop should apply side effects from that decision instead of deriving behavior from
+nested inline branches.
+
+### 4. Event emission stays outside the pure kernel
+
+This slice should keep event names and payload structure unchanged. The kernel only decides what
+the next state transition is. Event emission remains an effectful layer applied by the loop.
+
+This preserves compatibility while still reducing control-flow complexity.
+
+## Testing Strategy
+
+1. Add kernel-level tests for pure decision helpers:
+   - verify failure replan with remaining budget
+   - verify failure terminalized by session governor override
+   - plan failure replan preserves failed-subgraph restart cursor
+   - plan failure terminalization maps to current failure codes
+2. Keep existing high-level safe-lane runtime tests green.
+3. Re-run targeted `turn_coordinator` tests before wider package verification.
+
+## Acceptance Criteria
+
+1. `execute_turn_with_safe_lane_plan(...)` becomes thinner and coordinates explicit kernel steps.
+2. Cross-round mutation lives in a typed state container.
+3. Verify / route / terminal decisions become explicit and unit-testable.
+4. No intentional safe-lane behavior changes are introduced.
+5. Existing safe-lane runtime tests remain green.

--- a/docs/plans/2026-03-13-safe-lane-plan-kernelization.md
+++ b/docs/plans/2026-03-13-safe-lane-plan-kernelization.md
@@ -1,0 +1,87 @@
+# Safe-Lane Plan Loop Kernelization Implementation Plan
+
+Goal: refactor the safe-lane plan execution loop into an explicit behavior-preserving kernel with
+typed state, round outcome, and next-step decision boundaries.
+
+Architecture: keep `ConversationTurnCoordinator` as the public entrypoint, but move the implicit
+safe-lane round/replan/terminal decision logic into explicit internal helpers around
+`execute_turn_with_safe_lane_plan(...)`.
+
+Tech Stack: Rust, async conversation runtime traits, plan executor / verifier runtime, cargo test
+
+## Task 1: Lock the safe-lane kernelization target in docs
+
+Files:
+- create `docs/plans/2026-03-13-safe-lane-plan-kernelization-design.md`
+- create `docs/plans/2026-03-13-safe-lane-plan-kernelization.md`
+
+Checks:
+- `rg -n "execute_turn_with_safe_lane_plan|SafeLaneFailureRoute::from_failure|with_backpressure_guard|with_session_governor_override|terminal_turn_result_from_plan_failure_with_route" crates/app/src/conversation/turn_coordinator.rs`
+- `ls docs/plans/2026-03-13-safe-lane-plan-kernelization-design.md docs/plans/2026-03-13-safe-lane-plan-kernelization.md`
+
+## Task 2: Add failing kernel-level tests
+
+File:
+- modify `crates/app/src/conversation/turn_coordinator.rs`
+
+Add focused tests for new pure helpers that do not exist yet:
+
+1. verify failure with retryable signal and remaining budget chooses replan
+2. verify failure under governor no-replan terminalizes with governor-specific failure code
+3. plan failure replan preserves failed-subgraph restart cursor
+4. terminal plan failure under backpressure / governor keeps current failure-code mapping
+
+Check:
+- run the new targeted test and confirm RED
+
+## Task 3: Introduce typed internal safe-lane kernel structures
+
+File:
+- modify `crates/app/src/conversation/turn_coordinator.rs`
+
+Add minimal internal types for:
+
+1. safe-lane loop state
+2. round execution outcome
+3. next-step decision
+4. replan update
+
+Keep them local to `turn_coordinator.rs`.
+
+## Task 4: Refactor `execute_turn_with_safe_lane_plan(...)`
+
+File:
+- modify `crates/app/src/conversation/turn_coordinator.rs`
+
+Use the kernel helpers to:
+
+1. initialize session state
+2. evaluate one round
+3. derive next-step decision
+4. apply state mutation and event emission
+
+Preserve:
+
+1. current event names and payload meanings
+2. current route-reason semantics
+3. current terminal failure-code mapping
+4. current replan cursor behavior
+5. current route provenance fields and labels
+
+## Task 5: Re-run targeted safe-lane coverage
+
+Checks:
+- `cargo test -p loongclaw-app turn_coordinator::tests::safe_lane_ -- --test-threads=1`
+- `cargo test -p loongclaw-app handle_turn_with_runtime_safe_lane -- --test-threads=1`
+
+Add one high-level regression test only if the kernelized path exposes an uncovered branch.
+
+## Task 6: Run full verification
+
+Checks:
+- `cargo test -p loongclaw-app turn_coordinator -- --test-threads=1`
+- `cargo test -p loongclaw-app -- --test-threads=1`
+- `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
+
+Final diff review:
+- `git diff -- crates/app/src/conversation/turn_coordinator.rs docs/plans/2026-03-13-safe-lane-plan-kernelization-design.md docs/plans/2026-03-13-safe-lane-plan-kernelization.md`

--- a/docs/plans/2026-03-13-turn-checkpoint-kernel-implementation.md
+++ b/docs/plans/2026-03-13-turn-checkpoint-kernel-implementation.md
@@ -1,0 +1,114 @@
+# Turn Checkpoint Kernel Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a compact typed turn checkpoint seam to the provider-path turn runtime so lane execution, reply decision, and finalization can be snapshotted without event replay.
+
+**Architecture:** Keep the boundary narrow and behavior-preserving. Add snapshot structs around the existing provider turn stages, carry safe-lane terminal route provenance through the provider lane execution path, and make the finalization boundary consume the typed checkpoint instead of ad hoc local state.
+
+**Tech Stack:** Rust, `loongclaw-app`, provider-path coordinator, unit tests, `cargo fmt`, `cargo test`, `cargo clippy`
+
+---
+
+### Task 1: Define the checkpoint seam with failing tests
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Test: `crates/app/src/conversation/turn_coordinator.rs`
+
+**Step 1: Write the failing tests**
+
+Add unit tests for:
+- safe-lane terminal execution snapshot preserves route provenance and completion-pass reply mode
+- inline provider error snapshot skips lane/reply stages and persists as inline error
+- propagated provider error snapshot records return-error finalization with no persistence
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app turn_checkpoint_snapshot_ -- --test-threads=1`
+Expected: FAIL with missing snapshot types/builders
+
+**Step 3: Write minimal implementation**
+
+Add compact checkpoint structs/enums and pure builders for:
+- preparation summary
+- provider request summary
+- lane execution summary
+- reply decision summary
+- finalization summary
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app turn_checkpoint_snapshot_ -- --test-threads=1`
+Expected: PASS
+
+### Task 2: Carry safe-lane terminal provenance into the provider lane summary
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Test: `crates/app/src/conversation/turn_coordinator.rs`
+
+**Step 1: Write the failing test**
+
+Add a unit test showing that safe-lane terminal route provenance is available from the provider lane execution summary without inferring from failure codes.
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app safe_lane_turn_outcome_ -- --test-threads=1`
+Expected: FAIL with missing typed outcome plumbing
+
+**Step 3: Write minimal implementation**
+
+Change the safe-lane execution path to return a typed outcome that includes:
+- `TurnResult`
+- optional terminal `SafeLaneFailureRoute`
+
+Thread that summary through `ProviderTurnLaneExecution`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app safe_lane_turn_outcome_ -- --test-threads=1`
+Expected: PASS
+
+### Task 3: Put the checkpoint on the finalization boundary
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Test: `crates/app/src/conversation/turn_coordinator.rs`
+
+**Step 1: Write the failing test**
+
+Add a unit test showing the provider finalization boundary consumes the typed checkpoint mode rather than a separate raw persistence mode argument.
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app finalize_provider_turn_reply_ -- --test-threads=1`
+Expected: FAIL with signature/behavior mismatch
+
+**Step 3: Write minimal implementation**
+
+Refactor `finalize_provider_turn_reply(...)` to consume the checkpoint finalization summary while preserving behavior.
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app finalize_provider_turn_reply_ -- --test-threads=1`
+Expected: PASS
+
+### Task 4: Align design note and run full verification
+
+**Files:**
+- Modify: `docs/plans/2026-03-13-hybrid-turn-kernel-convergence-design.md`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+
+**Step 1: Update design note**
+
+Document the checkpoint seam and the decision to keep it compact, typed, and event-schema-neutral.
+
+**Step 2: Run repository verification**
+
+Run:
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all --check`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --test-threads=1`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
+
+Expected: all pass

--- a/docs/plans/2026-03-13-turn-checkpoint-persistence-design.md
+++ b/docs/plans/2026-03-13-turn-checkpoint-persistence-design.md
@@ -1,0 +1,209 @@
+# Turn Checkpoint Persistence Design
+
+Date: 2026-03-13
+Branch: `feat/turn-loop-kernelization-20260313`
+Scope: durable provider-turn checkpoint persistence without event-replay-first coupling
+Status: implemented on this branch
+
+## Goal
+
+Persist a compact, versioned turn checkpoint around the provider-path finalization boundary so the
+runtime can audit and recover finalization progress without introducing a replay-first execution
+model or a new storage schema.
+
+## Why this slice exists
+
+The in-memory `TurnCheckpointSnapshot` seam already makes the outer provider turn path typed and
+snapshot-friendly, but it still disappears if the process exits between:
+
+1. user/assistant turn persistence
+2. `after_turn(...)`
+3. context compaction
+
+That gap matters because reply durability and post-turn side effects are separate runtime phases.
+If the system loses process state in that window, we want an auditable durable marker that says
+which phase completed and where finalization stopped.
+
+## Design choice
+
+Use a versioned `conversation_event` named `turn_checkpoint` with a compact payload:
+
+1. `schema_version`
+2. `stage`
+3. `checkpoint`
+4. `finalization_progress`
+5. optional `failure`
+
+The `checkpoint` field serializes the existing typed provider-turn seam:
+
+1. preparation summary
+2. provider request decision
+3. lane execution summary
+4. reply decision summary
+5. finalization summary
+
+This keeps the durable contract aligned with the kernel seam instead of re-deriving control flow
+from ad hoc assistant event histories.
+
+## Stage model
+
+The persisted protocol uses three stages:
+
+1. `post_persist`
+2. `finalized`
+3. `finalization_failed`
+
+### `post_persist`
+
+Persisted immediately after user/assistant turns are durably written.
+
+Meaning:
+
+1. the user-visible reply is durable
+2. `after_turn` may still be pending
+3. context compaction may still be pending
+
+### `finalized`
+
+Persisted after all configured post-turn side effects finish.
+
+Meaning:
+
+1. the reply is durable
+2. `after_turn` completed or was skipped
+3. compaction completed, was skipped, or failed open
+
+### `finalization_failed`
+
+Persisted when a fail-closed post-turn step aborts finalization after reply persistence.
+
+Meaning:
+
+1. the reply is durable
+2. the finalization boundary did not finish cleanly
+3. the payload identifies the failed step and captured error string
+
+## Progress model
+
+`finalization_progress` tracks the per-step outcome with a small status vocabulary:
+
+1. `pending`
+2. `skipped`
+3. `completed`
+4. `failed`
+5. `failed_open`
+
+This lets the runtime distinguish:
+
+1. an interrupted turn that stopped after reply persistence
+2. a cleanly finalized turn
+3. a fail-open compaction path
+4. a fail-closed post-finalization failure
+
+## Why not persist the full reply in the checkpoint
+
+That would push the architecture toward replay/reconstruction from checkpoint payloads and would
+duplicate the assistant reply in the durable protocol. This slice intentionally stops one boundary
+later:
+
+1. persist the real user/assistant turns first
+2. persist a compact kernel checkpoint describing finalization state
+
+That makes recovery meaningful for the `after_turn` / compaction window without inflating the
+checkpoint into a second source of truth for the reply body.
+
+## Why reuse `conversation_event`
+
+Reusing the existing generic conversation-event channel keeps storage stable and avoids schema
+churn. This is acceptable because provider history assembly already filters internal assistant
+records with:
+
+1. `type = "conversation_event"`
+2. `type = "tool_decision"`
+3. `type = "tool_outcome"`
+
+So persisted checkpoints remain queryable in memory history without contaminating prompt context.
+
+## Recovery value
+
+This slice does not attempt full interrupted-turn replay.
+
+It does provide durable evidence for the highest-value partial-finalization window:
+
+1. if the latest checkpoint is `post_persist`, the reply is durable but finalization did not finish
+2. if the latest checkpoint is `finalization_failed`, the reply is durable and the failed step is
+   explicit
+3. if the latest checkpoint is `finalized`, the provider turn reached a clean durable boundary
+
+That is enough for future repair tooling, harness diagnostics, or recovery loops to avoid guessing.
+
+The branch now also includes:
+
+1. a typed `turn_checkpoint` analytics summary layer for latest-stage / latest-progress /
+   failure-step recovery reads
+2. a restart-style sqlite verification that proves checkpoint events survive durable reload while
+   remaining filtered out of provider prompt history
+3. a narrow session checkpoint reader plus CLI summary surface so operators can inspect
+   `not_durable` / `pending_finalization` / `finalized` / `finalization_failed` state without
+   introducing a replay subsystem or a new policy loop
+4. a narrow tail-repair harness that only replays `after_turn` / compaction from the durable
+   checkpoint boundary and persists a new terminal `turn_checkpoint` event
+5. a manual CLI repair entrypoint (`/turn_checkpoint_repair`) so operators can run that tail
+   repair without re-entering provider turn execution, including explicit refusal reasons such as
+   `checkpoint_identity_missing` and `checkpoint_identity_mismatch`
+6. a checkpoint turn-identity fingerprint so repair can verify that the rebuilt visible
+   user/assistant tail still matches the durable checkpoint before rerunning side effects
+
+## Non-goals
+
+1. no giant orchestrator abstraction
+2. no event-replay-first turn reconstruction
+3. no new database schema
+4. no policy retuning mixed into checkpoint persistence
+5. no duplication of full assistant replies inside checkpoint events
+
+## Tail repair semantics
+
+The repair harness intentionally stays narrower than a workflow replay system.
+
+It does:
+
+1. load the latest durable `turn_checkpoint`
+2. derive a typed recovery action from the persisted finalization state
+3. rebuild current visible session context from durable memory
+4. recover the latest durable user/assistant turn pair
+5. verify that recovered pair against the checkpoint identity fingerprint
+6. rerun only the missing tail steps (`after_turn`, compaction)
+7. persist a new `finalized` or `finalization_failed` checkpoint event
+
+It does not:
+
+1. rerun provider inference
+2. reconstruct the assistant reply from checkpoint payloads
+3. replay arbitrary intermediate lane state
+4. auto-retry when the durable reply turn itself is unavailable
+5. guess when the rebuilt visible tail no longer matches the durable checkpoint
+
+This keeps the recovery boundary aligned with the external durability guidance used for the
+design:
+
+1. resume from persisted boundaries, not arbitrary lines of code
+2. keep side effects isolated and idempotent where possible
+3. avoid monolithic replay of a larger turn block when only the finalization tail is incomplete
+
+Automatic recovery recommendation is additionally gated by checkpoint identity presence. If the
+latest durable tail requires recovery but no identity fingerprint is present, summary surfaces,
+startup health, and the repair entrypoint all downgrade to manual inspection instead of attempting
+tail execution on a weakly identified checkpoint.
+
+## Validation hardening
+
+The current validation matrix now covers durable restart behavior, not just in-memory repair flow.
+
+It verifies:
+
+1. a successful repair writes a new terminal `finalized` checkpoint into durable sqlite history
+2. a repeated repair on that same session becomes a noop instead of rerunning `after_turn` or
+   compaction side effects
+3. a failed repair durably writes `finalization_failed`
+4. a later retry resumes from that failed durable tail and only reruns the remaining step

--- a/docs/plans/2026-03-13-turn-loop-kernelization-design.md
+++ b/docs/plans/2026-03-13-turn-loop-kernelization-design.md
@@ -1,0 +1,177 @@
+# Turn Loop Kernelization Design
+
+Date: 2026-03-13
+Branch: `feat/turn-loop-kernelization-20260313`
+Scope: behavior-preserving kernelization of the fast-lane conversation turn loop
+Status: Approved for implementation
+
+## Problem
+
+`crates/app/src/conversation/turn_loop.rs` currently concentrates too many responsibilities in
+`ConversationTurnLoop::handle_turn_with_runtime(...)`:
+
+1. round-state progression
+2. provider error handling
+3. tool execution result handling
+4. tool-loop detection consumption
+5. follow-up message assembly
+6. second-pass completion fallback
+7. turn persistence and final reply return
+
+The code already works, but its control flow is difficult to reason about because state, decisions,
+and side effects are interleaved inside one large loop with repeated match branches.
+
+## Goals
+
+1. Keep external behavior stable for the current fast-lane turn loop.
+2. Introduce explicit typed round evaluation and next-step decision boundaries.
+3. Separate pure decision logic from side effects such as persistence and completion requests.
+4. Keep loop guard semantics, raw-tool-output mode, and follow-up prompt behavior unchanged.
+5. Make future evolution toward a stronger hybrid agent loop safer by reducing hidden state
+   transitions.
+
+## Non-Goals
+
+1. No user-visible turn-loop policy changes in this slice.
+2. No safe-lane `turn_coordinator` redesign in this slice.
+3. No context-engine API redesign in this slice.
+4. No ACP behavior changes in this slice.
+
+## Approaches Considered
+
+### A. Helper extraction only
+
+Move repeated branches into helper functions but keep the implicit control flow shape.
+
+Pros:
+- smallest patch
+- low short-term risk
+
+Cons:
+- hidden state transitions remain
+- hard to prove behavior in future changes
+- does not create a real kernel boundary
+
+### B. Behavior-preserving turn kernel
+
+Introduce explicit session state, round evaluation, and next-step decision structures while keeping
+current externally visible behavior intact.
+
+Pros:
+- gives the turn loop a real state-machine boundary
+- keeps refactor risk manageable because behavior does not intentionally change
+- creates durable seams for later hybrid/runtime evolution
+
+Cons:
+- larger patch than pure helper extraction
+- requires new kernel-level tests
+
+### C. Kernelization plus policy cleanup
+
+Kernelize the loop and also tighten round-budget / loop-guard / raw-fallback semantics in the same
+change.
+
+Pros:
+- potentially cleaner end state immediately
+
+Cons:
+- mixes refactor and behavior change
+- increases regression risk sharply
+- harder to review and attribute failures
+
+## Decision
+
+Implement Approach B.
+
+The correct first step is to make the fast-lane turn loop explicit and testable without changing its
+observable behavior. Once the kernel exists, later policy adjustments can happen on top of a stable
+state machine instead of inside a monolithic function.
+
+## Target Design
+
+### 1. Explicit session state
+
+Introduce a typed session-state container for the active turn loop that owns:
+
+1. assembled messages
+2. raw-output request mode
+3. last raw reply
+4. loop supervisor state
+5. follow-up payload budget
+6. current round index
+
+This keeps mutable per-turn-loop state in one place instead of scattering it across locals.
+
+### 2. Explicit round evaluation
+
+Represent one round of work as a typed evaluation result that captures:
+
+1. provider turn
+2. whether tool intents existed
+3. the `TurnResult`
+4. loop-guard verdict for this round
+5. the raw reply candidate
+
+This separates “what happened in the round” from “what should happen next.”
+
+### 3. Explicit next-step decision kernel
+
+Add a typed decision enum that describes the next action:
+
+1. continue with follow-up messages
+2. finalize directly with a known reply
+3. finalize through a second-pass completion request
+4. finalize with raw fallback
+5. finalize provider error inline
+
+The outer loop then applies side effects from that decision instead of deriving behavior ad hoc from
+nested branches.
+
+### 4. Finalization boundary
+
+Unify persistence and return handling behind a narrow finalization path so:
+
+1. success persistence stays centralized
+2. inline provider-error persistence stays centralized
+3. round-budget fallback stays centralized
+
+This reduces the chance of future changes forgetting one persistence path.
+
+The boundary should carry one explicit reply persistence class instead of duplicating separate
+"persist success" and "persist inline provider error" terminal variants. The actual lifecycle after
+that persist step still stays local to the caller. In `turn_loop` this remains a simple
+persist-or-return boundary. In the coordinator path the same persistence class feeds checkpoint
+finalization, after-turn hooks, and context-compaction policy without pretending those later stages
+are shared semantics.
+
+### 5. Provider request boundary
+
+Provider-turn request results should also be normalized before the loop body consumes them:
+
+1. successful provider turns continue into round evaluation
+2. inline provider errors normalize into one terminal action
+3. propagated provider errors normalize into one terminal action
+
+This keeps provider error handling aligned with the same typed terminal boundary used by success
+finalization and round-limit fallback, instead of letting `handle_turn_with_runtime(...)` branch
+directly into persistence code.
+
+## Testing Strategy
+
+1. Preserve existing behavior tests around `handle_turn_with_runtime(...)`.
+2. Add kernel-level tests for round-decision mapping:
+   - tool result with continue
+   - tool result with hard stop
+   - tool failure with continue
+   - tool failure with hard stop
+   - raw-output mode bypassing second-pass completion
+3. Keep follow-up helper tests in `turn_loop.rs` and extend them where needed.
+4. Re-run targeted conversation tests first, then broader `loongclaw-app` coverage.
+
+## Acceptance Criteria
+
+1. `handle_turn_with_runtime(...)` becomes thinner and primarily coordinates kernel steps.
+2. Round evaluation and next-step decisions become explicit types.
+3. No intentional external behavior changes are introduced in this slice.
+4. Existing turn-loop behavior tests stay green.
+5. New kernel-focused tests cover the decision matrix that was previously implicit.

--- a/docs/plans/2026-03-13-turn-loop-kernelization.md
+++ b/docs/plans/2026-03-13-turn-loop-kernelization.md
@@ -1,0 +1,132 @@
+# Turn Loop Kernelization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refactor the fast-lane conversation turn loop into an explicit behavior-preserving kernel with typed round evaluation and decision boundaries.
+
+**Architecture:** Keep `ConversationTurnLoop` as the public entrypoint, but move the current implicit control flow into explicit internal session-state, round-evaluation, and next-step decision helpers. Preserve current external behavior while reducing control-flow coupling between tool-loop detection, follow-up prompt assembly, completion fallback, and persistence.
+
+**Tech Stack:** Rust, async conversation runtime traits, existing conversation tests, cargo test
+
+---
+
+### Task 1: Lock the kernelization target in docs
+
+**Files:**
+- Modify: `docs/plans/2026-03-13-turn-loop-kernelization-design.md`
+- Create: `docs/plans/2026-03-13-turn-loop-kernelization.md`
+
+**Step 1: Re-read the current turn loop and tests**
+
+Run: `rg -n "handle_turn_with_runtime|ToolLoopSupervisor|append_tool_followup_messages" crates/app/src/conversation`
+Expected: current kernelization surface is fully enumerated.
+
+**Step 2: Confirm the design and implementation-plan docs exist**
+
+Run: `ls docs/plans/2026-03-13-turn-loop-kernelization-design.md docs/plans/2026-03-13-turn-loop-kernelization.md`
+Expected: both files exist.
+
+### Task 2: Add failing kernel-level tests for next-step decisions
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Test: `crates/app/src/conversation/turn_loop.rs`
+
+**Step 1: Write a failing test for tool-result rounds that should continue with follow-up**
+
+Add a focused unit test around the new decision helper.
+
+**Step 2: Run the targeted test to verify it fails**
+
+Run: `cargo test -p loongclaw-app turn_loop::tests::<new_test_name> -- --test-threads=1`
+Expected: FAIL because the new kernel decision helper or type does not exist yet.
+
+**Step 3: Repeat for hard-stop and raw-output bypass cases**
+
+Add separate failing tests for:
+- hard-stop with tool result
+- hard-stop with tool failure
+- raw-output mode bypassing second-pass completion
+
+### Task 3: Introduce explicit turn-loop kernel types
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+
+**Step 1: Add typed internal structures**
+
+Introduce minimal internal types for:
+- session state
+- round evaluation
+- next-step decision
+- finalization mode
+
+**Step 2: Keep constructors narrow and local**
+
+Implement the smallest helper methods needed to derive decisions from existing round data.
+
+**Step 3: Run targeted tests**
+
+Run: `cargo test -p loongclaw-app turn_loop -- --test-threads=1`
+Expected: the new decision tests still fail until the main loop consumes the kernel.
+
+### Task 4: Rewrite the main turn loop around the kernel
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+
+**Step 1: Route each round through explicit evaluation + decision helpers**
+
+Replace the large repeated match branches in `handle_turn_with_runtime(...)` with:
+- build round evaluation
+- derive decision
+- apply continue/finalize action
+
+**Step 2: Preserve current side effects**
+
+Ensure the refactor still:
+- persists inline provider errors correctly
+- persists successful replies exactly once
+- uses second-pass completion only on the same paths as before
+- preserves round-limit fallback behavior
+
+**Step 3: Run targeted tests to verify the refactor passes**
+
+Run: `cargo test -p loongclaw-app turn_loop -- --test-threads=1`
+Expected: PASS.
+
+### Task 5: Re-run existing high-level conversation coverage
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs` (only if current coverage reveals a missing kernel case)
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Run the existing turn-loop/conversation behavior tests**
+
+Run: `cargo test -p loongclaw-app handle_turn_with_runtime -- --test-threads=1`
+Expected: PASS.
+
+**Step 2: Add one regression test only if a previously implicit branch is not already covered**
+
+Keep this minimal and behavior-focused.
+
+### Task 6: Run broader verification and clean up
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/conversation/tests.rs` (if needed)
+
+**Step 1: Run package-level verification**
+
+Run: `cargo test -p loongclaw-app -- --test-threads=1`
+Expected: PASS.
+
+**Step 2: Run lint for the touched crate**
+
+Run: `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
+Expected: PASS.
+
+**Step 3: Review the final diff**
+
+Run: `git diff -- crates/app/src/conversation/turn_loop.rs crates/app/src/conversation/tests.rs docs/plans/2026-03-13-turn-loop-kernelization-design.md docs/plans/2026-03-13-turn-loop-kernelization.md`
+Expected: only the intended kernelization scope is present.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -342,7 +342,7 @@ Trade-off: SQLite is queryable but adds schema migration burden. JSONL is zero-s
 
 `persist_turn` currently uses `tokio::task::block_in_place` to bridge sync → async kernel calls. This works but blocks a tokio worker thread and panics on single-threaded runtimes.
 
-Approach: make `ConversationRuntime::persist_turn` async, update `ConversationOrchestrator` callers. Straightforward but touches 6+ files.
+Approach: make `ConversationRuntime::persist_turn` async, update `ConversationTurnCoordinator` callers. Straightforward but touches 6+ files.
 
 Trade-off: low risk, moderate churn. Unblocks single-threaded runtime compatibility.
 
@@ -360,7 +360,7 @@ Status (alpha-test): implemented.
 - Added registry/selection hooks (`register_context_engine`, `resolve_context_engine`, `LOONGCLAW_CONTEXT_ENGINE`) plus config-based selector (`[conversation].context_engine`) for future multi-engine evolution without invasive runtime refactors.
 - Added built-in `legacy` engine for rollback and behavior comparison against pre-seam assembly path.
 - Added engine metadata surface (`id`, `api_version`, `capabilities`) for diagnostics and compatibility checks before introducing more advanced engines.
-- Added explicit post-turn context compaction hook (`compact_context`) to reserve an upgrade seam for summarization/compression without rewriting orchestrator flow.
+- Added explicit post-turn context compaction hook (`compact_context`) to reserve an upgrade seam for summarization/compression without rewriting turn-coordinator flow.
 - Added reserved context-engine lifecycle hooks (`bootstrap`, `ingest`) as default no-op seams so future engine-owned import/indexing flows do not require another trait/runtime rewrite.
 - Added reserved subagent lifecycle hooks (`prepare_subagent_spawn`, `on_subagent_ended`) as default no-op seams so future multi-agent context wiring avoids trait-breaking refactors.
 - Added richer context assembly output (`messages`, optional `estimated_tokens`, optional `system_prompt_addition`) to pre-wire policy/runtime prompt augmentation without revisiting runtime boundaries.


### PR DESCRIPTION
## Summary

Closes #124

This PR refactors the conversation runtime around narrower typed turn-phase seams and durable checkpoint semantics.

### What changed

- kernelized provider-path continue, reply-tail, request-terminal, and resolved-terminal boundaries with typed local phase structs
- introduced typed turn-loop and safe-lane budget helpers for round limits, replans, escalating attempts, and backpressure ceilings
- preserved typed safe-lane failure route provenance so terminal overrides remain runtime facts instead of presentation strings
- promoted durable turn checkpoint semantics into typed analytics summaries, including explicit `checkpoint_durable` vs `reply_durable`
- updated chat/operator diagnostics so they render typed checkpoint facts instead of inferring durability from session state
- documented the convergence design and implementation notes for this runtime slice

### Why

The goal is to make the hybrid turn path more stable and maintainable without introducing an oversized orchestration layer. The resulting structure keeps fast-lane and safe-lane behavior local, while moving shared semantics into narrow typed contracts that are easier to test, review, and evolve.

### Validation

- `cargo test -p loongclaw-app --target-dir <local-absolute-path> -- --test-threads=1`
- `cargo clippy -p loongclaw-app --all-targets --all-features --target-dir <local-absolute-path> -- -D warnings`
