### PR TITLE
feat(approval): add operator attention views and filters

### DIFF
--- a/crates/app/src/conversation/persistence.rs
+++ b/crates/app/src/conversation/persistence.rs
@@ -1,10 +1,14 @@
-use serde_json::{Value, json};
+#[cfg(feature = "memory-sqlite")]
+use std::collections::BTreeSet;
 
+#[cfg(feature = "memory-sqlite")]
+use loongclaw_contracts::{Capability, MemoryCoreRequest};
+use serde_json::json;
+
+#[cfg(feature = "memory-sqlite")]
+use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::CliResult;
 use crate::KernelContext;
-use crate::acp::{
-    AcpTurnResult, PersistedAcpRuntimeEventContext, build_persisted_runtime_event_records,
-};
 
 use super::runtime::ConversationRuntime;
 use super::turn_engine::{ToolDecision, ToolOutcome};
@@ -20,15 +24,12 @@ pub(super) async fn persist_success_turns<R: ConversationRuntime + ?Sized>(
     assistant_reply: &str,
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<()> {
-    persist_and_ingest_turn(runtime, session_id, "user", user_input, kernel_ctx).await?;
-    persist_and_ingest_turn(
-        runtime,
-        session_id,
-        "assistant",
-        assistant_reply,
-        kernel_ctx,
-    )
-    .await?;
+    runtime
+        .persist_turn(session_id, "user", user_input, kernel_ctx)
+        .await?;
+    runtime
+        .persist_turn(session_id, "assistant", assistant_reply, kernel_ctx)
+        .await?;
     Ok(())
 }
 
@@ -46,21 +47,10 @@ pub(super) async fn persist_tool_decision<R: ConversationRuntime + ?Sized>(
     decision: &ToolDecision,
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<()> {
-    let content = json!({
-        "type": "tool_decision",
-        "turn_id": turn_id,
-        "tool_call_id": tool_call_id,
-        "decision": serde_json::to_value(decision)
-            .map_err(|e| format!("serialize tool decision: {e}"))?,
-    });
-    persist_and_ingest_turn(
-        runtime,
-        session_id,
-        "assistant",
-        &content.to_string(),
-        kernel_ctx,
-    )
-    .await
+    let content = tool_decision_turn_content(turn_id, tool_call_id, decision)?;
+    runtime
+        .persist_turn(session_id, "assistant", &content.to_string(), kernel_ctx)
+        .await
 }
 
 /// Persist a tool outcome as a structured JSON assistant message.
@@ -77,18 +67,102 @@ pub(super) async fn persist_tool_outcome<R: ConversationRuntime + ?Sized>(
     outcome: &ToolOutcome,
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<()> {
-    let content = json!({
+    let content = tool_outcome_turn_content(turn_id, tool_call_id, outcome)?;
+    runtime
+        .persist_turn(session_id, "assistant", &content.to_string(), kernel_ctx)
+        .await
+}
+
+fn tool_decision_turn_content(
+    turn_id: &str,
+    tool_call_id: &str,
+    decision: &ToolDecision,
+) -> Result<serde_json::Value, String> {
+    Ok(json!({
+        "type": "tool_decision",
+        "turn_id": turn_id,
+        "tool_call_id": tool_call_id,
+        "decision": serde_json::to_value(decision)
+            .map_err(|e| format!("serialize tool decision: {e}"))?,
+    }))
+}
+
+fn tool_outcome_turn_content(
+    turn_id: &str,
+    tool_call_id: &str,
+    outcome: &ToolOutcome,
+) -> Result<serde_json::Value, String> {
+    Ok(json!({
         "type": "tool_outcome",
         "turn_id": turn_id,
         "tool_call_id": tool_call_id,
         "outcome": serde_json::to_value(outcome)
             .map_err(|e| format!("serialize tool outcome: {e}"))?,
-    });
-    persist_and_ingest_turn(
-        runtime,
+    }))
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn persist_structured_assistant_turn_with_memory_config(
+    memory_config: &MemoryRuntimeConfig,
+    session_id: &str,
+    content: serde_json::Value,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<(), String> {
+    let serialized_content = content.to_string();
+    if let Some(ctx) = kernel_ctx {
+        let request = MemoryCoreRequest {
+            operation: "append_turn".to_owned(),
+            payload: json!({
+                "session_id": session_id,
+                "role": "assistant",
+                "content": serialized_content,
+            }),
+        };
+        let caps = BTreeSet::from([Capability::MemoryWrite]);
+        ctx.kernel
+            .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
+            .await
+            .map_err(|error| format!("persist assistant turn via kernel failed: {error}"))?;
+        return Ok(());
+    }
+
+    crate::memory::append_turn_direct(session_id, "assistant", &serialized_content, memory_config)
+        .map_err(|error| format!("persist assistant turn failed: {error}"))
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) async fn persist_tool_decision_with_memory_config(
+    memory_config: &MemoryRuntimeConfig,
+    session_id: &str,
+    turn_id: &str,
+    tool_call_id: &str,
+    decision: &ToolDecision,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<(), String> {
+    let content = tool_decision_turn_content(turn_id, tool_call_id, decision)?;
+    persist_structured_assistant_turn_with_memory_config(
+        memory_config,
         session_id,
-        "assistant",
-        &content.to_string(),
+        content,
+        kernel_ctx,
+    )
+    .await
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) async fn persist_tool_outcome_with_memory_config(
+    memory_config: &MemoryRuntimeConfig,
+    session_id: &str,
+    turn_id: &str,
+    tool_call_id: &str,
+    outcome: &ToolOutcome,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<(), String> {
+    let content = tool_outcome_turn_content(turn_id, tool_call_id, outcome)?;
+    persist_structured_assistant_turn_with_memory_config(
+        memory_config,
+        session_id,
+        content,
         kernel_ctx,
     )
     .await
@@ -101,127 +175,11 @@ pub(super) async fn persist_error_turns<R: ConversationRuntime + ?Sized>(
     synthetic_reply: &str,
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<()> {
-    persist_and_ingest_turn(runtime, session_id, "user", user_input, kernel_ctx).await?;
-    persist_and_ingest_turn(
-        runtime,
-        session_id,
-        "assistant",
-        synthetic_reply,
-        kernel_ctx,
-    )
-    .await?;
-    Ok(())
-}
-
-pub(super) async fn persist_success_turns_raw<R: ConversationRuntime + ?Sized>(
-    runtime: &R,
-    session_id: &str,
-    user_input: &str,
-    assistant_reply: &str,
-    kernel_ctx: Option<&KernelContext>,
-) -> CliResult<()> {
-    persist_turn_only(runtime, session_id, "user", user_input, kernel_ctx).await?;
-    persist_turn_only(
-        runtime,
-        session_id,
-        "assistant",
-        assistant_reply,
-        kernel_ctx,
-    )
-    .await?;
-    Ok(())
-}
-
-pub(super) async fn persist_error_turns_raw<R: ConversationRuntime + ?Sized>(
-    runtime: &R,
-    session_id: &str,
-    user_input: &str,
-    synthetic_reply: &str,
-    kernel_ctx: Option<&KernelContext>,
-) -> CliResult<()> {
-    persist_turn_only(runtime, session_id, "user", user_input, kernel_ctx).await?;
-    persist_turn_only(
-        runtime,
-        session_id,
-        "assistant",
-        synthetic_reply,
-        kernel_ctx,
-    )
-    .await?;
-    Ok(())
-}
-
-async fn persist_and_ingest_turn<R: ConversationRuntime + ?Sized>(
-    runtime: &R,
-    session_id: &str,
-    role: &str,
-    content: &str,
-    kernel_ctx: Option<&KernelContext>,
-) -> CliResult<()> {
     runtime
-        .persist_turn(session_id, role, content, kernel_ctx)
+        .persist_turn(session_id, "user", user_input, kernel_ctx)
         .await?;
     runtime
-        .ingest(
-            session_id,
-            &json!({
-                "role": role,
-                "content": content,
-            }),
-            kernel_ctx,
-        )
+        .persist_turn(session_id, "assistant", synthetic_reply, kernel_ctx)
         .await?;
     Ok(())
-}
-
-pub(super) async fn persist_conversation_event<R: ConversationRuntime + ?Sized>(
-    runtime: &R,
-    session_id: &str,
-    event_name: &str,
-    payload: Value,
-    kernel_ctx: Option<&KernelContext>,
-) -> CliResult<()> {
-    let content = json!({
-        "type": "conversation_event",
-        "event": event_name,
-        "payload": payload,
-    });
-    runtime
-        .persist_turn(session_id, "assistant", &content.to_string(), kernel_ctx)
-        .await
-}
-
-pub(super) async fn persist_acp_runtime_events<R: ConversationRuntime + ?Sized>(
-    runtime: &R,
-    session_id: &str,
-    context: &PersistedAcpRuntimeEventContext,
-    events: &[Value],
-    result: Option<&AcpTurnResult>,
-    error: Option<&str>,
-    kernel_ctx: Option<&KernelContext>,
-) -> CliResult<()> {
-    let records = build_persisted_runtime_event_records(context, events, result, error);
-    for record in records {
-        persist_conversation_event(
-            runtime,
-            session_id,
-            record.event,
-            record.payload,
-            kernel_ctx,
-        )
-        .await?;
-    }
-    Ok(())
-}
-
-async fn persist_turn_only<R: ConversationRuntime + ?Sized>(
-    runtime: &R,
-    session_id: &str,
-    role: &str,
-    content: &str,
-    kernel_ctx: Option<&KernelContext>,
-) -> CliResult<()> {
-    runtime
-        .persist_turn(session_id, role, content, kernel_ctx)
-        .await
 }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8174,6 +8174,24 @@ fn seed_pending_approval_request_with_snapshot(
     args_json: Value,
     execution_plane: &str,
 ) {
+    let governance_snapshot_json =
+        if let Some(descriptor) = crate::tools::tool_catalog().descriptor(tool_name) {
+            json!({
+                "execution_plane": descriptor.execution_plane,
+                "governance_scope": descriptor.governance_scope,
+                "risk_class": descriptor.risk_class,
+                "approval_mode": descriptor.approval_mode,
+                "audit_label": descriptor.audit_label,
+                "reason": format!("approval required for {tool_name}"),
+                "rule_id": "governed_tool_requires_per_call_approval",
+            })
+        } else {
+            json!({
+                "reason": format!("approval required for {tool_name}"),
+                "rule_id": "governed_tool_requires_per_call_approval",
+                "execution_plane": execution_plane,
+            })
+        };
     repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
         approval_request_id: approval_request_id.to_owned(),
         session_id: session_id.to_owned(),
@@ -8186,11 +8204,7 @@ fn seed_pending_approval_request_with_snapshot(
             "tool_name": tool_name,
             "args_json": args_json,
         }),
-        governance_snapshot_json: json!({
-            "reason": format!("approval required for {tool_name}"),
-            "rule_id": "governed_tool_requires_per_call_approval",
-            "execution_plane": execution_plane,
-        }),
+        governance_snapshot_json,
     })
     .expect("seed pending approval request");
 }
@@ -8542,6 +8556,14 @@ async fn approval_request_resume_once_executes_blocked_app_tool_and_marks_reques
                 text.contains("\"resumed_tool_output\":{"),
                 "expected resumed tool output envelope in output, got: {text}"
             );
+            assert!(
+                text.contains("\"execution_evidence\":{"),
+                "expected execution_evidence in output, got: {text}"
+            );
+            assert!(
+                text.contains("\"evidence_complete\":true"),
+                "expected complete execution evidence in output, got: {text}"
+            );
         }
         other => panic!("expected FinalText, got: {other:?}"),
     }
@@ -8595,6 +8617,1003 @@ async fn approval_request_resume_once_executes_blocked_app_tool_and_marks_reques
     assert!(events
         .iter()
         .any(|event| event.event_kind == "tool_approval_execution_started"));
+    assert!(events
+        .iter()
+        .any(|event| event.event_kind == "tool_approval_execution_finished"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resume_once_persists_terminal_outcome_for_original_blocked_call() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-resume-once-transcript-outcome");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "timeout_seconds": 60,
+        }),
+    })
+    .expect("append queued child event");
+    seed_pending_approval_request_with_snapshot(
+        &repo,
+        "apr-approve-once-transcript-outcome",
+        "root-session",
+        "session_cancel",
+        json!({
+            "session_id": "child-session",
+        }),
+        "App",
+    );
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-approve-once-transcript-outcome",
+        "approve_once",
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(_) => {}
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    let turns = crate::memory::window_direct("root-session", 20, &memory_config)
+        .expect("load root session transcript");
+    let replay_outcome = turns
+        .iter()
+        .find_map(|turn| {
+            let json = serde_json::from_str::<serde_json::Value>(&turn.content).ok()?;
+            if json["type"] == "tool_outcome"
+                && json["turn_id"] == "turn-apr-approve-once-transcript-outcome"
+                && json["tool_call_id"] == "call-apr-approve-once-transcript-outcome"
+            {
+                Some(json)
+            } else {
+                None
+            }
+        })
+        .expect("replayed original tool call should persist a terminal tool_outcome");
+
+    assert_eq!(replay_outcome["outcome"]["status"], "ok");
+    assert_eq!(replay_outcome["outcome"]["governance_allowed"], true);
+    assert_eq!(
+        replay_outcome["outcome"]["governance"]["execution_plane"],
+        "App"
+    );
+    assert_eq!(
+        replay_outcome["outcome"]["governance"]["audit_label"],
+        "session_cancel"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resume_once_persists_replay_decision_before_terminal_outcome() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-resume-once-replay-decision");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "timeout_seconds": 60,
+        }),
+    })
+    .expect("append queued child event");
+    seed_pending_approval_request_with_snapshot(
+        &repo,
+        "apr-replay-decision",
+        "root-session",
+        "session_cancel",
+        json!({
+            "session_id": "child-session",
+        }),
+        "App",
+    );
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn("root-session", "apr-replay-decision", "approve_once");
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(_) => {}
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    let relevant_turns = crate::memory::window_direct("root-session", 20, &memory_config)
+        .expect("load root session transcript")
+        .into_iter()
+        .filter_map(|turn| {
+            let json = serde_json::from_str::<serde_json::Value>(&turn.content).ok()?;
+            (json["turn_id"] == "turn-apr-replay-decision"
+                && json["tool_call_id"] == "call-apr-replay-decision")
+                .then_some(json)
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        relevant_turns.len(),
+        2,
+        "expected replay decision and outcome"
+    );
+    assert_eq!(relevant_turns[0]["type"], "tool_decision");
+    assert_eq!(relevant_turns[1]["type"], "tool_outcome");
+    assert_eq!(relevant_turns[0]["decision"]["allow"], true);
+    assert_eq!(relevant_turns[0]["decision"]["approval_required"], false);
+    assert_eq!(
+        relevant_turns[0]["decision"]["reason"],
+        "approval_request_approve_once"
+    );
+    assert_eq!(
+        relevant_turns[0]["decision"]["governance"]["execution_plane"],
+        "App"
+    );
+    assert_eq!(relevant_turns[1]["outcome"]["status"], "ok");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resume_once_rechecks_app_tool_visibility_for_request_session() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-resume-once-app-visibility");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    seed_pending_approval_request_with_snapshot(
+        &repo,
+        "apr-approve-once-app-visibility",
+        "child-session",
+        "sessions_list",
+        json!({}),
+        "App",
+    );
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-approve-once-app-visibility",
+        "approve_once",
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::ToolError(error) => assert!(
+            error.contains("tool_not_visible: sessions_list"),
+            "expected child replay visibility error, got: {error}"
+        ),
+        other => panic!("expected ToolError, got: {other:?}"),
+    }
+
+    let resolved = repo
+        .load_approval_request("apr-approve-once-app-visibility")
+        .expect("load approval request")
+        .expect("executed approval request");
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert!(
+        resolved
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("tool_not_visible: sessions_list")),
+        "expected tool visibility failure in approval request last_error, got: {:?}",
+        resolved.last_error
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resume_once_rejects_invalid_replay_governance_snapshot_before_execution()
+{
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-resume-once-invalid-replay-governance");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "timeout_seconds": 60,
+        }),
+    })
+    .expect("append queued child event");
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-invalid-replay-governance".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-apr-invalid-replay-governance".to_owned(),
+        tool_call_id: "call-apr-invalid-replay-governance".to_owned(),
+        tool_name: "session_cancel".to_owned(),
+        approval_key: "tool:session_cancel".to_owned(),
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "tool_name": "session_cancel",
+            "args_json": {
+                "session_id": "child-session",
+            },
+        }),
+        governance_snapshot_json: json!({
+            "execution_plane": "App",
+        }),
+    })
+    .expect("seed invalid approval request");
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-invalid-replay-governance",
+        "approve_once",
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::ToolError(error) => assert!(
+            error.contains("approval_request_invalid_governance_snapshot"),
+            "expected invalid governance snapshot error, got: {error}"
+        ),
+        other => panic!("expected ToolError, got: {other:?}"),
+    }
+
+    let resolved = repo
+        .load_approval_request("apr-invalid-replay-governance")
+        .expect("load approval request")
+        .expect("resolved approval request");
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert!(
+        resolved
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("approval_request_invalid_governance_snapshot")),
+        "expected invalid governance snapshot last_error, got: {:?}",
+        resolved.last_error
+    );
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session");
+    assert_eq!(child.state, crate::session::repository::SessionState::Ready);
+
+    let events = repo
+        .list_recent_events("root-session", 20)
+        .expect("list approval events");
+    assert!(events
+        .iter()
+        .any(|event| event.event_kind == "tool_approval_execution_started"));
+    assert!(events
+        .iter()
+        .any(|event| event.event_kind == "tool_approval_execution_failed"));
+    assert!(!events
+        .iter()
+        .any(|event| event.event_kind == "tool_approval_execution_finished"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resume_once_persists_terminal_outcome_for_original_orchestration_call() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-resume-once-orchestration-transcript-outcome");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    seed_pending_approval_request(
+        &repo,
+        "apr-approve-once-orchestration-transcript-outcome",
+        "root-session",
+        "delegate_async",
+    );
+
+    let orchestration_dispatcher =
+        Arc::new(RecordingApprovalResolveOrchestrationDispatcher::default());
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    )
+    .with_approval_resolution_orchestration_dispatcher(orchestration_dispatcher.clone());
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-approve-once-orchestration-transcript-outcome",
+        "approve_once",
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            orchestration_dispatcher.as_ref(),
+            None,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(_) => {}
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    let turns = crate::memory::window_direct("root-session", 20, &memory_config)
+        .expect("load root session transcript");
+    let replay_outcome = turns
+        .iter()
+        .find_map(|turn| {
+            let json = serde_json::from_str::<serde_json::Value>(&turn.content).ok()?;
+            if json["type"] == "tool_outcome"
+                && json["turn_id"] == "turn-apr-approve-once-orchestration-transcript-outcome"
+                && json["tool_call_id"] == "call-apr-approve-once-orchestration-transcript-outcome"
+            {
+                Some(json)
+            } else {
+                None
+            }
+        })
+        .expect("replayed orchestration tool should persist a terminal tool_outcome");
+
+    assert_eq!(replay_outcome["outcome"]["status"], "ok");
+    assert_eq!(replay_outcome["outcome"]["governance_allowed"], true);
+    assert_eq!(
+        replay_outcome["outcome"]["governance"]["execution_plane"],
+        "Orchestration"
+    );
+    assert_eq!(
+        replay_outcome["outcome"]["governance"]["audit_label"],
+        "delegate_async"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_replay_outcome_persistence_routes_through_kernel_when_context_provided() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-replay-outcome-kernel-memory");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "timeout_seconds": 60,
+        }),
+    })
+    .expect("append queued child event");
+    seed_pending_approval_request_with_snapshot(
+        &repo,
+        "apr-replay-outcome-kernel-memory",
+        "root-session",
+        "session_cancel",
+        json!({
+            "session_id": "child-session",
+        }),
+        "App",
+    );
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-replay-outcome-kernel-memory",
+        "approve_once",
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (kernel_ctx, _memory_invocations) = build_kernel_context(audit.clone());
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            Some(&kernel_ctx),
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(_) => {}
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    let events = audit.snapshot();
+    let memory_plane_invocations = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                &event.kind,
+                loongclaw_kernel::AuditEventKind::PlaneInvoked {
+                    plane: loongclaw_contracts::ExecutionPlane::Memory,
+                    ..
+                }
+            )
+        })
+        .count();
+    assert!(
+        memory_plane_invocations >= 1,
+        "expected replay outcome persistence to route through kernel memory plane, got events: {events:?}"
+    );
+
+    let captured = _memory_invocations.lock().expect("memory invocations lock");
+    let persisted = captured
+        .iter()
+        .filter(|request| request.operation == "append_turn")
+        .filter_map(|request| {
+            let content = request.payload["content"].as_str()?;
+            serde_json::from_str::<serde_json::Value>(content).ok()
+        })
+        .find(|json| {
+            json["type"] == "tool_outcome"
+                && json["turn_id"] == "turn-apr-replay-outcome-kernel-memory"
+                && json["tool_call_id"] == "call-apr-replay-outcome-kernel-memory"
+        })
+        .expect("expected serialized replay tool_outcome append_turn invocation");
+    assert_eq!(persisted["type"], "tool_outcome");
+    assert_eq!(
+        persisted["turn_id"],
+        "turn-apr-replay-outcome-kernel-memory"
+    );
+    assert_eq!(
+        persisted["tool_call_id"],
+        "call-apr-replay-outcome-kernel-memory"
+    );
+    assert_eq!(persisted["outcome"]["status"], "ok");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_replay_decision_persistence_routes_through_kernel_before_outcome() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-replay-decision-kernel-memory");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "timeout_seconds": 60,
+        }),
+    })
+    .expect("append queued child event");
+    seed_pending_approval_request_with_snapshot(
+        &repo,
+        "apr-replay-decision-kernel-memory",
+        "root-session",
+        "session_cancel",
+        json!({
+            "session_id": "child-session",
+        }),
+        "App",
+    );
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-replay-decision-kernel-memory",
+        "approve_once",
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (kernel_ctx, memory_invocations) = build_kernel_context(audit);
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            Some(&kernel_ctx),
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(_) => {}
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    let captured = memory_invocations.lock().expect("memory invocations lock");
+    let relevant = captured
+        .iter()
+        .filter(|request| request.operation == "append_turn")
+        .map(|request| {
+            serde_json::from_str::<serde_json::Value>(
+                request.payload["content"]
+                    .as_str()
+                    .expect("kernel append_turn content should be serialized as a string"),
+            )
+            .expect("kernel append_turn content should be valid JSON")
+        })
+        .filter(|json| {
+            json["turn_id"] == "turn-apr-replay-decision-kernel-memory"
+                && json["tool_call_id"] == "call-apr-replay-decision-kernel-memory"
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(relevant.len(), 2, "expected replay decision and outcome");
+    assert_eq!(relevant[0]["type"], "tool_decision");
+    assert_eq!(relevant[1]["type"], "tool_outcome");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resume_once_rejects_replay_decision_persistence_failure_before_execution()
+{
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-replay-decision-kernel-failure");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "timeout_seconds": 60,
+        }),
+    })
+    .expect("append queued child event");
+    seed_pending_approval_request_with_snapshot(
+        &repo,
+        "apr-replay-decision-kernel-failure",
+        "root-session",
+        "session_cancel",
+        json!({
+            "session_id": "child-session",
+        }),
+        "App",
+    );
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-replay-decision-kernel-failure",
+        "approve_once",
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+    let kernel_ctx = build_failing_kernel_context("forced memory failure");
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            Some(&kernel_ctx),
+        )
+        .await;
+
+    match result {
+        TurnResult::ToolError(error) => assert!(
+            error.contains("persist assistant turn via kernel failed"),
+            "expected replay decision persistence failure, got: {error}"
+        ),
+        other => panic!("expected ToolError, got: {other:?}"),
+    }
+
+    let resolved = repo
+        .load_approval_request("apr-replay-decision-kernel-failure")
+        .expect("load approval request")
+        .expect("resolved approval request");
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert!(
+        resolved
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("persist assistant turn via kernel failed")),
+        "expected replay decision persistence last_error, got: {:?}",
+        resolved.last_error
+    );
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session");
+    assert_eq!(child.state, crate::session::repository::SessionState::Ready);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resume_once_records_successful_replay_outcome_persistence_gap_in_last_error(
+) {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-replay-outcome-kernel-failure");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "timeout_seconds": 60,
+        }),
+    })
+    .expect("append queued child event");
+    seed_pending_approval_request_with_snapshot(
+        &repo,
+        "apr-replay-outcome-kernel-failure",
+        "root-session",
+        "session_cancel",
+        json!({
+            "session_id": "child-session",
+        }),
+        "App",
+    );
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-replay-outcome-kernel-failure",
+        "approve_once",
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+    let kernel_ctx = build_fail_after_n_kernel_context(2, "forced outcome persistence failure");
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            Some(&kernel_ctx),
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("\"status\":\"executed\""),
+                "expected executed status in output, got: {text}"
+            );
+            assert!(
+                text.contains("persist assistant turn via kernel failed"),
+                "expected durable replay outcome persistence warning in output, got: {text}"
+            );
+            assert!(
+                text.contains("\"execution_evidence\":{"),
+                "expected execution_evidence in output, got: {text}"
+            );
+            assert!(
+                text.contains("\"evidence_complete\":false"),
+                "expected incomplete execution evidence in output, got: {text}"
+            );
+        }
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    let resolved = repo
+        .load_approval_request("apr-replay-outcome-kernel-failure")
+        .expect("load approval request")
+        .expect("resolved approval request");
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert!(
+        resolved
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("persist assistant turn via kernel failed")),
+        "expected replay outcome persistence last_error, got: {:?}",
+        resolved.last_error
+    );
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+
+    let events = repo
+        .list_recent_events("root-session", 20)
+        .expect("list approval events");
     assert!(events
         .iter()
         .any(|event| event.event_kind == "tool_approval_execution_finished"));
@@ -8700,6 +9719,125 @@ async fn approval_request_resume_once_records_execution_failure_and_last_error()
     assert!(events
         .iter()
         .any(|event| event.event_kind == "tool_approval_execution_failed"));
+
+    let turns = crate::memory::window_direct("root-session", 20, &memory_config)
+        .expect("load root session transcript");
+    let replay_outcome = turns
+        .iter()
+        .find_map(|turn| {
+            let json = serde_json::from_str::<serde_json::Value>(&turn.content).ok()?;
+            if json["type"] == "tool_outcome"
+                && json["turn_id"] == "turn-apr-approve-once-failure"
+                && json["tool_call_id"] == "call-apr-approve-once-failure"
+            {
+                Some(json)
+            } else {
+                None
+            }
+        })
+        .expect("failed replay should persist a terminal tool_outcome");
+    assert_eq!(replay_outcome["outcome"]["status"], "error");
+    assert_eq!(replay_outcome["outcome"]["error_code"], "tool_error");
+    assert!(
+        replay_outcome["outcome"]["human_reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("session_cancel_not_cancellable")),
+        "expected persisted failure reason, got: {replay_outcome}"
+    );
+    assert_eq!(replay_outcome["outcome"]["governance_allowed"], true);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resume_once_records_failure_outcome_persistence_gap_in_last_error() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-replay-failure-outcome-kernel-failure");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create child session");
+    seed_pending_approval_request_with_snapshot(
+        &repo,
+        "apr-replay-failure-outcome-kernel-failure",
+        "root-session",
+        "session_cancel",
+        json!({
+            "session_id": "child-session",
+        }),
+        "App",
+    );
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-replay-failure-outcome-kernel-failure",
+        "approve_once",
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+    let kernel_ctx =
+        build_fail_after_n_kernel_context(2, "forced failure outcome persistence failure");
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            Some(&kernel_ctx),
+        )
+        .await;
+
+    match result {
+        TurnResult::ToolError(error) => assert!(
+            error.contains("session_cancel_not_cancellable"),
+            "expected original tool failure, got: {error}"
+        ),
+        other => panic!("expected ToolError, got: {other:?}"),
+    }
+
+    let resolved = repo
+        .load_approval_request("apr-replay-failure-outcome-kernel-failure")
+        .expect("load approval request")
+        .expect("resolved approval request");
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert!(
+        resolved.last_error.as_deref().is_some_and(|error| {
+            error.contains("session_cancel_not_cancellable")
+                && error.contains("persist assistant turn via kernel failed")
+        }),
+        "expected original failure plus persistence gap in last_error, got: {:?}",
+        resolved.last_error
+    );
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -9448,6 +10586,88 @@ fn build_kernel_context(
     (ctx, invocations)
 }
 
+fn build_failing_kernel_context(message: &str) -> KernelContext {
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(
+        StaticPolicyEngine::default(),
+        clock,
+        Arc::new(InMemoryAuditSink::default()),
+    );
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::MemoryWrite, Capability::MemoryRead]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+
+    let adapter = FailingTestMemoryAdapter {
+        message: message.to_owned(),
+    };
+    kernel.register_core_memory_adapter(adapter);
+    kernel
+        .set_default_core_memory_adapter("test-memory-failing")
+        .expect("set default memory adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+
+    KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    }
+}
+
+fn build_fail_after_n_kernel_context(fail_on_call: usize, message: &str) -> KernelContext {
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(
+        StaticPolicyEngine::default(),
+        clock,
+        Arc::new(InMemoryAuditSink::default()),
+    );
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::MemoryWrite, Capability::MemoryRead]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+
+    let adapter = FailAfterNTestMemoryAdapter {
+        fail_on_call,
+        calls: Arc::new(Mutex::new(0)),
+        message: message.to_owned(),
+    };
+    kernel.register_core_memory_adapter(adapter);
+    kernel
+        .set_default_core_memory_adapter("test-memory-fail-after-n")
+        .expect("set default memory adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+
+    KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    }
+}
+
 struct SharedTestMemoryAdapter {
     invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
 }
@@ -9466,6 +10686,52 @@ impl CoreMemoryAdapter for SharedTestMemoryAdapter {
             .lock()
             .expect("invocations lock")
             .push(request);
+        Ok(MemoryCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({}),
+        })
+    }
+}
+
+struct FailingTestMemoryAdapter {
+    message: String,
+}
+
+#[async_trait]
+impl CoreMemoryAdapter for FailingTestMemoryAdapter {
+    fn name(&self) -> &str {
+        "test-memory-failing"
+    }
+
+    async fn execute_core_memory(
+        &self,
+        _request: MemoryCoreRequest,
+    ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
+        Err(MemoryPlaneError::Execution(self.message.clone()))
+    }
+}
+
+struct FailAfterNTestMemoryAdapter {
+    fail_on_call: usize,
+    calls: Arc<Mutex<usize>>,
+    message: String,
+}
+
+#[async_trait]
+impl CoreMemoryAdapter for FailAfterNTestMemoryAdapter {
+    fn name(&self) -> &str {
+        "test-memory-fail-after-n"
+    }
+
+    async fn execute_core_memory(
+        &self,
+        _request: MemoryCoreRequest,
+    ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
+        let mut calls = self.calls.lock().expect("memory calls lock");
+        *calls += 1;
+        if *calls == self.fail_on_call {
+            return Err(MemoryPlaneError::Execution(self.message.clone()));
+        }
         Ok(MemoryCoreOutcome {
             status: "ok".to_owned(),
             payload: json!({}),

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8544,6 +8544,11 @@ async fn approval_request_resume_once_executes_blocked_app_tool_and_marks_reques
 
     match result {
         TurnResult::FinalText(text) => {
+            let payload = text
+                .strip_prefix("[ok] ")
+                .expect("approval resolve output should use [ok] envelope");
+            let json: Value = serde_json::from_str(payload)
+                .expect("approval resolve output should be valid json");
             assert!(
                 text.contains("\"approval_request_id\":\"apr-approve-once-success\""),
                 "expected approval request id in output, got: {text}"
@@ -8561,8 +8566,16 @@ async fn approval_request_resume_once_executes_blocked_app_tool_and_marks_reques
                 "expected execution_evidence in output, got: {text}"
             );
             assert!(
+                text.contains("\"execution_integrity\":{"),
+                "expected execution_integrity in output, got: {text}"
+            );
+            assert!(
                 text.contains("\"evidence_complete\":true"),
                 "expected complete execution evidence in output, got: {text}"
+            );
+            assert_eq!(
+                json["approval_request"]["execution_integrity"]["status"],
+                "complete"
             );
         }
         other => panic!("expected FinalText, got: {other:?}"),
@@ -9565,6 +9578,11 @@ async fn approval_request_resume_once_records_successful_replay_outcome_persiste
 
     match result {
         TurnResult::FinalText(text) => {
+            let payload = text
+                .strip_prefix("[ok] ")
+                .expect("approval resolve output should use [ok] envelope");
+            let json: Value = serde_json::from_str(payload)
+                .expect("approval resolve output should be valid json");
             assert!(
                 text.contains("\"status\":\"executed\""),
                 "expected executed status in output, got: {text}"
@@ -9578,8 +9596,16 @@ async fn approval_request_resume_once_records_successful_replay_outcome_persiste
                 "expected execution_evidence in output, got: {text}"
             );
             assert!(
+                text.contains("\"execution_integrity\":{"),
+                "expected execution_integrity in output, got: {text}"
+            );
+            assert!(
                 text.contains("\"evidence_complete\":false"),
                 "expected incomplete execution evidence in output, got: {text}"
+            );
+            assert_eq!(
+                json["approval_request"]["execution_integrity"]["status"],
+                "incomplete"
             );
         }
         other => panic!("expected FinalText, got: {other:?}"),

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8335,6 +8335,11 @@ async fn approval_request_resolve_deny_transitions_request_and_emits_event() {
 
     match result {
         TurnResult::FinalText(text) => {
+            let payload = text
+                .strip_prefix("[ok] ")
+                .expect("approval resolve output should use [ok] envelope");
+            let json: Value = serde_json::from_str(payload)
+                .expect("approval resolve output should be valid json");
             assert!(
                 text.contains("\"approval_request_id\":\"apr-deny\""),
                 "expected approval request id in output, got: {text}"
@@ -8343,6 +8348,14 @@ async fn approval_request_resolve_deny_transitions_request_and_emits_event() {
                 text.contains("\"status\":\"denied\""),
                 "expected denied status in output, got: {text}"
             );
+            assert_eq!(json["resolution"]["decision"], "deny");
+            assert_eq!(json["resolution"]["request_status"], "denied");
+            assert_eq!(json["resolution"]["replay_attempted"], false);
+            assert_eq!(json["resolution"]["replay_result"], "not_attempted");
+            assert_eq!(json["resolution"]["integrity_status"], "not_started");
+            assert_eq!(json["resolution"]["needs_attention"], false);
+            assert_eq!(json["resolution"]["attention_reason"], Value::Null);
+            assert_eq!(json["resolution"]["recommended_action"], Value::Null);
         }
         other => panic!("expected FinalText, got: {other:?}"),
     }
@@ -8577,6 +8590,14 @@ async fn approval_request_resume_once_executes_blocked_app_tool_and_marks_reques
                 json["approval_request"]["execution_integrity"]["status"],
                 "complete"
             );
+            assert_eq!(json["resolution"]["decision"], "approve_once");
+            assert_eq!(json["resolution"]["request_status"], "executed");
+            assert_eq!(json["resolution"]["replay_attempted"], true);
+            assert_eq!(json["resolution"]["replay_result"], "completed_cleanly");
+            assert_eq!(json["resolution"]["integrity_status"], "complete");
+            assert_eq!(json["resolution"]["needs_attention"], false);
+            assert_eq!(json["resolution"]["attention_reason"], Value::Null);
+            assert_eq!(json["resolution"]["recommended_action"], Value::Null);
         }
         other => panic!("expected FinalText, got: {other:?}"),
     }
@@ -9606,6 +9627,20 @@ async fn approval_request_resume_once_records_successful_replay_outcome_persiste
             assert_eq!(
                 json["approval_request"]["execution_integrity"]["status"],
                 "incomplete"
+            );
+            assert_eq!(json["resolution"]["decision"], "approve_once");
+            assert_eq!(json["resolution"]["request_status"], "executed");
+            assert_eq!(json["resolution"]["replay_attempted"], true);
+            assert_eq!(
+                json["resolution"]["replay_result"],
+                "completed_with_attention"
+            );
+            assert_eq!(json["resolution"]["integrity_status"], "incomplete");
+            assert_eq!(json["resolution"]["needs_attention"], true);
+            assert_eq!(json["resolution"]["attention_reason"], "integrity_gap");
+            assert_eq!(
+                json["resolution"]["recommended_action"],
+                "inspect_replay_persistence"
             );
         }
         other => panic!("expected FinalText, got: {other:?}"),

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+#[cfg(feature = "memory-sqlite")]
+use std::{fs, path::PathBuf};
 
 use async_trait::async_trait;
 use loongclaw_contracts::{Capability, ExecutionRoute, HarnessKind, MemoryPlaneError};
@@ -8,277 +10,131 @@ use loongclaw_kernel::{
     CoreMemoryAdapter, FixedClock, InMemoryAuditSink, LoongClawKernel, MemoryCoreOutcome,
     MemoryCoreRequest, StaticPolicyEngine, VerticalPackManifest,
 };
-use serde_json::{Value, json};
+#[cfg(feature = "memory-sqlite")]
+use rusqlite::Connection;
+use serde_json::{json, Value};
+use tokio::sync::{oneshot, Notify};
+use tokio::time::sleep;
 
 use super::super::config::{
-    CliChannelConfig, ConversationConfig, ExternalSkillsConfig, FeishuChannelConfig,
-    LoongClawConfig, MemoryConfig, ProviderConfig, TelegramChannelConfig, ToolConfig,
+    CliChannelConfig, ConversationConfig, FeishuChannelConfig, LoongClawConfig, MemoryConfig,
+    ProviderConfig, TelegramChannelConfig, ToolConfig,
 };
 use super::persistence::format_provider_error_reply;
 use super::runtime::DefaultConversationRuntime;
 use super::*;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::SessionRepository;
 use crate::CliResult;
 use crate::KernelContext;
-use crate::acp::{
-    ACP_TURN_METADATA_ACK_CURSOR, ACP_TURN_METADATA_ROUTING_INTENT,
-    ACP_TURN_METADATA_SOURCE_MESSAGE_ID, ACP_TURN_METADATA_TRACE_ID, AcpBackendMetadata,
-    AcpCapability, AcpConversationTurnOptions, AcpRoutingIntent, AcpRuntimeBackend,
-    AcpSessionBootstrap, AcpSessionHandle, AcpSessionState, AcpTurnEventSink, AcpTurnProvenance,
-    AcpTurnRequest, AcpTurnResult, AcpTurnStopReason, register_acp_backend,
-};
-use crate::memory::MEMORY_OP_WINDOW;
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Default)]
+struct FakeAsyncDelegateSpawner {
+    requests: Arc<Mutex<Vec<crate::conversation::turn_engine::AsyncDelegateSpawnRequest>>>,
+    spawn_error: Option<String>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl crate::conversation::turn_engine::AsyncDelegateSpawner for FakeAsyncDelegateSpawner {
+    async fn spawn(
+        &self,
+        request: crate::conversation::turn_engine::AsyncDelegateSpawnRequest,
+    ) -> Result<(), String> {
+        self.requests
+            .lock()
+            .expect("async delegate requests lock")
+            .push(request);
+        match &self.spawn_error {
+            Some(error) => Err(error.clone()),
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct PanicAsyncDelegateSpawner;
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl crate::conversation::turn_engine::AsyncDelegateSpawner for PanicAsyncDelegateSpawner {
+    async fn spawn(
+        &self,
+        _request: crate::conversation::turn_engine::AsyncDelegateSpawnRequest,
+    ) -> Result<(), String> {
+        panic!("panic-async-spawn");
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct GatedFakeAsyncDelegateSpawner {
+    requests: Arc<Mutex<Vec<crate::conversation::turn_engine::AsyncDelegateSpawnRequest>>>,
+    request_tx:
+        Mutex<Option<oneshot::Sender<crate::conversation::turn_engine::AsyncDelegateSpawnRequest>>>,
+    release_notify: Arc<Notify>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl GatedFakeAsyncDelegateSpawner {
+    fn new() -> (
+        Self,
+        oneshot::Receiver<crate::conversation::turn_engine::AsyncDelegateSpawnRequest>,
+        Arc<Notify>,
+    ) {
+        let (request_tx, request_rx) = oneshot::channel();
+        let release_notify = Arc::new(Notify::new());
+        (
+            Self {
+                requests: Arc::new(Mutex::new(Vec::new())),
+                request_tx: Mutex::new(Some(request_tx)),
+                release_notify: release_notify.clone(),
+            },
+            request_rx,
+            release_notify,
+        )
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl crate::conversation::turn_engine::AsyncDelegateSpawner for GatedFakeAsyncDelegateSpawner {
+    async fn spawn(
+        &self,
+        request: crate::conversation::turn_engine::AsyncDelegateSpawnRequest,
+    ) -> Result<(), String> {
+        self.requests
+            .lock()
+            .expect("async delegate requests lock")
+            .push(request.clone());
+        let request_tx = self
+            .request_tx
+            .lock()
+            .expect("async delegate request sender lock")
+            .take()
+            .expect("single gated async delegate request sender");
+        request_tx
+            .send(request)
+            .expect("gated async delegate request receiver");
+        self.release_notify.notified().await;
+        Ok(())
+    }
+}
 
 struct FakeRuntime {
     seed_messages: Vec<Value>,
+    tool_view: crate::tools::ToolView,
     completion_responses: Mutex<VecDeque<Result<String, String>>>,
     turn_responses: Mutex<VecDeque<Result<ProviderTurn, String>>>,
-    compact_result: Result<(), String>,
     persisted: Mutex<Vec<(String, String, String)>>,
-    bootstrap_calls: Mutex<Vec<String>>,
-    ingested_messages: Mutex<Vec<(String, Value)>>,
     requested_messages: Mutex<Vec<Value>>,
     turn_requested_messages: Mutex<Vec<Vec<Value>>>,
+    built_tool_views: Mutex<Vec<crate::tools::ToolView>>,
+    turn_requested_tool_views: Mutex<Vec<crate::tools::ToolView>>,
     completion_requested_messages: Mutex<Vec<Vec<Value>>>,
+    turn_delays: Mutex<VecDeque<Duration>>,
     completion_calls: Mutex<usize>,
     turn_calls: Mutex<usize>,
-    after_turn_calls: Mutex<Vec<(String, String, String, usize)>>,
-    compact_calls: Mutex<Vec<(String, usize)>>,
-}
-
-struct StubContextEngine;
-struct StubEnvContextEngine;
-struct StubSystemPromptAdditionEngine;
-struct RecordingLifecycleContextEngine {
-    calls: Arc<Mutex<Vec<String>>>,
-}
-
-#[derive(Default)]
-struct RoutedAcpState {
-    ensure_calls: usize,
-    turn_calls: usize,
-    last_bootstrap: Option<AcpSessionBootstrap>,
-    last_request: Option<AcpTurnRequest>,
-}
-
-struct RoutedAcpBackend {
-    id: &'static str,
-    shared: Arc<Mutex<RoutedAcpState>>,
-    fail_turn: bool,
-    emitted_events: Vec<Value>,
-}
-
-#[derive(Default)]
-struct RecordingAcpEventSink {
-    events: Mutex<Vec<Value>>,
-}
-
-impl RecordingAcpEventSink {
-    fn snapshot(&self) -> Vec<Value> {
-        self.events
-            .lock()
-            .expect("recording ACP event sink lock")
-            .clone()
-    }
-}
-
-impl AcpTurnEventSink for RecordingAcpEventSink {
-    fn on_event(&self, event: &Value) -> CliResult<()> {
-        self.events
-            .lock()
-            .expect("recording ACP event sink lock")
-            .push(event.clone());
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl ConversationContextEngine for StubContextEngine {
-    fn id(&self) -> &'static str {
-        "stub-context-engine"
-    }
-
-    async fn assemble_messages(
-        &self,
-        _config: &LoongClawConfig,
-        _session_id: &str,
-        _include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
-    ) -> CliResult<Vec<Value>> {
-        Ok(vec![json!({
-            "role": "system",
-            "content": "stub-context-engine",
-        })])
-    }
-}
-
-#[async_trait]
-impl ConversationContextEngine for StubEnvContextEngine {
-    fn id(&self) -> &'static str {
-        "stub-env-context-engine"
-    }
-
-    async fn assemble_messages(
-        &self,
-        _config: &LoongClawConfig,
-        _session_id: &str,
-        _include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
-    ) -> CliResult<Vec<Value>> {
-        Ok(vec![json!({
-            "role": "system",
-            "content": "stub-env-context-engine",
-        })])
-    }
-}
-
-#[async_trait]
-impl ConversationContextEngine for StubSystemPromptAdditionEngine {
-    fn id(&self) -> &'static str {
-        "stub-system-prompt-addition"
-    }
-
-    fn metadata(&self) -> ContextEngineMetadata {
-        ContextEngineMetadata::new(self.id(), [ContextEngineCapability::SystemPromptAddition])
-    }
-
-    async fn assemble_context(
-        &self,
-        _config: &LoongClawConfig,
-        _session_id: &str,
-        _include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
-    ) -> CliResult<AssembledConversationContext> {
-        Ok(AssembledConversationContext {
-            messages: vec![json!({
-                "role": "system",
-                "content": "base-system-prompt",
-            })],
-            estimated_tokens: Some(42),
-            system_prompt_addition: Some("runtime-policy-addition".to_owned()),
-        })
-    }
-
-    async fn assemble_messages(
-        &self,
-        _config: &LoongClawConfig,
-        _session_id: &str,
-        _include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
-    ) -> CliResult<Vec<Value>> {
-        Ok(vec![json!({
-            "role": "system",
-            "content": "base-system-prompt",
-        })])
-    }
-}
-
-#[async_trait]
-impl ConversationContextEngine for RecordingLifecycleContextEngine {
-    fn id(&self) -> &'static str {
-        "recording-lifecycle-context-engine"
-    }
-
-    async fn bootstrap(
-        &self,
-        _config: &LoongClawConfig,
-        session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
-    ) -> CliResult<ContextEngineBootstrapResult> {
-        self.calls
-            .lock()
-            .expect("recording context engine lock")
-            .push(format!("bootstrap:{session_id}"));
-        Ok(ContextEngineBootstrapResult {
-            bootstrapped: true,
-            imported_messages: Some(0),
-            reason: None,
-        })
-    }
-
-    async fn ingest(
-        &self,
-        session_id: &str,
-        message: &Value,
-        _kernel_ctx: Option<&KernelContext>,
-    ) -> CliResult<ContextEngineIngestResult> {
-        let role = message
-            .get("role")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown");
-        self.calls
-            .lock()
-            .expect("recording context engine lock")
-            .push(format!("ingest:{session_id}:{role}"));
-        Ok(ContextEngineIngestResult { ingested: true })
-    }
-
-    async fn prepare_subagent_spawn(
-        &self,
-        parent_session_id: &str,
-        subagent_session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
-    ) -> CliResult<()> {
-        self.calls
-            .lock()
-            .expect("recording context engine lock")
-            .push(format!(
-                "prepare_subagent_spawn:{parent_session_id}:{subagent_session_id}"
-            ));
-        Ok(())
-    }
-
-    async fn on_subagent_ended(
-        &self,
-        parent_session_id: &str,
-        subagent_session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
-    ) -> CliResult<()> {
-        self.calls
-            .lock()
-            .expect("recording context engine lock")
-            .push(format!(
-                "on_subagent_ended:{parent_session_id}:{subagent_session_id}"
-            ));
-        Ok(())
-    }
-
-    async fn assemble_messages(
-        &self,
-        _config: &LoongClawConfig,
-        _session_id: &str,
-        _include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
-    ) -> CliResult<Vec<Value>> {
-        Ok(Vec::new())
-    }
-}
-
-fn context_engine_env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
-
-struct ScopedEnvVar {
-    previous: Option<Option<String>>,
-}
-
-impl ScopedEnvVar {
-    fn set(key: &'static str, value: &str) -> Self {
-        assert_eq!(key, CONTEXT_ENGINE_ENV, "unexpected scoped env key");
-        let previous = Some(super::context_engine_registry::context_engine_id_from_env());
-        super::context_engine_registry::set_context_engine_env_override(Some(value));
-        Self { previous }
-    }
-}
-
-impl Drop for ScopedEnvVar {
-    fn drop(&mut self) {
-        if let Some(previous) = self.previous.as_ref() {
-            super::context_engine_registry::set_context_engine_env_override(previous.as_deref());
-        } else {
-            super::context_engine_registry::clear_context_engine_env_override();
-        }
-    }
 }
 
 impl FakeRuntime {
@@ -304,6 +160,10 @@ impl FakeRuntime {
         Self::with_turns_and_completions(seed_messages, vec![turn], vec![completion])
     }
 
+    fn with_turns(seed_messages: Vec<Value>, turns: Vec<Result<ProviderTurn, String>>) -> Self {
+        Self::with_turns_and_completions(seed_messages, turns, Vec::new())
+    }
+
     fn with_turns_and_completions(
         seed_messages: Vec<Value>,
         turns: Vec<Result<ProviderTurn, String>>,
@@ -311,181 +171,68 @@ impl FakeRuntime {
     ) -> Self {
         Self {
             seed_messages,
+            tool_view: crate::tools::runtime_tool_view(),
             completion_responses: Mutex::new(VecDeque::from(completions)),
             turn_responses: Mutex::new(VecDeque::from(turns)),
-            compact_result: Ok(()),
             persisted: Mutex::new(Vec::new()),
-            bootstrap_calls: Mutex::new(Vec::new()),
-            ingested_messages: Mutex::new(Vec::new()),
             requested_messages: Mutex::new(Vec::new()),
             turn_requested_messages: Mutex::new(Vec::new()),
+            built_tool_views: Mutex::new(Vec::new()),
+            turn_requested_tool_views: Mutex::new(Vec::new()),
             completion_requested_messages: Mutex::new(Vec::new()),
+            turn_delays: Mutex::new(VecDeque::new()),
             completion_calls: Mutex::new(0),
             turn_calls: Mutex::new(0),
-            after_turn_calls: Mutex::new(Vec::new()),
-            compact_calls: Mutex::new(Vec::new()),
         }
     }
+
+    fn with_tool_view(mut self, tool_view: crate::tools::ToolView) -> Self {
+        self.tool_view = tool_view;
+        self
+    }
+
+    fn with_turn_delays(self, delays: Vec<Duration>) -> Self {
+        let runtime = self;
+        *runtime.turn_delays.lock().expect("turn delays lock") = VecDeque::from(delays);
+        runtime
+    }
 }
 
-fn unique_acp_test_id(prefix: &str, suffix: &str) -> String {
-    format!(
-        "{prefix}-{suffix}-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos()
-    )
+struct PanicRuntime {
+    tool_view: crate::tools::ToolView,
 }
 
-fn register_routed_acp_backend(
-    suffix: &str,
-    fail_turn: bool,
-) -> (&'static str, Arc<Mutex<RoutedAcpState>>) {
-    register_routed_acp_backend_with_events(suffix, fail_turn, Vec::new())
-}
-
-fn register_routed_acp_backend_with_events(
-    suffix: &str,
-    fail_turn: bool,
-    emitted_events: Vec<Value>,
-) -> (&'static str, Arc<Mutex<RoutedAcpState>>) {
-    let backend_id: &'static str =
-        Box::leak(unique_acp_test_id("conversation-acp-backend", suffix).into_boxed_str());
-    let shared = Arc::new(Mutex::new(RoutedAcpState::default()));
-    register_acp_backend(backend_id, {
-        let shared = shared.clone();
-        move || {
-            Box::new(RoutedAcpBackend {
-                id: backend_id,
-                shared: shared.clone(),
-                fail_turn,
-                emitted_events: emitted_events.clone(),
-            })
+impl PanicRuntime {
+    fn new() -> Self {
+        Self {
+            tool_view: crate::tools::runtime_tool_view(),
         }
-    })
-    .expect("register routed ACP backend");
-    (backend_id, shared)
-}
-
-fn unique_acp_sqlite_path(suffix: &str) -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "{}.sqlite3",
-            unique_acp_test_id("conversation-acp", suffix)
-        ))
-        .display()
-        .to_string()
-}
-
-#[async_trait]
-impl AcpRuntimeBackend for RoutedAcpBackend {
-    fn id(&self) -> &'static str {
-        self.id
-    }
-
-    fn metadata(&self) -> AcpBackendMetadata {
-        AcpBackendMetadata::new(
-            self.id(),
-            [
-                AcpCapability::SessionLifecycle,
-                AcpCapability::TurnExecution,
-            ],
-            "Conversation ACP routing test backend",
-        )
-    }
-
-    async fn ensure_session(
-        &self,
-        _config: &LoongClawConfig,
-        request: &AcpSessionBootstrap,
-    ) -> CliResult<AcpSessionHandle> {
-        let mut guard = self.shared.lock().expect("routed ACP state lock");
-        guard.ensure_calls += 1;
-        guard.last_bootstrap = Some(request.clone());
-        Ok(AcpSessionHandle {
-            session_key: request.session_key.clone(),
-            backend_id: self.id().to_owned(),
-            runtime_session_name: format!("routed-{}", request.session_key),
-            working_directory: None,
-            backend_session_id: Some(format!("backend-{}", request.session_key)),
-            agent_session_id: Some(format!("agent-{}", request.session_key)),
-            binding: request.binding.clone(),
-        })
-    }
-
-    async fn run_turn(
-        &self,
-        _config: &LoongClawConfig,
-        _session: &AcpSessionHandle,
-        request: &AcpTurnRequest,
-    ) -> CliResult<AcpTurnResult> {
-        let mut guard = self.shared.lock().expect("routed ACP state lock");
-        guard.turn_calls += 1;
-        guard.last_request = Some(request.clone());
-        if self.fail_turn {
-            return Err("synthetic ACP routing failure".to_owned());
-        }
-        Ok(AcpTurnResult {
-            output_text: format!("acp: {}", request.input),
-            state: AcpSessionState::Ready,
-            usage: None,
-            events: self.emitted_events.clone(),
-            stop_reason: Some(AcpTurnStopReason::Completed),
-        })
-    }
-
-    async fn cancel(
-        &self,
-        _config: &LoongClawConfig,
-        _session: &AcpSessionHandle,
-    ) -> CliResult<()> {
-        Ok(())
-    }
-
-    async fn close(&self, _config: &LoongClawConfig, _session: &AcpSessionHandle) -> CliResult<()> {
-        Ok(())
     }
 }
 
 #[async_trait]
 impl ConversationRuntime for FakeRuntime {
-    async fn bootstrap(
+    fn tool_view(
         &self,
         _config: &LoongClawConfig,
-        session_id: &str,
+        _session_id: &str,
         _kernel_ctx: Option<&KernelContext>,
-    ) -> CliResult<ContextEngineBootstrapResult> {
-        self.bootstrap_calls
-            .lock()
-            .expect("bootstrap lock")
-            .push(session_id.to_owned());
-        Ok(ContextEngineBootstrapResult {
-            bootstrapped: true,
-            imported_messages: Some(0),
-            reason: None,
-        })
+    ) -> CliResult<crate::tools::ToolView> {
+        Ok(self.tool_view.clone())
     }
 
-    async fn ingest(
-        &self,
-        session_id: &str,
-        message: &Value,
-        _kernel_ctx: Option<&KernelContext>,
-    ) -> CliResult<ContextEngineIngestResult> {
-        self.ingested_messages
-            .lock()
-            .expect("ingest lock")
-            .push((session_id.to_owned(), message.clone()));
-        Ok(ContextEngineIngestResult { ingested: true })
-    }
-    async fn build_messages(
+    fn build_messages(
         &self,
         _config: &LoongClawConfig,
         _session_id: &str,
         _include_system_prompt: bool,
+        tool_view: &crate::tools::ToolView,
         _kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<Vec<Value>> {
+        self.built_tool_views
+            .lock()
+            .expect("built tool views lock")
+            .push(tool_view.clone());
         Ok(self.seed_messages.clone())
     }
 
@@ -493,7 +240,6 @@ impl ConversationRuntime for FakeRuntime {
         &self,
         _config: &LoongClawConfig,
         messages: &[Value],
-        _kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<String> {
         let mut calls = self.completion_calls.lock().expect("completion calls lock");
         *calls += 1;
@@ -502,20 +248,29 @@ impl ConversationRuntime for FakeRuntime {
             .lock()
             .expect("completion request lock")
             .push(messages.to_vec());
-        drop(calls);
         self.completion_responses
             .lock()
             .expect("completion response lock")
             .pop_front()
             .unwrap_or_else(|| Err("unexpected_completion_call".to_owned()))
+            .map_err(|error| error.to_owned())
     }
 
     async fn request_turn(
         &self,
         _config: &LoongClawConfig,
         messages: &[Value],
-        _kernel_ctx: Option<&KernelContext>,
+        tool_view: &crate::tools::ToolView,
     ) -> CliResult<ProviderTurn> {
+        let delay = {
+            self.turn_delays
+                .lock()
+                .expect("turn delays lock")
+                .pop_front()
+        };
+        if let Some(delay) = delay {
+            sleep(delay).await;
+        }
         let mut calls = self.turn_calls.lock().expect("turn calls lock");
         *calls += 1;
         *self.requested_messages.lock().expect("request lock") = messages.to_vec();
@@ -523,12 +278,16 @@ impl ConversationRuntime for FakeRuntime {
             .lock()
             .expect("turn request lock")
             .push(messages.to_vec());
-        drop(calls);
+        self.turn_requested_tool_views
+            .lock()
+            .expect("turn request tool views lock")
+            .push(tool_view.clone());
         self.turn_responses
             .lock()
             .expect("turn response lock")
             .pop_front()
             .unwrap_or_else(|| Err("unexpected_turn_call".to_owned()))
+            .map_err(|error| error.to_owned())
     }
 
     async fn persist_turn(
@@ -545,283 +304,168 @@ impl ConversationRuntime for FakeRuntime {
         ));
         Ok(())
     }
+}
 
-    async fn after_turn(
-        &self,
-        session_id: &str,
-        user_input: &str,
-        assistant_reply: &str,
-        messages: &[Value],
-        _kernel_ctx: Option<&KernelContext>,
-    ) -> CliResult<()> {
-        self.after_turn_calls
-            .lock()
-            .expect("after-turn lock")
-            .push((
-                session_id.to_owned(),
-                user_input.to_owned(),
-                assistant_reply.to_owned(),
-                messages.len(),
-            ));
-        Ok(())
-    }
-
-    async fn compact_context(
+#[async_trait]
+impl ConversationRuntime for PanicRuntime {
+    fn tool_view(
         &self,
         _config: &LoongClawConfig,
-        session_id: &str,
-        messages: &[Value],
+        _session_id: &str,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<crate::tools::ToolView> {
+        Ok(self.tool_view.clone())
+    }
+
+    fn build_messages(
+        &self,
+        _config: &LoongClawConfig,
+        _session_id: &str,
+        _include_system_prompt: bool,
+        _tool_view: &crate::tools::ToolView,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<Vec<Value>> {
+        Ok(Vec::new())
+    }
+
+    async fn request_completion(
+        &self,
+        _config: &LoongClawConfig,
+        _messages: &[Value],
+    ) -> CliResult<String> {
+        Err("unexpected_completion_call".to_owned())
+    }
+
+    async fn request_turn(
+        &self,
+        _config: &LoongClawConfig,
+        _messages: &[Value],
+        _tool_view: &crate::tools::ToolView,
+    ) -> CliResult<ProviderTurn> {
+        panic!("panic-runtime-request-turn");
+    }
+
+    async fn persist_turn(
+        &self,
+        _session_id: &str,
+        _role: &str,
+        _content: &str,
         _kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<()> {
-        self.compact_calls
-            .lock()
-            .expect("compact lock")
-            .push((session_id.to_owned(), messages.len()));
-        self.compact_result.clone()
+        Ok(())
     }
 }
 
 fn test_config() -> LoongClawConfig {
+    let mut tools = ToolConfig::default();
+    // Most conversation tests exercise delegate runtime behavior rather than approval UX.
+    tools.approval.approved_calls =
+        vec!["tool:delegate".to_owned(), "tool:delegate_async".to_owned()];
     LoongClawConfig {
         provider: ProviderConfig::default(),
         cli: CliChannelConfig::default(),
         telegram: TelegramChannelConfig::default(),
         feishu: FeishuChannelConfig::default(),
-        conversation: ConversationConfig::default(),
-        tools: ToolConfig::default(),
-        external_skills: ExternalSkillsConfig::default(),
+        tools,
         memory: MemoryConfig::default(),
-        acp: crate::config::AcpConfig::default(),
+        conversation: ConversationConfig::default(),
     }
 }
 
-#[tokio::test]
-async fn default_runtime_supports_injected_context_engine() {
-    let runtime = DefaultConversationRuntime::with_context_engine(StubContextEngine);
-    let messages = runtime
-        .build_messages(&test_config(), "session-injected", true, None)
-        .await
-        .expect("build messages via injected context engine");
-
-    assert_eq!(messages.len(), 1);
-    assert_eq!(messages[0]["role"], "system");
-    assert_eq!(messages[0]["content"], "stub-context-engine");
+#[cfg(feature = "memory-sqlite")]
+fn isolated_sqlite_path(test_name: &str) -> String {
+    let base = std::env::temp_dir().join(format!(
+        "loongclaw-conversation-tests-{test_name}-{}",
+        std::process::id()
+    ));
+    let _ = fs::create_dir_all(&base);
+    let db_path = base.join("memory.sqlite3");
+    let _ = fs::remove_file(&db_path);
+    db_path.display().to_string()
 }
 
-#[tokio::test]
-async fn default_runtime_can_resolve_context_engine_from_registry() {
-    register_context_engine("stub-registry", || Box::new(StubContextEngine))
-        .expect("register context engine");
-    let runtime = DefaultConversationRuntime::from_engine_id(Some("stub-registry"))
-        .expect("resolve context engine from registry");
-    let messages = runtime
-        .build_messages(&test_config(), "session-registry", true, None)
-        .await
-        .expect("build messages via registry context engine");
-
-    assert_eq!(messages.len(), 1);
-    assert_eq!(messages[0]["content"], "stub-context-engine");
-}
-
-#[tokio::test]
-#[allow(clippy::await_holding_lock)] // env var mutation is process-global; keep lock for full test body.
-async fn default_runtime_prefers_configured_context_engine_when_env_not_set() {
-    let _env_lock = context_engine_env_lock().lock().expect("env lock");
-    register_context_engine("stub-config", || Box::new(StubContextEngine))
-        .expect("register context engine");
-    let _scoped_env = ScopedEnvVar::set(CONTEXT_ENGINE_ENV, "");
-    let mut config = test_config();
-    config.conversation.context_engine = Some("stub-config".to_owned());
-
-    let runtime = DefaultConversationRuntime::from_config_or_env(&config)
-        .expect("resolve context engine from config");
-    let messages = runtime
-        .build_messages(&config, "session-config", true, None)
-        .await
-        .expect("build messages via configured context engine");
-
-    assert_eq!(messages.len(), 1);
-    assert_eq!(messages[0]["content"], "stub-context-engine");
-}
-
-#[test]
-fn default_runtime_exposes_context_engine_metadata() {
-    let runtime = DefaultConversationRuntime::default();
-    let metadata = runtime.context_engine_metadata();
-    assert_eq!(metadata.id, DEFAULT_CONTEXT_ENGINE_ID);
-    assert_eq!(metadata.api_version, CONTEXT_ENGINE_API_VERSION);
-}
-
-#[tokio::test]
-async fn default_runtime_delegates_bootstrap_and_ingest_to_context_engine() {
-    let calls = Arc::new(Mutex::new(Vec::new()));
-    let runtime =
-        DefaultConversationRuntime::with_context_engine(RecordingLifecycleContextEngine {
-            calls: calls.clone(),
-        });
-
-    let bootstrap = runtime
-        .bootstrap(&test_config(), "session-lifecycle", None)
-        .await
-        .expect("bootstrap should delegate to context engine");
-    let ingest = runtime
-        .ingest(
-            "session-lifecycle",
-            &json!({
-                "role": "user",
-                "content": "hello",
-            }),
-            None,
-        )
-        .await
-        .expect("ingest should delegate to context engine");
-
-    assert!(bootstrap.bootstrapped);
-    assert!(ingest.ingested);
-    assert_eq!(
-        calls.lock().expect("recording calls lock").clone(),
-        vec![
-            "bootstrap:session-lifecycle".to_owned(),
-            "ingest:session-lifecycle:user".to_owned(),
-        ]
-    );
-}
-
-#[tokio::test]
-async fn default_runtime_delegates_subagent_lifecycle_to_context_engine() {
-    let calls = Arc::new(Mutex::new(Vec::new()));
-    let runtime =
-        DefaultConversationRuntime::with_context_engine(RecordingLifecycleContextEngine {
-            calls: calls.clone(),
-        });
-
-    runtime
-        .prepare_subagent_spawn("session-parent", "session-child", None)
-        .await
-        .expect("prepare_subagent_spawn should delegate to context engine");
-    runtime
-        .on_subagent_ended("session-parent", "session-child", None)
-        .await
-        .expect("on_subagent_ended should delegate to context engine");
-
-    assert_eq!(
-        calls.lock().expect("recording calls lock").clone(),
-        vec![
-            "prepare_subagent_spawn:session-parent:session-child".to_owned(),
-            "on_subagent_ended:session-parent:session-child".to_owned(),
-        ]
-    );
-}
-
-#[tokio::test]
-async fn default_runtime_build_context_applies_system_prompt_addition() {
-    let runtime = DefaultConversationRuntime::with_context_engine(StubSystemPromptAdditionEngine);
-    let assembled = runtime
-        .build_context(&test_config(), "session-system-addition", true, None)
-        .await
-        .expect("build context with system prompt addition");
-
-    assert_eq!(assembled.estimated_tokens, Some(42));
-    assert_eq!(
-        assembled.system_prompt_addition.as_deref(),
-        Some("runtime-policy-addition")
-    );
-    assert_eq!(assembled.messages.len(), 1);
-    assert_eq!(assembled.messages[0]["role"], "system");
-    let merged = assembled.messages[0]["content"]
-        .as_str()
-        .expect("system prompt should stay string");
-    assert_eq!(
-        merged, "runtime-policy-addition\n\nbase-system-prompt",
-        "system prompt addition should be prepended"
-    );
-}
-
-#[test]
-fn resolve_context_engine_selection_uses_default_when_unset() {
-    let _env_lock = context_engine_env_lock().lock().expect("env lock");
-    let _scoped_env = ScopedEnvVar::set(CONTEXT_ENGINE_ENV, "");
-    let config = test_config();
-    let selection = resolve_context_engine_selection(&config);
-    assert_eq!(selection.id, DEFAULT_CONTEXT_ENGINE_ID);
-    assert_eq!(selection.source, ContextEngineSelectionSource::Default);
-    assert_eq!(selection.source.as_str(), "default");
-}
-
-#[test]
-fn resolve_context_engine_selection_prefers_env_over_config() {
-    let _env_lock = context_engine_env_lock().lock().expect("env lock");
-    let _scoped_env = ScopedEnvVar::set(CONTEXT_ENGINE_ENV, "stub-env-priority");
-    let mut config = test_config();
-    config.conversation.context_engine = Some("stub-config".to_owned());
-
-    let selection = resolve_context_engine_selection(&config);
-    assert_eq!(selection.id, "stub-env-priority");
-    assert_eq!(selection.source, ContextEngineSelectionSource::Env);
-}
-
-#[test]
-fn resolve_context_engine_selection_uses_config_when_env_missing() {
-    let _env_lock = context_engine_env_lock().lock().expect("env lock");
-    let _scoped_env = ScopedEnvVar::set(CONTEXT_ENGINE_ENV, "");
-    let mut config = test_config();
-    config.conversation.context_engine = Some("legacy".to_owned());
-
-    let selection = resolve_context_engine_selection(&config);
-    assert_eq!(selection.id, "legacy");
-    assert_eq!(selection.source, ContextEngineSelectionSource::Config);
-}
-
-#[test]
-fn collect_context_engine_runtime_snapshot_reports_compaction_and_selection() {
-    let _env_lock = context_engine_env_lock().lock().expect("env lock");
-    let _scoped_env = ScopedEnvVar::set(CONTEXT_ENGINE_ENV, "");
-    let mut config = test_config();
-    config.conversation.compact_enabled = true;
-    config.conversation.compact_min_messages = Some(7);
-    config.conversation.compact_fail_open = false;
-
-    let snapshot = collect_context_engine_runtime_snapshot(&config)
-        .expect("collect context engine runtime snapshot");
-    assert_eq!(snapshot.selected.id, DEFAULT_CONTEXT_ENGINE_ID);
-    assert_eq!(
-        snapshot.selected.source,
-        ContextEngineSelectionSource::Default
-    );
-    assert_eq!(snapshot.selected_metadata.id, DEFAULT_CONTEXT_ENGINE_ID);
-    assert!(
-        snapshot
-            .available
-            .iter()
-            .any(|metadata| metadata.id == DEFAULT_CONTEXT_ENGINE_ID)
-    );
-    assert_eq!(snapshot.compaction.min_messages, Some(7));
-    assert_eq!(snapshot.compaction.trigger_estimated_tokens, None);
-    assert!(!snapshot.compaction.fail_open);
-}
-
-#[tokio::test]
-#[allow(clippy::await_holding_lock)] // env var mutation is process-global; keep lock for full test body.
-async fn default_runtime_prefers_env_context_engine_over_config() {
-    let _env_lock = context_engine_env_lock().lock().expect("env lock");
-    register_context_engine("stub-config-env-priority", || Box::new(StubContextEngine))
-        .expect("register config context engine");
-    register_context_engine("stub-env-priority", || Box::new(StubEnvContextEngine))
-        .expect("register env context engine");
-    let _scoped_env = ScopedEnvVar::set(CONTEXT_ENGINE_ENV, "stub-env-priority");
+#[cfg(feature = "memory-sqlite")]
+fn isolated_test_config(test_name: &str) -> (LoongClawConfig, PathBuf) {
+    let base = std::env::temp_dir().join(format!(
+        "loongclaw-conversation-tests-{test_name}-{}",
+        std::process::id()
+    ));
+    let _ = fs::create_dir_all(&base);
+    let db_path = base.join("memory.sqlite3");
+    let _ = fs::remove_file(&db_path);
 
     let mut config = test_config();
-    config.conversation.context_engine = Some("stub-config-env-priority".to_owned());
+    config.memory.sqlite_path = db_path.display().to_string();
+    (config, db_path)
+}
 
-    let runtime = DefaultConversationRuntime::from_config_or_env(&config)
-        .expect("resolve context engine from env override");
-    let messages = runtime
-        .build_messages(&config, "session-env-priority", true, None)
-        .await
-        .expect("build messages via env-selected context engine");
+#[cfg(feature = "memory-sqlite")]
+fn isolated_approval_request_store(
+    test_name: &str,
+) -> (
+    crate::conversation::turn_engine::SessionRepositoryApprovalRequestStore,
+    crate::memory::runtime_config::MemoryRuntimeConfig,
+) {
+    let sqlite_path = PathBuf::from(isolated_sqlite_path(test_name));
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(sqlite_path),
+    };
+    (
+        crate::conversation::turn_engine::SessionRepositoryApprovalRequestStore::new(
+            memory_config.clone(),
+        ),
+        memory_config,
+    )
+}
 
-    assert_eq!(messages.len(), 1);
-    assert_eq!(messages[0]["content"], "stub-env-context-engine");
+fn expect_needs_approval(
+    result: TurnResult,
+) -> crate::conversation::turn_engine::ApprovalRequirement {
+    match result {
+        TurnResult::NeedsApproval(requirement) => requirement,
+        other => panic!("expected NeedsApproval, got {other:?}"),
+    }
+}
+
+#[cfg(all(feature = "memory-sqlite", feature = "channel-telegram"))]
+fn spawn_telegram_send_server_once() -> (
+    String,
+    std::sync::mpsc::Receiver<String>,
+    std::thread::JoinHandle<()>,
+) {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind telegram stub");
+    let addr = listener.local_addr().expect("telegram stub addr");
+    let (request_tx, request_rx) = std::sync::mpsc::channel();
+    let server = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut request_buf = [0_u8; 8192];
+            let read = stream
+                .read(&mut request_buf)
+                .expect("read telegram request");
+            request_tx
+                .send(String::from_utf8_lossy(&request_buf[..read]).into_owned())
+                .expect("send telegram request capture");
+            let body = serde_json::to_string(&json!({
+                "ok": true,
+                "result": {
+                    "message_id": 1
+                }
+            }))
+            .expect("serialize telegram stub body");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write telegram response");
+        }
+    });
+    (format!("http://{addr}"), request_rx, server)
 }
 
 #[tokio::test]
@@ -830,8 +474,8 @@ async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
         vec![json!({"role": "system", "content": "sys"})],
         Ok("assistant-reply".to_owned()),
     );
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
         .handle_turn_with_runtime(
             &test_config(),
             "session-1",
@@ -844,14 +488,6 @@ async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
         .expect("handle turn success");
 
     assert_eq!(reply, "assistant-reply");
-    assert_eq!(
-        runtime
-            .bootstrap_calls
-            .lock()
-            .expect("bootstrap lock")
-            .as_slice(),
-        ["session-1"]
-    );
 
     let requested = runtime.requested_messages.lock().expect("requested lock");
     assert_eq!(requested.len(), 2);
@@ -876,1368 +512,3417 @@ async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
             "assistant-reply".to_owned(),
         )
     );
-
-    let ingested = runtime
-        .ingested_messages
-        .lock()
-        .expect("ingest lock")
-        .clone();
-    assert_eq!(ingested.len(), 2);
-    assert_eq!(ingested[0].0, "session-1");
-    assert_eq!(ingested[0].1["role"], "user");
-    assert_eq!(ingested[0].1["content"], "hello");
-    assert_eq!(ingested[1].0, "session-1");
-    assert_eq!(ingested[1].1["role"], "assistant");
-    assert_eq!(ingested[1].1["content"], "assistant-reply");
-
-    let after_turn = runtime
-        .after_turn_calls
-        .lock()
-        .expect("after-turn lock")
-        .clone();
-    assert_eq!(after_turn.len(), 1);
-    assert_eq!(after_turn[0].0, "session-1");
-    assert_eq!(after_turn[0].1, "hello");
-    assert_eq!(after_turn[0].2, "assistant-reply");
-    assert_eq!(after_turn[0].3, 3);
-
-    let compact = runtime.compact_calls.lock().expect("compact lock").clone();
-    assert_eq!(compact.len(), 1);
-    assert_eq!(compact[0].0, "session-1");
-    assert_eq!(compact[0].1, 3);
 }
 
+#[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_keeps_provider_path_by_default_when_acp_enabled() {
-    let (backend_id, shared) = register_routed_acp_backend("success", false);
+async fn handle_turn_with_runtime_registers_root_session_metadata() {
     let runtime = FakeRuntime::new(
         vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-normal-path".to_owned()),
+        Ok("assistant-reply".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
     let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.default_agent = Some("claude".to_owned());
-    config.acp.allowed_agents = vec!["claude".to_owned()];
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.bindings_enabled = true;
-    config.acp.dispatch.bootstrap_mcp_servers =
-        vec![" Filesystem ".to_owned(), "filesystem".to_owned()];
-    config.memory.sqlite_path = unique_acp_sqlite_path("success");
+    config.memory.sqlite_path = isolated_sqlite_path("register-root-session");
 
-    let reply = orchestrator
+    let reply = ConversationTurnLoop::new()
         .handle_turn_with_runtime(
             &config,
-            "telegram:42",
-            "hello from channel",
+            "root-session",
+            "hello",
             ProviderErrorMode::Propagate,
             &runtime,
             None,
         )
         .await
-        .expect("default handle_turn should stay on provider path");
+        .expect("handle turn success");
 
-    assert_eq!(reply, "provider-normal-path");
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
-    assert_eq!(shared.lock().expect("ACP shared state").turn_calls, 0);
+    assert_eq!(reply, "assistant-reply");
+
+    let repo = crate::session::repository::SessionRepository::new(
+        &crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+    )
+    .expect("session repository");
+    let session = repo
+        .load_session("root-session")
+        .expect("load session")
+        .expect("session row");
+    assert_eq!(session.kind, crate::session::repository::SessionKind::Root);
+    assert_eq!(session.parent_session_id, None);
+    assert_eq!(
+        session.state,
+        crate::session::repository::SessionState::Ready
+    );
 }
 
+#[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_routes_explicit_acp_turns_through_acp() {
-    let (backend_id, shared) = register_routed_acp_backend("success-explicit", false);
+async fn handle_turn_with_runtime_and_context_registers_child_session_metadata() {
     let runtime = FakeRuntime::new(
         vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-should-not-run".to_owned()),
+        Ok("assistant-reply".to_owned()),
     );
-    let orchestrator = ConversationOrchestrator::new();
     let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.default_agent = Some("claude".to_owned());
-    config.acp.allowed_agents = vec!["claude".to_owned()];
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.bindings_enabled = true;
-    config.acp.dispatch.bootstrap_mcp_servers =
-        vec![" Filesystem ".to_owned(), "filesystem".to_owned()];
-    config.memory.sqlite_path = unique_acp_sqlite_path("success-explicit");
+    config.memory.sqlite_path = isolated_sqlite_path("register-child-session");
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
 
-    let reply = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime_and_context(
             &config,
-            &ConversationSessionAddress::from_session_id("telegram:42"),
-            "hello from channel",
+            &session_context,
+            "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            &AcpConversationTurnOptions {
-                routing_intent: AcpRoutingIntent::Explicit,
-                ..AcpConversationTurnOptions::default()
+            &NoopAppToolDispatcher,
+            &NoopOrchestrationToolDispatcher,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert_eq!(reply, "assistant-reply");
+
+    let repo = crate::session::repository::SessionRepository::new(
+        &crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+    )
+    .expect("session repository");
+    let session = repo
+        .load_session("child-session")
+        .expect("load session")
+        .expect("session row");
+    assert_eq!(
+        session.kind,
+        crate::session::repository::SessionKind::DelegateChild
+    );
+    assert_eq!(session.parent_session_id.as_deref(), Some("root-session"));
+    assert_eq!(
+        session.state,
+        crate::session::repository::SessionState::Ready
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn default_runtime_tool_view_for_resumed_child_session_respects_remaining_depth() {
+    let (mut config, db_path) = isolated_test_config("resumed-child-tool-view");
+    config.tools.delegate.max_depth = 2;
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+
+    let runtime = DefaultConversationRuntime;
+    let child_view = runtime
+        .tool_view(&config, "child-session", None)
+        .expect("child tool view");
+    assert!(child_view.contains("delegate"));
+    assert!(child_view.contains("session_status"));
+    assert!(child_view.contains("sessions_history"));
+    assert!(!child_view.contains("sessions_list"));
+
+    config.tools.delegate.max_depth = 1;
+    let exhausted_view = runtime
+        .tool_view(&config, "child-session", None)
+        .expect("exhausted child tool view");
+    assert!(!exhausted_view.contains("delegate"));
+    assert!(exhausted_view.contains("session_status"));
+    assert!(exhausted_view.contains("sessions_history"));
+    assert!(!exhausted_view.contains("sessions_list"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_self_only_can_read_own_status_via_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("child-self-status");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
             },
             None,
         )
         .await
-        .expect("explicit ACP turn should route through ACP");
+        .expect("child self status outcome");
 
-    assert_eq!(reply, "acp: hello from channel");
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 0);
+    assert_eq!(outcome.payload["session"]["session_id"], "child-session");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_self_only_can_read_own_history_via_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("child-self-history");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create child");
+    crate::memory::append_turn_direct(
+        "child-session",
+        "user",
+        "hello from child",
+        &crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+    )
+    .expect("append child turn");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_history".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "limit": 10
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("child self history outcome");
+
+    let turns = outcome.payload["turns"].as_array().expect("turns array");
+    assert_eq!(turns.len(), 1);
+    assert_eq!(turns[0]["content"], "hello from child");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_hidden_sessions_list_is_rejected_by_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("child-hidden-sessions-list");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_list".to_owned(),
+                payload: json!({}),
+            },
+            None,
+        )
+        .await
+        .expect_err("child should not execute hidden sessions_list");
+
+    assert!(
+        error.contains("tool_not_visible: sessions_list"),
+        "expected tool_not_visible for sessions_list, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_hidden_session_wait_is_rejected_by_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("child-hidden-session-wait");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 10
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("child should not execute hidden session_wait");
+
+    assert!(
+        error.contains("tool_not_visible: session_wait"),
+        "expected tool_not_visible for session_wait, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_hidden_session_recover_is_rejected_by_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("child-hidden-session-recover");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_recover".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("child should not execute hidden session_recover");
+
+    assert!(
+        error.contains("tool_not_visible: session_recover"),
+        "expected tool_not_visible for session_recover, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_hidden_session_cancel_is_rejected_by_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("child-hidden-session-cancel");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_cancel".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("child should not execute hidden session_cancel");
+
+    assert!(
+        error.contains("tool_not_visible: session_cancel"),
+        "expected tool_not_visible for session_cancel, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct CancelRequestingAppToolDispatcher {
+    memory_config: crate::memory::runtime_config::MemoryRuntimeConfig,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl AppToolDispatcher for CancelRequestingAppToolDispatcher {
+    async fn execute_app_tool(
+        &self,
+        session_context: &SessionContext,
+        request: loongclaw_contracts::ToolCoreRequest,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+        if request.tool_name != "session_status" {
+            return Err(format!("unexpected app tool: {}", request.tool_name));
+        }
+        let repo = SessionRepository::new(&self.memory_config)?;
+        repo.transition_session_with_event_if_current(
+            &session_context.session_id,
+            crate::session::repository::TransitionSessionWithEventIfCurrentRequest {
+                expected_state: crate::session::repository::SessionState::Running,
+                next_state: crate::session::repository::SessionState::Running,
+                last_error: None,
+                event_kind: "delegate_cancel_requested".to_owned(),
+                actor_session_id: session_context.parent_session_id.clone(),
+                event_payload_json: json!({
+                    "reference": "running",
+                    "cancel_reason": "operator_requested"
+                }),
+            },
+        )?;
+        Ok(loongclaw_contracts::ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "cancel_requested": true
+            }),
+        })
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_cancel_request_stops_before_next_round() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-cancel");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Inspecting child session".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "session_status".to_owned(),
+                args_json: json!({
+                    "session_id": "child-session"
+                }),
+                source: "provider_tool_call".to_owned(),
+                session_id: "child-session".to_owned(),
+                turn_id: "turn-1".to_owned(),
+                tool_call_id: "call-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        })],
+    );
+
+    let outcome = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &runtime,
+        &CancelRequestingAppToolDispatcher {
+            memory_config: memory_config.clone(),
+        },
+        "child-session",
+        "child task",
+        60,
+        None,
+    )
+    .await
+    .expect("delegate child cancellation outcome");
+
+    assert_eq!(outcome.status, "error");
     assert_eq!(
-        *runtime
-            .completion_calls
+        outcome.payload["error"],
+        "delegate_cancelled: operator_requested"
+    );
+    assert_eq!(
+        *runtime.turn_calls.lock().expect("turn calls lock"),
+        1,
+        "cancel should stop before a second provider round"
+    );
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert_eq!(
+        child.last_error.as_deref(),
+        Some("delegate_cancelled: operator_requested")
+    );
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_cancel_requested"));
+    assert!(event_kinds.contains(&"delegate_cancelled"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "error");
+    assert_eq!(
+        terminal_outcome.payload_json["error"],
+        "delegate_cancelled: operator_requested"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_forged_root_tool_view_still_rejects_hidden_sessions_list() {
+    let (config, db_path) = isolated_test_config("child-forged-root-view-sessions-list");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_list".to_owned(),
+                payload: json!({}),
+            },
+            None,
+        )
+        .await
+        .expect_err("forged child root tool view should not expose sessions_list");
+
+    assert!(
+        error.contains("tool_not_visible: sessions_list"),
+        "expected tool_not_visible for sessions_list, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn depth_exhausted_child_forged_root_tool_view_still_rejects_delegate_async() {
+    let (mut config, db_path) = isolated_test_config("child-forged-root-view-delegate-async");
+    config.tools.delegate.max_depth = 1;
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultOrchestrationToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let error = dispatcher
+        .execute_orchestration_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "delegate_async".to_owned(),
+                payload: json!({
+                    "task": "nested child task",
+                    "timeout_seconds": 5
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("depth exhausted child should not execute forged delegate_async");
+
+    assert!(
+        error.contains("tool_not_visible: delegate_async"),
+        "expected tool_not_visible for delegate_async, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_self_only_cannot_inspect_descendant_status_via_default_dispatcher() {
+    let (mut config, db_path) = isolated_test_config("child-descendant-denied");
+    config.tools.delegate.max_depth = 2;
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create child");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "grandchild-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("child-session".to_owned()),
+        label: Some("Grandchild".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create grandchild");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::delegate_child_tool_view_for_config_with_delegate(&config.tools, true),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "grandchild-session"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("child should not inspect descendant status");
+
+    assert!(
+        error.contains("visibility_denied"),
+        "expected visibility_denied, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_returns_completed_for_terminal_visible_session() {
+    let (config, db_path) = isolated_test_config("session-wait-completed");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create child");
+    repo.upsert_terminal_outcome(
+        "child-session",
+        "ok",
+        json!({
+            "child_session_id": "child-session",
+            "final_output": "done"
+        }),
+    )
+    .expect("upsert terminal outcome");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 50
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["wait_status"], "completed");
+    assert_eq!(outcome.payload["session"]["session_id"], "child-session");
+    assert_eq!(outcome.payload["terminal_outcome_state"], "present");
+    assert!(outcome.payload["terminal_outcome_missing_reason"].is_null());
+    assert_eq!(outcome.payload["terminal_outcome"]["status"], "ok");
+}
+
+#[cfg(all(feature = "memory-sqlite", feature = "channel-telegram"))]
+#[tokio::test]
+async fn sessions_send_delivers_to_known_root_channel_session_without_mutating_transcript() {
+    let (base_url, request_rx, server) = spawn_telegram_send_server_once();
+    let (mut config, db_path) = isolated_test_config("sessions-send-telegram-success");
+    config.tools.messages.enabled = true;
+    config.telegram.enabled = true;
+    config.telegram.bot_token = Some("123456:telegram-test-token".to_owned());
+    config.telegram.bot_token_env = None;
+    config.telegram.base_url = base_url;
+    config.telegram.allowed_chat_ids = vec![123];
+
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "controller-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Controller".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create controller root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "telegram:123".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Telegram Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create telegram root");
+    crate::memory::append_turn_direct("telegram:123", "user", "previous inbound", &memory_config)
+        .expect("append prior transcript turn");
+    let before_turns =
+        crate::memory::window_direct("telegram:123", 10, &memory_config).expect("window turns");
+    let before_summary = repo
+        .load_session_summary("telegram:123")
+        .expect("load target summary before send")
+        .expect("target summary before send");
+
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "controller-root",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:123",
+                    "text": "hello root channel"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("sessions_send outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["tool"], "sessions_send");
+    assert_eq!(outcome.payload["session_id"], "telegram:123");
+    assert_eq!(outcome.payload["channel"], "telegram");
+    assert_eq!(outcome.payload["target"], "123");
+    assert_eq!(outcome.payload["delivery"], "sent");
+    assert_eq!(outcome.payload["text_length"], 18);
+
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("telegram request should be captured");
+    assert!(request.starts_with("POST /bot123456:telegram-test-token/sendMessage "));
+    assert!(request.contains("\"chat_id\":123"));
+    assert!(request.contains("\"text\":\"hello root channel\""));
+
+    let after_turns =
+        crate::memory::window_direct("telegram:123", 10, &memory_config).expect("window turns");
+    assert_eq!(after_turns.len(), before_turns.len());
+    assert_eq!(after_turns[0].role, before_turns[0].role);
+    assert_eq!(after_turns[0].content, before_turns[0].content);
+
+    let after_summary = repo
+        .load_session_summary("telegram:123")
+        .expect("load target summary after send")
+        .expect("target summary after send");
+    assert_eq!(after_summary.turn_count, before_summary.turn_count);
+    assert_eq!(after_summary.state, before_summary.state);
+
+    let events = repo
+        .list_recent_events("telegram:123", 10)
+        .expect("list target events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_kind, "session_message_sent");
+    assert_eq!(
+        events[0].actor_session_id.as_deref(),
+        Some("controller-root")
+    );
+    assert_eq!(events[0].payload_json["channel"], "telegram");
+    assert_eq!(events[0].payload_json["target"], "123");
+    assert_eq!(events[0].payload_json["text_length"], 18);
+    assert_eq!(events[0].payload_json["delivery"], "sent");
+    assert!(events[0].payload_json.get("text").is_none());
+
+    server.join().expect("telegram stub join");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn sessions_send_rejects_unknown_target_session() {
+    let (mut config, db_path) = isolated_test_config("sessions-send-unknown-target");
+    config.tools.messages.enabled = true;
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "controller-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Controller".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create controller root");
+
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "controller-root",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:999",
+                    "text": "hello"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("unknown session target must be rejected");
+
+    assert!(
+        error.contains("session_not_found: `telegram:999`"),
+        "expected session_not_found error, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn sessions_send_rejects_delegate_child_target() {
+    let (mut config, db_path) = isolated_test_config("sessions-send-child-target");
+    config.tools.messages.enabled = true;
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "controller-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Controller".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create controller root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "telegram:123".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("controller-root".to_owned()),
+        label: Some("Pretend Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child target");
+
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "controller-root",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:123",
+                    "text": "hello"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("delegate child target must be rejected");
+
+    assert!(
+        error.contains("sessions_send_not_supported") && error.contains("not a root session"),
+        "expected root-session rejection, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn sessions_send_rejects_target_not_in_channel_allowlist() {
+    let (mut config, db_path) = isolated_test_config("sessions-send-disallowed-target");
+    config.tools.messages.enabled = true;
+    config.telegram.enabled = true;
+    config.telegram.bot_token = Some("123456:telegram-test-token".to_owned());
+    config.telegram.bot_token_env = None;
+    config.telegram.allowed_chat_ids = vec![456];
+
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "controller-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Controller".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create controller root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "telegram:123".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Telegram Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create telegram root");
+
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "controller-root",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:123",
+                    "text": "hello"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("disallowed target must be rejected");
+
+    assert!(
+        error.contains("sessions_send_target_not_allowed"),
+        "expected allowlist rejection, got: {error}"
+    );
+}
+
+#[cfg(all(feature = "memory-sqlite", feature = "channel-telegram"))]
+#[tokio::test]
+async fn sessions_send_materializes_legacy_root_session_before_recording_event() {
+    let (base_url, request_rx, server) = spawn_telegram_send_server_once();
+    let (mut config, db_path) = isolated_test_config("sessions-send-legacy-target");
+    config.tools.messages.enabled = true;
+    config.telegram.enabled = true;
+    config.telegram.bot_token = Some("123456:telegram-test-token".to_owned());
+    config.telegram.bot_token_env = None;
+    config.telegram.base_url = base_url;
+    config.telegram.allowed_chat_ids = vec![123];
+
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "controller-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Controller".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create controller root");
+    crate::memory::append_turn_direct("telegram:123", "user", "legacy inbound", &memory_config)
+        .expect("append legacy transcript turn");
+    assert!(repo
+        .load_session("telegram:123")
+        .expect("load target row before send")
+        .is_none());
+    assert!(repo
+        .load_session_summary_with_legacy_fallback("telegram:123")
+        .expect("load legacy summary")
+        .is_some());
+
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "controller-root",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:123",
+                    "text": "hello legacy"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("legacy target sessions_send outcome");
+
+    assert_eq!(outcome.status, "ok");
+    let target_row = repo
+        .load_session("telegram:123")
+        .expect("load target row after send")
+        .expect("target row should be materialized");
+    assert_eq!(
+        target_row.kind,
+        crate::session::repository::SessionKind::Root
+    );
+
+    let events = repo
+        .list_recent_events("telegram:123", 10)
+        .expect("list target events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_kind, "session_message_sent");
+
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("telegram request should be captured");
+    assert!(request.contains("\"text\":\"hello legacy\""));
+
+    server.join().expect("telegram stub join");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_hidden_sessions_send_is_rejected_by_default_dispatcher() {
+    let (mut config, db_path) = isolated_test_config("child-hidden-sessions-send");
+    config.tools.messages.enabled = true;
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::delegate_child_tool_view_for_config(&config.tools),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:123",
+                    "text": "hello"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("child should not execute hidden sessions_send");
+
+    assert!(
+        error.contains("tool_not_visible: sessions_send"),
+        "expected tool_not_visible for sessions_send, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_times_out_for_non_terminal_session() {
+    let (config, db_path) = isolated_test_config("session-wait-timeout");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 10
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "timeout");
+    assert_eq!(outcome.payload["wait_status"], "timeout");
+    assert_eq!(outcome.payload["session"]["state"], "running");
+    assert_eq!(outcome.payload["terminal_outcome_state"], "not_terminal");
+    assert!(outcome.payload["terminal_outcome_missing_reason"].is_null());
+    assert!(outcome.payload["terminal_outcome"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_batch_returns_mixed_completed_timeout_and_hidden_results() {
+    let (config, db_path) = isolated_test_config("session-wait-batch");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "completed-child".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Completed".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create completed child");
+    repo.upsert_terminal_outcome(
+        "completed-child",
+        "ok",
+        json!({
+            "child_session_id": "completed-child",
+            "final_output": "done"
+        }),
+    )
+    .expect("upsert terminal outcome");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "running-child".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Running".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create running child");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "hidden-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Hidden".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create hidden root");
+
+    let dispatcher = DefaultAppToolDispatcher::new(memory_config, config.tools.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_ids": ["hidden-root", "completed-child", "running-child"],
+                    "timeout_ms": 10
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait batch outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["tool"], "session_wait");
+    assert_eq!(outcome.payload["current_session_id"], "root-session");
+    assert_eq!(outcome.payload["requested_count"], 3);
+    assert_eq!(outcome.payload["timeout_ms"], 10);
+    assert!(outcome.payload["after_id"].is_null());
+    assert_eq!(outcome.payload["result_counts"]["ok"], 1);
+    assert_eq!(outcome.payload["result_counts"]["timeout"], 1);
+    assert_eq!(outcome.payload["result_counts"]["skipped_not_visible"], 1);
+
+    let results = outcome.payload["results"]
+        .as_array()
+        .expect("batch results array");
+    let ids: Vec<&str> = results
+        .iter()
+        .filter_map(|item| item.get("session_id"))
+        .filter_map(Value::as_str)
+        .collect();
+    assert_eq!(ids, vec!["hidden-root", "completed-child", "running-child"]);
+
+    let hidden = results
+        .iter()
+        .find(|item| item["session_id"] == "hidden-root")
+        .expect("hidden batch result");
+    assert_eq!(hidden["result"], "skipped_not_visible");
+    assert!(hidden["inspection"].is_null());
+    assert!(hidden["message"]
+        .as_str()
+        .expect("hidden message")
+        .contains("visibility_denied"));
+
+    let completed = results
+        .iter()
+        .find(|item| item["session_id"] == "completed-child")
+        .expect("completed batch result");
+    assert_eq!(completed["result"], "ok");
+    assert_eq!(completed["inspection"]["wait_status"], "completed");
+    assert_eq!(completed["inspection"]["session"]["state"], "completed");
+    assert_eq!(completed["inspection"]["terminal_outcome"]["status"], "ok");
+
+    let running = results
+        .iter()
+        .find(|item| item["session_id"] == "running-child")
+        .expect("running batch result");
+    assert_eq!(running["result"], "timeout");
+    assert_eq!(running["inspection"]["wait_status"], "timeout");
+    assert_eq!(running["inspection"]["session"]["state"], "running");
+    assert!(running["inspection"]["terminal_outcome"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_reports_delegate_lifecycle_for_queued_child() {
+    let (config, db_path) = isolated_test_config("session-wait-delegate-lifecycle");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "label": "Child",
+            "timeout_seconds": 30
+        }),
+    })
+    .expect("append queued event");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 10
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "timeout");
+    assert_eq!(outcome.payload["wait_status"], "timeout");
+    assert_eq!(outcome.payload["session"]["state"], "ready");
+    assert_eq!(outcome.payload["delegate_lifecycle"]["mode"], "async");
+    assert_eq!(outcome.payload["delegate_lifecycle"]["phase"], "queued");
+    assert_eq!(outcome.payload["delegate_lifecycle"]["timeout_seconds"], 30);
+    assert_eq!(
+        outcome.payload["delegate_lifecycle"]["staleness"]["reference"],
+        "queued"
+    );
+    assert_eq!(
+        outcome.payload["delegate_lifecycle"]["staleness"]["state"],
+        "fresh"
+    );
+    assert!(outcome.payload["delegate_lifecycle"]["queued_at"].is_number());
+    assert!(outcome.payload["delegate_lifecycle"]["started_at"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_reports_pending_cancel_request_for_running_child() {
+    let (config, db_path) = isolated_test_config("session-wait-cancel-requested");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "timeout_seconds": 60
+        }),
+    })
+    .expect("append queued event");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "timeout_seconds": 60
+        }),
+    })
+    .expect("append started event");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_cancel_requested".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "reference": "running",
+            "cancel_reason": "operator_requested"
+        }),
+    })
+    .expect("append cancel requested event");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 10
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "timeout");
+    assert_eq!(outcome.payload["wait_status"], "timeout");
+    assert_eq!(outcome.payload["delegate_lifecycle"]["phase"], "running");
+    assert_eq!(
+        outcome.payload["delegate_lifecycle"]["cancellation"]["state"],
+        "requested"
+    );
+    assert_eq!(
+        outcome.payload["delegate_lifecycle"]["cancellation"]["reference"],
+        "running"
+    );
+    assert_eq!(
+        outcome.payload["delegate_lifecycle"]["cancellation"]["reason"],
+        "operator_requested"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_reports_missing_terminal_outcome_for_recovered_failed_session() {
+    let (config, db_path) = isolated_test_config("session-wait-recovered-failed");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Failed,
+    })
+    .expect("create child");
+    repo.update_session_state(
+        "child-session",
+        crate::session::repository::SessionState::Failed,
+        Some("opaque_recovery_failure".to_owned()),
+    )
+    .expect("update child status");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_recovery_applied".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "recovery_kind": "async_spawn_failure_persist_failed",
+            "recovered_state": "failed",
+            "recovery_error": "delegate_async_spawn_failure_persist_failed: sqlite_busy; original spawn error: boom",
+            "original_error": "boom"
+        }),
+    })
+    .expect("append failed event");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 50
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["wait_status"], "completed");
+    assert_eq!(outcome.payload["session"]["state"], "failed");
+    assert_eq!(outcome.payload["terminal_outcome_state"], "missing");
+    assert_eq!(
+        outcome.payload["terminal_outcome_missing_reason"],
+        "async_spawn_failure_persist_failed"
+    );
+    assert_eq!(
+        outcome.payload["recovery"]["kind"],
+        "async_spawn_failure_persist_failed"
+    );
+    assert_eq!(
+        outcome.payload["recovery"]["event_kind"],
+        "delegate_recovery_applied"
+    );
+    assert_eq!(outcome.payload["recovery"]["original_error"], "boom");
+    assert_eq!(outcome.payload["recovery"]["source"], "event");
+    assert!(outcome.payload["terminal_outcome"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_synthesizes_recovery_from_last_error_when_event_missing() {
+    let (config, db_path) = isolated_test_config("session-wait-recovery-fallback");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Failed,
+    })
+    .expect("create child");
+    repo.update_session_state(
+        "child-session",
+        crate::session::repository::SessionState::Failed,
+        Some(
+            "delegate_async_spawn_failure_persist_failed: sqlite_busy; original spawn error: boom"
+                .to_owned(),
+        ),
+    )
+    .expect("update child status");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 50
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["wait_status"], "completed");
+    assert_eq!(outcome.payload["terminal_outcome_state"], "missing");
+    assert_eq!(
+        outcome.payload["terminal_outcome_missing_reason"],
+        "async_spawn_failure_persist_failed"
+    );
+    assert_eq!(
+        outcome.payload["recovery"]["kind"],
+        "async_spawn_failure_persist_failed"
+    );
+    assert_eq!(outcome.payload["recovery"]["source"], "last_error");
+    assert_eq!(
+        outcome.payload["recovery"]["recovery_error"],
+        "delegate_async_spawn_failure_persist_failed: sqlite_busy; original spawn error: boom"
+    );
+    assert!(outcome.payload["recovery"]["event_kind"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_synthesizes_unknown_recovery_when_metadata_missing() {
+    let (config, db_path) = isolated_test_config("session-wait-recovery-unknown");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Failed,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 50
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["wait_status"], "completed");
+    assert_eq!(outcome.payload["terminal_outcome_state"], "missing");
+    assert_eq!(
+        outcome.payload["terminal_outcome_missing_reason"],
+        "unknown"
+    );
+    assert_eq!(outcome.payload["recovery"]["kind"], "unknown");
+    assert_eq!(outcome.payload["recovery"]["source"], "none");
+    assert!(outcome.payload["recovery"]["recovery_error"].is_null());
+    assert!(outcome.payload["recovery"]["event_kind"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_returns_incremental_events_after_after_id_when_session_completes() {
+    let (config, db_path) = isolated_test_config("session-wait-after-id-completed");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child");
+    let started_event = repo
+        .append_event(crate::session::repository::NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "child task"
+            }),
+        })
+        .expect("append started event");
+
+    let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), config.tools.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let finalize_memory_config = memory_config.clone();
+    let finalize_task = tokio::spawn(async move {
+        sleep(Duration::from_millis(10)).await;
+        let finalize_repo =
+            SessionRepository::new(&finalize_memory_config).expect("finalize session repository");
+        finalize_repo
+            .finalize_session_terminal(
+                "child-session",
+                crate::session::repository::FinalizeSessionTerminalRequest {
+                    state: crate::session::repository::SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({
+                        "turn_count": 1
+                    }),
+                    outcome_status: "ok".to_owned(),
+                    outcome_payload_json: json!({
+                        "child_session_id": "child-session",
+                        "final_output": "done"
+                    }),
+                },
+            )
+            .expect("finalize child session")
+    });
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 100,
+                    "after_id": started_event.id
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    finalize_task.await.expect("join finalize task");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["wait_status"], "completed");
+    assert_eq!(outcome.payload["after_id"], started_event.id);
+    assert_eq!(outcome.payload["session"]["state"], "completed");
+    assert_eq!(outcome.payload["terminal_outcome"]["status"], "ok");
+    let events = outcome.payload["events"]
+        .as_array()
+        .expect("session_wait events array");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["event_kind"], "delegate_completed");
+    assert!(
+        outcome.payload["next_after_id"]
+            .as_i64()
+            .expect("next_after_id")
+            > started_event.id
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_timeout_returns_incremental_events_observed_while_waiting() {
+    let (config, db_path) = isolated_test_config("session-wait-after-id-timeout");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), config.tools.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let append_memory_config = memory_config.clone();
+    let append_task = tokio::spawn(async move {
+        sleep(Duration::from_millis(10)).await;
+        let append_repo =
+            SessionRepository::new(&append_memory_config).expect("append session repository");
+        append_repo
+            .append_event(crate::session::repository::NewSessionEvent {
+                session_id: "child-session".to_owned(),
+                event_kind: "delegate_started".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                payload_json: json!({
+                    "task": "child task"
+                }),
+            })
+            .expect("append started event")
+    });
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 100,
+                    "after_id": 0
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    let started_event = append_task.await.expect("join append task");
+
+    assert_eq!(outcome.status, "timeout");
+    assert_eq!(outcome.payload["wait_status"], "timeout");
+    assert_eq!(outcome.payload["after_id"], 0);
+    assert_eq!(outcome.payload["session"]["state"], "running");
+    assert!(outcome.payload["terminal_outcome"].is_null());
+    let events = outcome.payload["events"]
+        .as_array()
+        .expect("session_wait events array");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["event_kind"], "delegate_started");
+    assert_eq!(events[0]["id"], started_event.id);
+    assert_eq!(outcome.payload["next_after_id"], started_event.id);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_after_id_on_terminal_session_drains_until_terminal_event() {
+    let (config, db_path) = isolated_test_config("session-wait-terminal-drain");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child");
+
+    let mut last_event_id = 0_i64;
+    for index in 0..60 {
+        last_event_id = repo
+            .append_event(crate::session::repository::NewSessionEvent {
+                session_id: "child-session".to_owned(),
+                event_kind: format!("delegate_progress_{index}"),
+                actor_session_id: Some("root-session".to_owned()),
+                payload_json: json!({
+                    "step": index
+                }),
+            })
+            .expect("append progress event")
+            .id;
+    }
+    let finalized = repo
+        .finalize_session_terminal(
+            "child-session",
+            crate::session::repository::FinalizeSessionTerminalRequest {
+                state: crate::session::repository::SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                event_payload_json: json!({
+                    "turn_count": 1
+                }),
+                outcome_status: "ok".to_owned(),
+                outcome_payload_json: json!({
+                    "child_session_id": "child-session",
+                    "final_output": "done"
+                }),
+            },
+        )
+        .expect("finalize child session");
+
+    let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), config.tools.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 100,
+                    "after_id": 0
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["wait_status"], "completed");
+    assert_eq!(outcome.payload["session"]["state"], "completed");
+    let events = outcome.payload["events"]
+        .as_array()
+        .expect("session_wait events array");
+    assert_eq!(events.len(), 61);
+    assert_eq!(events[0]["id"], 1);
+    assert_eq!(
+        events.last().expect("last session_wait event")["event_kind"],
+        "delegate_completed"
+    );
+    assert_eq!(
+        outcome.payload["next_after_id"],
+        finalized.event.id.max(last_event_id)
+    );
+    assert_eq!(outcome.payload["terminal_outcome"]["status"], "ok");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_async_queue_returns_handle_and_records_queued_event() {
+    let (config, db_path) = isolated_test_config("delegate-async-queued");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner::default());
+    let dispatcher = DefaultOrchestrationToolDispatcher::with_async_delegate_spawner(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+        spawner.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_orchestration_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "delegate_async".to_owned(),
+                payload: json!({
+                    "task": "child task",
+                    "label": "async-child",
+                    "timeout_seconds": 9
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("delegate_async outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["mode"], "async");
+    assert_eq!(outcome.payload["state"], "queued");
+    assert_eq!(outcome.payload["label"], "async-child");
+    let child_session_id = outcome.payload["child_session_id"]
+        .as_str()
+        .expect("child_session_id")
+        .to_owned();
+    assert!(child_session_id.starts_with("delegate:"));
+
+    let requests = tokio::time::timeout(Duration::from_millis(250), async {
+        loop {
+            let maybe_requests = {
+                let requests = spawner
+                    .requests
+                    .lock()
+                    .expect("async delegate requests lock");
+                (requests.len() == 1).then(|| requests.clone())
+            };
+            if let Some(requests) = maybe_requests {
+                break requests;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("async delegate request should be dispatched");
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].child_session_id, child_session_id);
+    assert_eq!(requests[0].parent_session_id, "root-session");
+    assert_eq!(requests[0].task, "child task");
+    assert_eq!(requests[0].label.as_deref(), Some("async-child"));
+    assert_eq!(requests[0].timeout_seconds, 9);
+
+    let child = repo
+        .load_session_summary(&child_session_id)
+        .expect("load child summary")
+        .expect("child summary");
+    assert_eq!(child.state, crate::session::repository::SessionState::Ready);
+    assert_eq!(child.label.as_deref(), Some("async-child"));
+    let events = repo
+        .list_recent_events(&child_session_id, 10)
+        .expect("list child events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_kind, "delegate_queued");
+    assert!(repo
+        .load_terminal_outcome(&child_session_id)
+        .expect("load terminal outcome")
+        .is_none());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_async_returns_handle_without_waiting_for_spawn_completion() {
+    let (config, db_path) = isolated_test_config("delegate-async-immediate-return");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+
+    let (spawner, request_rx, release_notify) = GatedFakeAsyncDelegateSpawner::new();
+    let dispatcher = DefaultOrchestrationToolDispatcher::with_async_delegate_spawner(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+        Arc::new(spawner),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let queued_dispatcher = dispatcher.clone();
+    let queued_session_context = session_context.clone();
+    let queued_call = tokio::spawn(async move {
+        queued_dispatcher
+            .execute_orchestration_tool(
+                &queued_session_context,
+                loongclaw_contracts::ToolCoreRequest {
+                    tool_name: "delegate_async".to_owned(),
+                    payload: json!({
+                        "task": "child task",
+                        "label": "async-child",
+                        "timeout_seconds": 9
+                    }),
+                },
+                None,
+            )
+            .await
+    });
+
+    let spawn_request = tokio::time::timeout(Duration::from_millis(250), request_rx)
+        .await
+        .expect("delegate_async should dispatch spawn quickly")
+        .expect("gated async delegate spawn request");
+    let queued = tokio::time::timeout(Duration::from_millis(250), queued_call)
+        .await
+        .expect("delegate_async should return handle without waiting for spawn gate")
+        .expect("join queued task")
+        .expect("delegate_async outcome");
+
+    assert_eq!(queued.status, "ok");
+    assert_eq!(queued.payload["mode"], "async");
+    assert_eq!(queued.payload["state"], "queued");
+    assert_eq!(queued.payload["label"], "async-child");
+    let child_session_id = queued.payload["child_session_id"]
+        .as_str()
+        .expect("child_session_id")
+        .to_owned();
+    assert_eq!(spawn_request.child_session_id, child_session_id);
+    assert_eq!(spawn_request.parent_session_id, "root-session");
+    assert_eq!(spawn_request.task, "child task");
+    assert_eq!(spawn_request.label.as_deref(), Some("async-child"));
+    assert_eq!(spawn_request.timeout_seconds, 9);
+
+    let child = repo
+        .load_session_summary(&child_session_id)
+        .expect("load child summary")
+        .expect("child summary");
+    assert_eq!(child.state, crate::session::repository::SessionState::Ready);
+    assert_eq!(child.label.as_deref(), Some("async-child"));
+    let events = repo
+        .list_recent_events(&child_session_id, 10)
+        .expect("list child events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_kind, "delegate_queued");
+    assert!(repo
+        .load_terminal_outcome(&child_session_id)
+        .expect("load terminal outcome")
+        .is_none());
+
+    release_notify.notify_waiters();
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_async_queue_failure_does_not_leave_orphan_child_session() {
+    let (config, db_path) = isolated_test_config("delegate-async-queue-rollback");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner::default());
+    let dispatcher = DefaultOrchestrationToolDispatcher::with_async_delegate_spawner(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+        spawner.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let conn = Connection::open(&db_path).expect("open sqlite connection");
+    conn.execute(
+        "CREATE TRIGGER fail_delegate_queue_event
+         BEFORE INSERT ON session_events
+         BEGIN
+            SELECT RAISE(FAIL, 'forced delegate queue failure');
+         END;",
+        [],
+    )
+    .expect("create session_events failure trigger");
+
+    let error = dispatcher
+        .execute_orchestration_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "delegate_async".to_owned(),
+                payload: json!({
+                    "task": "child task",
+                    "label": "async-child"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("delegate_async should fail when queued event cannot be written");
+    assert!(error.contains("insert session event failed"));
+
+    let sessions = repo
+        .list_sessions()
+        .expect("list sessions after queue failure");
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].session_id, "root-session");
+    assert_eq!(
+        spawner
+            .requests
             .lock()
-            .expect("completion calls lock"),
+            .expect("async delegate requests lock")
+            .len(),
         0
     );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_async_spawn_failure_is_observable_after_queued_handle_returns() {
+    let (config, db_path) = isolated_test_config("delegate-async-spawn-failed");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner {
+        requests: Arc::new(Mutex::new(Vec::new())),
+        spawn_error: Some("spawn unavailable".to_owned()),
+    });
+    let orchestration_dispatcher = DefaultOrchestrationToolDispatcher::with_async_delegate_spawner(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+        spawner,
+    );
+    let app_dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = orchestration_dispatcher
+        .execute_orchestration_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "delegate_async".to_owned(),
+                payload: json!({
+                    "task": "child task",
+                    "label": "async-child"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("delegate_async outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["mode"], "async");
+    assert_eq!(outcome.payload["state"], "queued");
+    let child_session_id = outcome.payload["child_session_id"]
+        .as_str()
+        .expect("child_session_id");
+
+    let waited = app_dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": child_session_id,
+                    "timeout_ms": 500
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(waited.status, "ok");
+    assert_eq!(waited.payload["wait_status"], "completed");
+    assert_eq!(waited.payload["session"]["state"], "failed");
+    assert_eq!(waited.payload["terminal_outcome"]["status"], "error");
+    assert_eq!(
+        waited.payload["terminal_outcome"]["payload"]["error"],
+        "spawn unavailable"
+    );
+
+    let child = repo
+        .load_session_summary(child_session_id)
+        .expect("load child summary")
+        .expect("child summary");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert_eq!(child.last_error.as_deref(), Some("spawn unavailable"));
+    let events = repo
+        .list_recent_events(child_session_id, 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_queued"));
+    assert!(event_kinds.contains(&"delegate_spawn_failed"));
+    let terminal_outcome = repo
+        .load_terminal_outcome(child_session_id)
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "error");
+    assert_eq!(terminal_outcome.payload_json["error"], "spawn unavailable");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_async_spawn_panic_is_observable_after_queued_handle_returns() {
+    let (config, db_path) = isolated_test_config("delegate-async-spawn-panic");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+
+    let orchestration_dispatcher = DefaultOrchestrationToolDispatcher::with_async_delegate_spawner(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+        Arc::new(PanicAsyncDelegateSpawner),
+    );
+    let app_dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = orchestration_dispatcher
+        .execute_orchestration_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "delegate_async".to_owned(),
+                payload: json!({
+                    "task": "child task",
+                    "label": "async-child"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("delegate_async outcome");
+
+    assert_eq!(outcome.status, "ok");
+    let child_session_id = outcome.payload["child_session_id"]
+        .as_str()
+        .expect("child_session_id");
+
+    let waited = app_dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": child_session_id,
+                    "timeout_ms": 500
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(waited.status, "ok");
+    assert_eq!(waited.payload["wait_status"], "completed");
+    assert_eq!(waited.payload["session"]["state"], "failed");
+    assert_eq!(waited.payload["terminal_outcome"]["status"], "error");
+    assert_eq!(
+        waited.payload["terminal_outcome"]["payload"]["error"],
+        "delegate_async_spawn_panic: panic-async-spawn"
+    );
+
+    let child = repo
+        .load_session_summary(child_session_id)
+        .expect("load child summary")
+        .expect("child summary");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert_eq!(
+        child.last_error.as_deref(),
+        Some("delegate_async_spawn_panic: panic-async-spawn")
+    );
+    let events = repo
+        .list_recent_events(child_session_id, 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_queued"));
+    assert!(event_kinds.contains(&"delegate_spawn_failed"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_async_spawn_failure_persistence_failure_recovers_to_failed_state() {
+    let (config, db_path) = isolated_test_config("delegate-async-spawn-failure-persistence");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+
+    let conn = Connection::open(&db_path).expect("open sqlite connection");
+    conn.execute(
+        "CREATE TRIGGER fail_async_spawn_terminal_outcome
+         BEFORE INSERT ON session_terminal_outcomes
+         BEGIN
+            SELECT RAISE(FAIL, 'forced async spawn terminal outcome failure');
+         END;",
+        [],
+    )
+    .expect("create terminal outcome failure trigger");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner {
+        requests: Arc::new(Mutex::new(Vec::new())),
+        spawn_error: Some("spawn unavailable".to_owned()),
+    });
+    let orchestration_dispatcher = DefaultOrchestrationToolDispatcher::with_async_delegate_spawner(
+        memory_config.clone(),
+        config.tools.clone(),
+        spawner.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = orchestration_dispatcher
+        .execute_orchestration_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "delegate_async".to_owned(),
+                payload: json!({
+                    "task": "child task",
+                    "label": "async-child"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("delegate_async outcome");
+    let child_session_id = outcome.payload["child_session_id"]
+        .as_str()
+        .expect("child_session_id")
+        .to_owned();
+
+    let child = tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            let child = repo
+                .load_session_summary(&child_session_id)
+                .expect("load child summary")
+                .expect("child summary");
+            if child.state == crate::session::repository::SessionState::Failed {
+                break child;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("child should recover to failed state");
+
+    assert!(child
+        .last_error
+        .as_deref()
+        .expect("child last_error")
+        .contains("delegate_async_spawn_failure_persist_failed"));
+    let events = repo
+        .list_recent_events(&child_session_id, 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_queued"));
+    assert!(!event_kinds.contains(&"delegate_spawn_failed"));
+    let recovery_event = events
+        .iter()
+        .find(|event| event.event_kind == "delegate_recovery_applied")
+        .expect("delegate recovery event");
+    assert_eq!(
+        recovery_event.payload_json["recovery_kind"],
+        "async_spawn_failure_persist_failed"
+    );
+    assert_eq!(recovery_event.payload_json["recovered_state"], "failed");
+    assert_eq!(
+        recovery_event.payload_json["original_error"],
+        "spawn unavailable"
+    );
+    assert!(repo
+        .load_terminal_outcome(&child_session_id)
+        .expect("load terminal outcome")
+        .is_none());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_success_persists_terminal_outcome() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-success");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Child final output".to_owned(),
+            tool_intents: vec![],
+            raw_meta: Value::Null,
+        })],
+    );
+
+    let outcome = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "child task",
+        60,
+        None,
+    )
+    .await
+    .expect("delegate child background outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["child_session_id"], "child-session");
+    assert_eq!(outcome.payload["final_output"], "Child final output");
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Completed
+    );
+    assert_eq!(child.last_error, None);
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_completed"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "ok");
+    assert_eq!(
+        terminal_outcome.payload_json["final_output"],
+        "Child final output"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_terminal_finalize_failure_recovers_to_failed_state() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-finalize-failure");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let conn = Connection::open(&db_path).expect("open sqlite connection");
+    conn.execute(
+        "CREATE TRIGGER fail_child_terminal_outcome
+         BEFORE INSERT ON session_terminal_outcomes
+         BEGIN
+            SELECT RAISE(FAIL, 'forced child terminal outcome failure');
+         END;",
+        [],
+    )
+    .expect("create terminal outcome failure trigger");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Child final output".to_owned(),
+            tool_intents: vec![],
+            raw_meta: Value::Null,
+        })],
+    );
+
+    let error = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "child task",
+        60,
+        None,
+    )
+    .await
+    .expect_err("terminal finalize failure should surface as error");
+
     assert!(
-        runtime
-            .requested_messages
-            .lock()
-            .expect("requested messages lock")
-            .is_empty(),
-        "provider path should not build or request provider messages for explicit ACP turns"
+        error.contains("delegate_terminal_finalize_failed"),
+        "error: {error}"
     );
 
-    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
-    assert_eq!(persisted.len(), 2);
-    assert_eq!(persisted[0].0, "telegram:42");
-    assert_eq!(persisted[0].1, "user");
-    assert_eq!(persisted[1].1, "assistant");
-    assert_eq!(persisted[1].2, "acp: hello from channel");
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert!(child
+        .last_error
+        .as_deref()
+        .expect("child last_error")
+        .contains("delegate_terminal_finalize_failed"));
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(!event_kinds.contains(&"delegate_completed"));
+    let recovery_event = events
+        .iter()
+        .find(|event| event.event_kind == "delegate_recovery_applied")
+        .expect("delegate recovery event");
+    assert_eq!(
+        recovery_event.payload_json["recovery_kind"],
+        "terminal_finalize_persist_failed"
+    );
+    assert_eq!(recovery_event.payload_json["recovered_state"], "failed");
+    assert_eq!(
+        recovery_event.payload_json["attempted_terminal_event_kind"],
+        "delegate_completed"
+    );
+
+    assert!(repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .is_none());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_terminal_finalize_failure_falls_back_when_recovery_event_persist_fails(
+) {
+    let (config, db_path) =
+        isolated_test_config("delegate-child-background-finalize-recovery-fallback");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let conn = Connection::open(&db_path).expect("open sqlite connection");
+    conn.execute(
+        "CREATE TRIGGER fail_child_terminal_outcome
+         BEFORE INSERT ON session_terminal_outcomes
+         BEGIN
+            SELECT RAISE(FAIL, 'forced child terminal outcome failure');
+         END;",
+        [],
+    )
+    .expect("create terminal outcome failure trigger");
+    conn.execute(
+        "CREATE TRIGGER fail_delegate_recovery_event
+         BEFORE INSERT ON session_events
+         WHEN NEW.event_kind = 'delegate_recovery_applied'
+         BEGIN
+            SELECT RAISE(FAIL, 'forced delegate recovery event failure');
+         END;",
+        [],
+    )
+    .expect("create recovery event failure trigger");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Child final output".to_owned(),
+            tool_intents: vec![],
+            raw_meta: Value::Null,
+        })],
+    );
+
+    let error = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "child task",
+        60,
+        None,
+    )
+    .await
+    .expect_err("terminal finalize failure should surface as error");
+
     assert!(
-        runtime
-            .bootstrap_calls
-            .lock()
-            .expect("bootstrap lock")
-            .is_empty()
-    );
-    assert!(
-        runtime
-            .ingested_messages
-            .lock()
-            .expect("ingest lock")
-            .is_empty()
-    );
-    assert!(
-        runtime
-            .after_turn_calls
-            .lock()
-            .expect("after-turn lock")
-            .is_empty()
-    );
-    assert!(
-        runtime
-            .compact_calls
-            .lock()
-            .expect("compact lock")
-            .is_empty()
+        error.contains("delegate_terminal_recovery_event_failed"),
+        "error: {error}"
     );
 
-    let state = shared.lock().expect("ACP shared state");
-    assert_eq!(state.ensure_calls, 1);
-    assert_eq!(state.turn_calls, 1);
-    let bootstrap = state
-        .last_bootstrap
-        .clone()
-        .expect("ACP bootstrap should be captured");
-    assert_eq!(bootstrap.conversation_id.as_deref(), Some("telegram:42"));
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
     assert_eq!(
-        bootstrap
-            .binding
-            .as_ref()
-            .map(|binding| binding.route_session_id.as_str()),
-        Some("telegram:42")
+        child.state,
+        crate::session::repository::SessionState::Failed
     );
-    assert_eq!(bootstrap.session_key, "agent:claude:telegram:42");
-    assert_eq!(bootstrap.mcp_servers, vec!["filesystem".to_owned()]);
-    assert_eq!(
-        bootstrap.metadata.get("acp_agent").map(String::as_str),
-        Some("claude")
-    );
-    assert_eq!(
-        bootstrap
-            .metadata
-            .get("loongclaw.acp.activation_origin")
-            .map(String::as_str),
-        Some("explicit_request")
-    );
-    let request = state
-        .last_request
-        .clone()
-        .expect("ACP request should be captured");
-    assert_eq!(request.session_key, "agent:claude:telegram:42");
-    assert_eq!(request.input, "hello from channel");
-    assert_eq!(
-        request
-            .metadata
-            .get("loongclaw.acp.routing_origin")
-            .map(String::as_str),
-        Some("explicit_request")
-    );
-}
+    assert!(child
+        .last_error
+        .as_deref()
+        .expect("child last_error")
+        .contains("delegate_terminal_finalize_failed"));
 
-#[tokio::test]
-async fn handle_turn_with_runtime_merges_additional_acp_bootstrap_mcp_servers_from_options() {
-    let (backend_id, shared) = register_routed_acp_backend("bootstrap-mcp-options", false);
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-should-not-run".to_owned()),
-    );
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.default_agent = Some("claude".to_owned());
-    config.acp.allowed_agents = vec!["claude".to_owned()];
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.dispatch.bootstrap_mcp_servers = vec![" Filesystem ".to_owned()];
-    config.memory.sqlite_path = unique_acp_sqlite_path("bootstrap-mcp-options");
-    let extra_servers = vec![
-        "search".to_owned(),
-        "filesystem".to_owned(),
-        " Search ".to_owned(),
-    ];
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(!event_kinds.contains(&"delegate_completed"));
+    assert!(!event_kinds.contains(&"delegate_recovery_applied"));
 
-    let reply = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
-            &config,
-            &ConversationSessionAddress::from_session_id("telegram:4242"),
-            "hello with extra bootstrap mcp",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            &AcpConversationTurnOptions {
-                routing_intent: AcpRoutingIntent::Explicit,
-                additional_bootstrap_mcp_servers: Some(extra_servers.as_slice()),
-                ..AcpConversationTurnOptions::default()
+    let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), config.tools.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+    let waited = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 50
+                }),
             },
             None,
         )
         .await
-        .expect("ACP-routed turn with additional bootstrap MCP servers should succeed");
+        .expect("session_wait outcome");
 
-    assert_eq!(reply, "acp: hello with extra bootstrap mcp");
-    let state = shared.lock().expect("ACP shared state");
-    let bootstrap = state
-        .last_bootstrap
-        .clone()
-        .expect("ACP bootstrap should be captured");
+    assert_eq!(waited.payload["terminal_outcome_state"], "missing");
     assert_eq!(
-        bootstrap.mcp_servers,
-        vec!["filesystem".to_owned(), "search".to_owned()]
+        waited.payload["terminal_outcome_missing_reason"],
+        "terminal_finalize_persist_failed"
+    );
+    assert_eq!(
+        waited.payload["recovery"]["kind"],
+        "terminal_finalize_persist_failed"
+    );
+    assert_eq!(waited.payload["recovery"]["source"], "last_error");
+    assert!(waited.payload["recovery"]["event_kind"].is_null());
+
+    assert!(repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .is_none());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_rerun_does_not_overwrite_terminal_outcome() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-rerun");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let first_runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Child final output".to_owned(),
+            tool_intents: vec![],
+            raw_meta: Value::Null,
+        })],
+    );
+
+    let first_outcome = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &first_runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "child task",
+        60,
+        None,
+    )
+    .await
+    .expect("first delegate child background outcome");
+    assert_eq!(first_outcome.status, "ok");
+
+    let second_runtime =
+        FakeRuntime::with_turns(vec![], vec![Err("child runtime failed".to_owned())]);
+
+    let second_error = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &second_runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "child task retry",
+        60,
+        None,
+    )
+    .await
+    .expect_err("rerun should be rejected after terminal completion");
+    assert!(second_error.contains("not runnable"));
+    assert!(second_error.contains("completed"));
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Completed
+    );
+    assert_eq!(child.last_error, None);
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert_eq!(
+        event_kinds
+            .iter()
+            .filter(|kind| **kind == "delegate_started")
+            .count(),
+        1
+    );
+    assert_eq!(
+        event_kinds
+            .iter()
+            .filter(|kind| **kind == "delegate_completed")
+            .count(),
+        1
+    );
+    assert!(!event_kinds.contains(&"delegate_failed"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "ok");
+    assert_eq!(
+        terminal_outcome.payload_json["final_output"],
+        "Child final output"
     );
 }
 
+#[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_applies_acp_turn_provenance_metadata() {
-    let (backend_id, shared) = register_routed_acp_backend("turn-provenance", false);
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-should-not-run".to_owned()),
-    );
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.default_agent = Some("claude".to_owned());
-    config.acp.allowed_agents = vec!["claude".to_owned()];
-    config.acp.backend = Some(backend_id.to_owned());
-    config.memory.sqlite_path = unique_acp_sqlite_path("turn-provenance");
+async fn delegate_child_background_failure_persists_terminal_outcome() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-failure");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
 
-    let reply = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
-            &config,
-            &ConversationSessionAddress::from_session_id("telegram:4242"),
-            "hello with provenance",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            &AcpConversationTurnOptions {
-                routing_intent: AcpRoutingIntent::Explicit,
-                provenance: AcpTurnProvenance {
-                    trace_id: Some("trace-123"),
-                    source_message_id: Some("message-42"),
-                    ack_cursor: Some("cursor-9"),
-                },
-                ..AcpConversationTurnOptions::default()
-            },
-            None,
-        )
-        .await
-        .expect("ACP-routed turn with provenance should succeed");
+    let runtime = FakeRuntime::with_turns(vec![], vec![Err("child runtime failed".to_owned())]);
 
-    assert_eq!(reply, "acp: hello with provenance");
-    let state = shared.lock().expect("ACP shared state");
-    let request = state
-        .last_request
-        .clone()
-        .expect("ACP request should be captured");
+    let outcome = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "child task",
+        60,
+        None,
+    )
+    .await
+    .expect("delegate child background outcome");
+
+    assert_eq!(outcome.status, "error");
+    assert_eq!(outcome.payload["child_session_id"], "child-session");
+    assert_eq!(outcome.payload["error"], "child runtime failed");
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
     assert_eq!(
-        request
-            .metadata
-            .get(ACP_TURN_METADATA_TRACE_ID)
-            .map(String::as_str),
-        Some("trace-123")
+        child.state,
+        crate::session::repository::SessionState::Failed
     );
+    assert_eq!(child.last_error.as_deref(), Some("child runtime failed"));
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_failed"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "error");
     assert_eq!(
-        request
-            .metadata
-            .get(ACP_TURN_METADATA_SOURCE_MESSAGE_ID)
-            .map(String::as_str),
-        Some("message-42")
-    );
-    assert_eq!(
-        request
-            .metadata
-            .get(ACP_TURN_METADATA_ACK_CURSOR)
-            .map(String::as_str),
-        Some("cursor-9")
-    );
-    assert_eq!(
-        request
-            .metadata
-            .get(ACP_TURN_METADATA_ROUTING_INTENT)
-            .map(String::as_str),
-        Some("explicit")
+        terminal_outcome.payload_json["error"],
+        "child runtime failed"
     );
 }
 
+#[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_applies_acp_working_directory_from_options() {
-    let (backend_id, shared) = register_routed_acp_backend("turn-working-directory", false);
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-should-not-run".to_owned()),
-    );
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.default_agent = Some("claude".to_owned());
-    config.acp.allowed_agents = vec!["claude".to_owned()];
-    config.acp.backend = Some(backend_id.to_owned());
-    config.memory.sqlite_path = unique_acp_sqlite_path("turn-working-directory");
-    let working_directory = PathBuf::from("/workspace/project");
+async fn delegate_child_background_timeout_persists_terminal_outcome() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-timeout");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
 
-    let reply = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
-            &config,
-            &ConversationSessionAddress::from_session_id("telegram:4242"),
-            "hello with working directory",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            &AcpConversationTurnOptions {
-                routing_intent: AcpRoutingIntent::Explicit,
-                working_directory: Some(working_directory.as_path()),
-                ..AcpConversationTurnOptions::default()
-            },
-            None,
-        )
-        .await
-        .expect("ACP-routed turn with working directory should succeed");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Too slow".to_owned(),
+            tool_intents: vec![],
+            raw_meta: Value::Null,
+        })],
+    )
+    .with_turn_delays(vec![Duration::from_millis(1_100)]);
 
-    assert_eq!(reply, "acp: hello with working directory");
-    let state = shared.lock().expect("ACP shared state");
-    let bootstrap = state
-        .last_bootstrap
-        .clone()
-        .expect("ACP bootstrap should be captured");
-    let request = state
-        .last_request
-        .clone()
-        .expect("ACP request should be captured");
-    assert_eq!(
-        bootstrap.working_directory.as_deref(),
-        Some(working_directory.as_path())
-    );
-    assert_eq!(
-        request.working_directory.as_deref(),
-        Some(working_directory.as_path())
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_falls_back_to_dispatch_acp_working_directory() {
-    let (backend_id, shared) = register_routed_acp_backend("dispatch-working-directory", false);
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-should-not-run".to_owned()),
-    );
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.default_agent = Some("claude".to_owned());
-    config.acp.allowed_agents = vec!["claude".to_owned()];
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.dispatch.working_directory = Some(" /workspace/dispatch ".to_owned());
-    config.memory.sqlite_path = unique_acp_sqlite_path("dispatch-working-directory");
-
-    let reply = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
-            &config,
-            &ConversationSessionAddress::from_session_id("telegram:4343"),
-            "hello with dispatch working directory",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            &AcpConversationTurnOptions {
-                routing_intent: AcpRoutingIntent::Explicit,
-                ..AcpConversationTurnOptions::default()
-            },
-            None,
-        )
-        .await
-        .expect("ACP-routed turn should inherit dispatch working directory");
-
-    assert_eq!(reply, "acp: hello with dispatch working directory");
-    let state = shared.lock().expect("ACP shared state");
-    let bootstrap = state
-        .last_bootstrap
-        .clone()
-        .expect("ACP bootstrap should be captured");
-    let request = state
-        .last_request
-        .clone()
-        .expect("ACP request should be captured");
-    assert_eq!(
-        bootstrap.working_directory.as_deref(),
-        Some(std::path::Path::new("/workspace/dispatch"))
-    );
-    assert_eq!(
-        request.working_directory.as_deref(),
-        Some(std::path::Path::new("/workspace/dispatch"))
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_uses_provider_path_when_acp_dispatch_is_disabled() {
-    let (backend_id, shared) = register_routed_acp_backend("dispatch-disabled", false);
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-path-reply".to_owned()),
-    );
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.dispatch.enabled = false;
-    config.memory.sqlite_path = unique_acp_sqlite_path("dispatch-disabled");
-
-    let reply = orchestrator
-        .handle_turn_with_runtime(
-            &config,
-            "telegram:424242",
-            "hello provider path",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("provider path should remain available when ACP dispatch is disabled");
-
-    assert_eq!(reply, "provider-path-reply");
-    assert_eq!(
-        shared.lock().expect("ACP shared state").turn_calls,
-        0,
-        "ACP backend should not receive turns when dispatch is disabled"
-    );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
-    assert_eq!(
-        runtime
-            .bootstrap_calls
-            .lock()
-            .expect("bootstrap lock")
-            .as_slice(),
-        ["telegram:424242"]
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_explicit_acp_request_bypasses_dispatch_gate() {
-    let (backend_id, shared) = register_routed_acp_backend("dispatch-disabled-explicit", false);
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-should-not-run".to_owned()),
-    );
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.dispatch.enabled = false;
-    config.memory.sqlite_path = unique_acp_sqlite_path("dispatch-disabled-explicit");
-
-    let reply = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
-            &config,
-            &ConversationSessionAddress::from_session_id("telegram:424242"),
-            "hello explicit acp path",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            &AcpConversationTurnOptions {
-                routing_intent: AcpRoutingIntent::Explicit,
-                ..AcpConversationTurnOptions::default()
-            },
-            None,
-        )
-        .await
-        .expect("explicit ACP requests should bypass automatic dispatch gating");
-
-    assert_eq!(reply, "acp: hello explicit acp path");
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 0);
-    assert_eq!(shared.lock().expect("ACP shared state").turn_calls, 1);
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_explicit_acp_request_fails_closed_when_acp_is_disabled() {
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-should-not-run".to_owned()),
-    );
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = false;
-
-    let reply = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
-            &config,
-            &ConversationSessionAddress::from_session_id("telegram:424242"),
-            "hello explicit disabled acp path",
-            ProviderErrorMode::InlineMessage,
-            &runtime,
-            &AcpConversationTurnOptions {
-                routing_intent: AcpRoutingIntent::Explicit,
-                ..AcpConversationTurnOptions::default()
-            },
-            None,
-        )
-        .await
-        .expect("inline mode should synthesize a clear ACP-disabled reply");
-
-    assert_eq!(
-        reply,
-        format_provider_error_reply("ACP is disabled by policy (`acp.enabled=false`)")
-    );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 0);
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_routes_only_agent_prefixed_sessions_when_configured() {
-    let (backend_id, shared) = register_routed_acp_backend("prefixed-only", false);
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-fallback".to_owned()),
-    );
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.dispatch.conversation_routing =
-        crate::config::AcpConversationRoutingMode::AgentPrefixedOnly;
-    config.memory.sqlite_path = unique_acp_sqlite_path("prefixed-only");
-
-    let non_prefixed = orchestrator
-        .handle_turn_with_runtime(
-            &config,
-            "telegram:600",
-            "should stay on provider path",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("non-prefixed session should stay on provider path");
-    assert_eq!(non_prefixed, "provider-fallback");
-
-    let prefixed = orchestrator
-        .handle_turn_with_runtime(
-            &config,
-            "agent:codex:review-thread",
-            "should route through ACP",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("prefixed session should route through ACP");
-    assert_eq!(prefixed, "acp: should route through ACP");
-
-    let state = shared.lock().expect("ACP shared state");
-    assert_eq!(state.turn_calls, 1);
-    let bootstrap = state
-        .last_bootstrap
-        .clone()
-        .expect("ACP bootstrap should be captured for prefixed session");
-    assert_eq!(
-        bootstrap
-            .metadata
-            .get("loongclaw.acp.activation_origin")
-            .map(String::as_str),
-        Some("automatic_agent_prefixed")
-    );
-    let request = state
-        .last_request
-        .clone()
-        .expect("ACP request should be captured for prefixed session");
-    assert_eq!(request.session_key, "agent:codex:review-thread");
-    assert_eq!(
-        request
-            .metadata
-            .get("loongclaw.acp.routing_origin")
-            .map(String::as_str),
-        Some("automatic_agent_prefixed")
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_routes_only_allowed_channels_into_acp() {
-    let (backend_id, shared) = register_routed_acp_backend("channel-allowlist", false);
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-feishu-reply".to_owned()),
-    );
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.dispatch.conversation_routing = crate::config::AcpConversationRoutingMode::All;
-    config.acp.dispatch.allowed_channels = vec!["telegram".to_owned()];
-    config.memory.sqlite_path = unique_acp_sqlite_path("channel-allowlist");
-
-    let telegram = orchestrator
-        .handle_turn_with_runtime(
-            &config,
-            "telegram:100",
-            "hello telegram",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("telegram session should route through ACP");
-    assert_eq!(telegram, "acp: hello telegram");
-
-    {
-        let state = shared.lock().expect("ACP shared state");
-        let bootstrap = state
-            .last_bootstrap
-            .clone()
-            .expect("ACP bootstrap should be captured for allowlisted channel session");
-        assert_eq!(
-            bootstrap
-                .metadata
-                .get("loongclaw.acp.activation_origin")
-                .map(String::as_str),
-            Some("automatic_dispatch")
-        );
-        let request = state
-            .last_request
-            .clone()
-            .expect("ACP request should be captured for allowlisted channel session");
-        assert_eq!(
-            request
-                .metadata
-                .get("loongclaw.acp.routing_origin")
-                .map(String::as_str),
-            Some("automatic_dispatch")
-        );
-    }
-
-    let feishu = orchestrator
-        .handle_turn_with_runtime(
-            &config,
-            "feishu:oc_123",
-            "hello feishu",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("feishu session should stay on provider path");
-    assert_eq!(feishu, "provider-feishu-reply");
-
-    let state = shared.lock().expect("ACP shared state");
-    assert_eq!(state.turn_calls, 1);
-    let request = state
-        .last_request
-        .clone()
-        .expect("ACP request should exist for telegram session");
-    assert_eq!(request.session_key, "agent:codex:telegram:100");
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_and_address_routes_structured_channel_scope_into_acp() {
-    let (backend_id, shared) = register_routed_acp_backend("structured-channel-address", false);
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-reply".to_owned()),
-    );
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.dispatch.conversation_routing = crate::config::AcpConversationRoutingMode::All;
-    config.acp.dispatch.allowed_channels = vec!["telegram".to_owned()];
-    config.memory.sqlite_path = unique_acp_sqlite_path("structured-channel-address");
-    let address = ConversationSessionAddress::from_session_id("opaque-session")
-        .with_channel_scope("telegram", "100");
-
-    let reply = orchestrator
-        .handle_turn_with_runtime_and_address(
-            &config,
-            &address,
-            "hello structured route",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("structured channel address should route through ACP");
-
-    assert_eq!(reply, "acp: hello structured route");
-
-    let state = shared.lock().expect("ACP shared state");
-    assert_eq!(state.turn_calls, 1);
-    let request = state
-        .last_request
-        .clone()
-        .expect("ACP request should be captured");
-    let bootstrap = state
-        .last_bootstrap
-        .clone()
-        .expect("ACP bootstrap should be captured");
-    assert_eq!(request.session_key, "agent:codex:opaque-session");
-    assert_eq!(
-        bootstrap
-            .binding
-            .as_ref()
-            .map(|binding| binding.route_session_id.as_str()),
-        Some("telegram:100")
-    );
-    assert_eq!(
-        bootstrap
-            .binding
-            .as_ref()
-            .and_then(|binding| binding.channel_id.as_deref()),
-        Some("telegram")
-    );
-    assert_eq!(
-        request.metadata.get("channel").map(String::as_str),
-        Some("telegram")
-    );
-    assert_eq!(
-        request
-            .metadata
-            .get("channel_conversation_id")
-            .map(String::as_str),
-        Some("100")
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_and_address_enforces_account_and_thread_dispatch_scope() {
-    let (backend_id, shared) =
-        register_routed_acp_backend("structured-account-thread-scope", false);
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-reply".to_owned()),
-    );
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.dispatch.conversation_routing = crate::config::AcpConversationRoutingMode::All;
-    config.acp.dispatch.allowed_channels = vec!["feishu".to_owned()];
-    config.acp.dispatch.allowed_account_ids = vec!["lark-prod".to_owned()];
-    config.acp.dispatch.thread_routing = crate::config::AcpDispatchThreadRoutingMode::ThreadOnly;
-    config.memory.sqlite_path = unique_acp_sqlite_path("structured-account-thread-scope");
-
-    let allowed = ConversationSessionAddress::from_session_id("opaque-session")
-        .with_channel_scope("feishu", "oc_123")
-        .with_account_id("lark-prod")
-        .with_thread_id("om_thread_1");
-    let blocked = ConversationSessionAddress::from_session_id("opaque-session-root")
-        .with_channel_scope("feishu", "oc_123")
-        .with_account_id("lark-prod");
-
-    let allowed_reply = orchestrator
-        .handle_turn_with_runtime_and_address(
-            &config,
-            &allowed,
-            "hello allowed",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("thread-bound allowed address should route through ACP");
-    assert_eq!(allowed_reply, "acp: hello allowed");
-
-    let blocked_reply = orchestrator
-        .handle_turn_with_runtime_and_address(
-            &config,
-            &blocked,
-            "hello blocked",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("root conversation should stay on provider path");
-    assert_eq!(blocked_reply, "provider-reply");
-
-    let state = shared.lock().expect("ACP shared state");
-    assert_eq!(state.turn_calls, 1);
-    let bootstrap = state
-        .last_bootstrap
-        .clone()
-        .expect("ACP bootstrap should be captured");
-    assert_eq!(
-        bootstrap
-            .binding
-            .as_ref()
-            .map(|binding| binding.route_session_id.as_str()),
-        Some("feishu:lark-prod:oc_123:om_thread_1")
-    );
-    assert_eq!(
-        bootstrap
-            .binding
-            .as_ref()
-            .and_then(|binding| binding.account_id.as_deref()),
-        Some("lark-prod")
-    );
-    assert_eq!(
-        bootstrap
-            .binding
-            .as_ref()
-            .and_then(|binding| binding.thread_id.as_deref()),
-        Some("om_thread_1")
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_formats_acp_errors_inline_when_requested() {
-    let (backend_id, shared) = register_routed_acp_backend("inline-error", true);
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("provider-should-not-run".to_owned()),
-    );
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.backend = Some(backend_id.to_owned());
-    config.memory.sqlite_path = unique_acp_sqlite_path("inline-error");
-
-    let reply = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
-            &config,
-            &ConversationSessionAddress::from_session_id("feishu:oc_123"),
-            "hello from feishu",
-            ProviderErrorMode::InlineMessage,
-            &runtime,
-            &AcpConversationTurnOptions {
-                routing_intent: AcpRoutingIntent::Explicit,
-                ..AcpConversationTurnOptions::default()
-            },
-            None,
-        )
-        .await
-        .expect("ACP inline error mode should synthesize a reply");
-
-    assert_eq!(
-        reply,
-        format_provider_error_reply("synthetic ACP routing failure")
-    );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 0);
-    assert_eq!(
-        shared.lock().expect("ACP shared state").turn_calls,
+    let outcome = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "slow child task",
         1,
-        "ACP backend should have received the routed turn"
-    );
-    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
-    assert_eq!(persisted.len(), 2);
-    assert_eq!(persisted[0].0, "feishu:oc_123");
+        None,
+    )
+    .await
+    .expect("delegate child background outcome");
+
+    assert_eq!(outcome.status, "timeout");
+    assert_eq!(outcome.payload["child_session_id"], "child-session");
+    assert_eq!(outcome.payload["error"], "delegate_timeout");
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
     assert_eq!(
-        persisted[1].2,
-        format_provider_error_reply("synthetic ACP routing failure")
+        child.state,
+        crate::session::repository::SessionState::TimedOut
     );
-}
+    assert_eq!(child.last_error.as_deref(), Some("delegate_timeout"));
 
-#[tokio::test]
-async fn handle_turn_with_runtime_reuses_shared_acp_session_between_turns() {
-    let (backend_id, shared) = register_routed_acp_backend("reuse", false);
-    let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.backend = Some(backend_id.to_owned());
-    config.memory.sqlite_path = unique_acp_sqlite_path("reuse");
-
-    let first = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
-            &config,
-            &ConversationSessionAddress::from_session_id("telegram:4242"),
-            "first",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            &AcpConversationTurnOptions {
-                routing_intent: AcpRoutingIntent::Explicit,
-                ..AcpConversationTurnOptions::default()
-            },
-            None,
-        )
-        .await
-        .expect("first ACP-routed turn");
-    let second = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
-            &config,
-            &ConversationSessionAddress::from_session_id("telegram:4242"),
-            "second",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            &AcpConversationTurnOptions {
-                routing_intent: AcpRoutingIntent::Explicit,
-                ..AcpConversationTurnOptions::default()
-            },
-            None,
-        )
-        .await
-        .expect("second ACP-routed turn");
-
-    assert_eq!(first, "acp: first");
-    assert_eq!(second, "acp: second");
-    let state = shared.lock().expect("ACP shared state");
-    assert_eq!(
-        state.ensure_calls, 1,
-        "ACP session should be reused through the shared control-plane manager"
-    );
-    assert_eq!(state.turn_calls, 2);
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_persists_acp_runtime_events_when_enabled() {
-    let (backend_id, _shared) = register_routed_acp_backend_with_events(
-        "runtime-events",
-        false,
-        vec![
-            json!({
-                "type": "text",
-                "content": "partial hello"
-            }),
-            json!({
-                "type": "done",
-                "stopReason": "completed"
-            }),
-        ],
-    );
-    let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
-    let orchestrator = ConversationOrchestrator::new();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.emit_runtime_events = true;
-    config.memory.sqlite_path = unique_acp_sqlite_path("runtime-events");
-
-    let reply = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
-            &config,
-            &ConversationSessionAddress::from_session_id("telegram:777"),
-            "hello runtime events",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            &AcpConversationTurnOptions {
-                routing_intent: AcpRoutingIntent::Explicit,
-                ..AcpConversationTurnOptions::default()
-            },
-            None,
-        )
-        .await
-        .expect("ACP-routed turn with runtime events should succeed");
-
-    assert_eq!(reply, "acp: hello runtime events");
-    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
-    let event_records = persisted
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
         .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            parsed.get("event")?.as_str().map(ToOwned::to_owned)
-        })
-        .collect::<Vec<_>>();
-    assert!(
-        event_records.iter().any(|event| event == "acp_turn_event"),
-        "expected persisted ACP turn event records, got: {event_records:?}"
-    );
-    assert!(
-        event_records.iter().any(|event| event == "acp_turn_final"),
-        "expected persisted ACP turn final record, got: {event_records:?}"
-    );
-    let agent_ids = persisted
-        .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            parsed
-                .get("payload")?
-                .get("agent_id")?
-                .as_str()
-                .map(ToOwned::to_owned)
-        })
-        .collect::<Vec<_>>();
-    assert!(
-        agent_ids.iter().any(|agent| agent == "codex"),
-        "expected persisted ACP runtime records to expose explicit agent_id, got: {agent_ids:?}"
-    );
-    let routing_intents = persisted
-        .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            parsed
-                .get("payload")?
-                .get("routing_intent")?
-                .as_str()
-                .map(ToOwned::to_owned)
-        })
-        .collect::<Vec<_>>();
-    assert!(
-        routing_intents.iter().any(|intent| intent == "explicit"),
-        "expected persisted ACP runtime records to keep routing_intent, got: {routing_intents:?}"
-    );
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_timed_out"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "timeout");
+    assert_eq!(terminal_outcome.payload_json["error"], "delegate_timeout");
 }
 
+#[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_streams_acp_runtime_events_to_external_sink_without_persisting() {
-    let (backend_id, _shared) = register_routed_acp_backend_with_events(
-        "external-runtime-events",
-        false,
-        vec![
-            json!({
-                "type": "text",
-                "content": "partial hello"
-            }),
-            json!({
-                "type": "done",
-                "stopReason": "completed"
-            }),
-        ],
-    );
-    let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
-    let orchestrator = ConversationOrchestrator::new();
-    let sink = RecordingAcpEventSink::default();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.emit_runtime_events = false;
-    config.memory.sqlite_path = unique_acp_sqlite_path("external-runtime-events");
+async fn delegate_child_background_panic_persists_failed_terminal_outcome() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-panic");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
 
-    let acp_options = AcpConversationTurnOptions::from_event_sink(Some(&sink));
-    let reply = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
-            &config,
-            &ConversationSessionAddress::from_session_id("telegram:778"),
-            "hello external runtime events",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            &acp_options,
-            None,
-        )
-        .await
-        .expect("ACP-routed turn with external event sink should succeed");
+    let outcome = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &PanicRuntime::new(),
+        &NoopAppToolDispatcher,
+        "child-session",
+        "panic child task",
+        60,
+        None,
+    )
+    .await
+    .expect("delegate child panic outcome");
 
-    assert_eq!(reply, "acp: hello external runtime events");
+    assert_eq!(outcome.status, "error");
+    assert_eq!(outcome.payload["child_session_id"], "child-session");
     assert_eq!(
-        sink.snapshot(),
-        vec![
-            json!({
-                "type": "text",
-                "content": "partial hello"
-            }),
-            json!({
-                "type": "done",
-                "stopReason": "completed"
-            }),
-        ]
+        outcome.payload["error"],
+        "delegate_child_panic: panic-runtime-request-turn"
     );
-    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
     assert_eq!(
-        persisted.len(),
-        2,
-        "only user/assistant turns should persist"
+        child.state,
+        crate::session::repository::SessionState::Failed
     );
-    assert!(persisted.iter().all(|(_, role, content)| {
-        *role != "assistant"
-            || serde_json::from_str::<Value>(content)
-                .ok()
-                .and_then(|value| value.get("type").and_then(Value::as_str).map(str::to_owned))
-                .as_deref()
-                != Some("conversation_event")
-    }));
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_streams_and_persists_acp_runtime_events_when_both_enabled() {
-    let (backend_id, _shared) = register_routed_acp_backend_with_events(
-        "external-and-persisted-runtime-events",
-        false,
-        vec![
-            json!({
-                "type": "text",
-                "content": "partial hello"
-            }),
-            json!({
-                "type": "done",
-                "stopReason": "completed"
-            }),
-        ],
-    );
-    let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
-    let orchestrator = ConversationOrchestrator::new();
-    let sink = RecordingAcpEventSink::default();
-    let mut config = test_config();
-    config.acp.enabled = true;
-    config.acp.backend = Some(backend_id.to_owned());
-    config.acp.emit_runtime_events = true;
-    config.memory.sqlite_path = unique_acp_sqlite_path("external-and-persisted-runtime-events");
-
-    let acp_options = AcpConversationTurnOptions::from_event_sink(Some(&sink));
-    let reply = orchestrator
-        .handle_turn_with_runtime_and_address_and_acp_options(
-            &config,
-            &ConversationSessionAddress::from_session_id("telegram:779"),
-            "hello external and persisted runtime events",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            &acp_options,
-            None,
-        )
-        .await
-        .expect("ACP-routed turn with external sink and persistence should succeed");
-
-    assert_eq!(reply, "acp: hello external and persisted runtime events");
     assert_eq!(
-        sink.snapshot(),
-        vec![
-            json!({
-                "type": "text",
-                "content": "partial hello"
-            }),
-            json!({
-                "type": "done",
-                "stopReason": "completed"
-            }),
-        ]
+        child.last_error.as_deref(),
+        Some("delegate_child_panic: panic-runtime-request-turn")
     );
-    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
-    let event_records = persisted
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
         .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            parsed.get("event")?.as_str().map(ToOwned::to_owned)
-        })
-        .collect::<Vec<_>>();
-    assert!(event_records.iter().any(|event| event == "acp_turn_event"));
-    assert!(event_records.iter().any(|event| event == "acp_turn_final"));
-}
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_failed"));
 
-#[tokio::test]
-async fn handle_turn_with_runtime_skips_compaction_when_disabled() {
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("assistant-reply".to_owned()),
-    );
-    let mut config = test_config();
-    config.conversation.compact_enabled = false;
-
-    let orchestrator = ConversationOrchestrator::new();
-    let reply = orchestrator
-        .handle_turn_with_runtime(
-            &config,
-            "session-no-compact",
-            "hello",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("handle turn success");
-
-    assert_eq!(reply, "assistant-reply");
-    assert!(
-        runtime
-            .compact_calls
-            .lock()
-            .expect("compact lock")
-            .is_empty()
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_skips_compaction_below_min_messages() {
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("assistant-reply".to_owned()),
-    );
-    let mut config = test_config();
-    config.conversation.compact_min_messages = Some(10);
-
-    let orchestrator = ConversationOrchestrator::new();
-    let reply = orchestrator
-        .handle_turn_with_runtime(
-            &config,
-            "session-no-compact-threshold",
-            "hello",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("handle turn success");
-
-    assert_eq!(reply, "assistant-reply");
-    assert!(
-        runtime
-            .compact_calls
-            .lock()
-            .expect("compact lock")
-            .is_empty()
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_skips_compaction_below_token_threshold() {
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("assistant-reply".to_owned()),
-    );
-    let mut config = test_config();
-    config.conversation.compact_min_messages = None;
-    config.conversation.compact_trigger_estimated_tokens = Some(100_000);
-
-    let orchestrator = ConversationOrchestrator::new();
-    let reply = orchestrator
-        .handle_turn_with_runtime(
-            &config,
-            "session-no-compact-token-threshold",
-            "hello",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("handle turn success");
-
-    assert_eq!(reply, "assistant-reply");
-    assert!(
-        runtime
-            .compact_calls
-            .lock()
-            .expect("compact lock")
-            .is_empty()
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_compacts_when_token_threshold_reached() {
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("assistant-reply".to_owned()),
-    );
-    let mut config = test_config();
-    config.conversation.compact_min_messages = Some(999);
-    config.conversation.compact_trigger_estimated_tokens = Some(1);
-
-    let orchestrator = ConversationOrchestrator::new();
-    let reply = orchestrator
-        .handle_turn_with_runtime(
-            &config,
-            "session-compact-token-threshold",
-            "hello",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("handle turn success");
-
-    assert_eq!(reply, "assistant-reply");
-    let compact = runtime.compact_calls.lock().expect("compact lock").clone();
-    assert_eq!(compact.len(), 1);
-    assert_eq!(compact[0].0, "session-compact-token-threshold");
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_compaction_error_is_ignored_when_fail_open() {
-    let mut runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("assistant-reply".to_owned()),
-    );
-    runtime.compact_result = Err("compact failure".to_owned());
-    let mut config = test_config();
-    config.conversation.compact_fail_open = true;
-
-    let orchestrator = ConversationOrchestrator::new();
-    let reply = orchestrator
-        .handle_turn_with_runtime(
-            &config,
-            "session-compact-fail-open",
-            "hello",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("fail-open mode should keep turn successful");
-
-    assert_eq!(reply, "assistant-reply");
-    let compact = runtime.compact_calls.lock().expect("compact lock").clone();
-    assert_eq!(compact.len(), 1);
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_compaction_error_propagates_when_fail_closed() {
-    let mut runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("assistant-reply".to_owned()),
-    );
-    runtime.compact_result = Err("compact failure".to_owned());
-    let mut config = test_config();
-    config.conversation.compact_fail_open = false;
-
-    let orchestrator = ConversationOrchestrator::new();
-    let error = orchestrator
-        .handle_turn_with_runtime(
-            &config,
-            "session-compact-fail-closed",
-            "hello",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect_err("fail-closed mode should propagate compaction error");
-
-    assert!(
-        error.contains("compact failure"),
-        "unexpected error: {error}"
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "error");
+    assert_eq!(
+        terminal_outcome.payload_json["error"],
+        "delegate_child_panic: panic-runtime-request-turn"
     );
 }
 
 #[tokio::test]
 async fn handle_turn_with_runtime_propagates_error_without_persisting() {
     let runtime = FakeRuntime::new(vec![], Err("timeout".to_owned()));
-    let coordinator = ConversationTurnCoordinator::new();
-    let error = coordinator
+    let turn_loop = ConversationTurnLoop::new();
+    let error = turn_loop
         .handle_turn_with_runtime(
             &test_config(),
             "session-2",
@@ -2250,43 +3935,14 @@ async fn handle_turn_with_runtime_propagates_error_without_persisting() {
         .expect_err("propagate mode should return error");
 
     assert!(error.contains("timeout"));
-    assert_eq!(
-        runtime
-            .bootstrap_calls
-            .lock()
-            .expect("bootstrap lock")
-            .as_slice(),
-        ["session-2"]
-    );
     assert!(runtime.persisted.lock().expect("persisted lock").is_empty());
-    assert!(
-        runtime
-            .ingested_messages
-            .lock()
-            .expect("ingest lock")
-            .is_empty()
-    );
-    assert!(
-        runtime
-            .after_turn_calls
-            .lock()
-            .expect("after-turn lock")
-            .is_empty()
-    );
-    assert!(
-        runtime
-            .compact_calls
-            .lock()
-            .expect("compact lock")
-            .is_empty()
-    );
 }
 
 #[tokio::test]
 async fn handle_turn_with_runtime_inline_mode_returns_synthetic_reply_and_persists() {
     let runtime = FakeRuntime::new(vec![], Err("timeout".to_owned()));
-    let coordinator = ConversationTurnCoordinator::new();
-    let output = coordinator
+    let turn_loop = ConversationTurnLoop::new();
+    let output = turn_loop
         .handle_turn_with_runtime(
             &test_config(),
             "session-3",
@@ -2299,14 +3955,6 @@ async fn handle_turn_with_runtime_inline_mode_returns_synthetic_reply_and_persis
         .expect("inline mode should return synthetic reply");
 
     assert_eq!(output, "[provider_error] timeout");
-    assert_eq!(
-        runtime
-            .bootstrap_calls
-            .lock()
-            .expect("bootstrap lock")
-            .as_slice(),
-        ["session-3"]
-    );
 
     let persisted = runtime.persisted.lock().expect("persisted lock");
     assert_eq!(persisted.len(), 2);
@@ -2326,65 +3974,884 @@ async fn handle_turn_with_runtime_inline_mode_returns_synthetic_reply_and_persis
             "[provider_error] timeout".to_owned(),
         )
     );
+}
 
-    let ingested = runtime
-        .ingested_messages
+#[tokio::test]
+async fn handle_turn_with_runtime_uses_session_tool_view_from_runtime() {
+    let child_view = crate::tools::planned_delegate_child_tool_view();
+    let runtime = FakeRuntime::new(vec![], Ok("assistant-reply".to_owned()))
+        .with_tool_view(child_view.clone());
+    let turn_loop = ConversationTurnLoop::new();
+
+    let reply = turn_loop
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-child",
+            "hello",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert_eq!(reply, "assistant-reply");
+    assert_eq!(
+        runtime
+            .built_tool_views
+            .lock()
+            .expect("built tool views lock")
+            .as_slice(),
+        &[child_view.clone()]
+    );
+    assert_eq!(
+        runtime
+            .turn_requested_tool_views
+            .lock()
+            .expect("turn request tool views lock")
+            .as_slice(),
+        &[child_view]
+    );
+}
+
+#[tokio::test]
+async fn conversation_turn_uses_tool_view_from_session_context() {
+    let runtime = FakeRuntime::new(vec![], Ok("assistant-reply".to_owned()));
+    let turn_loop = ConversationTurnLoop::new();
+    let child_context = crate::conversation::SessionContext::child(
+        "delegate:child-1",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let reply = turn_loop
+        .handle_turn_with_runtime_and_context(
+            &test_config(),
+            &child_context,
+            "hello",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            &crate::conversation::NoopAppToolDispatcher,
+            &crate::conversation::NoopOrchestrationToolDispatcher,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert_eq!(reply, "assistant-reply");
+    assert_eq!(
+        runtime
+            .built_tool_views
+            .lock()
+            .expect("built tool views lock")
+            .as_slice(),
+        &[crate::tools::planned_delegate_child_tool_view()]
+    );
+    assert_eq!(
+        runtime
+            .turn_requested_tool_views
+            .lock()
+            .expect("turn request tool views lock")
+            .as_slice(),
+        &[crate::tools::planned_delegate_child_tool_view()]
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_executes_session_tools_via_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("default-session-tools");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Listing sessions.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "sessions_list".to_owned(),
+                args_json: json!({}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "root-session".to_owned(),
+                turn_id: "turn-session-tools".to_owned(),
+                tool_call_id: "call-session-tools".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        })],
+    );
+    let turn_loop = ConversationTurnLoop::new();
+
+    let reply = turn_loop
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert!(
+        reply.contains("\"current_session_id\":\"root-session\""),
+        "reply should contain session tool payload, got: {reply}"
+    );
+    assert!(
+        reply.contains("\"session_id\":\"root-session\""),
+        "reply should list the registered root session, got: {reply}"
+    );
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    let session = repo
+        .load_session("root-session")
+        .expect("load session")
+        .expect("root session row");
+    assert_eq!(session.session_id, "root-session");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_creates_child_session_and_returns_structured_result() {
+    let (config, db_path) = isolated_test_config("delegate-happy-path");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "child task",
+                        "label": "research-subtask"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Child final output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert!(
+        reply.contains("\"label\":\"research-subtask\""),
+        "reply: {reply}"
+    );
+    assert!(
+        reply.contains("\"final_output\":\"Child final output\""),
+        "reply: {reply}"
+    );
+    assert!(
+        reply.contains("\"child_session_id\":\"delegate:"),
+        "reply: {reply}"
+    );
+
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    let child = repo
+        .list_visible_sessions("root-session")
+        .expect("list visible sessions")
+        .into_iter()
+        .find(|session| session.parent_session_id.as_deref() == Some("root-session"))
+        .expect("child session summary");
+    assert_eq!(
+        child.kind,
+        crate::session::repository::SessionKind::DelegateChild
+    );
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Completed
+    );
+    assert_eq!(child.label.as_deref(), Some("research-subtask"));
+
+    let events = repo
+        .list_recent_events(&child.session_id, 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_completed"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome(&child.session_id)
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "ok");
+    assert_eq!(
+        terminal_outcome.payload_json["final_output"],
+        "Child final output"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_start_failure_does_not_leave_orphan_child_session() {
+    let (config, db_path) = isolated_test_config("delegate-start-rollback");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    })
+    .expect("session repository");
+    let conn = Connection::open(&db_path).expect("open sqlite connection");
+    conn.execute(
+        "CREATE TRIGGER fail_delegate_started_event
+         BEFORE INSERT ON session_events
+         WHEN NEW.event_kind = 'delegate_started'
+         BEGIN
+            SELECT RAISE(FAIL, 'forced delegate started failure');
+         END;",
+        [],
+    )
+    .expect("create delegate_started failure trigger");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Delegating.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "delegate".to_owned(),
+                args_json: json!({
+                    "task": "child task",
+                    "label": "research-subtask"
+                }),
+                source: "provider_tool_call".to_owned(),
+                session_id: "root-session".to_owned(),
+                turn_id: "turn-delegate-parent".to_owned(),
+                tool_call_id: "call-delegate-parent".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        })],
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn should surface tool error");
+
+    assert!(
+        reply.contains("insert session event failed"),
+        "reply: {reply}"
+    );
+
+    let sessions = repo
+        .list_sessions()
+        .expect("list sessions after delegate start failure");
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].session_id, "root-session");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_uses_restricted_tool_view() {
+    let (config, _db_path) = isolated_test_config("delegate-child-tool-view");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "child task",
+                        "label": "child-view"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Child output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert_eq!(
+        runtime
+            .turn_requested_tool_views
+            .lock()
+            .expect("turn request tool views lock")
+            .as_slice(),
+        &[
+            crate::tools::runtime_tool_view(),
+            crate::tools::planned_delegate_child_tool_view(),
+        ]
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_tool_view_allows_shell_when_config_enabled() {
+    let (mut config, _db_path) = isolated_test_config("delegate-child-shell");
+    config.tools.delegate.allow_shell_in_child = true;
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "child task",
+                        "label": "child-shell"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Child output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    let requested = runtime
+        .turn_requested_tool_views
         .lock()
-        .expect("ingest lock")
-        .clone();
-    assert_eq!(ingested.len(), 2);
-    assert_eq!(ingested[0].1["role"], "user");
-    assert_eq!(ingested[0].1["content"], "hello");
-    assert_eq!(ingested[1].1["role"], "assistant");
-    assert_eq!(ingested[1].1["content"], "[provider_error] timeout");
+        .expect("turn request tool views lock");
+    assert_eq!(requested.len(), 2);
+    assert!(requested[1].contains("shell.exec"));
+}
 
-    let after_turn = runtime
-        .after_turn_calls
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_timeout_sets_child_session_to_timed_out() {
+    let (config, db_path) = isolated_test_config("delegate-timeout");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "slow child task",
+                        "label": "timeout-child",
+                        "timeout_seconds": 1
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Too slow".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    )
+    .with_turn_delays(vec![Duration::ZERO, Duration::from_millis(1_100)]);
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert!(reply.contains("[timeout]"), "reply: {reply}");
+    assert!(
+        reply.contains("\"error\":\"delegate_timeout\""),
+        "reply: {reply}"
+    );
+
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    let child = repo
+        .list_visible_sessions("root-session")
+        .expect("list visible sessions")
+        .into_iter()
+        .find(|session| session.parent_session_id.as_deref() == Some("root-session"))
+        .expect("child session summary");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::TimedOut
+    );
+    assert_eq!(child.last_error.as_deref(), Some("delegate_timeout"));
+
+    let events = repo
+        .list_recent_events(&child.session_id, 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_timed_out"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome(&child.session_id)
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "timeout");
+    assert_eq!(terminal_outcome.payload_json["error"], "delegate_timeout");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_terminal_outcome_persists_for_failed_child() {
+    let (config, db_path) = isolated_test_config("delegate-failed-terminal-outcome");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "failing child task",
+                        "label": "failed-child"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Err("child runtime failed".to_owned()),
+        ],
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert!(reply.contains("[error]"), "reply: {reply}");
+    assert!(
+        reply.contains("\"error\":\"child runtime failed\""),
+        "reply: {reply}"
+    );
+
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    let child = repo
+        .list_visible_sessions("root-session")
+        .expect("list visible sessions")
+        .into_iter()
+        .find(|session| session.parent_session_id.as_deref() == Some("root-session"))
+        .expect("child session summary");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert_eq!(child.label.as_deref(), Some("failed-child"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome(&child.session_id)
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "error");
+    assert_eq!(
+        terminal_outcome.payload_json["error"],
+        "child runtime failed"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_cannot_reenter_delegate() {
+    let (config, _db_path) = isolated_test_config("delegate-reenter");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "show raw json tool output",
+                        "label": "nested-child"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Trying nested delegate.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({"task": "nested"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "delegate:child".to_owned(),
+                    turn_id: "turn-delegate-child".to_owned(),
+                    tool_call_id: "call-delegate-child".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert!(
+        reply.contains("tool_not_visible: delegate"),
+        "reply should surface nested delegate denial, got: {reply}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_can_reenter_when_max_depth_allows() {
+    let (mut config, db_path) = isolated_test_config("delegate-nested-allowed");
+    config.tools.delegate.max_depth = 2;
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating from root.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "show raw json tool output",
+                        "label": "child"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-root".to_owned(),
+                    tool_call_id: "call-root".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Delegating from child.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "final grandchild task",
+                        "label": "grandchild"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "delegate:child-runtime".to_owned(),
+                    turn_id: "turn-child".to_owned(),
+                    tool_call_id: "call-child".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Grandchild final output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("nested delegate success");
+
+    assert!(
+        reply.contains("Grandchild final output"),
+        "reply should include nested delegate final output, got: {reply}"
+    );
+
+    let requested = runtime
+        .turn_requested_tool_views
         .lock()
-        .expect("after-turn lock")
-        .clone();
-    assert_eq!(after_turn.len(), 1);
-    assert_eq!(after_turn[0].0, "session-3");
-    assert_eq!(after_turn[0].1, "hello");
-    assert_eq!(after_turn[0].2, "[provider_error] timeout");
-    assert_eq!(after_turn[0].3, 2);
+        .expect("turn request tool views lock");
+    assert_eq!(requested.len(), 3);
+    assert!(requested[1].contains("delegate"));
+    assert!(!requested[2].contains("delegate"));
 
-    let compact = runtime.compact_calls.lock().expect("compact lock").clone();
-    assert_eq!(compact.len(), 1);
-    assert_eq!(compact[0].0, "session-3");
-    assert_eq!(compact[0].1, 2);
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    let visible = repo
+        .list_visible_sessions("root-session")
+        .expect("visible sessions");
+    let descendant_ids: Vec<&str> = visible
+        .iter()
+        .map(|session| session.session_id.as_str())
+        .collect();
+    assert!(descendant_ids.contains(&"root-session"));
+    assert!(
+        visible.len() >= 3,
+        "expected root, child, grandchild; got: {visible:?}"
+    );
+    assert!(
+        visible
+            .iter()
+            .any(|session| session.parent_session_id.as_deref() == Some("root-session")),
+        "expected direct child session in visible set: {visible:?}"
+    );
+    assert!(
+        visible
+            .iter()
+            .any(|session| session.parent_session_id.is_some()
+                && session.parent_session_id.as_deref() != Some("root-session")),
+        "expected descendant grandchild session in visible set: {visible:?}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_returns_depth_exceeded_when_nested_delegate_exceeds_max_depth() {
+    let (mut config, db_path) = isolated_test_config("delegate-depth-exceeded");
+    config.tools.delegate.max_depth = 1;
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Trying nested delegate despite depth.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "delegate".to_owned(),
+                args_json: json!({
+                    "task": "nested",
+                    "label": "too-deep"
+                }),
+                source: "provider_tool_call".to_owned(),
+                session_id: "delegate:stale-child".to_owned(),
+                turn_id: "turn-child".to_owned(),
+                tool_call_id: "call-child".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        })],
+    );
+    let session_context = SessionContext::child(
+        "delegate:stale-child",
+        "root-session",
+        crate::tools::delegate_child_tool_view_for_config_with_delegate(&config.tools, true),
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime_and_context(
+            &config,
+            &session_context,
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            &DefaultAppToolDispatcher::new(
+                crate::memory::runtime_config::MemoryRuntimeConfig {
+                    sqlite_path: Some(config.memory.resolved_sqlite_path()),
+                },
+                config.tools.clone(),
+            ),
+            &DefaultOrchestrationToolDispatcher::new(
+                crate::memory::runtime_config::MemoryRuntimeConfig {
+                    sqlite_path: Some(config.memory.resolved_sqlite_path()),
+                },
+                config.tools.clone(),
+            ),
+            None,
+        )
+        .await
+        .expect("depth exceeded reply");
+
+    assert!(
+        reply.contains("delegate_depth_exceeded"),
+        "reply should surface depth enforcement, got: {reply}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_tool_turn_uses_natural_language_completion_by_default() {
+async fn handle_turn_with_runtime_denies_tool_outside_session_tool_view() {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Trying a shell command.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "shell.exec".to_owned(),
+                args_json: json!({"command": "echo", "args": ["blocked by tool view"]}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-child".to_owned(),
+                turn_id: "turn-child".to_owned(),
+                tool_call_id: "call-child".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        })],
+        Vec::new(),
+    )
+    .with_tool_view(crate::tools::planned_delegate_child_tool_view());
+    let turn_loop = ConversationTurnLoop::new();
+
+    let reply = turn_loop
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-child",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("turn should return denied raw reply");
+
+    assert!(
+        reply.contains("tool_not_visible: shell.exec"),
+        "reply should surface tool-view denial, got: {reply}"
+    );
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_tool_turn_runs_second_turn_for_natural_language_reply() {
     use super::integration_tests::TurnTestHarness;
 
     let harness = TurnTestHarness::new();
     std::fs::write(
         harness.temp_dir.join("note.md"),
-        "hello from coordinator test",
+        "hello from orchestrator test",
     )
     .expect("seed test note");
 
-    let runtime = FakeRuntime::with_turn_and_completion(
+    let runtime = FakeRuntime::with_turns(
         vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Reading the file now.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-tool".to_owned(),
-                turn_id: "turn-tool".to_owned(),
-                tool_call_id: "call-tool".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("Summary: the note says hello from coordinator test.".to_owned()),
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Reading the file now.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "note.md"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-tool".to_owned(),
+                    turn_id: "turn-tool".to_owned(),
+                    tool_call_id: "call-tool".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Summary: the note says hello from orchestrator test.".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
     );
 
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
         .handle_turn_with_runtime(
             &test_config(),
             "session-tool",
@@ -2396,7 +4863,10 @@ async fn handle_turn_with_runtime_tool_turn_uses_natural_language_completion_by_
         .await
         .expect("tool turn should succeed");
 
-    assert_eq!(reply, "Summary: the note says hello from coordinator test.");
+    assert_eq!(
+        reply,
+        "Summary: the note says hello from orchestrator test."
+    );
     assert!(
         !reply.contains("[ok]"),
         "default reply should not contain raw tool marker, got: {reply}"
@@ -2406,9 +4876,24 @@ async fn handle_turn_with_runtime_tool_turn_uses_natural_language_completion_by_
             .completion_calls
             .lock()
             .expect("completion calls lock"),
-        1
+        0
     );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+
+    let requested_turns = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock");
+    assert_eq!(requested_turns.len(), 2);
+    let second_turn_payload = serde_json::to_string(&requested_turns[1]).expect("serialize turns");
+    assert!(
+        second_turn_payload.contains("[tool_result]"),
+        "second turn should include tool result context, got: {second_turn_payload}"
+    );
+    assert!(
+        second_turn_payload.contains("Original request"),
+        "second turn should include followup prompt, got: {second_turn_payload}"
+    );
 
     let persisted = runtime.persisted.lock().expect("persisted lock");
     assert_eq!(persisted.len(), 2);
@@ -2424,7 +4909,7 @@ async fn handle_turn_with_runtime_tool_turn_raw_request_skips_second_pass_comple
     let harness = TurnTestHarness::new();
     std::fs::write(
         harness.temp_dir.join("note.md"),
-        "hello from coordinator test",
+        "hello from orchestrator test",
     )
     .expect("seed test note");
 
@@ -2445,8 +4930,8 @@ async fn handle_turn_with_runtime_tool_turn_raw_request_skips_second_pass_comple
         Ok("this must not be used".to_owned()),
     );
 
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
         .handle_turn_with_runtime(
             &test_config(),
             "session-tool-raw",
@@ -2473,1709 +4958,846 @@ async fn handle_turn_with_runtime_tool_turn_raw_request_skips_second_pass_comple
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_honors_configured_tool_result_summary_limit_on_fast_lane() {
+async fn handle_turn_with_runtime_supports_multiple_tool_rounds_before_final_answer() {
     use super::integration_tests::TurnTestHarness;
 
     let harness = TurnTestHarness::new();
-    std::fs::write(harness.temp_dir.join("large-note.md"), "x".repeat(8_000))
-        .expect("seed large test note");
+    std::fs::write(harness.temp_dir.join("note_a.md"), "first note").expect("seed note_a");
+    std::fs::write(harness.temp_dir.join("note_b.md"), "second note").expect("seed note_b");
 
-    let runtime = FakeRuntime::with_turn_and_completion(
+    let runtime = FakeRuntime::with_turns(
         vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Reading large note.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "large-note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-fast-limit".to_owned(),
-                turn_id: "turn-fast-limit".to_owned(),
-                tool_call_id: "call-fast-limit".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Reading note_a.md.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "note_a.md"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-multi-tool".to_owned(),
+                    turn_id: "turn-1".to_owned(),
+                    tool_call_id: "call-1".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Need note_b.md as well.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "note_b.md"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-multi-tool".to_owned(),
+                    turn_id: "turn-2".to_owned(),
+                    tool_call_id: "call-2".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Summary: note_a says first note; note_b says second note."
+                    .to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
     );
 
-    let mut config = test_config();
-    config.conversation.tool_result_payload_summary_limit_chars = 256;
-
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
         .handle_turn_with_runtime(
-            &config,
-            "session-fast-limit",
-            "read large-note.md and show raw json tool output",
+            &test_config(),
+            "session-multi-tool",
+            "read note_a.md and note_b.md then summarize",
             ProviderErrorMode::Propagate,
             &runtime,
             Some(&harness.kernel_ctx),
         )
         .await
-        .expect("tool turn should succeed");
+        .expect("multi-tool turn should succeed");
 
-    let line = reply
-        .lines()
-        .find(|entry| entry.starts_with("[ok] "))
-        .expect("reply should include tool envelope line");
-    let envelope: Value = serde_json::from_str(
-        line.strip_prefix("[ok] ")
-            .expect("tool line should keep status prefix"),
-    )
-    .expect("tool envelope should be valid json");
-
-    assert_eq!(envelope["payload_truncated"], true);
-    assert!(
-        envelope["payload_chars"]
-            .as_u64()
-            .expect("payload chars should exist")
-            > 256
+    assert_eq!(
+        reply,
+        "Summary: note_a says first note; note_b says second note."
     );
-    let summary = envelope["payload_summary"]
-        .as_str()
-        .expect("payload summary should be a string");
-    assert!(
-        summary.contains("...(truncated "),
-        "summary should contain truncation marker, got: {summary}"
-    );
-    assert!(
-        summary.chars().count() <= 420,
-        "summary should respect configured bound, chars={}",
-        summary.chars().count()
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_honors_configured_tool_result_summary_limit_on_safe_lane_plan() {
-    use super::integration_tests::TurnTestHarness;
-
-    let harness = TurnTestHarness::new();
-    std::fs::write(harness.temp_dir.join("large-note.md"), "x".repeat(8_000))
-        .expect("seed large test note");
-
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Running deployment read checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "large-note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-limit".to_owned(),
-                turn_id: "turn-safe-limit".to_owned(),
-                tool_call_id: "call-safe-limit".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 3);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
     );
 
-    let mut config = test_config();
-    config.conversation.safe_lane_plan_execution_enabled = true;
-    config.conversation.tool_result_payload_summary_limit_chars = 256;
-
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
-        .handle_turn_with_runtime(
-            &config,
-            "session-safe-limit",
-            "deploy production safely and show raw json tool output",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            Some(&harness.kernel_ctx),
-        )
-        .await
-        .expect("safe-lane plan turn should succeed");
-
-    let line = reply
-        .lines()
-        .find(|entry| entry.starts_with("[ok] "))
-        .expect("reply should include tool envelope line");
-    let envelope: Value = serde_json::from_str(
-        line.strip_prefix("[ok] ")
-            .expect("tool line should keep status prefix"),
-    )
-    .expect("tool envelope should be valid json");
-
-    assert_eq!(envelope["payload_truncated"], true);
+    let requested_turns = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock");
+    assert_eq!(requested_turns.len(), 3);
+    let third_turn_payload = serde_json::to_string(&requested_turns[2]).expect("serialize turns");
+    let tool_result_mentions = third_turn_payload.matches("[tool_result]").count();
     assert!(
-        envelope["payload_chars"]
-            .as_u64()
-            .expect("payload chars should exist")
-            > 256
-    );
-    let summary = envelope["payload_summary"]
-        .as_str()
-        .expect("payload summary should be a string");
-    assert!(
-        summary.contains("...(truncated "),
-        "summary should contain truncation marker, got: {summary}"
-    );
-    assert!(
-        summary.chars().count() <= 420,
-        "summary should respect configured bound, chars={}",
-        summary.chars().count()
+        tool_result_mentions >= 2,
+        "third turn should include at least two tool_result entries, got: {third_turn_payload}"
     );
 }
 
 #[tokio::test]
-async fn handle_turn_with_runtime_safe_lane_honors_configured_tool_step_budget() {
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
+async fn handle_turn_with_runtime_repeated_tool_signature_guard_warns_then_triggers_completion() {
+    let repeated_tool_turn = || {
         Ok(ProviderTurn {
-            assistant_text: "Executing deployment checks.".to_owned(),
-            tool_intents: vec![
-                ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-safe-budget".to_owned(),
-                    turn_id: "turn-safe-budget".to_owned(),
-                    tool_call_id: "call-safe-budget-1".to_owned(),
-                },
-                ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "checklist.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-safe-budget".to_owned(),
-                    turn_id: "turn-safe-budget".to_owned(),
-                    tool_call_id: "call-safe-budget-2".to_owned(),
-                },
-            ],
+            assistant_text: "Reading the file again.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-loop-guard".to_owned(),
+                turn_id: "turn-loop-guard".to_owned(),
+                tool_call_id: "call-loop-guard".to_owned(),
+            }],
             raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
+        })
+    };
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            repeated_tool_turn(),
+            repeated_tool_turn(),
+            repeated_tool_turn(),
+            repeated_tool_turn(),
+        ],
+        vec![Ok(
+            "I cannot access additional context, but here's what I found.".to_owned(),
+        )],
     );
 
-    let mut config = test_config();
-    config.conversation.safe_lane_max_tool_steps_per_turn = 2;
-
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
         .handle_turn_with_runtime(
-            &config,
-            "session-safe-budget",
-            "deploy to production with secret token and show raw json tool output",
+            &test_config(),
+            "session-loop-guard",
+            "read note.md",
             ProviderErrorMode::Propagate,
             &runtime,
             None,
         )
         .await
-        .expect("safe lane should execute with configured step budget");
+        .expect("loop guard fallback should succeed");
 
-    assert!(
-        reply.contains("no_kernel_context"),
-        "expected kernel-context denial once tool-step budget is honored, got: {reply}"
-    );
-    assert!(
-        !reply.contains("max_tool_steps_exceeded"),
-        "safe lane should not hit max_tool_steps after config override, got: {reply}"
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_safe_lane_plan_path_bypasses_turn_step_limit() {
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Executing deployment checks.".to_owned(),
-            tool_intents: vec![
-                ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-safe-plan".to_owned(),
-                    turn_id: "turn-safe-plan".to_owned(),
-                    tool_call_id: "call-safe-plan-1".to_owned(),
-                },
-                ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "checklist.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-safe-plan".to_owned(),
-                    turn_id: "turn-safe-plan".to_owned(),
-                    tool_call_id: "call-safe-plan-2".to_owned(),
-                },
-            ],
-            raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
-    );
-
-    let mut config = test_config();
-    config.conversation.safe_lane_plan_execution_enabled = true;
-    config.conversation.safe_lane_max_tool_steps_per_turn = 1;
-
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
-        .handle_turn_with_runtime(
-            &config,
-            "session-safe-plan",
-            "deploy to production with secret token and show raw json tool output",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("safe lane plan path should return inline tool error");
-
-    assert!(
-        reply.contains("no_kernel_context"),
-        "expected kernel-context denial from plan execution path, got: {reply}"
-    );
-    assert!(
-        !reply.contains("max_tool_steps_exceeded"),
-        "plan path should not use TurnEngine max_tool_steps gate, got: {reply}"
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_safe_lane_plan_persists_runtime_events_when_enabled() {
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Executing deployment checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-events".to_owned(),
-                turn_id: "turn-safe-events".to_owned(),
-                tool_call_id: "call-safe-events-1".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
-    );
-
-    let mut config = test_config();
-    config.conversation.safe_lane_plan_execution_enabled = true;
-    config.conversation.safe_lane_emit_runtime_events = true;
-    config.conversation.safe_lane_replan_max_rounds = 0;
-
-    let coordinator = ConversationTurnCoordinator::new();
-    let _reply = coordinator
-        .handle_turn_with_runtime(
-            &config,
-            "session-safe-events",
-            "deploy to production with secret token and show raw json tool output",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("safe lane plan should produce a reply");
-
-    let persisted = runtime.persisted.lock().expect("persisted lock");
-    let event_records = persisted
-        .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            Some((
-                parsed.get("event")?.as_str()?.to_owned(),
-                parsed.get("payload").cloned().unwrap_or(Value::Null),
-            ))
-        })
-        .collect::<Vec<_>>();
-    let event_names = event_records
-        .iter()
-        .map(|(event, _)| event.to_owned())
-        .collect::<Vec<_>>();
-
-    assert!(
-        event_names.iter().any(|name| name == "lane_selected"),
-        "expected lane_selected event, got: {event_names:?}"
-    );
-    assert!(
-        event_names.iter().any(|name| name == "plan_round_started"),
-        "expected plan_round_started event, got: {event_names:?}"
-    );
-    assert!(
-        event_names
-            .iter()
-            .any(|name| name == "plan_round_completed"),
-        "expected plan_round_completed event, got: {event_names:?}"
-    );
-    assert!(
-        event_names.iter().any(|name| name == "final_status"),
-        "expected final_status event, got: {event_names:?}"
-    );
-
-    let plan_round_completed_payload = event_records
-        .iter()
-        .find_map(|(event, payload)| (event == "plan_round_completed").then_some(payload))
-        .expect("plan_round_completed payload should exist");
-    let plan_stats = plan_round_completed_payload
-        .get("tool_output_stats")
-        .expect("plan_round_completed should include tool_output_stats");
     assert_eq!(
-        plan_stats
-            .get("truncated_result_lines")
-            .and_then(Value::as_u64),
-        Some(0)
+        reply,
+        "I cannot access additional context, but here's what I found."
     );
-    let plan_health = plan_round_completed_payload
-        .get("health_signal")
-        .expect("plan_round_completed should include health_signal");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 4);
     assert_eq!(
-        plan_health.get("severity").and_then(Value::as_str),
-        Some("ok")
-    );
-    assert_eq!(
-        plan_health
-            .get("flags")
-            .and_then(Value::as_array)
-            .map(Vec::len),
-        Some(0)
-    );
-
-    let final_status_payload = event_records
-        .iter()
-        .find_map(|(event, payload)| (event == "final_status").then_some(payload))
-        .expect("final_status payload should exist");
-    let final_stats = final_status_payload
-        .get("tool_output_stats")
-        .expect("final_status should include tool_output_stats");
-    assert_eq!(
-        final_stats.get("result_lines").and_then(Value::as_u64),
-        Some(0)
-    );
-    let final_health = final_status_payload
-        .get("health_signal")
-        .expect("final_status should include health_signal");
-    assert_eq!(
-        final_health.get("severity").and_then(Value::as_str),
-        Some("ok")
-    );
-}
-
-#[tokio::test]
-async fn handle_turn_with_runtime_safe_lane_plan_skips_runtime_events_when_disabled() {
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Executing deployment checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-events-off".to_owned(),
-                turn_id: "turn-safe-events-off".to_owned(),
-                tool_call_id: "call-safe-events-off-1".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
-    );
-
-    let mut config = test_config();
-    config.conversation.safe_lane_plan_execution_enabled = true;
-    config.conversation.safe_lane_emit_runtime_events = false;
-    config.conversation.safe_lane_replan_max_rounds = 0;
-
-    let coordinator = ConversationTurnCoordinator::new();
-    let _reply = coordinator
-        .handle_turn_with_runtime(
-            &config,
-            "session-safe-events-off",
-            "deploy to production with secret token and show raw json tool output",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            None,
-        )
-        .await
-        .expect("safe lane plan should produce a reply");
-
-    let persisted = runtime.persisted.lock().expect("persisted lock");
-    let event_count = persisted
-        .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            (parsed.get("type")?.as_str()? == "conversation_event").then_some(())
-        })
-        .count();
-    assert_eq!(event_count, 0, "unexpected runtime events: {persisted:?}");
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_safe_lane_plan_emits_kernel_runtime_audit_events() {
-    use super::integration_tests::TurnTestHarness;
-
-    let harness = TurnTestHarness::new();
-    std::fs::write(harness.temp_dir.join("note.md"), "safe lane audit probe")
-        .expect("write note fixture");
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Executing deployment checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-audit-on".to_owned(),
-                turn_id: "turn-safe-audit-on".to_owned(),
-                tool_call_id: "call-safe-audit-on-1".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
-    );
-
-    let mut config = test_config();
-    config.conversation.safe_lane_plan_execution_enabled = true;
-    config.conversation.safe_lane_emit_runtime_events = true;
-    config.conversation.safe_lane_replan_max_rounds = 0;
-
-    let coordinator = ConversationTurnCoordinator::new();
-    let _reply = coordinator
-        .handle_turn_with_runtime(
-            &config,
-            "session-safe-audit-on",
-            "deploy to production with secret token and show raw json tool output",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            Some(&harness.kernel_ctx),
-        )
-        .await
-        .expect("safe lane plan should produce a reply");
-
-    let events = harness.audit.snapshot();
-    #[allow(clippy::wildcard_enum_match_arm)]
-    let runtime_ops = events
-        .iter()
-        .filter_map(|event| match &event.kind {
-            loongclaw_kernel::AuditEventKind::PlaneInvoked {
-                pack_id,
-                plane,
-                tier,
-                primary_adapter,
-                operation,
-                ..
-            } if *plane == loongclaw_contracts::ExecutionPlane::Runtime
-                && operation.starts_with("conversation.safe_lane.") =>
-            {
-                Some((
-                    pack_id.to_owned(),
-                    *tier,
-                    primary_adapter.to_owned(),
-                    operation.to_owned(),
-                ))
-            }
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-
-    assert!(
-        runtime_ops
-            .iter()
-            .any(|(_, _, _, operation)| operation == "conversation.safe_lane.lane_selected"),
-        "expected lane_selected runtime audit event, got: {runtime_ops:?}"
-    );
-    assert!(
-        runtime_ops
-            .iter()
-            .any(|(_, _, _, operation)| operation == "conversation.safe_lane.final_status"),
-        "expected final_status runtime audit event, got: {runtime_ops:?}"
-    );
-    assert!(
-        runtime_ops.iter().all(|(pack_id, tier, adapter, _)| {
-            pack_id == "test-pack"
-                && *tier == loongclaw_contracts::PlaneTier::Core
-                && adapter == "conversation.safe_lane"
-        }),
-        "unexpected runtime audit metadata: {runtime_ops:?}"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_safe_lane_plan_does_not_emit_kernel_runtime_audit_when_disabled()
-{
-    use super::integration_tests::TurnTestHarness;
-
-    let harness = TurnTestHarness::new();
-    std::fs::write(harness.temp_dir.join("note.md"), "safe lane audit disabled")
-        .expect("write note fixture");
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Executing deployment checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-audit-off".to_owned(),
-                turn_id: "turn-safe-audit-off".to_owned(),
-                tool_call_id: "call-safe-audit-off-1".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
-    );
-
-    let mut config = test_config();
-    config.conversation.safe_lane_plan_execution_enabled = true;
-    config.conversation.safe_lane_emit_runtime_events = false;
-    config.conversation.safe_lane_replan_max_rounds = 0;
-
-    let coordinator = ConversationTurnCoordinator::new();
-    let _reply = coordinator
-        .handle_turn_with_runtime(
-            &config,
-            "session-safe-audit-off",
-            "deploy to production with secret token and show raw json tool output",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            Some(&harness.kernel_ctx),
-        )
-        .await
-        .expect("safe lane plan should produce a reply");
-
-    let has_safe_lane_runtime_event = harness.audit.snapshot().iter().any(|event| {
-        matches!(
-            &event.kind,
-            loongclaw_kernel::AuditEventKind::PlaneInvoked {
-                plane: loongclaw_contracts::ExecutionPlane::Runtime,
-                operation,
-                ..
-            } if operation.starts_with("conversation.safe_lane.")
-        )
-    });
-
-    assert!(
-        !has_safe_lane_runtime_event,
-        "safe-lane runtime audit events should be disabled"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_safe_lane_plan_replans_after_transient_tool_failure() {
-    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
-    use loongclaw_kernel::CoreToolAdapter;
-
-    struct FlakyOnceToolAdapter {
-        calls: Arc<Mutex<usize>>,
-    }
-
-    #[async_trait]
-    impl CoreToolAdapter for FlakyOnceToolAdapter {
-        fn name(&self) -> &str {
-            "flaky-once-tools"
-        }
-
-        async fn execute_core_tool(
-            &self,
-            request: ToolCoreRequest,
-        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
-            let current_call = {
-                let mut calls = self.calls.lock().expect("flaky calls lock");
-                *calls = calls.saturating_add(1);
-                *calls
-            };
-            if current_call == 1 {
-                return Err(ToolPlaneError::Execution(
-                    "transient tool failure".to_owned(),
-                ));
-            }
-            Ok(ToolCoreOutcome {
-                status: "ok".to_owned(),
-                payload: json!({
-                    "tool": request.tool_name,
-                    "attempt": current_call
-                }),
-            })
-        }
-    }
-
-    let call_counter = Arc::new(Mutex::new(0usize));
-    let audit = Arc::new(InMemoryAuditSink::default());
-    let clock = Arc::new(FixedClock::new(1_700_000_000));
-    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
-
-    let pack = VerticalPackManifest {
-        pack_id: "test-pack".to_owned(),
-        domain: "testing".to_owned(),
-        version: "0.1.0".to_owned(),
-        default_route: ExecutionRoute {
-            harness_kind: HarnessKind::EmbeddedPi,
-            adapter: None,
-        },
-        allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
-        metadata: BTreeMap::new(),
-    };
-    kernel.register_pack(pack).expect("register pack");
-    kernel.register_core_tool_adapter(FlakyOnceToolAdapter {
-        calls: call_counter.clone(),
-    });
-    kernel
-        .set_default_core_tool_adapter("flaky-once-tools")
-        .expect("set default core tool adapter");
-
-    let token = kernel
-        .issue_token("test-pack", "test-agent", 3600)
-        .expect("issue token");
-    let ctx = KernelContext {
-        kernel: Arc::new(kernel),
-        token,
-    };
-
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Running checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-replan".to_owned(),
-                turn_id: "turn-safe-replan".to_owned(),
-                tool_call_id: "call-safe-replan-1".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
-    );
-
-    let mut config = test_config();
-    config.conversation.safe_lane_plan_execution_enabled = true;
-    config.conversation.safe_lane_node_max_attempts = 1;
-    config.conversation.safe_lane_replan_max_rounds = 1;
-    config.conversation.safe_lane_replan_max_node_attempts = 2;
-    config.conversation.safe_lane_event_sample_every = 2;
-
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
-        .handle_turn_with_runtime(
-            &config,
-            "session-safe-replan",
-            "deploy to production with secret token and show raw json tool output",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            Some(&ctx),
-        )
-        .await
-        .expect("safe lane plan should recover via bounded replan");
-
-    assert!(
-        reply.contains("[ok]"),
-        "expected successful tool output after replan, got: {reply}"
-    );
-    assert!(
-        !reply.contains("transient tool failure"),
-        "final reply should not leak first transient failure after successful replan, got: {reply}"
-    );
-    let calls = *call_counter.lock().expect("call counter lock");
-    assert_eq!(calls, 2, "expected one failure + one replan success");
-
-    let persisted = runtime.persisted.lock().expect("persisted lock");
-    let failed_round_payload = persisted
-        .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            if parsed.get("event")?.as_str()? != "plan_round_completed" {
-                return None;
-            }
-            let payload = parsed.get("payload")?;
-            if payload.get("status")?.as_str()? != "failed" {
-                return None;
-            }
-            Some(payload.clone())
-        })
-        .next()
-        .expect("failed plan_round_completed payload");
-    assert_eq!(failed_round_payload["failure_kind"], "retryable");
-    assert_eq!(
-        failed_round_payload["failure_code"],
-        "safe_lane_plan_node_retryable_error"
-    );
-    assert_eq!(failed_round_payload["failure_retryable"], true);
-    assert_eq!(failed_round_payload["route_decision"], "replan");
-    assert_eq!(failed_round_payload["route_reason"], "retryable_failure");
-
-    let has_sampled_out_success_round = !persisted.iter().any(|(_, role, content)| {
-        if role != "assistant" {
-            return false;
-        }
-        let parsed = match serde_json::from_str::<Value>(content) {
-            Ok(value) => value,
-            Err(_) => return false,
-        };
-        if parsed.get("type").and_then(Value::as_str) != Some("conversation_event") {
-            return false;
-        }
-        if parsed.get("event").and_then(Value::as_str) != Some("plan_round_completed") {
-            return false;
-        }
-        let payload = match parsed.get("payload") {
-            Some(value) => value,
-            None => return false,
-        };
-        payload.get("status").and_then(Value::as_str) == Some("succeeded")
-            && payload.get("round").and_then(Value::as_u64) == Some(1)
-    });
-    assert!(
-        has_sampled_out_success_round,
-        "round-1 plan_round_completed should be sampled out"
-    );
-
-    let final_status_payload = persisted
-        .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            if parsed.get("event")?.as_str()? != "final_status" {
-                return None;
-            }
-            parsed.get("payload").cloned()
-        })
-        .next_back()
-        .expect("final_status payload");
-    assert_eq!(final_status_payload["status"], "succeeded");
-    assert_eq!(final_status_payload["metrics"]["rounds_started"], 2);
-    assert_eq!(final_status_payload["metrics"]["rounds_succeeded"], 1);
-    assert_eq!(final_status_payload["metrics"]["rounds_failed"], 1);
-    assert_eq!(final_status_payload["metrics"]["verify_failures"], 0);
-    assert_eq!(final_status_payload["metrics"]["replans_triggered"], 1);
-    assert!(
-        final_status_payload["metrics"]["total_attempts_used"]
-            .as_u64()
-            .unwrap_or_default()
-            >= 2
-    );
-
-    let summary = summarize_safe_lane_events(
-        persisted
-            .iter()
-            .filter_map(|(_, role, content)| (role == "assistant").then_some(content.as_str())),
-    );
-    assert_eq!(summary.final_status, Some(SafeLaneFinalStatus::Succeeded));
-    assert_eq!(summary.replan_triggered_events, 1);
-    assert_eq!(
-        summary
-            .latest_metrics
-            .as_ref()
-            .map(|metrics| metrics.rounds_started),
-        Some(2)
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_safe_lane_backpressure_guard_blocks_retry_storm() {
-    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
-    use loongclaw_kernel::CoreToolAdapter;
-
-    struct FlakyAlwaysRetryableAdapter {
-        calls: Arc<Mutex<usize>>,
-    }
-
-    #[async_trait]
-    impl CoreToolAdapter for FlakyAlwaysRetryableAdapter {
-        fn name(&self) -> &str {
-            "flaky-always-retryable-tools"
-        }
-
-        async fn execute_core_tool(
-            &self,
-            _request: ToolCoreRequest,
-        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
-            {
-                let mut calls = self.calls.lock().expect("flaky calls lock");
-                *calls = calls.saturating_add(1);
-            }
-            Err(ToolPlaneError::Execution(
-                "transient tool failure".to_owned(),
-            ))
-        }
-    }
-
-    let call_counter = Arc::new(Mutex::new(0usize));
-    let audit = Arc::new(InMemoryAuditSink::default());
-    let clock = Arc::new(FixedClock::new(1_700_000_000));
-    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
-
-    let pack = VerticalPackManifest {
-        pack_id: "test-pack".to_owned(),
-        domain: "testing".to_owned(),
-        version: "0.1.0".to_owned(),
-        default_route: ExecutionRoute {
-            harness_kind: HarnessKind::EmbeddedPi,
-            adapter: None,
-        },
-        allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
-        metadata: BTreeMap::new(),
-    };
-    kernel.register_pack(pack).expect("register pack");
-    kernel.register_core_tool_adapter(FlakyAlwaysRetryableAdapter {
-        calls: call_counter.clone(),
-    });
-    kernel
-        .set_default_core_tool_adapter("flaky-always-retryable-tools")
-        .expect("set default core tool adapter");
-
-    let token = kernel
-        .issue_token("test-pack", "test-agent", 3600)
-        .expect("issue token");
-    let ctx = KernelContext {
-        kernel: Arc::new(kernel),
-        token,
-    };
-
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Running checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-backpressure".to_owned(),
-                turn_id: "turn-safe-backpressure".to_owned(),
-                tool_call_id: "call-safe-backpressure-1".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
-    );
-
-    let mut config = test_config();
-    config.conversation.safe_lane_plan_execution_enabled = true;
-    config.conversation.safe_lane_node_max_attempts = 1;
-    config.conversation.safe_lane_replan_max_rounds = 3;
-    config.conversation.safe_lane_replan_max_node_attempts = 4;
-    config.conversation.safe_lane_backpressure_guard_enabled = true;
-    config
-        .conversation
-        .safe_lane_backpressure_max_total_attempts = 1;
-    config.conversation.safe_lane_backpressure_max_replans = 10;
-
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
-        .handle_turn_with_runtime(
-            &config,
-            "session-safe-backpressure",
-            "deploy to production with secret token and show raw json tool output",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            Some(&ctx),
-        )
-        .await
-        .expect("safe lane should fail-fast under backpressure guard");
-
-    assert!(
-        reply.contains("safe_lane_plan_backpressure_guard"),
-        "expected explicit backpressure guard reason, got: {reply}"
-    );
-    let calls = *call_counter.lock().expect("call counter lock");
-    assert_eq!(
-        calls, 1,
-        "backpressure guard should block further replan retries"
-    );
-
-    let persisted = runtime.persisted.lock().expect("persisted lock");
-    let final_status_payload = persisted
-        .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            if parsed.get("event")?.as_str()? != "final_status" {
-                return None;
-            }
-            parsed.get("payload").cloned()
-        })
-        .next_back()
-        .expect("final_status payload");
-    assert_eq!(
-        final_status_payload["route_reason"],
-        "backpressure_attempts_exhausted"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_safe_lane_verify_non_retryable_failure_skips_replan() {
-    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
-    use loongclaw_kernel::CoreToolAdapter;
-
-    struct DenyMarkerAdapter {
-        calls: Arc<Mutex<usize>>,
-    }
-
-    #[async_trait]
-    impl CoreToolAdapter for DenyMarkerAdapter {
-        fn name(&self) -> &str {
-            "deny-marker-tools"
-        }
-
-        async fn execute_core_tool(
-            &self,
-            _request: ToolCoreRequest,
-        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
-            let current_call = {
-                let mut calls = self.calls.lock().expect("anchor mismatch calls lock");
-                *calls = calls.saturating_add(1);
-                *calls
-            };
-            Ok(ToolCoreOutcome {
-                status: "ok".to_owned(),
-                payload: json!({
-                    "attempt": current_call,
-                    "message": "simulated tool_not_found marker"
-                }),
-            })
-        }
-    }
-
-    let call_counter = Arc::new(Mutex::new(0usize));
-    let audit = Arc::new(InMemoryAuditSink::default());
-    let clock = Arc::new(FixedClock::new(1_700_000_000));
-    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
-
-    let pack = VerticalPackManifest {
-        pack_id: "test-pack".to_owned(),
-        domain: "testing".to_owned(),
-        version: "0.1.0".to_owned(),
-        default_route: ExecutionRoute {
-            harness_kind: HarnessKind::EmbeddedPi,
-            adapter: None,
-        },
-        allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
-        metadata: BTreeMap::new(),
-    };
-    kernel.register_pack(pack).expect("register pack");
-    kernel.register_core_tool_adapter(DenyMarkerAdapter {
-        calls: call_counter.clone(),
-    });
-    kernel
-        .set_default_core_tool_adapter("deny-marker-tools")
-        .expect("set default core tool adapter");
-
-    let token = kernel
-        .issue_token("test-pack", "test-agent", 3600)
-        .expect("issue token");
-    let ctx = KernelContext {
-        kernel: Arc::new(kernel),
-        token,
-    };
-
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Running checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-verify-nonretryable".to_owned(),
-                turn_id: "turn-safe-verify-nonretryable".to_owned(),
-                tool_call_id: "call-safe-verify-nonretryable-1".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
-    );
-
-    let mut config = test_config();
-    config.conversation.safe_lane_plan_execution_enabled = true;
-    config.conversation.safe_lane_node_max_attempts = 1;
-    config.conversation.safe_lane_replan_max_rounds = 3;
-    config.conversation.safe_lane_replan_max_node_attempts = 4;
-
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
-        .handle_turn_with_runtime(
-            &config,
-            "session-safe-verify-nonretryable",
-            "deploy to production with secret token and show raw json tool output",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            Some(&ctx),
-        )
-        .await
-        .expect("safe lane should return verify failure");
-
-    assert!(
-        reply.contains("safe_lane_plan_verify_failed"),
-        "expected verify failure in reply, got: {reply}"
-    );
-    let calls = *call_counter.lock().expect("call counter lock");
-    assert_eq!(
-        calls, 1,
-        "non-retryable verify failure should not trigger replan tool re-execution"
-    );
-
-    let persisted = runtime.persisted.lock().expect("persisted lock");
-    let verify_failed_payload = persisted
-        .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            if parsed.get("event")?.as_str()? != "verify_failed" {
-                return None;
-            }
-            parsed.get("payload").cloned()
-        })
-        .next_back()
-        .expect("verify_failed payload");
-    assert_eq!(verify_failed_payload["failure_kind"], "non_retryable");
-    assert_eq!(
-        verify_failed_payload["failure_code"],
-        "safe_lane_plan_verify_failed"
-    );
-    assert_eq!(verify_failed_payload["failure_retryable"], false);
-    assert_eq!(verify_failed_payload["route_decision"], "terminal");
-    assert_eq!(
-        verify_failed_payload["route_reason"],
-        "non_retryable_failure"
-    );
-
-    let final_status_payload = persisted
-        .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            if parsed.get("event")?.as_str()? != "final_status" {
-                return None;
-            }
-            parsed.get("payload").cloned()
-        })
-        .next_back()
-        .expect("final_status payload");
-    assert_eq!(final_status_payload["failure_kind"], "non_retryable");
-    assert_eq!(
-        final_status_payload["failure_code"],
-        "safe_lane_plan_verify_failed"
-    );
-    assert_eq!(final_status_payload["failure_retryable"], false);
-    assert_eq!(final_status_payload["route_decision"], "terminal");
-    assert_eq!(
-        final_status_payload["route_reason"],
-        "non_retryable_failure"
-    );
-    assert_eq!(final_status_payload["metrics"]["rounds_started"], 1);
-    assert_eq!(final_status_payload["metrics"]["rounds_succeeded"], 1);
-    assert_eq!(final_status_payload["metrics"]["rounds_failed"], 0);
-    assert_eq!(final_status_payload["metrics"]["verify_failures"], 1);
-    assert_eq!(final_status_payload["metrics"]["replans_triggered"], 0);
-
-    let summary = summarize_safe_lane_events(
-        persisted
-            .iter()
-            .filter_map(|(_, role, content)| (role == "assistant").then_some(content.as_str())),
-    );
-    assert_eq!(summary.final_status, Some(SafeLaneFinalStatus::Failed));
-    assert_eq!(
-        summary.final_failure_code.as_deref(),
-        Some("safe_lane_plan_verify_failed")
-    );
-    assert_eq!(summary.verify_failed_events, 1);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_safe_lane_session_governor_forces_no_replan() {
-    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
-    use loongclaw_kernel::{CoreMemoryAdapter, CoreToolAdapter};
-
-    struct FlakyAlwaysRetryableAdapter {
-        calls: Arc<Mutex<usize>>,
-    }
-
-    #[async_trait]
-    impl CoreToolAdapter for FlakyAlwaysRetryableAdapter {
-        fn name(&self) -> &str {
-            "flaky-governor-tools"
-        }
-
-        async fn execute_core_tool(
-            &self,
-            _request: ToolCoreRequest,
-        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
-            {
-                let mut calls = self.calls.lock().expect("flaky calls lock");
-                *calls = calls.saturating_add(1);
-            }
-            Err(ToolPlaneError::Execution(
-                "transient tool failure".to_owned(),
-            ))
-        }
-    }
-
-    struct ChronicFailureMemoryAdapter;
-
-    #[async_trait]
-    impl CoreMemoryAdapter for ChronicFailureMemoryAdapter {
-        fn name(&self) -> &str {
-            "chronic-failure-memory"
-        }
-
-        async fn execute_core_memory(
-            &self,
-            request: MemoryCoreRequest,
-        ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
-            if request.operation == MEMORY_OP_WINDOW {
-                return Ok(MemoryCoreOutcome {
-                    status: "ok".to_owned(),
-                    payload: json!({
-                        "turns": [
-                            {
-                                "role": "assistant",
-                                "content": "{\"type\":\"conversation_event\",\"event\":\"final_status\",\"payload\":{\"status\":\"failed\",\"failure_code\":\"safe_lane_plan_node_retryable_error\",\"route_decision\":\"terminal\"}}",
-                                "ts": 1
-                            }
-                        ]
-                    }),
-                });
-            }
-            Ok(MemoryCoreOutcome {
-                status: "ok".to_owned(),
-                payload: json!({}),
-            })
-        }
-    }
-
-    let call_counter = Arc::new(Mutex::new(0usize));
-    let audit = Arc::new(InMemoryAuditSink::default());
-    let clock = Arc::new(FixedClock::new(1_700_000_000));
-    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
-
-    let pack = VerticalPackManifest {
-        pack_id: "test-pack".to_owned(),
-        domain: "testing".to_owned(),
-        version: "0.1.0".to_owned(),
-        default_route: ExecutionRoute {
-            harness_kind: HarnessKind::EmbeddedPi,
-            adapter: None,
-        },
-        allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::MemoryRead]),
-        metadata: BTreeMap::new(),
-    };
-    kernel.register_pack(pack).expect("register pack");
-    kernel.register_core_memory_adapter(ChronicFailureMemoryAdapter);
-    kernel
-        .set_default_core_memory_adapter("chronic-failure-memory")
-        .expect("set default core memory adapter");
-    kernel.register_core_tool_adapter(FlakyAlwaysRetryableAdapter {
-        calls: call_counter.clone(),
-    });
-    kernel
-        .set_default_core_tool_adapter("flaky-governor-tools")
-        .expect("set default core tool adapter");
-
-    let token = kernel
-        .issue_token("test-pack", "test-agent", 3600)
-        .expect("issue token");
-    let ctx = KernelContext {
-        kernel: Arc::new(kernel),
-        token,
-    };
-
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Running checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-governor".to_owned(),
-                turn_id: "turn-safe-governor".to_owned(),
-                tool_call_id: "call-safe-governor-1".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
-    );
-
-    let mut config = test_config();
-    config.conversation.safe_lane_plan_execution_enabled = true;
-    config.conversation.safe_lane_node_max_attempts = 1;
-    config.conversation.safe_lane_replan_max_rounds = 3;
-    config.conversation.safe_lane_replan_max_node_attempts = 4;
-    config.conversation.safe_lane_session_governor_enabled = true;
-    config
-        .conversation
-        .safe_lane_session_governor_failed_final_status_threshold = 1;
-    config
-        .conversation
-        .safe_lane_session_governor_backpressure_failure_threshold = 9;
-    config
-        .conversation
-        .safe_lane_session_governor_force_no_replan = true;
-    config
-        .conversation
-        .safe_lane_session_governor_force_node_max_attempts = 1;
-
-    let coordinator = ConversationTurnCoordinator::new();
-    let _reply = coordinator
-        .handle_turn_with_runtime(
-            &config,
-            "session-safe-governor",
-            "deploy to production with secret token and show raw json tool output",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            Some(&ctx),
-        )
-        .await
-        .expect("safe lane should fail without replan under governor");
-
-    let calls = *call_counter.lock().expect("call counter lock");
-    assert_eq!(calls, 1, "governor should suppress replans");
-
-    let persisted = runtime.persisted.lock().expect("persisted lock");
-    let lane_selected_payload = persisted
-        .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            if parsed.get("event")?.as_str()? != "lane_selected" {
-                return None;
-            }
-            parsed.get("payload").cloned()
-        })
-        .next_back()
-        .expect("lane_selected payload");
-    assert_eq!(lane_selected_payload["session_governor"]["engaged"], true);
-    assert_eq!(
-        lane_selected_payload["session_governor"]["force_no_replan"],
-        true
-    );
-    assert_eq!(
-        lane_selected_payload["session_governor"]["failed_threshold_triggered"],
-        true
-    );
-    assert_eq!(
-        lane_selected_payload["session_governor"]["trend_enabled"],
-        true
-    );
-    assert_eq!(
-        lane_selected_payload["session_governor"]["trend_samples"],
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
         1
     );
-    assert_eq!(
-        lane_selected_payload["session_governor"]["trend_threshold_triggered"],
-        false
+
+    let completion_payloads = runtime
+        .completion_requested_messages
+        .lock()
+        .expect("completion requests lock");
+    assert_eq!(completion_payloads.len(), 1);
+    let serialized = serde_json::to_string(&completion_payloads[0]).expect("serialize completion");
+    assert!(
+        serialized.contains("[tool_loop_guard]"),
+        "completion fallback payload should include loop guard marker, got: {serialized}"
     );
-    assert_eq!(
-        lane_selected_payload["session_governor"]["recovery_threshold_triggered"],
-        false
+    assert!(
+        serialized.contains("Detected tool-loop behavior across rounds."),
+        "completion fallback should include generic tool-loop guard prompt, got: {serialized}"
     );
-    assert_eq!(
-        lane_selected_payload["session_governor"]["trend_failure_ewma"],
-        Value::Null
+    assert!(
+        serialized.contains("Loop guard reason:"),
+        "completion fallback should include loop guard reason section, got: {serialized}"
+    );
+    assert!(
+        serialized.matches("[tool_failure]").count() == 4,
+        "completion fallback should preserve the latest tool failure context before guard fallback, got: {serialized}"
     );
 
-    let round_started_payload = persisted
-        .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            if parsed.get("event")?.as_str()? != "plan_round_started" {
-                return None;
-            }
-            parsed.get("payload").cloned()
-        })
-        .next_back()
-        .expect("plan_round_started payload");
-    assert_eq!(round_started_payload["effective_max_rounds"], 0);
-    assert_eq!(round_started_payload["effective_max_node_attempts"], 1);
-
-    let final_status_payload = persisted
-        .iter()
-        .filter_map(|(_, role, content)| {
-            if role != "assistant" {
-                return None;
-            }
-            let parsed = serde_json::from_str::<Value>(content).ok()?;
-            if parsed.get("type")?.as_str()? != "conversation_event" {
-                return None;
-            }
-            if parsed.get("event")?.as_str()? != "final_status" {
-                return None;
-            }
-            parsed.get("payload").cloned()
-        })
-        .next_back()
-        .expect("final_status payload");
-    assert_eq!(
-        final_status_payload["route_reason"],
-        "session_governor_no_replan"
+    let turn_payloads = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn requests lock");
+    assert_eq!(turn_payloads.len(), 4);
+    let warning_turn_payload =
+        serde_json::to_string(&turn_payloads[3]).expect("serialize warning turn");
+    assert!(
+        warning_turn_payload.contains("[tool_loop_warning]"),
+        "warning turn payload should include loop warning marker before hard stop, got: {warning_turn_payload}"
     );
-    assert_eq!(
-        final_status_payload["failure_code"],
-        "safe_lane_plan_session_governor_no_replan"
-    );
-    assert_eq!(final_status_payload["metrics"]["replans_triggered"], 0);
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_safe_lane_session_governor_requests_extended_history_window() {
-    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
-    use loongclaw_kernel::{CoreMemoryAdapter, CoreToolAdapter};
-
-    struct NoopToolAdapter;
-
-    #[async_trait]
-    impl CoreToolAdapter for NoopToolAdapter {
-        fn name(&self) -> &str {
-            "noop-governor-tool"
-        }
-
-        async fn execute_core_tool(
-            &self,
-            _request: ToolCoreRequest,
-        ) -> Result<ToolCoreOutcome, loongclaw_contracts::ToolPlaneError> {
-            Ok(ToolCoreOutcome {
-                status: "ok".to_owned(),
-                payload: json!({"ok": true}),
-            })
-        }
-    }
-
-    struct CapturingMemoryAdapter {
-        invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
-    }
-
-    #[async_trait]
-    impl CoreMemoryAdapter for CapturingMemoryAdapter {
-        fn name(&self) -> &str {
-            "capturing-governor-memory"
-        }
-
-        async fn execute_core_memory(
-            &self,
-            request: MemoryCoreRequest,
-        ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
-            self.invocations
-                .lock()
-                .expect("memory invocations lock")
-                .push(request.clone());
-            if request.operation == MEMORY_OP_WINDOW {
-                return Ok(MemoryCoreOutcome {
-                    status: "ok".to_owned(),
-                    payload: json!({
-                        "turns": []
-                    }),
-                });
-            }
-            Ok(MemoryCoreOutcome {
-                status: "ok".to_owned(),
-                payload: json!({}),
-            })
-        }
-    }
-
-    let memory_invocations = Arc::new(Mutex::new(Vec::<MemoryCoreRequest>::new()));
-    let audit = Arc::new(InMemoryAuditSink::default());
-    let clock = Arc::new(FixedClock::new(1_700_000_000));
-    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
-
-    let pack = VerticalPackManifest {
-        pack_id: "test-pack".to_owned(),
-        domain: "testing".to_owned(),
-        version: "0.1.0".to_owned(),
-        default_route: ExecutionRoute {
-            harness_kind: HarnessKind::EmbeddedPi,
-            adapter: None,
-        },
-        allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([
-            Capability::InvokeTool,
-            Capability::MemoryRead,
-            Capability::MemoryWrite,
-        ]),
-        metadata: BTreeMap::new(),
-    };
-    kernel.register_pack(pack).expect("register pack");
-    kernel.register_core_tool_adapter(NoopToolAdapter);
-    kernel
-        .set_default_core_tool_adapter("noop-governor-tool")
-        .expect("set default core tool adapter");
-    kernel.register_core_memory_adapter(CapturingMemoryAdapter {
-        invocations: memory_invocations.clone(),
-    });
-    kernel
-        .set_default_core_memory_adapter("capturing-governor-memory")
-        .expect("set default core memory adapter");
-
-    let token = kernel
-        .issue_token("test-pack", "test-agent", 3600)
-        .expect("issue token");
-    let ctx = KernelContext {
-        kernel: Arc::new(kernel),
-        token,
-    };
-
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
+#[tokio::test]
+async fn handle_turn_with_runtime_ping_pong_loop_guard_triggers_completion() {
+    let turn_for = |path: &str, call_id: &str| {
         Ok(ProviderTurn {
-            assistant_text: "Running checks.".to_owned(),
+            assistant_text: format!("Trying to read {path}."),
             tool_intents: vec![ToolIntent {
                 tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
+                args_json: json!({ "path": path }),
                 source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-governor-window".to_owned(),
-                turn_id: "turn-safe-governor-window".to_owned(),
-                tool_call_id: "call-safe-governor-window-1".to_owned(),
+                session_id: "session-ping-pong-guard".to_owned(),
+                turn_id: format!("turn-ping-pong-{path}"),
+                tool_call_id: call_id.to_owned(),
             }],
             raw_meta: Value::Null,
-        }),
-        Ok("unused".to_owned()),
+        })
+    };
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            turn_for("note_a.md", "call-ping-a-1"),
+            turn_for("note_b.md", "call-ping-b-1"),
+            turn_for("note_a.md", "call-ping-a-2"),
+            turn_for("note_b.md", "call-ping-b-2"),
+            turn_for("note_a.md", "call-ping-a-3"),
+        ],
+        vec![Ok("Switching strategy after loop warning.".to_owned())],
     );
 
     let mut config = test_config();
-    config.conversation.safe_lane_plan_execution_enabled = true;
-    config.conversation.safe_lane_session_governor_enabled = true;
-    config.conversation.safe_lane_session_governor_window_turns = 200;
+    config.conversation.turn_loop.max_rounds = 6;
+    config.conversation.turn_loop.max_repeated_tool_call_rounds = 8;
+    config.conversation.turn_loop.max_ping_pong_cycles = 2;
+    config.conversation.turn_loop.max_same_tool_failure_rounds = 8;
 
-    let coordinator = ConversationTurnCoordinator::new();
-    let _ = coordinator
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
         .handle_turn_with_runtime(
             &config,
-            "session-safe-governor-window",
-            "deploy to production with secret token and show raw json tool output",
+            "session-ping-pong-guard",
+            "read note_a then note_b",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&ctx),
+            None,
         )
         .await
-        .expect("safe lane turn should complete");
+        .expect("ping-pong loop guard fallback should succeed");
 
-    let captured = memory_invocations
-        .lock()
-        .expect("memory invocations lock")
-        .clone();
-    let window_request = captured
-        .iter()
-        .find(|request| request.operation == MEMORY_OP_WINDOW)
-        .expect("window request should be issued");
+    assert_eq!(reply, "Switching strategy after loop warning.");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 5);
     assert_eq!(
-        window_request.payload["session_id"],
-        "session-safe-governor-window"
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        1
     );
-    assert_eq!(window_request.payload["limit"], 200);
-    assert_eq!(window_request.payload["allow_extended_limit"], true);
+
+    let completion_payloads = runtime
+        .completion_requested_messages
+        .lock()
+        .expect("completion requests lock");
+    assert_eq!(completion_payloads.len(), 1);
+    let completion_payload =
+        serde_json::to_string(&completion_payloads[0]).expect("serialize completion");
+    assert!(
+        completion_payload.contains("[tool_loop_guard]"),
+        "completion payload should include loop guard marker, got: {completion_payload}"
+    );
+    assert!(
+        completion_payload.contains("Loop guard reason:"),
+        "completion payload should include loop guard reason section, got: {completion_payload}"
+    );
+    assert!(
+        completion_payload.matches("[tool_failure]").count() == 5,
+        "completion payload should include the latest tool failure payload before hard stop, got: {completion_payload}"
+    );
+    assert!(
+        completion_payload.contains("ping_pong_tool_patterns"),
+        "completion payload should include ping-pong reason, got: {completion_payload}"
+    );
+
+    let turn_payloads = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn requests lock");
+    assert_eq!(turn_payloads.len(), 5);
+    let warning_turn_payload =
+        serde_json::to_string(&turn_payloads[4]).expect("serialize warning turn");
+    assert!(
+        warning_turn_payload.contains("[tool_loop_warning]"),
+        "warning turn payload should include loop warning marker, got: {warning_turn_payload}"
+    );
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_failure_streak_guard_triggers_completion() {
+    let turn_for = |path: &str, call_id: &str| {
+        Ok(ProviderTurn {
+            assistant_text: format!("Attempting read for {path}."),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({ "path": path }),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-failure-streak-guard".to_owned(),
+                turn_id: format!("turn-failure-streak-{path}"),
+                tool_call_id: call_id.to_owned(),
+            }],
+            raw_meta: Value::Null,
+        })
+    };
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            turn_for("note_1.md", "call-failure-1"),
+            turn_for("note_2.md", "call-failure-2"),
+            turn_for("note_3.md", "call-failure-3"),
+            turn_for("note_4.md", "call-failure-4"),
+        ],
+        vec![Ok("Stopping after repeated tool failures.".to_owned())],
+    );
+
+    let mut config = test_config();
+    config.conversation.turn_loop.max_rounds = 5;
+    config.conversation.turn_loop.max_repeated_tool_call_rounds = 8;
+    config.conversation.turn_loop.max_ping_pong_cycles = 8;
+    config.conversation.turn_loop.max_same_tool_failure_rounds = 3;
+
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
+        .handle_turn_with_runtime(
+            &config,
+            "session-failure-streak-guard",
+            "read those notes",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("failure-streak loop guard fallback should succeed");
+
+    assert_eq!(reply, "Stopping after repeated tool failures.");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 4);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        1
+    );
+
+    let completion_payloads = runtime
+        .completion_requested_messages
+        .lock()
+        .expect("completion requests lock");
+    assert_eq!(completion_payloads.len(), 1);
+    let completion_payload =
+        serde_json::to_string(&completion_payloads[0]).expect("serialize completion");
+    assert!(
+        completion_payload.contains("[tool_loop_guard]"),
+        "completion payload should include loop guard marker, got: {completion_payload}"
+    );
+    assert!(
+        completion_payload.contains("Loop guard reason:"),
+        "completion payload should include loop guard reason section, got: {completion_payload}"
+    );
+    assert!(
+        completion_payload.matches("[tool_failure]").count() == 4,
+        "completion payload should include the latest tool failure payload before hard stop, got: {completion_payload}"
+    );
+    assert!(
+        completion_payload.contains("tool_failure_streak"),
+        "completion payload should include failure-streak reason, got: {completion_payload}"
+    );
+
+    let turn_payloads = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn requests lock");
+    assert_eq!(turn_payloads.len(), 4);
+    let warning_turn_payload =
+        serde_json::to_string(&turn_payloads[3]).expect("serialize warning turn");
+    assert!(
+        warning_turn_payload.contains("[tool_loop_warning]"),
+        "warning turn payload should include loop warning marker, got: {warning_turn_payload}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_safe_lane_replans_failed_subgraph_only() {
-    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
-    use loongclaw_kernel::CoreToolAdapter;
+async fn handle_turn_with_runtime_truncates_large_tool_result_in_followup_payload() {
+    use super::integration_tests::TurnTestHarness;
 
-    #[derive(Default)]
-    struct CallCounters {
-        note: usize,
-        checklist: usize,
-    }
+    let harness = TurnTestHarness::new();
+    let large_note = format!("BEGIN-UNIQUE-{}-END-UNIQUE", "x".repeat(1_600));
+    std::fs::write(harness.temp_dir.join("large_note.md"), large_note).expect("seed large note");
 
-    struct FailChecklistOnceAdapter {
-        counters: Arc<Mutex<CallCounters>>,
-    }
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Reading large note.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "large_note.md"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-truncate-tool-result".to_owned(),
+                    turn_id: "turn-truncate-tool-result-1".to_owned(),
+                    tool_call_id: "call-truncate-tool-result-1".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Summary completed.".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
 
-    #[async_trait]
-    impl CoreToolAdapter for FailChecklistOnceAdapter {
-        fn name(&self) -> &str {
-            "fail-checklist-once-tools"
-        }
+    let mut config = test_config();
+    config
+        .conversation
+        .turn_loop
+        .max_followup_tool_payload_chars = 220;
 
-        async fn execute_core_tool(
-            &self,
-            request: ToolCoreRequest,
-        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
-            let path = request
-                .payload
-                .get("path")
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_owned();
-            let (note_calls, checklist_calls) = {
-                let mut counters = self.counters.lock().expect("counters lock");
-                match path.as_str() {
-                    "note.md" => counters.note = counters.note.saturating_add(1),
-                    "checklist.md" => counters.checklist = counters.checklist.saturating_add(1),
-                    _ => {}
-                }
-                (counters.note, counters.checklist)
-            };
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
+        .handle_turn_with_runtime(
+            &config,
+            "session-truncate-tool-result",
+            "read large_note.md and summarize",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("tool-result truncation path should succeed");
 
-            if path == "checklist.md" && checklist_calls == 1 {
-                return Err(ToolPlaneError::Execution(
-                    "transient checklist failure".to_owned(),
-                ));
-            }
+    assert_eq!(reply, "Summary completed.");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
 
-            Ok(ToolCoreOutcome {
-                status: "ok".to_owned(),
-                payload: json!({
-                    "path": path,
-                    "note_calls": note_calls,
-                    "checklist_calls": checklist_calls
-                }),
-            })
-        }
-    }
+    let requested_turns = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock");
+    assert_eq!(requested_turns.len(), 2);
+    let second_turn_payload = serde_json::to_string(&requested_turns[1]).expect("serialize turns");
+    assert!(
+        second_turn_payload.contains("[tool_result_truncated]"),
+        "followup payload should include tool-result truncation marker, got: {second_turn_payload}"
+    );
+    assert!(
+        second_turn_payload.contains("BEGIN-UNIQUE-"),
+        "followup payload should retain leading tool context, got: {second_turn_payload}"
+    );
+    assert!(
+        !second_turn_payload.contains("-END-UNIQUE"),
+        "followup payload should trim tail content when truncated, got: {second_turn_payload}"
+    );
+}
 
-    let counters = Arc::new(Mutex::new(CallCounters::default()));
-    let audit = Arc::new(InMemoryAuditSink::default());
-    let clock = Arc::new(FixedClock::new(1_700_000_000));
-    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+#[tokio::test]
+async fn handle_turn_with_runtime_truncates_large_tool_failure_in_followup_payload() {
+    let oversized_tool_name = format!("tool_{}", "z".repeat(900));
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Attempting unknown tool.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: oversized_tool_name.clone(),
+                    args_json: json!({}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-truncate-tool-failure".to_owned(),
+                    turn_id: "turn-truncate-tool-failure-1".to_owned(),
+                    tool_call_id: "call-truncate-tool-failure-1".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Fallback answer after tool failure.".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
 
-    let pack = VerticalPackManifest {
-        pack_id: "test-pack".to_owned(),
-        domain: "testing".to_owned(),
-        version: "0.1.0".to_owned(),
-        default_route: ExecutionRoute {
-            harness_kind: HarnessKind::EmbeddedPi,
-            adapter: None,
-        },
-        allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
-        metadata: BTreeMap::new(),
-    };
-    kernel.register_pack(pack).expect("register pack");
-    kernel.register_core_tool_adapter(FailChecklistOnceAdapter {
-        counters: counters.clone(),
-    });
-    kernel
-        .set_default_core_tool_adapter("fail-checklist-once-tools")
-        .expect("set default core tool adapter");
+    let mut config = test_config();
+    config
+        .conversation
+        .turn_loop
+        .max_followup_tool_payload_chars = 180;
+    config.conversation.turn_loop.max_repeated_tool_call_rounds = 5;
 
-    let token = kernel
-        .issue_token("test-pack", "test-agent", 3600)
-        .expect("issue token");
-    let ctx = KernelContext {
-        kernel: Arc::new(kernel),
-        token,
-    };
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
+        .handle_turn_with_runtime(
+            &config,
+            "session-truncate-tool-failure",
+            "run this tool",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("tool-failure truncation path should succeed");
+
+    assert_eq!(reply, "Fallback answer after tool failure.");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+
+    let requested_turns = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock");
+    assert_eq!(requested_turns.len(), 2);
+    let second_turn_payload = serde_json::to_string(&requested_turns[1]).expect("serialize turns");
+    assert!(
+        second_turn_payload.contains("[tool_failure_truncated]"),
+        "followup payload should include tool-failure truncation marker, got: {second_turn_payload}"
+    );
+    assert!(
+        second_turn_payload.contains("tool_not_found"),
+        "followup payload should retain failure type, got: {second_turn_payload}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_enforces_total_followup_payload_budget_across_rounds() {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    std::fs::write(
+        harness.temp_dir.join("note_a.md"),
+        format!("NOTE-A-BEGIN-{}-NOTE-A-END", "a".repeat(1_200)),
+    )
+    .expect("seed note_a");
+    std::fs::write(
+        harness.temp_dir.join("note_b.md"),
+        format!("NOTE-B-BEGIN-{}-NOTE-B-END", "b".repeat(1_200)),
+    )
+    .expect("seed note_b");
+    std::fs::write(
+        harness.temp_dir.join("note_c.md"),
+        format!("NOTE-C-BEGIN-{}-NOTE-C-END", "c".repeat(1_200)),
+    )
+    .expect("seed note_c");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Reading note A.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "note_a.md"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-total-budget".to_owned(),
+                    turn_id: "turn-total-budget-1".to_owned(),
+                    tool_call_id: "call-total-budget-1".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Reading note B.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "note_b.md"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-total-budget".to_owned(),
+                    turn_id: "turn-total-budget-2".to_owned(),
+                    tool_call_id: "call-total-budget-2".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Reading note C.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "note_c.md"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-total-budget".to_owned(),
+                    turn_id: "turn-total-budget-3".to_owned(),
+                    tool_call_id: "call-total-budget-3".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Final synthesis after bounded context.".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    let mut config = test_config();
+    config.conversation.turn_loop.max_rounds = 4;
+    config.conversation.turn_loop.max_repeated_tool_call_rounds = 8;
+    config.conversation.turn_loop.max_ping_pong_cycles = 8;
+    config.conversation.turn_loop.max_same_tool_failure_rounds = 8;
+    config
+        .conversation
+        .turn_loop
+        .max_followup_tool_payload_chars = 600;
+    config
+        .conversation
+        .turn_loop
+        .max_followup_tool_payload_chars_total = 120;
+
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
+        .handle_turn_with_runtime(
+            &config,
+            "session-total-budget",
+            "read all notes then summarize",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("total followup payload budget path should succeed");
+
+    assert_eq!(reply, "Final synthesis after bounded context.");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 4);
+
+    let requested_turns = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock");
+    assert_eq!(requested_turns.len(), 4);
+    let fourth_turn_payload = serde_json::to_string(&requested_turns[3]).expect("serialize turns");
+    assert!(
+        fourth_turn_payload.contains("[tool_result_truncated]"),
+        "fourth turn should still include truncation marker, got: {fourth_turn_payload}"
+    );
+    assert!(
+        fourth_turn_payload.contains("budget_exhausted=true"),
+        "fourth turn should report exhausted total payload budget, got: {fourth_turn_payload}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_turn_loop_policy_override_allows_multiple_tool_steps() {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    std::fs::write(harness.temp_dir.join("note_a.md"), "first note").expect("seed note_a");
+    std::fs::write(harness.temp_dir.join("note_b.md"), "second note").expect("seed note_b");
 
     let runtime = FakeRuntime::with_turn_and_completion(
         vec![],
         Ok(ProviderTurn {
-            assistant_text: "Running checks.".to_owned(),
+            assistant_text: "Reading both notes.".to_owned(),
             tool_intents: vec![
                 ToolIntent {
                     tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note.md"}),
+                    args_json: json!({"path": "note_a.md"}),
                     source: "provider_tool_call".to_owned(),
-                    session_id: "session-safe-subgraph".to_owned(),
-                    turn_id: "turn-safe-subgraph".to_owned(),
-                    tool_call_id: "call-safe-subgraph-1".to_owned(),
+                    session_id: "session-step-override".to_owned(),
+                    turn_id: "turn-step-override".to_owned(),
+                    tool_call_id: "call-step-1".to_owned(),
                 },
                 ToolIntent {
                     tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "checklist.md"}),
+                    args_json: json!({"path": "note_b.md"}),
                     source: "provider_tool_call".to_owned(),
-                    session_id: "session-safe-subgraph".to_owned(),
-                    turn_id: "turn-safe-subgraph".to_owned(),
-                    tool_call_id: "call-safe-subgraph-2".to_owned(),
+                    session_id: "session-step-override".to_owned(),
+                    turn_id: "turn-step-override".to_owned(),
+                    tool_call_id: "call-step-2".to_owned(),
                 },
             ],
             raw_meta: Value::Null,
         }),
-        Ok("unused".to_owned()),
+        Ok("this must not be used".to_owned()),
     );
 
     let mut config = test_config();
-    config.conversation.safe_lane_plan_execution_enabled = true;
-    config.conversation.safe_lane_node_max_attempts = 1;
-    config.conversation.safe_lane_replan_max_rounds = 1;
-    config.conversation.safe_lane_replan_max_node_attempts = 2;
+    config.conversation.turn_loop.max_tool_steps_per_round = 2;
 
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
         .handle_turn_with_runtime(
             &config,
-            "session-safe-subgraph",
-            "deploy to production with secret token and show raw json tool output",
+            "session-step-override",
+            "read note_a.md and note_b.md, return raw tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&ctx),
+            Some(&harness.kernel_ctx),
         )
         .await
-        .expect("safe lane should recover by replaying only failed subgraph");
+        .expect("multiple tool steps should be allowed by override");
 
     assert!(
-        reply.contains("note.md"),
-        "expected note output, got: {reply}"
+        reply.matches("[ok]").count() >= 2,
+        "expected at least two tool outputs, got: {reply}"
     );
-    assert!(
-        reply.contains("checklist.md"),
-        "expected checklist output, got: {reply}"
-    );
-
-    let counters = counters.lock().expect("counters lock");
-    assert_eq!(counters.note, 1, "note.md should not be re-executed");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
     assert_eq!(
-        counters.checklist, 2,
-        "checklist.md should execute once + one replan retry"
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_approval_resolution_replays_delegate_through_turn_loop_path() {
+    let (config, db_path) = isolated_test_config("approval-resolve-delegate-turn-loop");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    seed_pending_approval_request(&repo, "apr-turn-loop-delegate", "root-session", "delegate");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(approval_request_resolve_turn(
+                "root-session",
+                "apr-turn-loop-delegate",
+                "approve_once",
+            )),
+            Ok(ProviderTurn {
+                assistant_text: "Approved child output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("approval resolve delegate replay should succeed");
+
+    assert!(
+        reply.contains("Approved child output"),
+        "reply should include delegate child output after approval replay, got: {reply}"
+    );
+
+    let resolved = repo
+        .load_approval_request("apr-turn-loop-delegate")
+        .expect("load approval request")
+        .expect("executed approval request");
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+
+    let visible = repo
+        .list_visible_sessions("root-session")
+        .expect("list visible sessions after replay");
+    assert!(
+        visible
+            .iter()
+            .any(|session| session.parent_session_id.as_deref() == Some("root-session")),
+        "expected approved delegate replay to create a child session, got: {visible:?}"
+    );
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_turn_loop_policy_override_allows_more_repeated_rounds() {
+    let repeated_tool_turn = || {
+        Ok(ProviderTurn {
+            assistant_text: "Trying file.read again.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "file.read".to_owned(),
+                args_json: json!({"path": "note.md"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-loop-override".to_owned(),
+                turn_id: "turn-loop-override".to_owned(),
+                tool_call_id: "call-loop-override".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        })
+    };
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            repeated_tool_turn(),
+            repeated_tool_turn(),
+            repeated_tool_turn(),
+            repeated_tool_turn(),
+            Ok(ProviderTurn {
+                assistant_text: "Final answer after four retries.".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    let mut config = test_config();
+    config.conversation.turn_loop.max_rounds = 5;
+    config.conversation.turn_loop.max_repeated_tool_call_rounds = 4;
+    config.conversation.turn_loop.max_ping_pong_cycles = 8;
+    config.conversation.turn_loop.max_same_tool_failure_rounds = 8;
+
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
+        .handle_turn_with_runtime(
+            &config,
+            "session-loop-override",
+            "read note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("policy override should permit extra repeated rounds");
+
+    assert_eq!(reply, "Final answer after four retries.");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 5);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
     );
 }
 
 #[tokio::test]
 async fn handle_turn_with_runtime_tool_denial_returns_inline_reply_even_in_propagate_mode() {
-    let runtime = FakeRuntime::with_turn_and_completion(
+    let runtime = FakeRuntime::with_turns(
         vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Reading the file now.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-denied".to_owned(),
-                turn_id: "turn-denied".to_owned(),
-                tool_call_id: "call-denied".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("MODEL_DENIED_REPLY".to_owned()),
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Reading the file now.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "note.md"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-denied".to_owned(),
+                    turn_id: "turn-denied".to_owned(),
+                    tool_call_id: "call-denied".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "MODEL_DENIED_REPLY".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
     );
 
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
         .handle_turn_with_runtime(
             &test_config(),
             "session-denied",
@@ -4201,13 +5823,100 @@ async fn handle_turn_with_runtime_tool_denial_returns_inline_reply_even_in_propa
             .completion_calls
             .lock()
             .expect("completion calls lock"),
-        1,
-        "tool-denied fallback should run a completion pass for language-aware output"
+        0,
+        "tool-denied loop should continue with request_turn without completion fallback"
     );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
 
     let persisted = runtime.persisted.lock().expect("persisted lock");
     assert_eq!(persisted.len(), 2);
     assert_eq!(persisted[1].2, reply);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_required_reply_includes_request_id_tool_reason_and_valid_decisions() {
+    let sqlite_path = isolated_sqlite_path("approval-required-reply");
+    let _ = fs::remove_file(&sqlite_path);
+    let mut config = test_config();
+    config.memory.sqlite_path = sqlite_path.clone();
+    config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
+
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(PathBuf::from(&sqlite_path)),
+    })
+    .expect("approval reply repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    create_async_child_session(
+        &repo,
+        "child-session",
+        "root-session",
+        crate::session::repository::SessionState::Ready,
+    );
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(single_tool_turn(
+            "root-session",
+            "turn-approval-required-reply",
+            "call-approval-required-reply",
+            "session_cancel",
+            json!({
+                "session_id": "child-session",
+            }),
+        ))],
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "cancel the child session",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("approval-required turn should return inline reply");
+
+    let requests = repo
+        .list_approval_requests_for_session("root-session", None)
+        .expect("list approval requests");
+    let request = requests
+        .first()
+        .expect("approval request should be materialized");
+
+    assert!(
+        reply.contains(&request.approval_request_id),
+        "reply should include approval request id, got: {reply}"
+    );
+    assert!(
+        reply.contains("session_cancel"),
+        "reply should include tool name, got: {reply}"
+    );
+    assert!(
+        reply.contains("tool:session_cancel"),
+        "reply should include human-readable reason, got: {reply}"
+    );
+    assert!(
+        reply.contains("approve_once"),
+        "reply should include approve_once decision, got: {reply}"
+    );
+    assert!(
+        reply.contains("approve_always"),
+        "reply should include approve_always decision, got: {reply}"
+    );
+    assert!(
+        reply.contains("deny"),
+        "reply should include deny decision, got: {reply}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4215,25 +5924,31 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
     use super::integration_tests::TurnTestHarness;
 
     let harness = TurnTestHarness::new();
-    let runtime = FakeRuntime::with_turn_and_completion(
+    let runtime = FakeRuntime::with_turns(
         vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Reading the file now.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!("not an object"),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-tool-error".to_owned(),
-                turn_id: "turn-tool-error".to_owned(),
-                tool_call_id: "call-tool-error".to_owned(),
-            }],
-            raw_meta: Value::Null,
-        }),
-        Ok("MODEL_ERROR_REPLY".to_owned()),
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Reading the file now.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!("not an object"),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-tool-error".to_owned(),
+                    turn_id: "turn-tool-error".to_owned(),
+                    tool_call_id: "call-tool-error".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "MODEL_ERROR_REPLY".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
     );
 
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
         .handle_turn_with_runtime(
             &test_config(),
             "session-tool-error",
@@ -4260,9 +5975,10 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
             .completion_calls
             .lock()
             .expect("completion calls lock"),
-        1,
-        "tool-error fallback should run a completion pass for language-aware output"
+        0,
+        "tool-error loop should continue with request_turn without completion fallback"
     );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
 
     let persisted = runtime.persisted.lock().expect("persisted lock");
     assert_eq!(persisted.len(), 2);
@@ -4271,8 +5987,7 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
 
 #[tokio::test]
 async fn handle_turn_with_runtime_tool_failure_completion_error_uses_raw_reason_without_markers() {
-    let runtime = FakeRuntime::with_turn_and_completion(
-        vec![],
+    let repeated_tool_turn = || {
         Ok(ProviderTurn {
             assistant_text: "Reading the file now.".to_owned(),
             tool_intents: vec![ToolIntent {
@@ -4284,14 +5999,27 @@ async fn handle_turn_with_runtime_tool_failure_completion_error_uses_raw_reason_
                 tool_call_id: "call-denied-fallback".to_owned(),
             }],
             raw_meta: Value::Null,
-        }),
-        Err("completion_unavailable".to_owned()),
+        })
+    };
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            repeated_tool_turn(),
+            repeated_tool_turn(),
+            repeated_tool_turn(),
+            repeated_tool_turn(),
+        ],
+        vec![Err("completion_unavailable".to_owned())],
     );
 
-    let coordinator = ConversationTurnCoordinator::new();
-    let reply = coordinator
+    let mut config = test_config();
+    config.conversation.turn_loop.max_repeated_tool_call_rounds = 8;
+
+    let turn_loop = ConversationTurnLoop::new();
+    let reply = turn_loop
         .handle_turn_with_runtime(
-            &test_config(),
+            &config,
             "session-denied-fallback",
             "read note.md",
             ProviderErrorMode::Propagate,
@@ -4324,6 +6052,7 @@ async fn handle_turn_with_runtime_tool_failure_completion_error_uses_raw_reason_
             .expect("completion calls lock"),
         1
     );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 4);
 }
 
 #[test]
@@ -4359,7 +6088,6 @@ fn turn_engine_no_tool_intents_returns_final_text() {
         raw_meta: serde_json::Value::Null,
     };
     let result = engine.evaluate_turn(&turn);
-    #[allow(clippy::wildcard_enum_match_arm)]
     match result {
         TurnResult::FinalText(text) => assert_eq!(text, "Hello!"),
         other => panic!("expected FinalText, got {:?}", other),
@@ -4368,7 +6096,7 @@ fn turn_engine_no_tool_intents_returns_final_text() {
 
 #[test]
 fn provider_tool_aliases_flow_through_parse_and_turn_validation() {
-    use crate::conversation::turn_engine::{TurnEngine, TurnResult};
+    use crate::conversation::turn_engine::TurnEngine;
     use crate::provider::extract_provider_turn;
 
     let response_body = serde_json::json!({
@@ -4393,21 +6121,17 @@ fn provider_tool_aliases_flow_through_parse_and_turn_validation() {
 
     let engine = TurnEngine::new(1);
     let result = engine.evaluate_turn(&turn);
-    #[allow(clippy::wildcard_enum_match_arm)]
-    match result {
-        TurnResult::NeedsApproval(reason) => {
-            assert!(
-                reason.contains("kernel_context_required"),
-                "reason: {reason}"
-            );
-        }
-        other => panic!("expected NeedsApproval, got {:?}", other),
-    }
+    let requirement = expect_needs_approval(result);
+    assert!(
+        requirement.reason.contains("kernel_context_required"),
+        "reason: {}",
+        requirement.reason
+    );
 }
 
 #[test]
 fn turn_engine_unknown_tool_returns_tool_denied() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine};
     let engine = TurnEngine::new(1);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
@@ -4422,7 +6146,6 @@ fn turn_engine_unknown_tool_returns_tool_denied() {
         raw_meta: serde_json::Value::Null,
     };
     let result = engine.evaluate_turn(&turn);
-    #[allow(clippy::wildcard_enum_match_arm)]
     match result {
         TurnResult::ToolDenied(reason) => {
             assert!(reason.contains("tool_not_found"), "reason: {reason}")
@@ -4432,35 +6155,28 @@ fn turn_engine_unknown_tool_returns_tool_denied() {
 }
 
 #[test]
-fn turn_engine_unknown_tool_exposes_structured_policy_denial() {
-    use crate::conversation::turn_engine::{
-        ProviderTurn, ToolIntent, TurnEngine, TurnFailureKind, TurnResult,
-    };
+fn turn_engine_known_tool_outside_tool_view_returns_tool_denied() {
+    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+
     let engine = TurnEngine::new(1);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
         tool_intents: vec![ToolIntent {
-            tool_name: "nonexistent.tool".to_owned(),
-            args_json: serde_json::json!({}),
+            tool_name: "shell.exec".to_owned(),
+            args_json: serde_json::json!({"command": "echo", "args": ["hello"]}),
             source: "provider_tool_call".to_owned(),
-            session_id: "s1".to_owned(),
-            turn_id: "t1".to_owned(),
-            tool_call_id: "c1".to_owned(),
+            session_id: "s-child".to_owned(),
+            turn_id: "t-child".to_owned(),
+            tool_call_id: "c-child".to_owned(),
         }],
         raw_meta: serde_json::Value::Null,
     };
 
-    let result = engine.evaluate_turn(&turn);
-    #[allow(clippy::wildcard_enum_match_arm)]
+    let result =
+        engine.evaluate_turn_in_view(&turn, &crate::tools::planned_delegate_child_tool_view());
     match result {
-        TurnResult::ToolDenied(failure) => {
-            assert_eq!(failure.kind, TurnFailureKind::PolicyDenied);
-            assert_eq!(failure.code, "tool_not_found");
-            assert!(!failure.retryable);
-            assert!(
-                failure.reason.contains("tool_not_found"),
-                "failure={failure:?}"
-            );
+        TurnResult::ToolDenied(reason) => {
+            assert!(reason.contains("tool_not_visible"), "reason: {reason}")
         }
         other => panic!("expected ToolDenied, got {:?}", other),
     }
@@ -4484,7 +6200,6 @@ fn turn_engine_exceeding_max_steps_returns_denied() {
         raw_meta: serde_json::Value::Null,
     };
     let result = engine.evaluate_turn(&turn);
-    #[allow(clippy::wildcard_enum_match_arm)]
     match result {
         TurnResult::ToolDenied(reason) => assert!(
             reason.contains("max_tool_steps_exceeded"),
@@ -4496,7 +6211,7 @@ fn turn_engine_exceeding_max_steps_returns_denied() {
 
 #[test]
 fn turn_engine_known_tool_with_no_kernel_returns_tool_denied() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine};
     let engine = TurnEngine::new(1);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
@@ -4512,16 +6227,12 @@ fn turn_engine_known_tool_with_no_kernel_returns_tool_denied() {
     };
     // Without kernel context, known tools should be validated but flagged as needing execution
     let result = engine.evaluate_turn(&turn);
-    #[allow(clippy::wildcard_enum_match_arm)]
-    match result {
-        TurnResult::NeedsApproval(reason) => {
-            assert!(
-                reason.contains("kernel_context_required"),
-                "reason: {reason}"
-            );
-        }
-        other => panic!("expected NeedsApproval, got {:?}", other),
-    }
+    let requirement = expect_needs_approval(result);
+    assert!(
+        requirement.reason.contains("kernel_context_required"),
+        "reason: {}",
+        requirement.reason
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4541,151 +6252,12 @@ async fn turn_engine_execute_turn_no_kernel_returns_denied() {
         raw_meta: serde_json::Value::Null,
     };
     let result = engine.execute_turn(&turn, None).await;
-    #[allow(clippy::wildcard_enum_match_arm)]
     match result {
         TurnResult::ToolDenied(reason) => {
             assert!(reason.contains("no_kernel_context"), "reason: {reason}");
         }
         other => panic!("expected ToolDenied, got {:?}", other),
     }
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn turn_engine_tool_execution_error_is_marked_retryable() {
-    use crate::conversation::turn_engine::{
-        ProviderTurn, ToolIntent, TurnEngine, TurnFailureKind, TurnResult,
-    };
-    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
-    use loongclaw_kernel::CoreToolAdapter;
-
-    struct RetryableErrorToolAdapter;
-
-    #[async_trait]
-    impl CoreToolAdapter for RetryableErrorToolAdapter {
-        fn name(&self) -> &str {
-            "retryable-error-tools"
-        }
-
-        async fn execute_core_tool(
-            &self,
-            _request: ToolCoreRequest,
-        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
-            Err(ToolPlaneError::Execution("transient failure".to_owned()))
-        }
-    }
-
-    let audit = Arc::new(InMemoryAuditSink::default());
-    let clock = Arc::new(FixedClock::new(1_700_000_000));
-    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
-
-    let pack = VerticalPackManifest {
-        pack_id: "test-pack".to_owned(),
-        domain: "testing".to_owned(),
-        version: "0.1.0".to_owned(),
-        default_route: ExecutionRoute {
-            harness_kind: HarnessKind::EmbeddedPi,
-            adapter: None,
-        },
-        allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
-        metadata: BTreeMap::new(),
-    };
-    kernel.register_pack(pack).expect("register pack");
-    kernel.register_core_tool_adapter(RetryableErrorToolAdapter);
-    kernel
-        .set_default_core_tool_adapter("retryable-error-tools")
-        .expect("set default");
-
-    let token = kernel
-        .issue_token("test-pack", "test-agent", 3600)
-        .expect("issue token");
-
-    let ctx = KernelContext {
-        kernel: Arc::new(kernel),
-        token,
-    };
-
-    let engine = TurnEngine::new(1);
-    let turn = ProviderTurn {
-        assistant_text: "".to_owned(),
-        tool_intents: vec![ToolIntent {
-            tool_name: "file.read".to_owned(),
-            args_json: json!({"path": "test.txt"}),
-            source: "provider_tool_call".to_owned(),
-            session_id: "s1".to_owned(),
-            turn_id: "t1".to_owned(),
-            tool_call_id: "c1".to_owned(),
-        }],
-        raw_meta: serde_json::Value::Null,
-    };
-
-    let result = engine.execute_turn(&turn, Some(&ctx)).await;
-    #[allow(clippy::wildcard_enum_match_arm)]
-    match result {
-        TurnResult::ToolError(failure) => {
-            assert_eq!(failure.kind, TurnFailureKind::Retryable);
-            assert_eq!(failure.code, "tool_execution_failed");
-            assert!(failure.retryable);
-            assert!(
-                failure.reason.contains("transient failure"),
-                "failure={failure:?}"
-            );
-        }
-        other => panic!("expected ToolError, got {:?}", other),
-    }
-}
-
-#[test]
-fn kernel_error_classification_table_is_stable() {
-    use crate::conversation::turn_engine::{KernelFailureClass, classify_kernel_error};
-    use loongclaw_contracts::{KernelError, PolicyError, RuntimePlaneError, ToolPlaneError};
-
-    let policy_error = KernelError::Policy(PolicyError::ToolCallDenied {
-        tool_name: "file.read".to_owned(),
-        reason: "blocked".to_owned(),
-    });
-    assert_eq!(
-        classify_kernel_error(&policy_error),
-        KernelFailureClass::PolicyDenied
-    );
-
-    let boundary_error = KernelError::PackCapabilityBoundary {
-        pack_id: "test-pack".to_owned(),
-        capability: Capability::InvokeTool,
-    };
-    assert_eq!(
-        classify_kernel_error(&boundary_error),
-        KernelFailureClass::PolicyDenied
-    );
-
-    let connector_error = KernelError::ConnectorNotAllowed {
-        connector: "shell".to_owned(),
-        pack_id: "test-pack".to_owned(),
-    };
-    assert_eq!(
-        classify_kernel_error(&connector_error),
-        KernelFailureClass::PolicyDenied
-    );
-
-    let retryable_tool_error =
-        KernelError::ToolPlane(ToolPlaneError::Execution("temporary outage".to_owned()));
-    assert_eq!(
-        classify_kernel_error(&retryable_tool_error),
-        KernelFailureClass::RetryableExecution
-    );
-
-    let non_retryable_tool_error = KernelError::ToolPlane(ToolPlaneError::NoDefaultCoreAdapter);
-    assert_eq!(
-        classify_kernel_error(&non_retryable_tool_error),
-        KernelFailureClass::NonRetryable
-    );
-
-    let runtime_error =
-        KernelError::RuntimePlane(RuntimePlaneError::Execution("runtime failure".to_owned()));
-    assert_eq!(
-        classify_kernel_error(&runtime_error),
-        KernelFailureClass::NonRetryable
-    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4760,29 +6332,11 @@ async fn turn_engine_executes_known_tool_with_kernel() {
     };
 
     let result = engine.execute_turn(&turn, Some(&ctx)).await;
-    #[allow(clippy::wildcard_enum_match_arm)]
     match result {
         TurnResult::FinalText(text) => {
-            let line = text.lines().next().expect("tool result line should exist");
-            let payload = line
-                .strip_prefix("[ok] ")
-                .expect("tool result line should keep [ok] prefix");
-            let envelope: Value =
-                serde_json::from_str(payload).expect("tool result envelope should be json");
             assert!(
-                payload.contains("\"tool\":\"file.read\""),
+                text.contains("\"tool\":\"file.read\""),
                 "expected echoed tool payload in output, got: {text}"
-            );
-            assert_eq!(envelope["status"], "ok");
-            assert_eq!(envelope["tool"], "file.read");
-            assert_eq!(envelope["tool_call_id"], "c1");
-            assert_eq!(envelope["payload_truncated"], false);
-            assert!(
-                envelope["payload_summary"]
-                    .as_str()
-                    .expect("payload summary should be string")
-                    .contains("\"path\":\"test.txt\""),
-                "expected payload summary to include original args, got: {envelope:?}"
             );
         }
         TurnResult::ToolDenied(reason) => {
@@ -4808,213 +6362,208 @@ async fn turn_engine_executes_known_tool_with_kernel() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn turn_engine_truncates_oversized_tool_payload_summary() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
-    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
-    use loongclaw_kernel::CoreToolAdapter;
+async fn turn_engine_routes_app_tools_through_dispatcher() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 
-    struct LargePayloadToolAdapter;
+    #[derive(Default)]
+    struct RecordingAppDispatcher {
+        calls: Mutex<Vec<(String, String)>>,
+    }
 
     #[async_trait]
-    impl CoreToolAdapter for LargePayloadToolAdapter {
-        fn name(&self) -> &str {
-            "large-payload-tools"
-        }
-
-        async fn execute_core_tool(
+    impl crate::conversation::AppToolDispatcher for RecordingAppDispatcher {
+        async fn execute_app_tool(
             &self,
+            session_context: &crate::conversation::SessionContext,
             request: ToolCoreRequest,
-        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls.lock().expect("dispatcher calls lock").push((
+                session_context.session_id.clone(),
+                request.tool_name.clone(),
+            ));
             Ok(ToolCoreOutcome {
                 status: "ok".to_owned(),
                 payload: json!({
-                    "tool": request.tool_name,
-                    "blob": "x".repeat(10_000)
+                    "session_id": session_context.session_id,
+                    "tool_name": request.tool_name,
                 }),
             })
         }
     }
 
-    let audit = Arc::new(InMemoryAuditSink::default());
-    let clock = Arc::new(FixedClock::new(1_700_000_000));
-    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
-
-    let pack = VerticalPackManifest {
-        pack_id: "test-pack".to_owned(),
-        domain: "testing".to_owned(),
-        version: "0.1.0".to_owned(),
-        default_route: ExecutionRoute {
-            harness_kind: HarnessKind::EmbeddedPi,
-            adapter: None,
-        },
-        allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
-        metadata: BTreeMap::new(),
-    };
-    kernel.register_pack(pack).expect("register pack");
-    kernel.register_core_tool_adapter(LargePayloadToolAdapter);
-    kernel
-        .set_default_core_tool_adapter("large-payload-tools")
-        .expect("set default");
-
-    let token = kernel
-        .issue_token("test-pack", "test-agent", 3600)
-        .expect("issue token");
-
-    let ctx = KernelContext {
-        kernel: Arc::new(kernel),
-        token,
-    };
-
-    let engine = TurnEngine::new(5);
+    let dispatcher = RecordingAppDispatcher::default();
+    let engine = TurnEngine::new(1);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
         tool_intents: vec![ToolIntent {
-            tool_name: "file.read".to_owned(),
-            args_json: json!({"path": "test.txt"}),
+            tool_name: "sessions_list".to_owned(),
+            args_json: json!({}),
             source: "provider_tool_call".to_owned(),
-            session_id: "s1".to_owned(),
-            turn_id: "t1".to_owned(),
-            tool_call_id: "c-large".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-app-1".to_owned(),
+            tool_call_id: "call-app-1".to_owned(),
         }],
-        raw_meta: serde_json::Value::Null,
+        raw_meta: Value::Null,
     };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+    let orchestration_dispatcher = crate::conversation::NoopOrchestrationToolDispatcher;
 
-    let result = engine.execute_turn(&turn, Some(&ctx)).await;
-    #[allow(clippy::wildcard_enum_match_arm)]
+    let result = engine
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &dispatcher,
+            &orchestration_dispatcher,
+            None,
+        )
+        .await;
+
     match result {
         TurnResult::FinalText(text) => {
-            let line = text.lines().next().expect("tool result line should exist");
-            let payload = line
-                .strip_prefix("[ok] ")
-                .expect("tool result line should keep [ok] prefix");
-            let envelope: Value =
-                serde_json::from_str(payload).expect("tool result envelope should be json");
-
-            assert_eq!(envelope["tool"], "file.read");
-            assert_eq!(envelope["tool_call_id"], "c-large");
-            assert_eq!(envelope["payload_truncated"], true);
             assert!(
-                envelope["payload_chars"]
-                    .as_u64()
-                    .expect("payload chars should exist")
-                    > 2048
-            );
-            let summary = envelope["payload_summary"]
-                .as_str()
-                .expect("payload summary should be string");
-            assert!(
-                summary.contains("...(truncated "),
-                "expected truncated marker, got: {summary}"
-            );
-            assert!(
-                summary.chars().count() <= 2200,
-                "truncated summary should stay bounded, chars={}",
-                summary.chars().count()
+                text.contains("\"tool_name\":\"sessions_list\""),
+                "expected dispatcher payload in output, got: {text}"
             );
         }
-        other => panic!("expected FinalText, got {:?}", other),
+        other => panic!("expected FinalText, got: {other:?}"),
     }
+
+    assert_eq!(
+        dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .as_slice(),
+        &[("root-session".to_owned(), "sessions_list".to_owned())]
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
-    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
-    use loongclaw_kernel::CoreToolAdapter;
+async fn turn_engine_routes_orchestration_tools_through_orchestration_dispatcher() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 
-    struct ExternalSkillInvokeAdapter;
+    #[derive(Default)]
+    struct RecordingAppDispatcher {
+        calls: Mutex<Vec<(String, String)>>,
+    }
 
     #[async_trait]
-    impl CoreToolAdapter for ExternalSkillInvokeAdapter {
-        fn name(&self) -> &str {
-            "external-skill-invoke-adapter"
-        }
-
-        async fn execute_core_tool(
+    impl crate::conversation::AppToolDispatcher for RecordingAppDispatcher {
+        async fn execute_app_tool(
             &self,
+            session_context: &crate::conversation::SessionContext,
             request: ToolCoreRequest,
-        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls.lock().expect("dispatcher calls lock").push((
+                session_context.session_id.clone(),
+                request.tool_name.clone(),
+            ));
             Ok(ToolCoreOutcome {
                 status: "ok".to_owned(),
                 payload: json!({
-                    "tool": request.tool_name,
-                    "instructions": "Follow the managed skill instruction. ".repeat(200),
-                    "invocation_summary": "Loaded managed external skill instructions."
+                    "lane": "app",
+                    "tool_name": request.tool_name,
                 }),
             })
         }
     }
 
-    let audit = Arc::new(InMemoryAuditSink::default());
-    let clock = Arc::new(FixedClock::new(1_700_000_000));
-    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+    #[derive(Default)]
+    struct RecordingOrchestrationDispatcher {
+        calls: Mutex<Vec<(String, String)>>,
+    }
 
-    let pack = VerticalPackManifest {
-        pack_id: "test-pack".to_owned(),
-        domain: "testing".to_owned(),
-        version: "0.1.0".to_owned(),
-        default_route: ExecutionRoute {
-            harness_kind: HarnessKind::EmbeddedPi,
-            adapter: None,
-        },
-        allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
-        metadata: BTreeMap::new(),
-    };
-    kernel.register_pack(pack).expect("register pack");
-    kernel.register_core_tool_adapter(ExternalSkillInvokeAdapter);
-    kernel
-        .set_default_core_tool_adapter("external-skill-invoke-adapter")
-        .expect("set default");
+    #[async_trait]
+    impl crate::conversation::OrchestrationToolDispatcher for RecordingOrchestrationDispatcher {
+        async fn execute_orchestration_tool(
+            &self,
+            session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls.lock().expect("dispatcher calls lock").push((
+                session_context.session_id.clone(),
+                request.tool_name.clone(),
+            ));
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "lane": "orchestration",
+                    "tool_name": request.tool_name,
+                }),
+            })
+        }
+    }
 
-    let token = kernel
-        .issue_token("test-pack", "test-agent", 3600)
-        .expect("issue token");
-
-    let ctx = KernelContext {
-        kernel: Arc::new(kernel),
-        token,
-    };
-
-    let engine = TurnEngine::new(5);
+    let app_dispatcher = RecordingAppDispatcher::default();
+    let orchestration_dispatcher = RecordingOrchestrationDispatcher::default();
+    let mut tool_config = ToolConfig::default();
+    tool_config.approval.mode = crate::config::GovernedToolApprovalMode::Disabled;
+    let governance = crate::conversation::DefaultToolGovernanceEvaluator::new(tool_config);
+    let engine = TurnEngine::new(1);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
         tool_intents: vec![ToolIntent {
-            tool_name: "external_skills.invoke".to_owned(),
-            args_json: json!({"skill_id": "demo-skill"}),
+            tool_name: "delegate_async".to_owned(),
+            args_json: json!({
+                "task": "inspect child branch",
+            }),
             source: "provider_tool_call".to_owned(),
-            session_id: "s1".to_owned(),
-            turn_id: "t1".to_owned(),
-            tool_call_id: "c-skill".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-orch-1".to_owned(),
+            tool_call_id: "call-orch-1".to_owned(),
         }],
-        raw_meta: serde_json::Value::Null,
+        raw_meta: Value::Null,
     };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
 
-    let result = engine.execute_turn(&turn, Some(&ctx)).await;
+    let result = engine
+        .execute_turn_in_context_with_governance(
+            &turn,
+            &session_context,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+        )
+        .await;
+
     match result {
         TurnResult::FinalText(text) => {
-            let line = text.lines().next().expect("tool result line should exist");
-            let payload = line
-                .strip_prefix("[ok] ")
-                .expect("tool result line should keep [ok] prefix");
-            let envelope: Value =
-                serde_json::from_str(payload).expect("tool result envelope should be valid json");
-            assert_eq!(envelope["tool"], "external_skills.invoke");
-            assert_eq!(envelope["payload_truncated"], json!(false));
             assert!(
-                envelope["payload_summary"]
-                    .as_str()
-                    .expect("payload summary should be text")
-                    .contains("Follow the managed skill instruction."),
-                "payload summary should keep invoke instructions intact: {envelope:?}"
+                text.contains("\"lane\":\"orchestration\""),
+                "expected orchestration dispatcher payload in output, got: {text}"
             );
         }
-        other @ TurnResult::NeedsApproval(_)
-        | other @ TurnResult::ToolDenied(_)
-        | other @ TurnResult::ToolError(_)
-        | other @ TurnResult::ProviderError(_) => panic!("unexpected result: {other:?}"),
+        other => panic!("expected FinalText, got: {other:?}"),
     }
+
+    assert!(
+        app_dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .is_empty(),
+        "delegate_async should not be routed through the app dispatcher"
+    );
+    assert_eq!(
+        orchestration_dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .as_slice(),
+        &[("root-session".to_owned(), "delegate_async".to_owned())]
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -5089,7 +6638,6 @@ async fn turn_engine_execute_turn_denied_without_capability() {
     };
 
     let result = engine.execute_turn(&turn, Some(&ctx)).await;
-    #[allow(clippy::wildcard_enum_match_arm)]
     match result {
         TurnResult::ToolDenied(reason) => {
             assert!(
@@ -5104,14 +6652,1029 @@ async fn turn_engine_execute_turn_denied_without_capability() {
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_app_tools_are_preflighted_before_dispatch() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct RecordingGovernanceEvaluator {
+        calls: Mutex<Vec<(String, String, String)>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::ToolGovernanceEvaluator for RecordingGovernanceEvaluator {
+        async fn evaluate_tool_governance(
+            &self,
+            descriptor: &crate::tools::ToolDescriptor,
+            _intent: &ToolIntent,
+            session_context: &crate::conversation::SessionContext,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> crate::conversation::ToolGovernanceDecision {
+            self.calls.lock().expect("governance calls lock").push((
+                session_context.session_id.clone(),
+                descriptor.name.to_owned(),
+                descriptor.audit_label.to_owned(),
+            ));
+            crate::conversation::ToolGovernanceDecision::allow(descriptor)
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingAppDispatcher {
+        calls: Mutex<Vec<(String, String)>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for RecordingAppDispatcher {
+        async fn execute_app_tool(
+            &self,
+            session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls.lock().expect("dispatcher calls lock").push((
+                session_context.session_id.clone(),
+                request.tool_name.clone(),
+            ));
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "lane": "app",
+                    "tool_name": request.tool_name,
+                }),
+            })
+        }
+    }
+
+    let governance = RecordingGovernanceEvaluator::default();
+    let app_dispatcher = RecordingAppDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "sessions_list".to_owned(),
+            args_json: json!({}),
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-governance-app-1".to_owned(),
+            tool_call_id: "call-governance-app-1".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+    let orchestration_dispatcher = crate::conversation::NoopOrchestrationToolDispatcher;
+
+    let result = engine
+        .execute_turn_in_context_with_governance(
+            &turn,
+            &session_context,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("\"lane\":\"app\""),
+                "expected app dispatcher payload in output, got: {text}"
+            );
+        }
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    assert_eq!(
+        governance
+            .calls
+            .lock()
+            .expect("governance calls lock")
+            .as_slice(),
+        &[(
+            "root-session".to_owned(),
+            "sessions_list".to_owned(),
+            "sessions_list".to_owned(),
+        )]
+    );
+    assert_eq!(
+        app_dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .as_slice(),
+        &[("root-session".to_owned(), "sessions_list".to_owned())]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_denials_short_circuit_dispatch() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct DenyingGovernanceEvaluator {
+        calls: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::ToolGovernanceEvaluator for DenyingGovernanceEvaluator {
+        async fn evaluate_tool_governance(
+            &self,
+            descriptor: &crate::tools::ToolDescriptor,
+            _intent: &ToolIntent,
+            _session_context: &crate::conversation::SessionContext,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> crate::conversation::ToolGovernanceDecision {
+            self.calls
+                .lock()
+                .expect("governance calls lock")
+                .push(descriptor.name.to_owned());
+            crate::conversation::ToolGovernanceDecision::deny(
+                descriptor,
+                "blocked_by_test_policy",
+                "test_deny",
+            )
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingAppDispatcher {
+        calls: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for RecordingAppDispatcher {
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls
+                .lock()
+                .expect("dispatcher calls lock")
+                .push(request.tool_name.clone());
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({}),
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingOrchestrationDispatcher {
+        calls: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::OrchestrationToolDispatcher for RecordingOrchestrationDispatcher {
+        async fn execute_orchestration_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls
+                .lock()
+                .expect("dispatcher calls lock")
+                .push(request.tool_name.clone());
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({}),
+            })
+        }
+    }
+
+    let governance = DenyingGovernanceEvaluator::default();
+    let app_dispatcher = RecordingAppDispatcher::default();
+    let orchestration_dispatcher = RecordingOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "sessions_list".to_owned(),
+            args_json: json!({}),
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-governance-deny-1".to_owned(),
+            tool_call_id: "call-governance-deny-1".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance(
+            &turn,
+            &session_context,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::ToolDenied(reason) => {
+            assert_eq!(reason, "blocked_by_test_policy");
+        }
+        other => panic!("expected ToolDenied, got: {other:?}"),
+    }
+
+    assert_eq!(
+        governance
+            .calls
+            .lock()
+            .expect("governance calls lock")
+            .as_slice(),
+        &["sessions_list".to_owned()]
+    );
+    assert!(
+        app_dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .is_empty(),
+        "app dispatcher should not run after governance denial"
+    );
+    assert!(
+        orchestration_dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .is_empty(),
+        "orchestration dispatcher should not run after governance denial"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_approval_requirements_short_circuit_orchestration_dispatch() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct ApprovalGovernanceEvaluator {
+        calls: Mutex<Vec<(String, String)>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::ToolGovernanceEvaluator for ApprovalGovernanceEvaluator {
+        async fn evaluate_tool_governance(
+            &self,
+            descriptor: &crate::tools::ToolDescriptor,
+            _intent: &ToolIntent,
+            session_context: &crate::conversation::SessionContext,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> crate::conversation::ToolGovernanceDecision {
+            self.calls.lock().expect("governance calls lock").push((
+                session_context.session_id.clone(),
+                descriptor.name.to_owned(),
+            ));
+            crate::conversation::ToolGovernanceDecision::require_approval(
+                descriptor,
+                "delegate requires operator approval",
+                "test_approval",
+            )
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingOrchestrationDispatcher {
+        calls: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::OrchestrationToolDispatcher for RecordingOrchestrationDispatcher {
+        async fn execute_orchestration_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls
+                .lock()
+                .expect("dispatcher calls lock")
+                .push(request.tool_name.clone());
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({}),
+            })
+        }
+    }
+
+    let governance = ApprovalGovernanceEvaluator::default();
+    let app_dispatcher = crate::conversation::NoopAppToolDispatcher;
+    let orchestration_dispatcher = RecordingOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "delegate_async".to_owned(),
+            args_json: json!({
+                "task": "inspect child branch",
+            }),
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-governance-approval-1".to_owned(),
+            tool_call_id: "call-governance-approval-1".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance(
+            &turn,
+            &session_context,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+        )
+        .await;
+
+    let requirement = expect_needs_approval(result);
+    assert_eq!(requirement.reason, "delegate requires operator approval");
+
+    assert_eq!(
+        governance
+            .calls
+            .lock()
+            .expect("governance calls lock")
+            .as_slice(),
+        &[("root-session".to_owned(), "delegate_async".to_owned())]
+    );
+    assert!(
+        orchestration_dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .is_empty(),
+        "orchestration dispatcher should not run when approval is required"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_approval_requires_delegate_under_default_medium_balanced() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct RecordingOrchestrationDispatcher {
+        calls: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::OrchestrationToolDispatcher for RecordingOrchestrationDispatcher {
+        async fn execute_orchestration_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls
+                .lock()
+                .expect("dispatcher calls lock")
+                .push(request.tool_name.clone());
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({}),
+            })
+        }
+    }
+
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let app_dispatcher = crate::conversation::NoopAppToolDispatcher;
+    let orchestration_dispatcher = RecordingOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "delegate".to_owned(),
+            args_json: json!({
+                "task": "child task",
+            }),
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-governance-default-delegate".to_owned(),
+            tool_call_id: "call-governance-default-delegate".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance(
+            &turn,
+            &session_context,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+        )
+        .await;
+
+    let requirement = expect_needs_approval(result);
+    assert!(
+        requirement.reason.contains("tool:delegate"),
+        "expected delegate approval key in reason, got: {}",
+        requirement.reason
+    );
+
+    assert!(
+        orchestration_dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .is_empty(),
+        "orchestration dispatcher should not run when delegate needs approval"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_approval_requires_delegate_async_under_default_medium_balanced() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct RecordingOrchestrationDispatcher {
+        calls: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::OrchestrationToolDispatcher for RecordingOrchestrationDispatcher {
+        async fn execute_orchestration_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls
+                .lock()
+                .expect("dispatcher calls lock")
+                .push(request.tool_name.clone());
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({}),
+            })
+        }
+    }
+
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let app_dispatcher = crate::conversation::NoopAppToolDispatcher;
+    let orchestration_dispatcher = RecordingOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "delegate_async".to_owned(),
+            args_json: json!({
+                "task": "inspect child branch",
+            }),
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-governance-default-delegate-async".to_owned(),
+            tool_call_id: "call-governance-default-delegate-async".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance(
+            &turn,
+            &session_context,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+        )
+        .await;
+
+    let requirement = expect_needs_approval(result);
+    assert!(
+        requirement.reason.contains("tool:delegate_async"),
+        "expected delegate_async approval key in reason, got: {}",
+        requirement.reason
+    );
+
+    assert!(
+        orchestration_dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .is_empty(),
+        "orchestration dispatcher should not run when delegate_async needs approval"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_approval_allows_elevated_app_tools_under_default_medium_balanced() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct RecordingAppDispatcher {
+        calls: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for RecordingAppDispatcher {
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls
+                .lock()
+                .expect("dispatcher calls lock")
+                .push(request.tool_name.clone());
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool_name": request.tool_name,
+                }),
+            })
+        }
+    }
+
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let app_dispatcher = RecordingAppDispatcher::default();
+    let orchestration_dispatcher = crate::conversation::NoopOrchestrationToolDispatcher;
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "session_cancel".to_owned(),
+            args_json: json!({
+                "session_id": "delegate:child-1",
+            }),
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-governance-default-session-cancel".to_owned(),
+            tool_call_id: "call-governance-default-session-cancel".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance(
+            &turn,
+            &session_context,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("\"tool_name\":\"session_cancel\""),
+                "expected app dispatcher payload, got: {text}"
+            );
+        }
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    assert_eq!(
+        app_dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .as_slice(),
+        &["session_cancel".to_owned()]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_approval_requires_elevated_app_tools_under_strict_mode() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct RecordingAppDispatcher {
+        calls: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for RecordingAppDispatcher {
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls
+                .lock()
+                .expect("dispatcher calls lock")
+                .push(request.tool_name.clone());
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({}),
+            })
+        }
+    }
+
+    let mut tool_config = ToolConfig::default();
+    tool_config.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
+    let governance = crate::conversation::DefaultToolGovernanceEvaluator::new(tool_config);
+    let app_dispatcher = RecordingAppDispatcher::default();
+    let orchestration_dispatcher = crate::conversation::NoopOrchestrationToolDispatcher;
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "session_cancel".to_owned(),
+            args_json: json!({
+                "session_id": "delegate:child-1",
+            }),
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-governance-strict-session-cancel".to_owned(),
+            tool_call_id: "call-governance-strict-session-cancel".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance(
+            &turn,
+            &session_context,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+        )
+        .await;
+
+    let requirement = expect_needs_approval(result);
+    assert!(
+        requirement.reason.contains("tool:session_cancel"),
+        "expected session_cancel approval key in reason, got: {}",
+        requirement.reason
+    );
+
+    assert!(
+        app_dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .is_empty(),
+        "app dispatcher should not run when strict approval is required"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_approval_disabled_mode_allows_policy_driven_tools() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct RecordingOrchestrationDispatcher {
+        calls: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::OrchestrationToolDispatcher for RecordingOrchestrationDispatcher {
+        async fn execute_orchestration_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls
+                .lock()
+                .expect("dispatcher calls lock")
+                .push(request.tool_name.clone());
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool_name": request.tool_name,
+                }),
+            })
+        }
+    }
+
+    let mut tool_config = ToolConfig::default();
+    tool_config.approval.mode = crate::config::GovernedToolApprovalMode::Disabled;
+    let governance = crate::conversation::DefaultToolGovernanceEvaluator::new(tool_config);
+    let app_dispatcher = crate::conversation::NoopAppToolDispatcher;
+    let orchestration_dispatcher = RecordingOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "delegate_async".to_owned(),
+            args_json: json!({
+                "task": "inspect child branch",
+            }),
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-governance-disabled-delegate-async".to_owned(),
+            tool_call_id: "call-governance-disabled-delegate-async".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance(
+            &turn,
+            &session_context,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("\"tool_name\":\"delegate_async\""),
+                "expected orchestration dispatcher payload, got: {text}"
+            );
+        }
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    assert_eq!(
+        orchestration_dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .as_slice(),
+        &["delegate_async".to_owned()]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_preapproval_allows_approved_delegate_call() {
+    let mut tool_config = ToolConfig::default();
+    tool_config.approval.approved_calls = vec!["tool:delegate".to_owned()];
+    let governance = crate::conversation::DefaultToolGovernanceEvaluator::new(tool_config);
+    let catalog = crate::tools::tool_catalog();
+    let descriptor = catalog.resolve("delegate").expect("delegate descriptor");
+    let intent = ToolIntent {
+        tool_name: "delegate".to_owned(),
+        args_json: json!({"task": "child task"}),
+        source: "provider_tool_call".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-governance-preapproved-delegate".to_owned(),
+        tool_call_id: "call-governance-preapproved-delegate".to_owned(),
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let decision = crate::conversation::ToolGovernanceEvaluator::evaluate_tool_governance(
+        &governance,
+        descriptor,
+        &intent,
+        &session_context,
+        None,
+    )
+    .await;
+
+    assert!(decision.allow);
+    assert!(!decision.approval_required);
+    assert_eq!(decision.rule_id, "governed_tool_preapproved_call");
+    assert!(
+        decision.reason.contains("tool:delegate"),
+        "expected approval key in reason, got: {}",
+        decision.reason
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_preapproval_denied_calls_override_approved_calls() {
+    let mut tool_config = ToolConfig::default();
+    tool_config.approval.approved_calls = vec!["tool:delegate".to_owned()];
+    tool_config.approval.denied_calls = vec!["tool:delegate".to_owned()];
+    let governance = crate::conversation::DefaultToolGovernanceEvaluator::new(tool_config);
+    let catalog = crate::tools::tool_catalog();
+    let descriptor = catalog.resolve("delegate").expect("delegate descriptor");
+    let intent = ToolIntent {
+        tool_name: "delegate".to_owned(),
+        args_json: json!({"task": "child task"}),
+        source: "provider_tool_call".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-governance-denylist-delegate".to_owned(),
+        tool_call_id: "call-governance-denylist-delegate".to_owned(),
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let decision = crate::conversation::ToolGovernanceEvaluator::evaluate_tool_governance(
+        &governance,
+        descriptor,
+        &intent,
+        &session_context,
+        None,
+    )
+    .await;
+
+    assert!(!decision.allow);
+    assert!(!decision.approval_required);
+    assert_eq!(decision.rule_id, "governed_tool_denied_call");
+    assert!(
+        decision.reason.contains("tool:delegate"),
+        "expected approval key in reason, got: {}",
+        decision.reason
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_preapproval_one_time_full_access_allows_high_risk_delegate() {
+    let mut tool_config = ToolConfig::default();
+    tool_config.approval.strategy = crate::config::GovernedToolApprovalStrategy::OneTimeFullAccess;
+    tool_config.approval.one_time_full_access_granted = true;
+    tool_config.approval.one_time_full_access_expires_at_epoch_s = Some(4_000_000_000);
+    tool_config.approval.one_time_full_access_remaining_uses = Some(2);
+    let governance = crate::conversation::DefaultToolGovernanceEvaluator::new(tool_config);
+    let catalog = crate::tools::tool_catalog();
+    let descriptor = catalog
+        .resolve("delegate_async")
+        .expect("delegate_async descriptor");
+    let intent = ToolIntent {
+        tool_name: "delegate_async".to_owned(),
+        args_json: json!({"task": "child task"}),
+        source: "provider_tool_call".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-governance-one-time-delegate-async".to_owned(),
+        tool_call_id: "call-governance-one-time-delegate-async".to_owned(),
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let decision = crate::conversation::ToolGovernanceEvaluator::evaluate_tool_governance(
+        &governance,
+        descriptor,
+        &intent,
+        &session_context,
+        None,
+    )
+    .await;
+
+    assert!(decision.allow);
+    assert!(!decision.approval_required);
+    assert_eq!(decision.rule_id, "governed_tool_one_time_full_access");
+    assert!(
+        decision.reason.contains("tool:delegate_async"),
+        "expected approval key in reason, got: {}",
+        decision.reason
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_preapproval_expired_one_time_full_access_requires_approval() {
+    let mut tool_config = ToolConfig::default();
+    tool_config.approval.strategy = crate::config::GovernedToolApprovalStrategy::OneTimeFullAccess;
+    tool_config.approval.one_time_full_access_granted = true;
+    tool_config.approval.one_time_full_access_expires_at_epoch_s = Some(1);
+    tool_config.approval.one_time_full_access_remaining_uses = Some(2);
+    let governance = crate::conversation::DefaultToolGovernanceEvaluator::new(tool_config);
+    let catalog = crate::tools::tool_catalog();
+    let descriptor = catalog
+        .resolve("delegate_async")
+        .expect("delegate_async descriptor");
+    let intent = ToolIntent {
+        tool_name: "delegate_async".to_owned(),
+        args_json: json!({"task": "child task"}),
+        source: "provider_tool_call".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-governance-expired-one-time-delegate-async".to_owned(),
+        tool_call_id: "call-governance-expired-one-time-delegate-async".to_owned(),
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let decision = crate::conversation::ToolGovernanceEvaluator::evaluate_tool_governance(
+        &governance,
+        descriptor,
+        &intent,
+        &session_context,
+        None,
+    )
+    .await;
+
+    assert!(!decision.allow);
+    assert!(decision.approval_required);
+    assert_eq!(
+        decision.rule_id,
+        "governed_tool_requires_one_time_full_access"
+    );
+    assert!(
+        decision.reason.contains("expired"),
+        "expected expiration reason, got: {}",
+        decision.reason
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governance_preapproval_exhausted_one_time_full_access_requires_approval() {
+    let mut tool_config = ToolConfig::default();
+    tool_config.approval.strategy = crate::config::GovernedToolApprovalStrategy::OneTimeFullAccess;
+    tool_config.approval.one_time_full_access_granted = true;
+    tool_config.approval.one_time_full_access_expires_at_epoch_s = Some(4_000_000_000);
+    tool_config.approval.one_time_full_access_remaining_uses = Some(0);
+    let governance = crate::conversation::DefaultToolGovernanceEvaluator::new(tool_config);
+    let catalog = crate::tools::tool_catalog();
+    let descriptor = catalog.resolve("delegate").expect("delegate descriptor");
+    let intent = ToolIntent {
+        tool_name: "delegate".to_owned(),
+        args_json: json!({"task": "child task"}),
+        source: "provider_tool_call".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-governance-exhausted-one-time-delegate".to_owned(),
+        tool_call_id: "call-governance-exhausted-one-time-delegate".to_owned(),
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let decision = crate::conversation::ToolGovernanceEvaluator::evaluate_tool_governance(
+        &governance,
+        descriptor,
+        &intent,
+        &session_context,
+        None,
+    )
+    .await;
+
+    assert!(!decision.allow);
+    assert!(decision.approval_required);
+    assert_eq!(
+        decision.rule_id,
+        "governed_tool_requires_one_time_full_access"
+    );
+    assert!(
+        decision.reason.contains("no remaining uses"),
+        "expected exhausted grant reason, got: {}",
+        decision.reason
+    );
+}
+
 // --- Tool lifecycle persistence tests ---
 
 #[tokio::test]
 async fn turn_engine_persists_tool_lifecycle_events() {
     use super::persistence::{persist_tool_decision, persist_tool_outcome};
-    use crate::conversation::turn_engine::{ToolDecision, ToolOutcome};
+    use crate::conversation::turn_engine::{ToolDecision, ToolGovernanceSnapshot, ToolOutcome};
+    use crate::tools::{ToolApprovalMode, ToolExecutionPlane, ToolGovernanceScope, ToolRiskClass};
 
     let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance = ToolGovernanceSnapshot {
+        execution_plane: ToolExecutionPlane::Orchestration,
+        governance_scope: ToolGovernanceScope::TopologyMutation,
+        risk_class: ToolRiskClass::High,
+        approval_mode: ToolApprovalMode::PolicyDriven,
+        audit_label: "delegate_async".to_owned(),
+        reason: "policy_ok".to_owned(),
+        rule_id: "rule-42".to_owned(),
+    };
 
     let decision = ToolDecision {
         allow: true,
@@ -5119,6 +7682,7 @@ async fn turn_engine_persists_tool_lifecycle_events() {
         approval_required: false,
         reason: "policy_ok".to_owned(),
         rule_id: "rule-42".to_owned(),
+        governance: governance.clone(),
     };
 
     let outcome = ToolOutcome {
@@ -5127,6 +7691,8 @@ async fn turn_engine_persists_tool_lifecycle_events() {
         error_code: None,
         human_reason: None,
         audit_event_id: Some("audit-001".to_owned()),
+        governance_allowed: true,
+        governance: Some(governance),
     };
 
     persist_tool_decision(&runtime, "sess-1", "turn-1", "call-1", &decision, None)
@@ -5154,6 +7720,18 @@ async fn turn_engine_persists_tool_lifecycle_events() {
     assert_eq!(decision_json["tool_call_id"], "call-1");
     assert_eq!(decision_json["decision"]["allow"], true);
     assert_eq!(decision_json["decision"]["rule_id"], "rule-42");
+    assert_eq!(
+        decision_json["decision"]["governance"]["governance_scope"],
+        "TopologyMutation"
+    );
+    assert_eq!(
+        decision_json["decision"]["governance"]["risk_class"],
+        "High"
+    );
+    assert_eq!(
+        decision_json["decision"]["governance"]["audit_label"],
+        "delegate_async"
+    );
 
     // Verify outcome content has correct correlation IDs and type
     let outcome_json: serde_json::Value =
@@ -5163,6 +7741,1668 @@ async fn turn_engine_persists_tool_lifecycle_events() {
     assert_eq!(outcome_json["tool_call_id"], "call-1");
     assert_eq!(outcome_json["outcome"]["status"], "ok");
     assert_eq!(outcome_json["outcome"]["audit_event_id"], "audit-001");
+    assert_eq!(outcome_json["outcome"]["governance_allowed"], true);
+    assert_eq!(
+        outcome_json["outcome"]["governance"]["approval_mode"],
+        "PolicyDriven"
+    );
+    assert_eq!(
+        outcome_json["outcome"]["governance"]["audit_label"],
+        "delegate_async"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_persists_tool_lifecycle_events_for_governed_app_dispatch() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct RecordingGovernanceEvaluator;
+
+    #[async_trait]
+    impl crate::conversation::ToolGovernanceEvaluator for RecordingGovernanceEvaluator {
+        async fn evaluate_tool_governance(
+            &self,
+            descriptor: &crate::tools::ToolDescriptor,
+            _intent: &ToolIntent,
+            _session_context: &crate::conversation::SessionContext,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> crate::conversation::ToolGovernanceDecision {
+            crate::conversation::ToolGovernanceDecision::allow(descriptor)
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingAppDispatcher;
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for RecordingAppDispatcher {
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool_name": request.tool_name,
+                    "items": 3,
+                }),
+            })
+        }
+    }
+
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance = RecordingGovernanceEvaluator;
+    let app_dispatcher = RecordingAppDispatcher;
+    let orchestration_dispatcher = crate::conversation::NoopOrchestrationToolDispatcher;
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "sessions_list".to_owned(),
+            args_json: json!({}),
+            source: "provider_tool_call".to_owned(),
+            session_id: "session-governance-persist".to_owned(),
+            turn_id: "turn-governance-persist".to_owned(),
+            tool_call_id: "call-governance-persist".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "session-governance-persist",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("\"tool_name\":\"sessions_list\""),
+                "expected app outcome in output, got: {text}"
+            );
+        }
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    assert_eq!(persisted.len(), 2, "expected decision and outcome records");
+
+    let decision_json: serde_json::Value =
+        serde_json::from_str(&persisted[0].2).expect("decision json parse");
+    assert_eq!(decision_json["type"], "tool_decision");
+    assert_eq!(
+        decision_json["decision"]["governance"]["execution_plane"],
+        "App"
+    );
+    assert_eq!(decision_json["decision"]["governance"]["risk_class"], "Low");
+    assert_eq!(
+        decision_json["decision"]["governance"]["audit_label"],
+        "sessions_list"
+    );
+
+    let outcome_json: serde_json::Value =
+        serde_json::from_str(&persisted[1].2).expect("outcome json parse");
+    assert_eq!(outcome_json["type"], "tool_outcome");
+    assert_eq!(outcome_json["outcome"]["governance_allowed"], true);
+    assert_eq!(outcome_json["outcome"]["status"], "ok");
+    assert_eq!(
+        outcome_json["outcome"]["governance"]["execution_plane"],
+        "App"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_persists_governed_tool_approval_required_lifecycle_events() {
+    #[derive(Default)]
+    struct RecordingOrchestrationDispatcher {
+        calls: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::OrchestrationToolDispatcher for RecordingOrchestrationDispatcher {
+        async fn execute_orchestration_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: loongclaw_contracts::ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+            self.calls
+                .lock()
+                .expect("dispatcher calls lock")
+                .push(request.tool_name.clone());
+            Ok(loongclaw_contracts::ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({}),
+            })
+        }
+    }
+
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let app_dispatcher = crate::conversation::NoopAppToolDispatcher;
+    let orchestration_dispatcher = RecordingOrchestrationDispatcher::default();
+    let (approval_request_store, memory_config) =
+        isolated_approval_request_store("governed-approval-request-persist");
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "delegate_async".to_owned(),
+            args_json: json!({
+                "task": "inspect child branch",
+            }),
+            source: "provider_tool_call".to_owned(),
+            session_id: "session-governance-approval-persist".to_owned(),
+            turn_id: "turn-governance-approval-persist".to_owned(),
+            tool_call_id: "call-governance-approval-persist".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "session-governance-approval-persist",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            Some(&approval_request_store),
+            None,
+        )
+        .await;
+
+    let requirement = expect_needs_approval(result);
+    assert_eq!(
+        requirement.kind,
+        crate::conversation::turn_engine::ApprovalRequirementKind::GovernedTool
+    );
+    assert_eq!(requirement.tool_name.as_deref(), Some("delegate_async"));
+    assert_eq!(
+        requirement.approval_key.as_deref(),
+        Some("tool:delegate_async")
+    );
+    assert!(
+        requirement.reason.contains("tool:delegate_async"),
+        "expected approval key in reason, got: {}",
+        requirement.reason
+    );
+    assert_eq!(
+        requirement.rule_id,
+        "governed_tool_requires_per_call_approval"
+    );
+    let approval_request_id = requirement
+        .approval_request_id
+        .clone()
+        .expect("approval request id");
+
+    assert!(
+        orchestration_dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .is_empty(),
+        "orchestration dispatcher should not run when approval is required"
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    assert_eq!(persisted.len(), 2, "expected decision and outcome records");
+
+    let decision_json: serde_json::Value =
+        serde_json::from_str(&persisted[0].2).expect("decision json parse");
+    assert_eq!(decision_json["type"], "tool_decision");
+    assert_eq!(decision_json["decision"]["allow"], false);
+    assert_eq!(decision_json["decision"]["deny"], false);
+    assert_eq!(decision_json["decision"]["approval_required"], true);
+    assert_eq!(
+        decision_json["decision"]["rule_id"],
+        "governed_tool_requires_per_call_approval"
+    );
+    assert!(decision_json["decision"]["reason"]
+        .as_str()
+        .expect("decision reason")
+        .contains("tool:delegate_async"));
+    assert_eq!(
+        decision_json["decision"]["governance"]["execution_plane"],
+        "Orchestration"
+    );
+    assert_eq!(
+        decision_json["decision"]["governance"]["risk_class"],
+        "High"
+    );
+
+    let outcome_json: serde_json::Value =
+        serde_json::from_str(&persisted[1].2).expect("outcome json parse");
+    assert_eq!(outcome_json["type"], "tool_outcome");
+    assert_eq!(outcome_json["outcome"]["status"], "approval_required");
+    assert_eq!(outcome_json["outcome"]["error_code"], "approval_required");
+    assert_eq!(outcome_json["outcome"]["governance_allowed"], false);
+    assert_eq!(
+        outcome_json["outcome"]["human_reason"],
+        decision_json["decision"]["reason"]
+    );
+    assert_eq!(
+        outcome_json["outcome"]["governance"]["audit_label"],
+        "delegate_async"
+    );
+
+    let repo = SessionRepository::new(&memory_config).expect("approval request repository");
+    let stored = repo
+        .load_approval_request(&approval_request_id)
+        .expect("load approval request")
+        .expect("approval request row");
+    assert_eq!(stored.session_id, "session-governance-approval-persist");
+    assert_eq!(stored.turn_id, "turn-governance-approval-persist");
+    assert_eq!(stored.tool_call_id, "call-governance-approval-persist");
+    assert_eq!(stored.tool_name, "delegate_async");
+    assert_eq!(stored.approval_key, "tool:delegate_async");
+    assert_eq!(
+        stored.status,
+        crate::session::repository::ApprovalRequestStatus::Pending
+    );
+    assert_eq!(
+        stored.governance_snapshot_json["rule_id"],
+        "governed_tool_requires_per_call_approval"
+    );
+    assert_eq!(stored.request_payload_json["tool_name"], "delegate_async");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governed_tool_approval_request_reuses_deterministic_id_for_same_blocked_call() {
+    #[derive(Default)]
+    struct RecordingOrchestrationDispatcher;
+
+    #[async_trait]
+    impl crate::conversation::OrchestrationToolDispatcher for RecordingOrchestrationDispatcher {
+        async fn execute_orchestration_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            _request: loongclaw_contracts::ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+            panic!("orchestration dispatcher should not run when approval is required");
+        }
+    }
+
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let app_dispatcher = crate::conversation::NoopAppToolDispatcher;
+    let orchestration_dispatcher = RecordingOrchestrationDispatcher;
+    let (approval_request_store, memory_config) =
+        isolated_approval_request_store("governed-approval-request-reuse");
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "delegate".to_owned(),
+            args_json: json!({
+                "task": "inspect repo",
+            }),
+            source: "provider_tool_call".to_owned(),
+            session_id: "session-governance-approval-reuse".to_owned(),
+            turn_id: "turn-governance-approval-reuse".to_owned(),
+            tool_call_id: "call-governance-approval-reuse".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "session-governance-approval-reuse",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let first = expect_needs_approval(
+        engine
+            .execute_turn_in_context_with_governance_and_persistence(
+                &turn,
+                &session_context,
+                &runtime,
+                &governance,
+                &app_dispatcher,
+                &orchestration_dispatcher,
+                Some(&approval_request_store),
+                None,
+            )
+            .await,
+    );
+    let second = expect_needs_approval(
+        engine
+            .execute_turn_in_context_with_governance_and_persistence(
+                &turn,
+                &session_context,
+                &runtime,
+                &governance,
+                &app_dispatcher,
+                &orchestration_dispatcher,
+                Some(&approval_request_store),
+                None,
+            )
+            .await,
+    );
+
+    assert_eq!(first.approval_request_id, second.approval_request_id);
+
+    let repo = SessionRepository::new(&memory_config).expect("approval request repository");
+    let requests = repo
+        .list_approval_requests_for_session("session-governance-approval-reuse", None)
+        .expect("list approval requests");
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].approval_request_id,
+        first.approval_request_id.unwrap()
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Default)]
+struct RecordingApprovalResolveOrchestrationDispatcher {
+    calls: Mutex<Vec<String>>,
+    kernel_ctx_present: Mutex<Vec<bool>>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl crate::conversation::OrchestrationToolDispatcher
+    for RecordingApprovalResolveOrchestrationDispatcher
+{
+    async fn execute_orchestration_tool(
+        &self,
+        _session_context: &crate::conversation::SessionContext,
+        request: loongclaw_contracts::ToolCoreRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+        self.calls
+            .lock()
+            .expect("approval resolve orchestration calls lock")
+            .push(request.tool_name.clone());
+        self.kernel_ctx_present
+            .lock()
+            .expect("approval resolve orchestration kernel ctx lock")
+            .push(kernel_ctx.is_some());
+        Ok(loongclaw_contracts::ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({}),
+        })
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn seed_pending_approval_request(
+    repo: &SessionRepository,
+    approval_request_id: &str,
+    session_id: &str,
+    tool_name: &str,
+) {
+    seed_pending_approval_request_with_snapshot(
+        repo,
+        approval_request_id,
+        session_id,
+        tool_name,
+        json!({
+            "task": format!("task-{approval_request_id}")
+        }),
+        "Orchestration",
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn seed_pending_approval_request_with_snapshot(
+    repo: &SessionRepository,
+    approval_request_id: &str,
+    session_id: &str,
+    tool_name: &str,
+    args_json: Value,
+    execution_plane: &str,
+) {
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: approval_request_id.to_owned(),
+        session_id: session_id.to_owned(),
+        turn_id: format!("turn-{approval_request_id}"),
+        tool_call_id: format!("call-{approval_request_id}"),
+        tool_name: tool_name.to_owned(),
+        approval_key: format!("tool:{tool_name}"),
+        request_payload_json: json!({
+            "session_id": session_id,
+            "tool_name": tool_name,
+            "args_json": args_json,
+        }),
+        governance_snapshot_json: json!({
+            "reason": format!("approval required for {tool_name}"),
+            "rule_id": "governed_tool_requires_per_call_approval",
+            "execution_plane": execution_plane,
+        }),
+    })
+    .expect("seed pending approval request");
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_resolve_turn(
+    session_id: &str,
+    approval_request_id: &str,
+    decision: &str,
+) -> ProviderTurn {
+    ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "approval_request_resolve".to_owned(),
+            args_json: json!({
+                "approval_request_id": approval_request_id,
+                "decision": decision,
+            }),
+            source: "provider_tool_call".to_owned(),
+            session_id: session_id.to_owned(),
+            turn_id: format!("turn-resolve-{approval_request_id}-{decision}"),
+            tool_call_id: format!("call-resolve-{approval_request_id}-{decision}"),
+        }],
+        raw_meta: Value::Null,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn single_tool_turn(
+    session_id: &str,
+    turn_id: &str,
+    tool_call_id: &str,
+    tool_name: &str,
+    args_json: Value,
+) -> ProviderTurn {
+    ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: tool_name.to_owned(),
+            args_json,
+            source: "provider_tool_call".to_owned(),
+            session_id: session_id.to_owned(),
+            turn_id: turn_id.to_owned(),
+            tool_call_id: tool_call_id.to_owned(),
+        }],
+        raw_meta: Value::Null,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn create_async_child_session(
+    repo: &SessionRepository,
+    session_id: &str,
+    parent_session_id: &str,
+    state: crate::session::repository::SessionState,
+) {
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: session_id.to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some(parent_session_id.to_owned()),
+        label: Some(session_id.to_owned()),
+        state,
+    })
+    .expect("create async child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: session_id.to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some(parent_session_id.to_owned()),
+        payload_json: json!({
+            "task": format!("task-{session_id}"),
+            "timeout_seconds": 60,
+        }),
+    })
+    .expect("append queued child event");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resolve_deny_transitions_request_and_emits_event() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-resolve-deny");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    seed_pending_approval_request(&repo, "apr-deny", "child-session", "delegate_async");
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn("root-session", "apr-deny", "deny");
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("\"approval_request_id\":\"apr-deny\""),
+                "expected approval request id in output, got: {text}"
+            );
+            assert!(
+                text.contains("\"status\":\"denied\""),
+                "expected denied status in output, got: {text}"
+            );
+        }
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    assert!(
+        orchestration_dispatcher
+            .calls
+            .lock()
+            .expect("approval resolve orchestration calls lock")
+            .is_empty(),
+        "deny resolution must not execute the blocked orchestration tool"
+    );
+
+    let resolved = repo
+        .load_approval_request("apr-deny")
+        .expect("load approval request")
+        .expect("denied approval request");
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Denied
+    );
+    assert_eq!(
+        resolved.decision,
+        Some(crate::session::repository::ApprovalDecision::Deny)
+    );
+    assert_eq!(
+        resolved.resolved_by_session_id.as_deref(),
+        Some("root-session")
+    );
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child approval events");
+    let approval_event = events
+        .iter()
+        .find(|event| event.event_kind == "tool_approval_resolved")
+        .expect("tool_approval_resolved event");
+    assert_eq!(
+        approval_event.payload_json["approval_request_id"],
+        "apr-deny"
+    );
+    assert_eq!(approval_event.payload_json["decision"], "deny");
+    assert_eq!(approval_event.payload_json["status"], "denied");
+    assert_eq!(
+        approval_event.payload_json["resolved_by_session_id"],
+        "root-session"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resolve_deny_rejects_non_pending_request_without_dispatch() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-resolve-deny-duplicate");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    seed_pending_approval_request(&repo, "apr-deny-duplicate", "root-session", "delegate");
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn("root-session", "apr-deny-duplicate", "deny");
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let first = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            None,
+        )
+        .await;
+    assert!(
+        matches!(first, TurnResult::FinalText(_)),
+        "expected first deny resolve to succeed, got: {first:?}"
+    );
+
+    let second = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            None,
+        )
+        .await;
+    match second {
+        TurnResult::ToolError(error) => assert!(
+            error.contains("approval_request_not_pending"),
+            "expected not-pending error, got: {error}"
+        ),
+        other => panic!("expected ToolError, got: {other:?}"),
+    }
+
+    assert!(
+        orchestration_dispatcher
+            .calls
+            .lock()
+            .expect("approval resolve orchestration calls lock")
+            .is_empty(),
+        "deny resolution must not execute the blocked orchestration tool"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resume_once_executes_blocked_app_tool_and_marks_request_executed() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-resume-once-success");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "timeout_seconds": 60,
+        }),
+    })
+    .expect("append queued child event");
+    seed_pending_approval_request_with_snapshot(
+        &repo,
+        "apr-approve-once-success",
+        "root-session",
+        "session_cancel",
+        json!({
+            "session_id": "child-session",
+        }),
+        "App",
+    );
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn =
+        approval_request_resolve_turn("root-session", "apr-approve-once-success", "approve_once");
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("\"approval_request_id\":\"apr-approve-once-success\""),
+                "expected approval request id in output, got: {text}"
+            );
+            assert!(
+                text.contains("\"status\":\"executed\""),
+                "expected executed status in output, got: {text}"
+            );
+            assert!(
+                text.contains("\"resumed_tool_output\":{"),
+                "expected resumed tool output envelope in output, got: {text}"
+            );
+        }
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    assert!(
+        orchestration_dispatcher
+            .calls
+            .lock()
+            .expect("approval resolve orchestration calls lock")
+            .is_empty(),
+        "approve_once app-tool replay must not use orchestration dispatcher"
+    );
+
+    let resolved = repo
+        .load_approval_request("apr-approve-once-success")
+        .expect("load approval request")
+        .expect("executed approval request");
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert_eq!(
+        resolved.decision,
+        Some(crate::session::repository::ApprovalDecision::ApproveOnce)
+    );
+    assert_eq!(
+        resolved.resolved_by_session_id.as_deref(),
+        Some("root-session")
+    );
+    assert!(
+        resolved.executed_at.is_some(),
+        "expected executed_at to be set"
+    );
+    assert_eq!(resolved.last_error, None);
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+
+    let events = repo
+        .list_recent_events("root-session", 20)
+        .expect("list approval execution events");
+    assert!(events
+        .iter()
+        .any(|event| event.event_kind == "tool_approval_resolved"));
+    assert!(events
+        .iter()
+        .any(|event| event.event_kind == "tool_approval_execution_started"));
+    assert!(events
+        .iter()
+        .any(|event| event.event_kind == "tool_approval_execution_finished"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resume_once_records_execution_failure_and_last_error() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-resume-once-failure");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create child session");
+    seed_pending_approval_request_with_snapshot(
+        &repo,
+        "apr-approve-once-failure",
+        "root-session",
+        "session_cancel",
+        json!({
+            "session_id": "child-session",
+        }),
+        "App",
+    );
+
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    );
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn =
+        approval_request_resolve_turn("root-session", "apr-approve-once-failure", "approve_once");
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::ToolError(error) => assert!(
+            error.contains("session_cancel_not_cancellable"),
+            "expected session_cancel failure, got: {error}"
+        ),
+        other => panic!("expected ToolError, got: {other:?}"),
+    }
+
+    let resolved = repo
+        .load_approval_request("apr-approve-once-failure")
+        .expect("load approval request")
+        .expect("executed approval request");
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert_eq!(
+        resolved.decision,
+        Some(crate::session::repository::ApprovalDecision::ApproveOnce)
+    );
+    assert!(
+        resolved
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("session_cancel_not_cancellable")),
+        "expected last_error to persist execution failure, got: {:?}",
+        resolved.last_error
+    );
+
+    let events = repo
+        .list_recent_events("root-session", 20)
+        .expect("list approval failure events");
+    assert!(events
+        .iter()
+        .any(|event| event.event_kind == "tool_approval_execution_started"));
+    assert!(events
+        .iter()
+        .any(|event| event.event_kind == "tool_approval_execution_failed"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resume_once_replays_orchestration_tool_through_dispatcher() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-resume-once-orchestration");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    seed_pending_approval_request(
+        &repo,
+        "apr-approve-once-orchestration",
+        "root-session",
+        "delegate",
+    );
+
+    let orchestration_dispatcher =
+        Arc::new(RecordingApprovalResolveOrchestrationDispatcher::default());
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    )
+    .with_approval_resolution_orchestration_dispatcher(orchestration_dispatcher.clone());
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-approve-once-orchestration",
+        "approve_once",
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            orchestration_dispatcher.as_ref(),
+            None,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("\"approval_request_id\":\"apr-approve-once-orchestration\""),
+                "expected approval request id in output, got: {text}"
+            );
+            assert!(
+                text.contains("\"status\":\"executed\""),
+                "expected executed status in output, got: {text}"
+            );
+            assert!(
+                text.contains("\"resumed_tool_output\":{"),
+                "expected resumed tool output envelope in output, got: {text}"
+            );
+        }
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    assert_eq!(
+        orchestration_dispatcher
+            .calls
+            .lock()
+            .expect("approval resolve orchestration calls lock")
+            .as_slice(),
+        ["delegate"],
+        "approve_once orchestration replay should route through orchestration dispatcher"
+    );
+    assert_eq!(
+        orchestration_dispatcher
+            .kernel_ctx_present
+            .lock()
+            .expect("approval resolve orchestration kernel ctx lock")
+            .as_slice(),
+        [false],
+        "this path does not provide a kernel context in this test"
+    );
+
+    let resolved = repo
+        .load_approval_request("apr-approve-once-orchestration")
+        .expect("load approval request")
+        .expect("executed approval request");
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert_eq!(
+        resolved.decision,
+        Some(crate::session::repository::ApprovalDecision::ApproveOnce)
+    );
+    assert!(
+        resolved.executed_at.is_some(),
+        "expected executed_at to be set"
+    );
+    assert_eq!(resolved.last_error, None);
+
+    let events = repo
+        .list_recent_events("root-session", 20)
+        .expect("list approval orchestration events");
+    assert!(events
+        .iter()
+        .any(|event| event.event_kind == "tool_approval_execution_started"));
+    assert!(events
+        .iter()
+        .any(|event| event.event_kind == "tool_approval_execution_finished"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_resume_once_replays_orchestration_tool_with_kernel_ctx_when_provided() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let governance =
+        crate::conversation::DefaultToolGovernanceEvaluator::new(ToolConfig::default());
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-resume-once-orchestration-kernel-ctx");
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    seed_pending_approval_request(
+        &repo,
+        "apr-approve-once-orchestration-kernel-ctx",
+        "root-session",
+        "delegate_async",
+    );
+
+    let orchestration_dispatcher =
+        Arc::new(RecordingApprovalResolveOrchestrationDispatcher::default());
+    let app_dispatcher = crate::conversation::DefaultAppToolDispatcher::new(
+        memory_config.clone(),
+        ToolConfig::default(),
+    )
+    .with_approval_resolution_orchestration_dispatcher(orchestration_dispatcher.clone());
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-approve-once-orchestration-kernel-ctx",
+        "approve_once",
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (kernel_ctx, _memory_invocations) = build_kernel_context(audit);
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            orchestration_dispatcher.as_ref(),
+            None,
+            Some(&kernel_ctx),
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains(
+                    "\"approval_request_id\":\"apr-approve-once-orchestration-kernel-ctx\""
+                ),
+                "expected approval request id in output, got: {text}"
+            );
+            assert!(
+                text.contains("\"status\":\"executed\""),
+                "expected executed status in output, got: {text}"
+            );
+        }
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    assert_eq!(
+        orchestration_dispatcher
+            .calls
+            .lock()
+            .expect("approval resolve orchestration calls lock")
+            .as_slice(),
+        ["delegate_async"],
+        "approve_once orchestration replay should route through orchestration dispatcher"
+    );
+    assert_eq!(
+        orchestration_dispatcher
+            .kernel_ctx_present
+            .lock()
+            .expect("approval resolve orchestration kernel ctx lock")
+            .as_slice(),
+        [true],
+        "approval replay should preserve the original kernel context for orchestration replay"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_always_grant_scopes_to_root_lineage_and_replays_request() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let (_approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-always-grant-root-scope");
+    let mut tool_config = ToolConfig::default();
+    tool_config.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
+    let governance = crate::conversation::DefaultToolGovernanceEvaluator::with_memory_config(
+        memory_config.clone(),
+        tool_config.clone(),
+    );
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    create_async_child_session(
+        &repo,
+        "child-session",
+        "root-session",
+        crate::session::repository::SessionState::Ready,
+    );
+    seed_pending_approval_request_with_snapshot(
+        &repo,
+        "apr-approve-always-lineage-root",
+        "root-session",
+        "session_cancel",
+        json!({
+            "session_id": "child-session",
+        }),
+        "App",
+    );
+
+    let app_dispatcher =
+        crate::conversation::DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-approve-always-lineage-root",
+        "approve_always",
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &turn,
+            &session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            None,
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("\"approval_request_id\":\"apr-approve-always-lineage-root\""),
+                "expected approval request id in output, got: {text}"
+            );
+            assert!(
+                text.contains("\"status\":\"executed\""),
+                "expected executed status in output, got: {text}"
+            );
+            assert!(
+                text.contains("\"resumed_tool_output\":{"),
+                "expected resumed tool output envelope in output, got: {text}"
+            );
+        }
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    let resolved = repo
+        .load_approval_request("apr-approve-always-lineage-root")
+        .expect("load approval request")
+        .expect("executed approval request");
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert_eq!(
+        resolved.decision,
+        Some(crate::session::repository::ApprovalDecision::ApproveAlways)
+    );
+
+    let root_grant = repo
+        .load_approval_grant("root-session", "tool:session_cancel")
+        .expect("load root-lineage approval grant");
+    assert!(root_grant.is_some(), "expected grant at root lineage scope");
+    let child_grant = repo
+        .load_approval_grant("child-session", "tool:session_cancel")
+        .expect("load child-scope approval grant");
+    assert!(
+        child_grant.is_none(),
+        "approve_always should scope to the lineage root, not the requesting child"
+    );
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child")
+        .expect("child session");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_always_grant_auto_allows_same_lineage_but_not_unrelated_root() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let (approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-always-grant-lineage-reuse");
+    let mut tool_config = ToolConfig::default();
+    tool_config.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
+    let governance = crate::conversation::DefaultToolGovernanceEvaluator::with_memory_config(
+        memory_config.clone(),
+        tool_config.clone(),
+    );
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    create_async_child_session(
+        &repo,
+        "child-session",
+        "root-session",
+        crate::session::repository::SessionState::Ready,
+    );
+    create_async_child_session(
+        &repo,
+        "sibling-child-session",
+        "root-session",
+        crate::session::repository::SessionState::Ready,
+    );
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "other-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Other Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create other root session");
+    create_async_child_session(
+        &repo,
+        "other-child-session",
+        "other-root",
+        crate::session::repository::SessionState::Ready,
+    );
+
+    seed_pending_approval_request_with_snapshot(
+        &repo,
+        "apr-approve-always-lineage-reuse",
+        "root-session",
+        "session_cancel",
+        json!({
+            "session_id": "child-session",
+        }),
+        "App",
+    );
+
+    let app_dispatcher =
+        crate::conversation::DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+    let orchestration_dispatcher = RecordingApprovalResolveOrchestrationDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let approval_turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-approve-always-lineage-reuse",
+        "approve_always",
+    );
+    let root_session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let approval_result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &approval_turn,
+            &root_session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            Some(&approval_request_store),
+            None,
+        )
+        .await;
+    match approval_result {
+        TurnResult::FinalText(_) => {}
+        other => panic!("expected FinalText after approve_always, got: {other:?}"),
+    }
+
+    let same_lineage_turn = single_tool_turn(
+        "root-session",
+        "turn-lineage-grant-reuse",
+        "call-lineage-grant-reuse",
+        "session_cancel",
+        json!({
+            "session_id": "sibling-child-session",
+        }),
+    );
+    let same_lineage_result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &same_lineage_turn,
+            &root_session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            Some(&approval_request_store),
+            None,
+        )
+        .await;
+    match same_lineage_result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("\"session_id\":\"sibling-child-session\""),
+                "expected same-lineage session_cancel output, got: {text}"
+            );
+            assert!(
+                !text.contains("approval_request_id"),
+                "same-lineage grant should bypass new approval request creation: {text}"
+            );
+        }
+        other => panic!("expected FinalText for same-lineage grant reuse, got: {other:?}"),
+    }
+
+    let sibling = repo
+        .load_session("sibling-child-session")
+        .expect("load sibling child")
+        .expect("sibling child session");
+    assert_eq!(
+        sibling.state,
+        crate::session::repository::SessionState::Failed
+    );
+
+    let root_requests = repo
+        .list_approval_requests_for_session("root-session", None)
+        .expect("list root approval requests");
+    assert_eq!(
+        root_requests.len(),
+        1,
+        "same-lineage reuse should not create another approval request"
+    );
+
+    let other_root_context = crate::conversation::SessionContext::root_with_tool_view(
+        "other-root",
+        crate::tools::planned_root_tool_view(),
+    );
+    let other_turn = single_tool_turn(
+        "other-root",
+        "turn-other-root-session-cancel",
+        "call-other-root-session-cancel",
+        "session_cancel",
+        json!({
+            "session_id": "other-child-session",
+        }),
+    );
+    let other_result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &other_turn,
+            &other_root_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            Some(&approval_request_store),
+            None,
+        )
+        .await;
+
+    let requirement = expect_needs_approval(other_result);
+    assert_eq!(requirement.tool_name.as_deref(), Some("session_cancel"));
+    assert_eq!(
+        requirement.approval_key.as_deref(),
+        Some("tool:session_cancel")
+    );
+    assert!(
+        requirement.approval_request_id.is_some(),
+        "unrelated root should materialize a new approval request"
+    );
+
+    let other_requests = repo
+        .list_approval_requests_for_session("other-root", None)
+        .expect("list unrelated-root approval requests");
+    assert_eq!(
+        other_requests.len(),
+        1,
+        "unrelated root should not inherit the original lineage grant"
+    );
+
+    let other_child = repo
+        .load_session("other-child-session")
+        .expect("load unrelated child")
+        .expect("unrelated child session");
+    assert_eq!(
+        other_child.state,
+        crate::session::repository::SessionState::Ready
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_request_always_grant_replays_orchestration_tool_and_reuses_lineage_scope() {
+    let runtime = FakeRuntime::new(vec![], Ok(String::new()));
+    let (approval_request_store, memory_config) =
+        isolated_approval_request_store("approval-always-orchestration-lineage");
+    let mut tool_config = ToolConfig::default();
+    tool_config.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
+    let governance = crate::conversation::DefaultToolGovernanceEvaluator::with_memory_config(
+        memory_config.clone(),
+        tool_config.clone(),
+    );
+    let repo = SessionRepository::new(&memory_config).expect("approval resolve repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "other-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Other Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create other root session");
+    seed_pending_approval_request(
+        &repo,
+        "apr-approve-always-orchestration",
+        "root-session",
+        "delegate_async",
+    );
+
+    let orchestration_dispatcher =
+        Arc::new(RecordingApprovalResolveOrchestrationDispatcher::default());
+    let app_dispatcher =
+        crate::conversation::DefaultAppToolDispatcher::new(memory_config.clone(), tool_config)
+            .with_approval_resolution_orchestration_dispatcher(orchestration_dispatcher.clone());
+    let engine = TurnEngine::new(1);
+    let root_session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+    let approval_turn = approval_request_resolve_turn(
+        "root-session",
+        "apr-approve-always-orchestration",
+        "approve_always",
+    );
+
+    let approval_result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &approval_turn,
+            &root_session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            orchestration_dispatcher.as_ref(),
+            Some(&approval_request_store),
+            None,
+        )
+        .await;
+    match approval_result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("\"approval_request_id\":\"apr-approve-always-orchestration\""),
+                "expected approval request id in output, got: {text}"
+            );
+            assert!(
+                text.contains("\"status\":\"executed\""),
+                "expected executed status in output, got: {text}"
+            );
+        }
+        other => panic!("expected FinalText after approve_always, got: {other:?}"),
+    }
+
+    let root_grant = repo
+        .load_approval_grant("root-session", "tool:delegate_async")
+        .expect("load root-lineage orchestration approval grant");
+    assert!(
+        root_grant.is_some(),
+        "expected orchestration grant at root lineage scope"
+    );
+
+    let same_lineage_turn = single_tool_turn(
+        "root-session",
+        "turn-orchestration-lineage-grant",
+        "call-orchestration-lineage-grant",
+        "delegate_async",
+        json!({
+            "task": "same-lineage-task",
+        }),
+    );
+    let same_lineage_result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &same_lineage_turn,
+            &root_session_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            orchestration_dispatcher.as_ref(),
+            Some(&approval_request_store),
+            None,
+        )
+        .await;
+    match same_lineage_result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("[ok] {}"),
+                "expected orchestration dispatcher output for same-lineage replay, got: {text}"
+            );
+        }
+        other => {
+            panic!("expected FinalText for same-lineage orchestration grant reuse, got: {other:?}")
+        }
+    }
+
+    let root_requests = repo
+        .list_approval_requests_for_session("root-session", None)
+        .expect("list root orchestration approval requests");
+    assert_eq!(
+        root_requests.len(),
+        1,
+        "same-lineage orchestration grant reuse should not create another approval request"
+    );
+
+    let other_root_context = crate::conversation::SessionContext::root_with_tool_view(
+        "other-root",
+        crate::tools::planned_root_tool_view(),
+    );
+    let other_turn = single_tool_turn(
+        "other-root",
+        "turn-orchestration-other-root",
+        "call-orchestration-other-root",
+        "delegate_async",
+        json!({
+            "task": "other-root-task",
+        }),
+    );
+    let other_result = engine
+        .execute_turn_in_context_with_governance_and_persistence(
+            &other_turn,
+            &other_root_context,
+            &runtime,
+            &governance,
+            &app_dispatcher,
+            orchestration_dispatcher.as_ref(),
+            Some(&approval_request_store),
+            None,
+        )
+        .await;
+    let requirement = expect_needs_approval(other_result);
+    assert_eq!(requirement.tool_name.as_deref(), Some("delegate_async"));
+    assert_eq!(
+        requirement.approval_key.as_deref(),
+        Some("tool:delegate_async")
+    );
+
+    let calls = orchestration_dispatcher
+        .calls
+        .lock()
+        .expect("approval resolve orchestration calls lock")
+        .clone();
+    assert_eq!(
+        calls,
+        vec!["delegate_async".to_owned(), "delegate_async".to_owned()],
+        "orchestration dispatcher should run once for approve_always replay and once for same-lineage reuse"
+    );
 }
 
 // --- Kernel-routed memory tests ---
@@ -5222,26 +9462,13 @@ impl CoreMemoryAdapter for SharedTestMemoryAdapter {
         &self,
         request: MemoryCoreRequest,
     ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
-        let payload = if request.operation == crate::memory::MEMORY_OP_WINDOW {
-            json!({
-                "turns": [
-                    {
-                        "role": "assistant",
-                        "content": "kernel-memory-window",
-                        "ts": 1
-                    }
-                ]
-            })
-        } else {
-            json!({})
-        };
         self.invocations
             .lock()
             .expect("invocations lock")
             .push(request);
         Ok(MemoryCoreOutcome {
             status: "ok".to_owned(),
-            payload,
+            payload: json!({}),
         })
     }
 }
@@ -5251,7 +9478,7 @@ async fn persist_turn_routes_through_kernel_when_context_provided() {
     let audit = Arc::new(InMemoryAuditSink::default());
     let (ctx, invocations) = build_kernel_context(audit.clone());
 
-    let runtime = DefaultConversationRuntime::default();
+    let runtime = DefaultConversationRuntime;
     runtime
         .persist_turn("session-k1", "user", "kernel-hello", Some(&ctx))
         .await
@@ -5260,7 +9487,7 @@ async fn persist_turn_routes_through_kernel_when_context_provided() {
     // Verify the memory adapter received the request.
     let captured = invocations.lock().expect("invocations lock");
     assert_eq!(captured.len(), 1);
-    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_APPEND_TURN);
+    assert_eq!(captured[0].operation, "append_turn");
     assert_eq!(captured[0].payload["session_id"], "session-k1");
     assert_eq!(captured[0].payload["role"], "user");
     assert_eq!(captured[0].payload["content"], "kernel-hello");
@@ -5282,52 +9509,20 @@ async fn persist_turn_routes_through_kernel_when_context_provided() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn build_messages_routes_memory_window_through_kernel_when_context_provided() {
-    let audit = Arc::new(InMemoryAuditSink::default());
-    let (ctx, invocations) = build_kernel_context(audit.clone());
-    let runtime = DefaultConversationRuntime::default();
-    let config = test_config();
+#[test]
+fn default_runtime_build_messages_respects_restricted_tool_view() {
+    let runtime = DefaultConversationRuntime;
+    let view = crate::tools::ToolView::from_tool_names(["file.read"]);
+
     let messages = runtime
-        .build_messages(&config, "session-k-window", true, Some(&ctx))
-        .await
-        .expect("build messages via kernel");
+        .build_messages(&test_config(), "noop-session", true, &view, None)
+        .expect("build messages");
 
-    assert!(
-        !messages.is_empty(),
-        "expected at least system prompt message, got: {messages:?}"
-    );
-    assert_eq!(messages[0]["role"], "system");
-    assert!(
-        messages
-            .iter()
-            .any(|message| message["content"] == "kernel-memory-window"),
-        "messages should include history loaded from kernel window payload"
-    );
-
-    let captured = invocations.lock().expect("invocations lock");
-    assert_eq!(captured.len(), 1);
-    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
-    assert_eq!(captured[0].payload["session_id"], "session-k-window");
-    assert_eq!(
-        captured[0].payload["limit"],
-        json!(config.memory.sliding_window)
-    );
-
-    let events = audit.snapshot();
-    let has_memory_plane = events.iter().any(|event| {
-        matches!(
-            &event.kind,
-            loongclaw_kernel::AuditEventKind::PlaneInvoked {
-                plane: loongclaw_contracts::ExecutionPlane::Memory,
-                ..
-            }
-        )
-    });
-    assert!(
-        has_memory_plane,
-        "audit should contain memory plane invocation"
-    );
+    assert!(!messages.is_empty());
+    let system_content = messages[0]["content"].as_str().expect("system content");
+    assert!(system_content.contains("- file.read: Read file contents"));
+    assert!(!system_content.contains("- file.write: Write file contents"));
+    assert!(!system_content.contains("- shell.exec: Execute shell commands"));
 }
 
 #[cfg(not(feature = "memory-sqlite"))]
@@ -5335,7 +9530,7 @@ async fn build_messages_routes_memory_window_through_kernel_when_context_provide
 async fn persist_turn_without_memory_sqlite_is_noop_with_kernel_context() {
     let ctx = crate::context::bootstrap_kernel_context("test-agent-no-memory", 60)
         .expect("bootstrap kernel context without memory-sqlite");
-    let runtime = DefaultConversationRuntime::default();
+    let runtime = DefaultConversationRuntime;
     runtime
         .persist_turn("session-k0", "user", "no-memory", Some(&ctx))
         .await

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -24,7 +24,10 @@ use crate::tools::{
     ToolDescriptor, ToolExecutionPlane, ToolGovernanceScope, ToolRiskClass, ToolView,
 };
 
-use super::persistence::{persist_tool_decision, persist_tool_outcome};
+use super::persistence::{
+    persist_tool_decision, persist_tool_decision_with_memory_config, persist_tool_outcome,
+    persist_tool_outcome_with_memory_config,
+};
 use super::runtime::{ConversationRuntime, SessionContext};
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
@@ -1099,21 +1102,6 @@ impl DefaultApprovalResolutionRuntime {
         .map(|_| ())
     }
 
-    fn effective_tool_config_for_request_session(
-        &self,
-        repo: &SessionRepository,
-        session_id: &str,
-    ) -> Result<ToolConfig, String> {
-        let mut tool_config = self.tool_config.clone();
-        if repo
-            .load_session(session_id)?
-            .is_some_and(|session| session.parent_session_id.is_some())
-        {
-            tool_config.sessions.visibility = SessionVisibility::SelfOnly;
-        }
-        Ok(tool_config)
-    }
-
     fn request_lineage_root_session_id(
         &self,
         repo: &SessionRepository,
@@ -1203,23 +1191,24 @@ impl DefaultApprovalResolutionRuntime {
         kernel_ctx: Option<&KernelContext>,
     ) -> Result<ToolCoreOutcome, String> {
         let (execution_plane, replay_request) = self.replay_request(approval_request)?;
-        let effective_tool_config =
-            self.effective_tool_config_for_request_session(repo, &approval_request.session_id)?;
 
         match execution_plane {
             ToolExecutionPlane::App => {
-                crate::tools::execute_app_tool_with_runtime_support(
-                    replay_request,
-                    &approval_request.session_id,
-                    &self.memory_config,
-                    &effective_tool_config,
-                    crate::tools::AppToolRuntimeSupport {
-                        app_config: self.app_config.as_deref(),
-                        kernel_ctx,
-                        approval_runtime: None,
-                    },
-                )
-                .await
+                let session_context =
+                    self.replay_session_context(repo, &approval_request.session_id)?;
+                let app_dispatcher = match &self.app_config {
+                    Some(config) => DefaultAppToolDispatcher::production_with_config(
+                        self.memory_config.clone(),
+                        config.as_ref().clone(),
+                    ),
+                    None => DefaultAppToolDispatcher::production(
+                        self.memory_config.clone(),
+                        self.tool_config.clone(),
+                    ),
+                };
+                app_dispatcher
+                    .execute_app_tool(&session_context, replay_request, kernel_ctx)
+                    .await
             }
             ToolExecutionPlane::Orchestration => {
                 let orchestration_replayer = orchestration_replayer.ok_or_else(|| {
@@ -1237,6 +1226,104 @@ impl DefaultApprovalResolutionRuntime {
                     .to_owned(),
             ),
         }
+    }
+
+    fn replay_governance_snapshot(
+        &self,
+        approval_request: &crate::session::repository::ApprovalRequestRecord,
+    ) -> Option<ToolGovernanceSnapshot> {
+        serde_json::from_value(approval_request.governance_snapshot_json.clone()).ok()
+    }
+
+    fn replay_decision(
+        &self,
+        approval_request: &crate::session::repository::ApprovalRequestRecord,
+    ) -> Result<ToolDecision, String> {
+        let governance = self
+            .replay_governance_snapshot(approval_request)
+            .ok_or_else(|| {
+                "approval_request_invalid_governance_snapshot: failed to deserialize replay governance snapshot"
+                    .to_owned()
+            })?;
+        let decision = approval_request.decision.ok_or_else(|| {
+            "approval_request_missing_decision: approved replay is missing approval decision"
+                .to_owned()
+        })?;
+        let reason = format!("approval_request_{}", decision.as_str());
+        Ok(ToolDecision {
+            allow: true,
+            deny: false,
+            approval_required: false,
+            reason: reason.clone(),
+            rule_id: reason,
+            governance,
+        })
+    }
+
+    fn replay_success_outcome(
+        &self,
+        approval_request: &crate::session::repository::ApprovalRequestRecord,
+        resumed_tool_output: &ToolCoreOutcome,
+    ) -> ToolOutcome {
+        ToolOutcome {
+            status: resumed_tool_output.status.clone(),
+            payload: resumed_tool_output.payload.clone(),
+            error_code: None,
+            human_reason: None,
+            audit_event_id: None,
+            governance_allowed: true,
+            governance: self.replay_governance_snapshot(approval_request),
+        }
+    }
+
+    fn replay_failure_outcome(
+        &self,
+        approval_request: &crate::session::repository::ApprovalRequestRecord,
+        error: &str,
+    ) -> ToolOutcome {
+        ToolOutcome {
+            status: "error".to_owned(),
+            payload: serde_json::Value::Null,
+            error_code: Some("tool_error".to_owned()),
+            human_reason: Some(error.to_owned()),
+            audit_event_id: None,
+            governance_allowed: true,
+            governance: self.replay_governance_snapshot(approval_request),
+        }
+    }
+
+    async fn persist_replayed_outcome(
+        &self,
+        approval_request: &crate::session::repository::ApprovalRequestRecord,
+        outcome: &ToolOutcome,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<(), String> {
+        persist_tool_outcome_with_memory_config(
+            &self.memory_config,
+            &approval_request.session_id,
+            &approval_request.turn_id,
+            &approval_request.tool_call_id,
+            outcome,
+            kernel_ctx,
+        )
+        .await
+    }
+
+    async fn persist_replayed_decision(
+        &self,
+        approval_request: &crate::session::repository::ApprovalRequestRecord,
+        decision: &ToolDecision,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<(), String> {
+        persist_tool_decision_with_memory_config(
+            &self.memory_config,
+            &approval_request.session_id,
+            &approval_request.turn_id,
+            &approval_request.tool_call_id,
+            decision,
+            kernel_ctx,
+        )
+        .await
     }
 
     async fn execute_approved_request(
@@ -1264,13 +1351,58 @@ impl DefaultApprovalResolutionRuntime {
                     "approval_request_not_approved: `{approval_request_id}` is no longer approved"
                 )
             })?;
+        let replay_decision_persist_error = match self.replay_decision(&executing) {
+            Ok(replay_decision) => self
+                .persist_replayed_decision(&executing, &replay_decision, kernel_ctx)
+                .await
+                .err(),
+            Err(error) => Some(error),
+        };
         self.append_approval_event(
             repo,
             &executing,
             current_session_id,
             TOOL_APPROVAL_EXECUTION_STARTED_EVENT_KIND,
-            serde_json::json!({}),
+            serde_json::json!({
+                "replay_decision_persisted": replay_decision_persist_error.is_none(),
+                "replay_decision_persist_error": replay_decision_persist_error.clone(),
+            }),
         )?;
+        if let Some(error) = replay_decision_persist_error {
+            let executed_at = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_secs() as i64)
+                .unwrap_or(0);
+            let executed = repo
+                .transition_approval_request_if_current(
+                    approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Executing,
+                        next_status: ApprovalRequestStatus::Executed,
+                        decision: None,
+                        resolved_by_session_id: None,
+                        executed_at: Some(executed_at),
+                        last_error: Some(error.clone()),
+                    },
+                )?
+                .ok_or_else(|| {
+                    format!(
+                        "approval_request_not_executing: `{approval_request_id}` is no longer executing"
+                    )
+                })?;
+            self.append_approval_event(
+                repo,
+                &executed,
+                current_session_id,
+                TOOL_APPROVAL_EXECUTION_FAILED_EVENT_KIND,
+                serde_json::json!({
+                    "error": error.clone(),
+                    "replay_decision_persisted": false,
+                    "replay_decision_persist_error": error.clone(),
+                }),
+            )?;
+            return Err(error);
+        }
 
         match self
             .replay_approved_request(repo, &executing, orchestration_replayer, kernel_ctx)
@@ -1298,6 +1430,31 @@ impl DefaultApprovalResolutionRuntime {
                             "approval_request_not_executing: `{approval_request_id}` is no longer executing"
                         )
                     })?;
+                let replay_outcome = self.replay_success_outcome(&executing, &resumed_tool_output);
+                let replay_outcome_persist_error = self
+                    .persist_replayed_outcome(&executing, &replay_outcome, kernel_ctx)
+                    .await
+                    .err();
+                let executed = if let Some(error) = replay_outcome_persist_error.as_ref() {
+                    repo.transition_approval_request_if_current(
+                        approval_request_id,
+                        TransitionApprovalRequestIfCurrentRequest {
+                            expected_status: ApprovalRequestStatus::Executed,
+                            next_status: ApprovalRequestStatus::Executed,
+                            decision: None,
+                            resolved_by_session_id: None,
+                            executed_at: executed.executed_at,
+                            last_error: Some(error.clone()),
+                        },
+                    )?
+                    .ok_or_else(|| {
+                        format!(
+                            "approval_request_not_executed: `{approval_request_id}` lost executed state before recording replay outcome persistence error"
+                        )
+                    })?
+                } else {
+                    executed
+                };
                 self.append_approval_event(
                     repo,
                     &executed,
@@ -1305,6 +1462,8 @@ impl DefaultApprovalResolutionRuntime {
                     TOOL_APPROVAL_EXECUTION_FINISHED_EVENT_KIND,
                     serde_json::json!({
                         "resumed_tool_status": resumed_tool_output.status.clone(),
+                        "replay_outcome_persisted": replay_outcome_persist_error.is_none(),
+                        "replay_outcome_persist_error": replay_outcome_persist_error.clone(),
                     }),
                 )?;
                 Ok(crate::tools::approval::ApprovalResolutionOutcome {
@@ -1334,6 +1493,36 @@ impl DefaultApprovalResolutionRuntime {
                             "approval_request_not_executing: `{approval_request_id}` is no longer executing"
                         )
                     })?;
+                let replay_outcome = self.replay_failure_outcome(&executing, &error);
+                let replay_outcome_persist_error = self
+                    .persist_replayed_outcome(&executing, &replay_outcome, kernel_ctx)
+                    .await
+                    .err();
+                let error = if let Some(persist_error) = replay_outcome_persist_error.as_ref() {
+                    format!("{error}; replay_outcome_persist_error: {persist_error}")
+                } else {
+                    error
+                };
+                let executed = if replay_outcome_persist_error.is_some() {
+                    repo.transition_approval_request_if_current(
+                        approval_request_id,
+                        TransitionApprovalRequestIfCurrentRequest {
+                            expected_status: ApprovalRequestStatus::Executed,
+                            next_status: ApprovalRequestStatus::Executed,
+                            decision: None,
+                            resolved_by_session_id: None,
+                            executed_at: executed.executed_at,
+                            last_error: Some(error.clone()),
+                        },
+                    )?
+                    .ok_or_else(|| {
+                        format!(
+                            "approval_request_not_executed: `{approval_request_id}` lost executed state before recording replay failure outcome persistence error"
+                        )
+                    })?
+                } else {
+                    executed
+                };
                 self.append_approval_event(
                     repo,
                     &executed,
@@ -1341,6 +1530,8 @@ impl DefaultApprovalResolutionRuntime {
                     TOOL_APPROVAL_EXECUTION_FAILED_EVENT_KIND,
                     serde_json::json!({
                         "error": error.clone(),
+                        "replay_outcome_persisted": replay_outcome_persist_error.is_none(),
+                        "replay_outcome_persist_error": replay_outcome_persist_error.clone(),
                     }),
                 )?;
                 Err(error)

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1,13 +1,47 @@
+use async_trait::async_trait;
 use std::collections::BTreeSet;
-use std::fmt;
-use std::ops::Deref;
-
-use loongclaw_contracts::{
-    Capability, KernelError, ToolCoreOutcome, ToolCoreRequest, ToolPlaneError,
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(feature = "memory-sqlite")]
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
 };
-use serde::{Deserialize, Serialize};
 
+use loongclaw_contracts::{Capability, KernelError, ToolCoreOutcome, ToolCoreRequest};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::config::{
+    GovernedToolApprovalMode, GovernedToolApprovalStrategy, LoongClawConfig, SessionVisibility,
+    ToolConfig,
+};
 use crate::context::KernelContext;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+use crate::tools::{
+    delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
+    runtime_tool_view, runtime_tool_view_for_config, tool_catalog, ToolApprovalMode,
+    ToolDescriptor, ToolExecutionPlane, ToolGovernanceScope, ToolRiskClass, ToolView,
+};
+
+use super::persistence::{persist_tool_decision, persist_tool_outcome};
+use super::runtime::{ConversationRuntime, SessionContext};
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{
+    ApprovalDecision, ApprovalRequestStatus, NewApprovalGrantRecord, NewApprovalRequestRecord,
+    NewSessionEvent, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    TransitionApprovalRequestIfCurrentRequest,
+};
+
+pub use crate::tools::delegate::{AsyncDelegateSpawnRequest, AsyncDelegateSpawner};
+#[cfg(feature = "memory-sqlite")]
+const TOOL_APPROVAL_RESOLVED_EVENT_KIND: &str = "tool_approval_resolved";
+#[cfg(feature = "memory-sqlite")]
+const TOOL_APPROVAL_EXECUTION_STARTED_EVENT_KIND: &str = "tool_approval_execution_started";
+#[cfg(feature = "memory-sqlite")]
+const TOOL_APPROVAL_EXECUTION_FINISHED_EVENT_KIND: &str = "tool_approval_execution_finished";
+#[cfg(feature = "memory-sqlite")]
+const TOOL_APPROVAL_EXECUTION_FAILED_EVENT_KIND: &str = "tool_approval_execution_failed";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProviderTurn {
@@ -26,6 +60,17 @@ pub struct ToolIntent {
     pub tool_call_id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolGovernanceSnapshot {
+    pub execution_plane: ToolExecutionPlane,
+    pub governance_scope: ToolGovernanceScope,
+    pub risk_class: ToolRiskClass,
+    pub approval_mode: ToolApprovalMode,
+    pub audit_label: String,
+    pub reason: String,
+    pub rule_id: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolDecision {
     pub allow: bool,
@@ -33,6 +78,20 @@ pub struct ToolDecision {
     pub approval_required: bool,
     pub reason: String,
     pub rule_id: String,
+    pub governance: ToolGovernanceSnapshot,
+}
+
+impl ToolDecision {
+    fn from_governance(decision: &ToolGovernanceDecision) -> Self {
+        Self {
+            allow: decision.allow,
+            deny: !decision.allow && !decision.approval_required,
+            approval_required: decision.approval_required,
+            reason: decision.reason.clone(),
+            rule_id: decision.rule_id.clone(),
+            governance: decision.snapshot(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,232 +101,1580 @@ pub struct ToolOutcome {
     pub error_code: Option<String>,
     pub human_reason: Option<String>,
     pub audit_event_id: Option<String>,
+    pub governance_allowed: bool,
+    pub governance: Option<ToolGovernanceSnapshot>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ToolResultEnvelope {
-    pub status: String,
-    pub tool: String,
-    pub tool_call_id: String,
-    pub payload_summary: String,
-    pub payload_chars: usize,
-    pub payload_truncated: bool,
+impl ToolOutcome {
+    fn governed(
+        status: impl Into<String>,
+        payload: serde_json::Value,
+        error_code: Option<String>,
+        human_reason: Option<String>,
+        audit_event_id: Option<String>,
+        governance_allowed: bool,
+        decision: &ToolGovernanceDecision,
+    ) -> Self {
+        Self {
+            status: status.into(),
+            payload,
+            error_code,
+            human_reason,
+            audit_event_id,
+            governance_allowed,
+            governance: Some(decision.snapshot()),
+        }
+    }
 }
 
-const TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS: usize = 2048;
-const MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS: usize = 256;
-const MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS: usize = 64_000;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TurnFailureKind {
-    ApprovalRequired,
-    PolicyDenied,
-    Retryable,
-    NonRetryable,
-    Provider,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TurnFailure {
-    pub kind: TurnFailureKind,
-    pub code: String,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolGovernanceDecision {
+    pub allow: bool,
+    pub approval_required: bool,
     pub reason: String,
-    pub retryable: bool,
+    pub rule_id: String,
+    pub execution_plane: ToolExecutionPlane,
+    pub governance_scope: ToolGovernanceScope,
+    pub risk_class: ToolRiskClass,
+    pub approval_mode: ToolApprovalMode,
+    pub audit_label: &'static str,
 }
 
-impl TurnFailure {
-    pub fn approval_required(code: impl Into<String>, reason: impl Into<String>) -> Self {
-        Self {
-            kind: TurnFailureKind::ApprovalRequired,
-            code: code.into(),
-            reason: reason.into(),
-            retryable: false,
+impl ToolGovernanceDecision {
+    pub fn snapshot(&self) -> ToolGovernanceSnapshot {
+        ToolGovernanceSnapshot {
+            execution_plane: self.execution_plane,
+            governance_scope: self.governance_scope,
+            risk_class: self.risk_class,
+            approval_mode: self.approval_mode,
+            audit_label: self.audit_label.to_owned(),
+            reason: self.reason.clone(),
+            rule_id: self.rule_id.clone(),
         }
     }
 
-    pub fn policy_denied(code: impl Into<String>, reason: impl Into<String>) -> Self {
+    pub fn allow(descriptor: &ToolDescriptor) -> Self {
         Self {
-            kind: TurnFailureKind::PolicyDenied,
-            code: code.into(),
-            reason: reason.into(),
-            retryable: false,
+            allow: true,
+            approval_required: false,
+            reason: "governance_allow".to_owned(),
+            rule_id: "default_governance_allow".to_owned(),
+            execution_plane: descriptor.execution_plane,
+            governance_scope: descriptor.governance_scope,
+            risk_class: descriptor.risk_class,
+            approval_mode: descriptor.approval_mode,
+            audit_label: descriptor.audit_label,
         }
     }
 
-    pub fn retryable(code: impl Into<String>, reason: impl Into<String>) -> Self {
+    pub fn allow_with_rule(
+        descriptor: &ToolDescriptor,
+        reason: impl Into<String>,
+        rule_id: impl Into<String>,
+    ) -> Self {
         Self {
-            kind: TurnFailureKind::Retryable,
-            code: code.into(),
+            allow: true,
+            approval_required: false,
             reason: reason.into(),
-            retryable: true,
+            rule_id: rule_id.into(),
+            execution_plane: descriptor.execution_plane,
+            governance_scope: descriptor.governance_scope,
+            risk_class: descriptor.risk_class,
+            approval_mode: descriptor.approval_mode,
+            audit_label: descriptor.audit_label,
         }
     }
 
-    pub fn non_retryable(code: impl Into<String>, reason: impl Into<String>) -> Self {
+    pub fn deny(
+        descriptor: &ToolDescriptor,
+        reason: impl Into<String>,
+        rule_id: impl Into<String>,
+    ) -> Self {
         Self {
-            kind: TurnFailureKind::NonRetryable,
-            code: code.into(),
+            allow: false,
+            approval_required: false,
             reason: reason.into(),
-            retryable: false,
+            rule_id: rule_id.into(),
+            execution_plane: descriptor.execution_plane,
+            governance_scope: descriptor.governance_scope,
+            risk_class: descriptor.risk_class,
+            approval_mode: descriptor.approval_mode,
+            audit_label: descriptor.audit_label,
         }
     }
 
-    pub fn provider(code: impl Into<String>, reason: impl Into<String>) -> Self {
+    pub fn require_approval(
+        descriptor: &ToolDescriptor,
+        reason: impl Into<String>,
+        rule_id: impl Into<String>,
+    ) -> Self {
         Self {
-            kind: TurnFailureKind::Provider,
-            code: code.into(),
+            allow: false,
+            approval_required: true,
             reason: reason.into(),
-            retryable: false,
+            rule_id: rule_id.into(),
+            execution_plane: descriptor.execution_plane,
+            governance_scope: descriptor.governance_scope,
+            risk_class: descriptor.risk_class,
+            approval_mode: descriptor.approval_mode,
+            audit_label: descriptor.audit_label,
         }
-    }
-
-    pub fn as_str(&self) -> &str {
-        self.reason.as_str()
     }
 }
 
-impl Deref for TurnFailure {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
-        self.reason.as_str()
-    }
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalRequirementKind {
+    KernelContextRequired,
+    GovernedTool,
 }
 
-impl fmt::Display for TurnFailure {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.reason.as_str())
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ApprovalRequirement {
+    pub kind: ApprovalRequirementKind,
+    pub reason: String,
+    pub rule_id: String,
+    pub tool_name: Option<String>,
+    pub approval_key: Option<String>,
+    pub approval_request_id: Option<String>,
+}
+
+impl ApprovalRequirement {
+    pub fn kernel_context_required() -> Self {
+        Self {
+            kind: ApprovalRequirementKind::KernelContextRequired,
+            reason: "kernel_context_required".to_owned(),
+            rule_id: "kernel_context_required".to_owned(),
+            tool_name: None,
+            approval_key: None,
+            approval_request_id: None,
+        }
+    }
+
+    pub fn governed_tool(
+        tool_name: impl Into<String>,
+        approval_key: impl Into<String>,
+        reason: impl Into<String>,
+        rule_id: impl Into<String>,
+        approval_request_id: Option<String>,
+    ) -> Self {
+        Self {
+            kind: ApprovalRequirementKind::GovernedTool,
+            reason: reason.into(),
+            rule_id: rule_id.into(),
+            tool_name: Some(tool_name.into()),
+            approval_key: Some(approval_key.into()),
+            approval_request_id,
+        }
     }
 }
 
 #[derive(Debug, Clone)]
 pub enum TurnResult {
     FinalText(String),
-    NeedsApproval(TurnFailure),
-    ToolDenied(TurnFailure),
-    ToolError(TurnFailure),
-    ProviderError(TurnFailure),
+    NeedsApproval(ApprovalRequirement),
+    ToolDenied(String),
+    ToolError(String),
+    ProviderError(String),
 }
 
-impl TurnResult {
-    pub fn needs_approval(code: impl Into<String>, reason: impl Into<String>) -> Self {
-        Self::NeedsApproval(TurnFailure::approval_required(code, reason))
-    }
-
-    pub fn policy_denied(code: impl Into<String>, reason: impl Into<String>) -> Self {
-        Self::ToolDenied(TurnFailure::policy_denied(code, reason))
-    }
-
-    pub fn retryable_tool_error(code: impl Into<String>, reason: impl Into<String>) -> Self {
-        Self::ToolError(TurnFailure::retryable(code, reason))
-    }
-
-    pub fn non_retryable_tool_error(code: impl Into<String>, reason: impl Into<String>) -> Self {
-        Self::ToolError(TurnFailure::non_retryable(code, reason))
-    }
-
-    pub fn provider_error(code: impl Into<String>, reason: impl Into<String>) -> Self {
-        Self::ProviderError(TurnFailure::provider(code, reason))
-    }
-
-    pub fn failure(&self) -> Option<&TurnFailure> {
-        match self {
-            TurnResult::FinalText(_) => None,
-            TurnResult::NeedsApproval(failure)
-            | TurnResult::ToolDenied(failure)
-            | TurnResult::ToolError(failure)
-            | TurnResult::ProviderError(failure) => Some(failure),
-        }
-    }
+#[async_trait]
+pub trait AppToolDispatcher: Send + Sync {
+    async fn execute_app_tool(
+        &self,
+        session_context: &SessionContext,
+        request: ToolCoreRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ToolCoreOutcome, String>;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum KernelFailureClass {
-    PolicyDenied,
-    RetryableExecution,
-    NonRetryable,
+#[async_trait]
+pub trait OrchestrationToolDispatcher: Send + Sync {
+    async fn execute_orchestration_tool(
+        &self,
+        session_context: &SessionContext,
+        request: ToolCoreRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ToolCoreOutcome, String>;
 }
 
-pub(crate) fn classify_kernel_error(error: &KernelError) -> KernelFailureClass {
-    #[allow(clippy::wildcard_enum_match_arm)]
-    match error {
-        KernelError::Policy(_)
-        | KernelError::PackCapabilityBoundary { .. }
-        | KernelError::ConnectorNotAllowed { .. } => KernelFailureClass::PolicyDenied,
-        KernelError::ToolPlane(ToolPlaneError::Execution(_)) => {
-            KernelFailureClass::RetryableExecution
-        }
-        _ => KernelFailureClass::NonRetryable,
-    }
+#[async_trait]
+pub(crate) trait ApprovalOrchestrationReplayer: Send + Sync {
+    async fn replay_orchestration_request(
+        &self,
+        session_context: &SessionContext,
+        request: ToolCoreRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ToolCoreOutcome, String>;
 }
 
-#[allow(dead_code)]
-pub(crate) fn format_tool_result_line(intent: &ToolIntent, outcome: &ToolCoreOutcome) -> String {
-    format_tool_result_line_with_limit(intent, outcome, TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS)
+#[async_trait]
+pub trait ToolGovernanceEvaluator: Send + Sync {
+    async fn evaluate_tool_governance(
+        &self,
+        descriptor: &ToolDescriptor,
+        intent: &ToolIntent,
+        session_context: &SessionContext,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> ToolGovernanceDecision;
 }
 
-pub(crate) fn format_tool_result_line_with_limit(
-    intent: &ToolIntent,
-    outcome: &ToolCoreOutcome,
-    payload_summary_limit_chars: usize,
-) -> String {
-    let envelope = build_tool_result_envelope(intent, outcome, payload_summary_limit_chars);
-    let encoded = serde_json::to_string(&envelope).unwrap_or_else(|_| {
-        format!(
-            "{{\"status\":\"{}\",\"tool\":\"{}\",\"tool_call_id\":\"{}\",\"payload_summary\":\"[tool_payload_unserializable]\",\"payload_chars\":0,\"payload_truncated\":false}}",
-            outcome.status,
-            crate::tools::canonical_tool_name(intent.tool_name.as_str()),
-            intent.tool_call_id
+#[async_trait]
+trait ToolLifecycleRecorder: Send + Sync {
+    async fn persist_tool_decision(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        tool_call_id: &str,
+        decision: &ToolDecision,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<(), String>;
+
+    async fn persist_tool_outcome(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        tool_call_id: &str,
+        outcome: &ToolOutcome,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<(), String>;
+}
+
+pub(crate) trait GovernedApprovalRequestStore: Send + Sync {
+    fn ensure_governed_approval_request(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &ToolDescriptor,
+        governance_decision: &ToolGovernanceDecision,
+    ) -> Result<String, String>;
+}
+
+struct RuntimeToolLifecycleRecorder<'a, R: ConversationRuntime + ?Sized> {
+    runtime: &'a R,
+}
+
+#[async_trait]
+impl<R: ConversationRuntime + ?Sized> ToolLifecycleRecorder
+    for RuntimeToolLifecycleRecorder<'_, R>
+{
+    async fn persist_tool_decision(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        tool_call_id: &str,
+        decision: &ToolDecision,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<(), String> {
+        persist_tool_decision(
+            self.runtime,
+            session_id,
+            turn_id,
+            tool_call_id,
+            decision,
+            kernel_ctx,
         )
-    });
-    format!("[{}] {encoded}", outcome.status)
+        .await
+    }
+
+    async fn persist_tool_outcome(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        tool_call_id: &str,
+        outcome: &ToolOutcome,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<(), String> {
+        persist_tool_outcome(
+            self.runtime,
+            session_id,
+            turn_id,
+            tool_call_id,
+            outcome,
+            kernel_ctx,
+        )
+        .await
+    }
 }
 
-fn build_tool_result_envelope(
+#[cfg(feature = "memory-sqlite")]
+#[derive(Clone)]
+pub(crate) struct SessionRepositoryApprovalRequestStore {
+    memory_config: MemoryRuntimeConfig,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl SessionRepositoryApprovalRequestStore {
+    pub(crate) fn new(memory_config: MemoryRuntimeConfig) -> Self {
+        Self { memory_config }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl GovernedApprovalRequestStore for SessionRepositoryApprovalRequestStore {
+    fn ensure_governed_approval_request(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &ToolDescriptor,
+        governance_decision: &ToolGovernanceDecision,
+    ) -> Result<String, String> {
+        let repo = SessionRepository::new(&self.memory_config)?;
+        let kind = if session_context.parent_session_id.is_some() {
+            SessionKind::DelegateChild
+        } else {
+            SessionKind::Root
+        };
+        let _ = repo.ensure_session(NewSessionRecord {
+            session_id: session_context.session_id.clone(),
+            kind,
+            parent_session_id: session_context.parent_session_id.clone(),
+            label: None,
+            state: SessionState::Ready,
+        })?;
+
+        let approval_request_id =
+            governed_approval_request_id(session_context, descriptor.name, intent);
+        let request_payload_json = serde_json::json!({
+            "session_id": session_context.session_id,
+            "parent_session_id": session_context.parent_session_id,
+            "turn_id": intent.turn_id,
+            "tool_call_id": intent.tool_call_id,
+            "tool_name": descriptor.name,
+            "args_json": intent.args_json,
+            "source": intent.source,
+            "execution_plane": descriptor.execution_plane,
+        });
+        let governance_snapshot_json = serde_json::to_value(governance_decision.snapshot())
+            .map_err(|error| format!("serialize governed approval snapshot failed: {error}"))?;
+        let stored = repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id: approval_request_id.clone(),
+            session_id: session_context.session_id.clone(),
+            turn_id: intent.turn_id.clone(),
+            tool_call_id: intent.tool_call_id.clone(),
+            tool_name: descriptor.name.to_owned(),
+            approval_key: format!("tool:{}", descriptor.name),
+            request_payload_json,
+            governance_snapshot_json,
+        })?;
+        Ok(stored.approval_request_id)
+    }
+}
+
+fn governed_approval_request_id(
+    session_context: &SessionContext,
+    tool_name: &str,
     intent: &ToolIntent,
-    outcome: &ToolCoreOutcome,
-    payload_summary_limit_chars: usize,
-) -> ToolResultEnvelope {
-    let normalized_limit = effective_payload_summary_limit(intent, payload_summary_limit_chars)
-        .clamp(
-            MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
-            MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(session_context.session_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(intent.turn_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(intent.tool_call_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(tool_name.as_bytes());
+    format!("apr_{:x}", hasher.finalize())
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AsyncDelegateSubprocessPlan {
+    program: PathBuf,
+    args: Vec<String>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_async_delegate_subprocess_plan(
+    executable_path: &Path,
+    config_path: Option<&str>,
+    request: &crate::tools::delegate::AsyncDelegateSpawnRequest,
+) -> AsyncDelegateSubprocessPlan {
+    let mut args = vec!["run-turn".to_owned()];
+    if let Some(config_path) = config_path.map(str::trim).filter(|value| !value.is_empty()) {
+        args.push("--config".to_owned());
+        args.push(config_path.to_owned());
+    }
+    args.extend([
+        "--session".to_owned(),
+        request.child_session_id.clone(),
+        "--input".to_owned(),
+        request.task.clone(),
+        "--timeout-seconds".to_owned(),
+        request.timeout_seconds.to_string(),
+        "--delegate-child".to_owned(),
+    ]);
+    AsyncDelegateSubprocessPlan {
+        program: executable_path.to_path_buf(),
+        args,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone)]
+struct SubprocessAsyncDelegateSpawner {
+    executable_path: PathBuf,
+    config_path: Option<String>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl SubprocessAsyncDelegateSpawner {
+    fn from_current_process() -> Result<Self, String> {
+        let executable_path = std::env::current_exe().map_err(|error| {
+            format!("resolve current executable for async delegate failed: {error}")
+        })?;
+        let config_path = std::env::var("LOONGCLAW_CONFIG_PATH")
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty());
+        Ok(Self {
+            executable_path,
+            config_path,
+        })
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl crate::tools::delegate::AsyncDelegateSpawner for SubprocessAsyncDelegateSpawner {
+    async fn spawn(
+        &self,
+        request: crate::tools::delegate::AsyncDelegateSpawnRequest,
+    ) -> Result<(), String> {
+        let plan = build_async_delegate_subprocess_plan(
+            &self.executable_path,
+            self.config_path.as_deref(),
+            &request,
         );
-    let payload_text = serde_json::to_string(&outcome.payload)
-        .unwrap_or_else(|_| "[tool_payload_unserializable]".to_owned());
-    let (payload_summary, payload_chars, payload_truncated) =
-        truncate_by_chars(payload_text.as_str(), normalized_limit);
-
-    ToolResultEnvelope {
-        status: outcome.status.clone(),
-        tool: crate::tools::canonical_tool_name(intent.tool_name.as_str()).to_owned(),
-        tool_call_id: intent.tool_call_id.clone(),
-        payload_summary,
-        payload_chars,
-        payload_truncated,
+        let mut command = tokio::process::Command::new(&plan.program);
+        command.args(&plan.args);
+        command.stdin(Stdio::null());
+        command.stdout(Stdio::null());
+        command.stderr(Stdio::null());
+        let child = command
+            .spawn()
+            .map_err(|error| format!("spawn async delegate subprocess failed: {error}"))?;
+        drop(child);
+        Ok(())
     }
 }
 
-fn effective_payload_summary_limit(intent: &ToolIntent, default_limit: usize) -> usize {
-    if crate::tools::canonical_tool_name(intent.tool_name.as_str()) == "external_skills.invoke" {
-        return MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS;
+pub struct NoopAppToolDispatcher;
+
+#[async_trait]
+impl AppToolDispatcher for NoopAppToolDispatcher {
+    async fn execute_app_tool(
+        &self,
+        _session_context: &SessionContext,
+        request: ToolCoreRequest,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ToolCoreOutcome, String> {
+        Err(format!("app_tool_not_implemented: {}", request.tool_name))
     }
-    default_limit
 }
 
-fn truncate_by_chars(value: &str, limit: usize) -> (String, usize, bool) {
-    let total_chars = value.chars().count();
-    if total_chars <= limit {
-        return (value.to_owned(), total_chars, false);
+pub struct NoopOrchestrationToolDispatcher;
+
+#[async_trait]
+impl OrchestrationToolDispatcher for NoopOrchestrationToolDispatcher {
+    async fn execute_orchestration_tool(
+        &self,
+        _session_context: &SessionContext,
+        request: ToolCoreRequest,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ToolCoreOutcome, String> {
+        Err(format!(
+            "orchestration_tool_not_implemented: {}",
+            request.tool_name
+        ))
     }
-    let mut truncated = String::new();
-    for ch in value.chars().take(limit) {
-        truncated.push(ch);
+}
+
+pub struct NoopToolGovernanceEvaluator;
+
+#[async_trait]
+impl ToolGovernanceEvaluator for NoopToolGovernanceEvaluator {
+    async fn evaluate_tool_governance(
+        &self,
+        descriptor: &ToolDescriptor,
+        _intent: &ToolIntent,
+        _session_context: &SessionContext,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> ToolGovernanceDecision {
+        ToolGovernanceDecision::allow(descriptor)
     }
-    let omitted = total_chars.saturating_sub(limit);
-    truncated.push_str(&format!("...(truncated {omitted} chars)"));
-    (truncated, total_chars, true)
+}
+
+#[derive(Debug, Clone)]
+pub struct DefaultToolGovernanceEvaluator {
+    tool_config: ToolConfig,
+    memory_config: Option<MemoryRuntimeConfig>,
+}
+
+impl DefaultToolGovernanceEvaluator {
+    pub fn new(tool_config: ToolConfig) -> Self {
+        Self {
+            tool_config,
+            memory_config: None,
+        }
+    }
+
+    pub fn with_memory_config(memory_config: MemoryRuntimeConfig, tool_config: ToolConfig) -> Self {
+        Self {
+            tool_config,
+            memory_config: Some(memory_config),
+        }
+    }
+
+    fn approval_key(&self, descriptor: &ToolDescriptor) -> String {
+        format!("tool:{}", descriptor.name)
+    }
+
+    fn one_time_full_access_state(&self, now_epoch_s: u64) -> (bool, Option<String>) {
+        let approval = &self.tool_config.approval;
+        if !approval.one_time_full_access_granted {
+            return (false, None);
+        }
+        if let Some(deadline) = approval.one_time_full_access_expires_at_epoch_s {
+            if now_epoch_s > deadline {
+                return (
+                    false,
+                    Some(format!(
+                        "one-time full access grant expired at {deadline}, now is {now_epoch_s}"
+                    )),
+                );
+            }
+        }
+        if matches!(approval.one_time_full_access_remaining_uses, Some(0)) {
+            return (
+                false,
+                Some("one-time full access grant has no remaining uses".to_owned()),
+            );
+        }
+        (true, None)
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn runtime_grant_scope_session_id(
+        &self,
+        session_id: &str,
+        approval_key: &str,
+    ) -> Result<Option<String>, String> {
+        let memory_config = match &self.memory_config {
+            Some(memory_config) => memory_config,
+            None => return Ok(None),
+        };
+        let repo = SessionRepository::new(memory_config)?;
+        let Some(scope_session_id) = repo.lineage_root_session_id(session_id)? else {
+            return Ok(None);
+        };
+        let grant = repo.load_approval_grant(&scope_session_id, approval_key)?;
+        Ok(grant.map(|_| scope_session_id))
+    }
+}
+
+impl Default for DefaultToolGovernanceEvaluator {
+    fn default() -> Self {
+        Self::new(ToolConfig::default())
+    }
+}
+
+#[async_trait]
+impl ToolGovernanceEvaluator for DefaultToolGovernanceEvaluator {
+    async fn evaluate_tool_governance(
+        &self,
+        descriptor: &ToolDescriptor,
+        _intent: &ToolIntent,
+        session_context: &SessionContext,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> ToolGovernanceDecision {
+        if descriptor.execution_plane == ToolExecutionPlane::Core
+            || descriptor.approval_mode != ToolApprovalMode::PolicyDriven
+        {
+            return ToolGovernanceDecision::allow(descriptor);
+        }
+
+        let approval = &self.tool_config.approval;
+        let approval_key = self.approval_key(descriptor);
+        if approval
+            .denied_calls
+            .iter()
+            .any(|entry| entry == &approval_key)
+        {
+            return ToolGovernanceDecision::deny(
+                descriptor,
+                format!("governed tool {approval_key} is denied by approval policy"),
+                "governed_tool_denied_call",
+            );
+        }
+
+        if matches!(approval.mode, GovernedToolApprovalMode::Disabled) {
+            return ToolGovernanceDecision::allow_with_rule(
+                descriptor,
+                format!(
+                    "governed tool {approval_key} is allowed because approval mode is disabled"
+                ),
+                "governed_tool_approval_disabled",
+            );
+        }
+
+        let approval_required = match approval.mode {
+            GovernedToolApprovalMode::Disabled => false,
+            GovernedToolApprovalMode::MediumBalanced => {
+                matches!(descriptor.risk_class, ToolRiskClass::High)
+            }
+            GovernedToolApprovalMode::Strict => true,
+        };
+
+        if !approval_required {
+            return ToolGovernanceDecision::allow_with_rule(
+                descriptor,
+                format!(
+                    "governed tool {approval_key} is allowed by medium-balanced approval policy"
+                ),
+                "governed_tool_medium_balanced_allow",
+            );
+        }
+
+        #[cfg(feature = "memory-sqlite")]
+        match self.runtime_grant_scope_session_id(&session_context.session_id, &approval_key) {
+            Ok(Some(scope_session_id)) => {
+                return ToolGovernanceDecision::allow_with_rule(
+                    descriptor,
+                    format!(
+                        "governed tool {approval_key} is allowed by runtime approval grant scoped to root session `{scope_session_id}`"
+                    ),
+                    "governed_tool_runtime_approval_grant",
+                );
+            }
+            Ok(None) => {}
+            Err(error) => {
+                return ToolGovernanceDecision::require_approval(
+                    descriptor,
+                    format!(
+                        "operator approval required for governed tool {approval_key}; runtime grant lookup failed: {error}"
+                    ),
+                    "governed_tool_runtime_grant_lookup_failed",
+                );
+            }
+        }
+
+        let now_epoch_s = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0);
+        let (one_time_full_access_active, one_time_full_access_rejected_reason) =
+            self.one_time_full_access_state(now_epoch_s);
+
+        match approval.strategy {
+            GovernedToolApprovalStrategy::PerCall
+                if approval
+                    .approved_calls
+                    .iter()
+                    .any(|entry| entry == &approval_key) =>
+            {
+                ToolGovernanceDecision::allow_with_rule(
+                    descriptor,
+                    format!("governed tool {approval_key} is pre-approved by approval policy"),
+                    "governed_tool_preapproved_call",
+                )
+            }
+            GovernedToolApprovalStrategy::OneTimeFullAccess if one_time_full_access_active => {
+                ToolGovernanceDecision::allow_with_rule(
+                    descriptor,
+                    format!(
+                        "governed tool {approval_key} is allowed by one-time full access grant"
+                    ),
+                    "governed_tool_one_time_full_access",
+                )
+            }
+            GovernedToolApprovalStrategy::OneTimeFullAccess => {
+                ToolGovernanceDecision::require_approval(
+                    descriptor,
+                    one_time_full_access_rejected_reason.unwrap_or_else(|| {
+                        format!(
+                            "operator approval required for governed tool {approval_key}; \
+                             one-time full access is not granted"
+                        )
+                    }),
+                    "governed_tool_requires_one_time_full_access",
+                )
+            }
+            GovernedToolApprovalStrategy::PerCall => ToolGovernanceDecision::require_approval(
+                descriptor,
+                format!(
+                    "operator approval required for governed tool {approval_key}; add it to \
+                     tools.approval.approved_calls or enable one_time_full_access"
+                ),
+                "governed_tool_requires_per_call_approval",
+            ),
+        }
+    }
+}
+
+pub(crate) fn effective_tool_config_for_session(
+    tool_config: &ToolConfig,
+    session_context: &SessionContext,
+) -> ToolConfig {
+    let mut tool_config = tool_config.clone();
+    if session_context.parent_session_id.is_some() {
+        tool_config.sessions.visibility = SessionVisibility::SelfOnly;
+    }
+    tool_config
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn effective_tool_view_for_session(
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    session_context: &SessionContext,
+) -> Result<ToolView, String> {
+    let repo = crate::session::repository::SessionRepository::new(memory_config)?;
+    if let Some(session) = repo.load_session(&session_context.session_id)? {
+        if session.parent_session_id.is_some() {
+            let depth = repo
+                .session_lineage_depth(&session_context.session_id)
+                .map_err(|error| {
+                    format!(
+                        "compute session lineage depth for dispatcher tool view failed: {error}"
+                    )
+                })?;
+            let allow_nested_delegate = depth < tool_config.delegate.max_depth;
+            return Ok(delegate_child_tool_view_for_config_with_delegate(
+                tool_config,
+                allow_nested_delegate,
+            ));
+        }
+        return Ok(runtime_tool_view_for_config(tool_config));
+    }
+    if repo
+        .load_session_summary_with_legacy_fallback(&session_context.session_id)?
+        .is_some_and(|session| {
+            session.kind == crate::session::repository::SessionKind::DelegateChild
+        })
+    {
+        return Ok(delegate_child_tool_view_for_config(tool_config));
+    }
+    Ok(runtime_tool_view_for_config(tool_config))
+}
+
+#[cfg(not(feature = "memory-sqlite"))]
+fn effective_tool_view_for_session(
+    _memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    _session_context: &SessionContext,
+) -> Result<ToolView, String> {
+    Ok(runtime_tool_view_for_config(tool_config))
+}
+
+#[derive(Clone)]
+pub struct DefaultAppToolDispatcher {
+    memory_config: MemoryRuntimeConfig,
+    tool_config: ToolConfig,
+    app_config: Option<Arc<LoongClawConfig>>,
+    #[cfg(feature = "memory-sqlite")]
+    approval_runtime: Option<Arc<dyn crate::tools::approval::ApprovalResolutionRuntime>>,
+}
+
+impl DefaultAppToolDispatcher {
+    pub fn new(memory_config: MemoryRuntimeConfig, tool_config: ToolConfig) -> Self {
+        Self {
+            #[cfg(feature = "memory-sqlite")]
+            approval_runtime: default_approval_runtime(&memory_config, &tool_config, None, None),
+            memory_config,
+            tool_config,
+            app_config: None,
+        }
+    }
+
+    pub fn with_config(memory_config: MemoryRuntimeConfig, config: LoongClawConfig) -> Self {
+        Self {
+            #[cfg(feature = "memory-sqlite")]
+            approval_runtime: default_approval_runtime(
+                &memory_config,
+                &config.tools,
+                Some(Arc::new(config.clone())),
+                None,
+            ),
+            memory_config,
+            tool_config: config.tools.clone(),
+            app_config: Some(Arc::new(config)),
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    pub fn production(memory_config: MemoryRuntimeConfig, tool_config: ToolConfig) -> Self {
+        Self {
+            approval_runtime: default_approval_runtime(&memory_config, &tool_config, None, None),
+            memory_config,
+            tool_config,
+            app_config: None,
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    pub fn production_with_config(
+        memory_config: MemoryRuntimeConfig,
+        config: LoongClawConfig,
+    ) -> Self {
+        Self {
+            approval_runtime: default_approval_runtime(
+                &memory_config,
+                &config.tools,
+                Some(Arc::new(config.clone())),
+                None,
+            ),
+            memory_config,
+            tool_config: config.tools.clone(),
+            app_config: Some(Arc::new(config)),
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    pub fn with_approval_resolution_orchestration_dispatcher(
+        mut self,
+        orchestration_dispatcher: Arc<dyn OrchestrationToolDispatcher>,
+    ) -> Self {
+        self.approval_runtime = default_approval_runtime(
+            &self.memory_config,
+            &self.tool_config,
+            self.app_config.clone(),
+            Some(orchestration_dispatcher),
+        );
+        self
+    }
+
+    pub fn runtime() -> Self {
+        #[cfg(feature = "memory-sqlite")]
+        {
+            return Self::production(
+                crate::memory::runtime_config::get_memory_runtime_config().clone(),
+                ToolConfig::default(),
+            );
+        }
+        #[cfg(not(feature = "memory-sqlite"))]
+        Self::new(
+            crate::memory::runtime_config::get_memory_runtime_config().clone(),
+            ToolConfig::default(),
+        )
+    }
+}
+
+impl Default for DefaultAppToolDispatcher {
+    fn default() -> Self {
+        Self::runtime()
+    }
+}
+
+#[async_trait]
+impl AppToolDispatcher for DefaultAppToolDispatcher {
+    async fn execute_app_tool(
+        &self,
+        session_context: &SessionContext,
+        request: ToolCoreRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ToolCoreOutcome, String> {
+        let canonical_tool_name = crate::tools::canonical_tool_name(request.tool_name.as_str());
+        let effective_tool_view = effective_tool_view_for_session(
+            &self.memory_config,
+            &self.tool_config,
+            session_context,
+        )?;
+        if let Some(descriptor) = tool_catalog().descriptor(canonical_tool_name) {
+            if descriptor.execution_plane == ToolExecutionPlane::App
+                && (!session_context.tool_view.contains(descriptor.name)
+                    || !effective_tool_view.contains(descriptor.name))
+            {
+                return Err(format!("tool_not_visible: {}", descriptor.name));
+            }
+        }
+        let effective_tool_config =
+            effective_tool_config_for_session(&self.tool_config, session_context);
+        crate::tools::execute_app_tool_with_runtime_support(
+            request,
+            &session_context.session_id,
+            &self.memory_config,
+            &effective_tool_config,
+            crate::tools::AppToolRuntimeSupport {
+                app_config: self.app_config.as_deref(),
+                kernel_ctx,
+                #[cfg(feature = "memory-sqlite")]
+                approval_runtime: self.approval_runtime.clone(),
+            },
+        )
+        .await
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn default_approval_runtime(
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    app_config: Option<Arc<LoongClawConfig>>,
+    orchestration_dispatcher: Option<Arc<dyn OrchestrationToolDispatcher>>,
+) -> Option<Arc<dyn crate::tools::approval::ApprovalResolutionRuntime>> {
+    Some(Arc::new(DefaultApprovalResolutionRuntime::new(
+        memory_config.clone(),
+        tool_config.clone(),
+        app_config,
+        orchestration_dispatcher,
+    )))
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Clone)]
+pub(crate) struct DefaultApprovalResolutionRuntime {
+    memory_config: MemoryRuntimeConfig,
+    tool_config: ToolConfig,
+    app_config: Option<Arc<LoongClawConfig>>,
+    orchestration_dispatcher: Option<Arc<dyn OrchestrationToolDispatcher>>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl DefaultApprovalResolutionRuntime {
+    pub(crate) fn new(
+        memory_config: MemoryRuntimeConfig,
+        tool_config: ToolConfig,
+        app_config: Option<Arc<LoongClawConfig>>,
+        orchestration_dispatcher: Option<Arc<dyn OrchestrationToolDispatcher>>,
+    ) -> Self {
+        Self {
+            memory_config,
+            tool_config,
+            app_config,
+            orchestration_dispatcher,
+        }
+    }
+
+    fn append_approval_event(
+        &self,
+        repo: &SessionRepository,
+        approval_request: &crate::session::repository::ApprovalRequestRecord,
+        actor_session_id: &str,
+        event_kind: &str,
+        extra_payload: serde_json::Value,
+    ) -> Result<(), String> {
+        let mut payload = serde_json::Map::new();
+        payload.insert(
+            "approval_request_id".to_owned(),
+            serde_json::Value::String(approval_request.approval_request_id.clone()),
+        );
+        payload.insert(
+            "tool_name".to_owned(),
+            serde_json::Value::String(approval_request.tool_name.clone()),
+        );
+        payload.insert(
+            "approval_key".to_owned(),
+            serde_json::Value::String(approval_request.approval_key.clone()),
+        );
+        payload.insert(
+            "status".to_owned(),
+            serde_json::Value::String(approval_request.status.as_str().to_owned()),
+        );
+        if let Some(decision) = approval_request.decision {
+            payload.insert(
+                "decision".to_owned(),
+                serde_json::Value::String(decision.as_str().to_owned()),
+            );
+        }
+        payload.insert(
+            "turn_id".to_owned(),
+            serde_json::Value::String(approval_request.turn_id.clone()),
+        );
+        payload.insert(
+            "tool_call_id".to_owned(),
+            serde_json::Value::String(approval_request.tool_call_id.clone()),
+        );
+        if let Some(object) = extra_payload.as_object() {
+            for (key, value) in object {
+                payload.insert(key.clone(), value.clone());
+            }
+        }
+        repo.append_event(NewSessionEvent {
+            session_id: approval_request.session_id.clone(),
+            event_kind: event_kind.to_owned(),
+            actor_session_id: Some(actor_session_id.to_owned()),
+            payload_json: serde_json::Value::Object(payload),
+        })
+        .map(|_| ())
+    }
+
+    fn effective_tool_config_for_request_session(
+        &self,
+        repo: &SessionRepository,
+        session_id: &str,
+    ) -> Result<ToolConfig, String> {
+        let mut tool_config = self.tool_config.clone();
+        if repo
+            .load_session(session_id)?
+            .is_some_and(|session| session.parent_session_id.is_some())
+        {
+            tool_config.sessions.visibility = SessionVisibility::SelfOnly;
+        }
+        Ok(tool_config)
+    }
+
+    fn request_lineage_root_session_id(
+        &self,
+        repo: &SessionRepository,
+        approval_request: &crate::session::repository::ApprovalRequestRecord,
+    ) -> Result<String, String> {
+        repo.lineage_root_session_id(&approval_request.session_id)?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_session_not_found: `{}`",
+                    approval_request.session_id
+                )
+            })
+    }
+
+    fn replay_request(
+        &self,
+        approval_request: &crate::session::repository::ApprovalRequestRecord,
+    ) -> Result<(ToolExecutionPlane, ToolCoreRequest), String> {
+        let execution_plane = match approval_request
+            .governance_snapshot_json
+            .get("execution_plane")
+            .and_then(serde_json::Value::as_str)
+        {
+            Some("App") => ToolExecutionPlane::App,
+            Some("Orchestration") => ToolExecutionPlane::Orchestration,
+            Some(other) => {
+                return Err(format!(
+                    "approval_request_invalid_execution_plane: `{other}`"
+                ));
+            }
+            None => {
+                return Err(
+                    "approval_request_invalid_execution_plane: missing governance snapshot execution_plane"
+                        .to_owned(),
+                );
+            }
+        };
+        let tool_name = approval_request
+            .request_payload_json
+            .get("tool_name")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| "approval_request_invalid_payload: missing tool_name".to_owned())?;
+        let args_json = approval_request
+            .request_payload_json
+            .get("args_json")
+            .cloned()
+            .ok_or_else(|| "approval_request_invalid_payload: missing args_json".to_owned())?;
+
+        Ok((
+            execution_plane,
+            ToolCoreRequest {
+                tool_name: tool_name.to_owned(),
+                payload: args_json,
+            },
+        ))
+    }
+
+    fn replay_session_context(
+        &self,
+        repo: &SessionRepository,
+        session_id: &str,
+    ) -> Result<SessionContext, String> {
+        let root_context = SessionContext::root_with_tool_view(
+            session_id.to_owned(),
+            runtime_tool_view_for_config(&self.tool_config),
+        );
+        let tool_view =
+            effective_tool_view_for_session(&self.memory_config, &self.tool_config, &root_context)?;
+        let parent_session_id = repo
+            .load_session(session_id)?
+            .and_then(|session| session.parent_session_id);
+        Ok(match parent_session_id {
+            Some(parent_session_id) => {
+                SessionContext::child(session_id.to_owned(), parent_session_id, tool_view)
+            }
+            None => SessionContext::root_with_tool_view(session_id.to_owned(), tool_view),
+        })
+    }
+
+    async fn replay_approved_request(
+        &self,
+        repo: &SessionRepository,
+        approval_request: &crate::session::repository::ApprovalRequestRecord,
+        orchestration_replayer: Option<&(dyn ApprovalOrchestrationReplayer + '_)>,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ToolCoreOutcome, String> {
+        let (execution_plane, replay_request) = self.replay_request(approval_request)?;
+        let effective_tool_config =
+            self.effective_tool_config_for_request_session(repo, &approval_request.session_id)?;
+
+        match execution_plane {
+            ToolExecutionPlane::App => {
+                crate::tools::execute_app_tool_with_runtime_support(
+                    replay_request,
+                    &approval_request.session_id,
+                    &self.memory_config,
+                    &effective_tool_config,
+                    crate::tools::AppToolRuntimeSupport {
+                        app_config: self.app_config.as_deref(),
+                        kernel_ctx,
+                        approval_runtime: None,
+                    },
+                )
+                .await
+            }
+            ToolExecutionPlane::Orchestration => {
+                let orchestration_replayer = orchestration_replayer.ok_or_else(|| {
+                        "approval_request_resume_not_supported: orchestration replay dispatcher not configured"
+                            .to_owned()
+                    })?;
+                let session_context =
+                    self.replay_session_context(repo, &approval_request.session_id)?;
+                orchestration_replayer
+                    .replay_orchestration_request(&session_context, replay_request, kernel_ctx)
+                    .await
+            }
+            ToolExecutionPlane::Core => Err(
+                "approval_request_resume_not_supported: core-plane tools do not create approval requests"
+                    .to_owned(),
+            ),
+        }
+    }
+
+    async fn execute_approved_request(
+        &self,
+        repo: &SessionRepository,
+        current_session_id: &str,
+        approval_request_id: &str,
+        orchestration_replayer: Option<&(dyn ApprovalOrchestrationReplayer + '_)>,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
+        let executing = repo
+            .transition_approval_request_if_current(
+                approval_request_id,
+                TransitionApprovalRequestIfCurrentRequest {
+                    expected_status: ApprovalRequestStatus::Approved,
+                    next_status: ApprovalRequestStatus::Executing,
+                    decision: None,
+                    resolved_by_session_id: None,
+                    executed_at: None,
+                    last_error: None,
+                },
+            )?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_not_approved: `{approval_request_id}` is no longer approved"
+                )
+            })?;
+        self.append_approval_event(
+            repo,
+            &executing,
+            current_session_id,
+            TOOL_APPROVAL_EXECUTION_STARTED_EVENT_KIND,
+            serde_json::json!({}),
+        )?;
+
+        match self
+            .replay_approved_request(repo, &executing, orchestration_replayer, kernel_ctx)
+            .await
+        {
+            Ok(resumed_tool_output) => {
+                let executed_at = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|duration| duration.as_secs() as i64)
+                    .unwrap_or(0);
+                let executed = repo
+                    .transition_approval_request_if_current(
+                        approval_request_id,
+                        TransitionApprovalRequestIfCurrentRequest {
+                            expected_status: ApprovalRequestStatus::Executing,
+                            next_status: ApprovalRequestStatus::Executed,
+                            decision: None,
+                            resolved_by_session_id: None,
+                            executed_at: Some(executed_at),
+                            last_error: None,
+                        },
+                    )?
+                    .ok_or_else(|| {
+                        format!(
+                            "approval_request_not_executing: `{approval_request_id}` is no longer executing"
+                        )
+                    })?;
+                self.append_approval_event(
+                    repo,
+                    &executed,
+                    current_session_id,
+                    TOOL_APPROVAL_EXECUTION_FINISHED_EVENT_KIND,
+                    serde_json::json!({
+                        "resumed_tool_status": resumed_tool_output.status.clone(),
+                    }),
+                )?;
+                Ok(crate::tools::approval::ApprovalResolutionOutcome {
+                    approval_request: executed,
+                    resumed_tool_output: Some(resumed_tool_output),
+                })
+            }
+            Err(error) => {
+                let executed_at = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|duration| duration.as_secs() as i64)
+                    .unwrap_or(0);
+                let executed = repo
+                    .transition_approval_request_if_current(
+                        approval_request_id,
+                        TransitionApprovalRequestIfCurrentRequest {
+                            expected_status: ApprovalRequestStatus::Executing,
+                            next_status: ApprovalRequestStatus::Executed,
+                            decision: None,
+                            resolved_by_session_id: None,
+                            executed_at: Some(executed_at),
+                            last_error: Some(error.clone()),
+                        },
+                    )?
+                    .ok_or_else(|| {
+                        format!(
+                            "approval_request_not_executing: `{approval_request_id}` is no longer executing"
+                        )
+                    })?;
+                self.append_approval_event(
+                    repo,
+                    &executed,
+                    current_session_id,
+                    TOOL_APPROVAL_EXECUTION_FAILED_EVENT_KIND,
+                    serde_json::json!({
+                        "error": error.clone(),
+                    }),
+                )?;
+                Err(error)
+            }
+        }
+    }
+
+    pub(crate) async fn resolve_approval_request_with_orchestration_replayer(
+        &self,
+        request: crate::tools::approval::ApprovalResolutionRequest,
+        orchestration_replayer: Option<&(dyn ApprovalOrchestrationReplayer + '_)>,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
+        let repo = SessionRepository::new(&self.memory_config)?;
+        let approval_request = repo
+            .load_approval_request(&request.approval_request_id)?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_not_found: `{}`",
+                    request.approval_request_id
+                )
+            })?;
+        let is_visible = match request.visibility {
+            SessionVisibility::SelfOnly => {
+                request.current_session_id == approval_request.session_id
+            }
+            SessionVisibility::Children => {
+                request.current_session_id == approval_request.session_id
+                    || repo.is_session_visible(
+                        &request.current_session_id,
+                        &approval_request.session_id,
+                    )?
+            }
+        };
+        if !is_visible {
+            return Err(format!(
+                "visibility_denied: session `{}` is not visible from `{}`",
+                approval_request.session_id, request.current_session_id
+            ));
+        }
+
+        match request.decision {
+            ApprovalDecision::Deny => {
+                let resolved = repo.transition_approval_request_if_current(
+                    &request.approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Pending,
+                        next_status: ApprovalRequestStatus::Denied,
+                        decision: Some(ApprovalDecision::Deny),
+                        resolved_by_session_id: Some(request.current_session_id.clone()),
+                        executed_at: None,
+                        last_error: None,
+                    },
+                )?;
+                let resolved = match resolved {
+                    Some(resolved) => resolved,
+                    None => {
+                        let latest = repo
+                            .load_approval_request(&request.approval_request_id)?
+                            .ok_or_else(|| {
+                                format!(
+                                    "approval_request_not_found: `{}`",
+                                    request.approval_request_id
+                                )
+                            })?;
+                        return Err(format!(
+                            "approval_request_not_pending: `{}` is already {}",
+                            request.approval_request_id,
+                            latest.status.as_str()
+                        ));
+                    }
+                };
+                repo.append_event(NewSessionEvent {
+                    session_id: resolved.session_id.clone(),
+                    event_kind: TOOL_APPROVAL_RESOLVED_EVENT_KIND.to_owned(),
+                    actor_session_id: Some(request.current_session_id.clone()),
+                    payload_json: serde_json::json!({
+                        "approval_request_id": resolved.approval_request_id,
+                        "decision": ApprovalDecision::Deny.as_str(),
+                        "status": resolved.status.as_str(),
+                        "resolved_by_session_id": request.current_session_id,
+                    }),
+                })?;
+                Ok(crate::tools::approval::ApprovalResolutionOutcome {
+                    approval_request: resolved,
+                    resumed_tool_output: None,
+                })
+            }
+            ApprovalDecision::ApproveOnce => {
+                let approved = match repo.transition_approval_request_if_current(
+                    &request.approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Pending,
+                        next_status: ApprovalRequestStatus::Approved,
+                        decision: Some(ApprovalDecision::ApproveOnce),
+                        resolved_by_session_id: Some(request.current_session_id.clone()),
+                        executed_at: None,
+                        last_error: None,
+                    },
+                )? {
+                    Some(approved) => approved,
+                    None => {
+                        let latest = repo
+                            .load_approval_request(&request.approval_request_id)?
+                            .ok_or_else(|| {
+                                format!(
+                                    "approval_request_not_found: `{}`",
+                                    request.approval_request_id
+                                )
+                            })?;
+                        return Err(format!(
+                            "approval_request_not_pending: `{}` is already {}",
+                            request.approval_request_id,
+                            latest.status.as_str()
+                        ));
+                    }
+                };
+                self.append_approval_event(
+                    &repo,
+                    &approved,
+                    &request.current_session_id,
+                    TOOL_APPROVAL_RESOLVED_EVENT_KIND,
+                    serde_json::json!({
+                        "resolved_by_session_id": request.current_session_id,
+                    }),
+                )?;
+                self.execute_approved_request(
+                    &repo,
+                    &request.current_session_id,
+                    &request.approval_request_id,
+                    orchestration_replayer,
+                    kernel_ctx,
+                )
+                .await
+            }
+            ApprovalDecision::ApproveAlways => {
+                let approved = match repo.transition_approval_request_if_current(
+                    &request.approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Pending,
+                        next_status: ApprovalRequestStatus::Approved,
+                        decision: Some(ApprovalDecision::ApproveAlways),
+                        resolved_by_session_id: Some(request.current_session_id.clone()),
+                        executed_at: None,
+                        last_error: None,
+                    },
+                )? {
+                    Some(approved) => approved,
+                    None => {
+                        let latest = repo
+                            .load_approval_request(&request.approval_request_id)?
+                            .ok_or_else(|| {
+                                format!(
+                                    "approval_request_not_found: `{}`",
+                                    request.approval_request_id
+                                )
+                            })?;
+                        return Err(format!(
+                            "approval_request_not_pending: `{}` is already {}",
+                            request.approval_request_id,
+                            latest.status.as_str()
+                        ));
+                    }
+                };
+                let grant_scope_session_id =
+                    self.request_lineage_root_session_id(&repo, &approved)?;
+                repo.upsert_approval_grant(NewApprovalGrantRecord {
+                    scope_session_id: grant_scope_session_id.clone(),
+                    approval_key: approved.approval_key.clone(),
+                    created_by_session_id: Some(request.current_session_id.clone()),
+                })?;
+                self.append_approval_event(
+                    &repo,
+                    &approved,
+                    &request.current_session_id,
+                    TOOL_APPROVAL_RESOLVED_EVENT_KIND,
+                    serde_json::json!({
+                        "resolved_by_session_id": request.current_session_id,
+                        "grant_scope_session_id": grant_scope_session_id,
+                    }),
+                )?;
+                self.execute_approved_request(
+                    &repo,
+                    &request.current_session_id,
+                    &request.approval_request_id,
+                    orchestration_replayer,
+                    kernel_ctx,
+                )
+                .await
+            }
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct DispatcherApprovalOrchestrationReplayer<'a> {
+    dispatcher: &'a (dyn OrchestrationToolDispatcher + 'a),
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl ApprovalOrchestrationReplayer for DispatcherApprovalOrchestrationReplayer<'_> {
+    async fn replay_orchestration_request(
+        &self,
+        session_context: &SessionContext,
+        request: ToolCoreRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ToolCoreOutcome, String> {
+        self.dispatcher
+            .execute_orchestration_tool(session_context, request, kernel_ctx)
+            .await
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl crate::tools::approval::ApprovalResolutionRuntime for DefaultApprovalResolutionRuntime {
+    async fn resolve_approval_request(
+        &self,
+        request: crate::tools::approval::ApprovalResolutionRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
+        let dispatcher_replayer = self
+            .orchestration_dispatcher
+            .as_deref()
+            .map(|dispatcher| DispatcherApprovalOrchestrationReplayer { dispatcher });
+        self.resolve_approval_request_with_orchestration_replayer(
+            request,
+            dispatcher_replayer
+                .as_ref()
+                .map(|replayer| replayer as &(dyn ApprovalOrchestrationReplayer + '_)),
+            kernel_ctx,
+        )
+        .await
+    }
+}
+
+#[derive(Clone)]
+pub struct DefaultOrchestrationToolDispatcher {
+    memory_config: MemoryRuntimeConfig,
+    tool_config: ToolConfig,
+    async_delegate_spawner: Option<Arc<dyn crate::tools::delegate::AsyncDelegateSpawner>>,
+}
+
+impl DefaultOrchestrationToolDispatcher {
+    pub fn new(memory_config: MemoryRuntimeConfig, tool_config: ToolConfig) -> Self {
+        Self {
+            memory_config,
+            tool_config,
+            async_delegate_spawner: None,
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    pub fn production(memory_config: MemoryRuntimeConfig, tool_config: ToolConfig) -> Self {
+        let async_delegate_spawner = SubprocessAsyncDelegateSpawner::from_current_process()
+            .ok()
+            .map(|spawner| Arc::new(spawner) as Arc<dyn AsyncDelegateSpawner>);
+        Self {
+            memory_config,
+            tool_config,
+            async_delegate_spawner,
+        }
+    }
+
+    pub fn with_async_delegate_spawner(
+        memory_config: MemoryRuntimeConfig,
+        tool_config: ToolConfig,
+        async_delegate_spawner: Arc<dyn crate::tools::delegate::AsyncDelegateSpawner>,
+    ) -> Self {
+        Self {
+            memory_config,
+            tool_config,
+            async_delegate_spawner: Some(async_delegate_spawner),
+        }
+    }
+
+    pub fn runtime() -> Self {
+        #[cfg(feature = "memory-sqlite")]
+        {
+            return Self::production(
+                crate::memory::runtime_config::get_memory_runtime_config().clone(),
+                ToolConfig::default(),
+            );
+        }
+        #[cfg(not(feature = "memory-sqlite"))]
+        Self::new(
+            crate::memory::runtime_config::get_memory_runtime_config().clone(),
+            ToolConfig::default(),
+        )
+    }
+}
+
+impl Default for DefaultOrchestrationToolDispatcher {
+    fn default() -> Self {
+        Self::runtime()
+    }
+}
+
+#[async_trait]
+impl OrchestrationToolDispatcher for DefaultOrchestrationToolDispatcher {
+    async fn execute_orchestration_tool(
+        &self,
+        session_context: &SessionContext,
+        request: ToolCoreRequest,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ToolCoreOutcome, String> {
+        let canonical_tool_name = crate::tools::canonical_tool_name(request.tool_name.as_str());
+        let effective_tool_view = effective_tool_view_for_session(
+            &self.memory_config,
+            &self.tool_config,
+            session_context,
+        )?;
+        if let Some(descriptor) = tool_catalog().descriptor(canonical_tool_name) {
+            if descriptor.execution_plane == ToolExecutionPlane::Orchestration
+                && (!session_context.tool_view.contains(descriptor.name)
+                    || !effective_tool_view.contains(descriptor.name))
+            {
+                return Err(format!("tool_not_visible: {}", descriptor.name));
+            }
+        }
+        let effective_tool_config =
+            effective_tool_config_for_session(&self.tool_config, session_context);
+        crate::tools::execute_orchestration_tool_with_runtime_support(
+            request,
+            &session_context.session_id,
+            &self.memory_config,
+            &effective_tool_config,
+            crate::tools::OrchestrationToolRuntimeSupport {
+                async_delegate_spawner: self.async_delegate_spawner.clone(),
+            },
+        )
+        .await
+    }
 }
 
 /// Single orchestration boundary for tool-call evaluation and execution.
@@ -276,33 +1683,28 @@ fn truncate_by_chars(value: &str, limit: usize) -> (String, usize, bool) {
 /// `execute_turn` performs policy-gated tool execution through the kernel.
 pub struct TurnEngine {
     max_tool_steps: usize,
-    tool_result_payload_summary_limit_chars: usize,
 }
 
 impl TurnEngine {
     pub fn new(max_tool_steps: usize) -> Self {
-        Self::with_tool_result_payload_summary_limit(
-            max_tool_steps,
-            TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
-        )
-    }
-
-    pub fn with_tool_result_payload_summary_limit(
-        max_tool_steps: usize,
-        tool_result_payload_summary_limit_chars: usize,
-    ) -> Self {
-        Self {
-            max_tool_steps,
-            tool_result_payload_summary_limit_chars: tool_result_payload_summary_limit_chars.clamp(
-                MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
-                MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
-            ),
-        }
+        Self { max_tool_steps }
     }
 
     /// Evaluate a provider turn and produce a deterministic result.
     /// Does NOT execute tools — just validates and gates.
     pub fn evaluate_turn(&self, turn: &ProviderTurn) -> TurnResult {
+        self.evaluate_turn_in_view(turn, &runtime_tool_view())
+    }
+
+    pub fn evaluate_turn_in_view(&self, turn: &ProviderTurn, tool_view: &ToolView) -> TurnResult {
+        self.evaluate_turn_in_context(turn, &session_context_from_turn(turn, tool_view.clone()))
+    }
+
+    pub fn evaluate_turn_in_context(
+        &self,
+        turn: &ProviderTurn,
+        session_context: &SessionContext,
+    ) -> TurnResult {
         // No tool intents → just return the text
         if turn.tool_intents.is_empty() {
             return TurnResult::FinalText(turn.assistant_text.clone());
@@ -310,19 +1712,22 @@ impl TurnEngine {
 
         // Too many tool intents for current step limit
         if turn.tool_intents.len() > self.max_tool_steps {
-            return TurnResult::policy_denied("max_tool_steps_exceeded", "max_tool_steps_exceeded");
+            return TurnResult::ToolDenied("max_tool_steps_exceeded".to_owned());
         }
 
         // Check each tool intent
+        let catalog = tool_catalog();
         for intent in &turn.tool_intents {
-            if !crate::tools::is_known_tool_name(&intent.tool_name) {
-                let reason = format!("tool_not_found: {}", intent.tool_name);
-                return TurnResult::policy_denied("tool_not_found", reason);
+            let Some(descriptor) = catalog.resolve(&intent.tool_name) else {
+                return TurnResult::ToolDenied(format!("tool_not_found: {}", intent.tool_name));
+            };
+            if !session_context.tool_view.contains(descriptor.name) {
+                return TurnResult::ToolDenied(format!("tool_not_visible: {}", intent.tool_name));
             }
         }
 
         // All tools validated — execution requires a kernel context
-        TurnResult::needs_approval("kernel_context_required", "kernel_context_required")
+        TurnResult::NeedsApproval(ApprovalRequirement::kernel_context_required())
     }
 
     /// Execute a provider turn with policy-gated tool execution through the kernel.
@@ -339,6 +1744,120 @@ impl TurnEngine {
         turn: &ProviderTurn,
         kernel_ctx: Option<&KernelContext>,
     ) -> TurnResult {
+        self.execute_turn_in_view(turn, &runtime_tool_view(), kernel_ctx)
+            .await
+    }
+
+    pub async fn execute_turn_in_view(
+        &self,
+        turn: &ProviderTurn,
+        tool_view: &ToolView,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> TurnResult {
+        self.execute_turn_in_context(
+            turn,
+            &session_context_from_turn(turn, tool_view.clone()),
+            &DefaultAppToolDispatcher::runtime(),
+            &DefaultOrchestrationToolDispatcher::runtime(),
+            kernel_ctx,
+        )
+        .await
+    }
+
+    pub async fn execute_turn_in_context<
+        A: AppToolDispatcher + ?Sized,
+        O: OrchestrationToolDispatcher + ?Sized,
+    >(
+        &self,
+        turn: &ProviderTurn,
+        session_context: &SessionContext,
+        app_dispatcher: &A,
+        orchestration_dispatcher: &O,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> TurnResult {
+        let governance = DefaultToolGovernanceEvaluator::default();
+        self.execute_turn_in_context_with_governance(
+            turn,
+            session_context,
+            &governance,
+            app_dispatcher,
+            orchestration_dispatcher,
+            kernel_ctx,
+        )
+        .await
+    }
+
+    pub async fn execute_turn_in_context_with_governance<
+        G: ToolGovernanceEvaluator + ?Sized,
+        A: AppToolDispatcher + ?Sized,
+        O: OrchestrationToolDispatcher + ?Sized,
+    >(
+        &self,
+        turn: &ProviderTurn,
+        session_context: &SessionContext,
+        governance_evaluator: &G,
+        app_dispatcher: &A,
+        orchestration_dispatcher: &O,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> TurnResult {
+        self.execute_turn_in_context_internal(
+            turn,
+            session_context,
+            None,
+            None,
+            governance_evaluator,
+            app_dispatcher,
+            orchestration_dispatcher,
+            kernel_ctx,
+        )
+        .await
+    }
+
+    pub(crate) async fn execute_turn_in_context_with_governance_and_persistence<
+        R: ConversationRuntime + ?Sized,
+        G: ToolGovernanceEvaluator + ?Sized,
+        A: AppToolDispatcher + ?Sized,
+        O: OrchestrationToolDispatcher + ?Sized,
+    >(
+        &self,
+        turn: &ProviderTurn,
+        session_context: &SessionContext,
+        runtime: &R,
+        governance_evaluator: &G,
+        app_dispatcher: &A,
+        orchestration_dispatcher: &O,
+        approval_request_store: Option<&(dyn GovernedApprovalRequestStore + '_)>,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> TurnResult {
+        let recorder = RuntimeToolLifecycleRecorder { runtime };
+        self.execute_turn_in_context_internal(
+            turn,
+            session_context,
+            Some(&recorder),
+            approval_request_store,
+            governance_evaluator,
+            app_dispatcher,
+            orchestration_dispatcher,
+            kernel_ctx,
+        )
+        .await
+    }
+
+    async fn execute_turn_in_context_internal<
+        G: ToolGovernanceEvaluator + ?Sized,
+        A: AppToolDispatcher + ?Sized,
+        O: OrchestrationToolDispatcher + ?Sized,
+    >(
+        &self,
+        turn: &ProviderTurn,
+        session_context: &SessionContext,
+        lifecycle_recorder: Option<&(dyn ToolLifecycleRecorder + '_)>,
+        approval_request_store: Option<&(dyn GovernedApprovalRequestStore + '_)>,
+        governance_evaluator: &G,
+        app_dispatcher: &A,
+        orchestration_dispatcher: &O,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> TurnResult {
         // No tool intents → just return the text
         if turn.tool_intents.is_empty() {
             return TurnResult::FinalText(turn.assistant_text.clone());
@@ -346,60 +1865,335 @@ impl TurnEngine {
 
         // Too many tool intents for current step limit
         if turn.tool_intents.len() > self.max_tool_steps {
-            return TurnResult::policy_denied("max_tool_steps_exceeded", "max_tool_steps_exceeded");
+            return TurnResult::ToolDenied("max_tool_steps_exceeded".to_owned());
         }
 
         // Check each tool intent is known
+        let catalog = tool_catalog();
         for intent in &turn.tool_intents {
-            if !crate::tools::is_known_tool_name(&intent.tool_name) {
-                let reason = format!("tool_not_found: {}", intent.tool_name);
-                return TurnResult::policy_denied("tool_not_found", reason);
+            let Some(descriptor) = catalog.resolve(&intent.tool_name) else {
+                return TurnResult::ToolDenied(format!("tool_not_found: {}", intent.tool_name));
+            };
+            if !session_context.tool_view.contains(descriptor.name) {
+                return TurnResult::ToolDenied(format!("tool_not_visible: {}", intent.tool_name));
             }
         }
-
-        // Require kernel context for execution
-        let ctx = match kernel_ctx {
-            Some(ctx) => ctx,
-            None => return TurnResult::policy_denied("no_kernel_context", "no_kernel_context"),
-        };
 
         // Execute each tool intent through the kernel
         let mut outputs = Vec::new();
         for intent in &turn.tool_intents {
+            let descriptor = catalog
+                .resolve(&intent.tool_name)
+                .expect("tool descriptor should remain resolvable after validation");
             let request = ToolCoreRequest {
-                tool_name: intent.tool_name.clone(),
+                tool_name: descriptor.name.to_owned(),
                 payload: intent.args_json.clone(),
             };
-            let caps = BTreeSet::from([Capability::InvokeTool]);
-            match ctx
-                .kernel
-                .execute_tool_core(ctx.pack_id(), &ctx.token, &caps, None, request)
-                .await
-            {
-                Ok(outcome) => {
-                    outputs.push(format_tool_result_line_with_limit(
-                        intent,
-                        &outcome,
-                        self.tool_result_payload_summary_limit_chars,
-                    ));
-                }
-                Err(e) => {
-                    let reason = format!("{e}");
-                    return match classify_kernel_error(&e) {
-                        KernelFailureClass::PolicyDenied => {
-                            TurnResult::policy_denied("kernel_policy_denied", reason)
-                        }
-                        KernelFailureClass::RetryableExecution => {
-                            TurnResult::retryable_tool_error("tool_execution_failed", reason)
-                        }
-                        KernelFailureClass::NonRetryable => {
-                            TurnResult::non_retryable_tool_error("kernel_execution_failed", reason)
-                        }
+            match descriptor.execution_plane {
+                ToolExecutionPlane::Core => {
+                    let ctx = match kernel_ctx {
+                        Some(ctx) => ctx,
+                        None => return TurnResult::ToolDenied("no_kernel_context".to_owned()),
                     };
+                    let caps = BTreeSet::from([Capability::InvokeTool]);
+                    match ctx
+                        .kernel
+                        .execute_tool_core(ctx.pack_id(), &ctx.token, &caps, None, request)
+                        .await
+                    {
+                        Ok(outcome) => {
+                            outputs.push(format!("[{}] {}", outcome.status, outcome.payload));
+                        }
+                        Err(e) => {
+                            return match &e {
+                                KernelError::Policy(_)
+                                | KernelError::PackCapabilityBoundary { .. } => {
+                                    TurnResult::ToolDenied(format!("{e}"))
+                                }
+                                _ => TurnResult::ToolError(format!("{e}")),
+                            };
+                        }
+                    }
+                }
+                ToolExecutionPlane::App | ToolExecutionPlane::Orchestration => {
+                    let governance_decision = governance_evaluator
+                        .evaluate_tool_governance(descriptor, intent, session_context, kernel_ctx)
+                        .await;
+                    let tool_decision = ToolDecision::from_governance(&governance_decision);
+                    if let Some(recorder) = lifecycle_recorder {
+                        if let Err(error) = recorder
+                            .persist_tool_decision(
+                                &session_context.session_id,
+                                &intent.turn_id,
+                                &intent.tool_call_id,
+                                &tool_decision,
+                                kernel_ctx,
+                            )
+                            .await
+                        {
+                            return TurnResult::ToolError(format!(
+                                "persist tool decision failed: {error}"
+                            ));
+                        }
+                    }
+                    if governance_decision.approval_required {
+                        if let Some(recorder) = lifecycle_recorder {
+                            let outcome = ToolOutcome::governed(
+                                "approval_required",
+                                serde_json::Value::Null,
+                                Some("approval_required".to_owned()),
+                                Some(governance_decision.reason.clone()),
+                                None,
+                                false,
+                                &governance_decision,
+                            );
+                            if let Err(error) = recorder
+                                .persist_tool_outcome(
+                                    &session_context.session_id,
+                                    &intent.turn_id,
+                                    &intent.tool_call_id,
+                                    &outcome,
+                                    kernel_ctx,
+                                )
+                                .await
+                            {
+                                return TurnResult::ToolError(format!(
+                                    "persist tool outcome failed: {error}"
+                                ));
+                            }
+                        }
+                        let approval_key = format!("tool:{}", descriptor.name);
+                        let approval_request_id = match approval_request_store {
+                            Some(store) => match store.ensure_governed_approval_request(
+                                session_context,
+                                intent,
+                                descriptor,
+                                &governance_decision,
+                            ) {
+                                Ok(approval_request_id) => Some(approval_request_id),
+                                Err(error) => {
+                                    return TurnResult::ToolError(format!(
+                                        "persist approval request failed: {error}"
+                                    ));
+                                }
+                            },
+                            None => None,
+                        };
+                        return TurnResult::NeedsApproval(ApprovalRequirement::governed_tool(
+                            descriptor.name,
+                            approval_key,
+                            governance_decision.reason.clone(),
+                            governance_decision.rule_id.clone(),
+                            approval_request_id,
+                        ));
+                    }
+                    if !governance_decision.allow {
+                        if let Some(recorder) = lifecycle_recorder {
+                            let outcome = ToolOutcome::governed(
+                                "denied",
+                                serde_json::Value::Null,
+                                Some("tool_denied".to_owned()),
+                                Some(governance_decision.reason.clone()),
+                                None,
+                                false,
+                                &governance_decision,
+                            );
+                            if let Err(error) = recorder
+                                .persist_tool_outcome(
+                                    &session_context.session_id,
+                                    &intent.turn_id,
+                                    &intent.tool_call_id,
+                                    &outcome,
+                                    kernel_ctx,
+                                )
+                                .await
+                            {
+                                return TurnResult::ToolError(format!(
+                                    "persist tool outcome failed: {error}"
+                                ));
+                            }
+                        }
+                        return TurnResult::ToolDenied(governance_decision.reason);
+                    }
+                    match descriptor.execution_plane {
+                        ToolExecutionPlane::App => match app_dispatcher
+                            .execute_app_tool(session_context, request, kernel_ctx)
+                            .await
+                        {
+                            Ok(outcome) => {
+                                if let Some(recorder) = lifecycle_recorder {
+                                    let tool_outcome = ToolOutcome::governed(
+                                        outcome.status.clone(),
+                                        outcome.payload.clone(),
+                                        None,
+                                        None,
+                                        None,
+                                        true,
+                                        &governance_decision,
+                                    );
+                                    if let Err(error) = recorder
+                                        .persist_tool_outcome(
+                                            &session_context.session_id,
+                                            &intent.turn_id,
+                                            &intent.tool_call_id,
+                                            &tool_outcome,
+                                            kernel_ctx,
+                                        )
+                                        .await
+                                    {
+                                        return TurnResult::ToolError(format!(
+                                            "persist tool outcome failed: {error}"
+                                        ));
+                                    }
+                                }
+                                outputs.push(format!("[{}] {}", outcome.status, outcome.payload));
+                            }
+                            Err(error) => {
+                                if let Some(recorder) = lifecycle_recorder {
+                                    let tool_outcome = ToolOutcome::governed(
+                                        "error",
+                                        serde_json::Value::Null,
+                                        Some("tool_error".to_owned()),
+                                        Some(error.clone()),
+                                        None,
+                                        true,
+                                        &governance_decision,
+                                    );
+                                    if let Err(persist_error) = recorder
+                                        .persist_tool_outcome(
+                                            &session_context.session_id,
+                                            &intent.turn_id,
+                                            &intent.tool_call_id,
+                                            &tool_outcome,
+                                            kernel_ctx,
+                                        )
+                                        .await
+                                    {
+                                        return TurnResult::ToolError(format!(
+                                            "persist tool outcome failed: {persist_error}"
+                                        ));
+                                    }
+                                }
+                                return TurnResult::ToolError(error);
+                            }
+                        },
+                        ToolExecutionPlane::Orchestration => match orchestration_dispatcher
+                            .execute_orchestration_tool(session_context, request, kernel_ctx)
+                            .await
+                        {
+                            Ok(outcome) => {
+                                if let Some(recorder) = lifecycle_recorder {
+                                    let tool_outcome = ToolOutcome::governed(
+                                        outcome.status.clone(),
+                                        outcome.payload.clone(),
+                                        None,
+                                        None,
+                                        None,
+                                        true,
+                                        &governance_decision,
+                                    );
+                                    if let Err(error) = recorder
+                                        .persist_tool_outcome(
+                                            &session_context.session_id,
+                                            &intent.turn_id,
+                                            &intent.tool_call_id,
+                                            &tool_outcome,
+                                            kernel_ctx,
+                                        )
+                                        .await
+                                    {
+                                        return TurnResult::ToolError(format!(
+                                            "persist tool outcome failed: {error}"
+                                        ));
+                                    }
+                                }
+                                outputs.push(format!("[{}] {}", outcome.status, outcome.payload));
+                            }
+                            Err(error) => {
+                                if let Some(recorder) = lifecycle_recorder {
+                                    let tool_outcome = ToolOutcome::governed(
+                                        "error",
+                                        serde_json::Value::Null,
+                                        Some("tool_error".to_owned()),
+                                        Some(error.clone()),
+                                        None,
+                                        true,
+                                        &governance_decision,
+                                    );
+                                    if let Err(persist_error) = recorder
+                                        .persist_tool_outcome(
+                                            &session_context.session_id,
+                                            &intent.turn_id,
+                                            &intent.tool_call_id,
+                                            &tool_outcome,
+                                            kernel_ctx,
+                                        )
+                                        .await
+                                    {
+                                        return TurnResult::ToolError(format!(
+                                            "persist tool outcome failed: {persist_error}"
+                                        ));
+                                    }
+                                }
+                                return TurnResult::ToolError(error);
+                            }
+                        },
+                        ToolExecutionPlane::Core => unreachable!(
+                            "core tools should not enter app/orchestration governance branch"
+                        ),
+                    }
                 }
             }
         }
 
         TurnResult::FinalText(outputs.join("\n"))
     }
+}
+
+#[cfg(all(test, feature = "memory-sqlite"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delegate_async_subprocess_plan_includes_config_path_and_delegate_child_flag() {
+        let request = crate::tools::delegate::AsyncDelegateSpawnRequest {
+            child_session_id: "delegate:child-1".to_owned(),
+            parent_session_id: "root-session".to_owned(),
+            task: "child task".to_owned(),
+            label: Some("research".to_owned()),
+            timeout_seconds: 19,
+        };
+
+        let plan = build_async_delegate_subprocess_plan(
+            std::path::Path::new("/tmp/loongclawd"),
+            Some("/tmp/loongclaw.toml"),
+            &request,
+        );
+
+        assert_eq!(plan.program, std::path::PathBuf::from("/tmp/loongclawd"));
+        assert_eq!(
+            plan.args,
+            vec![
+                "run-turn",
+                "--config",
+                "/tmp/loongclaw.toml",
+                "--session",
+                "delegate:child-1",
+                "--input",
+                "child task",
+                "--timeout-seconds",
+                "19",
+                "--delegate-child",
+            ]
+        );
+    }
+}
+
+fn session_context_from_turn(turn: &ProviderTurn, tool_view: ToolView) -> SessionContext {
+    let session_id = turn
+        .tool_intents
+        .first()
+        .map(|intent| intent.session_id.as_str())
+        .unwrap_or("default");
+    SessionContext::root_with_tool_view(session_id, tool_view)
 }

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -1,25 +1,55 @@
+use async_trait::async_trait;
+use futures_util::FutureExt;
+use std::any::Any;
 use std::collections::VecDeque;
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use serde_json::{Value, json};
+use serde_json::{json, Value};
+use tokio::time::timeout;
 
 use crate::CliResult;
 use crate::KernelContext;
 
 use super::super::config::LoongClawConfig;
-use super::ProviderErrorMode;
 use super::persistence::{format_provider_error_reply, persist_error_turns, persist_success_turns};
-use super::runtime::{ConversationRuntime, DefaultConversationRuntime};
-use super::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
-use super::turn_shared::{
-    build_external_skill_followup_user_prompt, build_external_skill_system_message,
-    build_tool_followup_user_prompt, compose_assistant_reply, join_non_empty_lines,
-    parse_external_skill_invoke_context, user_requested_raw_tool_output,
+use super::runtime::{ConversationRuntime, DefaultConversationRuntime, SessionContext};
+#[cfg(feature = "memory-sqlite")]
+use super::turn_engine::SessionRepositoryApprovalRequestStore;
+#[cfg(feature = "memory-sqlite")]
+use super::turn_engine::{
+    effective_tool_config_for_session, ApprovalOrchestrationReplayer,
+    DefaultApprovalResolutionRuntime,
 };
+use super::turn_engine::{
+    AppToolDispatcher, ApprovalRequirement, ApprovalRequirementKind, DefaultAppToolDispatcher,
+    DefaultOrchestrationToolDispatcher, DefaultToolGovernanceEvaluator,
+    GovernedApprovalRequestStore, OrchestrationToolDispatcher, ProviderTurn, ToolIntent,
+    TurnEngine, TurnResult,
+};
+use super::ProviderErrorMode;
+
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::recovery::{build_terminal_finalize_recovery_payload, RECOVERY_EVENT_KIND};
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{
+    CreateSessionWithEventRequest, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    TransitionSessionWithEventIfCurrentRequest,
+};
+#[cfg(feature = "memory-sqlite")]
+use crate::session::{
+    delegate_cancelled_error, parse_delegate_cancelled_reason, DELEGATE_CANCELLED_EVENT_KIND,
+    DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED, DELEGATE_CANCEL_REQUESTED_EVENT_KIND,
+};
+use crate::tools::runtime_tool_view_for_config;
 
 #[derive(Default)]
 pub struct ConversationTurnLoop;
 
+const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
 const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
 
 impl ConversationTurnLoop {
@@ -35,9 +65,34 @@ impl ConversationTurnLoop {
         error_mode: ProviderErrorMode,
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<String> {
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
-        self.handle_turn_with_runtime(
-            config, session_id, user_input, error_mode, &runtime, kernel_ctx,
+        let session_context = SessionContext::root_with_tool_view(
+            session_id,
+            runtime_tool_view_for_config(&config.tools),
+        );
+        self.handle_turn_in_session(config, &session_context, user_input, error_mode, kernel_ctx)
+            .await
+    }
+
+    pub async fn handle_turn_in_session(
+        &self,
+        config: &LoongClawConfig,
+        session_context: &SessionContext,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<String> {
+        let runtime = DefaultConversationRuntime;
+        let app_dispatcher = default_app_tool_dispatcher(config);
+        let orchestration_dispatcher = default_orchestration_tool_dispatcher(config);
+        self.handle_turn_with_runtime_and_context(
+            config,
+            session_context,
+            user_input,
+            error_mode,
+            &runtime,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            kernel_ctx,
         )
         .await
     }
@@ -51,9 +106,71 @@ impl ConversationTurnLoop {
         runtime: &R,
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<String> {
-        let mut messages = runtime
-            .build_messages(config, session_id, true, kernel_ctx)
-            .await?;
+        let session_context = runtime.session_context(config, session_id, kernel_ctx)?;
+        let app_dispatcher = default_app_tool_dispatcher(config);
+        let orchestration_dispatcher = default_orchestration_tool_dispatcher(config);
+        self.handle_turn_with_runtime_and_context(
+            config,
+            &session_context,
+            user_input,
+            error_mode,
+            runtime,
+            &app_dispatcher,
+            &orchestration_dispatcher,
+            kernel_ctx,
+        )
+        .await
+    }
+
+    pub async fn handle_turn_with_runtime_and_context<
+        R: ConversationRuntime + ?Sized,
+        A: AppToolDispatcher + ?Sized,
+        O: OrchestrationToolDispatcher + ?Sized,
+    >(
+        &self,
+        config: &LoongClawConfig,
+        session_context: &SessionContext,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        runtime: &R,
+        app_dispatcher: &A,
+        orchestration_dispatcher: &O,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<String> {
+        #[cfg(feature = "memory-sqlite")]
+        ensure_session_registered(config, session_context)?;
+
+        #[cfg(feature = "memory-sqlite")]
+        let approval_aware_app_dispatcher = TurnLoopAppToolDispatcher {
+            turn_loop: self,
+            config,
+            runtime,
+            base: app_dispatcher,
+            orchestration_dispatcher,
+        };
+        let turn_loop_dispatcher = TurnLoopOrchestrationToolDispatcher {
+            turn_loop: self,
+            config,
+            runtime,
+            app_dispatcher,
+            fallback: orchestration_dispatcher,
+        };
+        #[cfg(not(feature = "memory-sqlite"))]
+        let turn_loop_dispatcher = TurnLoopOrchestrationToolDispatcher {
+            turn_loop: self,
+            config,
+            runtime,
+            app_dispatcher,
+            fallback: orchestration_dispatcher,
+        };
+        #[cfg(feature = "memory-sqlite")]
+        let app_dispatcher_ref = &approval_aware_app_dispatcher;
+        #[cfg(not(feature = "memory-sqlite"))]
+        let app_dispatcher_ref = app_dispatcher;
+        let session_id = session_context.session_id.as_str();
+        let tool_view = &session_context.tool_view;
+        let mut messages =
+            runtime.build_messages(config, session_id, true, tool_view, kernel_ctx)?;
         messages.push(json!({
             "role": "user",
             "content": user_input,
@@ -66,9 +183,21 @@ impl ConversationTurnLoop {
             policy.max_followup_tool_payload_chars,
             policy.max_followup_tool_payload_chars_total,
         );
+        #[cfg(feature = "memory-sqlite")]
+        let approval_request_store =
+            SessionRepositoryApprovalRequestStore::new(memory_runtime_config_for(config));
 
         for round_index in 0..policy.max_rounds {
-            let turn = match runtime.request_turn(config, &messages, kernel_ctx).await {
+            #[cfg(feature = "memory-sqlite")]
+            if session_context.parent_session_id.is_some() {
+                if let Some(cancel_reason) =
+                    load_delegate_child_cancel_request(config, session_context)?
+                {
+                    return Err(delegate_cancelled_error(&cancel_reason));
+                }
+            }
+
+            let turn = match runtime.request_turn(config, &messages, tool_view).await {
                 Ok(turn) => turn,
                 Err(error) => {
                     return match error_mode {
@@ -91,14 +220,27 @@ impl ConversationTurnLoop {
             let current_tool_name_signature =
                 had_tool_intents.then(|| tool_name_signature(&turn.tool_intents));
 
-            let turn_result = TurnEngine::with_tool_result_payload_summary_limit(
-                policy.max_tool_steps_per_round,
-                config
-                    .conversation
-                    .tool_result_payload_summary_limit_chars(),
-            )
-            .execute_turn(&turn, kernel_ctx)
-            .await;
+            let governance_evaluator = DefaultToolGovernanceEvaluator::with_memory_config(
+                memory_runtime_config_for(config),
+                config.tools.clone(),
+            );
+            #[cfg(feature = "memory-sqlite")]
+            let approval_request_store_ref: Option<&dyn GovernedApprovalRequestStore> =
+                Some(&approval_request_store);
+            #[cfg(not(feature = "memory-sqlite"))]
+            let approval_request_store_ref = None;
+            let turn_result = TurnEngine::new(policy.max_tool_steps_per_round)
+                .execute_turn_in_context_with_governance_and_persistence(
+                    &turn,
+                    session_context,
+                    runtime,
+                    &governance_evaluator,
+                    app_dispatcher_ref,
+                    &turn_loop_dispatcher,
+                    approval_request_store_ref,
+                    kernel_ctx,
+                )
+                .await;
             let loop_supervisor_verdict = if let (Some(signature), Some(name_signature)) = (
                 current_tool_signature.as_deref(),
                 current_tool_name_signature.as_deref(),
@@ -116,7 +258,6 @@ impl ConversationTurnLoop {
                 None
             };
 
-            #[allow(clippy::wildcard_enum_match_arm)]
             let reply = match turn_result {
                 TurnResult::FinalText(tool_text) if had_tool_intents => {
                     let raw_reply =
@@ -140,7 +281,6 @@ impl ConversationTurnLoop {
                                 runtime,
                                 config,
                                 &messages,
-                                kernel_ctx,
                                 raw_reply.as_str(),
                             )
                             .await
@@ -170,7 +310,6 @@ impl ConversationTurnLoop {
                                 runtime,
                                 config,
                                 &messages,
-                                kernel_ctx,
                                 raw_reply.as_str(),
                             )
                             .await
@@ -203,7 +342,6 @@ impl ConversationTurnLoop {
                                 runtime,
                                 config,
                                 &messages,
-                                kernel_ctx,
                                 raw_reply.as_str(),
                             )
                             .await
@@ -233,7 +371,6 @@ impl ConversationTurnLoop {
                                 runtime,
                                 config,
                                 &messages,
-                                kernel_ctx,
                                 raw_reply.as_str(),
                             )
                             .await
@@ -266,7 +403,6 @@ impl ConversationTurnLoop {
                                 runtime,
                                 config,
                                 &messages,
-                                kernel_ctx,
                                 raw_reply.as_str(),
                             )
                             .await
@@ -296,7 +432,6 @@ impl ConversationTurnLoop {
                                 runtime,
                                 config,
                                 &messages,
-                                kernel_ctx,
                                 raw_reply.as_str(),
                             )
                             .await
@@ -321,6 +456,756 @@ impl ConversationTurnLoop {
     }
 }
 
+#[cfg(feature = "memory-sqlite")]
+struct TurnLoopApprovalResolutionRuntime<'a, R: ?Sized, A: ?Sized, O: ?Sized> {
+    inner: DefaultApprovalResolutionRuntime,
+    replayer: TurnLoopApprovalOrchestrationReplayer<'a, R, A, O>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct TurnLoopApprovalOrchestrationReplayer<'a, R: ?Sized, A: ?Sized, O: ?Sized> {
+    turn_loop: &'a ConversationTurnLoop,
+    config: &'a LoongClawConfig,
+    runtime: &'a R,
+    app_dispatcher: &'a A,
+    orchestration_dispatcher: &'a O,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl<R, A, O> crate::tools::approval::ApprovalResolutionRuntime
+    for TurnLoopApprovalResolutionRuntime<'_, R, A, O>
+where
+    R: ConversationRuntime + ?Sized,
+    A: AppToolDispatcher + ?Sized,
+    O: OrchestrationToolDispatcher + ?Sized,
+{
+    async fn resolve_approval_request(
+        &self,
+        request: crate::tools::approval::ApprovalResolutionRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
+        self.inner
+            .resolve_approval_request_with_orchestration_replayer(
+                request,
+                Some(&self.replayer),
+                kernel_ctx,
+            )
+            .await
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl<R, A, O> ApprovalOrchestrationReplayer for TurnLoopApprovalOrchestrationReplayer<'_, R, A, O>
+where
+    R: ConversationRuntime + ?Sized,
+    A: AppToolDispatcher + ?Sized,
+    O: OrchestrationToolDispatcher + ?Sized,
+{
+    async fn replay_orchestration_request(
+        &self,
+        session_context: &SessionContext,
+        request: loongclaw_contracts::ToolCoreRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+        match request.tool_name.as_str() {
+            "delegate" => {
+                execute_delegate_tool(
+                    self.turn_loop,
+                    self.config,
+                    self.runtime,
+                    self.app_dispatcher,
+                    self.orchestration_dispatcher,
+                    session_context,
+                    request.payload,
+                    kernel_ctx,
+                )
+                .await
+            }
+            _ => {
+                self.orchestration_dispatcher
+                    .execute_orchestration_tool(session_context, request, kernel_ctx)
+                    .await
+            }
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct TurnLoopAppToolDispatcher<'a, R: ?Sized, A: ?Sized, O: ?Sized> {
+    turn_loop: &'a ConversationTurnLoop,
+    config: &'a LoongClawConfig,
+    runtime: &'a R,
+    base: &'a A,
+    orchestration_dispatcher: &'a O,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl<R, A, O> AppToolDispatcher for TurnLoopAppToolDispatcher<'_, R, A, O>
+where
+    R: ConversationRuntime + ?Sized,
+    A: AppToolDispatcher + ?Sized,
+    O: OrchestrationToolDispatcher + ?Sized,
+{
+    async fn execute_app_tool(
+        &self,
+        session_context: &SessionContext,
+        request: loongclaw_contracts::ToolCoreRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+        let canonical_tool_name = crate::tools::canonical_tool_name(request.tool_name.as_str());
+        if canonical_tool_name != "approval_request_resolve" {
+            return self
+                .base
+                .execute_app_tool(session_context, request, kernel_ctx)
+                .await;
+        }
+
+        let approval_runtime = TurnLoopApprovalResolutionRuntime {
+            inner: DefaultApprovalResolutionRuntime::new(
+                memory_runtime_config_for(self.config),
+                self.config.tools.clone(),
+                Some(Arc::new(self.config.clone())),
+                None,
+            ),
+            replayer: TurnLoopApprovalOrchestrationReplayer {
+                turn_loop: self.turn_loop,
+                config: self.config,
+                runtime: self.runtime,
+                app_dispatcher: self.base,
+                orchestration_dispatcher: self.orchestration_dispatcher,
+            },
+        };
+        let effective_tool_config =
+            effective_tool_config_for_session(&self.config.tools, session_context);
+        crate::tools::approval::execute_approval_tool_with_runtime_support(
+            request,
+            &session_context.session_id,
+            &memory_runtime_config_for(self.config),
+            &effective_tool_config,
+            Some(&approval_runtime),
+            kernel_ctx,
+        )
+        .await
+    }
+}
+
+struct TurnLoopOrchestrationToolDispatcher<'a, R: ?Sized, A: ?Sized, O: ?Sized> {
+    turn_loop: &'a ConversationTurnLoop,
+    config: &'a LoongClawConfig,
+    runtime: &'a R,
+    app_dispatcher: &'a A,
+    fallback: &'a O,
+}
+
+#[async_trait]
+impl<R, A, O> OrchestrationToolDispatcher for TurnLoopOrchestrationToolDispatcher<'_, R, A, O>
+where
+    R: ConversationRuntime + ?Sized,
+    A: AppToolDispatcher + ?Sized,
+    O: OrchestrationToolDispatcher + ?Sized,
+{
+    async fn execute_orchestration_tool(
+        &self,
+        session_context: &SessionContext,
+        request: loongclaw_contracts::ToolCoreRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+        match request.tool_name.as_str() {
+            "delegate" => {
+                execute_delegate_tool(
+                    self.turn_loop,
+                    self.config,
+                    self.runtime,
+                    self.app_dispatcher,
+                    self.fallback,
+                    session_context,
+                    request.payload,
+                    kernel_ctx,
+                )
+                .await
+            }
+            _ => {
+                self.fallback
+                    .execute_orchestration_tool(session_context, request, kernel_ctx)
+                    .await
+            }
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn ensure_session_registered(
+    config: &LoongClawConfig,
+    session_context: &SessionContext,
+) -> CliResult<()> {
+    let repo = SessionRepository::new(&memory_runtime_config_for(config))?;
+    let kind = if session_context.parent_session_id.is_some() {
+        SessionKind::DelegateChild
+    } else {
+        SessionKind::Root
+    };
+    let _ = repo.ensure_session(NewSessionRecord {
+        session_id: session_context.session_id.clone(),
+        kind,
+        parent_session_id: session_context.parent_session_id.clone(),
+        label: None,
+        state: SessionState::Ready,
+    })?;
+    Ok(())
+}
+
+fn default_app_tool_dispatcher(config: &LoongClawConfig) -> DefaultAppToolDispatcher {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        return DefaultAppToolDispatcher::production_with_config(
+            memory_runtime_config_for(config),
+            config.clone(),
+        );
+    }
+    #[cfg(not(feature = "memory-sqlite"))]
+    DefaultAppToolDispatcher::new(memory_runtime_config_for(config), config.tools.clone())
+}
+
+fn default_orchestration_tool_dispatcher(
+    config: &LoongClawConfig,
+) -> DefaultOrchestrationToolDispatcher {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        return DefaultOrchestrationToolDispatcher::production(
+            memory_runtime_config_for(config),
+            config.tools.clone(),
+        );
+    }
+    #[cfg(not(feature = "memory-sqlite"))]
+    DefaultOrchestrationToolDispatcher::new(memory_runtime_config_for(config), config.tools.clone())
+}
+
+fn memory_runtime_config_for(config: &LoongClawConfig) -> MemoryRuntimeConfig {
+    MemoryRuntimeConfig {
+        sqlite_path: Some(config.memory.resolved_sqlite_path()),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub async fn run_delegate_child_turn(
+    turn_loop: &ConversationTurnLoop,
+    config: &LoongClawConfig,
+    child_session_id: &str,
+    user_input: &str,
+    timeout_seconds: u64,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+    let runtime = DefaultConversationRuntime;
+    let app_dispatcher = default_app_tool_dispatcher(config);
+    run_delegate_child_turn_with_runtime(
+        turn_loop,
+        config,
+        &runtime,
+        &app_dispatcher,
+        child_session_id,
+        user_input,
+        timeout_seconds,
+        kernel_ctx,
+    )
+    .await
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub async fn run_delegate_child_turn_with_runtime<R, A>(
+    turn_loop: &ConversationTurnLoop,
+    config: &LoongClawConfig,
+    runtime: &R,
+    app_dispatcher: &A,
+    child_session_id: &str,
+    user_input: &str,
+    timeout_seconds: u64,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String>
+where
+    R: ConversationRuntime + ?Sized,
+    A: AppToolDispatcher + ?Sized,
+{
+    let orchestration_dispatcher = default_orchestration_tool_dispatcher(config);
+    run_delegate_child_turn_with_runtime_and_dispatchers(
+        turn_loop,
+        config,
+        runtime,
+        app_dispatcher,
+        &orchestration_dispatcher,
+        child_session_id,
+        user_input,
+        timeout_seconds,
+        kernel_ctx,
+    )
+    .await
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn run_delegate_child_turn_with_runtime_and_dispatchers<R, A, O>(
+    turn_loop: &ConversationTurnLoop,
+    config: &LoongClawConfig,
+    runtime: &R,
+    app_dispatcher: &A,
+    orchestration_dispatcher: &O,
+    child_session_id: &str,
+    user_input: &str,
+    timeout_seconds: u64,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String>
+where
+    R: ConversationRuntime + ?Sized,
+    A: AppToolDispatcher + ?Sized,
+    O: OrchestrationToolDispatcher + ?Sized,
+{
+    let repo = SessionRepository::new(&memory_runtime_config_for(config))?;
+    let child_execution = load_delegate_child_execution_context(&repo, config, child_session_id)?;
+
+    if repo
+        .transition_session_with_event_if_current(
+            child_session_id,
+            TransitionSessionWithEventIfCurrentRequest {
+                expected_state: SessionState::Ready,
+                next_state: SessionState::Running,
+                last_error: None,
+                event_kind: "delegate_started".to_owned(),
+                actor_session_id: Some(child_execution.parent_session_id.clone()),
+                event_payload_json: json!({
+                    "task": user_input,
+                    "label": child_execution.child_label.clone(),
+                    "timeout_seconds": timeout_seconds,
+                }),
+            },
+        )?
+        .is_none()
+    {
+        let latest_child_session = repo
+            .load_session(child_session_id)?
+            .ok_or_else(|| format!("delegate child session `{child_session_id}` not found"))?;
+        return Err(format!(
+            "delegate child session `{child_session_id}` is not runnable from state `{}`",
+            latest_child_session.state.as_str()
+        ));
+    }
+
+    run_started_delegate_child_turn_with_runtime(
+        turn_loop,
+        config,
+        runtime,
+        app_dispatcher,
+        orchestration_dispatcher,
+        child_session_id,
+        user_input,
+        timeout_seconds,
+        kernel_ctx,
+        child_execution,
+    )
+    .await
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct DelegateChildExecutionContext {
+    parent_session_id: String,
+    child_label: Option<String>,
+    child_can_delegate: bool,
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_delegate_child_execution_context(
+    repo: &SessionRepository,
+    config: &LoongClawConfig,
+    child_session_id: &str,
+) -> Result<DelegateChildExecutionContext, String> {
+    let child_session = repo
+        .load_session(child_session_id)?
+        .ok_or_else(|| format!("delegate child session `{child_session_id}` not found"))?;
+    if child_session.kind != SessionKind::DelegateChild {
+        return Err(format!(
+            "session `{child_session_id}` is not a delegate child session"
+        ));
+    }
+    let parent_session_id = child_session.parent_session_id.clone().ok_or_else(|| {
+        format!("delegate child session `{child_session_id}` is missing parent_session_id")
+    })?;
+    let child_label = child_session.label.clone();
+    let child_depth = repo.session_lineage_depth(child_session_id)?;
+    let child_can_delegate = child_depth < config.tools.delegate.max_depth;
+
+    Ok(DelegateChildExecutionContext {
+        parent_session_id,
+        child_label,
+        child_can_delegate,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_delegate_child_cancel_request(
+    config: &LoongClawConfig,
+    session_context: &SessionContext,
+) -> Result<Option<String>, String> {
+    let repo = SessionRepository::new(&memory_runtime_config_for(config))?;
+    let recent_events = repo.list_recent_events(&session_context.session_id, 1)?;
+    let Some(event) = recent_events.last() else {
+        return Ok(None);
+    };
+    if event.event_kind != DELEGATE_CANCEL_REQUESTED_EVENT_KIND {
+        return Ok(None);
+    }
+    let reason = event
+        .payload_json
+        .get("cancel_reason")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED)
+        .to_owned();
+    Ok(Some(reason))
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn run_started_delegate_child_turn_with_runtime<R, A, O>(
+    turn_loop: &ConversationTurnLoop,
+    config: &LoongClawConfig,
+    runtime: &R,
+    app_dispatcher: &A,
+    orchestration_dispatcher: &O,
+    child_session_id: &str,
+    user_input: &str,
+    timeout_seconds: u64,
+    kernel_ctx: Option<&KernelContext>,
+    child_execution: DelegateChildExecutionContext,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String>
+where
+    R: ConversationRuntime + ?Sized,
+    A: AppToolDispatcher + ?Sized,
+    O: OrchestrationToolDispatcher + ?Sized,
+{
+    let repo = SessionRepository::new(&memory_runtime_config_for(config))?;
+    let child_context = SessionContext::child(
+        child_session_id.to_owned(),
+        child_execution.parent_session_id.clone(),
+        crate::tools::delegate_child_tool_view_for_config_with_delegate(
+            &config.tools,
+            child_execution.child_can_delegate,
+        ),
+    );
+    let start = Instant::now();
+    let child_result = timeout(Duration::from_secs(timeout_seconds), async {
+        AssertUnwindSafe(turn_loop.handle_turn_with_runtime_and_context(
+            config,
+            &child_context,
+            user_input,
+            ProviderErrorMode::Propagate,
+            runtime,
+            app_dispatcher,
+            orchestration_dispatcher,
+            kernel_ctx,
+        ))
+        .catch_unwind()
+        .await
+    })
+    .await;
+    let duration_ms = start.elapsed().as_millis() as u64;
+
+    match child_result {
+        Ok(Ok(Ok(final_output))) => {
+            let turn_count = repo
+                .load_session_summary(child_session_id)?
+                .map(|session| session.turn_count)
+                .unwrap_or_default();
+            let outcome = crate::tools::delegate::delegate_success_outcome(
+                child_session_id.to_owned(),
+                child_execution.child_label,
+                final_output,
+                turn_count,
+                duration_ms,
+            );
+            finalize_delegate_child_terminal_with_recovery(
+                &repo,
+                child_session_id,
+                crate::session::repository::FinalizeSessionTerminalRequest {
+                    state: SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some(child_execution.parent_session_id.clone()),
+                    event_payload_json: json!({
+                        "turn_count": turn_count,
+                        "duration_ms": duration_ms,
+                    }),
+                    outcome_status: outcome.status.clone(),
+                    outcome_payload_json: outcome.payload.clone(),
+                },
+            )?;
+            Ok(outcome)
+        }
+        Ok(Ok(Err(error))) => {
+            let outcome = crate::tools::delegate::delegate_error_outcome(
+                child_session_id.to_owned(),
+                child_execution.child_label,
+                error.clone(),
+                duration_ms,
+            );
+            let (event_kind, event_payload_json) =
+                if let Some(cancel_reason) = parse_delegate_cancelled_reason(&error) {
+                    (
+                        DELEGATE_CANCELLED_EVENT_KIND.to_owned(),
+                        json!({
+                            "error": error,
+                            "duration_ms": duration_ms,
+                            "cancel_reason": cancel_reason,
+                            "reference": "running",
+                        }),
+                    )
+                } else {
+                    (
+                        "delegate_failed".to_owned(),
+                        json!({
+                            "error": error,
+                            "duration_ms": duration_ms,
+                        }),
+                    )
+                };
+            finalize_delegate_child_terminal_with_recovery(
+                &repo,
+                child_session_id,
+                crate::session::repository::FinalizeSessionTerminalRequest {
+                    state: SessionState::Failed,
+                    last_error: Some(error.clone()),
+                    event_kind,
+                    actor_session_id: Some(child_execution.parent_session_id.clone()),
+                    event_payload_json,
+                    outcome_status: outcome.status.clone(),
+                    outcome_payload_json: outcome.payload.clone(),
+                },
+            )?;
+            Ok(outcome)
+        }
+        Ok(Err(panic_payload)) => {
+            let panic_error = format_delegate_child_panic(panic_payload);
+            let outcome = crate::tools::delegate::delegate_error_outcome(
+                child_session_id.to_owned(),
+                child_execution.child_label,
+                panic_error.clone(),
+                duration_ms,
+            );
+            finalize_delegate_child_terminal_with_recovery(
+                &repo,
+                child_session_id,
+                crate::session::repository::FinalizeSessionTerminalRequest {
+                    state: SessionState::Failed,
+                    last_error: Some(panic_error.clone()),
+                    event_kind: "delegate_failed".to_owned(),
+                    actor_session_id: Some(child_execution.parent_session_id.clone()),
+                    event_payload_json: json!({
+                        "error": panic_error,
+                        "duration_ms": duration_ms,
+                    }),
+                    outcome_status: outcome.status.clone(),
+                    outcome_payload_json: outcome.payload.clone(),
+                },
+            )?;
+            Ok(outcome)
+        }
+        Err(_) => {
+            let timeout_error = "delegate_timeout".to_owned();
+            let outcome = crate::tools::delegate::delegate_timeout_outcome(
+                child_session_id.to_owned(),
+                child_execution.child_label,
+                duration_ms,
+            );
+            finalize_delegate_child_terminal_with_recovery(
+                &repo,
+                child_session_id,
+                crate::session::repository::FinalizeSessionTerminalRequest {
+                    state: SessionState::TimedOut,
+                    last_error: Some(timeout_error.clone()),
+                    event_kind: "delegate_timed_out".to_owned(),
+                    actor_session_id: Some(child_execution.parent_session_id.clone()),
+                    event_payload_json: json!({
+                        "error": timeout_error,
+                        "duration_ms": duration_ms,
+                    }),
+                    outcome_status: outcome.status.clone(),
+                    outcome_payload_json: outcome.payload.clone(),
+                },
+            )?;
+            Ok(outcome)
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn finalize_delegate_child_terminal_with_recovery(
+    repo: &SessionRepository,
+    child_session_id: &str,
+    request: crate::session::repository::FinalizeSessionTerminalRequest,
+) -> Result<(), String> {
+    let recovery_request = request.clone();
+    match repo.finalize_session_terminal(child_session_id, request) {
+        Ok(_) => Ok(()),
+        Err(finalize_error) => {
+            let recovery_error = format!("delegate_terminal_finalize_failed: {finalize_error}");
+            match repo.transition_session_with_event_if_current(
+                child_session_id,
+                TransitionSessionWithEventIfCurrentRequest {
+                    expected_state: SessionState::Running,
+                    next_state: SessionState::Failed,
+                    last_error: Some(recovery_error.clone()),
+                    event_kind: RECOVERY_EVENT_KIND.to_owned(),
+                    actor_session_id: recovery_request.actor_session_id.clone(),
+                    event_payload_json: build_terminal_finalize_recovery_payload(
+                        &recovery_request,
+                        &recovery_error,
+                    ),
+                },
+            ) {
+                Ok(Some(_)) => Err(recovery_error),
+                Ok(None) => {
+                    delegate_terminal_recovery_skipped_error(repo, child_session_id, recovery_error)
+                }
+                Err(recovery_event_error) => match repo.update_session_state_if_current(
+                    child_session_id,
+                    SessionState::Running,
+                    SessionState::Failed,
+                    Some(recovery_error.clone()),
+                ) {
+                    Ok(Some(_)) => Err(format!(
+                        "{recovery_error}; delegate_terminal_recovery_event_failed: {recovery_event_error}"
+                    )),
+                    Ok(None) => delegate_terminal_recovery_skipped_error(
+                        repo,
+                        child_session_id,
+                        recovery_error,
+                    ),
+                    Err(mark_error) => Err(format!(
+                        "{recovery_error}; delegate_terminal_recovery_failed: {mark_error}"
+                    )),
+                },
+            }
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn delegate_terminal_recovery_skipped_error(
+    repo: &SessionRepository,
+    child_session_id: &str,
+    recovery_error: String,
+) -> Result<(), String> {
+    let current_state = repo
+        .load_session(child_session_id)?
+        .map(|session| session.state.as_str().to_owned())
+        .unwrap_or_else(|| "missing".to_owned());
+    Err(format!(
+        "{recovery_error}; delegate_terminal_recovery_skipped_from_state: {current_state}"
+    ))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn format_delegate_child_panic(panic_payload: Box<dyn Any + Send>) -> String {
+    let panic_payload = match panic_payload.downcast::<String>() {
+        Ok(message) => return format!("delegate_child_panic: {}", *message),
+        Err(panic_payload) => panic_payload,
+    };
+    match panic_payload.downcast::<&'static str>() {
+        Ok(message) => format!("delegate_child_panic: {}", *message),
+        Err(_) => "delegate_child_panic".to_owned(),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn execute_delegate_tool<R, A, O>(
+    turn_loop: &ConversationTurnLoop,
+    config: &LoongClawConfig,
+    runtime: &R,
+    app_dispatcher: &A,
+    orchestration_dispatcher: &O,
+    session_context: &SessionContext,
+    payload: Value,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String>
+where
+    R: ConversationRuntime + ?Sized,
+    A: AppToolDispatcher + ?Sized,
+    O: OrchestrationToolDispatcher + ?Sized,
+{
+    if !config.tools.delegate.enabled {
+        return Err("app_tool_disabled: delegate is disabled by config".to_owned());
+    }
+
+    let delegate_request = crate::tools::delegate::parse_delegate_request_with_default_timeout(
+        &payload,
+        config.tools.delegate.timeout_seconds,
+    )?;
+    let child_session_id = crate::tools::delegate::next_delegate_session_id();
+    let repo = SessionRepository::new(&memory_runtime_config_for(config))?;
+    let current_depth = repo.session_lineage_depth(&session_context.session_id)?;
+    let next_child_depth = current_depth.saturating_add(1);
+    if next_child_depth > config.tools.delegate.max_depth {
+        return Err(format!(
+            "delegate_depth_exceeded: next child depth {next_child_depth} exceeds configured max_depth {}",
+            config.tools.delegate.max_depth
+        ));
+    }
+    let child_label = delegate_request.label.clone();
+    let child_can_delegate = next_child_depth < config.tools.delegate.max_depth;
+
+    repo.create_session_with_event(CreateSessionWithEventRequest {
+        session: NewSessionRecord {
+            session_id: child_session_id.clone(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some(session_context.session_id.clone()),
+            label: child_label.clone(),
+            state: SessionState::Running,
+        },
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some(session_context.session_id.clone()),
+        event_payload_json: json!({
+            "task": delegate_request.task,
+            "label": child_label.clone(),
+            "timeout_seconds": delegate_request.timeout_seconds,
+        }),
+    })?;
+    run_started_delegate_child_turn_with_runtime(
+        turn_loop,
+        config,
+        runtime,
+        app_dispatcher,
+        orchestration_dispatcher,
+        &child_session_id,
+        &delegate_request.task,
+        delegate_request.timeout_seconds,
+        kernel_ctx,
+        DelegateChildExecutionContext {
+            parent_session_id: session_context.session_id.clone(),
+            child_label,
+            child_can_delegate,
+        },
+    )
+    .await
+}
+
+#[cfg(not(feature = "memory-sqlite"))]
+async fn execute_delegate_tool<R, A, O>(
+    _turn_loop: &ConversationTurnLoop,
+    _config: &LoongClawConfig,
+    _runtime: &R,
+    _app_dispatcher: &A,
+    _orchestration_dispatcher: &O,
+    _session_context: &SessionContext,
+    _payload: Value,
+    _kernel_ctx: Option<&KernelContext>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String>
+where
+    R: ConversationRuntime + ?Sized,
+    A: AppToolDispatcher + ?Sized,
+    O: OrchestrationToolDispatcher + ?Sized,
+{
+    Err("delegate requires sqlite memory support (enable feature `memory-sqlite`)".to_owned())
+}
+
 fn append_tool_followup_messages(
     messages: &mut Vec<Value>,
     assistant_preface: &str,
@@ -336,27 +1221,6 @@ fn append_tool_followup_messages(
             "content": preface,
         }));
     }
-    if let Some(skill_context) = parse_external_skill_invoke_context(tool_result_text) {
-        messages.push(json!({
-            "role": "system",
-            "content": build_external_skill_system_message(&skill_context),
-        }));
-        if let Some(reason) = loop_warning_reason {
-            messages.push(json!({
-                "role": "assistant",
-                "content": format!("[tool_loop_warning]\n{reason}"),
-            }));
-        }
-        messages.push(json!({
-            "role": "user",
-            "content": build_external_skill_followup_user_prompt(
-                user_input,
-                loop_warning_reason,
-                &skill_context,
-            ),
-        }));
-        return;
-    }
     let bounded_result = followup_payload_budget.truncate_payload("tool_result", tool_result_text);
     messages.push(json!({
         "role": "assistant",
@@ -370,11 +1234,7 @@ fn append_tool_followup_messages(
     }
     messages.push(json!({
         "role": "user",
-        "content": build_tool_followup_user_prompt(
-            user_input,
-            loop_warning_reason,
-            Some(tool_result_text),
-        ),
+        "content": build_tool_followup_prompt(user_input, loop_warning_reason),
     }));
 }
 
@@ -407,7 +1267,7 @@ fn append_tool_failure_followup_messages(
     }
     messages.push(json!({
         "role": "user",
-        "content": build_tool_followup_user_prompt(user_input, loop_warning_reason, None),
+        "content": build_tool_followup_prompt(user_input, loop_warning_reason),
     }));
 }
 
@@ -444,22 +1304,16 @@ fn append_repeated_tool_guard_followup_messages(
 }
 
 fn build_tool_loop_guard_prompt(user_input: &str, reason: &str) -> String {
-    format!(
-        "{TOOL_LOOP_GUARD_PROMPT}\n\nLoop guard reason:\n{reason}\n\nOriginal request:\n{user_input}"
-    )
+    format!("{TOOL_LOOP_GUARD_PROMPT}\n\nLoop guard reason:\n{reason}\n\nOriginal request:\n{user_input}")
 }
 
 async fn request_completion_with_raw_fallback<R: ConversationRuntime + ?Sized>(
     runtime: &R,
     config: &LoongClawConfig,
     messages: &[Value],
-    kernel_ctx: Option<&KernelContext>,
     raw_reply: &str,
 ) -> String {
-    match runtime
-        .request_completion(config, messages, kernel_ctx)
-        .await
-    {
+    match runtime.request_completion(config, messages).await {
         Ok(final_reply) => {
             let trimmed = final_reply.trim();
             if trimmed.is_empty() {
@@ -470,6 +1324,31 @@ async fn request_completion_with_raw_fallback<R: ConversationRuntime + ?Sized>(
         }
         Err(_) => raw_reply.to_owned(),
     }
+}
+
+fn user_requested_raw_tool_output(user_input: &str) -> bool {
+    let normalized = user_input.to_ascii_lowercase();
+    [
+        "raw",
+        "json",
+        "payload",
+        "verbatim",
+        "exact output",
+        "full output",
+        "tool output",
+        "[ok]",
+    ]
+    .iter()
+    .any(|signal| normalized.contains(signal))
+}
+
+fn build_tool_followup_prompt(user_input: &str, loop_warning_reason: Option<&str>) -> String {
+    if let Some(reason) = loop_warning_reason {
+        return format!(
+            "{TOOL_FOLLOWUP_PROMPT}\n\nLoop warning:\n{reason}\nAvoid repeating the same tool call with unchanged results. Try a different tool, adjust arguments, or provide a best-effort final answer if evidence is sufficient.\n\nOriginal request:\n{user_input}"
+        );
+    }
+    format!("{TOOL_FOLLOWUP_PROMPT}\n\nOriginal request:\n{user_input}")
 }
 
 fn truncate_followup_tool_payload(label: &str, text: &str, max_chars: usize) -> String {
@@ -656,7 +1535,7 @@ impl ToolLoopSupervisor {
         }
 
         self.recent_rounds.push_back(ToolLoopObservation {
-            pattern,
+            pattern: pattern.clone(),
             tool_name_signature: tool_name_signature.to_owned(),
             failed,
         });
@@ -772,129 +1651,57 @@ impl ToolLoopSupervisor {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn append_tool_followup_messages_adds_truncation_hint_to_user_prompt() {
-        let mut messages = Vec::new();
-        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
-
-        append_tool_followup_messages(
-            &mut messages,
-            "preface",
-            r#"[ok] {"payload_truncated":true,"payload_summary":"..."}"#,
-            "summarize note.md",
-            &mut budget,
-            None,
-        );
-
-        let user_prompt = messages
-            .last()
-            .and_then(|message| message.get("content"))
-            .and_then(Value::as_str)
-            .expect("user followup prompt should exist");
-        assert!(
-            user_prompt.contains(crate::conversation::turn_shared::TOOL_TRUNCATION_HINT_PROMPT)
-        );
+fn compose_assistant_reply(
+    assistant_preface: &str,
+    had_tool_intents: bool,
+    turn_result: TurnResult,
+) -> String {
+    match turn_result {
+        TurnResult::FinalText(text) => {
+            if had_tool_intents {
+                join_non_empty_lines(&[assistant_preface, text.as_str()])
+            } else {
+                text
+            }
+        }
+        TurnResult::NeedsApproval(requirement) => join_non_empty_lines(&[
+            assistant_preface,
+            format_approval_required_reply(&requirement).as_str(),
+        ]),
+        TurnResult::ToolDenied(reason) => join_non_empty_lines(&[assistant_preface, &reason]),
+        TurnResult::ToolError(reason) => join_non_empty_lines(&[assistant_preface, &reason]),
+        TurnResult::ProviderError(reason) => {
+            let inline = format_provider_error_reply(&reason);
+            join_non_empty_lines(&[assistant_preface, inline.as_str()])
+        }
     }
+}
 
-    #[test]
-    fn append_tool_failure_followup_messages_omits_truncation_hint_in_user_prompt() {
-        let mut messages = Vec::new();
-        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
-
-        append_tool_failure_followup_messages(
-            &mut messages,
-            "preface",
-            "tool_timeout ...(truncated 200 chars)",
-            "summarize note.md",
-            &mut budget,
-            None,
-        );
-
-        let user_prompt = messages
-            .last()
-            .and_then(|message| message.get("content"))
-            .and_then(Value::as_str)
-            .expect("user followup prompt should exist");
-        assert!(
-            !user_prompt.contains(crate::conversation::turn_shared::TOOL_TRUNCATION_HINT_PROMPT)
-        );
+fn format_approval_required_reply(requirement: &ApprovalRequirement) -> String {
+    match requirement.kind {
+        ApprovalRequirementKind::GovernedTool => {
+            let tool_name = requirement.tool_name.as_deref().unwrap_or("governed tool");
+            let mut lines = vec![format!(
+                "[tool_approval_required] Approval required before running `{tool_name}`."
+            )];
+            if let Some(approval_request_id) = requirement.approval_request_id.as_deref() {
+                lines.push(format!("Request ID: {approval_request_id}"));
+            }
+            lines.push(format!("Reason: {}", requirement.reason));
+            lines.push("Allowed decisions: approve_once, approve_always, deny.".to_owned());
+            lines.join("\n")
+        }
+        ApprovalRequirementKind::KernelContextRequired => {
+            format!("[tool_approval_required] {}", requirement.reason)
+        }
     }
+}
 
-    #[test]
-    fn append_tool_followup_messages_promotes_external_skill_invoke_into_system_context() {
-        let mut messages = Vec::new();
-        let mut budget = FollowupPayloadBudget::new(64, 64);
-
-        append_tool_followup_messages(
-            &mut messages,
-            "preface",
-            r#"[ok] {"status":"ok","tool":"external_skills.invoke","tool_call_id":"call-1","payload_summary":"{\"skill_id\":\"demo-skill\",\"display_name\":\"Demo Skill\",\"instructions\":\"Follow the managed skill instruction before answering.\"}","payload_chars":180,"payload_truncated":false}"#,
-            "summarize note.md",
-            &mut budget,
-            None,
-        );
-
-        assert_eq!(messages[0]["role"], "assistant");
-        assert_eq!(messages[1]["role"], "system");
-        let system_content = messages[1]["content"]
-            .as_str()
-            .expect("system content should exist");
-        assert!(system_content.contains("Demo Skill"));
-        assert!(system_content.contains("Follow the managed skill instruction before answering."));
-        assert!(
-            !system_content.contains("[tool_result_truncated]"),
-            "invoke instructions should not be funneled through followup truncation markers"
-        );
-
-        let user_prompt = messages[2]["content"]
-            .as_str()
-            .expect("user prompt should exist");
-        assert!(user_prompt.contains("managed external skill"));
-        assert!(user_prompt.contains("Original request:\nsummarize note.md"));
-    }
-
-    #[test]
-    fn append_tool_followup_messages_keeps_large_external_skill_instructions_intact() {
-        let mut messages = Vec::new();
-        let mut budget = FollowupPayloadBudget::new(32, 32);
-        let instructions = format!("prefix {}\nsuffix-marker", "x".repeat(512));
-        let payload_summary = serde_json::json!({
-            "skill_id": "demo-skill",
-            "display_name": "Demo Skill",
-            "instructions": instructions,
-        })
-        .to_string();
-        let tool_result = format!(
-            "[ok] {}",
-            serde_json::json!({
-                "status": "ok",
-                "tool": "external_skills.invoke",
-                "tool_call_id": "call-2",
-                "payload_summary": payload_summary,
-                "payload_chars": 2048,
-                "payload_truncated": false
-            })
-        );
-
-        append_tool_followup_messages(
-            &mut messages,
-            "",
-            tool_result.as_str(),
-            "apply the skill",
-            &mut budget,
-            None,
-        );
-
-        let system_content = messages[0]["content"]
-            .as_str()
-            .expect("system content should exist");
-        assert!(
-            system_content.contains("suffix-marker"),
-            "system context should preserve the tail of large invoke instructions"
-        );
-    }
+fn join_non_empty_lines(parts: &[&str]) -> String {
+    parts
+        .iter()
+        .map(|part| part.trim())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
 }

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -34,6 +34,7 @@ const APPROVAL_ATTENTION_STALE_MAX_SECONDS: i64 = 4 * 60 * 60;
 struct ApprovalRequestsListRequest {
     session_id: Option<String>,
     status: Option<ApprovalRequestStatus>,
+    resolved_by_session_id: Option<String>,
     execution_plane: Option<ToolExecutionPlane>,
     governance_scope: Option<ToolGovernanceScope>,
     risk_class: Option<ToolRiskClass>,
@@ -384,6 +385,11 @@ fn execute_approval_requests_list(
         request_summaries
             .retain(|item| approval_request_decision_from_json(item) == Some(decision));
     }
+    if let Some(resolved_by_session_id) = request.resolved_by_session_id.as_deref() {
+        request_summaries.retain(|item| {
+            approval_request_resolved_by_session_id_from_json(item) == Some(resolved_by_session_id)
+        });
+    }
     if let Some(execution_plane) = request.execution_plane {
         request_summaries.retain(|item| {
             approval_request_execution_plane_from_json(item) == Some(execution_plane)
@@ -519,6 +525,7 @@ fn execute_approval_requests_list(
             "filter": {
                 "session_id": request.session_id,
                 "status": request.status.map(ApprovalRequestStatus::as_str),
+                "resolved_by_session_id": request.resolved_by_session_id,
                 "execution_plane": request.execution_plane.map(tool_execution_plane_as_str),
                 "governance_scope": request.governance_scope.map(tool_governance_scope_as_str),
                 "risk_class": request.risk_class.map(tool_risk_class_as_str),
@@ -878,6 +885,7 @@ fn approval_request_list_resolution_summary_json(requests: &[Value]) -> Value {
         ("completed_cleanly".to_owned(), 0usize),
         ("completed_with_attention".to_owned(), 0usize),
     ]);
+    let mut resolved_by_session_counts = BTreeMap::<String, usize>::new();
 
     for request in requests {
         let resolution = request.get("resolution").unwrap_or(&Value::Null);
@@ -899,12 +907,19 @@ fn approval_request_list_resolution_summary_json(requests: &[Value]) -> Value {
                 .entry(replay_result.to_owned())
                 .or_default() += 1;
         }
+        if let Some(resolved_by_session_id) = request.get("resolved_by_session_id").and_then(Value::as_str)
+        {
+            *resolved_by_session_counts
+                .entry(resolved_by_session_id.to_owned())
+                .or_default() += 1;
+        }
     }
 
     json!({
         "decision_counts": decision_counts,
         "request_status_counts": request_status_counts,
         "replay_result_counts": replay_result_counts,
+        "resolved_by_session_counts": resolved_by_session_counts,
     })
 }
 
@@ -1704,6 +1719,11 @@ fn approval_request_risk_class_from_json(request: &Value) -> Option<ToolRiskClas
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_resolved_by_session_id_from_json(request: &Value) -> Option<&str> {
+    request.get("resolved_by_session_id").and_then(Value::as_str)
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_grant_state_from_json(request: &Value) -> Option<ApprovalGrantState> {
     request
         .get("grant")
@@ -1957,6 +1977,7 @@ fn parse_approval_requests_list_request(
     Ok(ApprovalRequestsListRequest {
         session_id: optional_payload_string(payload, "session_id"),
         status: optional_payload_approval_request_status(payload, "status")?,
+        resolved_by_session_id: optional_payload_string(payload, "resolved_by_session_id"),
         execution_plane: optional_payload_tool_execution_plane(payload, "execution_plane")?,
         governance_scope: optional_payload_tool_governance_scope(payload, "governance_scope")?,
         risk_class: optional_payload_tool_risk_class(payload, "risk_class")?,
@@ -3488,6 +3509,119 @@ mod tests {
             deny_requests[0]["approval_request_id"],
             "apr-decision-denied"
         );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_summarizes_and_filters_by_resolver() {
+        let config = isolated_memory_config("approval-query-list-resolver-summary");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-resolver-pending",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-resolver-alpha",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-resolver-beta",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        repo.transition_approval_request_if_current(
+            "apr-resolver-alpha",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Denied,
+                decision: Some(ApprovalDecision::Deny),
+                resolved_by_session_id: Some("operator-alpha".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition alpha resolver request")
+        .expect("alpha resolver request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-resolver-beta",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Executed,
+                decision: Some(ApprovalDecision::ApproveOnce),
+                resolved_by_session_id: Some("operator-beta".to_owned()),
+                executed_at: Some(1_773_000_000),
+                last_error: None,
+            },
+        )
+        .expect("transition beta resolver request")
+        .expect("beta resolver request should transition");
+
+        let list_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for resolver summary");
+
+        let resolution_summary = &list_outcome.payload["resolution_summary"];
+        assert_eq!(
+            resolution_summary["resolved_by_session_counts"]["operator-alpha"],
+            1
+        );
+        assert_eq!(
+            resolution_summary["resolved_by_session_counts"]["operator-beta"],
+            1
+        );
+        assert_eq!(
+            resolution_summary["resolved_by_session_counts"]
+                .as_object()
+                .expect("resolver counts object")
+                .len(),
+            2
+        );
+
+        let filtered_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "resolved_by_session_id": "operator-beta",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for resolver filter");
+
+        assert_eq!(filtered_outcome.payload["matched_count"], 1);
+        assert_eq!(filtered_outcome.payload["returned_count"], 1);
+        assert_eq!(
+            filtered_outcome.payload["filter"]["resolved_by_session_id"],
+            "operator-beta"
+        );
+        let requests = filtered_outcome.payload["requests"]
+            .as_array()
+            .expect("resolver filtered requests array");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["approval_request_id"], "apr-resolver-beta");
+        assert_eq!(requests[0]["resolved_by_session_id"], "operator-beta");
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "memory-sqlite")]
-use std::{cmp::Ordering, collections::BTreeMap};
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, BTreeSet},
+};
 
 use async_trait::async_trait;
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
@@ -463,6 +466,7 @@ fn execute_approval_requests_list(
     let correlation_summary = approval_request_list_correlation_summary_json(&request_summaries);
     let governance_summary = approval_request_list_governance_summary_json(&request_summaries);
     let session_summary = approval_request_list_session_summary_json(&request_summaries);
+    let tool_summary = approval_request_list_tool_summary_json(&request_summaries);
     let matched_count = request_summaries.len();
     request_summaries.truncate(request.limit);
     let returned_count = request_summaries.len();
@@ -502,6 +506,7 @@ fn execute_approval_requests_list(
             "correlation_summary": correlation_summary,
             "governance_summary": governance_summary,
             "session_summary": session_summary,
+            "tool_summary": tool_summary,
             "requests": request_summaries,
         }),
     })
@@ -1015,6 +1020,141 @@ fn approval_request_list_session_summary_json(requests: &[Value]) -> Value {
     json!({
         "session_count": sessions.len(),
         "sessions": sessions,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_list_tool_summary_json(requests: &[Value]) -> Value {
+    #[derive(Default)]
+    struct ToolSummaryAccumulator {
+        tool_name: Option<String>,
+        execution_plane: Option<String>,
+        governance_scope: Option<String>,
+        risk_class: Option<String>,
+        request_count: usize,
+        pending_count: usize,
+        attention_count: usize,
+        session_ids: BTreeSet<String>,
+        oldest_pending_requested_at: Option<i64>,
+        oldest_pending_age_seconds: Option<i64>,
+        oldest_pending_age_bucket: Option<ApprovalAttentionAgeBucket>,
+    }
+
+    let mut tools = BTreeMap::<String, ToolSummaryAccumulator>::new();
+    for request in requests {
+        let Some(approval_key) = request.get("approval_key").and_then(Value::as_str) else {
+            continue;
+        };
+        let tool = tools.entry(approval_key.to_owned()).or_default();
+        tool.request_count += 1;
+
+        if let Some(tool_name) = request.get("tool_name").and_then(Value::as_str) {
+            tool.tool_name.get_or_insert_with(|| tool_name.to_owned());
+        }
+        if let Some(execution_plane) = request.get("execution_plane").and_then(Value::as_str) {
+            tool.execution_plane
+                .get_or_insert_with(|| execution_plane.to_owned());
+        }
+        if let Some(governance_scope) = request.get("governance_scope").and_then(Value::as_str) {
+            tool.governance_scope
+                .get_or_insert_with(|| governance_scope.to_owned());
+        }
+        if let Some(risk_class) = request.get("risk_class").and_then(Value::as_str) {
+            let should_replace = tool
+                .risk_class
+                .as_deref()
+                .map(|current| {
+                    tool_risk_class_priority(risk_class) < tool_risk_class_priority(current)
+                })
+                .unwrap_or(true);
+            if should_replace {
+                tool.risk_class = Some(risk_class.to_owned());
+            }
+        }
+        if let Some(session_id) = request.get("session_id").and_then(Value::as_str) {
+            tool.session_ids.insert(session_id.to_owned());
+        }
+
+        if request
+            .get("execution_integrity")
+            .and_then(|value| value.get("needs_attention"))
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            tool.attention_count += 1;
+        }
+
+        let pending_queue = request.get("pending_queue").unwrap_or(&Value::Null);
+        if pending_queue
+            .get("awaiting_decision")
+            .and_then(Value::as_bool)
+            != Some(true)
+        {
+            continue;
+        }
+
+        tool.pending_count += 1;
+        let requested_at = approval_request_requested_at(request);
+        tool.oldest_pending_requested_at = Some(
+            tool.oldest_pending_requested_at
+                .map(|current| current.min(requested_at))
+                .unwrap_or(requested_at),
+        );
+
+        if let Some(age_seconds) = pending_queue.get("age_seconds").and_then(Value::as_i64) {
+            let is_older = tool
+                .oldest_pending_age_seconds
+                .map(|current| age_seconds > current)
+                .unwrap_or(true);
+            if is_older {
+                tool.oldest_pending_age_seconds = Some(age_seconds);
+                tool.oldest_pending_age_bucket =
+                    approval_request_attention_age_bucket(Some(age_seconds));
+            }
+        }
+    }
+
+    let mut tools = tools.into_iter().collect::<Vec<_>>();
+    tools.sort_by(|(left_approval_key, left), (right_approval_key, right)| {
+        approval_request_session_hotspot_priority(left.oldest_pending_age_bucket)
+            .cmp(&approval_request_session_hotspot_priority(
+                right.oldest_pending_age_bucket,
+            ))
+            .then_with(|| right.pending_count.cmp(&left.pending_count))
+            .then_with(|| right.attention_count.cmp(&left.attention_count))
+            .then_with(|| {
+                right
+                    .oldest_pending_age_seconds
+                    .unwrap_or_default()
+                    .cmp(&left.oldest_pending_age_seconds.unwrap_or_default())
+            })
+            .then_with(|| right.request_count.cmp(&left.request_count))
+            .then_with(|| left_approval_key.cmp(right_approval_key))
+    });
+
+    let tools = tools
+        .into_iter()
+        .map(|(approval_key, tool)| {
+            json!({
+                "approval_key": approval_key,
+                "tool_name": tool.tool_name,
+                "execution_plane": tool.execution_plane,
+                "governance_scope": tool.governance_scope,
+                "risk_class": tool.risk_class,
+                "request_count": tool.request_count,
+                "pending_count": tool.pending_count,
+                "attention_count": tool.attention_count,
+                "session_count": tool.session_ids.len(),
+                "oldest_pending_requested_at": tool.oldest_pending_requested_at,
+                "oldest_pending_age_seconds": tool.oldest_pending_age_seconds,
+                "oldest_pending_age_bucket": tool.oldest_pending_age_bucket.map(ApprovalAttentionAgeBucket::as_str),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "tool_count": tools.len(),
+        "tools": tools,
     })
 }
 
@@ -1931,6 +2071,16 @@ fn tool_risk_class_as_str(value: ToolRiskClass) -> &'static str {
         ToolRiskClass::Low => "Low",
         ToolRiskClass::Elevated => "Elevated",
         ToolRiskClass::High => "High",
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn tool_risk_class_priority(value: &str) -> usize {
+    match value {
+        "High" => 0,
+        "Elevated" => 1,
+        "Low" => 2,
+        _ => 3,
     }
 }
 
@@ -3947,6 +4097,187 @@ mod tests {
             "apr-governance-high"
         );
         assert_eq!(topology_requests[0]["governance_scope"], "TopologyMutation");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_summarizes_tool_hotspots() {
+        let config = isolated_memory_config("approval-query-list-tool-summary");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        seed_request_with_governance(
+            &repo,
+            "apr-tool-delegate-pending-overdue",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+            "Orchestration",
+            "TopologyMutation",
+            "High",
+        );
+        seed_request_with_governance(
+            &repo,
+            "apr-tool-delegate-pending-fresh",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+            "Orchestration",
+            "TopologyMutation",
+            "High",
+        );
+        seed_request_with_governance(
+            &repo,
+            "apr-tool-delegate-attention",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+            "Orchestration",
+            "TopologyMutation",
+            "High",
+        );
+        seed_request_with_governance(
+            &repo,
+            "apr-tool-cancel-pending",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+            "App",
+            "Routine",
+            "Elevated",
+        );
+        seed_request_with_governance(
+            &repo,
+            "apr-tool-memory-complete",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+            "App",
+            "Routine",
+            "Low",
+        );
+
+        transition_request_status(
+            &repo,
+            "apr-tool-delegate-attention",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("tool failed for domain reasons"),
+        );
+        transition_request_status(
+            &repo,
+            "apr-tool-memory-complete",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            None,
+        );
+
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-tool-delegate-attention",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append delegate attention started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_failed".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-tool-delegate-attention",
+                "error": "tool failed for domain reasons",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append delegate attention failed event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-tool-memory-complete",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append memory complete started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-tool-memory-complete",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append memory complete finished event");
+
+        let now = test_unix_ts_now();
+        overwrite_request_requested_at(&config, "apr-tool-delegate-pending-overdue", now - 172_800);
+        overwrite_request_requested_at(&config, "apr-tool-delegate-pending-fresh", now - 60);
+        overwrite_request_requested_at(&config, "apr-tool-delegate-attention", now - 300);
+        overwrite_request_requested_at(&config, "apr-tool-cancel-pending", now - 7_200);
+        overwrite_request_requested_at(&config, "apr-tool-memory-complete", now - 30);
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for tool summary");
+
+        let tool_summary = &outcome.payload["tool_summary"];
+        assert_eq!(tool_summary["tool_count"], 3);
+        let tools = tool_summary["tools"]
+            .as_array()
+            .expect("tool summary tools array");
+        assert_eq!(tools.len(), 3);
+
+        assert_eq!(tools[0]["approval_key"], "tool:delegate_async");
+        assert_eq!(tools[0]["tool_name"], "delegate_async");
+        assert_eq!(tools[0]["execution_plane"], "Orchestration");
+        assert_eq!(tools[0]["risk_class"], "High");
+        assert_eq!(tools[0]["request_count"], 3);
+        assert_eq!(tools[0]["pending_count"], 2);
+        assert_eq!(tools[0]["attention_count"], 1);
+        assert_eq!(tools[0]["oldest_pending_age_bucket"], "overdue");
+        assert!(
+            tools[0]["oldest_pending_age_seconds"]
+                .as_i64()
+                .expect("delegate hotspot age")
+                >= 172_800
+        );
+
+        assert_eq!(tools[1]["approval_key"], "tool:session_cancel");
+        assert_eq!(tools[1]["tool_name"], "session_cancel");
+        assert_eq!(tools[1]["execution_plane"], "App");
+        assert_eq!(tools[1]["risk_class"], "Elevated");
+        assert_eq!(tools[1]["request_count"], 1);
+        assert_eq!(tools[1]["pending_count"], 1);
+        assert_eq!(tools[1]["attention_count"], 0);
+        assert_eq!(tools[1]["oldest_pending_age_bucket"], "stale");
+
+        assert_eq!(tools[2]["approval_key"], "tool:memory_search");
+        assert_eq!(tools[2]["tool_name"], "memory_search");
+        assert_eq!(tools[2]["execution_plane"], "App");
+        assert_eq!(tools[2]["risk_class"], "Low");
+        assert_eq!(tools[2]["request_count"], 1);
+        assert_eq!(tools[2]["pending_count"], 0);
+        assert_eq!(tools[2]["attention_count"], 0);
+        assert_eq!(tools[2]["oldest_pending_requested_at"], Value::Null);
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -112,6 +112,40 @@ impl ApprovalGrantAuditStatus {
 }
 
 #[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalGrantAttentionReason {
+    DurableGrantMissing,
+    GrantReviewOverdue,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl ApprovalGrantAttentionReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::DurableGrantMissing => "durable_grant_missing",
+            Self::GrantReviewOverdue => "grant_review_overdue",
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalGrantRecommendedAction {
+    InspectRuntimeGrantPersistence,
+    ReviewRuntimeGrantScope,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl ApprovalGrantRecommendedAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::InspectRuntimeGrantPersistence => "inspect_runtime_grant_persistence",
+            Self::ReviewRuntimeGrantScope => "review_runtime_grant_scope",
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
 impl ApprovalExecutionIntegrityStatus {
     fn as_str(self) -> &'static str {
         match self {
@@ -700,6 +734,7 @@ fn approval_request_summary_json_with_evidence(
     let pending_queue = approval_request_pending_queue_json(record);
     let grant_audit = approval_request_grant_audit_json(record, &grant);
     let grant_review = approval_request_grant_review_json(&grant);
+    let grant_attention = approval_request_grant_attention_json(&grant_audit, &grant_review);
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -737,6 +772,7 @@ fn approval_request_summary_json_with_evidence(
         "grant": grant,
         "grant_audit": grant_audit,
         "grant_review": grant_review,
+        "grant_attention": grant_attention,
         "pending_queue": pending_queue,
         "resolution": resolution,
         "execution_evidence": execution_evidence,
@@ -800,6 +836,48 @@ fn approval_request_grant_review_json(grant: &Value) -> Value {
         "last_changed_at": last_changed_at,
         "age_seconds": age_seconds,
         "age_bucket": age_bucket.map(ApprovalAttentionAgeBucket::as_str),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_attention_json(grant_audit: &Value, grant_review: &Value) -> Value {
+    let grant_review_age_bucket = grant_review
+        .get("age_bucket")
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_grant_review_age_bucket(value).ok());
+    let (needs_attention, attention_reason, recommended_action, age_bucket, escalation_level) =
+        match grant_audit.get("status").and_then(Value::as_str) {
+            Some("required_missing") => (
+                true,
+                Some(ApprovalGrantAttentionReason::DurableGrantMissing),
+                Some(ApprovalGrantRecommendedAction::InspectRuntimeGrantPersistence),
+                None,
+                Some(ApprovalEscalationLevel::Critical),
+            ),
+            _
+                if grant_review.get("reviewable").and_then(Value::as_bool) == Some(true)
+                    && matches!(
+                        grant_review_age_bucket,
+                        Some(ApprovalAttentionAgeBucket::Overdue)
+                    ) =>
+            {
+                (
+                    true,
+                    Some(ApprovalGrantAttentionReason::GrantReviewOverdue),
+                    Some(ApprovalGrantRecommendedAction::ReviewRuntimeGrantScope),
+                    grant_review_age_bucket,
+                    Some(ApprovalEscalationLevel::Elevated),
+                )
+            }
+            _ => (false, None, None, None, None),
+        };
+
+    json!({
+        "needs_attention": needs_attention,
+        "attention_reason": attention_reason.map(ApprovalGrantAttentionReason::as_str),
+        "recommended_action": recommended_action.map(ApprovalGrantRecommendedAction::as_str),
+        "age_bucket": age_bucket.map(ApprovalAttentionAgeBucket::as_str),
+        "escalation_level": escalation_level.map(ApprovalEscalationLevel::as_str),
     })
 }
 
@@ -1109,6 +1187,24 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
         ("stale".to_owned(), 0usize),
         ("overdue".to_owned(), 0usize),
     ]);
+    let mut attention_reason_counts = BTreeMap::from([
+        ("durable_grant_missing".to_owned(), 0usize),
+        ("grant_review_overdue".to_owned(), 0usize),
+    ]);
+    let mut attention_action_counts = BTreeMap::from([
+        ("inspect_runtime_grant_persistence".to_owned(), 0usize),
+        ("review_runtime_grant_scope".to_owned(), 0usize),
+    ]);
+    let mut attention_age_bucket_counts = BTreeMap::from([
+        ("fresh".to_owned(), 0usize),
+        ("stale".to_owned(), 0usize),
+        ("overdue".to_owned(), 0usize),
+    ]);
+    let mut attention_escalation_counts = BTreeMap::from([
+        ("elevated".to_owned(), 0usize),
+        ("critical".to_owned(), 0usize),
+    ]);
+    let mut attention_count = 0usize;
     let mut oldest_reviewable_age_seconds: Option<i64> = None;
     let mut oldest_reviewable_last_changed_at: Option<i64> = None;
 
@@ -1161,6 +1257,36 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
                     .and_then(Value::as_i64);
             }
         }
+        let grant_attention = request.get("grant_attention").unwrap_or(&Value::Null);
+        if grant_attention
+            .get("needs_attention")
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            attention_count += 1;
+            if let Some(reason) = grant_attention.get("attention_reason").and_then(Value::as_str) {
+                *attention_reason_counts.entry(reason.to_owned()).or_default() += 1;
+            }
+            if let Some(action) = grant_attention
+                .get("recommended_action")
+                .and_then(Value::as_str)
+            {
+                *attention_action_counts.entry(action.to_owned()).or_default() += 1;
+            }
+            if let Some(age_bucket) = grant_attention.get("age_bucket").and_then(Value::as_str) {
+                *attention_age_bucket_counts
+                    .entry(age_bucket.to_owned())
+                    .or_default() += 1;
+            }
+            if let Some(escalation) = grant_attention
+                .get("escalation_level")
+                .and_then(Value::as_str)
+            {
+                *attention_escalation_counts
+                    .entry(escalation.to_owned())
+                    .or_default() += 1;
+            }
+        }
     }
 
     json!({
@@ -1175,6 +1301,13 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
             "counts_by_age_bucket": counts_by_age_bucket,
             "oldest_reviewable_age_seconds": oldest_reviewable_age_seconds,
             "oldest_reviewable_last_changed_at": oldest_reviewable_last_changed_at,
+        },
+        "attention_summary": {
+            "needs_attention_count": attention_count,
+            "counts_by_reason": attention_reason_counts,
+            "recommended_action_counts": attention_action_counts,
+            "age_bucket_counts": attention_age_bucket_counts,
+            "counts_by_escalation": attention_escalation_counts,
         },
     })
 }
@@ -1425,6 +1558,7 @@ fn approval_request_detail_json_with_evidence(
     let pending_queue = approval_request_pending_queue_json(record);
     let grant_audit = approval_request_grant_audit_json(record, &grant);
     let grant_review = approval_request_grant_review_json(&grant);
+    let grant_attention = approval_request_grant_attention_json(&grant_audit, &grant_review);
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -1456,6 +1590,7 @@ fn approval_request_detail_json_with_evidence(
         "grant": grant,
         "grant_audit": grant_audit,
         "grant_review": grant_review,
+        "grant_attention": grant_attention,
         "pending_queue": pending_queue,
         "resolution": resolution,
         "execution_evidence": execution_evidence,
@@ -5513,6 +5648,210 @@ mod tests {
         assert_eq!(request["grant_review"]["reviewable"], true);
         assert_eq!(request["grant_review"]["age_bucket"], "overdue");
         assert_eq!(request["grant_review"]["last_changed_at"], overdue_updated_at);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_surfaces_grant_attention_state() {
+        let config = isolated_memory_config("approval-query-list-grant-attention");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        seed_request(
+            &repo,
+            "apr-grant-attention-missing",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-attention-overdue",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-attention-once",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        repo.transition_approval_request_if_current(
+            "apr-grant-attention-missing",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-missing".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition missing grant-attention request")
+        .expect("missing grant-attention request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-grant-attention-overdue",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-overdue".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition overdue grant-attention request")
+        .expect("overdue grant-attention request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-grant-attention-once",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Executed,
+                decision: Some(ApprovalDecision::ApproveOnce),
+                resolved_by_session_id: Some("operator-once".to_owned()),
+                executed_at: Some(1_773_000_000),
+                last_error: None,
+            },
+        )
+        .expect("transition approve_once grant-attention request")
+        .expect("approve_once grant-attention request should transition");
+
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:session_cancel",
+            Some("operator-overdue"),
+        );
+
+        let now = test_unix_ts_now();
+        let overdue_updated_at = now - (9 * 24 * 60 * 60);
+        overwrite_runtime_grant_timestamps(
+            &config,
+            "root-session",
+            "tool:session_cancel",
+            overdue_updated_at - 60,
+            overdue_updated_at,
+        );
+
+        let list_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant attention");
+
+        let attention_summary = &list_outcome.payload["grant_summary"]["attention_summary"];
+        assert_eq!(attention_summary["needs_attention_count"], 2);
+        assert_eq!(
+            attention_summary["counts_by_reason"]["durable_grant_missing"],
+            1
+        );
+        assert_eq!(
+            attention_summary["counts_by_reason"]["grant_review_overdue"],
+            1
+        );
+        assert_eq!(
+            attention_summary["recommended_action_counts"]["inspect_runtime_grant_persistence"],
+            1
+        );
+        assert_eq!(
+            attention_summary["recommended_action_counts"]["review_runtime_grant_scope"],
+            1
+        );
+        assert_eq!(attention_summary["age_bucket_counts"]["fresh"], 0);
+        assert_eq!(attention_summary["age_bucket_counts"]["stale"], 0);
+        assert_eq!(attention_summary["age_bucket_counts"]["overdue"], 1);
+        assert_eq!(attention_summary["counts_by_escalation"]["elevated"], 1);
+        assert_eq!(attention_summary["counts_by_escalation"]["critical"], 1);
+
+        let requests = list_outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        let missing_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-grant-attention-missing")
+            .expect("missing grant-attention request");
+        assert_eq!(missing_request["grant_attention"]["needs_attention"], true);
+        assert_eq!(
+            missing_request["grant_attention"]["attention_reason"],
+            "durable_grant_missing"
+        );
+        assert_eq!(
+            missing_request["grant_attention"]["recommended_action"],
+            "inspect_runtime_grant_persistence"
+        );
+        assert_eq!(missing_request["grant_attention"]["age_bucket"], Value::Null);
+        assert_eq!(
+            missing_request["grant_attention"]["escalation_level"],
+            "critical"
+        );
+
+        let overdue_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-grant-attention-overdue")
+            .expect("overdue grant-attention request");
+        assert_eq!(overdue_request["grant_attention"]["needs_attention"], true);
+        assert_eq!(
+            overdue_request["grant_attention"]["attention_reason"],
+            "grant_review_overdue"
+        );
+        assert_eq!(
+            overdue_request["grant_attention"]["recommended_action"],
+            "review_runtime_grant_scope"
+        );
+        assert_eq!(overdue_request["grant_attention"]["age_bucket"], "overdue");
+        assert_eq!(
+            overdue_request["grant_attention"]["escalation_level"],
+            "elevated"
+        );
+
+        let once_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-grant-attention-once")
+            .expect("approve_once grant-attention request");
+        assert_eq!(once_request["grant_attention"]["needs_attention"], false);
+        assert_eq!(once_request["grant_attention"]["attention_reason"], Value::Null);
+        assert_eq!(
+            once_request["grant_attention"]["recommended_action"],
+            Value::Null
+        );
+        assert_eq!(once_request["grant_attention"]["age_bucket"], Value::Null);
+        assert_eq!(once_request["grant_attention"]["escalation_level"], Value::Null);
+
+        let status_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-grant-attention-overdue",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome for grant attention");
+
+        let request = &status_outcome.payload["approval_request"];
+        assert_eq!(request["grant_attention"]["needs_attention"], true);
+        assert_eq!(
+            request["grant_attention"]["attention_reason"],
+            "grant_review_overdue"
+        );
+        assert_eq!(
+            request["grant_attention"]["recommended_action"],
+            "review_runtime_grant_scope"
+        );
+        assert_eq!(request["grant_attention"]["age_bucket"], "overdue");
+        assert_eq!(request["grant_attention"]["escalation_level"], "elevated");
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -463,8 +463,8 @@ async fn execute_approval_request_resolve(
         approval_request_execution_integrity_json(&outcome.approval_request, &execution_evidence);
     let resolution = approval_request_resolution_json(
         &outcome.approval_request,
+        &execution_evidence,
         &execution_integrity,
-        outcome.resumed_tool_output.as_ref(),
     );
 
     Ok(ToolCoreOutcome {
@@ -488,6 +488,8 @@ fn approval_request_summary_json_with_evidence(
     execution_evidence: Value,
     execution_integrity: Value,
 ) -> Value {
+    let resolution =
+        approval_request_resolution_json(record, &execution_evidence, &execution_integrity);
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -510,6 +512,7 @@ fn approval_request_summary_json_with_evidence(
             .governance_snapshot_json
             .get("rule_id")
             .and_then(Value::as_str),
+        "resolution": resolution,
         "execution_evidence": execution_evidence,
         "execution_integrity": execution_integrity,
     })
@@ -615,6 +618,8 @@ fn approval_request_detail_json_with_evidence(
     execution_evidence: Value,
     execution_integrity: Value,
 ) -> Value {
+    let resolution =
+        approval_request_resolution_json(record, &execution_evidence, &execution_integrity);
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -631,6 +636,7 @@ fn approval_request_detail_json_with_evidence(
         "last_error": record.last_error,
         "request_payload": record.request_payload_json,
         "governance_snapshot": record.governance_snapshot_json,
+        "resolution": resolution,
         "execution_evidence": execution_evidence,
         "execution_integrity": execution_integrity,
     })
@@ -639,16 +645,31 @@ fn approval_request_detail_json_with_evidence(
 #[cfg(feature = "memory-sqlite")]
 fn approval_request_resolution_json(
     record: &ApprovalRequestRecord,
+    execution_evidence: &Value,
     execution_integrity: &Value,
-    resumed_tool_output: Option<&ToolCoreOutcome>,
 ) -> Value {
-    let replay_attempted = resumed_tool_output.is_some();
+    let started_event_kind = execution_evidence
+        .get("started_event_kind")
+        .and_then(Value::as_str);
+    let terminal_event_kind = execution_evidence
+        .get("terminal_event_kind")
+        .and_then(Value::as_str);
+    let replay_attempted = started_event_kind.is_some()
+        || terminal_event_kind.is_some()
+        || matches!(
+            record.status,
+            ApprovalRequestStatus::Executing | ApprovalRequestStatus::Executed
+        );
     let needs_attention = execution_integrity
         .get("needs_attention")
         .and_then(Value::as_bool)
         .unwrap_or(false);
     let replay_result = if !replay_attempted {
         "not_attempted"
+    } else if matches!(record.status, ApprovalRequestStatus::Executing)
+        || (started_event_kind.is_some() && terminal_event_kind.is_none())
+    {
+        "in_progress"
     } else if needs_attention {
         "completed_with_attention"
     } else {
@@ -1620,6 +1641,20 @@ mod tests {
         );
         assert_eq!(
             root_request["execution_integrity"]["escalation_level"],
+            Value::Null
+        );
+        assert_eq!(root_request["resolution"]["decision"], Value::Null);
+        assert_eq!(root_request["resolution"]["request_status"], "pending");
+        assert_eq!(root_request["resolution"]["replay_attempted"], false);
+        assert_eq!(root_request["resolution"]["replay_result"], "not_attempted");
+        assert_eq!(
+            root_request["resolution"]["integrity_status"],
+            "not_started"
+        );
+        assert_eq!(root_request["resolution"]["needs_attention"], false);
+        assert_eq!(root_request["resolution"]["attention_reason"], Value::Null);
+        assert_eq!(
+            root_request["resolution"]["recommended_action"],
             Value::Null
         );
     }
@@ -2848,6 +2883,14 @@ mod tests {
             request["execution_integrity"]["escalation_level"],
             Value::Null
         );
+        assert_eq!(request["resolution"]["decision"], Value::Null);
+        assert_eq!(request["resolution"]["request_status"], "pending");
+        assert_eq!(request["resolution"]["replay_attempted"], false);
+        assert_eq!(request["resolution"]["replay_result"], "not_attempted");
+        assert_eq!(request["resolution"]["integrity_status"], "not_started");
+        assert_eq!(request["resolution"]["needs_attention"], false);
+        assert_eq!(request["resolution"]["attention_reason"], Value::Null);
+        assert_eq!(request["resolution"]["recommended_action"], Value::Null);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -2994,6 +3037,18 @@ mod tests {
         );
         assert_eq!(integrity["attention_age_bucket"], "overdue");
         assert_eq!(integrity["escalation_level"], "critical");
+        let resolution = &outcome.payload["approval_request"]["resolution"];
+        assert_eq!(resolution["decision"], Value::Null);
+        assert_eq!(resolution["request_status"], "executed");
+        assert_eq!(resolution["replay_attempted"], true);
+        assert_eq!(resolution["replay_result"], "completed_with_attention");
+        assert_eq!(resolution["integrity_status"], "incomplete");
+        assert_eq!(resolution["needs_attention"], true);
+        assert_eq!(resolution["attention_reason"], "integrity_gap");
+        assert_eq!(
+            resolution["recommended_action"],
+            "inspect_execution_event_stream"
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -28,6 +28,10 @@ const APPROVAL_REQUEST_EVIDENCE_EVENT_BUDGET_PER_RETURNED_REQUEST: usize = 4;
 const APPROVAL_ATTENTION_FRESH_MAX_SECONDS: i64 = 15 * 60;
 #[cfg(feature = "memory-sqlite")]
 const APPROVAL_ATTENTION_STALE_MAX_SECONDS: i64 = 4 * 60 * 60;
+#[cfg(feature = "memory-sqlite")]
+const APPROVAL_GRANT_REVIEW_FRESH_MAX_SECONDS: i64 = 24 * 60 * 60;
+#[cfg(feature = "memory-sqlite")]
+const APPROVAL_GRANT_REVIEW_STALE_MAX_SECONDS: i64 = 7 * 24 * 60 * 60;
 
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -661,6 +665,7 @@ fn approval_request_summary_json_with_evidence(
         approval_request_resolution_json(record, &execution_evidence, &execution_integrity);
     let pending_queue = approval_request_pending_queue_json(record);
     let grant_audit = approval_request_grant_audit_json(record, &grant);
+    let grant_review = approval_request_grant_review_json(&grant);
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -697,6 +702,7 @@ fn approval_request_summary_json_with_evidence(
             .and_then(Value::as_str),
         "grant": grant,
         "grant_audit": grant_audit,
+        "grant_review": grant_review,
         "pending_queue": pending_queue,
         "resolution": resolution,
         "execution_evidence": execution_evidence,
@@ -738,6 +744,43 @@ fn approval_request_grant_audit_json(record: &ApprovalRequestRecord, grant: &Val
         "has_durable_grant": has_durable_grant,
         "is_consistent": is_consistent,
     })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_review_json(grant: &Value) -> Value {
+    let reviewable = grant.get("state").and_then(Value::as_str) == Some("present");
+    let last_changed_at = if reviewable {
+        grant.get("updated_at").and_then(Value::as_i64).or_else(|| {
+            grant.get("created_at")
+                .and_then(Value::as_i64)
+                .filter(|value| *value > 0)
+        })
+    } else {
+        None
+    };
+    let age_seconds = last_changed_at.map(|ts| (approval_unix_ts_now() - ts).max(0));
+    let age_bucket = approval_grant_review_age_bucket(age_seconds);
+
+    json!({
+        "reviewable": reviewable,
+        "last_changed_at": last_changed_at,
+        "age_seconds": age_seconds,
+        "age_bucket": age_bucket.map(ApprovalAttentionAgeBucket::as_str),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_grant_review_age_bucket(
+    age_seconds: Option<i64>,
+) -> Option<ApprovalAttentionAgeBucket> {
+    let age_seconds = age_seconds?;
+    if age_seconds < APPROVAL_GRANT_REVIEW_FRESH_MAX_SECONDS {
+        Some(ApprovalAttentionAgeBucket::Fresh)
+    } else if age_seconds < APPROVAL_GRANT_REVIEW_STALE_MAX_SECONDS {
+        Some(ApprovalAttentionAgeBucket::Stale)
+    } else {
+        Some(ApprovalAttentionAgeBucket::Overdue)
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1025,6 +1068,14 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
     ]);
     let mut scope_session_counts = BTreeMap::<String, usize>::new();
     let mut created_by_session_counts = BTreeMap::<String, usize>::new();
+    let mut reviewable_count = 0usize;
+    let mut counts_by_age_bucket = BTreeMap::from([
+        ("fresh".to_owned(), 0usize),
+        ("stale".to_owned(), 0usize),
+        ("overdue".to_owned(), 0usize),
+    ]);
+    let mut oldest_reviewable_age_seconds: Option<i64> = None;
+    let mut oldest_reviewable_last_changed_at: Option<i64> = None;
 
     for request in requests {
         let grant = request.get("grant").unwrap_or(&Value::Null);
@@ -1050,6 +1101,24 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
         {
             *consistency_counts.entry(status.to_owned()).or_default() += 1;
         }
+        let grant_review = request.get("grant_review").unwrap_or(&Value::Null);
+        if grant_review.get("reviewable").and_then(Value::as_bool) == Some(true) {
+            reviewable_count += 1;
+        }
+        if let Some(age_bucket) = grant_review.get("age_bucket").and_then(Value::as_str) {
+            *counts_by_age_bucket.entry(age_bucket.to_owned()).or_default() += 1;
+        }
+        if let Some(age_seconds) = grant_review.get("age_seconds").and_then(Value::as_i64) {
+            let is_older = oldest_reviewable_age_seconds
+                .map(|current| age_seconds > current)
+                .unwrap_or(true);
+            if is_older {
+                oldest_reviewable_age_seconds = Some(age_seconds);
+                oldest_reviewable_last_changed_at = grant_review
+                    .get("last_changed_at")
+                    .and_then(Value::as_i64);
+            }
+        }
     }
 
     json!({
@@ -1057,6 +1126,13 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
         "consistency_counts": consistency_counts,
         "scope_session_counts": scope_session_counts,
         "created_by_session_counts": created_by_session_counts,
+        "review_summary": {
+            "reviewable_count": reviewable_count,
+            "non_reviewable_count": requests.len().saturating_sub(reviewable_count),
+            "counts_by_age_bucket": counts_by_age_bucket,
+            "oldest_reviewable_age_seconds": oldest_reviewable_age_seconds,
+            "oldest_reviewable_last_changed_at": oldest_reviewable_last_changed_at,
+        },
     })
 }
 
@@ -1305,6 +1381,7 @@ fn approval_request_detail_json_with_evidence(
         approval_request_resolution_json(record, &execution_evidence, &execution_integrity);
     let pending_queue = approval_request_pending_queue_json(record);
     let grant_audit = approval_request_grant_audit_json(record, &grant);
+    let grant_review = approval_request_grant_review_json(&grant);
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -1335,6 +1412,7 @@ fn approval_request_detail_json_with_evidence(
         "governance_snapshot": record.governance_snapshot_json,
         "grant": grant,
         "grant_audit": grant_audit,
+        "grant_review": grant_review,
         "pending_queue": pending_queue,
         "resolution": resolution,
         "execution_evidence": execution_evidence,
@@ -2661,9 +2739,33 @@ mod tests {
                  SET requested_at = ?2
                  WHERE approval_request_id = ?1",
                 params![approval_request_id, requested_at],
-            )
-            .expect("overwrite approval request requested_at");
+        )
+        .expect("overwrite approval request requested_at");
         assert_eq!(affected, 1, "expected to update one approval request row");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn overwrite_runtime_grant_timestamps(
+        config: &MemoryRuntimeConfig,
+        scope_session_id: &str,
+        approval_key: &str,
+        created_at: i64,
+        updated_at: i64,
+    ) {
+        let db_path = config
+            .sqlite_path
+            .as_ref()
+            .expect("sqlite path should be configured");
+        let conn = rusqlite::Connection::open(db_path).expect("open sqlite db");
+        let affected = conn
+            .execute(
+                "UPDATE approval_grants
+                 SET created_at = ?3, updated_at = ?4
+                 WHERE scope_session_id = ?1 AND approval_key = ?2",
+                params![scope_session_id, approval_key, created_at, updated_at],
+            )
+            .expect("overwrite runtime grant timestamps");
+        assert_eq!(affected, 1, "expected to update one approval grant row");
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -5137,6 +5239,161 @@ mod tests {
         let request = &status_outcome.payload["approval_request"];
         assert_eq!(request["grant_audit"]["status"], "required_present");
         assert_eq!(request["grant_audit"]["is_consistent"], true);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_surfaces_runtime_grant_review_age() {
+        let config = isolated_memory_config("approval-query-list-grant-review-age");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+
+        seed_request(
+            &repo,
+            "apr-grant-review-fresh",
+            "child-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-review-overdue",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-review-absent",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:delegate_async",
+            Some("operator-fresh"),
+        );
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:session_cancel",
+            Some("operator-overdue"),
+        );
+
+        let now = test_unix_ts_now();
+        let fresh_updated_at = now - (60 * 60);
+        let overdue_updated_at = now - (9 * 24 * 60 * 60);
+        overwrite_runtime_grant_timestamps(
+            &config,
+            "root-session",
+            "tool:delegate_async",
+            fresh_updated_at - 60,
+            fresh_updated_at,
+        );
+        overwrite_runtime_grant_timestamps(
+            &config,
+            "root-session",
+            "tool:session_cancel",
+            overdue_updated_at - 60,
+            overdue_updated_at,
+        );
+
+        let list_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant review age");
+
+        let grant_summary = &list_outcome.payload["grant_summary"]["review_summary"];
+        assert_eq!(grant_summary["reviewable_count"], 2);
+        assert_eq!(grant_summary["non_reviewable_count"], 1);
+        assert_eq!(grant_summary["counts_by_age_bucket"]["fresh"], 1);
+        assert_eq!(grant_summary["counts_by_age_bucket"]["stale"], 0);
+        assert_eq!(grant_summary["counts_by_age_bucket"]["overdue"], 1);
+        assert_eq!(
+            grant_summary["oldest_reviewable_last_changed_at"],
+            overdue_updated_at
+        );
+        assert!(
+            grant_summary["oldest_reviewable_age_seconds"]
+                .as_i64()
+                .expect("oldest reviewable age seconds")
+                >= 9 * 24 * 60 * 60
+        );
+
+        let requests = list_outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        let fresh_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-grant-review-fresh")
+            .expect("fresh review request");
+        assert_eq!(fresh_request["grant_review"]["reviewable"], true);
+        assert_eq!(
+            fresh_request["grant_review"]["last_changed_at"],
+            fresh_updated_at
+        );
+        assert_eq!(fresh_request["grant_review"]["age_bucket"], "fresh");
+        assert!(
+            fresh_request["grant_review"]["age_seconds"]
+                .as_i64()
+                .expect("fresh review age seconds")
+                >= 60 * 60
+        );
+
+        let overdue_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-grant-review-overdue")
+            .expect("overdue review request");
+        assert_eq!(overdue_request["grant_review"]["reviewable"], true);
+        assert_eq!(
+            overdue_request["grant_review"]["last_changed_at"],
+            overdue_updated_at
+        );
+        assert_eq!(overdue_request["grant_review"]["age_bucket"], "overdue");
+
+        let absent_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-grant-review-absent")
+            .expect("absent review request");
+        assert_eq!(absent_request["grant_review"]["reviewable"], false);
+        assert_eq!(absent_request["grant_review"]["last_changed_at"], Value::Null);
+        assert_eq!(absent_request["grant_review"]["age_seconds"], Value::Null);
+        assert_eq!(absent_request["grant_review"]["age_bucket"], Value::Null);
+
+        let status_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-grant-review-overdue",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome for grant review age");
+
+        let request = &status_outcome.payload["approval_request"];
+        assert_eq!(request["grant_review"]["reviewable"], true);
+        assert_eq!(request["grant_review"]["age_bucket"], "overdue");
+        assert_eq!(request["grant_review"]["last_changed_at"], overdue_updated_at);
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -28,6 +28,7 @@ struct ApprovalRequestsListRequest {
     integrity_status: Option<ApprovalExecutionIntegrityStatus>,
     needs_attention: Option<bool>,
     attention_reason: Option<ApprovalAttentionReason>,
+    prioritize_attention: bool,
     limit: usize,
 }
 
@@ -270,6 +271,16 @@ fn execute_approval_requests_list(
                 == Some(attention_reason)
         });
     }
+    if request.prioritize_attention {
+        request_summaries.sort_by(|left, right| {
+            approval_request_attention_priority(left)
+                .cmp(&approval_request_attention_priority(right))
+                .then_with(|| {
+                    approval_request_requested_at(right).cmp(&approval_request_requested_at(left))
+                })
+                .then_with(|| approval_request_id(left).cmp(approval_request_id(right)))
+        });
+    }
     let integrity_summary = approval_request_list_integrity_summary_json(&request_summaries);
     let matched_count = request_summaries.len();
     request_summaries.truncate(request.limit);
@@ -285,6 +296,7 @@ fn execute_approval_requests_list(
                 "integrity_status": request.integrity_status.map(ApprovalExecutionIntegrityStatus::as_str),
                 "needs_attention": request.needs_attention,
                 "attention_reason": request.attention_reason.map(ApprovalAttentionReason::as_str),
+                "prioritize_attention": request.prioritize_attention,
                 "limit": request.limit,
             },
             "visible_session_ids": target_session_ids,
@@ -786,6 +798,42 @@ fn approval_request_attention_reason_from_json(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_attention_priority(request: &Value) -> u8 {
+    let execution_integrity = request.get("execution_integrity").unwrap_or(&Value::Null);
+    if execution_integrity
+        .get("needs_attention")
+        .and_then(Value::as_bool)
+        != Some(true)
+    {
+        return 3;
+    }
+    match execution_integrity
+        .get("attention_reason")
+        .and_then(Value::as_str)
+    {
+        Some("integrity_gap") => 0,
+        Some("execution_failed") => 1,
+        Some(_) | None => 2,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_requested_at(request: &Value) -> i64 {
+    request
+        .get("requested_at")
+        .and_then(Value::as_i64)
+        .unwrap_or(i64::MIN)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_id(request: &Value) -> &str {
+    request
+        .get("approval_request_id")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn parse_approval_requests_list_request(
     payload: &Value,
     tool_config: &ToolConfig,
@@ -799,6 +847,10 @@ fn parse_approval_requests_list_request(
         )?,
         needs_attention: payload.get("needs_attention").and_then(Value::as_bool),
         attention_reason: optional_payload_approval_attention_reason(payload, "attention_reason")?,
+        prioritize_attention: payload
+            .get("prioritize_attention")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
         limit: optional_payload_limit(
             payload,
             "limit",
@@ -1613,6 +1665,172 @@ mod tests {
             execution_failed_requests[0]["execution_integrity"]["attention_reason"],
             "execution_failed"
         );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_prioritizes_attention_when_requested() {
+        let config = isolated_memory_config("approval-query-list-attention-priority");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-priority-not-started",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-priority-complete",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-priority-integrity-gap",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-priority-execution-failed",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        transition_request_status(
+            &repo,
+            "apr-priority-complete",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            None,
+        );
+        transition_request_status(
+            &repo,
+            "apr-priority-integrity-gap",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("persist assistant turn via kernel failed: forced outcome persistence failure"),
+        );
+        transition_request_status(
+            &repo,
+            "apr-priority-execution-failed",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("tool failed for domain reasons"),
+        );
+
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-priority-complete",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append complete started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-priority-complete",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append complete finished event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-priority-integrity-gap",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append integrity-gap started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-priority-integrity-gap",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": false,
+                "replay_outcome_persist_error": "persist assistant turn via kernel failed: forced outcome persistence failure",
+            }),
+        })
+        .expect("append integrity-gap finished event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-priority-execution-failed",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append execution-failed started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_failed".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-priority-execution-failed",
+                "error": "tool failed for domain reasons",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append execution-failed terminal event");
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "prioritize_attention": true,
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list prioritized outcome");
+
+        assert_eq!(outcome.payload["filter"]["prioritize_attention"], true);
+        let requests = outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        assert_eq!(requests.len(), 4);
+        assert_eq!(
+            requests[0]["approval_request_id"],
+            "apr-priority-integrity-gap"
+        );
+        assert_eq!(
+            requests[0]["execution_integrity"]["attention_reason"],
+            "integrity_gap"
+        );
+        assert_eq!(
+            requests[1]["approval_request_id"],
+            "apr-priority-execution-failed"
+        );
+        assert_eq!(
+            requests[1]["execution_integrity"]["attention_reason"],
+            "execution_failed"
+        );
+        assert_eq!(requests[2]["execution_integrity"]["needs_attention"], false);
+        assert_eq!(requests[3]["execution_integrity"]["needs_attention"], false);
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -1332,12 +1332,7 @@ fn approval_request_list_session_summary_json(requests: &[Value]) -> Value {
         let session = sessions.entry(session_id.to_owned()).or_default();
         session.request_count += 1;
 
-        if request
-            .get("execution_integrity")
-            .and_then(|value| value.get("needs_attention"))
-            .and_then(Value::as_bool)
-            == Some(true)
-        {
+        if approval_request_has_attention(request) {
             session.attention_count += 1;
         }
 
@@ -1463,12 +1458,7 @@ fn approval_request_list_tool_summary_json(requests: &[Value]) -> Value {
             tool.session_ids.insert(session_id.to_owned());
         }
 
-        if request
-            .get("execution_integrity")
-            .and_then(|value| value.get("needs_attention"))
-            .and_then(Value::as_bool)
-            == Some(true)
-        {
+        if approval_request_has_attention(request) {
             tool.attention_count += 1;
         }
 
@@ -2179,6 +2169,12 @@ fn approval_request_escalation_level(
 
 #[cfg(feature = "memory-sqlite")]
 fn approval_request_attention_priority(request: &Value) -> u8 {
+    approval_request_execution_attention_priority(request)
+        .min(approval_request_grant_attention_priority(request))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_execution_attention_priority(request: &Value) -> u8 {
     let execution_integrity = request.get("execution_integrity").unwrap_or(&Value::Null);
     if execution_integrity
         .get("needs_attention")
@@ -2198,7 +2194,30 @@ fn approval_request_attention_priority(request: &Value) -> u8 {
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_attention_priority(request: &Value) -> u8 {
+    let grant_attention = request.get("grant_attention").unwrap_or(&Value::Null);
+    if grant_attention
+        .get("needs_attention")
+        .and_then(Value::as_bool)
+        != Some(true)
+    {
+        return 3;
+    }
+    match grant_attention.get("attention_reason").and_then(Value::as_str) {
+        Some("durable_grant_missing") => 0,
+        Some("grant_review_overdue") => 1,
+        Some(_) | None => 2,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_escalation_priority(request: &Value) -> u8 {
+    approval_request_execution_escalation_priority(request)
+        .min(approval_request_grant_escalation_priority(request))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_execution_escalation_priority(request: &Value) -> u8 {
     match request
         .get("execution_integrity")
         .and_then(approval_request_escalation_level_from_json)
@@ -2207,6 +2226,33 @@ fn approval_request_escalation_priority(request: &Value) -> u8 {
         Some(ApprovalEscalationLevel::Elevated) => 1,
         None => 2,
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_escalation_priority(request: &Value) -> u8 {
+    match request
+        .get("grant_attention")
+        .and_then(|value| value.get("escalation_level"))
+        .and_then(Value::as_str)
+    {
+        Some("critical") => 0,
+        Some("elevated") => 1,
+        Some(_) | None => 2,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_has_attention(request: &Value) -> bool {
+    request
+        .get("execution_integrity")
+        .and_then(|value| value.get("needs_attention"))
+        .and_then(Value::as_bool)
+        == Some(true)
+        || request
+            .get("grant_attention")
+            .and_then(|value| value.get("needs_attention"))
+            .and_then(Value::as_bool)
+            == Some(true)
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -4365,6 +4411,123 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
+    fn approval_request_tool_query_list_prioritizes_grant_attention_when_requested() {
+        let config = isolated_memory_config("approval-query-list-grant-attention-priority");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        seed_request(
+            &repo,
+            "apr-priority-grant-missing",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-priority-grant-overdue",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-priority-grant-clean",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        repo.transition_approval_request_if_current(
+            "apr-priority-grant-missing",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-missing".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition missing grant-priority request")
+        .expect("missing grant-priority request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-priority-grant-overdue",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-overdue".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition overdue grant-priority request")
+        .expect("overdue grant-priority request should transition");
+
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:session_cancel",
+            Some("operator-overdue"),
+        );
+
+        let now = test_unix_ts_now();
+        overwrite_request_requested_at(&config, "apr-priority-grant-missing", now - 3_600);
+        overwrite_request_requested_at(&config, "apr-priority-grant-overdue", now - 60);
+        overwrite_request_requested_at(&config, "apr-priority-grant-clean", now - 30);
+        overwrite_runtime_grant_timestamps(
+            &config,
+            "root-session",
+            "tool:session_cancel",
+            now - (9 * 24 * 60 * 60) - 60,
+            now - (9 * 24 * 60 * 60),
+        );
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "prioritize_attention": true,
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list prioritized outcome for grant attention");
+
+        assert_eq!(outcome.payload["filter"]["prioritize_attention"], true);
+        let requests = outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        assert_eq!(requests.len(), 3);
+        assert_eq!(
+            requests[0]["approval_request_id"],
+            "apr-priority-grant-missing"
+        );
+        assert_eq!(
+            requests[0]["grant_attention"]["attention_reason"],
+            "durable_grant_missing"
+        );
+        assert_eq!(
+            requests[1]["approval_request_id"],
+            "apr-priority-grant-overdue"
+        );
+        assert_eq!(
+            requests[1]["grant_attention"]["attention_reason"],
+            "grant_review_overdue"
+        );
+        assert_eq!(
+            requests[2]["approval_request_id"],
+            "apr-priority-grant-clean"
+        );
+        assert_eq!(requests[2]["grant_attention"]["needs_attention"], false);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
     fn approval_request_tool_query_list_prioritizes_pending_queue_and_summarizes_age() {
         let config = isolated_memory_config("approval-query-list-pending-priority");
         let repo = SessionRepository::new(&config).expect("repository");
@@ -4995,6 +5158,142 @@ mod tests {
         assert_eq!(tools[2]["pending_count"], 0);
         assert_eq!(tools[2]["attention_count"], 0);
         assert_eq!(tools[2]["oldest_pending_requested_at"], Value::Null);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_summarizes_grant_attention_hotspots() {
+        let config = isolated_memory_config("approval-query-list-grant-attention-hotspots");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-hot",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+        seed_session(
+            &repo,
+            "child-calm",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+
+        seed_request(
+            &repo,
+            "apr-hotspot-grant-missing",
+            "child-hot",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-hotspot-grant-overdue",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-hotspot-clean",
+            "child-calm",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        repo.transition_approval_request_if_current(
+            "apr-hotspot-grant-missing",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-missing".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition hotspot missing request")
+        .expect("hotspot missing request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-hotspot-grant-overdue",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-overdue".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition hotspot overdue request")
+        .expect("hotspot overdue request should transition");
+
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:session_cancel",
+            Some("operator-overdue"),
+        );
+
+        let now = test_unix_ts_now();
+        overwrite_runtime_grant_timestamps(
+            &config,
+            "root-session",
+            "tool:session_cancel",
+            now - (9 * 24 * 60 * 60) - 60,
+            now - (9 * 24 * 60 * 60),
+        );
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant attention hotspots");
+
+        let sessions = outcome.payload["session_summary"]["sessions"]
+            .as_array()
+            .expect("session summary sessions array");
+        let child_hot = sessions
+            .iter()
+            .find(|item| item["session_id"] == "child-hot")
+            .expect("child-hot session summary");
+        assert_eq!(child_hot["attention_count"], 1);
+        let root = sessions
+            .iter()
+            .find(|item| item["session_id"] == "root-session")
+            .expect("root session summary");
+        assert_eq!(root["attention_count"], 1);
+        let child_calm = sessions
+            .iter()
+            .find(|item| item["session_id"] == "child-calm")
+            .expect("child-calm session summary");
+        assert_eq!(child_calm["attention_count"], 0);
+
+        let tools = outcome.payload["tool_summary"]["tools"]
+            .as_array()
+            .expect("tool summary tools array");
+        let delegate = tools
+            .iter()
+            .find(|item| item["approval_key"] == "tool:delegate_async")
+            .expect("delegate tool summary");
+        assert_eq!(delegate["attention_count"], 1);
+        let cancel = tools
+            .iter()
+            .find(|item| item["approval_key"] == "tool:session_cancel")
+            .expect("cancel tool summary");
+        assert_eq!(cancel["attention_count"], 1);
+        let memory = tools
+            .iter()
+            .find(|item| item["approval_key"] == "tool:memory_search")
+            .expect("memory tool summary");
+        assert_eq!(memory["attention_count"], 0);
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -3918,6 +3918,35 @@ mod tests {
             "apr-governance-high"
         );
         assert_eq!(high_risk_requests[0]["risk_class"], "High");
+
+        let topology_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "governance_scope": "TopologyMutation",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for governance_scope filter");
+
+        assert_eq!(
+            topology_outcome.payload["filter"]["governance_scope"],
+            "TopologyMutation"
+        );
+        assert_eq!(topology_outcome.payload["matched_count"], 1);
+        let topology_requests = topology_outcome.payload["requests"]
+            .as_array()
+            .expect("topology mutation requests array");
+        assert_eq!(topology_requests.len(), 1);
+        assert_eq!(
+            topology_requests[0]["approval_request_id"],
+            "apr-governance-high"
+        );
+        assert_eq!(topology_requests[0]["governance_scope"], "TopologyMutation");
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -4365,6 +4394,32 @@ mod tests {
         assert!(
             error.contains("approval_requests_list_invalid_request: unknown risk_class"),
             "expected risk_class validation error, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_governance_scope() {
+        let config = isolated_memory_config("approval-query-list-invalid-governance-scope");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "governance_scope": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("unknown governance_scope should be rejected");
+
+        assert!(
+            error.contains("approval_requests_list_invalid_request: unknown governance_scope"),
+            "expected governance_scope validation error, got: {error}"
         );
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -6,6 +6,8 @@ use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{json, Value};
 
 #[cfg(feature = "memory-sqlite")]
+use super::catalog::{ToolExecutionPlane, ToolGovernanceScope, ToolRiskClass};
+#[cfg(feature = "memory-sqlite")]
 use crate::config::SessionVisibility;
 use crate::config::ToolConfig;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
@@ -29,6 +31,9 @@ const APPROVAL_ATTENTION_STALE_MAX_SECONDS: i64 = 4 * 60 * 60;
 struct ApprovalRequestsListRequest {
     session_id: Option<String>,
     status: Option<ApprovalRequestStatus>,
+    execution_plane: Option<ToolExecutionPlane>,
+    governance_scope: Option<ToolGovernanceScope>,
+    risk_class: Option<ToolRiskClass>,
     pending_age_bucket: Option<ApprovalAttentionAgeBucket>,
     tool_name: Option<String>,
     approval_key: Option<String>,
@@ -352,6 +357,20 @@ fn execute_approval_requests_list(
         request_summaries
             .retain(|item| approval_request_decision_from_json(item) == Some(decision));
     }
+    if let Some(execution_plane) = request.execution_plane {
+        request_summaries.retain(|item| {
+            approval_request_execution_plane_from_json(item) == Some(execution_plane)
+        });
+    }
+    if let Some(governance_scope) = request.governance_scope {
+        request_summaries.retain(|item| {
+            approval_request_governance_scope_from_json(item) == Some(governance_scope)
+        });
+    }
+    if let Some(risk_class) = request.risk_class {
+        request_summaries
+            .retain(|item| approval_request_risk_class_from_json(item) == Some(risk_class));
+    }
     if let Some(tool_name) = request.tool_name.as_deref() {
         request_summaries
             .retain(|item| item.get("tool_name").and_then(Value::as_str) == Some(tool_name));
@@ -442,6 +461,7 @@ fn execute_approval_requests_list(
     let integrity_summary = approval_request_list_integrity_summary_json(&request_summaries);
     let resolution_summary = approval_request_list_resolution_summary_json(&request_summaries);
     let correlation_summary = approval_request_list_correlation_summary_json(&request_summaries);
+    let governance_summary = approval_request_list_governance_summary_json(&request_summaries);
     let session_summary = approval_request_list_session_summary_json(&request_summaries);
     let matched_count = request_summaries.len();
     request_summaries.truncate(request.limit);
@@ -454,6 +474,9 @@ fn execute_approval_requests_list(
             "filter": {
                 "session_id": request.session_id,
                 "status": request.status.map(ApprovalRequestStatus::as_str),
+                "execution_plane": request.execution_plane.map(tool_execution_plane_as_str),
+                "governance_scope": request.governance_scope.map(tool_governance_scope_as_str),
+                "risk_class": request.risk_class.map(tool_risk_class_as_str),
                 "pending_age_bucket": request.pending_age_bucket.map(ApprovalAttentionAgeBucket::as_str),
                 "tool_name": request.tool_name,
                 "approval_key": request.approval_key,
@@ -477,6 +500,7 @@ fn execute_approval_requests_list(
             "integrity_summary": integrity_summary,
             "resolution_summary": resolution_summary,
             "correlation_summary": correlation_summary,
+            "governance_summary": governance_summary,
             "session_summary": session_summary,
             "requests": request_summaries,
         }),
@@ -581,6 +605,18 @@ fn approval_request_summary_json_with_evidence(
         "tool_call_id": record.tool_call_id,
         "tool_name": record.tool_name,
         "approval_key": record.approval_key,
+        "execution_plane": record
+            .governance_snapshot_json
+            .get("execution_plane")
+            .and_then(Value::as_str),
+        "governance_scope": record
+            .governance_snapshot_json
+            .get("governance_scope")
+            .and_then(Value::as_str),
+        "risk_class": record
+            .governance_snapshot_json
+            .get("risk_class")
+            .and_then(Value::as_str),
         "status": record.status.as_str(),
         "decision": record.decision.map(|decision| decision.as_str()),
         "requested_at": record.requested_at,
@@ -844,6 +880,46 @@ fn approval_request_list_correlation_summary_json(requests: &[Value]) -> Value {
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_list_governance_summary_json(requests: &[Value]) -> Value {
+    let mut execution_plane_counts = BTreeMap::from([
+        ("Core".to_owned(), 0usize),
+        ("App".to_owned(), 0usize),
+        ("Orchestration".to_owned(), 0usize),
+    ]);
+    let mut governance_scope_counts = BTreeMap::from([
+        ("Routine".to_owned(), 0usize),
+        ("TopologyMutation".to_owned(), 0usize),
+    ]);
+    let mut risk_class_counts = BTreeMap::from([
+        ("Low".to_owned(), 0usize),
+        ("Elevated".to_owned(), 0usize),
+        ("High".to_owned(), 0usize),
+    ]);
+
+    for request in requests {
+        if let Some(execution_plane) = request.get("execution_plane").and_then(Value::as_str) {
+            *execution_plane_counts
+                .entry(execution_plane.to_owned())
+                .or_default() += 1;
+        }
+        if let Some(governance_scope) = request.get("governance_scope").and_then(Value::as_str) {
+            *governance_scope_counts
+                .entry(governance_scope.to_owned())
+                .or_default() += 1;
+        }
+        if let Some(risk_class) = request.get("risk_class").and_then(Value::as_str) {
+            *risk_class_counts.entry(risk_class.to_owned()).or_default() += 1;
+        }
+    }
+
+    json!({
+        "execution_plane_counts": execution_plane_counts,
+        "governance_scope_counts": governance_scope_counts,
+        "risk_class_counts": risk_class_counts,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_list_session_summary_json(requests: &[Value]) -> Value {
     #[derive(Default)]
     struct SessionSummaryAccumulator {
@@ -958,6 +1034,18 @@ fn approval_request_detail_json_with_evidence(
         "tool_call_id": record.tool_call_id,
         "tool_name": record.tool_name,
         "approval_key": record.approval_key,
+        "execution_plane": record
+            .governance_snapshot_json
+            .get("execution_plane")
+            .and_then(Value::as_str),
+        "governance_scope": record
+            .governance_snapshot_json
+            .get("governance_scope")
+            .and_then(Value::as_str),
+        "risk_class": record
+            .governance_snapshot_json
+            .get("risk_class")
+            .and_then(Value::as_str),
         "status": record.status.as_str(),
         "decision": record.decision.map(|decision| decision.as_str()),
         "requested_at": record.requested_at,
@@ -1330,6 +1418,30 @@ fn approval_request_execution_integrity_status_from_json(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_execution_plane_from_json(request: &Value) -> Option<ToolExecutionPlane> {
+    request
+        .get("execution_plane")
+        .and_then(Value::as_str)
+        .and_then(|value| parse_tool_execution_plane(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_governance_scope_from_json(request: &Value) -> Option<ToolGovernanceScope> {
+    request
+        .get("governance_scope")
+        .and_then(Value::as_str)
+        .and_then(|value| parse_tool_governance_scope(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_risk_class_from_json(request: &Value) -> Option<ToolRiskClass> {
+    request
+        .get("risk_class")
+        .and_then(Value::as_str)
+        .and_then(|value| parse_tool_risk_class(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_decision_from_json(request: &Value) -> Option<ApprovalDecision> {
     request
         .get("resolution")
@@ -1558,6 +1670,9 @@ fn parse_approval_requests_list_request(
     Ok(ApprovalRequestsListRequest {
         session_id: optional_payload_string(payload, "session_id"),
         status: optional_payload_approval_request_status(payload, "status")?,
+        execution_plane: optional_payload_tool_execution_plane(payload, "execution_plane")?,
+        governance_scope: optional_payload_tool_governance_scope(payload, "governance_scope")?,
+        risk_class: optional_payload_tool_risk_class(payload, "risk_class")?,
         pending_age_bucket: optional_payload_approval_pending_age_bucket(
             payload,
             "pending_age_bucket",
@@ -1684,6 +1799,36 @@ fn optional_payload_approval_request_status(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn optional_payload_tool_execution_plane(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ToolExecutionPlane>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_tool_execution_plane(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_tool_governance_scope(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ToolGovernanceScope>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_tool_governance_scope(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_tool_risk_class(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ToolRiskClass>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_tool_risk_class(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn optional_payload_approval_execution_integrity_status(
     payload: &Value,
     field: &str,
@@ -1761,6 +1906,67 @@ fn optional_payload_approval_escalation_level(
     optional_payload_string(payload, field)
         .map(|value| parse_approval_escalation_level(value.as_str()))
         .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn tool_execution_plane_as_str(value: ToolExecutionPlane) -> &'static str {
+    match value {
+        ToolExecutionPlane::Core => "Core",
+        ToolExecutionPlane::App => "App",
+        ToolExecutionPlane::Orchestration => "Orchestration",
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn tool_governance_scope_as_str(value: ToolGovernanceScope) -> &'static str {
+    match value {
+        ToolGovernanceScope::Routine => "Routine",
+        ToolGovernanceScope::TopologyMutation => "TopologyMutation",
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn tool_risk_class_as_str(value: ToolRiskClass) -> &'static str {
+    match value {
+        ToolRiskClass::Low => "Low",
+        ToolRiskClass::Elevated => "Elevated",
+        ToolRiskClass::High => "High",
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_tool_execution_plane(value: &str) -> Result<ToolExecutionPlane, String> {
+    match value {
+        "Core" => Ok(ToolExecutionPlane::Core),
+        "App" => Ok(ToolExecutionPlane::App),
+        "Orchestration" => Ok(ToolExecutionPlane::Orchestration),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown execution_plane `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_tool_governance_scope(value: &str) -> Result<ToolGovernanceScope, String> {
+    match value {
+        "Routine" => Ok(ToolGovernanceScope::Routine),
+        "TopologyMutation" => Ok(ToolGovernanceScope::TopologyMutation),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown governance_scope `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_tool_risk_class(value: &str) -> Result<ToolRiskClass, String> {
+    match value {
+        "Low" => Ok(ToolRiskClass::Low),
+        "Elevated" => Ok(ToolRiskClass::Elevated),
+        "High" => Ok(ToolRiskClass::High),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown risk_class `{value}`"
+        )),
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1970,6 +2176,43 @@ mod tests {
             }),
         })
         .expect("seed approval request");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn seed_request_with_governance(
+        repo: &SessionRepository,
+        approval_request_id: &str,
+        session_id: &str,
+        tool_name: &str,
+        rule_id: &str,
+        execution_plane: &str,
+        governance_scope: &str,
+        risk_class: &str,
+    ) {
+        repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id: approval_request_id.to_owned(),
+            session_id: session_id.to_owned(),
+            turn_id: format!("turn-{approval_request_id}"),
+            tool_call_id: format!("call-{approval_request_id}"),
+            tool_name: tool_name.to_owned(),
+            approval_key: format!("tool:{tool_name}"),
+            request_payload_json: json!({
+                "session_id": session_id,
+                "tool_name": tool_name,
+                "args_json": {
+                    "task": format!("run-{approval_request_id}")
+                },
+            }),
+            governance_snapshot_json: json!({
+                "reason": format!("approval required for {tool_name}"),
+                "rule_id": rule_id,
+                "execution_plane": execution_plane,
+                "governance_scope": governance_scope,
+                "risk_class": risk_class,
+                "approval_mode": "PolicyDriven",
+            }),
+        })
+        .expect("seed approval request with governance");
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -3554,6 +3797,131 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
+    fn approval_request_tool_query_list_filters_and_summarizes_by_governance_dimensions() {
+        let config = isolated_memory_config("approval-query-list-governance-summary");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        seed_request_with_governance(
+            &repo,
+            "apr-governance-high",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+            "Orchestration",
+            "TopologyMutation",
+            "High",
+        );
+        seed_request_with_governance(
+            &repo,
+            "apr-governance-elevated",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+            "App",
+            "Routine",
+            "Elevated",
+        );
+        seed_request_with_governance(
+            &repo,
+            "apr-governance-low",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+            "App",
+            "Routine",
+            "Low",
+        );
+
+        let summary_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for governance summary");
+
+        let governance_summary = &summary_outcome.payload["governance_summary"];
+        assert_eq!(governance_summary["execution_plane_counts"]["App"], 2);
+        assert_eq!(
+            governance_summary["execution_plane_counts"]["Orchestration"],
+            1
+        );
+        assert_eq!(governance_summary["governance_scope_counts"]["Routine"], 2);
+        assert_eq!(
+            governance_summary["governance_scope_counts"]["TopologyMutation"],
+            1
+        );
+        assert_eq!(governance_summary["risk_class_counts"]["Low"], 1);
+        assert_eq!(governance_summary["risk_class_counts"]["Elevated"], 1);
+        assert_eq!(governance_summary["risk_class_counts"]["High"], 1);
+
+        let orchestration_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "execution_plane": "Orchestration",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for execution_plane filter");
+
+        assert_eq!(
+            orchestration_outcome.payload["filter"]["execution_plane"],
+            "Orchestration"
+        );
+        assert_eq!(orchestration_outcome.payload["matched_count"], 1);
+        let orchestration_requests = orchestration_outcome.payload["requests"]
+            .as_array()
+            .expect("orchestration requests array");
+        assert_eq!(orchestration_requests.len(), 1);
+        assert_eq!(
+            orchestration_requests[0]["approval_request_id"],
+            "apr-governance-high"
+        );
+        assert_eq!(
+            orchestration_requests[0]["execution_plane"],
+            "Orchestration"
+        );
+
+        let high_risk_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "risk_class": "High",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for risk_class filter");
+
+        assert_eq!(high_risk_outcome.payload["filter"]["risk_class"], "High");
+        assert_eq!(high_risk_outcome.payload["matched_count"], 1);
+        let high_risk_requests = high_risk_outcome.payload["requests"]
+            .as_array()
+            .expect("high risk requests array");
+        assert_eq!(high_risk_requests.len(), 1);
+        assert_eq!(
+            high_risk_requests[0]["approval_request_id"],
+            "apr-governance-high"
+        );
+        assert_eq!(high_risk_requests[0]["risk_class"], "High");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
     fn approval_request_tool_query_list_surfaces_integrity_summary_counts() {
         let config = isolated_memory_config("approval-query-list-integrity-summary");
         let repo = SessionRepository::new(&config).expect("repository");
@@ -3945,6 +4313,58 @@ mod tests {
         assert!(
             error.contains("approval_requests_list_invalid_request: unknown pending_age_bucket"),
             "expected pending_age_bucket validation error, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_execution_plane() {
+        let config = isolated_memory_config("approval-query-list-invalid-execution-plane");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "execution_plane": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("unknown execution_plane should be rejected");
+
+        assert!(
+            error.contains("approval_requests_list_invalid_request: unknown execution_plane"),
+            "expected execution_plane validation error, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_risk_class() {
+        let config = isolated_memory_config("approval-query-list-invalid-risk-class");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "risk_class": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("unknown risk_class should be rejected");
+
+        assert!(
+            error.contains("approval_requests_list_invalid_request: unknown risk_class"),
+            "expected risk_class validation error, got: {error}"
         );
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "memory-sqlite")]
-use std::collections::BTreeMap;
+use std::{cmp::Ordering, collections::BTreeMap};
 
 use async_trait::async_trait;
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
@@ -29,6 +29,7 @@ const APPROVAL_ATTENTION_STALE_MAX_SECONDS: i64 = 4 * 60 * 60;
 struct ApprovalRequestsListRequest {
     session_id: Option<String>,
     status: Option<ApprovalRequestStatus>,
+    pending_age_bucket: Option<ApprovalAttentionAgeBucket>,
     tool_name: Option<String>,
     approval_key: Option<String>,
     rule_id: Option<String>,
@@ -40,6 +41,7 @@ struct ApprovalRequestsListRequest {
     recommended_action: Option<ApprovalRecommendedAction>,
     attention_age_bucket: Option<ApprovalAttentionAgeBucket>,
     escalation_level: Option<ApprovalEscalationLevel>,
+    prioritize_pending: bool,
     prioritize_attention: bool,
     limit: usize,
 }
@@ -362,6 +364,11 @@ fn execute_approval_requests_list(
         request_summaries
             .retain(|item| item.get("rule_id").and_then(Value::as_str) == Some(rule_id));
     }
+    if let Some(pending_age_bucket) = request.pending_age_bucket {
+        request_summaries.retain(|item| {
+            approval_request_pending_age_bucket_from_json(item) == Some(pending_age_bucket)
+        });
+    }
     if let Some(replay_result) = request.replay_result {
         request_summaries
             .retain(|item| approval_request_replay_result_from_json(item) == Some(replay_result));
@@ -402,20 +409,36 @@ fn execute_approval_requests_list(
                 == Some(escalation_level)
         });
     }
-    if request.prioritize_attention {
+    if request.prioritize_pending || request.prioritize_attention {
         request_summaries.sort_by(|left, right| {
-            approval_request_escalation_priority(left)
-                .cmp(&approval_request_escalation_priority(right))
-                .then_with(|| {
-                    approval_request_attention_priority(left)
-                        .cmp(&approval_request_attention_priority(right))
-                })
+            let mut ordering = Ordering::Equal;
+            if request.prioritize_pending {
+                ordering = approval_request_pending_priority(left)
+                    .cmp(&approval_request_pending_priority(right))
+                    .then_with(|| {
+                        approval_request_pending_age_seconds(right)
+                            .cmp(&approval_request_pending_age_seconds(left))
+                    });
+            }
+            if request.prioritize_attention {
+                ordering = ordering
+                    .then_with(|| {
+                        approval_request_escalation_priority(left)
+                            .cmp(&approval_request_escalation_priority(right))
+                    })
+                    .then_with(|| {
+                        approval_request_attention_priority(left)
+                            .cmp(&approval_request_attention_priority(right))
+                    });
+            }
+            ordering
                 .then_with(|| {
                     approval_request_requested_at(right).cmp(&approval_request_requested_at(left))
                 })
                 .then_with(|| approval_request_id(left).cmp(approval_request_id(right)))
         });
     }
+    let pending_summary = approval_request_list_pending_summary_json(&request_summaries);
     let integrity_summary = approval_request_list_integrity_summary_json(&request_summaries);
     let resolution_summary = approval_request_list_resolution_summary_json(&request_summaries);
     let correlation_summary = approval_request_list_correlation_summary_json(&request_summaries);
@@ -430,6 +453,7 @@ fn execute_approval_requests_list(
             "filter": {
                 "session_id": request.session_id,
                 "status": request.status.map(ApprovalRequestStatus::as_str),
+                "pending_age_bucket": request.pending_age_bucket.map(ApprovalAttentionAgeBucket::as_str),
                 "tool_name": request.tool_name,
                 "approval_key": request.approval_key,
                 "rule_id": request.rule_id,
@@ -441,12 +465,14 @@ fn execute_approval_requests_list(
                 "recommended_action": request.recommended_action.map(ApprovalRecommendedAction::as_str),
                 "attention_age_bucket": request.attention_age_bucket.map(ApprovalAttentionAgeBucket::as_str),
                 "escalation_level": request.escalation_level.map(ApprovalEscalationLevel::as_str),
+                "prioritize_pending": request.prioritize_pending,
                 "prioritize_attention": request.prioritize_attention,
                 "limit": request.limit,
             },
             "visible_session_ids": target_session_ids,
             "matched_count": matched_count,
             "returned_count": returned_count,
+            "pending_summary": pending_summary,
             "integrity_summary": integrity_summary,
             "resolution_summary": resolution_summary,
             "correlation_summary": correlation_summary,
@@ -545,6 +571,7 @@ fn approval_request_summary_json_with_evidence(
 ) -> Value {
     let resolution =
         approval_request_resolution_json(record, &execution_evidence, &execution_integrity);
+    let pending_queue = approval_request_pending_queue_json(record);
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -567,9 +594,76 @@ fn approval_request_summary_json_with_evidence(
             .governance_snapshot_json
             .get("rule_id")
             .and_then(Value::as_str),
+        "pending_queue": pending_queue,
         "resolution": resolution,
         "execution_evidence": execution_evidence,
         "execution_integrity": execution_integrity,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_pending_queue_json(record: &ApprovalRequestRecord) -> Value {
+    let awaiting_decision = matches!(record.status, ApprovalRequestStatus::Pending);
+    let age_seconds = if awaiting_decision {
+        Some((approval_unix_ts_now() - record.requested_at).max(0))
+    } else {
+        None
+    };
+    let age_bucket = approval_request_attention_age_bucket(age_seconds);
+
+    json!({
+        "awaiting_decision": awaiting_decision,
+        "age_seconds": age_seconds,
+        "age_bucket": age_bucket.map(ApprovalAttentionAgeBucket::as_str),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_list_pending_summary_json(requests: &[Value]) -> Value {
+    let mut pending_count = 0usize;
+    let mut counts_by_age_bucket = BTreeMap::from([
+        ("fresh".to_owned(), 0usize),
+        ("stale".to_owned(), 0usize),
+        ("overdue".to_owned(), 0usize),
+    ]);
+    let mut oldest_pending_requested_at: Option<i64> = None;
+    let mut oldest_pending_age_seconds: Option<i64> = None;
+
+    for request in requests {
+        let pending_queue = request.get("pending_queue").unwrap_or(&Value::Null);
+        if pending_queue
+            .get("awaiting_decision")
+            .and_then(Value::as_bool)
+            != Some(true)
+        {
+            continue;
+        }
+        pending_count += 1;
+        if let Some(age_bucket) = pending_queue.get("age_bucket").and_then(Value::as_str) {
+            *counts_by_age_bucket
+                .entry(age_bucket.to_owned())
+                .or_default() += 1;
+        }
+        let requested_at = approval_request_requested_at(request);
+        oldest_pending_requested_at = Some(
+            oldest_pending_requested_at
+                .map(|current| current.min(requested_at))
+                .unwrap_or(requested_at),
+        );
+        if let Some(age_seconds) = pending_queue.get("age_seconds").and_then(Value::as_i64) {
+            oldest_pending_age_seconds = Some(
+                oldest_pending_age_seconds
+                    .map(|current| current.max(age_seconds))
+                    .unwrap_or(age_seconds),
+            );
+        }
+    }
+
+    json!({
+        "pending_count": pending_count,
+        "counts_by_age_bucket": counts_by_age_bucket,
+        "oldest_pending_requested_at": oldest_pending_requested_at,
+        "oldest_pending_age_seconds": oldest_pending_age_seconds,
     })
 }
 
@@ -755,6 +849,7 @@ fn approval_request_detail_json_with_evidence(
 ) -> Value {
     let resolution =
         approval_request_resolution_json(record, &execution_evidence, &execution_integrity);
+    let pending_queue = approval_request_pending_queue_json(record);
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -771,6 +866,7 @@ fn approval_request_detail_json_with_evidence(
         "last_error": record.last_error,
         "request_payload": record.request_payload_json,
         "governance_snapshot": record.governance_snapshot_json,
+        "pending_queue": pending_queue,
         "resolution": resolution,
         "execution_evidence": execution_evidence,
         "execution_integrity": execution_integrity,
@@ -1288,6 +1384,44 @@ fn approval_request_requested_at(request: &Value) -> i64 {
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_pending_age_seconds(request: &Value) -> i64 {
+    request
+        .get("pending_queue")
+        .and_then(|value| value.get("age_seconds"))
+        .and_then(Value::as_i64)
+        .unwrap_or_default()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_pending_age_bucket_from_json(
+    request: &Value,
+) -> Option<ApprovalAttentionAgeBucket> {
+    request
+        .get("pending_queue")
+        .and_then(|value| value.get("age_bucket"))
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_pending_age_bucket(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_pending_priority(request: &Value) -> usize {
+    let pending_queue = request.get("pending_queue").unwrap_or(&Value::Null);
+    if pending_queue
+        .get("awaiting_decision")
+        .and_then(Value::as_bool)
+        != Some(true)
+    {
+        return 3;
+    }
+    match approval_request_pending_age_bucket_from_json(request) {
+        Some(ApprovalAttentionAgeBucket::Overdue) => 0,
+        Some(ApprovalAttentionAgeBucket::Stale) => 1,
+        Some(ApprovalAttentionAgeBucket::Fresh) => 2,
+        None => 2,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_unix_ts_now() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -1311,6 +1445,10 @@ fn parse_approval_requests_list_request(
     Ok(ApprovalRequestsListRequest {
         session_id: optional_payload_string(payload, "session_id"),
         status: optional_payload_approval_request_status(payload, "status")?,
+        pending_age_bucket: optional_payload_approval_pending_age_bucket(
+            payload,
+            "pending_age_bucket",
+        )?,
         tool_name: optional_payload_string(payload, "tool_name"),
         approval_key: optional_payload_string(payload, "approval_key"),
         rule_id: optional_payload_string(payload, "rule_id"),
@@ -1331,6 +1469,10 @@ fn parse_approval_requests_list_request(
             "attention_age_bucket",
         )?,
         escalation_level: optional_payload_approval_escalation_level(payload, "escalation_level")?,
+        prioritize_pending: payload
+            .get("prioritize_pending")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
         prioritize_attention: payload
             .get("prioritize_attention")
             .and_then(Value::as_bool)
@@ -1435,6 +1577,16 @@ fn optional_payload_approval_execution_integrity_status(
 ) -> Result<Option<ApprovalExecutionIntegrityStatus>, String> {
     optional_payload_string(payload, field)
         .map(|value| parse_approval_execution_integrity_status(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_pending_age_bucket(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalAttentionAgeBucket>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_pending_age_bucket(value.as_str()))
         .transpose()
 }
 
@@ -1550,6 +1702,18 @@ fn parse_approval_replay_result(value: &str) -> Result<ApprovalReplayResult, Str
         "completed_with_attention" => Ok(ApprovalReplayResult::CompletedWithAttention),
         _ => Err(format!(
             "approval_requests_list_invalid_request: unknown replay_result `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_pending_age_bucket(value: &str) -> Result<ApprovalAttentionAgeBucket, String> {
+    match value {
+        "fresh" => Ok(ApprovalAttentionAgeBucket::Fresh),
+        "stale" => Ok(ApprovalAttentionAgeBucket::Stale),
+        "overdue" => Ok(ApprovalAttentionAgeBucket::Overdue),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown pending_age_bucket `{value}`"
         )),
     }
 }
@@ -2978,6 +3142,134 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
+    fn approval_request_tool_query_list_prioritizes_pending_queue_and_summarizes_age() {
+        let config = isolated_memory_config("approval-query-list-pending-priority");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-pending-fresh",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-pending-stale",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-pending-overdue",
+            "root-session",
+            "shell.exec",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-pending-executed",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        transition_request_status(
+            &repo,
+            "apr-pending-executed",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            None,
+        );
+
+        let now = test_unix_ts_now();
+        overwrite_request_requested_at(&config, "apr-pending-fresh", now - 60);
+        overwrite_request_requested_at(&config, "apr-pending-stale", now - 7_200);
+        overwrite_request_requested_at(&config, "apr-pending-overdue", now - 172_800);
+        overwrite_request_requested_at(&config, "apr-pending-executed", now - 30);
+
+        let prioritized_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "prioritize_pending": true,
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list prioritized pending outcome");
+
+        assert_eq!(
+            prioritized_outcome.payload["filter"]["prioritize_pending"],
+            true
+        );
+        let requests = prioritized_outcome.payload["requests"]
+            .as_array()
+            .expect("pending-priority requests array");
+        assert_eq!(requests.len(), 4);
+        assert_eq!(requests[0]["approval_request_id"], "apr-pending-overdue");
+        assert_eq!(requests[0]["pending_queue"]["age_bucket"], "overdue");
+        assert_eq!(requests[1]["approval_request_id"], "apr-pending-stale");
+        assert_eq!(requests[1]["pending_queue"]["age_bucket"], "stale");
+        assert_eq!(requests[2]["approval_request_id"], "apr-pending-fresh");
+        assert_eq!(requests[2]["pending_queue"]["age_bucket"], "fresh");
+        assert_eq!(requests[3]["approval_request_id"], "apr-pending-executed");
+        assert_eq!(requests[3]["pending_queue"]["awaiting_decision"], false);
+        assert_eq!(requests[3]["pending_queue"]["age_seconds"], Value::Null);
+        assert_eq!(requests[3]["pending_queue"]["age_bucket"], Value::Null);
+
+        let pending_summary = &prioritized_outcome.payload["pending_summary"];
+        assert_eq!(pending_summary["pending_count"], 3);
+        assert_eq!(pending_summary["counts_by_age_bucket"]["fresh"], 1);
+        assert_eq!(pending_summary["counts_by_age_bucket"]["stale"], 1);
+        assert_eq!(pending_summary["counts_by_age_bucket"]["overdue"], 1);
+        assert_eq!(
+            pending_summary["oldest_pending_requested_at"],
+            now - 172_800
+        );
+        assert!(
+            pending_summary["oldest_pending_age_seconds"]
+                .as_i64()
+                .expect("oldest pending age seconds")
+                >= 172_800
+        );
+
+        let stale_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "pending_age_bucket": "stale",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list stale pending age outcome");
+
+        assert_eq!(
+            stale_outcome.payload["filter"]["pending_age_bucket"],
+            "stale"
+        );
+        assert_eq!(stale_outcome.payload["matched_count"], 1);
+        let stale_requests = stale_outcome.payload["requests"]
+            .as_array()
+            .expect("stale pending requests array");
+        assert_eq!(stale_requests.len(), 1);
+        assert_eq!(
+            stale_requests[0]["approval_request_id"],
+            "apr-pending-stale"
+        );
+        assert_eq!(stale_requests[0]["pending_queue"]["age_bucket"], "stale");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
     fn approval_request_tool_query_list_surfaces_integrity_summary_counts() {
         let config = isolated_memory_config("approval-query-list-integrity-summary");
         let repo = SessionRepository::new(&config).expect("repository");
@@ -3343,6 +3635,32 @@ mod tests {
         assert!(
             error.contains("approval_requests_list_invalid_request: unknown recommended_action"),
             "expected recommended_action validation error, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_pending_age_bucket() {
+        let config = isolated_memory_config("approval-query-list-invalid-pending-age-bucket");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "pending_age_bucket": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("unknown pending_age_bucket should be rejected");
+
+        assert!(
+            error.contains("approval_requests_list_invalid_request: unknown pending_age_bucket"),
+            "expected pending_age_bucket validation error, got: {error}"
         );
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -43,6 +43,7 @@ struct ApprovalRequestsListRequest {
     governance_scope: Option<ToolGovernanceScope>,
     risk_class: Option<ToolRiskClass>,
     grant_audit_status: Option<ApprovalGrantAuditStatus>,
+    grant_review_age_bucket: Option<ApprovalAttentionAgeBucket>,
     grant_state: Option<ApprovalGrantState>,
     grant_scope_session_id: Option<String>,
     grant_created_by_session_id: Option<String>,
@@ -433,6 +434,12 @@ fn execute_approval_requests_list(
             approval_request_grant_audit_status_from_json(item) == Some(grant_audit_status)
         });
     }
+    if let Some(grant_review_age_bucket) = request.grant_review_age_bucket {
+        request_summaries.retain(|item| {
+            approval_request_grant_review_age_bucket_from_json(item)
+                == Some(grant_review_age_bucket)
+        });
+    }
     if let Some(grant_state) = request.grant_state {
         request_summaries
             .retain(|item| approval_request_grant_state_from_json(item) == Some(grant_state));
@@ -559,6 +566,7 @@ fn execute_approval_requests_list(
                 "governance_scope": request.governance_scope.map(tool_governance_scope_as_str),
                 "risk_class": request.risk_class.map(tool_risk_class_as_str),
                 "grant_audit_status": request.grant_audit_status.map(ApprovalGrantAuditStatus::as_str),
+                "grant_review_age_bucket": request.grant_review_age_bucket.map(ApprovalAttentionAgeBucket::as_str),
                 "grant_state": request.grant_state.map(ApprovalGrantState::as_str),
                 "grant_scope_session_id": request.grant_scope_session_id,
                 "grant_created_by_session_id": request.grant_created_by_session_id,
@@ -1879,6 +1887,17 @@ fn approval_request_grant_audit_status_from_json(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_review_age_bucket_from_json(
+    request: &Value,
+) -> Option<ApprovalAttentionAgeBucket> {
+    request
+        .get("grant_review")
+        .and_then(|value| value.get("age_bucket"))
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_grant_review_age_bucket(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_resolved_by_session_id_from_json(request: &Value) -> Option<&str> {
     request.get("resolved_by_session_id").and_then(Value::as_str)
 }
@@ -2145,6 +2164,10 @@ fn parse_approval_requests_list_request(
             payload,
             "grant_audit_status",
         )?,
+        grant_review_age_bucket: optional_payload_approval_grant_review_age_bucket(
+            payload,
+            "grant_review_age_bucket",
+        )?,
         grant_state: optional_payload_approval_grant_state(payload, "grant_state")?,
         grant_scope_session_id: optional_payload_string(payload, "grant_scope_session_id"),
         grant_created_by_session_id: optional_payload_string(
@@ -2317,6 +2340,16 @@ fn optional_payload_approval_grant_audit_status(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_grant_review_age_bucket(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalAttentionAgeBucket>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_grant_review_age_bucket(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn optional_payload_approval_grant_state(
     payload: &Value,
     field: &str,
@@ -2485,6 +2518,20 @@ fn parse_approval_grant_audit_status(value: &str) -> Result<ApprovalGrantAuditSt
         "not_applicable" => Ok(ApprovalGrantAuditStatus::NotApplicable),
         _ => Err(format!(
             "approval_requests_list_invalid_request: unknown grant_audit_status `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_grant_review_age_bucket(
+    value: &str,
+) -> Result<ApprovalAttentionAgeBucket, String> {
+    match value {
+        "fresh" => Ok(ApprovalAttentionAgeBucket::Fresh),
+        "stale" => Ok(ApprovalAttentionAgeBucket::Stale),
+        "overdue" => Ok(ApprovalAttentionAgeBucket::Overdue),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown grant_review_age_bucket `{value}`"
         )),
     }
 }
@@ -5725,6 +5772,152 @@ mod tests {
         assert_eq!(
             error,
             "approval_requests_list_invalid_request: unknown grant_audit_status `broken`"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_filters_by_grant_review_age_bucket() {
+        let config = isolated_memory_config("approval-query-list-grant-review-filter");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        seed_request(
+            &repo,
+            "apr-grant-review-filter-fresh",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-review-filter-overdue",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-review-filter-absent",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:delegate_async",
+            Some("operator-fresh"),
+        );
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:session_cancel",
+            Some("operator-overdue"),
+        );
+
+        let now = test_unix_ts_now();
+        overwrite_runtime_grant_timestamps(
+            &config,
+            "root-session",
+            "tool:delegate_async",
+            now - (60 * 60) - 60,
+            now - (60 * 60),
+        );
+        overwrite_runtime_grant_timestamps(
+            &config,
+            "root-session",
+            "tool:session_cancel",
+            now - (9 * 24 * 60 * 60) - 60,
+            now - (9 * 24 * 60 * 60),
+        );
+
+        let overdue_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_review_age_bucket": "overdue",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for overdue grant-review filter");
+
+        assert_eq!(overdue_outcome.payload["matched_count"], 1);
+        assert_eq!(overdue_outcome.payload["returned_count"], 1);
+        assert_eq!(
+            overdue_outcome.payload["filter"]["grant_review_age_bucket"],
+            "overdue"
+        );
+        let requests = overdue_outcome.payload["requests"]
+            .as_array()
+            .expect("grant-review filtered requests");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0]["approval_request_id"],
+            "apr-grant-review-filter-overdue"
+        );
+        assert_eq!(requests[0]["grant_review"]["age_bucket"], "overdue");
+
+        let fresh_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_review_age_bucket": "fresh",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for fresh grant-review filter");
+
+        assert_eq!(fresh_outcome.payload["matched_count"], 1);
+        let requests = fresh_outcome.payload["requests"]
+            .as_array()
+            .expect("grant-review filtered requests");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0]["approval_request_id"],
+            "apr-grant-review-filter-fresh"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_grant_review_age_bucket() {
+        let config = isolated_memory_config("approval-query-list-invalid-grant-review-bucket");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-invalid-grant-review-bucket",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_review_age_bucket": "ancient",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("grant_review_age_bucket should reject unknown values");
+
+        assert_eq!(
+            error,
+            "approval_requests_list_invalid_request: unknown grant_review_age_bucket `ancient`"
         );
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -19,6 +19,10 @@ use crate::KernelContext;
 const APPROVAL_REQUEST_EVIDENCE_EVENT_LIMIT: usize = 64;
 #[cfg(feature = "memory-sqlite")]
 const APPROVAL_REQUEST_EVIDENCE_EVENT_BUDGET_PER_RETURNED_REQUEST: usize = 4;
+#[cfg(feature = "memory-sqlite")]
+const APPROVAL_ATTENTION_FRESH_MAX_SECONDS: i64 = 15 * 60;
+#[cfg(feature = "memory-sqlite")]
+const APPROVAL_ATTENTION_STALE_MAX_SECONDS: i64 = 4 * 60 * 60;
 
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,6 +33,8 @@ struct ApprovalRequestsListRequest {
     needs_attention: Option<bool>,
     attention_reason: Option<ApprovalAttentionReason>,
     recommended_action: Option<ApprovalRecommendedAction>,
+    attention_age_bucket: Option<ApprovalAttentionAgeBucket>,
+    escalation_level: Option<ApprovalEscalationLevel>,
     prioritize_attention: bool,
     limit: usize,
 }
@@ -88,6 +94,42 @@ impl ApprovalRecommendedAction {
             Self::InspectReplayPersistence => "inspect_replay_persistence",
             Self::InspectToolExecutionFailure => "inspect_tool_execution_failure",
             Self::InspectApprovalIntegrity => "inspect_approval_integrity",
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalAttentionAgeBucket {
+    Fresh,
+    Stale,
+    Overdue,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl ApprovalAttentionAgeBucket {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Fresh => "fresh",
+            Self::Stale => "stale",
+            Self::Overdue => "overdue",
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalEscalationLevel {
+    Elevated,
+    Critical,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl ApprovalEscalationLevel {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Elevated => "elevated",
+            Self::Critical => "critical",
         }
     }
 }
@@ -300,10 +342,28 @@ fn execute_approval_requests_list(
                 == Some(recommended_action)
         });
     }
+    if let Some(attention_age_bucket) = request.attention_age_bucket {
+        request_summaries.retain(|item| {
+            item.get("execution_integrity")
+                .and_then(approval_request_attention_age_bucket_from_json)
+                == Some(attention_age_bucket)
+        });
+    }
+    if let Some(escalation_level) = request.escalation_level {
+        request_summaries.retain(|item| {
+            item.get("execution_integrity")
+                .and_then(approval_request_escalation_level_from_json)
+                == Some(escalation_level)
+        });
+    }
     if request.prioritize_attention {
         request_summaries.sort_by(|left, right| {
-            approval_request_attention_priority(left)
-                .cmp(&approval_request_attention_priority(right))
+            approval_request_escalation_priority(left)
+                .cmp(&approval_request_escalation_priority(right))
+                .then_with(|| {
+                    approval_request_attention_priority(left)
+                        .cmp(&approval_request_attention_priority(right))
+                })
                 .then_with(|| {
                     approval_request_requested_at(right).cmp(&approval_request_requested_at(left))
                 })
@@ -326,6 +386,8 @@ fn execute_approval_requests_list(
                 "needs_attention": request.needs_attention,
                 "attention_reason": request.attention_reason.map(ApprovalAttentionReason::as_str),
                 "recommended_action": request.recommended_action.map(ApprovalRecommendedAction::as_str),
+                "attention_age_bucket": request.attention_age_bucket.map(ApprovalAttentionAgeBucket::as_str),
+                "escalation_level": request.escalation_level.map(ApprovalEscalationLevel::as_str),
                 "prioritize_attention": request.prioritize_attention,
                 "limit": request.limit,
             },
@@ -467,6 +529,15 @@ fn approval_request_list_integrity_summary_json(requests: &[Value]) -> Value {
         ("inspect_tool_execution_failure".to_owned(), 0usize),
         ("inspect_approval_integrity".to_owned(), 0usize),
     ]);
+    let mut age_bucket_counts = BTreeMap::from([
+        ("fresh".to_owned(), 0usize),
+        ("stale".to_owned(), 0usize),
+        ("overdue".to_owned(), 0usize),
+    ]);
+    let mut counts_by_escalation = BTreeMap::from([
+        ("elevated".to_owned(), 0usize),
+        ("critical".to_owned(), 0usize),
+    ]);
 
     for request in requests {
         let execution_integrity = request.get("execution_integrity").unwrap_or(&Value::Null);
@@ -502,6 +573,20 @@ fn approval_request_list_integrity_summary_json(requests: &[Value]) -> Value {
                     .entry(action.to_owned())
                     .or_default() += 1;
             }
+            if let Some(age_bucket) = execution_integrity
+                .get("attention_age_bucket")
+                .and_then(Value::as_str)
+            {
+                *age_bucket_counts.entry(age_bucket.to_owned()).or_default() += 1;
+            }
+            if let Some(escalation) = execution_integrity
+                .get("escalation_level")
+                .and_then(Value::as_str)
+            {
+                *counts_by_escalation
+                    .entry(escalation.to_owned())
+                    .or_default() += 1;
+            }
         }
     }
 
@@ -512,6 +597,8 @@ fn approval_request_list_integrity_summary_json(requests: &[Value]) -> Value {
             "needs_attention_count": needs_attention_count,
             "counts_by_reason": counts_by_reason,
             "recommended_action_counts": recommended_action_counts,
+            "age_bucket_counts": age_bucket_counts,
+            "counts_by_escalation": counts_by_escalation,
         },
     })
 }
@@ -712,7 +799,15 @@ fn approval_request_execution_integrity_json(
             (false, Value::Null)
         };
     let recommended_action =
-        approval_request_recommended_action_json(status, gap.as_str(), execution_error.is_null());
+        approval_request_recommended_action(status, gap.as_str(), execution_error.is_null());
+    let attention_age_seconds = if needs_attention {
+        Some((approval_unix_ts_now() - record.requested_at).max(0))
+    } else {
+        None
+    };
+    let attention_age_bucket = approval_request_attention_age_bucket(attention_age_seconds);
+    let escalation_level =
+        approval_request_escalation_level(attention_age_bucket, recommended_action);
 
     json!({
         "status": status.as_str(),
@@ -722,7 +817,10 @@ fn approval_request_execution_integrity_json(
         "evidence_complete": evidence_complete,
         "needs_attention": needs_attention,
         "attention_reason": attention_reason,
-        "recommended_action": recommended_action,
+        "recommended_action": recommended_action.map(ApprovalRecommendedAction::as_str),
+        "attention_age_seconds": attention_age_seconds,
+        "attention_age_bucket": attention_age_bucket.map(ApprovalAttentionAgeBucket::as_str),
+        "escalation_level": escalation_level.map(ApprovalEscalationLevel::as_str),
     })
 }
 
@@ -846,39 +944,27 @@ fn approval_request_attention_reason_from_json(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn approval_request_recommended_action_json(
+fn approval_request_recommended_action(
     status: ApprovalExecutionIntegrityStatus,
     gap: Option<&str>,
     execution_error_is_null: bool,
-) -> Value {
+) -> Option<ApprovalRecommendedAction> {
     match status {
-        ApprovalExecutionIntegrityStatus::Incomplete => match gap {
+        ApprovalExecutionIntegrityStatus::Incomplete => Some(match gap {
             Some("started_event_missing")
             | Some("terminal_event_missing")
-            | Some("execution_events_missing") => Value::String(
+            | Some("execution_events_missing") => {
                 ApprovalRecommendedAction::InspectExecutionEventStream
-                    .as_str()
-                    .to_owned(),
-            ),
+            }
             Some("replay_decision_and_outcome_missing")
             | Some("replay_decision_missing")
-            | Some("replay_outcome_missing") => Value::String(
-                ApprovalRecommendedAction::InspectReplayPersistence
-                    .as_str()
-                    .to_owned(),
-            ),
-            Some(_) | None => Value::String(
-                ApprovalRecommendedAction::InspectApprovalIntegrity
-                    .as_str()
-                    .to_owned(),
-            ),
-        },
-        ApprovalExecutionIntegrityStatus::Complete if !execution_error_is_null => Value::String(
-            ApprovalRecommendedAction::InspectToolExecutionFailure
-                .as_str()
-                .to_owned(),
-        ),
-        _ => Value::Null,
+            | Some("replay_outcome_missing") => ApprovalRecommendedAction::InspectReplayPersistence,
+            Some(_) | None => ApprovalRecommendedAction::InspectApprovalIntegrity,
+        }),
+        ApprovalExecutionIntegrityStatus::Complete if !execution_error_is_null => {
+            Some(ApprovalRecommendedAction::InspectToolExecutionFailure)
+        }
+        _ => None,
     }
 }
 
@@ -890,6 +976,58 @@ fn approval_request_recommended_action_from_json(
         .get("recommended_action")
         .and_then(Value::as_str)
         .and_then(|value| parse_approval_recommended_action(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_attention_age_bucket_from_json(
+    execution_integrity: &Value,
+) -> Option<ApprovalAttentionAgeBucket> {
+    execution_integrity
+        .get("attention_age_bucket")
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_attention_age_bucket(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_escalation_level_from_json(
+    execution_integrity: &Value,
+) -> Option<ApprovalEscalationLevel> {
+    execution_integrity
+        .get("escalation_level")
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_escalation_level(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_attention_age_bucket(
+    attention_age_seconds: Option<i64>,
+) -> Option<ApprovalAttentionAgeBucket> {
+    let attention_age_seconds = attention_age_seconds?;
+    if attention_age_seconds < APPROVAL_ATTENTION_FRESH_MAX_SECONDS {
+        Some(ApprovalAttentionAgeBucket::Fresh)
+    } else if attention_age_seconds < APPROVAL_ATTENTION_STALE_MAX_SECONDS {
+        Some(ApprovalAttentionAgeBucket::Stale)
+    } else {
+        Some(ApprovalAttentionAgeBucket::Overdue)
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_escalation_level(
+    attention_age_bucket: Option<ApprovalAttentionAgeBucket>,
+    recommended_action: Option<ApprovalRecommendedAction>,
+) -> Option<ApprovalEscalationLevel> {
+    let attention_age_bucket = attention_age_bucket?;
+    if matches!(attention_age_bucket, ApprovalAttentionAgeBucket::Overdue)
+        || matches!(
+            recommended_action,
+            Some(ApprovalRecommendedAction::InspectExecutionEventStream)
+        )
+    {
+        Some(ApprovalEscalationLevel::Critical)
+    } else {
+        Some(ApprovalEscalationLevel::Elevated)
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -913,11 +1051,31 @@ fn approval_request_attention_priority(request: &Value) -> u8 {
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_escalation_priority(request: &Value) -> u8 {
+    match request
+        .get("execution_integrity")
+        .and_then(approval_request_escalation_level_from_json)
+    {
+        Some(ApprovalEscalationLevel::Critical) => 0,
+        Some(ApprovalEscalationLevel::Elevated) => 1,
+        None => 2,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_requested_at(request: &Value) -> i64 {
     request
         .get("requested_at")
         .and_then(Value::as_i64)
         .unwrap_or(i64::MIN)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_unix_ts_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or_default()
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -946,6 +1104,11 @@ fn parse_approval_requests_list_request(
             payload,
             "recommended_action",
         )?,
+        attention_age_bucket: optional_payload_approval_attention_age_bucket(
+            payload,
+            "attention_age_bucket",
+        )?,
+        escalation_level: optional_payload_approval_escalation_level(payload, "escalation_level")?,
         prioritize_attention: payload
             .get("prioritize_attention")
             .and_then(Value::as_bool)
@@ -1074,6 +1237,26 @@ fn optional_payload_approval_recommended_action(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_attention_age_bucket(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalAttentionAgeBucket>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_attention_age_bucket(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_escalation_level(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalEscalationLevel>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_escalation_level(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn parse_approval_request_status(value: &str) -> Result<ApprovalRequestStatus, String> {
     match value {
         "pending" => Ok(ApprovalRequestStatus::Pending),
@@ -1133,6 +1316,29 @@ fn parse_approval_recommended_action(value: &str) -> Result<ApprovalRecommendedA
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn parse_approval_attention_age_bucket(value: &str) -> Result<ApprovalAttentionAgeBucket, String> {
+    match value {
+        "fresh" => Ok(ApprovalAttentionAgeBucket::Fresh),
+        "stale" => Ok(ApprovalAttentionAgeBucket::Stale),
+        "overdue" => Ok(ApprovalAttentionAgeBucket::Overdue),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown attention_age_bucket `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_escalation_level(value: &str) -> Result<ApprovalEscalationLevel, String> {
+    match value {
+        "elevated" => Ok(ApprovalEscalationLevel::Elevated),
+        "critical" => Ok(ApprovalEscalationLevel::Critical),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown escalation_level `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn parse_approval_decision(value: &str) -> Result<ApprovalDecision, String> {
     match value {
         "approve_once" => Ok(ApprovalDecision::ApproveOnce),
@@ -1147,8 +1353,10 @@ fn parse_approval_decision(value: &str) -> Result<ApprovalDecision, String> {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use loongclaw_contracts::ToolCoreRequest;
+    use rusqlite::params;
     use serde_json::json;
     use serde_json::Value;
 
@@ -1244,6 +1452,36 @@ mod tests {
     }
 
     #[cfg(feature = "memory-sqlite")]
+    fn test_unix_ts_now() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs() as i64)
+            .unwrap_or_default()
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn overwrite_request_requested_at(
+        config: &MemoryRuntimeConfig,
+        approval_request_id: &str,
+        requested_at: i64,
+    ) {
+        let db_path = config
+            .sqlite_path
+            .as_ref()
+            .expect("sqlite path should be configured");
+        let conn = rusqlite::Connection::open(db_path).expect("open sqlite db");
+        let affected = conn
+            .execute(
+                "UPDATE approval_requests
+                 SET requested_at = ?2
+                 WHERE approval_request_id = ?1",
+                params![approval_request_id, requested_at],
+            )
+            .expect("overwrite approval request requested_at");
+        assert_eq!(affected, 1, "expected to update one approval request row");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
     #[test]
     fn approval_request_tool_query_list_returns_only_visible_requests() {
         let config = isolated_memory_config("approval-query-list-visible");
@@ -1329,6 +1567,18 @@ mod tests {
             root_request["execution_integrity"]["recommended_action"],
             Value::Null
         );
+        assert_eq!(
+            root_request["execution_integrity"]["attention_age_seconds"],
+            Value::Null
+        );
+        assert_eq!(
+            root_request["execution_integrity"]["attention_age_bucket"],
+            Value::Null
+        );
+        assert_eq!(
+            root_request["execution_integrity"]["escalation_level"],
+            Value::Null
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1402,6 +1652,9 @@ mod tests {
         assert_eq!(integrity["needs_attention"], false);
         assert_eq!(integrity["attention_reason"], Value::Null);
         assert_eq!(integrity["recommended_action"], Value::Null);
+        assert_eq!(integrity["attention_age_seconds"], Value::Null);
+        assert_eq!(integrity["attention_age_bucket"], Value::Null);
+        assert_eq!(integrity["escalation_level"], Value::Null);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1733,6 +1986,9 @@ mod tests {
             }),
         })
         .expect("append in-progress started event");
+        let now = test_unix_ts_now();
+        overwrite_request_requested_at(&config, "apr-attention-integrity-gap", now - 7_200);
+        overwrite_request_requested_at(&config, "apr-attention-execution-failed", now - 300);
 
         let needs_attention_outcome = crate::tools::execute_app_tool_with_config(
             ToolCoreRequest {
@@ -1833,6 +2089,69 @@ mod tests {
             replay_persistence_requests[0]["execution_integrity"]["recommended_action"],
             "inspect_replay_persistence"
         );
+
+        let stale_age_bucket_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "attention_age_bucket": "stale",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for attention_age_bucket");
+
+        assert_eq!(
+            stale_age_bucket_outcome.payload["filter"]["attention_age_bucket"],
+            "stale"
+        );
+        assert_eq!(stale_age_bucket_outcome.payload["matched_count"], 1);
+        assert_eq!(stale_age_bucket_outcome.payload["returned_count"], 1);
+        let stale_age_bucket_requests = stale_age_bucket_outcome.payload["requests"]
+            .as_array()
+            .expect("attention_age_bucket requests array");
+        assert_eq!(stale_age_bucket_requests.len(), 1);
+        assert_eq!(
+            stale_age_bucket_requests[0]["approval_request_id"],
+            "apr-attention-integrity-gap"
+        );
+        assert_eq!(
+            stale_age_bucket_requests[0]["execution_integrity"]["attention_age_bucket"],
+            "stale"
+        );
+
+        let elevated_escalation_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "escalation_level": "elevated",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for escalation_level");
+
+        assert_eq!(
+            elevated_escalation_outcome.payload["filter"]["escalation_level"],
+            "elevated"
+        );
+        assert_eq!(elevated_escalation_outcome.payload["matched_count"], 2);
+        assert_eq!(elevated_escalation_outcome.payload["returned_count"], 2);
+        let elevated_escalation_requests = elevated_escalation_outcome.payload["requests"]
+            .as_array()
+            .expect("escalation_level requests array");
+        let elevated_escalation_ids = elevated_escalation_requests
+            .iter()
+            .filter_map(|item| item["approval_request_id"].as_str())
+            .collect::<Vec<_>>();
+        assert!(elevated_escalation_ids.contains(&"apr-attention-integrity-gap"));
+        assert!(elevated_escalation_ids.contains(&"apr-attention-execution-failed"));
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1869,6 +2188,13 @@ mod tests {
             "session_cancel",
             "governed_tool_requires_per_call_approval",
         );
+        seed_request(
+            &repo,
+            "apr-priority-missing-events",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
 
         transition_request_status(
             &repo,
@@ -1890,6 +2216,13 @@ mod tests {
             ApprovalRequestStatus::Pending,
             ApprovalRequestStatus::Executed,
             Some("tool failed for domain reasons"),
+        );
+        transition_request_status(
+            &repo,
+            "apr-priority-missing-events",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("approval request executed without persisted execution events"),
         );
 
         repo.append_event(crate::session::repository::NewSessionEvent {
@@ -1961,6 +2294,10 @@ mod tests {
             }),
         })
         .expect("append execution-failed terminal event");
+        let now = test_unix_ts_now();
+        overwrite_request_requested_at(&config, "apr-priority-integrity-gap", now - 7_200);
+        overwrite_request_requested_at(&config, "apr-priority-execution-failed", now - 300);
+        overwrite_request_requested_at(&config, "apr-priority-missing-events", now - 172_800);
 
         let outcome = crate::tools::execute_app_tool_with_config(
             ToolCoreRequest {
@@ -1980,25 +2317,41 @@ mod tests {
         let requests = outcome.payload["requests"]
             .as_array()
             .expect("requests array");
-        assert_eq!(requests.len(), 4);
+        assert_eq!(requests.len(), 5);
         assert_eq!(
             requests[0]["approval_request_id"],
-            "apr-priority-integrity-gap"
+            "apr-priority-missing-events"
         );
         assert_eq!(
-            requests[0]["execution_integrity"]["attention_reason"],
-            "integrity_gap"
+            requests[0]["execution_integrity"]["escalation_level"],
+            "critical"
         );
         assert_eq!(
             requests[1]["approval_request_id"],
-            "apr-priority-execution-failed"
+            "apr-priority-integrity-gap"
         );
         assert_eq!(
             requests[1]["execution_integrity"]["attention_reason"],
+            "integrity_gap"
+        );
+        assert_eq!(
+            requests[1]["execution_integrity"]["escalation_level"],
+            "elevated"
+        );
+        assert_eq!(
+            requests[2]["approval_request_id"],
+            "apr-priority-execution-failed"
+        );
+        assert_eq!(
+            requests[2]["execution_integrity"]["attention_reason"],
             "execution_failed"
         );
-        assert_eq!(requests[2]["execution_integrity"]["needs_attention"], false);
+        assert_eq!(
+            requests[2]["execution_integrity"]["escalation_level"],
+            "elevated"
+        );
         assert_eq!(requests[3]["execution_integrity"]["needs_attention"], false);
+        assert_eq!(requests[4]["execution_integrity"]["needs_attention"], false);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -2166,6 +2519,10 @@ mod tests {
             }),
         })
         .expect("append execution-failed terminal event");
+        let now = test_unix_ts_now();
+        overwrite_request_requested_at(&config, "apr-summary-incomplete", now - 7_200);
+        overwrite_request_requested_at(&config, "apr-summary-execution-failed", now - 300);
+        overwrite_request_requested_at(&config, "apr-summary-missing-events", now - 172_800);
 
         let outcome = crate::tools::execute_app_tool_with_config(
             ToolCoreRequest {
@@ -2214,6 +2571,26 @@ mod tests {
         assert_eq!(
             summary["attention_summary"]["recommended_action_counts"]
                 ["inspect_tool_execution_failure"],
+            1
+        );
+        assert_eq!(
+            summary["attention_summary"]["age_bucket_counts"]["fresh"],
+            1
+        );
+        assert_eq!(
+            summary["attention_summary"]["age_bucket_counts"]["stale"],
+            1
+        );
+        assert_eq!(
+            summary["attention_summary"]["age_bucket_counts"]["overdue"],
+            1
+        );
+        assert_eq!(
+            summary["attention_summary"]["counts_by_escalation"]["elevated"],
+            2
+        );
+        assert_eq!(
+            summary["attention_summary"]["counts_by_escalation"]["critical"],
             1
         );
     }
@@ -2267,6 +2644,58 @@ mod tests {
         assert!(
             error.contains("approval_requests_list_invalid_request: unknown recommended_action"),
             "expected recommended_action validation error, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_attention_age_bucket() {
+        let config = isolated_memory_config("approval-query-list-invalid-attention-age-bucket");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "attention_age_bucket": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("unknown attention_age_bucket should be rejected");
+
+        assert!(
+            error.contains("approval_requests_list_invalid_request: unknown attention_age_bucket"),
+            "expected attention_age_bucket validation error, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_escalation_level() {
+        let config = isolated_memory_config("approval-query-list-invalid-escalation-level");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "escalation_level": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("unknown escalation_level should be rejected");
+
+        assert!(
+            error.contains("approval_requests_list_invalid_request: unknown escalation_level"),
+            "expected escalation_level validation error, got: {error}"
         );
     }
 
@@ -2364,6 +2793,18 @@ mod tests {
             request["execution_integrity"]["recommended_action"],
             Value::Null
         );
+        assert_eq!(
+            request["execution_integrity"]["attention_age_seconds"],
+            Value::Null
+        );
+        assert_eq!(
+            request["execution_integrity"]["attention_age_bucket"],
+            Value::Null
+        );
+        assert_eq!(
+            request["execution_integrity"]["escalation_level"],
+            Value::Null
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -2402,6 +2843,8 @@ mod tests {
             }),
         })
         .expect("append finished event");
+        let now = test_unix_ts_now();
+        overwrite_request_requested_at(&config, "apr-visible-evidence", now - 7_200);
 
         let outcome = crate::tools::execute_app_tool_with_config(
             ToolCoreRequest {
@@ -2441,6 +2884,14 @@ mod tests {
             "inspect_replay_persistence"
         );
         assert!(
+            integrity["attention_age_seconds"]
+                .as_i64()
+                .is_some_and(|value| value >= 7_200),
+            "expected stale attention age in integrity payload, got: {integrity}"
+        );
+        assert_eq!(integrity["attention_age_bucket"], "stale");
+        assert_eq!(integrity["escalation_level"], "elevated");
+        assert!(
             integrity["integrity_error"]
                 .as_str()
                 .is_some_and(|error| error.contains("persist assistant turn via kernel failed")),
@@ -2469,6 +2920,8 @@ mod tests {
             ApprovalRequestStatus::Executed,
             Some("approval request executed without persisted execution events"),
         );
+        let now = test_unix_ts_now();
+        overwrite_request_requested_at(&config, "apr-visible-missing-events", now - 172_800);
 
         let outcome = crate::tools::execute_app_tool_with_config(
             ToolCoreRequest {
@@ -2490,6 +2943,14 @@ mod tests {
             integrity["recommended_action"],
             "inspect_execution_event_stream"
         );
+        assert!(
+            integrity["attention_age_seconds"]
+                .as_i64()
+                .is_some_and(|value| value >= 172_800),
+            "expected overdue attention age in integrity payload, got: {integrity}"
+        );
+        assert_eq!(integrity["attention_age_bucket"], "overdue");
+        assert_eq!(integrity["escalation_level"], "critical");
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -2528,6 +2989,8 @@ mod tests {
             }),
         })
         .expect("append failed event");
+        let now = test_unix_ts_now();
+        overwrite_request_requested_at(&config, "apr-visible-execution-failure", now - 300);
 
         let outcome = crate::tools::execute_app_tool_with_config(
             ToolCoreRequest {
@@ -2556,6 +3019,14 @@ mod tests {
             integrity["recommended_action"],
             "inspect_tool_execution_failure"
         );
+        assert!(
+            integrity["attention_age_seconds"]
+                .as_i64()
+                .is_some_and(|value| value >= 300),
+            "expected fresh attention age in integrity payload, got: {integrity}"
+        );
+        assert_eq!(integrity["attention_age_bucket"], "fresh");
+        assert_eq!(integrity["escalation_level"], "elevated");
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -238,6 +238,23 @@ impl ApprovalEscalationLevel {
 
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalAttentionSource {
+    Execution,
+    Grant,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl ApprovalAttentionSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Execution => "execution",
+            Self::Grant => "grant",
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ApprovalReplayResult {
     NotAttempted,
     InProgress,
@@ -502,8 +519,7 @@ fn execute_approval_requests_list(
     }
     if let Some(grant_escalation_level) = request.grant_escalation_level {
         request_summaries.retain(|item| {
-            approval_request_grant_escalation_level_from_json(item)
-                == Some(grant_escalation_level)
+            approval_request_grant_escalation_level_from_json(item) == Some(grant_escalation_level)
         });
     }
     if let Some(grant_state) = request.grant_state {
@@ -512,8 +528,7 @@ fn execute_approval_requests_list(
     }
     if let Some(grant_scope_session_id) = request.grant_scope_session_id.as_deref() {
         request_summaries.retain(|item| {
-            approval_request_grant_scope_session_id_from_json(item)
-                == Some(grant_scope_session_id)
+            approval_request_grant_scope_session_id_from_json(item) == Some(grant_scope_session_id)
         });
     }
     if let Some(grant_created_by_session_id) = request.grant_created_by_session_id.as_deref() {
@@ -769,6 +784,7 @@ fn approval_request_summary_json_with_evidence(
     let grant_audit = approval_request_grant_audit_json(record, &grant);
     let grant_review = approval_request_grant_review_json(&grant);
     let grant_attention = approval_request_grant_attention_json(&grant_audit, &grant_review);
+    let attention = approval_request_attention_json(&execution_integrity, &grant_attention);
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -807,6 +823,7 @@ fn approval_request_summary_json_with_evidence(
         "grant_audit": grant_audit,
         "grant_review": grant_review,
         "grant_attention": grant_attention,
+        "attention": attention,
         "pending_queue": pending_queue,
         "resolution": resolution,
         "execution_evidence": execution_evidence,
@@ -855,7 +872,8 @@ fn approval_request_grant_review_json(grant: &Value) -> Value {
     let reviewable = grant.get("state").and_then(Value::as_str) == Some("present");
     let last_changed_at = if reviewable {
         grant.get("updated_at").and_then(Value::as_i64).or_else(|| {
-            grant.get("created_at")
+            grant
+                .get("created_at")
                 .and_then(Value::as_i64)
                 .filter(|value| *value > 0)
         })
@@ -888,12 +906,11 @@ fn approval_request_grant_attention_json(grant_audit: &Value, grant_review: &Val
                 None,
                 Some(ApprovalEscalationLevel::Critical),
             ),
-            _
-                if grant_review.get("reviewable").and_then(Value::as_bool) == Some(true)
-                    && matches!(
-                        grant_review_age_bucket,
-                        Some(ApprovalAttentionAgeBucket::Overdue)
-                    ) =>
+            _ if grant_review.get("reviewable").and_then(Value::as_bool) == Some(true)
+                && matches!(
+                    grant_review_age_bucket,
+                    Some(ApprovalAttentionAgeBucket::Overdue)
+                ) =>
             {
                 (
                     true,
@@ -912,6 +929,147 @@ fn approval_request_grant_attention_json(grant_audit: &Value, grant_review: &Val
         "recommended_action": recommended_action.map(ApprovalGrantRecommendedAction::as_str),
         "age_bucket": age_bucket.map(ApprovalAttentionAgeBucket::as_str),
         "escalation_level": escalation_level.map(ApprovalEscalationLevel::as_str),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_execution_attention_signal_json(execution_integrity: &Value) -> Option<Value> {
+    if execution_integrity
+        .get("needs_attention")
+        .and_then(Value::as_bool)
+        != Some(true)
+    {
+        return None;
+    }
+
+    Some(json!({
+        "source": ApprovalAttentionSource::Execution.as_str(),
+        "reason": execution_integrity
+            .get("attention_reason")
+            .cloned()
+            .unwrap_or(Value::Null),
+        "recommended_action": execution_integrity
+            .get("recommended_action")
+            .cloned()
+            .unwrap_or(Value::Null),
+        "age_bucket": execution_integrity
+            .get("attention_age_bucket")
+            .cloned()
+            .unwrap_or(Value::Null),
+        "escalation_level": execution_integrity
+            .get("escalation_level")
+            .cloned()
+            .unwrap_or(Value::Null),
+    }))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_attention_signal_json(grant_attention: &Value) -> Option<Value> {
+    if grant_attention
+        .get("needs_attention")
+        .and_then(Value::as_bool)
+        != Some(true)
+    {
+        return None;
+    }
+
+    Some(json!({
+        "source": ApprovalAttentionSource::Grant.as_str(),
+        "reason": grant_attention
+            .get("attention_reason")
+            .cloned()
+            .unwrap_or(Value::Null),
+        "recommended_action": grant_attention
+            .get("recommended_action")
+            .cloned()
+            .unwrap_or(Value::Null),
+        "age_bucket": grant_attention
+            .get("age_bucket")
+            .cloned()
+            .unwrap_or(Value::Null),
+        "escalation_level": grant_attention
+            .get("escalation_level")
+            .cloned()
+            .unwrap_or(Value::Null),
+    }))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_attention_signals_json(
+    execution_integrity: &Value,
+    grant_attention: &Value,
+) -> Vec<Value> {
+    let mut signals = Vec::new();
+    if let Some(signal) = approval_request_execution_attention_signal_json(execution_integrity) {
+        signals.push(signal);
+    }
+    if let Some(signal) = approval_request_grant_attention_signal_json(grant_attention) {
+        signals.push(signal);
+    }
+    signals
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_attention_signal_escalation_level(
+    signal: &Value,
+) -> Option<ApprovalEscalationLevel> {
+    signal
+        .get("escalation_level")
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_escalation_level(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_attention_signal_reason_priority(signal: &Value) -> u8 {
+    match (
+        signal.get("source").and_then(Value::as_str),
+        signal.get("reason").and_then(Value::as_str),
+    ) {
+        (Some("execution"), Some("integrity_gap"))
+        | (Some("grant"), Some("durable_grant_missing")) => 0,
+        (Some("execution"), Some("execution_failed"))
+        | (Some("grant"), Some("grant_review_overdue")) => 1,
+        _ => 2,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_attention_signal_escalation_priority(signal: &Value) -> u8 {
+    match approval_request_attention_signal_escalation_level(signal) {
+        Some(ApprovalEscalationLevel::Critical) => 0,
+        Some(ApprovalEscalationLevel::Elevated) => 1,
+        None => 2,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_highest_attention_escalation_level(
+    signals: &[Value],
+) -> Option<ApprovalEscalationLevel> {
+    signals
+        .iter()
+        .filter_map(approval_request_attention_signal_escalation_level)
+        .min_by_key(|level| match level {
+            ApprovalEscalationLevel::Critical => 0u8,
+            ApprovalEscalationLevel::Elevated => 1u8,
+        })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_attention_json(execution_integrity: &Value, grant_attention: &Value) -> Value {
+    let signals = approval_request_attention_signals_json(execution_integrity, grant_attention);
+    let sources = signals
+        .iter()
+        .filter_map(|signal| signal.get("source").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+
+    json!({
+        "needs_attention": !signals.is_empty(),
+        "signal_count": signals.len(),
+        "sources": sources,
+        "highest_escalation_level": approval_request_highest_attention_escalation_level(&signals)
+            .map(ApprovalEscalationLevel::as_str),
+        "signals": signals,
     })
 }
 
@@ -1106,84 +1264,60 @@ fn approval_request_list_attention_summary_json(requests: &[Value]) -> Value {
     ]);
 
     for request in requests {
-        let execution_attention = request.get("execution_integrity").unwrap_or(&Value::Null);
-        let grant_attention = request.get("grant_attention").unwrap_or(&Value::Null);
-        let has_execution_attention = approval_request_has_execution_attention(request);
-        let has_grant_attention = approval_request_has_grant_attention(request);
-        if !(has_execution_attention || has_grant_attention) {
+        let attention = request.get("attention").unwrap_or(&Value::Null);
+        if attention.get("needs_attention").and_then(Value::as_bool) != Some(true) {
             continue;
         }
 
         needs_attention_count += 1;
-        match (has_execution_attention, has_grant_attention) {
-            (true, true) => {
-                *request_counts_by_source.entry("both".to_owned()).or_default() += 1;
+        let mut has_execution_attention = false;
+        let mut has_grant_attention = false;
+        for source in attention
+            .get("sources")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+        {
+            match source {
+                "execution" => has_execution_attention = true,
+                "grant" => has_grant_attention = true,
+                _ => {}
             }
-            (true, false) => {
-                *request_counts_by_source
-                    .entry("execution_only".to_owned())
-                    .or_default() += 1;
-            }
-            (false, true) => {
-                *request_counts_by_source
-                    .entry("grant_only".to_owned())
-                    .or_default() += 1;
-            }
-            (false, false) => {}
+        }
+        if has_execution_attention && has_grant_attention {
+            *request_counts_by_source
+                .entry("both".to_owned())
+                .or_default() += 1;
+        } else if has_execution_attention {
+            *request_counts_by_source
+                .entry("execution_only".to_owned())
+                .or_default() += 1;
+        } else if has_grant_attention {
+            *request_counts_by_source
+                .entry("grant_only".to_owned())
+                .or_default() += 1;
         }
 
-        if has_execution_attention {
+        for signal in attention
+            .get("signals")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
             signal_count += 1;
-            if let Some(reason) = execution_attention
-                .get("attention_reason")
-                .and_then(Value::as_str)
-            {
+            if let Some(reason) = signal.get("reason").and_then(Value::as_str) {
                 *counts_by_reason.entry(reason.to_owned()).or_default() += 1;
             }
-            if let Some(action) = execution_attention
-                .get("recommended_action")
-                .and_then(Value::as_str)
-            {
+            if let Some(action) = signal.get("recommended_action").and_then(Value::as_str) {
                 *recommended_action_counts
                     .entry(action.to_owned())
                     .or_default() += 1;
             }
-            if let Some(age_bucket) = execution_attention
-                .get("attention_age_bucket")
-                .and_then(Value::as_str)
-            {
+            if let Some(age_bucket) = signal.get("age_bucket").and_then(Value::as_str) {
                 *age_bucket_counts.entry(age_bucket.to_owned()).or_default() += 1;
             }
-            if let Some(escalation) = execution_attention
-                .get("escalation_level")
-                .and_then(Value::as_str)
-            {
-                *counts_by_escalation
-                    .entry(escalation.to_owned())
-                    .or_default() += 1;
-            }
-        }
-
-        if has_grant_attention {
-            signal_count += 1;
-            if let Some(reason) = grant_attention.get("attention_reason").and_then(Value::as_str) {
-                *counts_by_reason.entry(reason.to_owned()).or_default() += 1;
-            }
-            if let Some(action) = grant_attention
-                .get("recommended_action")
-                .and_then(Value::as_str)
-            {
-                *recommended_action_counts
-                    .entry(action.to_owned())
-                    .or_default() += 1;
-            }
-            if let Some(age_bucket) = grant_attention.get("age_bucket").and_then(Value::as_str) {
-                *age_bucket_counts.entry(age_bucket.to_owned()).or_default() += 1;
-            }
-            if let Some(escalation) = grant_attention
-                .get("escalation_level")
-                .and_then(Value::as_str)
-            {
+            if let Some(escalation) = signal.get("escalation_level").and_then(Value::as_str) {
                 *counts_by_escalation
                     .entry(escalation.to_owned())
                     .or_default() += 1;
@@ -1247,7 +1381,9 @@ fn approval_request_list_resolution_summary_json(requests: &[Value]) -> Value {
                 .entry(replay_result.to_owned())
                 .or_default() += 1;
         }
-        if let Some(resolved_by_session_id) = request.get("resolved_by_session_id").and_then(Value::as_str)
+        if let Some(resolved_by_session_id) = request
+            .get("resolved_by_session_id")
+            .and_then(Value::as_str)
         {
             *resolved_by_session_counts
                 .entry(resolved_by_session_id.to_owned())
@@ -1408,7 +1544,9 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
             reviewable_count += 1;
         }
         if let Some(age_bucket) = grant_review.get("age_bucket").and_then(Value::as_str) {
-            *counts_by_age_bucket.entry(age_bucket.to_owned()).or_default() += 1;
+            *counts_by_age_bucket
+                .entry(age_bucket.to_owned())
+                .or_default() += 1;
         }
         if let Some(age_seconds) = grant_review.get("age_seconds").and_then(Value::as_i64) {
             let is_older = oldest_reviewable_age_seconds
@@ -1416,9 +1554,8 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
                 .unwrap_or(true);
             if is_older {
                 oldest_reviewable_age_seconds = Some(age_seconds);
-                oldest_reviewable_last_changed_at = grant_review
-                    .get("last_changed_at")
-                    .and_then(Value::as_i64);
+                oldest_reviewable_last_changed_at =
+                    grant_review.get("last_changed_at").and_then(Value::as_i64);
             }
         }
         let grant_attention = request.get("grant_attention").unwrap_or(&Value::Null);
@@ -1428,14 +1565,21 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
             == Some(true)
         {
             attention_count += 1;
-            if let Some(reason) = grant_attention.get("attention_reason").and_then(Value::as_str) {
-                *attention_reason_counts.entry(reason.to_owned()).or_default() += 1;
+            if let Some(reason) = grant_attention
+                .get("attention_reason")
+                .and_then(Value::as_str)
+            {
+                *attention_reason_counts
+                    .entry(reason.to_owned())
+                    .or_default() += 1;
             }
             if let Some(action) = grant_attention
                 .get("recommended_action")
                 .and_then(Value::as_str)
             {
-                *attention_action_counts.entry(action.to_owned()).or_default() += 1;
+                *attention_action_counts
+                    .entry(action.to_owned())
+                    .or_default() += 1;
             }
             if let Some(age_bucket) = grant_attention.get("age_bucket").and_then(Value::as_str) {
                 *attention_age_bucket_counts
@@ -1713,6 +1857,7 @@ fn approval_request_detail_json_with_evidence(
     let grant_audit = approval_request_grant_audit_json(record, &grant);
     let grant_review = approval_request_grant_review_json(&grant);
     let grant_attention = approval_request_grant_attention_json(&grant_audit, &grant_review);
+    let attention = approval_request_attention_json(&execution_integrity, &grant_attention);
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -1745,6 +1890,7 @@ fn approval_request_detail_json_with_evidence(
         "grant_audit": grant_audit,
         "grant_review": grant_review,
         "grant_attention": grant_attention,
+        "attention": attention,
         "pending_queue": pending_queue,
         "resolution": resolution,
         "execution_evidence": execution_evidence,
@@ -2232,7 +2378,9 @@ fn approval_request_grant_escalation_level_from_json(
 
 #[cfg(feature = "memory-sqlite")]
 fn approval_request_resolved_by_session_id_from_json(request: &Value) -> Option<&str> {
-    request.get("resolved_by_session_id").and_then(Value::as_str)
+    request
+        .get("resolved_by_session_id")
+        .and_then(Value::as_str)
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -2376,7 +2524,24 @@ fn approval_request_escalation_level(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_attention_signal_values(request: &Value) -> Option<&[Value]> {
+    request
+        .get("attention")
+        .and_then(|value| value.get("signals"))
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_attention_priority(request: &Value) -> u8 {
+    if let Some(signals) = approval_request_attention_signal_values(request) {
+        return signals
+            .iter()
+            .map(approval_request_attention_signal_reason_priority)
+            .min()
+            .unwrap_or(3);
+    }
+
     approval_request_execution_attention_priority(request)
         .min(approval_request_grant_attention_priority(request))
 }
@@ -2411,7 +2576,10 @@ fn approval_request_grant_attention_priority(request: &Value) -> u8 {
     {
         return 3;
     }
-    match grant_attention.get("attention_reason").and_then(Value::as_str) {
+    match grant_attention
+        .get("attention_reason")
+        .and_then(Value::as_str)
+    {
         Some("durable_grant_missing") => 0,
         Some("grant_review_overdue") => 1,
         Some(_) | None => 2,
@@ -2420,6 +2588,14 @@ fn approval_request_grant_attention_priority(request: &Value) -> u8 {
 
 #[cfg(feature = "memory-sqlite")]
 fn approval_request_escalation_priority(request: &Value) -> u8 {
+    if let Some(signals) = approval_request_attention_signal_values(request) {
+        return signals
+            .iter()
+            .map(approval_request_attention_signal_escalation_priority)
+            .min()
+            .unwrap_or(2);
+    }
+
     approval_request_execution_escalation_priority(request)
         .min(approval_request_grant_escalation_priority(request))
 }
@@ -2469,7 +2645,14 @@ fn approval_request_has_grant_attention(request: &Value) -> bool {
 
 #[cfg(feature = "memory-sqlite")]
 fn approval_request_has_attention(request: &Value) -> bool {
-    approval_request_has_execution_attention(request) || approval_request_has_grant_attention(request)
+    request
+        .get("attention")
+        .and_then(|value| value.get("needs_attention"))
+        .and_then(Value::as_bool)
+        .unwrap_or_else(|| {
+            approval_request_has_execution_attention(request)
+                || approval_request_has_grant_attention(request)
+        })
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -2566,7 +2749,9 @@ fn parse_approval_requests_list_request(
             payload,
             "grant_review_age_bucket",
         )?,
-        grant_needs_attention: payload.get("grant_needs_attention").and_then(Value::as_bool),
+        grant_needs_attention: payload
+            .get("grant_needs_attention")
+            .and_then(Value::as_bool),
         grant_attention_reason: optional_payload_approval_grant_attention_reason(
             payload,
             "grant_attention_reason",
@@ -3012,9 +3197,7 @@ fn parse_approval_grant_recommended_action(
         "inspect_runtime_grant_persistence" => {
             Ok(ApprovalGrantRecommendedAction::InspectRuntimeGrantPersistence)
         }
-        "review_runtime_grant_scope" => {
-            Ok(ApprovalGrantRecommendedAction::ReviewRuntimeGrantScope)
-        }
+        "review_runtime_grant_scope" => Ok(ApprovalGrantRecommendedAction::ReviewRuntimeGrantScope),
         _ => Err(format!(
             "approval_requests_list_invalid_request: unknown grant_recommended_action `{value}`"
         )),
@@ -3036,9 +3219,7 @@ fn parse_approval_grant_attention_age_bucket(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn parse_approval_grant_escalation_level(
-    value: &str,
-) -> Result<ApprovalEscalationLevel, String> {
+fn parse_approval_grant_escalation_level(value: &str) -> Result<ApprovalEscalationLevel, String> {
     match value {
         "elevated" => Ok(ApprovalEscalationLevel::Elevated),
         "critical" => Ok(ApprovalEscalationLevel::Critical),
@@ -3370,8 +3551,8 @@ mod tests {
                  SET requested_at = ?2
                  WHERE approval_request_id = ?1",
                 params![approval_request_id, requested_at],
-        )
-        .expect("overwrite approval request requested_at");
+            )
+            .expect("overwrite approval request requested_at");
         assert_eq!(affected, 1, "expected to update one approval request row");
     }
 
@@ -4359,7 +4540,302 @@ mod tests {
             no_attention_outcome.payload["requests"][0]["approval_request_id"],
             "apr-operator-attn-clean"
         );
+    }
 
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_surfaces_canonical_attention_view() {
+        let config = isolated_memory_config("approval-query-canonical-attention-view");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        seed_request(
+            &repo,
+            "apr-canonical-attention-execution",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-canonical-attention-grant",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-canonical-attention-both",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        transition_request_status(
+            &repo,
+            "apr-canonical-attention-execution",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("persist assistant turn via kernel failed: forced outcome persistence failure"),
+        );
+        repo.transition_approval_request_if_current(
+            "apr-canonical-attention-grant",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-grant".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition canonical grant request")
+        .expect("canonical grant request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-canonical-attention-both",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Executed,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-both".to_owned()),
+                executed_at: Some(1_773_000_000),
+                last_error: Some("tool failed for domain reasons".to_owned()),
+            },
+        )
+        .expect("transition canonical both request")
+        .expect("canonical both request should transition");
+
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-canonical-attention-execution",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append canonical execution started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-canonical-attention-execution",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": false,
+                "replay_outcome_persist_error": "persist assistant turn via kernel failed: forced outcome persistence failure",
+            }),
+        })
+        .expect("append canonical execution finished event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-canonical-attention-both",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append canonical both started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_failed".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-canonical-attention-both",
+                "error": "tool failed for domain reasons",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append canonical both failed event");
+
+        let now = test_unix_ts_now();
+        overwrite_request_requested_at(&config, "apr-canonical-attention-execution", now - 7_200);
+        overwrite_request_requested_at(&config, "apr-canonical-attention-grant", now - 3_600);
+        overwrite_request_requested_at(&config, "apr-canonical-attention-both", now - 300);
+
+        let list_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for canonical attention view");
+
+        let attention_summary = &list_outcome.payload["attention_summary"];
+        assert_eq!(attention_summary["needs_attention_count"], 3);
+        assert_eq!(attention_summary["signal_count"], 4);
+        assert_eq!(
+            attention_summary["request_counts_by_source"]["execution_only"],
+            1
+        );
+        assert_eq!(
+            attention_summary["request_counts_by_source"]["grant_only"],
+            1
+        );
+        assert_eq!(attention_summary["request_counts_by_source"]["both"], 1);
+        assert_eq!(attention_summary["counts_by_reason"]["integrity_gap"], 1);
+        assert_eq!(attention_summary["counts_by_reason"]["execution_failed"], 1);
+        assert_eq!(
+            attention_summary["counts_by_reason"]["durable_grant_missing"],
+            2
+        );
+        assert_eq!(
+            attention_summary["counts_by_reason"]["grant_review_overdue"],
+            0
+        );
+        assert_eq!(
+            attention_summary["recommended_action_counts"]["inspect_replay_persistence"],
+            1
+        );
+        assert_eq!(
+            attention_summary["recommended_action_counts"]["inspect_tool_execution_failure"],
+            1
+        );
+        assert_eq!(
+            attention_summary["recommended_action_counts"]["inspect_runtime_grant_persistence"],
+            2
+        );
+        assert_eq!(
+            attention_summary["recommended_action_counts"]["review_runtime_grant_scope"],
+            0
+        );
+        assert_eq!(attention_summary["age_bucket_counts"]["fresh"], 1);
+        assert_eq!(attention_summary["age_bucket_counts"]["stale"], 1);
+        assert_eq!(attention_summary["age_bucket_counts"]["overdue"], 0);
+        assert_eq!(attention_summary["counts_by_escalation"]["elevated"], 2);
+        assert_eq!(attention_summary["counts_by_escalation"]["critical"], 2);
+
+        let requests = list_outcome.payload["requests"]
+            .as_array()
+            .expect("canonical attention requests array");
+        let execution_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-canonical-attention-execution")
+            .expect("canonical execution request");
+        assert_eq!(execution_request["attention"]["needs_attention"], true);
+        assert_eq!(execution_request["attention"]["signal_count"], 1);
+        assert_eq!(
+            execution_request["attention"]["highest_escalation_level"],
+            "elevated"
+        );
+        assert_eq!(
+            execution_request["attention"]["sources"],
+            json!(["execution"])
+        );
+        assert_eq!(
+            execution_request["attention"]["signals"][0]["source"],
+            "execution"
+        );
+        assert_eq!(
+            execution_request["attention"]["signals"][0]["reason"],
+            "integrity_gap"
+        );
+        assert_eq!(
+            execution_request["attention"]["signals"][0]["recommended_action"],
+            "inspect_replay_persistence"
+        );
+        assert_eq!(
+            execution_request["attention"]["signals"][0]["age_bucket"],
+            "stale"
+        );
+        assert_eq!(
+            execution_request["attention"]["signals"][0]["escalation_level"],
+            "elevated"
+        );
+
+        let grant_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-canonical-attention-grant")
+            .expect("canonical grant request");
+        assert_eq!(grant_request["attention"]["needs_attention"], true);
+        assert_eq!(grant_request["attention"]["signal_count"], 1);
+        assert_eq!(
+            grant_request["attention"]["highest_escalation_level"],
+            "critical"
+        );
+        assert_eq!(grant_request["attention"]["sources"], json!(["grant"]));
+        assert_eq!(grant_request["attention"]["signals"][0]["source"], "grant");
+        assert_eq!(
+            grant_request["attention"]["signals"][0]["reason"],
+            "durable_grant_missing"
+        );
+        assert_eq!(
+            grant_request["attention"]["signals"][0]["recommended_action"],
+            "inspect_runtime_grant_persistence"
+        );
+        assert_eq!(
+            grant_request["attention"]["signals"][0]["age_bucket"],
+            Value::Null
+        );
+        assert_eq!(
+            grant_request["attention"]["signals"][0]["escalation_level"],
+            "critical"
+        );
+
+        let both_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-canonical-attention-both")
+            .expect("canonical both request");
+        assert_eq!(both_request["attention"]["needs_attention"], true);
+        assert_eq!(both_request["attention"]["signal_count"], 2);
+        assert_eq!(
+            both_request["attention"]["highest_escalation_level"],
+            "critical"
+        );
+        assert_eq!(
+            both_request["attention"]["sources"],
+            json!(["execution", "grant"])
+        );
+        let both_signals = both_request["attention"]["signals"]
+            .as_array()
+            .expect("canonical both signals");
+        assert_eq!(both_signals.len(), 2);
+        assert_eq!(both_signals[0]["source"], "execution");
+        assert_eq!(both_signals[0]["reason"], "execution_failed");
+        assert_eq!(
+            both_signals[0]["recommended_action"],
+            "inspect_tool_execution_failure"
+        );
+        assert_eq!(both_signals[0]["age_bucket"], "fresh");
+        assert_eq!(both_signals[0]["escalation_level"], "elevated");
+        assert_eq!(both_signals[1]["source"], "grant");
+        assert_eq!(both_signals[1]["reason"], "durable_grant_missing");
+        assert_eq!(
+            both_signals[1]["recommended_action"],
+            "inspect_runtime_grant_persistence"
+        );
+        assert_eq!(both_signals[1]["age_bucket"], Value::Null);
+        assert_eq!(both_signals[1]["escalation_level"], "critical");
+
+        let status_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-canonical-attention-both",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome for canonical attention view");
+
+        let status_attention = &status_outcome.payload["approval_request"]["attention"];
+        assert_eq!(status_attention["needs_attention"], true);
+        assert_eq!(status_attention["signal_count"], 2);
+        assert_eq!(status_attention["highest_escalation_level"], "critical");
+        assert_eq!(status_attention["sources"], json!(["execution", "grant"]));
+        assert_eq!(status_attention["signals"][0]["source"], "execution");
+        assert_eq!(status_attention["signals"][1]["source"], "grant");
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -6298,7 +6774,10 @@ mod tests {
             .find(|item| item["approval_request_id"] == "apr-grant-audit-present")
             .expect("present durable grant request");
         assert_eq!(present_request["grant_audit"]["status"], "required_present");
-        assert_eq!(present_request["grant_audit"]["requires_durable_grant"], true);
+        assert_eq!(
+            present_request["grant_audit"]["requires_durable_grant"],
+            true
+        );
         assert_eq!(present_request["grant_audit"]["has_durable_grant"], true);
         assert_eq!(present_request["grant_audit"]["is_consistent"], true);
 
@@ -6307,7 +6786,10 @@ mod tests {
             .find(|item| item["approval_request_id"] == "apr-grant-audit-missing")
             .expect("missing durable grant request");
         assert_eq!(missing_request["grant_audit"]["status"], "required_missing");
-        assert_eq!(missing_request["grant_audit"]["requires_durable_grant"], true);
+        assert_eq!(
+            missing_request["grant_audit"]["requires_durable_grant"],
+            true
+        );
         assert_eq!(missing_request["grant_audit"]["has_durable_grant"], false);
         assert_eq!(missing_request["grant_audit"]["is_consistent"], false);
 
@@ -6470,7 +6952,10 @@ mod tests {
             .find(|item| item["approval_request_id"] == "apr-grant-review-absent")
             .expect("absent review request");
         assert_eq!(absent_request["grant_review"]["reviewable"], false);
-        assert_eq!(absent_request["grant_review"]["last_changed_at"], Value::Null);
+        assert_eq!(
+            absent_request["grant_review"]["last_changed_at"],
+            Value::Null
+        );
         assert_eq!(absent_request["grant_review"]["age_seconds"], Value::Null);
         assert_eq!(absent_request["grant_review"]["age_bucket"], Value::Null);
 
@@ -6490,7 +6975,10 @@ mod tests {
         let request = &status_outcome.payload["approval_request"];
         assert_eq!(request["grant_review"]["reviewable"], true);
         assert_eq!(request["grant_review"]["age_bucket"], "overdue");
-        assert_eq!(request["grant_review"]["last_changed_at"], overdue_updated_at);
+        assert_eq!(
+            request["grant_review"]["last_changed_at"],
+            overdue_updated_at
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -6632,7 +7120,10 @@ mod tests {
             missing_request["grant_attention"]["recommended_action"],
             "inspect_runtime_grant_persistence"
         );
-        assert_eq!(missing_request["grant_attention"]["age_bucket"], Value::Null);
+        assert_eq!(
+            missing_request["grant_attention"]["age_bucket"],
+            Value::Null
+        );
         assert_eq!(
             missing_request["grant_attention"]["escalation_level"],
             "critical"
@@ -6662,13 +7153,19 @@ mod tests {
             .find(|item| item["approval_request_id"] == "apr-grant-attention-once")
             .expect("approve_once grant-attention request");
         assert_eq!(once_request["grant_attention"]["needs_attention"], false);
-        assert_eq!(once_request["grant_attention"]["attention_reason"], Value::Null);
+        assert_eq!(
+            once_request["grant_attention"]["attention_reason"],
+            Value::Null
+        );
         assert_eq!(
             once_request["grant_attention"]["recommended_action"],
             Value::Null
         );
         assert_eq!(once_request["grant_attention"]["age_bucket"], Value::Null);
-        assert_eq!(once_request["grant_attention"]["escalation_level"], Value::Null);
+        assert_eq!(
+            once_request["grant_attention"]["escalation_level"],
+            Value::Null
+        );
 
         let status_outcome = crate::tools::execute_app_tool_with_config(
             ToolCoreRequest {
@@ -6766,11 +7263,13 @@ mod tests {
 
         let grant_summary = &list_outcome.payload["grant_summary"];
         assert_eq!(
-            grant_summary["created_by_approval_key_counts"]["operator-alpha"]["tool:delegate_async"],
+            grant_summary["created_by_approval_key_counts"]["operator-alpha"]
+                ["tool:delegate_async"],
             1
         );
         assert_eq!(
-            grant_summary["created_by_approval_key_counts"]["operator-alpha"]["tool:session_cancel"],
+            grant_summary["created_by_approval_key_counts"]["operator-alpha"]
+                ["tool:session_cancel"],
             1
         );
         assert_eq!(

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "memory-sqlite")]
+use std::collections::BTreeMap;
+
 use async_trait::async_trait;
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{json, Value};
@@ -11,6 +14,11 @@ use crate::session::repository::{
     ApprovalDecision, ApprovalRequestRecord, ApprovalRequestStatus, SessionRepository,
 };
 use crate::KernelContext;
+
+#[cfg(feature = "memory-sqlite")]
+const APPROVAL_REQUEST_EVIDENCE_EVENT_LIMIT: usize = 64;
+#[cfg(feature = "memory-sqlite")]
+const APPROVAL_REQUEST_EVIDENCE_EVENT_BUDGET_PER_RETURNED_REQUEST: usize = 4;
 
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -129,6 +137,7 @@ pub async fn execute_approval_tool_with_runtime_support(
                 execute_approval_request_resolve(
                     request.payload,
                     current_session_id,
+                    config,
                     tool_config,
                     runtime,
                     kernel_ctx,
@@ -181,6 +190,24 @@ fn execute_approval_requests_list(
     let matched_count = requests.len();
     requests.truncate(request.limit);
     let returned_count = requests.len();
+    let recent_events_by_session_id =
+        approval_request_recent_events_by_session_id(&repo, &requests)?;
+    let request_summaries = requests
+        .iter()
+        .map(|record| {
+            let session_events = recent_events_by_session_id
+                .get(&record.session_id)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            approval_request_summary_json_with_evidence(
+                record,
+                approval_request_execution_evidence_json_from_events(
+                    session_events,
+                    &record.approval_request_id,
+                ),
+            )
+        })
+        .collect::<Vec<_>>();
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
@@ -194,10 +221,7 @@ fn execute_approval_requests_list(
             "visible_session_ids": target_session_ids,
             "matched_count": matched_count,
             "returned_count": returned_count,
-            "requests": requests
-                .iter()
-                .map(approval_request_summary_json)
-                .collect::<Vec<_>>(),
+            "requests": request_summaries,
         }),
     })
 }
@@ -225,7 +249,10 @@ fn execute_approval_request_status(
         status: "ok".to_owned(),
         payload: json!({
             "current_session_id": current_session_id,
-            "approval_request": approval_request_detail_json(&request),
+            "approval_request": approval_request_detail_json_with_evidence(
+                &request,
+                approval_request_execution_evidence_json(&repo, &request)?,
+            ),
         }),
     })
 }
@@ -234,6 +261,7 @@ fn execute_approval_request_status(
 async fn execute_approval_request_resolve(
     payload: Value,
     current_session_id: &str,
+    config: &MemoryRuntimeConfig,
     tool_config: &ToolConfig,
     runtime: &(dyn ApprovalResolutionRuntime + '_),
     kernel_ctx: Option<&KernelContext>,
@@ -250,19 +278,26 @@ async fn execute_approval_request_resolve(
             kernel_ctx,
         )
         .await?;
+    let repo = SessionRepository::new(config)?;
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
             "current_session_id": current_session_id,
-            "approval_request": approval_request_detail_json(&outcome.approval_request),
+            "approval_request": approval_request_detail_json_with_evidence(
+                &outcome.approval_request,
+                approval_request_execution_evidence_json(&repo, &outcome.approval_request)?,
+            ),
             "resumed_tool_output": outcome.resumed_tool_output,
         }),
     })
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn approval_request_summary_json(record: &ApprovalRequestRecord) -> Value {
+fn approval_request_summary_json_with_evidence(
+    record: &ApprovalRequestRecord,
+    execution_evidence: Value,
+) -> Value {
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -285,11 +320,15 @@ fn approval_request_summary_json(record: &ApprovalRequestRecord) -> Value {
             .governance_snapshot_json
             .get("rule_id")
             .and_then(Value::as_str),
+        "execution_evidence": execution_evidence,
     })
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn approval_request_detail_json(record: &ApprovalRequestRecord) -> Value {
+fn approval_request_detail_json_with_evidence(
+    record: &ApprovalRequestRecord,
+    execution_evidence: Value,
+) -> Value {
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -306,6 +345,109 @@ fn approval_request_detail_json(record: &ApprovalRequestRecord) -> Value {
         "last_error": record.last_error,
         "request_payload": record.request_payload_json,
         "governance_snapshot": record.governance_snapshot_json,
+        "execution_evidence": execution_evidence,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_execution_evidence_json(
+    repo: &SessionRepository,
+    record: &ApprovalRequestRecord,
+) -> Result<Value, String> {
+    let events =
+        repo.list_recent_events(&record.session_id, APPROVAL_REQUEST_EVIDENCE_EVENT_LIMIT)?;
+    Ok(approval_request_execution_evidence_json_from_events(
+        &events,
+        &record.approval_request_id,
+    ))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_recent_events_by_session_id(
+    repo: &SessionRepository,
+    requests: &[ApprovalRequestRecord],
+) -> Result<BTreeMap<String, Vec<crate::session::repository::SessionEventRecord>>, String> {
+    let mut request_count_by_session_id = BTreeMap::<String, usize>::new();
+    for record in requests {
+        *request_count_by_session_id
+            .entry(record.session_id.clone())
+            .or_default() += 1;
+    }
+
+    let mut events_by_session_id = BTreeMap::new();
+    for (session_id, request_count) in request_count_by_session_id {
+        let event_limit = APPROVAL_REQUEST_EVIDENCE_EVENT_LIMIT.max(
+            request_count
+                .saturating_mul(APPROVAL_REQUEST_EVIDENCE_EVENT_BUDGET_PER_RETURNED_REQUEST),
+        );
+        let events = repo.list_recent_events(&session_id, event_limit)?;
+        events_by_session_id.insert(session_id, events);
+    }
+    Ok(events_by_session_id)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_execution_evidence_json_from_events(
+    events: &[crate::session::repository::SessionEventRecord],
+    approval_request_id: &str,
+) -> Value {
+    let mut started_event: Option<&crate::session::repository::SessionEventRecord> = None;
+    let mut terminal_event: Option<&crate::session::repository::SessionEventRecord> = None;
+
+    for event in events {
+        if event
+            .payload_json
+            .get("approval_request_id")
+            .and_then(Value::as_str)
+            != Some(approval_request_id)
+        {
+            continue;
+        }
+        match event.event_kind.as_str() {
+            "tool_approval_execution_started" => started_event = Some(event),
+            "tool_approval_execution_finished" | "tool_approval_execution_failed" => {
+                terminal_event = Some(event)
+            }
+            _ => {}
+        }
+    }
+
+    let replay_decision_persisted = started_event
+        .and_then(|event| event.payload_json.get("replay_decision_persisted"))
+        .and_then(Value::as_bool);
+    let replay_decision_persist_error = started_event
+        .and_then(|event| event.payload_json.get("replay_decision_persist_error"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let replay_outcome_persisted = terminal_event
+        .and_then(|event| event.payload_json.get("replay_outcome_persisted"))
+        .and_then(Value::as_bool);
+    let replay_outcome_persist_error = terminal_event
+        .and_then(|event| event.payload_json.get("replay_outcome_persist_error"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let execution_error = terminal_event
+        .and_then(|event| event.payload_json.get("error"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let evidence_complete = terminal_event
+        .map(|_| {
+            Value::Bool(
+                replay_decision_persisted.unwrap_or(false)
+                    && replay_outcome_persisted.unwrap_or(false),
+            )
+        })
+        .unwrap_or(Value::Null);
+
+    json!({
+        "started_event_kind": started_event.map(|event| event.event_kind.clone()),
+        "terminal_event_kind": terminal_event.map(|event| event.event_kind.clone()),
+        "replay_decision_persisted": replay_decision_persisted,
+        "replay_decision_persist_error": replay_decision_persist_error,
+        "replay_outcome_persisted": replay_outcome_persisted,
+        "replay_outcome_persist_error": replay_outcome_persist_error,
+        "execution_error": execution_error,
+        "evidence_complete": evidence_complete,
     })
 }
 
@@ -573,6 +715,151 @@ mod tests {
         assert!(request_ids.contains(&"apr-root-visible"));
         assert!(request_ids.contains(&"apr-child-visible"));
         assert!(!request_ids.contains(&"apr-hidden"));
+        let root_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-root-visible")
+            .expect("root visible request");
+        assert_eq!(
+            root_request["execution_evidence"]["terminal_event_kind"],
+            Value::Null
+        );
+        assert_eq!(
+            root_request["execution_evidence"]["evidence_complete"],
+            Value::Null
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_surfaces_execution_evidence() {
+        let config = isolated_memory_config("approval-query-list-evidence");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-list-evidence",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-list-evidence",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-list-evidence",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append finished event");
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({}),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome");
+
+        let requests = outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        let request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-list-evidence")
+            .expect("visible request");
+        let evidence = &request["execution_evidence"];
+        assert_eq!(
+            evidence["terminal_event_kind"],
+            "tool_approval_execution_finished"
+        );
+        assert_eq!(evidence["replay_decision_persisted"], true);
+        assert_eq!(evidence["replay_outcome_persisted"], true);
+        assert_eq!(evidence["evidence_complete"], true);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_scales_execution_evidence_window_for_returned_requests() {
+        let config = isolated_memory_config("approval-query-list-evidence-window");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        for index in 0..40 {
+            let approval_request_id = format!("apr-list-window-{index:02}");
+            seed_request(
+                &repo,
+                &approval_request_id,
+                "root-session",
+                "session_cancel",
+                "governed_tool_requires_per_call_approval",
+            );
+            repo.append_event(crate::session::repository::NewSessionEvent {
+                session_id: "root-session".to_owned(),
+                event_kind: "tool_approval_execution_started".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                payload_json: json!({
+                    "approval_request_id": approval_request_id,
+                    "replay_decision_persisted": true,
+                    "replay_decision_persist_error": null,
+                }),
+            })
+            .expect("append started event");
+            repo.append_event(crate::session::repository::NewSessionEvent {
+                session_id: "root-session".to_owned(),
+                event_kind: "tool_approval_execution_finished".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                payload_json: json!({
+                    "approval_request_id": approval_request_id,
+                    "resumed_tool_status": "ok",
+                    "replay_outcome_persisted": true,
+                    "replay_outcome_persist_error": null,
+                }),
+            })
+            .expect("append finished event");
+        }
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 40,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome");
+
+        let requests = outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        assert_eq!(requests.len(), 40);
+        let complete_evidence_count = requests
+            .iter()
+            .filter(|item| item["execution_evidence"]["evidence_complete"] == Value::Bool(true))
+            .count();
+        assert_eq!(
+            complete_evidence_count, 40,
+            "all returned requests should retain complete execution evidence"
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -623,6 +910,80 @@ mod tests {
         assert_eq!(
             request["request_payload"]["args_json"]["task"],
             "run-apr-child-visible"
+        );
+        assert_eq!(
+            request["execution_evidence"]["terminal_event_kind"],
+            Value::Null
+        );
+        assert_eq!(
+            request["execution_evidence"]["evidence_complete"],
+            Value::Null
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_status_surfaces_execution_evidence() {
+        let config = isolated_memory_config("approval-query-status-evidence");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-visible-evidence",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-visible-evidence",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-visible-evidence",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": false,
+                "replay_outcome_persist_error": "persist assistant turn via kernel failed: forced outcome persistence failure",
+            }),
+        })
+        .expect("append finished event");
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-visible-evidence",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome");
+
+        let evidence = &outcome.payload["approval_request"]["execution_evidence"];
+        assert_eq!(
+            evidence["terminal_event_kind"],
+            "tool_approval_execution_finished"
+        );
+        assert_eq!(evidence["replay_decision_persisted"], true);
+        assert_eq!(evidence["replay_outcome_persisted"], false);
+        assert_eq!(evidence["evidence_complete"], false);
+        assert!(
+            evidence["replay_outcome_persist_error"]
+                .as_str()
+                .is_some_and(|error| error.contains("persist assistant turn via kernel failed")),
+            "expected replay outcome persistence error in evidence, got: {evidence}"
         );
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -660,6 +660,7 @@ fn approval_request_summary_json_with_evidence(
     let resolution =
         approval_request_resolution_json(record, &execution_evidence, &execution_integrity);
     let pending_queue = approval_request_pending_queue_json(record);
+    let grant_audit = approval_request_grant_audit_json(record, &grant);
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -695,6 +696,7 @@ fn approval_request_summary_json_with_evidence(
             .get("rule_id")
             .and_then(Value::as_str),
         "grant": grant,
+        "grant_audit": grant_audit,
         "pending_queue": pending_queue,
         "resolution": resolution,
         "execution_evidence": execution_evidence,
@@ -716,6 +718,25 @@ fn approval_request_pending_queue_json(record: &ApprovalRequestRecord) -> Value 
         "awaiting_decision": awaiting_decision,
         "age_seconds": age_seconds,
         "age_bucket": age_bucket.map(ApprovalAttentionAgeBucket::as_str),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_audit_json(record: &ApprovalRequestRecord, grant: &Value) -> Value {
+    let has_durable_grant = grant.get("state").and_then(Value::as_str) == Some("present");
+    let (status, requires_durable_grant, is_consistent) = match record.decision {
+        Some(ApprovalDecision::ApproveAlways) if has_durable_grant => {
+            ("required_present", true, true)
+        }
+        Some(ApprovalDecision::ApproveAlways) => ("required_missing", true, false),
+        Some(_) | None => ("not_applicable", false, true),
+    };
+
+    json!({
+        "status": status,
+        "requires_durable_grant": requires_durable_grant,
+        "has_durable_grant": has_durable_grant,
+        "is_consistent": is_consistent,
     })
 }
 
@@ -997,6 +1018,11 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
         ("absent".to_owned(), 0usize),
         ("lineage_unresolved".to_owned(), 0usize),
     ]);
+    let mut consistency_counts = BTreeMap::from([
+        ("required_present".to_owned(), 0usize),
+        ("required_missing".to_owned(), 0usize),
+        ("not_applicable".to_owned(), 0usize),
+    ]);
     let mut scope_session_counts = BTreeMap::<String, usize>::new();
     let mut created_by_session_counts = BTreeMap::<String, usize>::new();
 
@@ -1017,10 +1043,18 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
                 .entry(created_by_session_id.to_owned())
                 .or_default() += 1;
         }
+        if let Some(status) = request
+            .get("grant_audit")
+            .and_then(|value| value.get("status"))
+            .and_then(Value::as_str)
+        {
+            *consistency_counts.entry(status.to_owned()).or_default() += 1;
+        }
     }
 
     json!({
         "counts_by_state": counts_by_state,
+        "consistency_counts": consistency_counts,
         "scope_session_counts": scope_session_counts,
         "created_by_session_counts": created_by_session_counts,
     })
@@ -1270,6 +1304,7 @@ fn approval_request_detail_json_with_evidence(
     let resolution =
         approval_request_resolution_json(record, &execution_evidence, &execution_integrity);
     let pending_queue = approval_request_pending_queue_json(record);
+    let grant_audit = approval_request_grant_audit_json(record, &grant);
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -1299,6 +1334,7 @@ fn approval_request_detail_json_with_evidence(
         "request_payload": record.request_payload_json,
         "governance_snapshot": record.governance_snapshot_json,
         "grant": grant,
+        "grant_audit": grant_audit,
         "pending_queue": pending_queue,
         "resolution": resolution,
         "execution_evidence": execution_evidence,
@@ -4959,6 +4995,148 @@ mod tests {
             requests[0]["grant"]["created_by_session_id"],
             "operator-beta"
         );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_surfaces_durable_grant_audit() {
+        let config = isolated_memory_config("approval-query-list-grant-audit");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        seed_request(
+            &repo,
+            "apr-grant-audit-present",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-audit-missing",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-audit-once",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        repo.transition_approval_request_if_current(
+            "apr-grant-audit-present",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-session".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition present durable grant request")
+        .expect("present durable grant request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-grant-audit-missing",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-session".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition missing durable grant request")
+        .expect("missing durable grant request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-grant-audit-once",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Executed,
+                decision: Some(ApprovalDecision::ApproveOnce),
+                resolved_by_session_id: Some("operator-session".to_owned()),
+                executed_at: Some(1_773_000_000),
+                last_error: None,
+            },
+        )
+        .expect("transition approve_once request")
+        .expect("approve_once request should transition");
+
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:delegate_async",
+            Some("operator-session"),
+        );
+
+        let list_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for durable grant audit");
+
+        let grant_summary = &list_outcome.payload["grant_summary"];
+        assert_eq!(grant_summary["consistency_counts"]["required_present"], 1);
+        assert_eq!(grant_summary["consistency_counts"]["required_missing"], 1);
+        assert_eq!(grant_summary["consistency_counts"]["not_applicable"], 1);
+
+        let requests = list_outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        let present_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-grant-audit-present")
+            .expect("present durable grant request");
+        assert_eq!(present_request["grant_audit"]["status"], "required_present");
+        assert_eq!(present_request["grant_audit"]["requires_durable_grant"], true);
+        assert_eq!(present_request["grant_audit"]["has_durable_grant"], true);
+        assert_eq!(present_request["grant_audit"]["is_consistent"], true);
+
+        let missing_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-grant-audit-missing")
+            .expect("missing durable grant request");
+        assert_eq!(missing_request["grant_audit"]["status"], "required_missing");
+        assert_eq!(missing_request["grant_audit"]["requires_durable_grant"], true);
+        assert_eq!(missing_request["grant_audit"]["has_durable_grant"], false);
+        assert_eq!(missing_request["grant_audit"]["is_consistent"], false);
+
+        let once_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-grant-audit-once")
+            .expect("approve_once request");
+        assert_eq!(once_request["grant_audit"]["status"], "not_applicable");
+        assert_eq!(once_request["grant_audit"]["requires_durable_grant"], false);
+        assert_eq!(once_request["grant_audit"]["has_durable_grant"], false);
+        assert_eq!(once_request["grant_audit"]["is_consistent"], true);
+
+        let status_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-grant-audit-present",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome for durable grant audit");
+
+        let request = &status_outcome.payload["approval_request"];
+        assert_eq!(request["grant_audit"]["status"], "required_present");
+        assert_eq!(request["grant_audit"]["is_consistent"], true);
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -371,6 +371,7 @@ fn execute_approval_requests_list(
         });
     }
     let integrity_summary = approval_request_list_integrity_summary_json(&request_summaries);
+    let resolution_summary = approval_request_list_resolution_summary_json(&request_summaries);
     let matched_count = request_summaries.len();
     request_summaries.truncate(request.limit);
     let returned_count = request_summaries.len();
@@ -395,6 +396,7 @@ fn execute_approval_requests_list(
             "matched_count": matched_count,
             "returned_count": returned_count,
             "integrity_summary": integrity_summary,
+            "resolution_summary": resolution_summary,
             "requests": request_summaries,
         }),
     })
@@ -609,6 +611,44 @@ fn approval_request_list_integrity_summary_json(requests: &[Value]) -> Value {
             "age_bucket_counts": age_bucket_counts,
             "counts_by_escalation": counts_by_escalation,
         },
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_list_resolution_summary_json(requests: &[Value]) -> Value {
+    let mut request_status_counts = BTreeMap::from([
+        ("pending".to_owned(), 0usize),
+        ("approved".to_owned(), 0usize),
+        ("executing".to_owned(), 0usize),
+        ("executed".to_owned(), 0usize),
+        ("denied".to_owned(), 0usize),
+        ("expired".to_owned(), 0usize),
+        ("cancelled".to_owned(), 0usize),
+    ]);
+    let mut replay_result_counts = BTreeMap::from([
+        ("not_attempted".to_owned(), 0usize),
+        ("in_progress".to_owned(), 0usize),
+        ("completed_cleanly".to_owned(), 0usize),
+        ("completed_with_attention".to_owned(), 0usize),
+    ]);
+
+    for request in requests {
+        let resolution = request.get("resolution").unwrap_or(&Value::Null);
+        if let Some(request_status) = resolution.get("request_status").and_then(Value::as_str) {
+            *request_status_counts
+                .entry(request_status.to_owned())
+                .or_default() += 1;
+        }
+        if let Some(replay_result) = resolution.get("replay_result").and_then(Value::as_str) {
+            *replay_result_counts
+                .entry(replay_result.to_owned())
+                .or_default() += 1;
+        }
+    }
+
+    json!({
+        "request_status_counts": request_status_counts,
+        "replay_result_counts": replay_result_counts,
     })
 }
 
@@ -2670,6 +2710,24 @@ mod tests {
         assert_eq!(
             summary["attention_summary"]["counts_by_escalation"]["critical"],
             1
+        );
+        let resolution_summary = &outcome.payload["resolution_summary"];
+        assert_eq!(resolution_summary["request_status_counts"]["pending"], 1);
+        assert_eq!(resolution_summary["request_status_counts"]["approved"], 0);
+        assert_eq!(resolution_summary["request_status_counts"]["executing"], 1);
+        assert_eq!(resolution_summary["request_status_counts"]["executed"], 4);
+        assert_eq!(resolution_summary["request_status_counts"]["denied"], 0);
+        assert_eq!(resolution_summary["request_status_counts"]["expired"], 0);
+        assert_eq!(resolution_summary["request_status_counts"]["cancelled"], 0);
+        assert_eq!(resolution_summary["replay_result_counts"]["not_attempted"], 1);
+        assert_eq!(resolution_summary["replay_result_counts"]["in_progress"], 1);
+        assert_eq!(
+            resolution_summary["replay_result_counts"]["completed_cleanly"],
+            1
+        );
+        assert_eq!(
+            resolution_summary["replay_result_counts"]["completed_with_attention"],
+            3
         );
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -42,6 +42,7 @@ struct ApprovalRequestsListRequest {
     execution_plane: Option<ToolExecutionPlane>,
     governance_scope: Option<ToolGovernanceScope>,
     risk_class: Option<ToolRiskClass>,
+    grant_audit_status: Option<ApprovalGrantAuditStatus>,
     grant_state: Option<ApprovalGrantState>,
     grant_scope_session_id: Option<String>,
     grant_created_by_session_id: Option<String>,
@@ -86,6 +87,25 @@ impl ApprovalGrantState {
             Self::Present => "present",
             Self::Absent => "absent",
             Self::LineageUnresolved => "lineage_unresolved",
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalGrantAuditStatus {
+    RequiredPresent,
+    RequiredMissing,
+    NotApplicable,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl ApprovalGrantAuditStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::RequiredPresent => "required_present",
+            Self::RequiredMissing => "required_missing",
+            Self::NotApplicable => "not_applicable",
         }
     }
 }
@@ -408,6 +428,11 @@ fn execute_approval_requests_list(
         request_summaries
             .retain(|item| approval_request_risk_class_from_json(item) == Some(risk_class));
     }
+    if let Some(grant_audit_status) = request.grant_audit_status {
+        request_summaries.retain(|item| {
+            approval_request_grant_audit_status_from_json(item) == Some(grant_audit_status)
+        });
+    }
     if let Some(grant_state) = request.grant_state {
         request_summaries
             .retain(|item| approval_request_grant_state_from_json(item) == Some(grant_state));
@@ -533,6 +558,7 @@ fn execute_approval_requests_list(
                 "execution_plane": request.execution_plane.map(tool_execution_plane_as_str),
                 "governance_scope": request.governance_scope.map(tool_governance_scope_as_str),
                 "risk_class": request.risk_class.map(tool_risk_class_as_str),
+                "grant_audit_status": request.grant_audit_status.map(ApprovalGrantAuditStatus::as_str),
                 "grant_state": request.grant_state.map(ApprovalGrantState::as_str),
                 "grant_scope_session_id": request.grant_scope_session_id,
                 "grant_created_by_session_id": request.grant_created_by_session_id,
@@ -1842,6 +1868,17 @@ fn approval_request_risk_class_from_json(request: &Value) -> Option<ToolRiskClas
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_audit_status_from_json(
+    request: &Value,
+) -> Option<ApprovalGrantAuditStatus> {
+    request
+        .get("grant_audit")
+        .and_then(|value| value.get("status"))
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_grant_audit_status(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_resolved_by_session_id_from_json(request: &Value) -> Option<&str> {
     request.get("resolved_by_session_id").and_then(Value::as_str)
 }
@@ -2104,6 +2141,10 @@ fn parse_approval_requests_list_request(
         execution_plane: optional_payload_tool_execution_plane(payload, "execution_plane")?,
         governance_scope: optional_payload_tool_governance_scope(payload, "governance_scope")?,
         risk_class: optional_payload_tool_risk_class(payload, "risk_class")?,
+        grant_audit_status: optional_payload_approval_grant_audit_status(
+            payload,
+            "grant_audit_status",
+        )?,
         grant_state: optional_payload_approval_grant_state(payload, "grant_state")?,
         grant_scope_session_id: optional_payload_string(payload, "grant_scope_session_id"),
         grant_created_by_session_id: optional_payload_string(
@@ -2266,6 +2307,16 @@ fn optional_payload_tool_risk_class(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_grant_audit_status(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalGrantAuditStatus>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_grant_audit_status(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn optional_payload_approval_grant_state(
     payload: &Value,
     field: &str,
@@ -2422,6 +2473,18 @@ fn parse_tool_risk_class(value: &str) -> Result<ToolRiskClass, String> {
         "High" => Ok(ToolRiskClass::High),
         _ => Err(format!(
             "approval_requests_list_invalid_request: unknown risk_class `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_grant_audit_status(value: &str) -> Result<ApprovalGrantAuditStatus, String> {
+    match value {
+        "required_present" => Ok(ApprovalGrantAuditStatus::RequiredPresent),
+        "required_missing" => Ok(ApprovalGrantAuditStatus::RequiredMissing),
+        "not_applicable" => Ok(ApprovalGrantAuditStatus::NotApplicable),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown grant_audit_status `{value}`"
         )),
     }
 }
@@ -5498,6 +5561,170 @@ mod tests {
                 .expect("operator-beta approval key counts")
                 .len(),
             1
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_filters_by_grant_audit_status() {
+        let config = isolated_memory_config("approval-query-list-grant-audit-filter");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        seed_request(
+            &repo,
+            "apr-grant-audit-filter-present",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-audit-filter-missing",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-audit-filter-once",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        repo.transition_approval_request_if_current(
+            "apr-grant-audit-filter-present",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-session".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition present grant-audit request")
+        .expect("present grant-audit request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-grant-audit-filter-missing",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-session".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition missing grant-audit request")
+        .expect("missing grant-audit request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-grant-audit-filter-once",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Executed,
+                decision: Some(ApprovalDecision::ApproveOnce),
+                resolved_by_session_id: Some("operator-session".to_owned()),
+                executed_at: Some(1_773_000_000),
+                last_error: None,
+            },
+        )
+        .expect("transition approve_once grant-audit request")
+        .expect("approve_once grant-audit request should transition");
+
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:delegate_async",
+            Some("operator-session"),
+        );
+
+        let missing_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_audit_status": "required_missing",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for missing grant-audit filter");
+
+        assert_eq!(missing_outcome.payload["matched_count"], 1);
+        assert_eq!(missing_outcome.payload["returned_count"], 1);
+        assert_eq!(
+            missing_outcome.payload["filter"]["grant_audit_status"],
+            "required_missing"
+        );
+        let requests = missing_outcome.payload["requests"]
+            .as_array()
+            .expect("grant-audit filtered requests");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0]["approval_request_id"],
+            "apr-grant-audit-filter-missing"
+        );
+        assert_eq!(requests[0]["grant_audit"]["status"], "required_missing");
+
+        let present_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_audit_status": "required_present",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for present grant-audit filter");
+
+        assert_eq!(present_outcome.payload["matched_count"], 1);
+        let requests = present_outcome.payload["requests"]
+            .as_array()
+            .expect("grant-audit filtered requests");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0]["approval_request_id"],
+            "apr-grant-audit-filter-present"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_grant_audit_status() {
+        let config = isolated_memory_config("approval-query-list-invalid-grant-audit-status");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-invalid-grant-audit-status",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_audit_status": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("grant_audit_status should reject unknown values");
+
+        assert_eq!(
+            error,
+            "approval_requests_list_invalid_request: unknown grant_audit_status `broken`"
         );
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -25,7 +25,29 @@ const APPROVAL_REQUEST_EVIDENCE_EVENT_BUDGET_PER_RETURNED_REQUEST: usize = 4;
 struct ApprovalRequestsListRequest {
     session_id: Option<String>,
     status: Option<ApprovalRequestStatus>,
+    integrity_status: Option<ApprovalExecutionIntegrityStatus>,
     limit: usize,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalExecutionIntegrityStatus {
+    NotStarted,
+    InProgress,
+    Complete,
+    Incomplete,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl ApprovalExecutionIntegrityStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::NotStarted => "not_started",
+            Self::InProgress => "in_progress",
+            Self::Complete => "complete",
+            Self::Incomplete => "incomplete",
+        }
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -187,13 +209,10 @@ fn execute_approval_requests_list(
             .then_with(|| left.approval_request_id.cmp(&right.approval_request_id))
     });
 
-    let matched_count = requests.len();
-    requests.truncate(request.limit);
-    let returned_count = requests.len();
     let recent_events_by_session_id =
         approval_request_recent_events_by_session_id(&repo, &requests)?;
-    let request_summaries = requests
-        .iter()
+    let mut request_summaries = requests
+        .into_iter()
         .map(|record| {
             let session_events = recent_events_by_session_id
                 .get(&record.session_id)
@@ -204,12 +223,22 @@ fn execute_approval_requests_list(
                 &record.approval_request_id,
             );
             approval_request_summary_json_with_evidence(
-                record,
+                &record,
                 execution_evidence.clone(),
-                approval_request_execution_integrity_json(record, &execution_evidence),
+                approval_request_execution_integrity_json(&record, &execution_evidence),
             )
         })
         .collect::<Vec<_>>();
+    if let Some(integrity_status) = request.integrity_status {
+        request_summaries.retain(|item| {
+            item.get("execution_integrity")
+                .and_then(approval_request_execution_integrity_status_from_json)
+                == Some(integrity_status)
+        });
+    }
+    let matched_count = request_summaries.len();
+    request_summaries.truncate(request.limit);
+    let returned_count = request_summaries.len();
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
@@ -218,6 +247,7 @@ fn execute_approval_requests_list(
             "filter": {
                 "session_id": request.session_id,
                 "status": request.status.map(ApprovalRequestStatus::as_str),
+                "integrity_status": request.integrity_status.map(ApprovalExecutionIntegrityStatus::as_str),
                 "limit": request.limit,
             },
             "visible_session_ids": target_session_ids,
@@ -419,9 +449,13 @@ fn approval_request_execution_integrity_json(
             | ApprovalRequestStatus::Approved
             | ApprovalRequestStatus::Denied
             | ApprovalRequestStatus::Expired
-            | ApprovalRequestStatus::Cancelled => ("not_started", Value::Null, Value::Null),
+            | ApprovalRequestStatus::Cancelled => (
+                ApprovalExecutionIntegrityStatus::NotStarted,
+                Value::Null,
+                Value::Null,
+            ),
             ApprovalRequestStatus::Executing => (
-                "incomplete",
+                ApprovalExecutionIntegrityStatus::Incomplete,
                 Value::String("started_event_missing".to_owned()),
                 first_non_null_json_value(
                     &[
@@ -432,7 +466,7 @@ fn approval_request_execution_integrity_json(
                 ),
             ),
             ApprovalRequestStatus::Executed => (
-                "incomplete",
+                ApprovalExecutionIntegrityStatus::Incomplete,
                 Value::String("execution_events_missing".to_owned()),
                 first_non_null_json_value(
                     &[
@@ -445,7 +479,7 @@ fn approval_request_execution_integrity_json(
         }
     } else if started_event_kind.is_none() && terminal_event_kind.is_some() {
         (
-            "incomplete",
+            ApprovalExecutionIntegrityStatus::Incomplete,
             Value::String("started_event_missing".to_owned()),
             first_non_null_json_value(
                 &[
@@ -457,9 +491,13 @@ fn approval_request_execution_integrity_json(
         )
     } else if started_event_kind.is_some() && terminal_event_kind.is_none() {
         match record.status {
-            ApprovalRequestStatus::Executing => ("in_progress", Value::Null, Value::Null),
+            ApprovalRequestStatus::Executing => (
+                ApprovalExecutionIntegrityStatus::InProgress,
+                Value::Null,
+                Value::Null,
+            ),
             _ => (
-                "incomplete",
+                ApprovalExecutionIntegrityStatus::Incomplete,
                 Value::String("terminal_event_missing".to_owned()),
                 first_non_null_json_value(
                     &[
@@ -471,10 +509,14 @@ fn approval_request_execution_integrity_json(
             ),
         }
     } else if replay_decision_persisted == Some(true) && replay_outcome_persisted == Some(true) {
-        ("complete", Value::Null, Value::Null)
+        (
+            ApprovalExecutionIntegrityStatus::Complete,
+            Value::Null,
+            Value::Null,
+        )
     } else if replay_decision_persisted != Some(true) && replay_outcome_persisted != Some(true) {
         (
-            "incomplete",
+            ApprovalExecutionIntegrityStatus::Incomplete,
             Value::String("replay_decision_and_outcome_missing".to_owned()),
             first_non_null_json_value(
                 &[
@@ -486,7 +528,7 @@ fn approval_request_execution_integrity_json(
         )
     } else if replay_decision_persisted != Some(true) {
         (
-            "incomplete",
+            ApprovalExecutionIntegrityStatus::Incomplete,
             Value::String("replay_decision_missing".to_owned()),
             first_non_null_json_value(
                 &[
@@ -498,7 +540,7 @@ fn approval_request_execution_integrity_json(
         )
     } else {
         (
-            "incomplete",
+            ApprovalExecutionIntegrityStatus::Incomplete,
             Value::String("replay_outcome_missing".to_owned()),
             first_non_null_json_value(
                 &[
@@ -511,7 +553,7 @@ fn approval_request_execution_integrity_json(
     };
 
     json!({
-        "status": status,
+        "status": status.as_str(),
         "gap": gap,
         "integrity_error": integrity_error,
         "execution_error": execution_error,
@@ -619,6 +661,16 @@ fn first_non_null_json_value(values: &[&Value], fallback: Option<&str>) -> Value
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_execution_integrity_status_from_json(
+    execution_integrity: &Value,
+) -> Option<ApprovalExecutionIntegrityStatus> {
+    execution_integrity
+        .get("status")
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_execution_integrity_status(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn parse_approval_requests_list_request(
     payload: &Value,
     tool_config: &ToolConfig,
@@ -626,6 +678,10 @@ fn parse_approval_requests_list_request(
     Ok(ApprovalRequestsListRequest {
         session_id: optional_payload_string(payload, "session_id"),
         status: optional_payload_approval_request_status(payload, "status")?,
+        integrity_status: optional_payload_approval_execution_integrity_status(
+            payload,
+            "integrity_status",
+        )?,
         limit: optional_payload_limit(
             payload,
             "limit",
@@ -720,6 +776,16 @@ fn optional_payload_approval_request_status(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_execution_integrity_status(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalExecutionIntegrityStatus>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_execution_integrity_status(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn parse_approval_request_status(value: &str) -> Result<ApprovalRequestStatus, String> {
     match value {
         "pending" => Ok(ApprovalRequestStatus::Pending),
@@ -731,6 +797,21 @@ fn parse_approval_request_status(value: &str) -> Result<ApprovalRequestStatus, S
         "cancelled" => Ok(ApprovalRequestStatus::Cancelled),
         _ => Err(format!(
             "approval_requests_list_invalid_request: unknown status `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_execution_integrity_status(
+    value: &str,
+) -> Result<ApprovalExecutionIntegrityStatus, String> {
+    match value {
+        "not_started" => Ok(ApprovalExecutionIntegrityStatus::NotStarted),
+        "in_progress" => Ok(ApprovalExecutionIntegrityStatus::InProgress),
+        "complete" => Ok(ApprovalExecutionIntegrityStatus::Complete),
+        "incomplete" => Ok(ApprovalExecutionIntegrityStatus::Incomplete),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown integrity_status `{value}`"
         )),
     }
 }
@@ -758,7 +839,8 @@ mod tests {
     use crate::config::ToolConfig;
     use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::{
-        NewApprovalRequestRecord, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+        ApprovalRequestStatus, NewApprovalRequestRecord, NewSessionRecord, SessionKind,
+        SessionRepository, SessionState, TransitionApprovalRequestIfCurrentRequest,
     };
 
     fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
@@ -820,6 +902,29 @@ mod tests {
             }),
         })
         .expect("seed approval request");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn transition_request_status(
+        repo: &SessionRepository,
+        approval_request_id: &str,
+        expected_status: ApprovalRequestStatus,
+        next_status: ApprovalRequestStatus,
+        last_error: Option<&str>,
+    ) {
+        repo.transition_approval_request_if_current(
+            approval_request_id,
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status,
+                next_status,
+                decision: None,
+                resolved_by_session_id: None,
+                executed_at: Some(1_773_000_000),
+                last_error: last_error.map(str::to_owned),
+            },
+        )
+        .expect("transition approval request")
+        .expect("approval request should transition");
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1041,6 +1146,172 @@ mod tests {
             })
             .count();
         assert_eq!(complete_integrity_count, 40);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_filters_by_execution_integrity_status() {
+        let config = isolated_memory_config("approval-query-list-integrity-filter");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-not-started",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-incomplete",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-complete",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-in-progress",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        transition_request_status(
+            &repo,
+            "apr-incomplete",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("persist assistant turn via kernel failed: forced outcome persistence failure"),
+        );
+        transition_request_status(
+            &repo,
+            "apr-complete",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            None,
+        );
+        transition_request_status(
+            &repo,
+            "apr-in-progress",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executing,
+            None,
+        );
+
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-incomplete",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append incomplete started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-incomplete",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": false,
+                "replay_outcome_persist_error": "persist assistant turn via kernel failed: forced outcome persistence failure",
+            }),
+        })
+        .expect("append incomplete finished event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-complete",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append complete started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-complete",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append complete finished event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-in-progress",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append in-progress started event");
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "integrity_status": "incomplete",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome");
+
+        assert_eq!(outcome.payload["filter"]["integrity_status"], "incomplete");
+        assert_eq!(outcome.payload["matched_count"], 1);
+        assert_eq!(outcome.payload["returned_count"], 1);
+        let requests = outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["approval_request_id"], "apr-incomplete");
+        assert_eq!(requests[0]["execution_integrity"]["status"], "incomplete");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_execution_integrity_status() {
+        let config = isolated_memory_config("approval-query-list-invalid-integrity-status");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "integrity_status": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("unknown integrity_status should be rejected");
+
+        assert!(
+            error.contains("approval_requests_list_invalid_request: unknown integrity_status"),
+            "expected integrity_status validation error, got: {error}"
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -378,6 +378,11 @@ fn approval_request_list_integrity_summary_json(requests: &[Value]) -> Value {
         ("incomplete".to_owned(), 0usize),
     ]);
     let mut incomplete_gap_counts = BTreeMap::<String, usize>::new();
+    let mut needs_attention_count = 0usize;
+    let mut counts_by_reason = BTreeMap::from([
+        ("integrity_gap".to_owned(), 0usize),
+        ("execution_failed".to_owned(), 0usize),
+    ]);
 
     for request in requests {
         let execution_integrity = request.get("execution_integrity").unwrap_or(&Value::Null);
@@ -393,11 +398,28 @@ fn approval_request_list_integrity_summary_json(requests: &[Value]) -> Value {
                 *incomplete_gap_counts.entry(gap.to_owned()).or_default() += 1;
             }
         }
+        if execution_integrity
+            .get("needs_attention")
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            needs_attention_count += 1;
+            if let Some(reason) = execution_integrity
+                .get("attention_reason")
+                .and_then(Value::as_str)
+            {
+                *counts_by_reason.entry(reason.to_owned()).or_default() += 1;
+            }
+        }
     }
 
     json!({
         "counts_by_status": counts_by_status,
         "incomplete_gap_counts": incomplete_gap_counts,
+        "attention_summary": {
+            "needs_attention_count": needs_attention_count,
+            "counts_by_reason": counts_by_reason,
+        },
     })
 }
 
@@ -586,12 +608,25 @@ fn approval_request_execution_integrity_json(
         )
     };
 
+    let (needs_attention, attention_reason) =
+        if matches!(status, ApprovalExecutionIntegrityStatus::Incomplete) {
+            (true, Value::String("integrity_gap".to_owned()))
+        } else if matches!(status, ApprovalExecutionIntegrityStatus::Complete)
+            && !execution_error.is_null()
+        {
+            (true, Value::String("execution_failed".to_owned()))
+        } else {
+            (false, Value::Null)
+        };
+
     json!({
         "status": status.as_str(),
         "gap": gap,
         "integrity_error": integrity_error,
         "execution_error": execution_error,
         "evidence_complete": evidence_complete,
+        "needs_attention": needs_attention,
+        "attention_reason": attention_reason,
     })
 }
 
@@ -1035,6 +1070,14 @@ mod tests {
         );
         assert_eq!(root_request["execution_integrity"]["status"], "not_started");
         assert_eq!(root_request["execution_integrity"]["gap"], Value::Null);
+        assert_eq!(
+            root_request["execution_integrity"]["needs_attention"],
+            false
+        );
+        assert_eq!(
+            root_request["execution_integrity"]["attention_reason"],
+            Value::Null
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1105,6 +1148,8 @@ mod tests {
         assert_eq!(integrity["gap"], Value::Null);
         assert_eq!(integrity["execution_error"], Value::Null);
         assert_eq!(integrity["integrity_error"], Value::Null);
+        assert_eq!(integrity["needs_attention"], false);
+        assert_eq!(integrity["attention_reason"], Value::Null);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1356,6 +1401,13 @@ mod tests {
             "session_cancel",
             "governed_tool_requires_per_call_approval",
         );
+        seed_request(
+            &repo,
+            "apr-summary-execution-failed",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
 
         transition_request_status(
             &repo,
@@ -1377,6 +1429,13 @@ mod tests {
             ApprovalRequestStatus::Pending,
             ApprovalRequestStatus::Executed,
             Some("persist assistant turn via kernel failed: forced outcome persistence failure"),
+        );
+        transition_request_status(
+            &repo,
+            "apr-summary-execution-failed",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("tool failed for domain reasons"),
         );
 
         repo.append_event(crate::session::repository::NewSessionEvent {
@@ -1436,6 +1495,29 @@ mod tests {
             }),
         })
         .expect("append incomplete finished event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-summary-execution-failed",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append execution-failed started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_failed".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-summary-execution-failed",
+                "error": "tool failed for domain reasons",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append execution-failed terminal event");
 
         let outcome = crate::tools::execute_app_tool_with_config(
             ToolCoreRequest {
@@ -1453,10 +1535,19 @@ mod tests {
         let summary = &outcome.payload["integrity_summary"];
         assert_eq!(summary["counts_by_status"]["not_started"], 1);
         assert_eq!(summary["counts_by_status"]["in_progress"], 1);
-        assert_eq!(summary["counts_by_status"]["complete"], 1);
+        assert_eq!(summary["counts_by_status"]["complete"], 2);
         assert_eq!(summary["counts_by_status"]["incomplete"], 1);
         assert_eq!(
             summary["incomplete_gap_counts"]["replay_outcome_missing"],
+            1
+        );
+        assert_eq!(summary["attention_summary"]["needs_attention_count"], 2);
+        assert_eq!(
+            summary["attention_summary"]["counts_by_reason"]["integrity_gap"],
+            1
+        );
+        assert_eq!(
+            summary["attention_summary"]["counts_by_reason"]["execution_failed"],
             1
         );
     }
@@ -1546,6 +1637,11 @@ mod tests {
         );
         assert_eq!(request["execution_integrity"]["status"], "not_started");
         assert_eq!(request["execution_integrity"]["gap"], Value::Null);
+        assert_eq!(request["execution_integrity"]["needs_attention"], false);
+        assert_eq!(
+            request["execution_integrity"]["attention_reason"],
+            Value::Null
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1616,6 +1712,8 @@ mod tests {
         assert_eq!(integrity["status"], "incomplete");
         assert_eq!(integrity["gap"], "replay_outcome_missing");
         assert_eq!(integrity["execution_error"], Value::Null);
+        assert_eq!(integrity["needs_attention"], true);
+        assert_eq!(integrity["attention_reason"], "integrity_gap");
         assert!(
             integrity["integrity_error"]
                 .as_str()
@@ -1682,6 +1780,8 @@ mod tests {
             integrity["execution_error"],
             "tool failed for domain reasons"
         );
+        assert_eq!(integrity["needs_attention"], true);
+        assert_eq!(integrity["attention_reason"], "execution_failed");
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -333,7 +333,7 @@ fn execute_approval_requests_list(
         approval_request_recent_events_by_session_id(&repo, &requests)?;
     let mut request_summaries = requests
         .into_iter()
-        .map(|record| {
+        .map(|record| -> Result<Value, String> {
             let session_events = recent_events_by_session_id
                 .get(&record.session_id)
                 .map(Vec::as_slice)
@@ -342,13 +342,15 @@ fn execute_approval_requests_list(
                 session_events,
                 &record.approval_request_id,
             );
-            approval_request_summary_json_with_evidence(
+            let grant = approval_request_runtime_grant_json(&repo, &record)?;
+            Ok(approval_request_summary_json_with_evidence(
                 &record,
+                grant,
                 execution_evidence.clone(),
                 approval_request_execution_integrity_json(&record, &execution_evidence),
-            )
+            ))
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, String>>()?;
     if let Some(integrity_status) = request.integrity_status {
         request_summaries.retain(|item| {
             item.get("execution_integrity")
@@ -465,6 +467,7 @@ fn execute_approval_requests_list(
     let resolution_summary = approval_request_list_resolution_summary_json(&request_summaries);
     let correlation_summary = approval_request_list_correlation_summary_json(&request_summaries);
     let governance_summary = approval_request_list_governance_summary_json(&request_summaries);
+    let grant_summary = approval_request_list_grant_summary_json(&request_summaries);
     let session_summary = approval_request_list_session_summary_json(&request_summaries);
     let tool_summary = approval_request_list_tool_summary_json(&request_summaries);
     let matched_count = request_summaries.len();
@@ -505,6 +508,7 @@ fn execute_approval_requests_list(
             "resolution_summary": resolution_summary,
             "correlation_summary": correlation_summary,
             "governance_summary": governance_summary,
+            "grant_summary": grant_summary,
             "session_summary": session_summary,
             "tool_summary": tool_summary,
             "requests": request_summaries,
@@ -533,6 +537,7 @@ fn execute_approval_request_status(
     let execution_evidence = approval_request_execution_evidence_json(&repo, &request)?;
     let execution_integrity =
         approval_request_execution_integrity_json(&request, &execution_evidence);
+    let grant = approval_request_runtime_grant_json(&repo, &request)?;
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
@@ -540,6 +545,7 @@ fn execute_approval_request_status(
             "current_session_id": current_session_id,
             "approval_request": approval_request_detail_json_with_evidence(
                 &request,
+                grant,
                 execution_evidence,
                 execution_integrity,
             ),
@@ -573,6 +579,7 @@ async fn execute_approval_request_resolve(
         approval_request_execution_evidence_json(&repo, &outcome.approval_request)?;
     let execution_integrity =
         approval_request_execution_integrity_json(&outcome.approval_request, &execution_evidence);
+    let grant = approval_request_runtime_grant_json(&repo, &outcome.approval_request)?;
     let resolution = approval_request_resolution_json(
         &outcome.approval_request,
         &execution_evidence,
@@ -586,6 +593,7 @@ async fn execute_approval_request_resolve(
             "resolution": resolution,
             "approval_request": approval_request_detail_json_with_evidence(
                 &outcome.approval_request,
+                grant,
                 execution_evidence,
                 execution_integrity,
             ),
@@ -597,6 +605,7 @@ async fn execute_approval_request_resolve(
 #[cfg(feature = "memory-sqlite")]
 fn approval_request_summary_json_with_evidence(
     record: &ApprovalRequestRecord,
+    grant: Value,
     execution_evidence: Value,
     execution_integrity: Value,
 ) -> Value {
@@ -637,6 +646,7 @@ fn approval_request_summary_json_with_evidence(
             .governance_snapshot_json
             .get("rule_id")
             .and_then(Value::as_str),
+        "grant": grant,
         "pending_queue": pending_queue,
         "resolution": resolution,
         "execution_evidence": execution_evidence,
@@ -925,6 +935,33 @@ fn approval_request_list_governance_summary_json(requests: &[Value]) -> Value {
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
+    let mut counts_by_state = BTreeMap::from([
+        ("present".to_owned(), 0usize),
+        ("absent".to_owned(), 0usize),
+        ("lineage_unresolved".to_owned(), 0usize),
+    ]);
+    let mut scope_session_counts = BTreeMap::<String, usize>::new();
+
+    for request in requests {
+        let grant = request.get("grant").unwrap_or(&Value::Null);
+        if let Some(state) = grant.get("state").and_then(Value::as_str) {
+            *counts_by_state.entry(state.to_owned()).or_default() += 1;
+        }
+        if let Some(scope_session_id) = grant.get("scope_session_id").and_then(Value::as_str) {
+            *scope_session_counts
+                .entry(scope_session_id.to_owned())
+                .or_default() += 1;
+        }
+    }
+
+    json!({
+        "counts_by_state": counts_by_state,
+        "scope_session_counts": scope_session_counts,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_list_session_summary_json(requests: &[Value]) -> Value {
     #[derive(Default)]
     struct SessionSummaryAccumulator {
@@ -1161,6 +1198,7 @@ fn approval_request_list_tool_summary_json(requests: &[Value]) -> Value {
 #[cfg(feature = "memory-sqlite")]
 fn approval_request_detail_json_with_evidence(
     record: &ApprovalRequestRecord,
+    grant: Value,
     execution_evidence: Value,
     execution_integrity: Value,
 ) -> Value {
@@ -1195,6 +1233,7 @@ fn approval_request_detail_json_with_evidence(
         "last_error": record.last_error,
         "request_payload": record.request_payload_json,
         "governance_snapshot": record.governance_snapshot_json,
+        "grant": grant,
         "pending_queue": pending_queue,
         "resolution": resolution,
         "execution_evidence": execution_evidence,
@@ -1251,6 +1290,39 @@ fn approval_request_resolution_json(
             .get("recommended_action")
             .cloned()
             .unwrap_or(Value::Null),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_runtime_grant_json(
+    repo: &SessionRepository,
+    record: &ApprovalRequestRecord,
+) -> Result<Value, String> {
+    let Some(scope_session_id) = repo.lineage_root_session_id(&record.session_id)? else {
+        return Ok(json!({
+            "state": "lineage_unresolved",
+            "scope_session_id": Value::Null,
+            "created_by_session_id": Value::Null,
+            "created_at": Value::Null,
+            "updated_at": Value::Null,
+        }));
+    };
+    let grant = repo.load_approval_grant(&scope_session_id, &record.approval_key)?;
+    Ok(match grant {
+        Some(grant) => json!({
+            "state": "present",
+            "scope_session_id": grant.scope_session_id,
+            "created_by_session_id": grant.created_by_session_id,
+            "created_at": grant.created_at,
+            "updated_at": grant.updated_at,
+        }),
+        None => json!({
+            "state": "absent",
+            "scope_session_id": scope_session_id,
+            "created_by_session_id": Value::Null,
+            "created_at": Value::Null,
+            "updated_at": Value::Null,
+        }),
     })
 }
 
@@ -2263,8 +2335,9 @@ mod tests {
     use crate::config::ToolConfig;
     use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::{
-        ApprovalDecision, ApprovalRequestStatus, NewApprovalRequestRecord, NewSessionRecord,
-        SessionKind, SessionRepository, SessionState, TransitionApprovalRequestIfCurrentRequest,
+        ApprovalDecision, ApprovalRequestStatus, NewApprovalGrantRecord, NewApprovalRequestRecord,
+        NewSessionRecord, SessionKind, SessionRepository, SessionState,
+        TransitionApprovalRequestIfCurrentRequest,
     };
 
     fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
@@ -2363,6 +2436,21 @@ mod tests {
             }),
         })
         .expect("seed approval request with governance");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn seed_runtime_grant(
+        repo: &SessionRepository,
+        scope_session_id: &str,
+        approval_key: &str,
+        created_by_session_id: Option<&str>,
+    ) {
+        repo.upsert_approval_grant(NewApprovalGrantRecord {
+            scope_session_id: scope_session_id.to_owned(),
+            approval_key: approval_key.to_owned(),
+            created_by_session_id: created_by_session_id.map(str::to_owned),
+        })
+        .expect("seed runtime grant");
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -4278,6 +4366,116 @@ mod tests {
         assert_eq!(tools[2]["pending_count"], 0);
         assert_eq!(tools[2]["attention_count"], 0);
         assert_eq!(tools[2]["oldest_pending_requested_at"], Value::Null);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_surfaces_runtime_grant_snapshots() {
+        let config = isolated_memory_config("approval-query-list-grant-summary");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+
+        seed_request_with_governance(
+            &repo,
+            "apr-grant-present",
+            "child-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+            "Orchestration",
+            "TopologyMutation",
+            "High",
+        );
+        seed_request_with_governance(
+            &repo,
+            "apr-grant-absent",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+            "App",
+            "Routine",
+            "Elevated",
+        );
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:delegate_async",
+            Some("operator-session"),
+        );
+
+        let list_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant summary");
+
+        let grant_summary = &list_outcome.payload["grant_summary"];
+        assert_eq!(grant_summary["counts_by_state"]["present"], 1);
+        assert_eq!(grant_summary["counts_by_state"]["absent"], 1);
+        assert_eq!(grant_summary["counts_by_state"]["lineage_unresolved"], 0);
+        assert_eq!(grant_summary["scope_session_counts"]["root-session"], 2);
+
+        let requests = list_outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        let present_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-grant-present")
+            .expect("present grant request");
+        assert_eq!(present_request["grant"]["state"], "present");
+        assert_eq!(present_request["grant"]["scope_session_id"], "root-session");
+        assert_eq!(
+            present_request["grant"]["created_by_session_id"],
+            "operator-session"
+        );
+        assert!(present_request["grant"]["created_at"].as_i64().is_some());
+        assert!(present_request["grant"]["updated_at"].as_i64().is_some());
+
+        let absent_request = requests
+            .iter()
+            .find(|item| item["approval_request_id"] == "apr-grant-absent")
+            .expect("absent grant request");
+        assert_eq!(absent_request["grant"]["state"], "absent");
+        assert_eq!(absent_request["grant"]["scope_session_id"], "root-session");
+        assert_eq!(
+            absent_request["grant"]["created_by_session_id"],
+            Value::Null
+        );
+        assert_eq!(absent_request["grant"]["created_at"], Value::Null);
+        assert_eq!(absent_request["grant"]["updated_at"], Value::Null);
+
+        let status_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-grant-present",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome for grant snapshot");
+
+        let request = &status_outcome.payload["approval_request"];
+        assert_eq!(request["grant"]["state"], "present");
+        assert_eq!(request["grant"]["scope_session_id"], "root-session");
+        assert_eq!(
+            request["grant"]["created_by_session_id"],
+            "operator-session"
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -236,6 +236,7 @@ fn execute_approval_requests_list(
                 == Some(integrity_status)
         });
     }
+    let integrity_summary = approval_request_list_integrity_summary_json(&request_summaries);
     let matched_count = request_summaries.len();
     request_summaries.truncate(request.limit);
     let returned_count = request_summaries.len();
@@ -253,6 +254,7 @@ fn execute_approval_requests_list(
             "visible_session_ids": target_session_ids,
             "matched_count": matched_count,
             "returned_count": returned_count,
+            "integrity_summary": integrity_summary,
             "requests": request_summaries,
         }),
     })
@@ -364,6 +366,38 @@ fn approval_request_summary_json_with_evidence(
             .and_then(Value::as_str),
         "execution_evidence": execution_evidence,
         "execution_integrity": execution_integrity,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_list_integrity_summary_json(requests: &[Value]) -> Value {
+    let mut counts_by_status = BTreeMap::from([
+        ("not_started".to_owned(), 0usize),
+        ("in_progress".to_owned(), 0usize),
+        ("complete".to_owned(), 0usize),
+        ("incomplete".to_owned(), 0usize),
+    ]);
+    let mut incomplete_gap_counts = BTreeMap::<String, usize>::new();
+
+    for request in requests {
+        let execution_integrity = request.get("execution_integrity").unwrap_or(&Value::Null);
+        let status = execution_integrity
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        if let Some(count) = counts_by_status.get_mut(status) {
+            *count += 1;
+        }
+        if status == "incomplete" {
+            if let Some(gap) = execution_integrity.get("gap").and_then(Value::as_str) {
+                *incomplete_gap_counts.entry(gap.to_owned()).or_default() += 1;
+            }
+        }
+    }
+
+    json!({
+        "counts_by_status": counts_by_status,
+        "incomplete_gap_counts": incomplete_gap_counts,
     })
 }
 
@@ -1286,6 +1320,145 @@ mod tests {
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0]["approval_request_id"], "apr-incomplete");
         assert_eq!(requests[0]["execution_integrity"]["status"], "incomplete");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_surfaces_integrity_summary_counts() {
+        let config = isolated_memory_config("approval-query-list-integrity-summary");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-summary-not-started",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-summary-in-progress",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-summary-complete",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-summary-incomplete",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        transition_request_status(
+            &repo,
+            "apr-summary-in-progress",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executing,
+            None,
+        );
+        transition_request_status(
+            &repo,
+            "apr-summary-complete",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            None,
+        );
+        transition_request_status(
+            &repo,
+            "apr-summary-incomplete",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("persist assistant turn via kernel failed: forced outcome persistence failure"),
+        );
+
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-summary-in-progress",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append in-progress started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-summary-complete",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append complete started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-summary-complete",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append complete finished event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-summary-incomplete",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append incomplete started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-summary-incomplete",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": false,
+                "replay_outcome_persist_error": "persist assistant turn via kernel failed: forced outcome persistence failure",
+            }),
+        })
+        .expect("append incomplete finished event");
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome");
+
+        let summary = &outcome.payload["integrity_summary"];
+        assert_eq!(summary["counts_by_status"]["not_started"], 1);
+        assert_eq!(summary["counts_by_status"]["in_progress"], 1);
+        assert_eq!(summary["counts_by_status"]["complete"], 1);
+        assert_eq!(summary["counts_by_status"]["incomplete"], 1);
+        assert_eq!(
+            summary["incomplete_gap_counts"]["replay_outcome_missing"],
+            1
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -1068,6 +1068,7 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
     ]);
     let mut scope_session_counts = BTreeMap::<String, usize>::new();
     let mut created_by_session_counts = BTreeMap::<String, usize>::new();
+    let mut created_by_approval_key_counts = BTreeMap::<String, BTreeMap<String, usize>>::new();
     let mut reviewable_count = 0usize;
     let mut counts_by_age_bucket = BTreeMap::from([
         ("fresh".to_owned(), 0usize),
@@ -1093,6 +1094,13 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
             *created_by_session_counts
                 .entry(created_by_session_id.to_owned())
                 .or_default() += 1;
+            if let Some(approval_key) = request.get("approval_key").and_then(Value::as_str) {
+                *created_by_approval_key_counts
+                    .entry(created_by_session_id.to_owned())
+                    .or_default()
+                    .entry(approval_key.to_owned())
+                    .or_default() += 1;
+            }
         }
         if let Some(status) = request
             .get("grant_audit")
@@ -1126,6 +1134,7 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
         "consistency_counts": consistency_counts,
         "scope_session_counts": scope_session_counts,
         "created_by_session_counts": created_by_session_counts,
+        "created_by_approval_key_counts": created_by_approval_key_counts,
         "review_summary": {
             "reviewable_count": reviewable_count,
             "non_reviewable_count": requests.len().saturating_sub(reviewable_count),
@@ -5394,6 +5403,102 @@ mod tests {
         assert_eq!(request["grant_review"]["reviewable"], true);
         assert_eq!(request["grant_review"]["age_bucket"], "overdue");
         assert_eq!(request["grant_review"]["last_changed_at"], overdue_updated_at);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_groups_runtime_grants_by_creator_and_action() {
+        let config = isolated_memory_config("approval-query-list-grant-creator-action-summary");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+
+        seed_request(
+            &repo,
+            "apr-grant-creator-action-a",
+            "child-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-creator-action-b",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-creator-action-c",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:delegate_async",
+            Some("operator-alpha"),
+        );
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:session_cancel",
+            Some("operator-alpha"),
+        );
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:memory_search",
+            Some("operator-beta"),
+        );
+
+        let list_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for creator/action summary");
+
+        let grant_summary = &list_outcome.payload["grant_summary"];
+        assert_eq!(
+            grant_summary["created_by_approval_key_counts"]["operator-alpha"]["tool:delegate_async"],
+            1
+        );
+        assert_eq!(
+            grant_summary["created_by_approval_key_counts"]["operator-alpha"]["tool:session_cancel"],
+            1
+        );
+        assert_eq!(
+            grant_summary["created_by_approval_key_counts"]["operator-beta"]["tool:memory_search"],
+            1
+        );
+        assert_eq!(
+            grant_summary["created_by_approval_key_counts"]["operator-alpha"]
+                .as_object()
+                .expect("operator-alpha approval key counts")
+                .len(),
+            2
+        );
+        assert_eq!(
+            grant_summary["created_by_approval_key_counts"]["operator-beta"]
+                .as_object()
+                .expect("operator-beta approval key counts")
+                .len(),
+            1
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -461,11 +461,17 @@ async fn execute_approval_request_resolve(
         approval_request_execution_evidence_json(&repo, &outcome.approval_request)?;
     let execution_integrity =
         approval_request_execution_integrity_json(&outcome.approval_request, &execution_evidence);
+    let resolution = approval_request_resolution_json(
+        &outcome.approval_request,
+        &execution_integrity,
+        outcome.resumed_tool_output.as_ref(),
+    );
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
             "current_session_id": current_session_id,
+            "resolution": resolution,
             "approval_request": approval_request_detail_json_with_evidence(
                 &outcome.approval_request,
                 execution_evidence,
@@ -627,6 +633,43 @@ fn approval_request_detail_json_with_evidence(
         "governance_snapshot": record.governance_snapshot_json,
         "execution_evidence": execution_evidence,
         "execution_integrity": execution_integrity,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_resolution_json(
+    record: &ApprovalRequestRecord,
+    execution_integrity: &Value,
+    resumed_tool_output: Option<&ToolCoreOutcome>,
+) -> Value {
+    let replay_attempted = resumed_tool_output.is_some();
+    let needs_attention = execution_integrity
+        .get("needs_attention")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let replay_result = if !replay_attempted {
+        "not_attempted"
+    } else if needs_attention {
+        "completed_with_attention"
+    } else {
+        "completed_cleanly"
+    };
+
+    json!({
+        "decision": record.decision.map(|decision| decision.as_str()),
+        "request_status": record.status.as_str(),
+        "replay_attempted": replay_attempted,
+        "replay_result": replay_result,
+        "integrity_status": execution_integrity.get("status").cloned().unwrap_or(Value::Null),
+        "needs_attention": needs_attention,
+        "attention_reason": execution_integrity
+            .get("attention_reason")
+            .cloned()
+            .unwrap_or(Value::Null),
+        "recommended_action": execution_integrity
+            .get("recommended_action")
+            .cloned()
+            .unwrap_or(Value::Null),
     })
 }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -44,6 +44,11 @@ struct ApprovalRequestsListRequest {
     risk_class: Option<ToolRiskClass>,
     grant_audit_status: Option<ApprovalGrantAuditStatus>,
     grant_review_age_bucket: Option<ApprovalAttentionAgeBucket>,
+    grant_needs_attention: Option<bool>,
+    grant_attention_reason: Option<ApprovalGrantAttentionReason>,
+    grant_recommended_action: Option<ApprovalGrantRecommendedAction>,
+    grant_attention_age_bucket: Option<ApprovalAttentionAgeBucket>,
+    grant_escalation_level: Option<ApprovalEscalationLevel>,
     grant_state: Option<ApprovalGrantState>,
     grant_scope_session_id: Option<String>,
     grant_created_by_session_id: Option<String>,
@@ -474,6 +479,33 @@ fn execute_approval_requests_list(
                 == Some(grant_review_age_bucket)
         });
     }
+    if let Some(grant_needs_attention) = request.grant_needs_attention {
+        request_summaries
+            .retain(|item| approval_request_has_grant_attention(item) == grant_needs_attention);
+    }
+    if let Some(grant_attention_reason) = request.grant_attention_reason {
+        request_summaries.retain(|item| {
+            approval_request_grant_attention_reason_from_json(item) == Some(grant_attention_reason)
+        });
+    }
+    if let Some(grant_recommended_action) = request.grant_recommended_action {
+        request_summaries.retain(|item| {
+            approval_request_grant_recommended_action_from_json(item)
+                == Some(grant_recommended_action)
+        });
+    }
+    if let Some(grant_attention_age_bucket) = request.grant_attention_age_bucket {
+        request_summaries.retain(|item| {
+            approval_request_grant_attention_age_bucket_from_json(item)
+                == Some(grant_attention_age_bucket)
+        });
+    }
+    if let Some(grant_escalation_level) = request.grant_escalation_level {
+        request_summaries.retain(|item| {
+            approval_request_grant_escalation_level_from_json(item)
+                == Some(grant_escalation_level)
+        });
+    }
     if let Some(grant_state) = request.grant_state {
         request_summaries
             .retain(|item| approval_request_grant_state_from_json(item) == Some(grant_state));
@@ -512,12 +544,7 @@ fn execute_approval_requests_list(
             .retain(|item| approval_request_replay_result_from_json(item) == Some(replay_result));
     }
     if let Some(needs_attention) = request.needs_attention {
-        request_summaries.retain(|item| {
-            item.get("execution_integrity")
-                .and_then(|value| value.get("needs_attention"))
-                .and_then(Value::as_bool)
-                == Some(needs_attention)
-        });
+        request_summaries.retain(|item| approval_request_has_attention(item) == needs_attention);
     }
     if let Some(attention_reason) = request.attention_reason {
         request_summaries.retain(|item| {
@@ -577,6 +604,7 @@ fn execute_approval_requests_list(
         });
     }
     let pending_summary = approval_request_list_pending_summary_json(&request_summaries);
+    let attention_summary = approval_request_list_attention_summary_json(&request_summaries);
     let integrity_summary = approval_request_list_integrity_summary_json(&request_summaries);
     let resolution_summary = approval_request_list_resolution_summary_json(&request_summaries);
     let correlation_summary = approval_request_list_correlation_summary_json(&request_summaries);
@@ -601,6 +629,11 @@ fn execute_approval_requests_list(
                 "risk_class": request.risk_class.map(tool_risk_class_as_str),
                 "grant_audit_status": request.grant_audit_status.map(ApprovalGrantAuditStatus::as_str),
                 "grant_review_age_bucket": request.grant_review_age_bucket.map(ApprovalAttentionAgeBucket::as_str),
+                "grant_needs_attention": request.grant_needs_attention,
+                "grant_attention_reason": request.grant_attention_reason.map(ApprovalGrantAttentionReason::as_str),
+                "grant_recommended_action": request.grant_recommended_action.map(ApprovalGrantRecommendedAction::as_str),
+                "grant_attention_age_bucket": request.grant_attention_age_bucket.map(ApprovalAttentionAgeBucket::as_str),
+                "grant_escalation_level": request.grant_escalation_level.map(ApprovalEscalationLevel::as_str),
                 "grant_state": request.grant_state.map(ApprovalGrantState::as_str),
                 "grant_scope_session_id": request.grant_scope_session_id,
                 "grant_created_by_session_id": request.grant_created_by_session_id,
@@ -624,6 +657,7 @@ fn execute_approval_requests_list(
             "matched_count": matched_count,
             "returned_count": returned_count,
             "pending_summary": pending_summary,
+            "attention_summary": attention_summary,
             "integrity_summary": integrity_summary,
             "resolution_summary": resolution_summary,
             "correlation_summary": correlation_summary,
@@ -1035,6 +1069,136 @@ fn approval_request_list_integrity_summary_json(requests: &[Value]) -> Value {
             "age_bucket_counts": age_bucket_counts,
             "counts_by_escalation": counts_by_escalation,
         },
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_list_attention_summary_json(requests: &[Value]) -> Value {
+    let mut needs_attention_count = 0usize;
+    let mut signal_count = 0usize;
+    let mut request_counts_by_source = BTreeMap::from([
+        ("execution_only".to_owned(), 0usize),
+        ("grant_only".to_owned(), 0usize),
+        ("both".to_owned(), 0usize),
+    ]);
+    let mut counts_by_reason = BTreeMap::from([
+        ("integrity_gap".to_owned(), 0usize),
+        ("execution_failed".to_owned(), 0usize),
+        ("durable_grant_missing".to_owned(), 0usize),
+        ("grant_review_overdue".to_owned(), 0usize),
+    ]);
+    let mut recommended_action_counts = BTreeMap::from([
+        ("inspect_execution_event_stream".to_owned(), 0usize),
+        ("inspect_replay_persistence".to_owned(), 0usize),
+        ("inspect_tool_execution_failure".to_owned(), 0usize),
+        ("inspect_approval_integrity".to_owned(), 0usize),
+        ("inspect_runtime_grant_persistence".to_owned(), 0usize),
+        ("review_runtime_grant_scope".to_owned(), 0usize),
+    ]);
+    let mut age_bucket_counts = BTreeMap::from([
+        ("fresh".to_owned(), 0usize),
+        ("stale".to_owned(), 0usize),
+        ("overdue".to_owned(), 0usize),
+    ]);
+    let mut counts_by_escalation = BTreeMap::from([
+        ("elevated".to_owned(), 0usize),
+        ("critical".to_owned(), 0usize),
+    ]);
+
+    for request in requests {
+        let execution_attention = request.get("execution_integrity").unwrap_or(&Value::Null);
+        let grant_attention = request.get("grant_attention").unwrap_or(&Value::Null);
+        let has_execution_attention = approval_request_has_execution_attention(request);
+        let has_grant_attention = approval_request_has_grant_attention(request);
+        if !(has_execution_attention || has_grant_attention) {
+            continue;
+        }
+
+        needs_attention_count += 1;
+        match (has_execution_attention, has_grant_attention) {
+            (true, true) => {
+                *request_counts_by_source.entry("both".to_owned()).or_default() += 1;
+            }
+            (true, false) => {
+                *request_counts_by_source
+                    .entry("execution_only".to_owned())
+                    .or_default() += 1;
+            }
+            (false, true) => {
+                *request_counts_by_source
+                    .entry("grant_only".to_owned())
+                    .or_default() += 1;
+            }
+            (false, false) => {}
+        }
+
+        if has_execution_attention {
+            signal_count += 1;
+            if let Some(reason) = execution_attention
+                .get("attention_reason")
+                .and_then(Value::as_str)
+            {
+                *counts_by_reason.entry(reason.to_owned()).or_default() += 1;
+            }
+            if let Some(action) = execution_attention
+                .get("recommended_action")
+                .and_then(Value::as_str)
+            {
+                *recommended_action_counts
+                    .entry(action.to_owned())
+                    .or_default() += 1;
+            }
+            if let Some(age_bucket) = execution_attention
+                .get("attention_age_bucket")
+                .and_then(Value::as_str)
+            {
+                *age_bucket_counts.entry(age_bucket.to_owned()).or_default() += 1;
+            }
+            if let Some(escalation) = execution_attention
+                .get("escalation_level")
+                .and_then(Value::as_str)
+            {
+                *counts_by_escalation
+                    .entry(escalation.to_owned())
+                    .or_default() += 1;
+            }
+        }
+
+        if has_grant_attention {
+            signal_count += 1;
+            if let Some(reason) = grant_attention.get("attention_reason").and_then(Value::as_str) {
+                *counts_by_reason.entry(reason.to_owned()).or_default() += 1;
+            }
+            if let Some(action) = grant_attention
+                .get("recommended_action")
+                .and_then(Value::as_str)
+            {
+                *recommended_action_counts
+                    .entry(action.to_owned())
+                    .or_default() += 1;
+            }
+            if let Some(age_bucket) = grant_attention.get("age_bucket").and_then(Value::as_str) {
+                *age_bucket_counts.entry(age_bucket.to_owned()).or_default() += 1;
+            }
+            if let Some(escalation) = grant_attention
+                .get("escalation_level")
+                .and_then(Value::as_str)
+            {
+                *counts_by_escalation
+                    .entry(escalation.to_owned())
+                    .or_default() += 1;
+            }
+        }
+    }
+
+    json!({
+        "needs_attention_count": needs_attention_count,
+        "signal_count": signal_count,
+        "request_counts_by_source": request_counts_by_source,
+        "counts_by_reason": counts_by_reason,
+        "recommended_action_counts": recommended_action_counts,
+        "age_bucket_counts": age_bucket_counts,
+        "counts_by_escalation": counts_by_escalation,
     })
 }
 
@@ -2023,6 +2187,50 @@ fn approval_request_grant_review_age_bucket_from_json(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_attention_reason_from_json(
+    request: &Value,
+) -> Option<ApprovalGrantAttentionReason> {
+    request
+        .get("grant_attention")
+        .and_then(|value| value.get("attention_reason"))
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_grant_attention_reason(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_recommended_action_from_json(
+    request: &Value,
+) -> Option<ApprovalGrantRecommendedAction> {
+    request
+        .get("grant_attention")
+        .and_then(|value| value.get("recommended_action"))
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_grant_recommended_action(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_attention_age_bucket_from_json(
+    request: &Value,
+) -> Option<ApprovalAttentionAgeBucket> {
+    request
+        .get("grant_attention")
+        .and_then(|value| value.get("age_bucket"))
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_grant_attention_age_bucket(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_escalation_level_from_json(
+    request: &Value,
+) -> Option<ApprovalEscalationLevel> {
+    request
+        .get("grant_attention")
+        .and_then(|value| value.get("escalation_level"))
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_grant_escalation_level(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_resolved_by_session_id_from_json(request: &Value) -> Option<&str> {
     request.get("resolved_by_session_id").and_then(Value::as_str)
 }
@@ -2242,17 +2450,26 @@ fn approval_request_grant_escalation_priority(request: &Value) -> u8 {
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn approval_request_has_attention(request: &Value) -> bool {
+fn approval_request_has_execution_attention(request: &Value) -> bool {
     request
         .get("execution_integrity")
         .and_then(|value| value.get("needs_attention"))
         .and_then(Value::as_bool)
         == Some(true)
-        || request
-            .get("grant_attention")
-            .and_then(|value| value.get("needs_attention"))
-            .and_then(Value::as_bool)
-            == Some(true)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_has_grant_attention(request: &Value) -> bool {
+    request
+        .get("grant_attention")
+        .and_then(|value| value.get("needs_attention"))
+        .and_then(Value::as_bool)
+        == Some(true)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_has_attention(request: &Value) -> bool {
+    approval_request_has_execution_attention(request) || approval_request_has_grant_attention(request)
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -2348,6 +2565,23 @@ fn parse_approval_requests_list_request(
         grant_review_age_bucket: optional_payload_approval_grant_review_age_bucket(
             payload,
             "grant_review_age_bucket",
+        )?,
+        grant_needs_attention: payload.get("grant_needs_attention").and_then(Value::as_bool),
+        grant_attention_reason: optional_payload_approval_grant_attention_reason(
+            payload,
+            "grant_attention_reason",
+        )?,
+        grant_recommended_action: optional_payload_approval_grant_recommended_action(
+            payload,
+            "grant_recommended_action",
+        )?,
+        grant_attention_age_bucket: optional_payload_approval_grant_attention_age_bucket(
+            payload,
+            "grant_attention_age_bucket",
+        )?,
+        grant_escalation_level: optional_payload_approval_grant_escalation_level(
+            payload,
+            "grant_escalation_level",
         )?,
         grant_state: optional_payload_approval_grant_state(payload, "grant_state")?,
         grant_scope_session_id: optional_payload_string(payload, "grant_scope_session_id"),
@@ -2527,6 +2761,46 @@ fn optional_payload_approval_grant_review_age_bucket(
 ) -> Result<Option<ApprovalAttentionAgeBucket>, String> {
     optional_payload_string(payload, field)
         .map(|value| parse_approval_grant_review_age_bucket(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_grant_attention_reason(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalGrantAttentionReason>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_grant_attention_reason(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_grant_recommended_action(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalGrantRecommendedAction>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_grant_recommended_action(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_grant_attention_age_bucket(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalAttentionAgeBucket>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_grant_attention_age_bucket(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_grant_escalation_level(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalEscalationLevel>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_grant_escalation_level(value.as_str()))
         .transpose()
 }
 
@@ -2713,6 +2987,63 @@ fn parse_approval_grant_review_age_bucket(
         "overdue" => Ok(ApprovalAttentionAgeBucket::Overdue),
         _ => Err(format!(
             "approval_requests_list_invalid_request: unknown grant_review_age_bucket `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_grant_attention_reason(
+    value: &str,
+) -> Result<ApprovalGrantAttentionReason, String> {
+    match value {
+        "durable_grant_missing" => Ok(ApprovalGrantAttentionReason::DurableGrantMissing),
+        "grant_review_overdue" => Ok(ApprovalGrantAttentionReason::GrantReviewOverdue),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown grant_attention_reason `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_grant_recommended_action(
+    value: &str,
+) -> Result<ApprovalGrantRecommendedAction, String> {
+    match value {
+        "inspect_runtime_grant_persistence" => {
+            Ok(ApprovalGrantRecommendedAction::InspectRuntimeGrantPersistence)
+        }
+        "review_runtime_grant_scope" => {
+            Ok(ApprovalGrantRecommendedAction::ReviewRuntimeGrantScope)
+        }
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown grant_recommended_action `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_grant_attention_age_bucket(
+    value: &str,
+) -> Result<ApprovalAttentionAgeBucket, String> {
+    match value {
+        "fresh" => Ok(ApprovalAttentionAgeBucket::Fresh),
+        "stale" => Ok(ApprovalAttentionAgeBucket::Stale),
+        "overdue" => Ok(ApprovalAttentionAgeBucket::Overdue),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown grant_attention_age_bucket `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_grant_escalation_level(
+    value: &str,
+) -> Result<ApprovalEscalationLevel, String> {
+    match value {
+        "elevated" => Ok(ApprovalEscalationLevel::Elevated),
+        "critical" => Ok(ApprovalEscalationLevel::Critical),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown grant_escalation_level `{value}`"
         )),
     }
 }
@@ -3816,6 +4147,219 @@ mod tests {
             in_progress_requests[0]["approval_request_id"],
             "apr-attention-in-progress"
         );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_unifies_needs_attention_and_summary() {
+        let config = isolated_memory_config("approval-query-list-operator-attention-unified");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        seed_request(
+            &repo,
+            "apr-operator-attn-execution-gap",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-operator-attn-grant-missing",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-operator-attn-grant-overdue",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-operator-attn-clean",
+            "root-session",
+            "shell.exec",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        transition_request_status(
+            &repo,
+            "apr-operator-attn-execution-gap",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("persist assistant turn via kernel failed: forced outcome persistence failure"),
+        );
+        repo.transition_approval_request_if_current(
+            "apr-operator-attn-grant-missing",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-missing".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition grant-missing operator attention request")
+        .expect("grant-missing operator attention request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-operator-attn-grant-overdue",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-overdue".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition grant-overdue operator attention request")
+        .expect("grant-overdue operator attention request should transition");
+
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-operator-attn-execution-gap",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append operator attention execution-gap started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-operator-attn-execution-gap",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": false,
+                "replay_outcome_persist_error": "persist assistant turn via kernel failed: forced outcome persistence failure",
+            }),
+        })
+        .expect("append operator attention execution-gap finished event");
+
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:memory_search",
+            Some("operator-overdue"),
+        );
+
+        let now = test_unix_ts_now();
+        overwrite_request_requested_at(&config, "apr-operator-attn-execution-gap", now - 7_200);
+        overwrite_request_requested_at(&config, "apr-operator-attn-grant-missing", now - 3_600);
+        overwrite_request_requested_at(&config, "apr-operator-attn-grant-overdue", now - 300);
+        overwrite_request_requested_at(&config, "apr-operator-attn-clean", now - 30);
+        overwrite_runtime_grant_timestamps(
+            &config,
+            "root-session",
+            "tool:memory_search",
+            now - (9 * 24 * 60 * 60) - 60,
+            now - (9 * 24 * 60 * 60),
+        );
+
+        let summary_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for unified operator attention summary");
+
+        let attention_summary = &summary_outcome.payload["attention_summary"];
+        assert_eq!(attention_summary["needs_attention_count"], 3);
+        assert_eq!(attention_summary["signal_count"], 3);
+        assert_eq!(
+            attention_summary["request_counts_by_source"]["execution_only"],
+            1
+        );
+        assert_eq!(
+            attention_summary["request_counts_by_source"]["grant_only"],
+            2
+        );
+        assert_eq!(attention_summary["request_counts_by_source"]["both"], 0);
+        assert_eq!(attention_summary["counts_by_reason"]["integrity_gap"], 1);
+        assert_eq!(
+            attention_summary["counts_by_reason"]["durable_grant_missing"],
+            1
+        );
+        assert_eq!(
+            attention_summary["counts_by_reason"]["grant_review_overdue"],
+            1
+        );
+        assert_eq!(
+            attention_summary["recommended_action_counts"]["inspect_replay_persistence"],
+            1
+        );
+        assert_eq!(
+            attention_summary["recommended_action_counts"]["inspect_runtime_grant_persistence"],
+            1
+        );
+        assert_eq!(
+            attention_summary["recommended_action_counts"]["review_runtime_grant_scope"],
+            1
+        );
+        assert_eq!(attention_summary["age_bucket_counts"]["fresh"], 0);
+        assert_eq!(attention_summary["age_bucket_counts"]["stale"], 1);
+        assert_eq!(attention_summary["age_bucket_counts"]["overdue"], 1);
+        assert_eq!(attention_summary["counts_by_escalation"]["elevated"], 2);
+        assert_eq!(attention_summary["counts_by_escalation"]["critical"], 1);
+
+        let needs_attention_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "needs_attention": true,
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for unified needs_attention filter");
+
+        assert_eq!(needs_attention_outcome.payload["matched_count"], 3);
+        let attention_ids = needs_attention_outcome.payload["requests"]
+            .as_array()
+            .expect("needs_attention requests array")
+            .iter()
+            .filter_map(|item| item["approval_request_id"].as_str())
+            .collect::<Vec<_>>();
+        assert!(attention_ids.contains(&"apr-operator-attn-execution-gap"));
+        assert!(attention_ids.contains(&"apr-operator-attn-grant-missing"));
+        assert!(attention_ids.contains(&"apr-operator-attn-grant-overdue"));
+
+        let no_attention_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "needs_attention": false,
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for unified no-attention filter");
+
+        assert_eq!(no_attention_outcome.payload["matched_count"], 1);
+        assert_eq!(
+            no_attention_outcome.payload["requests"][0]["approval_request_id"],
+            "apr-operator-attn-clean"
+        );
+
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -6523,6 +7067,269 @@ mod tests {
         assert_eq!(
             requests[0]["approval_request_id"],
             "apr-grant-review-filter-fresh"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_filters_by_grant_attention_state() {
+        let config = isolated_memory_config("approval-query-list-grant-attention-filter");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        seed_request(
+            &repo,
+            "apr-grant-attention-filter-missing",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-attention-filter-overdue",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-grant-attention-filter-clean",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        repo.transition_approval_request_if_current(
+            "apr-grant-attention-filter-missing",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-missing".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition missing grant-attention filter request")
+        .expect("missing grant-attention filter request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-grant-attention-filter-overdue",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("operator-overdue".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition overdue grant-attention filter request")
+        .expect("overdue grant-attention filter request should transition");
+
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:session_cancel",
+            Some("operator-overdue"),
+        );
+
+        let now = test_unix_ts_now();
+        overwrite_runtime_grant_timestamps(
+            &config,
+            "root-session",
+            "tool:session_cancel",
+            now - (9 * 24 * 60 * 60) - 60,
+            now - (9 * 24 * 60 * 60),
+        );
+
+        let needs_attention_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_needs_attention": true,
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant_needs_attention");
+
+        assert_eq!(needs_attention_outcome.payload["matched_count"], 2);
+        let attention_ids = needs_attention_outcome.payload["requests"]
+            .as_array()
+            .expect("grant attention requests array")
+            .iter()
+            .filter_map(|item| item["approval_request_id"].as_str())
+            .collect::<Vec<_>>();
+        assert!(attention_ids.contains(&"apr-grant-attention-filter-missing"));
+        assert!(attention_ids.contains(&"apr-grant-attention-filter-overdue"));
+
+        let no_attention_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_needs_attention": false,
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for non-grant attention");
+
+        assert_eq!(no_attention_outcome.payload["matched_count"], 1);
+        assert_eq!(
+            no_attention_outcome.payload["requests"][0]["approval_request_id"],
+            "apr-grant-attention-filter-clean"
+        );
+
+        let missing_reason_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_attention_reason": "durable_grant_missing",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant_attention_reason");
+
+        assert_eq!(missing_reason_outcome.payload["matched_count"], 1);
+        assert_eq!(
+            missing_reason_outcome.payload["requests"][0]["approval_request_id"],
+            "apr-grant-attention-filter-missing"
+        );
+
+        let overdue_action_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_recommended_action": "review_runtime_grant_scope",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant_recommended_action");
+
+        assert_eq!(overdue_action_outcome.payload["matched_count"], 1);
+        assert_eq!(
+            overdue_action_outcome.payload["requests"][0]["approval_request_id"],
+            "apr-grant-attention-filter-overdue"
+        );
+
+        let overdue_age_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_attention_age_bucket": "overdue",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant_attention_age_bucket");
+
+        assert_eq!(overdue_age_outcome.payload["matched_count"], 1);
+        assert_eq!(
+            overdue_age_outcome.payload["requests"][0]["approval_request_id"],
+            "apr-grant-attention-filter-overdue"
+        );
+
+        let critical_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_escalation_level": "critical",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant_escalation_level");
+
+        assert_eq!(critical_outcome.payload["matched_count"], 1);
+        assert_eq!(
+            critical_outcome.payload["requests"][0]["approval_request_id"],
+            "apr-grant-attention-filter-missing"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_grant_attention_reason() {
+        let config = isolated_memory_config("approval-query-list-invalid-grant-attention-reason");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-invalid-grant-attention-reason",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_attention_reason": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("grant_attention_reason should reject unknown values");
+
+        assert_eq!(
+            error,
+            "approval_requests_list_invalid_request: unknown grant_attention_reason `broken`"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_grant_recommended_action() {
+        let config = isolated_memory_config("approval-query-list-invalid-grant-recommended-action");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-invalid-grant-recommended-action",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_recommended_action": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("grant_recommended_action should reject unknown values");
+
+        assert_eq!(
+            error,
+            "approval_requests_list_invalid_request: unknown grant_recommended_action `broken`"
         );
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -28,6 +28,7 @@ struct ApprovalRequestsListRequest {
     integrity_status: Option<ApprovalExecutionIntegrityStatus>,
     needs_attention: Option<bool>,
     attention_reason: Option<ApprovalAttentionReason>,
+    recommended_action: Option<ApprovalRecommendedAction>,
     prioritize_attention: bool,
     limit: usize,
 }
@@ -66,6 +67,27 @@ impl ApprovalAttentionReason {
         match self {
             Self::IntegrityGap => "integrity_gap",
             Self::ExecutionFailed => "execution_failed",
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalRecommendedAction {
+    InspectExecutionEventStream,
+    InspectReplayPersistence,
+    InspectToolExecutionFailure,
+    InspectApprovalIntegrity,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl ApprovalRecommendedAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::InspectExecutionEventStream => "inspect_execution_event_stream",
+            Self::InspectReplayPersistence => "inspect_replay_persistence",
+            Self::InspectToolExecutionFailure => "inspect_tool_execution_failure",
+            Self::InspectApprovalIntegrity => "inspect_approval_integrity",
         }
     }
 }
@@ -271,6 +293,13 @@ fn execute_approval_requests_list(
                 == Some(attention_reason)
         });
     }
+    if let Some(recommended_action) = request.recommended_action {
+        request_summaries.retain(|item| {
+            item.get("execution_integrity")
+                .and_then(approval_request_recommended_action_from_json)
+                == Some(recommended_action)
+        });
+    }
     if request.prioritize_attention {
         request_summaries.sort_by(|left, right| {
             approval_request_attention_priority(left)
@@ -296,6 +325,7 @@ fn execute_approval_requests_list(
                 "integrity_status": request.integrity_status.map(ApprovalExecutionIntegrityStatus::as_str),
                 "needs_attention": request.needs_attention,
                 "attention_reason": request.attention_reason.map(ApprovalAttentionReason::as_str),
+                "recommended_action": request.recommended_action.map(ApprovalRecommendedAction::as_str),
                 "prioritize_attention": request.prioritize_attention,
                 "limit": request.limit,
             },
@@ -431,6 +461,12 @@ fn approval_request_list_integrity_summary_json(requests: &[Value]) -> Value {
         ("integrity_gap".to_owned(), 0usize),
         ("execution_failed".to_owned(), 0usize),
     ]);
+    let mut recommended_action_counts = BTreeMap::from([
+        ("inspect_execution_event_stream".to_owned(), 0usize),
+        ("inspect_replay_persistence".to_owned(), 0usize),
+        ("inspect_tool_execution_failure".to_owned(), 0usize),
+        ("inspect_approval_integrity".to_owned(), 0usize),
+    ]);
 
     for request in requests {
         let execution_integrity = request.get("execution_integrity").unwrap_or(&Value::Null);
@@ -458,6 +494,14 @@ fn approval_request_list_integrity_summary_json(requests: &[Value]) -> Value {
             {
                 *counts_by_reason.entry(reason.to_owned()).or_default() += 1;
             }
+            if let Some(action) = execution_integrity
+                .get("recommended_action")
+                .and_then(Value::as_str)
+            {
+                *recommended_action_counts
+                    .entry(action.to_owned())
+                    .or_default() += 1;
+            }
         }
     }
 
@@ -467,6 +511,7 @@ fn approval_request_list_integrity_summary_json(requests: &[Value]) -> Value {
         "attention_summary": {
             "needs_attention_count": needs_attention_count,
             "counts_by_reason": counts_by_reason,
+            "recommended_action_counts": recommended_action_counts,
         },
     })
 }
@@ -666,6 +711,8 @@ fn approval_request_execution_integrity_json(
         } else {
             (false, Value::Null)
         };
+    let recommended_action =
+        approval_request_recommended_action_json(status, gap.as_str(), execution_error.is_null());
 
     json!({
         "status": status.as_str(),
@@ -675,6 +722,7 @@ fn approval_request_execution_integrity_json(
         "evidence_complete": evidence_complete,
         "needs_attention": needs_attention,
         "attention_reason": attention_reason,
+        "recommended_action": recommended_action,
     })
 }
 
@@ -798,6 +846,53 @@ fn approval_request_attention_reason_from_json(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_recommended_action_json(
+    status: ApprovalExecutionIntegrityStatus,
+    gap: Option<&str>,
+    execution_error_is_null: bool,
+) -> Value {
+    match status {
+        ApprovalExecutionIntegrityStatus::Incomplete => match gap {
+            Some("started_event_missing")
+            | Some("terminal_event_missing")
+            | Some("execution_events_missing") => Value::String(
+                ApprovalRecommendedAction::InspectExecutionEventStream
+                    .as_str()
+                    .to_owned(),
+            ),
+            Some("replay_decision_and_outcome_missing")
+            | Some("replay_decision_missing")
+            | Some("replay_outcome_missing") => Value::String(
+                ApprovalRecommendedAction::InspectReplayPersistence
+                    .as_str()
+                    .to_owned(),
+            ),
+            Some(_) | None => Value::String(
+                ApprovalRecommendedAction::InspectApprovalIntegrity
+                    .as_str()
+                    .to_owned(),
+            ),
+        },
+        ApprovalExecutionIntegrityStatus::Complete if !execution_error_is_null => Value::String(
+            ApprovalRecommendedAction::InspectToolExecutionFailure
+                .as_str()
+                .to_owned(),
+        ),
+        _ => Value::Null,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_recommended_action_from_json(
+    execution_integrity: &Value,
+) -> Option<ApprovalRecommendedAction> {
+    execution_integrity
+        .get("recommended_action")
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_recommended_action(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_attention_priority(request: &Value) -> u8 {
     let execution_integrity = request.get("execution_integrity").unwrap_or(&Value::Null);
     if execution_integrity
@@ -847,6 +942,10 @@ fn parse_approval_requests_list_request(
         )?,
         needs_attention: payload.get("needs_attention").and_then(Value::as_bool),
         attention_reason: optional_payload_approval_attention_reason(payload, "attention_reason")?,
+        recommended_action: optional_payload_approval_recommended_action(
+            payload,
+            "recommended_action",
+        )?,
         prioritize_attention: payload
             .get("prioritize_attention")
             .and_then(Value::as_bool)
@@ -965,6 +1064,16 @@ fn optional_payload_approval_attention_reason(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_recommended_action(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalRecommendedAction>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_recommended_action(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn parse_approval_request_status(value: &str) -> Result<ApprovalRequestStatus, String> {
     match value {
         "pending" => Ok(ApprovalRequestStatus::Pending),
@@ -1002,6 +1111,23 @@ fn parse_approval_attention_reason(value: &str) -> Result<ApprovalAttentionReaso
         "execution_failed" => Ok(ApprovalAttentionReason::ExecutionFailed),
         _ => Err(format!(
             "approval_requests_list_invalid_request: unknown attention_reason `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_recommended_action(value: &str) -> Result<ApprovalRecommendedAction, String> {
+    match value {
+        "inspect_execution_event_stream" => {
+            Ok(ApprovalRecommendedAction::InspectExecutionEventStream)
+        }
+        "inspect_replay_persistence" => Ok(ApprovalRecommendedAction::InspectReplayPersistence),
+        "inspect_tool_execution_failure" => {
+            Ok(ApprovalRecommendedAction::InspectToolExecutionFailure)
+        }
+        "inspect_approval_integrity" => Ok(ApprovalRecommendedAction::InspectApprovalIntegrity),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown recommended_action `{value}`"
         )),
     }
 }
@@ -1199,6 +1325,10 @@ mod tests {
             root_request["execution_integrity"]["attention_reason"],
             Value::Null
         );
+        assert_eq!(
+            root_request["execution_integrity"]["recommended_action"],
+            Value::Null
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1271,6 +1401,7 @@ mod tests {
         assert_eq!(integrity["integrity_error"], Value::Null);
         assert_eq!(integrity["needs_attention"], false);
         assert_eq!(integrity["attention_reason"], Value::Null);
+        assert_eq!(integrity["recommended_action"], Value::Null);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1665,6 +1796,43 @@ mod tests {
             execution_failed_requests[0]["execution_integrity"]["attention_reason"],
             "execution_failed"
         );
+        assert_eq!(
+            execution_failed_requests[0]["execution_integrity"]["recommended_action"],
+            "inspect_tool_execution_failure"
+        );
+
+        let replay_persistence_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "recommended_action": "inspect_replay_persistence",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for recommended_action");
+
+        assert_eq!(
+            replay_persistence_outcome.payload["filter"]["recommended_action"],
+            "inspect_replay_persistence"
+        );
+        assert_eq!(replay_persistence_outcome.payload["matched_count"], 1);
+        assert_eq!(replay_persistence_outcome.payload["returned_count"], 1);
+        let replay_persistence_requests = replay_persistence_outcome.payload["requests"]
+            .as_array()
+            .expect("recommended_action requests array");
+        assert_eq!(replay_persistence_requests.len(), 1);
+        assert_eq!(
+            replay_persistence_requests[0]["approval_request_id"],
+            "apr-attention-integrity-gap"
+        );
+        assert_eq!(
+            replay_persistence_requests[0]["execution_integrity"]["recommended_action"],
+            "inspect_replay_persistence"
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1874,6 +2042,13 @@ mod tests {
             "session_cancel",
             "governed_tool_requires_per_call_approval",
         );
+        seed_request(
+            &repo,
+            "apr-summary-missing-events",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
 
         transition_request_status(
             &repo,
@@ -1902,6 +2077,13 @@ mod tests {
             ApprovalRequestStatus::Pending,
             ApprovalRequestStatus::Executed,
             Some("tool failed for domain reasons"),
+        );
+        transition_request_status(
+            &repo,
+            "apr-summary-missing-events",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("approval request executed without persisted execution events"),
         );
 
         repo.append_event(crate::session::repository::NewSessionEvent {
@@ -2002,18 +2184,36 @@ mod tests {
         assert_eq!(summary["counts_by_status"]["not_started"], 1);
         assert_eq!(summary["counts_by_status"]["in_progress"], 1);
         assert_eq!(summary["counts_by_status"]["complete"], 2);
-        assert_eq!(summary["counts_by_status"]["incomplete"], 1);
+        assert_eq!(summary["counts_by_status"]["incomplete"], 2);
+        assert_eq!(
+            summary["incomplete_gap_counts"]["execution_events_missing"],
+            1
+        );
         assert_eq!(
             summary["incomplete_gap_counts"]["replay_outcome_missing"],
             1
         );
-        assert_eq!(summary["attention_summary"]["needs_attention_count"], 2);
+        assert_eq!(summary["attention_summary"]["needs_attention_count"], 3);
         assert_eq!(
             summary["attention_summary"]["counts_by_reason"]["integrity_gap"],
-            1
+            2
         );
         assert_eq!(
             summary["attention_summary"]["counts_by_reason"]["execution_failed"],
+            1
+        );
+        assert_eq!(
+            summary["attention_summary"]["recommended_action_counts"]
+                ["inspect_execution_event_stream"],
+            1
+        );
+        assert_eq!(
+            summary["attention_summary"]["recommended_action_counts"]["inspect_replay_persistence"],
+            1
+        );
+        assert_eq!(
+            summary["attention_summary"]["recommended_action_counts"]
+                ["inspect_tool_execution_failure"],
             1
         );
     }
@@ -2041,6 +2241,32 @@ mod tests {
         assert!(
             error.contains("approval_requests_list_invalid_request: unknown attention_reason"),
             "expected attention_reason validation error, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_recommended_action() {
+        let config = isolated_memory_config("approval-query-list-invalid-recommended-action");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "recommended_action": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("unknown recommended_action should be rejected");
+
+        assert!(
+            error.contains("approval_requests_list_invalid_request: unknown recommended_action"),
+            "expected recommended_action validation error, got: {error}"
         );
     }
 
@@ -2134,6 +2360,10 @@ mod tests {
             request["execution_integrity"]["attention_reason"],
             Value::Null
         );
+        assert_eq!(
+            request["execution_integrity"]["recommended_action"],
+            Value::Null
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -2206,11 +2436,59 @@ mod tests {
         assert_eq!(integrity["execution_error"], Value::Null);
         assert_eq!(integrity["needs_attention"], true);
         assert_eq!(integrity["attention_reason"], "integrity_gap");
+        assert_eq!(
+            integrity["recommended_action"],
+            "inspect_replay_persistence"
+        );
         assert!(
             integrity["integrity_error"]
                 .as_str()
                 .is_some_and(|error| error.contains("persist assistant turn via kernel failed")),
             "expected replay outcome persistence integrity error, got: {integrity}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_status_recommends_event_stream_investigation_for_missing_execution_events(
+    ) {
+        let config = isolated_memory_config("approval-query-status-missing-execution-events");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-visible-missing-events",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        transition_request_status(
+            &repo,
+            "apr-visible-missing-events",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("approval request executed without persisted execution events"),
+        );
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-visible-missing-events",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome");
+
+        let integrity = &outcome.payload["approval_request"]["execution_integrity"];
+        assert_eq!(integrity["status"], "incomplete");
+        assert_eq!(integrity["gap"], "execution_events_missing");
+        assert_eq!(
+            integrity["recommended_action"],
+            "inspect_execution_event_stream"
         );
     }
 
@@ -2274,6 +2552,10 @@ mod tests {
         );
         assert_eq!(integrity["needs_attention"], true);
         assert_eq!(integrity["attention_reason"], "execution_failed");
+        assert_eq!(
+            integrity["recommended_action"],
+            "inspect_tool_execution_failure"
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -29,6 +29,8 @@ const APPROVAL_ATTENTION_STALE_MAX_SECONDS: i64 = 4 * 60 * 60;
 struct ApprovalRequestsListRequest {
     session_id: Option<String>,
     status: Option<ApprovalRequestStatus>,
+    decision: Option<ApprovalDecision>,
+    replay_result: Option<ApprovalReplayResult>,
     integrity_status: Option<ApprovalExecutionIntegrityStatus>,
     needs_attention: Option<bool>,
     attention_reason: Option<ApprovalAttentionReason>,
@@ -130,6 +132,27 @@ impl ApprovalEscalationLevel {
         match self {
             Self::Elevated => "elevated",
             Self::Critical => "critical",
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalReplayResult {
+    NotAttempted,
+    InProgress,
+    CompletedCleanly,
+    CompletedWithAttention,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl ApprovalReplayResult {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::NotAttempted => "not_attempted",
+            Self::InProgress => "in_progress",
+            Self::CompletedCleanly => "completed_cleanly",
+            Self::CompletedWithAttention => "completed_with_attention",
         }
     }
 }
@@ -320,6 +343,14 @@ fn execute_approval_requests_list(
                 == Some(integrity_status)
         });
     }
+    if let Some(decision) = request.decision {
+        request_summaries
+            .retain(|item| approval_request_decision_from_json(item) == Some(decision));
+    }
+    if let Some(replay_result) = request.replay_result {
+        request_summaries
+            .retain(|item| approval_request_replay_result_from_json(item) == Some(replay_result));
+    }
     if let Some(needs_attention) = request.needs_attention {
         request_summaries.retain(|item| {
             item.get("execution_integrity")
@@ -383,6 +414,8 @@ fn execute_approval_requests_list(
             "filter": {
                 "session_id": request.session_id,
                 "status": request.status.map(ApprovalRequestStatus::as_str),
+                "decision": request.decision.map(ApprovalDecision::as_str),
+                "replay_result": request.replay_result.map(ApprovalReplayResult::as_str),
                 "integrity_status": request.integrity_status.map(ApprovalExecutionIntegrityStatus::as_str),
                 "needs_attention": request.needs_attention,
                 "attention_reason": request.attention_reason.map(ApprovalAttentionReason::as_str),
@@ -616,6 +649,12 @@ fn approval_request_list_integrity_summary_json(requests: &[Value]) -> Value {
 
 #[cfg(feature = "memory-sqlite")]
 fn approval_request_list_resolution_summary_json(requests: &[Value]) -> Value {
+    let mut decision_counts = BTreeMap::from([
+        ("unresolved".to_owned(), 0usize),
+        ("approve_once".to_owned(), 0usize),
+        ("approve_always".to_owned(), 0usize),
+        ("deny".to_owned(), 0usize),
+    ]);
     let mut request_status_counts = BTreeMap::from([
         ("pending".to_owned(), 0usize),
         ("approved".to_owned(), 0usize),
@@ -634,6 +673,14 @@ fn approval_request_list_resolution_summary_json(requests: &[Value]) -> Value {
 
     for request in requests {
         let resolution = request.get("resolution").unwrap_or(&Value::Null);
+        match resolution.get("decision").and_then(Value::as_str) {
+            Some(decision) => {
+                *decision_counts.entry(decision.to_owned()).or_default() += 1;
+            }
+            None => {
+                *decision_counts.entry("unresolved".to_owned()).or_default() += 1;
+            }
+        }
         if let Some(request_status) = resolution.get("request_status").and_then(Value::as_str) {
             *request_status_counts
                 .entry(request_status.to_owned())
@@ -647,6 +694,7 @@ fn approval_request_list_resolution_summary_json(requests: &[Value]) -> Value {
     }
 
     json!({
+        "decision_counts": decision_counts,
         "request_status_counts": request_status_counts,
         "replay_result_counts": replay_result_counts,
     })
@@ -1038,6 +1086,24 @@ fn approval_request_execution_integrity_status_from_json(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_decision_from_json(request: &Value) -> Option<ApprovalDecision> {
+    request
+        .get("resolution")
+        .and_then(|value| value.get("decision"))
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_list_decision(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_replay_result_from_json(request: &Value) -> Option<ApprovalReplayResult> {
+    request
+        .get("resolution")
+        .and_then(|value| value.get("replay_result"))
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_replay_result(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_attention_reason_from_json(
     execution_integrity: &Value,
 ) -> Option<ApprovalAttentionReason> {
@@ -1198,6 +1264,8 @@ fn parse_approval_requests_list_request(
     Ok(ApprovalRequestsListRequest {
         session_id: optional_payload_string(payload, "session_id"),
         status: optional_payload_approval_request_status(payload, "status")?,
+        decision: optional_payload_approval_list_decision(payload, "decision")?,
+        replay_result: optional_payload_approval_replay_result(payload, "replay_result")?,
         integrity_status: optional_payload_approval_execution_integrity_status(
             payload,
             "integrity_status",
@@ -1321,6 +1389,26 @@ fn optional_payload_approval_execution_integrity_status(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_list_decision(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalDecision>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_list_decision(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_replay_result(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalReplayResult>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_replay_result(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn optional_payload_approval_attention_reason(
     payload: &Value,
     field: &str,
@@ -1387,6 +1475,31 @@ fn parse_approval_execution_integrity_status(
         "incomplete" => Ok(ApprovalExecutionIntegrityStatus::Incomplete),
         _ => Err(format!(
             "approval_requests_list_invalid_request: unknown integrity_status `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_list_decision(value: &str) -> Result<ApprovalDecision, String> {
+    match value {
+        "approve_once" => Ok(ApprovalDecision::ApproveOnce),
+        "approve_always" => Ok(ApprovalDecision::ApproveAlways),
+        "deny" => Ok(ApprovalDecision::Deny),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown decision `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_replay_result(value: &str) -> Result<ApprovalReplayResult, String> {
+    match value {
+        "not_attempted" => Ok(ApprovalReplayResult::NotAttempted),
+        "in_progress" => Ok(ApprovalReplayResult::InProgress),
+        "completed_cleanly" => Ok(ApprovalReplayResult::CompletedCleanly),
+        "completed_with_attention" => Ok(ApprovalReplayResult::CompletedWithAttention),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown replay_result `{value}`"
         )),
     }
 }
@@ -1467,8 +1580,8 @@ mod tests {
     use crate::config::ToolConfig;
     use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::{
-        ApprovalRequestStatus, NewApprovalRequestRecord, NewSessionRecord, SessionKind,
-        SessionRepository, SessionState, TransitionApprovalRequestIfCurrentRequest,
+        ApprovalDecision, ApprovalRequestStatus, NewApprovalRequestRecord, NewSessionRecord,
+        SessionKind, SessionRepository, SessionState, TransitionApprovalRequestIfCurrentRequest,
     };
 
     fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
@@ -2270,6 +2383,200 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(elevated_escalation_ids.contains(&"apr-attention-integrity-gap"));
         assert!(elevated_escalation_ids.contains(&"apr-attention-execution-failed"));
+
+        let completed_with_attention_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "replay_result": "completed_with_attention",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for replay_result");
+
+        assert_eq!(
+            completed_with_attention_outcome.payload["filter"]["replay_result"],
+            "completed_with_attention"
+        );
+        assert_eq!(completed_with_attention_outcome.payload["matched_count"], 2);
+        assert_eq!(
+            completed_with_attention_outcome.payload["returned_count"],
+            2
+        );
+        let completed_with_attention_requests = completed_with_attention_outcome.payload
+            ["requests"]
+            .as_array()
+            .expect("replay_result requests array");
+        let completed_with_attention_ids = completed_with_attention_requests
+            .iter()
+            .filter_map(|item| item["approval_request_id"].as_str())
+            .collect::<Vec<_>>();
+        assert!(completed_with_attention_ids.contains(&"apr-attention-integrity-gap"));
+        assert!(completed_with_attention_ids.contains(&"apr-attention-execution-failed"));
+
+        let in_progress_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "replay_result": "in_progress",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for in_progress replay_result");
+
+        assert_eq!(
+            in_progress_outcome.payload["filter"]["replay_result"],
+            "in_progress"
+        );
+        assert_eq!(in_progress_outcome.payload["matched_count"], 1);
+        assert_eq!(in_progress_outcome.payload["returned_count"], 1);
+        let in_progress_requests = in_progress_outcome.payload["requests"]
+            .as_array()
+            .expect("in_progress replay_result requests array");
+        assert_eq!(in_progress_requests.len(), 1);
+        assert_eq!(
+            in_progress_requests[0]["approval_request_id"],
+            "apr-attention-in-progress"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_filters_by_decision() {
+        let config = isolated_memory_config("approval-query-list-decision-filter");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-decision-pending",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-decision-denied",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-decision-approved",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-decision-once",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        repo.transition_approval_request_if_current(
+            "apr-decision-denied",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Denied,
+                decision: Some(ApprovalDecision::Deny),
+                resolved_by_session_id: Some("root-session".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition denied request")
+        .expect("denied request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-decision-approved",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("root-session".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition approved request")
+        .expect("approved request should transition");
+        repo.transition_approval_request_if_current(
+            "apr-decision-once",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Executed,
+                decision: Some(ApprovalDecision::ApproveOnce),
+                resolved_by_session_id: Some("root-session".to_owned()),
+                executed_at: Some(1_773_000_000),
+                last_error: None,
+            },
+        )
+        .expect("transition approve_once request")
+        .expect("approve_once request should transition");
+
+        let approve_always_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "decision": "approve_always",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for approve_always decision");
+
+        assert_eq!(
+            approve_always_outcome.payload["filter"]["decision"],
+            "approve_always"
+        );
+        assert_eq!(approve_always_outcome.payload["matched_count"], 1);
+        assert_eq!(approve_always_outcome.payload["returned_count"], 1);
+        let approve_always_requests = approve_always_outcome.payload["requests"]
+            .as_array()
+            .expect("approve_always decision requests array");
+        assert_eq!(approve_always_requests.len(), 1);
+        assert_eq!(
+            approve_always_requests[0]["approval_request_id"],
+            "apr-decision-approved"
+        );
+
+        let deny_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "decision": "deny",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for deny decision");
+
+        assert_eq!(deny_outcome.payload["filter"]["decision"], "deny");
+        assert_eq!(deny_outcome.payload["matched_count"], 1);
+        assert_eq!(deny_outcome.payload["returned_count"], 1);
+        let deny_requests = deny_outcome.payload["requests"]
+            .as_array()
+            .expect("deny decision requests array");
+        assert_eq!(deny_requests.len(), 1);
+        assert_eq!(
+            deny_requests[0]["approval_request_id"],
+            "apr-decision-denied"
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -2712,6 +3019,10 @@ mod tests {
             1
         );
         let resolution_summary = &outcome.payload["resolution_summary"];
+        assert_eq!(resolution_summary["decision_counts"]["unresolved"], 6);
+        assert_eq!(resolution_summary["decision_counts"]["approve_once"], 0);
+        assert_eq!(resolution_summary["decision_counts"]["approve_always"], 0);
+        assert_eq!(resolution_summary["decision_counts"]["deny"], 0);
         assert_eq!(resolution_summary["request_status_counts"]["pending"], 1);
         assert_eq!(resolution_summary["request_status_counts"]["approved"], 0);
         assert_eq!(resolution_summary["request_status_counts"]["executing"], 1);
@@ -2719,7 +3030,10 @@ mod tests {
         assert_eq!(resolution_summary["request_status_counts"]["denied"], 0);
         assert_eq!(resolution_summary["request_status_counts"]["expired"], 0);
         assert_eq!(resolution_summary["request_status_counts"]["cancelled"], 0);
-        assert_eq!(resolution_summary["replay_result_counts"]["not_attempted"], 1);
+        assert_eq!(
+            resolution_summary["replay_result_counts"]["not_attempted"],
+            1
+        );
         assert_eq!(resolution_summary["replay_result_counts"]["in_progress"], 1);
         assert_eq!(
             resolution_summary["replay_result_counts"]["completed_cleanly"],
@@ -2754,6 +3068,58 @@ mod tests {
         assert!(
             error.contains("approval_requests_list_invalid_request: unknown attention_reason"),
             "expected attention_reason validation error, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_decision() {
+        let config = isolated_memory_config("approval-query-list-invalid-decision");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "decision": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("unknown decision should be rejected");
+
+        assert!(
+            error.contains("approval_requests_list_invalid_request: unknown decision"),
+            "expected decision validation error, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_replay_result() {
+        let config = isolated_memory_config("approval-query-list-invalid-replay-result");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "replay_result": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("unknown replay_result should be rejected");
+
+        assert!(
+            error.contains("approval_requests_list_invalid_request: unknown replay_result"),
+            "expected replay_result validation error, got: {error}"
         );
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -1,0 +1,662 @@
+use async_trait::async_trait;
+use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+use serde_json::{json, Value};
+
+#[cfg(feature = "memory-sqlite")]
+use crate::config::SessionVisibility;
+use crate::config::ToolConfig;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{
+    ApprovalDecision, ApprovalRequestRecord, ApprovalRequestStatus, SessionRepository,
+};
+use crate::KernelContext;
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ApprovalRequestsListRequest {
+    session_id: Option<String>,
+    status: Option<ApprovalRequestStatus>,
+    limit: usize,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ApprovalRequestResolveRequest {
+    approval_request_id: String,
+    decision: ApprovalDecision,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone)]
+pub(crate) struct ApprovalResolutionRequest {
+    pub current_session_id: String,
+    pub approval_request_id: String,
+    pub decision: ApprovalDecision,
+    pub visibility: SessionVisibility,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone)]
+pub(crate) struct ApprovalResolutionOutcome {
+    pub approval_request: ApprovalRequestRecord,
+    pub resumed_tool_output: Option<ToolCoreOutcome>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+pub(crate) trait ApprovalResolutionRuntime: Send + Sync {
+    async fn resolve_approval_request(
+        &self,
+        request: ApprovalResolutionRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ApprovalResolutionOutcome, String>;
+}
+
+pub fn execute_approval_tool_with_policies(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (request, current_session_id, config, tool_config);
+        return Err(
+            "approval tools require sqlite memory support (enable feature `memory-sqlite`)"
+                .to_owned(),
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        if !tool_config.sessions.enabled {
+            return Err("app_tool_disabled: session tools are disabled by config".to_owned());
+        }
+        match request.tool_name.as_str() {
+            "approval_requests_list" => execute_approval_requests_list(
+                request.payload,
+                current_session_id,
+                config,
+                tool_config,
+            ),
+            "approval_request_status" => execute_approval_request_status(
+                request.payload,
+                current_session_id,
+                config,
+                tool_config,
+            ),
+            "approval_request_resolve" => {
+                Err("app_tool_requires_runtime_support: approval_request_resolve".to_owned())
+            }
+            other => Err(format!(
+                "app_tool_not_found: unknown approval tool `{other}`"
+            )),
+        }
+    }
+}
+
+pub async fn execute_approval_tool_with_runtime_support(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    runtime: Option<&(dyn ApprovalResolutionRuntime + '_)>,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (
+            request,
+            current_session_id,
+            config,
+            tool_config,
+            runtime,
+            kernel_ctx,
+        );
+        return Err(
+            "approval tools require sqlite memory support (enable feature `memory-sqlite`)"
+                .to_owned(),
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        match request.tool_name.as_str() {
+            "approval_request_resolve" => {
+                let runtime =
+                    runtime.ok_or_else(|| "approval_request_runtime_not_configured".to_owned())?;
+                execute_approval_request_resolve(
+                    request.payload,
+                    current_session_id,
+                    tool_config,
+                    runtime,
+                    kernel_ctx,
+                )
+                .await
+            }
+            _ => execute_approval_tool_with_policies(
+                request,
+                current_session_id,
+                config,
+                tool_config,
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_approval_requests_list(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let repo = SessionRepository::new(config)?;
+    let request = parse_approval_requests_list_request(&payload, tool_config)?;
+    let target_session_ids = match request.session_id.as_deref() {
+        Some(session_id) => {
+            ensure_visible(
+                &repo,
+                current_session_id,
+                session_id,
+                tool_config.sessions.visibility,
+            )?;
+            vec![session_id.to_owned()]
+        }
+        None => visible_session_ids(&repo, current_session_id, tool_config.sessions.visibility)?,
+    };
+
+    let mut requests = Vec::new();
+    for session_id in &target_session_ids {
+        requests.extend(repo.list_approval_requests_for_session(session_id, request.status)?);
+    }
+    requests.sort_by(|left, right| {
+        right
+            .requested_at
+            .cmp(&left.requested_at)
+            .then_with(|| left.approval_request_id.cmp(&right.approval_request_id))
+    });
+
+    let matched_count = requests.len();
+    requests.truncate(request.limit);
+    let returned_count = requests.len();
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "current_session_id": current_session_id,
+            "filter": {
+                "session_id": request.session_id,
+                "status": request.status.map(ApprovalRequestStatus::as_str),
+                "limit": request.limit,
+            },
+            "visible_session_ids": target_session_ids,
+            "matched_count": matched_count,
+            "returned_count": returned_count,
+            "requests": requests
+                .iter()
+                .map(approval_request_summary_json)
+                .collect::<Vec<_>>(),
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_approval_request_status(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let approval_request_id = required_payload_string(&payload, "approval_request_id")?;
+    let repo = SessionRepository::new(config)?;
+    let request = repo
+        .load_approval_request(&approval_request_id)?
+        .ok_or_else(|| format!("approval_request_not_found: `{approval_request_id}`"))?;
+    ensure_visible(
+        &repo,
+        current_session_id,
+        &request.session_id,
+        tool_config.sessions.visibility,
+    )?;
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "current_session_id": current_session_id,
+            "approval_request": approval_request_detail_json(&request),
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn execute_approval_request_resolve(
+    payload: Value,
+    current_session_id: &str,
+    tool_config: &ToolConfig,
+    runtime: &(dyn ApprovalResolutionRuntime + '_),
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<ToolCoreOutcome, String> {
+    let request = parse_approval_request_resolve_request(&payload)?;
+    let outcome = runtime
+        .resolve_approval_request(
+            ApprovalResolutionRequest {
+                current_session_id: current_session_id.to_owned(),
+                approval_request_id: request.approval_request_id,
+                decision: request.decision,
+                visibility: tool_config.sessions.visibility,
+            },
+            kernel_ctx,
+        )
+        .await?;
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "current_session_id": current_session_id,
+            "approval_request": approval_request_detail_json(&outcome.approval_request),
+            "resumed_tool_output": outcome.resumed_tool_output,
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_summary_json(record: &ApprovalRequestRecord) -> Value {
+    json!({
+        "approval_request_id": record.approval_request_id,
+        "session_id": record.session_id,
+        "turn_id": record.turn_id,
+        "tool_call_id": record.tool_call_id,
+        "tool_name": record.tool_name,
+        "approval_key": record.approval_key,
+        "status": record.status.as_str(),
+        "decision": record.decision.map(|decision| decision.as_str()),
+        "requested_at": record.requested_at,
+        "resolved_at": record.resolved_at,
+        "resolved_by_session_id": record.resolved_by_session_id,
+        "executed_at": record.executed_at,
+        "last_error": record.last_error,
+        "reason": record
+            .governance_snapshot_json
+            .get("reason")
+            .and_then(Value::as_str),
+        "rule_id": record
+            .governance_snapshot_json
+            .get("rule_id")
+            .and_then(Value::as_str),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_detail_json(record: &ApprovalRequestRecord) -> Value {
+    json!({
+        "approval_request_id": record.approval_request_id,
+        "session_id": record.session_id,
+        "turn_id": record.turn_id,
+        "tool_call_id": record.tool_call_id,
+        "tool_name": record.tool_name,
+        "approval_key": record.approval_key,
+        "status": record.status.as_str(),
+        "decision": record.decision.map(|decision| decision.as_str()),
+        "requested_at": record.requested_at,
+        "resolved_at": record.resolved_at,
+        "resolved_by_session_id": record.resolved_by_session_id,
+        "executed_at": record.executed_at,
+        "last_error": record.last_error,
+        "request_payload": record.request_payload_json,
+        "governance_snapshot": record.governance_snapshot_json,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_requests_list_request(
+    payload: &Value,
+    tool_config: &ToolConfig,
+) -> Result<ApprovalRequestsListRequest, String> {
+    Ok(ApprovalRequestsListRequest {
+        session_id: optional_payload_string(payload, "session_id"),
+        status: optional_payload_approval_request_status(payload, "status")?,
+        limit: optional_payload_limit(
+            payload,
+            "limit",
+            tool_config.sessions.list_limit,
+            tool_config.sessions.list_limit,
+        ),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_request_resolve_request(
+    payload: &Value,
+) -> Result<ApprovalRequestResolveRequest, String> {
+    Ok(ApprovalRequestResolveRequest {
+        approval_request_id: required_payload_string(payload, "approval_request_id")?,
+        decision: parse_approval_decision(&required_payload_string(payload, "decision")?)?,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn visible_session_ids(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    visibility: SessionVisibility,
+) -> Result<Vec<String>, String> {
+    match visibility {
+        SessionVisibility::SelfOnly => Ok(vec![current_session_id.to_owned()]),
+        SessionVisibility::Children => Ok(repo
+            .list_visible_sessions(current_session_id)?
+            .into_iter()
+            .map(|session| session.session_id)
+            .collect()),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn ensure_visible(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    target_session_id: &str,
+    visibility: SessionVisibility,
+) -> Result<(), String> {
+    let is_visible = match visibility {
+        SessionVisibility::SelfOnly => current_session_id == target_session_id,
+        SessionVisibility::Children => {
+            repo.is_session_visible(current_session_id, target_session_id)?
+        }
+    };
+    if is_visible {
+        return Ok(());
+    }
+    Err(format!(
+        "visibility_denied: session `{target_session_id}` is not visible from `{current_session_id}`"
+    ))
+}
+
+fn required_payload_string(payload: &Value, field: &str) -> Result<String, String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| format!("approval tool requires payload.{field}"))
+}
+
+fn optional_payload_string(payload: &Value, field: &str) -> Option<String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn optional_payload_limit(payload: &Value, field: &str, default: usize, max: usize) -> usize {
+    payload
+        .get(field)
+        .and_then(Value::as_u64)
+        .map(|value| value.clamp(1, max as u64) as usize)
+        .unwrap_or(default)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_request_status(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalRequestStatus>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_request_status(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_request_status(value: &str) -> Result<ApprovalRequestStatus, String> {
+    match value {
+        "pending" => Ok(ApprovalRequestStatus::Pending),
+        "approved" => Ok(ApprovalRequestStatus::Approved),
+        "executing" => Ok(ApprovalRequestStatus::Executing),
+        "executed" => Ok(ApprovalRequestStatus::Executed),
+        "denied" => Ok(ApprovalRequestStatus::Denied),
+        "expired" => Ok(ApprovalRequestStatus::Expired),
+        "cancelled" => Ok(ApprovalRequestStatus::Cancelled),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown status `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_decision(value: &str) -> Result<ApprovalDecision, String> {
+    match value {
+        "approve_once" => Ok(ApprovalDecision::ApproveOnce),
+        "approve_always" => Ok(ApprovalDecision::ApproveAlways),
+        "deny" => Ok(ApprovalDecision::Deny),
+        _ => Err(format!(
+            "approval_request_resolve_invalid_request: unknown decision `{value}`"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use loongclaw_contracts::ToolCoreRequest;
+    use serde_json::json;
+    use serde_json::Value;
+
+    use crate::config::ToolConfig;
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::repository::{
+        NewApprovalRequestRecord, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    };
+
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        let base = std::env::temp_dir().join(format!(
+            "loongclaw-approval-tools-{test_name}-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&base);
+        let db_path = base.join("memory.sqlite3");
+        let _ = fs::remove_file(&db_path);
+        MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn seed_session(
+        repo: &SessionRepository,
+        session_id: &str,
+        kind: SessionKind,
+        parent_session_id: Option<&str>,
+    ) {
+        repo.create_session(NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind,
+            parent_session_id: parent_session_id.map(str::to_owned),
+            label: Some(session_id.to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create session");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn seed_request(
+        repo: &SessionRepository,
+        approval_request_id: &str,
+        session_id: &str,
+        tool_name: &str,
+        rule_id: &str,
+    ) {
+        repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id: approval_request_id.to_owned(),
+            session_id: session_id.to_owned(),
+            turn_id: format!("turn-{approval_request_id}"),
+            tool_call_id: format!("call-{approval_request_id}"),
+            tool_name: tool_name.to_owned(),
+            approval_key: format!("tool:{tool_name}"),
+            request_payload_json: json!({
+                "session_id": session_id,
+                "tool_name": tool_name,
+                "args_json": {
+                    "task": format!("run-{approval_request_id}")
+                },
+            }),
+            governance_snapshot_json: json!({
+                "reason": format!("approval required for {tool_name}"),
+                "rule_id": rule_id,
+                "execution_plane": "Orchestration",
+            }),
+        })
+        .expect("seed approval request");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_returns_only_visible_requests() {
+        let config = isolated_memory_config("approval-query-list-visible");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+        seed_session(&repo, "hidden-root", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-root-visible",
+            "root-session",
+            "delegate_async",
+            "rule-root",
+        );
+        seed_request(
+            &repo,
+            "apr-child-visible",
+            "child-session",
+            "delegate",
+            "rule-child",
+        );
+        seed_request(
+            &repo,
+            "apr-hidden",
+            "hidden-root",
+            "delegate_async",
+            "rule-hidden",
+        );
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({}),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["matched_count"], 2);
+        assert_eq!(outcome.payload["returned_count"], 2);
+        let requests = outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        let request_ids = requests
+            .iter()
+            .filter_map(|item| item.get("approval_request_id"))
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>();
+        assert!(request_ids.contains(&"apr-root-visible"));
+        assert!(request_ids.contains(&"apr-child-visible"));
+        assert!(!request_ids.contains(&"apr-hidden"));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_status_returns_full_visible_request_detail() {
+        let config = isolated_memory_config("approval-query-status-visible");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+        seed_request(
+            &repo,
+            "apr-child-visible",
+            "child-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-child-visible",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome");
+
+        assert_eq!(outcome.status, "ok");
+        let request = &outcome.payload["approval_request"];
+        assert_eq!(request["approval_request_id"], "apr-child-visible");
+        assert_eq!(request["session_id"], "child-session");
+        assert_eq!(request["tool_name"], "delegate_async");
+        assert_eq!(request["approval_key"], "tool:delegate_async");
+        assert_eq!(request["status"], "pending");
+        assert_eq!(
+            request["governance_snapshot"]["rule_id"],
+            "governed_tool_requires_per_call_approval"
+        );
+        assert_eq!(request["request_payload"]["tool_name"], "delegate_async");
+        assert_eq!(
+            request["request_payload"]["args_json"]["task"],
+            "run-apr-child-visible"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_status_rejects_hidden_request() {
+        let config = isolated_memory_config("approval-query-status-hidden");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(&repo, "hidden-root", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-hidden",
+            "hidden-root",
+            "delegate_async",
+            "rule-hidden",
+        );
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-hidden",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("hidden approval request should be rejected");
+
+        assert!(
+            error.contains("visibility_denied"),
+            "expected visibility_denied, got: {error}"
+        );
+    }
+}

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -29,6 +29,9 @@ const APPROVAL_ATTENTION_STALE_MAX_SECONDS: i64 = 4 * 60 * 60;
 struct ApprovalRequestsListRequest {
     session_id: Option<String>,
     status: Option<ApprovalRequestStatus>,
+    tool_name: Option<String>,
+    approval_key: Option<String>,
+    rule_id: Option<String>,
     decision: Option<ApprovalDecision>,
     replay_result: Option<ApprovalReplayResult>,
     integrity_status: Option<ApprovalExecutionIntegrityStatus>,
@@ -347,6 +350,18 @@ fn execute_approval_requests_list(
         request_summaries
             .retain(|item| approval_request_decision_from_json(item) == Some(decision));
     }
+    if let Some(tool_name) = request.tool_name.as_deref() {
+        request_summaries
+            .retain(|item| item.get("tool_name").and_then(Value::as_str) == Some(tool_name));
+    }
+    if let Some(approval_key) = request.approval_key.as_deref() {
+        request_summaries
+            .retain(|item| item.get("approval_key").and_then(Value::as_str) == Some(approval_key));
+    }
+    if let Some(rule_id) = request.rule_id.as_deref() {
+        request_summaries
+            .retain(|item| item.get("rule_id").and_then(Value::as_str) == Some(rule_id));
+    }
     if let Some(replay_result) = request.replay_result {
         request_summaries
             .retain(|item| approval_request_replay_result_from_json(item) == Some(replay_result));
@@ -403,6 +418,7 @@ fn execute_approval_requests_list(
     }
     let integrity_summary = approval_request_list_integrity_summary_json(&request_summaries);
     let resolution_summary = approval_request_list_resolution_summary_json(&request_summaries);
+    let correlation_summary = approval_request_list_correlation_summary_json(&request_summaries);
     let matched_count = request_summaries.len();
     request_summaries.truncate(request.limit);
     let returned_count = request_summaries.len();
@@ -414,6 +430,9 @@ fn execute_approval_requests_list(
             "filter": {
                 "session_id": request.session_id,
                 "status": request.status.map(ApprovalRequestStatus::as_str),
+                "tool_name": request.tool_name,
+                "approval_key": request.approval_key,
+                "rule_id": request.rule_id,
                 "decision": request.decision.map(ApprovalDecision::as_str),
                 "replay_result": request.replay_result.map(ApprovalReplayResult::as_str),
                 "integrity_status": request.integrity_status.map(ApprovalExecutionIntegrityStatus::as_str),
@@ -430,6 +449,7 @@ fn execute_approval_requests_list(
             "returned_count": returned_count,
             "integrity_summary": integrity_summary,
             "resolution_summary": resolution_summary,
+            "correlation_summary": correlation_summary,
             "requests": request_summaries,
         }),
     })
@@ -697,6 +717,33 @@ fn approval_request_list_resolution_summary_json(requests: &[Value]) -> Value {
         "decision_counts": decision_counts,
         "request_status_counts": request_status_counts,
         "replay_result_counts": replay_result_counts,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_list_correlation_summary_json(requests: &[Value]) -> Value {
+    let mut tool_name_counts = BTreeMap::<String, usize>::new();
+    let mut approval_key_counts = BTreeMap::<String, usize>::new();
+    let mut rule_id_counts = BTreeMap::<String, usize>::new();
+
+    for request in requests {
+        if let Some(tool_name) = request.get("tool_name").and_then(Value::as_str) {
+            *tool_name_counts.entry(tool_name.to_owned()).or_default() += 1;
+        }
+        if let Some(approval_key) = request.get("approval_key").and_then(Value::as_str) {
+            *approval_key_counts
+                .entry(approval_key.to_owned())
+                .or_default() += 1;
+        }
+        if let Some(rule_id) = request.get("rule_id").and_then(Value::as_str) {
+            *rule_id_counts.entry(rule_id.to_owned()).or_default() += 1;
+        }
+    }
+
+    json!({
+        "tool_name_counts": tool_name_counts,
+        "approval_key_counts": approval_key_counts,
+        "rule_id_counts": rule_id_counts,
     })
 }
 
@@ -1264,6 +1311,9 @@ fn parse_approval_requests_list_request(
     Ok(ApprovalRequestsListRequest {
         session_id: optional_payload_string(payload, "session_id"),
         status: optional_payload_approval_request_status(payload, "status")?,
+        tool_name: optional_payload_string(payload, "tool_name"),
+        approval_key: optional_payload_string(payload, "approval_key"),
+        rule_id: optional_payload_string(payload, "rule_id"),
         decision: optional_payload_approval_list_decision(payload, "decision")?,
         replay_result: optional_payload_approval_replay_result(payload, "replay_result")?,
         integrity_status: optional_payload_approval_execution_integrity_status(
@@ -2577,6 +2627,153 @@ mod tests {
             deny_requests[0]["approval_request_id"],
             "apr-decision-denied"
         );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_filters_and_summarizes_by_correlation_fields() {
+        let config = isolated_memory_config("approval-query-list-correlation-filter");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-correlation-delegate-rule-a",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-correlation-delegate-rule-b",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_allowlist_grant",
+        );
+        seed_request(
+            &repo,
+            "apr-correlation-cancel-rule-a",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        let summary_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for correlation summary");
+
+        let correlation_summary = &summary_outcome.payload["correlation_summary"];
+        assert_eq!(correlation_summary["tool_name_counts"]["delegate_async"], 2);
+        assert_eq!(correlation_summary["tool_name_counts"]["session_cancel"], 1);
+        assert_eq!(
+            correlation_summary["approval_key_counts"]["tool:delegate_async"],
+            2
+        );
+        assert_eq!(
+            correlation_summary["approval_key_counts"]["tool:session_cancel"],
+            1
+        );
+        assert_eq!(
+            correlation_summary["rule_id_counts"]["governed_tool_requires_per_call_approval"],
+            2
+        );
+        assert_eq!(
+            correlation_summary["rule_id_counts"]["governed_tool_requires_allowlist_grant"],
+            1
+        );
+
+        let tool_name_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "tool_name": "delegate_async",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for tool_name filter");
+
+        assert_eq!(
+            tool_name_outcome.payload["filter"]["tool_name"],
+            "delegate_async"
+        );
+        assert_eq!(tool_name_outcome.payload["matched_count"], 2);
+        let tool_name_requests = tool_name_outcome.payload["requests"]
+            .as_array()
+            .expect("tool_name requests array");
+        assert_eq!(tool_name_requests.len(), 2);
+        assert!(tool_name_requests
+            .iter()
+            .all(|item| item["tool_name"] == "delegate_async"));
+
+        let approval_key_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "approval_key": "tool:session_cancel",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for approval_key filter");
+
+        assert_eq!(
+            approval_key_outcome.payload["filter"]["approval_key"],
+            "tool:session_cancel"
+        );
+        assert_eq!(approval_key_outcome.payload["matched_count"], 1);
+        let approval_key_requests = approval_key_outcome.payload["requests"]
+            .as_array()
+            .expect("approval_key requests array");
+        assert_eq!(approval_key_requests.len(), 1);
+        assert_eq!(
+            approval_key_requests[0]["approval_request_id"],
+            "apr-correlation-cancel-rule-a"
+        );
+
+        let rule_id_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "rule_id": "governed_tool_requires_per_call_approval",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for rule_id filter");
+
+        assert_eq!(
+            rule_id_outcome.payload["filter"]["rule_id"],
+            "governed_tool_requires_per_call_approval"
+        );
+        assert_eq!(rule_id_outcome.payload["matched_count"], 2);
+        let rule_id_requests = rule_id_outcome.payload["requests"]
+            .as_array()
+            .expect("rule_id requests array");
+        let rule_id_request_ids = rule_id_requests
+            .iter()
+            .filter_map(|item| item["approval_request_id"].as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(rule_id_request_ids.len(), 2);
+        assert!(rule_id_request_ids.contains(&"apr-correlation-delegate-rule-a"));
+        assert!(rule_id_request_ids.contains(&"apr-correlation-cancel-rule-a"));
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -199,12 +199,14 @@ fn execute_approval_requests_list(
                 .get(&record.session_id)
                 .map(Vec::as_slice)
                 .unwrap_or(&[]);
+            let execution_evidence = approval_request_execution_evidence_json_from_events(
+                session_events,
+                &record.approval_request_id,
+            );
             approval_request_summary_json_with_evidence(
                 record,
-                approval_request_execution_evidence_json_from_events(
-                    session_events,
-                    &record.approval_request_id,
-                ),
+                execution_evidence.clone(),
+                approval_request_execution_integrity_json(record, &execution_evidence),
             )
         })
         .collect::<Vec<_>>();
@@ -244,6 +246,9 @@ fn execute_approval_request_status(
         &request.session_id,
         tool_config.sessions.visibility,
     )?;
+    let execution_evidence = approval_request_execution_evidence_json(&repo, &request)?;
+    let execution_integrity =
+        approval_request_execution_integrity_json(&request, &execution_evidence);
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
@@ -251,7 +256,8 @@ fn execute_approval_request_status(
             "current_session_id": current_session_id,
             "approval_request": approval_request_detail_json_with_evidence(
                 &request,
-                approval_request_execution_evidence_json(&repo, &request)?,
+                execution_evidence,
+                execution_integrity,
             ),
         }),
     })
@@ -279,6 +285,10 @@ async fn execute_approval_request_resolve(
         )
         .await?;
     let repo = SessionRepository::new(config)?;
+    let execution_evidence =
+        approval_request_execution_evidence_json(&repo, &outcome.approval_request)?;
+    let execution_integrity =
+        approval_request_execution_integrity_json(&outcome.approval_request, &execution_evidence);
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
@@ -286,7 +296,8 @@ async fn execute_approval_request_resolve(
             "current_session_id": current_session_id,
             "approval_request": approval_request_detail_json_with_evidence(
                 &outcome.approval_request,
-                approval_request_execution_evidence_json(&repo, &outcome.approval_request)?,
+                execution_evidence,
+                execution_integrity,
             ),
             "resumed_tool_output": outcome.resumed_tool_output,
         }),
@@ -297,6 +308,7 @@ async fn execute_approval_request_resolve(
 fn approval_request_summary_json_with_evidence(
     record: &ApprovalRequestRecord,
     execution_evidence: Value,
+    execution_integrity: Value,
 ) -> Value {
     json!({
         "approval_request_id": record.approval_request_id,
@@ -321,6 +333,7 @@ fn approval_request_summary_json_with_evidence(
             .get("rule_id")
             .and_then(Value::as_str),
         "execution_evidence": execution_evidence,
+        "execution_integrity": execution_integrity,
     })
 }
 
@@ -328,6 +341,7 @@ fn approval_request_summary_json_with_evidence(
 fn approval_request_detail_json_with_evidence(
     record: &ApprovalRequestRecord,
     execution_evidence: Value,
+    execution_integrity: Value,
 ) -> Value {
     json!({
         "approval_request_id": record.approval_request_id,
@@ -346,6 +360,7 @@ fn approval_request_detail_json_with_evidence(
         "request_payload": record.request_payload_json,
         "governance_snapshot": record.governance_snapshot_json,
         "execution_evidence": execution_evidence,
+        "execution_integrity": execution_integrity,
     })
 }
 
@@ -360,6 +375,148 @@ fn approval_request_execution_evidence_json(
         &events,
         &record.approval_request_id,
     ))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_execution_integrity_json(
+    record: &ApprovalRequestRecord,
+    execution_evidence: &Value,
+) -> Value {
+    let started_event_kind = execution_evidence
+        .get("started_event_kind")
+        .and_then(Value::as_str);
+    let terminal_event_kind = execution_evidence
+        .get("terminal_event_kind")
+        .and_then(Value::as_str);
+    let replay_decision_persisted = execution_evidence
+        .get("replay_decision_persisted")
+        .and_then(Value::as_bool);
+    let replay_outcome_persisted = execution_evidence
+        .get("replay_outcome_persisted")
+        .and_then(Value::as_bool);
+    let replay_decision_persist_error = execution_evidence
+        .get("replay_decision_persist_error")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let replay_outcome_persist_error = execution_evidence
+        .get("replay_outcome_persist_error")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let execution_error = execution_evidence
+        .get("execution_error")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let evidence_complete = execution_evidence
+        .get("evidence_complete")
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    let (status, gap, integrity_error) = if started_event_kind.is_none()
+        && terminal_event_kind.is_none()
+    {
+        match record.status {
+            ApprovalRequestStatus::Pending
+            | ApprovalRequestStatus::Approved
+            | ApprovalRequestStatus::Denied
+            | ApprovalRequestStatus::Expired
+            | ApprovalRequestStatus::Cancelled => ("not_started", Value::Null, Value::Null),
+            ApprovalRequestStatus::Executing => (
+                "incomplete",
+                Value::String("started_event_missing".to_owned()),
+                first_non_null_json_value(
+                    &[
+                        &replay_decision_persist_error,
+                        &replay_outcome_persist_error,
+                    ],
+                    Some("approval_request_missing_execution_started_event"),
+                ),
+            ),
+            ApprovalRequestStatus::Executed => (
+                "incomplete",
+                Value::String("execution_events_missing".to_owned()),
+                first_non_null_json_value(
+                    &[
+                        &replay_decision_persist_error,
+                        &replay_outcome_persist_error,
+                    ],
+                    Some("approval_request_missing_execution_events"),
+                ),
+            ),
+        }
+    } else if started_event_kind.is_none() && terminal_event_kind.is_some() {
+        (
+            "incomplete",
+            Value::String("started_event_missing".to_owned()),
+            first_non_null_json_value(
+                &[
+                    &replay_decision_persist_error,
+                    &replay_outcome_persist_error,
+                ],
+                Some("approval_request_missing_execution_started_event"),
+            ),
+        )
+    } else if started_event_kind.is_some() && terminal_event_kind.is_none() {
+        match record.status {
+            ApprovalRequestStatus::Executing => ("in_progress", Value::Null, Value::Null),
+            _ => (
+                "incomplete",
+                Value::String("terminal_event_missing".to_owned()),
+                first_non_null_json_value(
+                    &[
+                        &replay_decision_persist_error,
+                        &replay_outcome_persist_error,
+                    ],
+                    Some("approval_request_missing_execution_terminal_event"),
+                ),
+            ),
+        }
+    } else if replay_decision_persisted == Some(true) && replay_outcome_persisted == Some(true) {
+        ("complete", Value::Null, Value::Null)
+    } else if replay_decision_persisted != Some(true) && replay_outcome_persisted != Some(true) {
+        (
+            "incomplete",
+            Value::String("replay_decision_and_outcome_missing".to_owned()),
+            first_non_null_json_value(
+                &[
+                    &replay_decision_persist_error,
+                    &replay_outcome_persist_error,
+                ],
+                record.last_error.as_deref(),
+            ),
+        )
+    } else if replay_decision_persisted != Some(true) {
+        (
+            "incomplete",
+            Value::String("replay_decision_missing".to_owned()),
+            first_non_null_json_value(
+                &[
+                    &replay_decision_persist_error,
+                    &replay_outcome_persist_error,
+                ],
+                record.last_error.as_deref(),
+            ),
+        )
+    } else {
+        (
+            "incomplete",
+            Value::String("replay_outcome_missing".to_owned()),
+            first_non_null_json_value(
+                &[
+                    &replay_outcome_persist_error,
+                    &replay_decision_persist_error,
+                ],
+                record.last_error.as_deref(),
+            ),
+        )
+    };
+
+    json!({
+        "status": status,
+        "gap": gap,
+        "integrity_error": integrity_error,
+        "execution_error": execution_error,
+        "evidence_complete": evidence_complete,
+    })
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -449,6 +606,16 @@ fn approval_request_execution_evidence_json_from_events(
         "execution_error": execution_error,
         "evidence_complete": evidence_complete,
     })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn first_non_null_json_value(values: &[&Value], fallback: Option<&str>) -> Value {
+    values
+        .iter()
+        .find(|value| !value.is_null())
+        .map(|value| (*value).clone())
+        .or_else(|| fallback.map(|value| Value::String(value.to_owned())))
+        .unwrap_or(Value::Null)
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -727,6 +894,8 @@ mod tests {
             root_request["execution_evidence"]["evidence_complete"],
             Value::Null
         );
+        assert_eq!(root_request["execution_integrity"]["status"], "not_started");
+        assert_eq!(root_request["execution_integrity"]["gap"], Value::Null);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -792,6 +961,11 @@ mod tests {
         assert_eq!(evidence["replay_decision_persisted"], true);
         assert_eq!(evidence["replay_outcome_persisted"], true);
         assert_eq!(evidence["evidence_complete"], true);
+        let integrity = &request["execution_integrity"];
+        assert_eq!(integrity["status"], "complete");
+        assert_eq!(integrity["gap"], Value::Null);
+        assert_eq!(integrity["execution_error"], Value::Null);
+        assert_eq!(integrity["integrity_error"], Value::Null);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -860,6 +1034,13 @@ mod tests {
             complete_evidence_count, 40,
             "all returned requests should retain complete execution evidence"
         );
+        let complete_integrity_count = requests
+            .iter()
+            .filter(|item| {
+                item["execution_integrity"]["status"] == Value::String("complete".to_owned())
+            })
+            .count();
+        assert_eq!(complete_integrity_count, 40);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -919,6 +1100,8 @@ mod tests {
             request["execution_evidence"]["evidence_complete"],
             Value::Null
         );
+        assert_eq!(request["execution_integrity"]["status"], "not_started");
+        assert_eq!(request["execution_integrity"]["gap"], Value::Null);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -984,6 +1167,76 @@ mod tests {
                 .as_str()
                 .is_some_and(|error| error.contains("persist assistant turn via kernel failed")),
             "expected replay outcome persistence error in evidence, got: {evidence}"
+        );
+        let integrity = &outcome.payload["approval_request"]["execution_integrity"];
+        assert_eq!(integrity["status"], "incomplete");
+        assert_eq!(integrity["gap"], "replay_outcome_missing");
+        assert_eq!(integrity["execution_error"], Value::Null);
+        assert!(
+            integrity["integrity_error"]
+                .as_str()
+                .is_some_and(|error| error.contains("persist assistant turn via kernel failed")),
+            "expected replay outcome persistence integrity error, got: {integrity}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_status_distinguishes_execution_failure_from_integrity_gap() {
+        let config = isolated_memory_config("approval-query-status-execution-failure");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-visible-execution-failure",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-visible-execution-failure",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_failed".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-visible-execution-failure",
+                "error": "tool failed for domain reasons",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append failed event");
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-visible-execution-failure",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome");
+
+        let integrity = &outcome.payload["approval_request"]["execution_integrity"];
+        assert_eq!(integrity["status"], "complete");
+        assert_eq!(integrity["gap"], Value::Null);
+        assert_eq!(integrity["integrity_error"], Value::Null);
+        assert_eq!(
+            integrity["execution_error"],
+            "tool failed for domain reasons"
         );
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -26,6 +26,8 @@ struct ApprovalRequestsListRequest {
     session_id: Option<String>,
     status: Option<ApprovalRequestStatus>,
     integrity_status: Option<ApprovalExecutionIntegrityStatus>,
+    needs_attention: Option<bool>,
+    attention_reason: Option<ApprovalAttentionReason>,
     limit: usize,
 }
 
@@ -46,6 +48,23 @@ impl ApprovalExecutionIntegrityStatus {
             Self::InProgress => "in_progress",
             Self::Complete => "complete",
             Self::Incomplete => "incomplete",
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalAttentionReason {
+    IntegrityGap,
+    ExecutionFailed,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl ApprovalAttentionReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::IntegrityGap => "integrity_gap",
+            Self::ExecutionFailed => "execution_failed",
         }
     }
 }
@@ -236,6 +255,21 @@ fn execute_approval_requests_list(
                 == Some(integrity_status)
         });
     }
+    if let Some(needs_attention) = request.needs_attention {
+        request_summaries.retain(|item| {
+            item.get("execution_integrity")
+                .and_then(|value| value.get("needs_attention"))
+                .and_then(Value::as_bool)
+                == Some(needs_attention)
+        });
+    }
+    if let Some(attention_reason) = request.attention_reason {
+        request_summaries.retain(|item| {
+            item.get("execution_integrity")
+                .and_then(approval_request_attention_reason_from_json)
+                == Some(attention_reason)
+        });
+    }
     let integrity_summary = approval_request_list_integrity_summary_json(&request_summaries);
     let matched_count = request_summaries.len();
     request_summaries.truncate(request.limit);
@@ -249,6 +283,8 @@ fn execute_approval_requests_list(
                 "session_id": request.session_id,
                 "status": request.status.map(ApprovalRequestStatus::as_str),
                 "integrity_status": request.integrity_status.map(ApprovalExecutionIntegrityStatus::as_str),
+                "needs_attention": request.needs_attention,
+                "attention_reason": request.attention_reason.map(ApprovalAttentionReason::as_str),
                 "limit": request.limit,
             },
             "visible_session_ids": target_session_ids,
@@ -740,6 +776,16 @@ fn approval_request_execution_integrity_status_from_json(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_attention_reason_from_json(
+    execution_integrity: &Value,
+) -> Option<ApprovalAttentionReason> {
+    execution_integrity
+        .get("attention_reason")
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_attention_reason(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn parse_approval_requests_list_request(
     payload: &Value,
     tool_config: &ToolConfig,
@@ -751,6 +797,8 @@ fn parse_approval_requests_list_request(
             payload,
             "integrity_status",
         )?,
+        needs_attention: payload.get("needs_attention").and_then(Value::as_bool),
+        attention_reason: optional_payload_approval_attention_reason(payload, "attention_reason")?,
         limit: optional_payload_limit(
             payload,
             "limit",
@@ -855,6 +903,16 @@ fn optional_payload_approval_execution_integrity_status(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_attention_reason(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalAttentionReason>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_attention_reason(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn parse_approval_request_status(value: &str) -> Result<ApprovalRequestStatus, String> {
     match value {
         "pending" => Ok(ApprovalRequestStatus::Pending),
@@ -881,6 +939,17 @@ fn parse_approval_execution_integrity_status(
         "incomplete" => Ok(ApprovalExecutionIntegrityStatus::Incomplete),
         _ => Err(format!(
             "approval_requests_list_invalid_request: unknown integrity_status `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_attention_reason(value: &str) -> Result<ApprovalAttentionReason, String> {
+    match value {
+        "integrity_gap" => Ok(ApprovalAttentionReason::IntegrityGap),
+        "execution_failed" => Ok(ApprovalAttentionReason::ExecutionFailed),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown attention_reason `{value}`"
         )),
     }
 }
@@ -1369,6 +1438,185 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
+    fn approval_request_tool_query_list_filters_by_attention_state() {
+        let config = isolated_memory_config("approval-query-list-attention-filter");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-attention-not-started",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-attention-integrity-gap",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-attention-execution-failed",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-attention-in-progress",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        transition_request_status(
+            &repo,
+            "apr-attention-integrity-gap",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("persist assistant turn via kernel failed: forced outcome persistence failure"),
+        );
+        transition_request_status(
+            &repo,
+            "apr-attention-execution-failed",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("tool failed for domain reasons"),
+        );
+        transition_request_status(
+            &repo,
+            "apr-attention-in-progress",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executing,
+            None,
+        );
+
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-attention-integrity-gap",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append integrity-gap started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-attention-integrity-gap",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": false,
+                "replay_outcome_persist_error": "persist assistant turn via kernel failed: forced outcome persistence failure",
+            }),
+        })
+        .expect("append integrity-gap finished event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-attention-execution-failed",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append execution-failed started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_failed".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-attention-execution-failed",
+                "error": "tool failed for domain reasons",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append execution-failed terminal event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-attention-in-progress",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append in-progress started event");
+
+        let needs_attention_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "needs_attention": true,
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for needs_attention");
+
+        assert_eq!(
+            needs_attention_outcome.payload["filter"]["needs_attention"],
+            true
+        );
+        assert_eq!(needs_attention_outcome.payload["matched_count"], 2);
+        assert_eq!(needs_attention_outcome.payload["returned_count"], 2);
+        let needs_attention_requests = needs_attention_outcome.payload["requests"]
+            .as_array()
+            .expect("needs attention requests array");
+        let needs_attention_ids = needs_attention_requests
+            .iter()
+            .filter_map(|item| item["approval_request_id"].as_str())
+            .collect::<Vec<_>>();
+        assert!(needs_attention_ids.contains(&"apr-attention-integrity-gap"));
+        assert!(needs_attention_ids.contains(&"apr-attention-execution-failed"));
+
+        let execution_failed_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "attention_reason": "execution_failed",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for attention_reason");
+
+        assert_eq!(
+            execution_failed_outcome.payload["filter"]["attention_reason"],
+            "execution_failed"
+        );
+        assert_eq!(execution_failed_outcome.payload["matched_count"], 1);
+        assert_eq!(execution_failed_outcome.payload["returned_count"], 1);
+        let execution_failed_requests = execution_failed_outcome.payload["requests"]
+            .as_array()
+            .expect("execution_failed requests array");
+        assert_eq!(execution_failed_requests.len(), 1);
+        assert_eq!(
+            execution_failed_requests[0]["approval_request_id"],
+            "apr-attention-execution-failed"
+        );
+        assert_eq!(
+            execution_failed_requests[0]["execution_integrity"]["attention_reason"],
+            "execution_failed"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
     fn approval_request_tool_query_list_surfaces_integrity_summary_counts() {
         let config = isolated_memory_config("approval-query-list-integrity-summary");
         let repo = SessionRepository::new(&config).expect("repository");
@@ -1549,6 +1797,32 @@ mod tests {
         assert_eq!(
             summary["attention_summary"]["counts_by_reason"]["execution_failed"],
             1
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_attention_reason() {
+        let config = isolated_memory_config("approval-query-list-invalid-attention-reason");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "attention_reason": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("unknown attention_reason should be rejected");
+
+        assert!(
+            error.contains("approval_requests_list_invalid_request: unknown attention_reason"),
+            "expected attention_reason validation error, got: {error}"
         );
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -37,6 +37,8 @@ struct ApprovalRequestsListRequest {
     execution_plane: Option<ToolExecutionPlane>,
     governance_scope: Option<ToolGovernanceScope>,
     risk_class: Option<ToolRiskClass>,
+    grant_state: Option<ApprovalGrantState>,
+    grant_scope_session_id: Option<String>,
     pending_age_bucket: Option<ApprovalAttentionAgeBucket>,
     tool_name: Option<String>,
     approval_key: Option<String>,
@@ -61,6 +63,25 @@ enum ApprovalExecutionIntegrityStatus {
     InProgress,
     Complete,
     Incomplete,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovalGrantState {
+    Present,
+    Absent,
+    LineageUnresolved,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl ApprovalGrantState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Present => "present",
+            Self::Absent => "absent",
+            Self::LineageUnresolved => "lineage_unresolved",
+        }
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -376,6 +397,16 @@ fn execute_approval_requests_list(
         request_summaries
             .retain(|item| approval_request_risk_class_from_json(item) == Some(risk_class));
     }
+    if let Some(grant_state) = request.grant_state {
+        request_summaries
+            .retain(|item| approval_request_grant_state_from_json(item) == Some(grant_state));
+    }
+    if let Some(grant_scope_session_id) = request.grant_scope_session_id.as_deref() {
+        request_summaries.retain(|item| {
+            approval_request_grant_scope_session_id_from_json(item)
+                == Some(grant_scope_session_id)
+        });
+    }
     if let Some(tool_name) = request.tool_name.as_deref() {
         request_summaries
             .retain(|item| item.get("tool_name").and_then(Value::as_str) == Some(tool_name));
@@ -484,6 +515,8 @@ fn execute_approval_requests_list(
                 "execution_plane": request.execution_plane.map(tool_execution_plane_as_str),
                 "governance_scope": request.governance_scope.map(tool_governance_scope_as_str),
                 "risk_class": request.risk_class.map(tool_risk_class_as_str),
+                "grant_state": request.grant_state.map(ApprovalGrantState::as_str),
+                "grant_scope_session_id": request.grant_scope_session_id,
                 "pending_age_bucket": request.pending_age_bucket.map(ApprovalAttentionAgeBucket::as_str),
                 "tool_name": request.tool_name,
                 "approval_key": request.approval_key,
@@ -1654,6 +1687,23 @@ fn approval_request_risk_class_from_json(request: &Value) -> Option<ToolRiskClas
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_state_from_json(request: &Value) -> Option<ApprovalGrantState> {
+    request
+        .get("grant")
+        .and_then(|value| value.get("state"))
+        .and_then(Value::as_str)
+        .and_then(|value| parse_approval_grant_state(value).ok())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_scope_session_id_from_json(request: &Value) -> Option<&str> {
+    request
+        .get("grant")
+        .and_then(|value| value.get("scope_session_id"))
+        .and_then(Value::as_str)
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_decision_from_json(request: &Value) -> Option<ApprovalDecision> {
     request
         .get("resolution")
@@ -1885,6 +1935,8 @@ fn parse_approval_requests_list_request(
         execution_plane: optional_payload_tool_execution_plane(payload, "execution_plane")?,
         governance_scope: optional_payload_tool_governance_scope(payload, "governance_scope")?,
         risk_class: optional_payload_tool_risk_class(payload, "risk_class")?,
+        grant_state: optional_payload_approval_grant_state(payload, "grant_state")?,
+        grant_scope_session_id: optional_payload_string(payload, "grant_scope_session_id"),
         pending_age_bucket: optional_payload_approval_pending_age_bucket(
             payload,
             "pending_age_bucket",
@@ -2041,6 +2093,16 @@ fn optional_payload_tool_risk_class(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_grant_state(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalGrantState>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_grant_state(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn optional_payload_approval_execution_integrity_status(
     payload: &Value,
     field: &str,
@@ -2187,6 +2249,18 @@ fn parse_tool_risk_class(value: &str) -> Result<ToolRiskClass, String> {
         "High" => Ok(ToolRiskClass::High),
         _ => Err(format!(
             "approval_requests_list_invalid_request: unknown risk_class `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_grant_state(value: &str) -> Result<ApprovalGrantState, String> {
+    match value {
+        "present" => Ok(ApprovalGrantState::Present),
+        "absent" => Ok(ApprovalGrantState::Absent),
+        "lineage_unresolved" => Ok(ApprovalGrantState::LineageUnresolved),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown grant_state `{value}`"
         )),
     }
 }
@@ -4475,6 +4549,132 @@ mod tests {
         assert_eq!(
             request["grant"]["created_by_session_id"],
             "operator-session"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_filters_by_runtime_grant_state() {
+        let config = isolated_memory_config("approval-query-list-grant-state-filter");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+
+        seed_request_with_governance(
+            &repo,
+            "apr-grant-present",
+            "child-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+            "Orchestration",
+            "TopologyMutation",
+            "High",
+        );
+        seed_request_with_governance(
+            &repo,
+            "apr-grant-absent",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+            "App",
+            "Routine",
+            "Elevated",
+        );
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:delegate_async",
+            Some("operator-session"),
+        );
+
+        let present_only = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_state": "present",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant_state filter");
+
+        assert_eq!(present_only.payload["matched_count"], 1);
+        assert_eq!(present_only.payload["returned_count"], 1);
+        assert_eq!(present_only.payload["filter"]["grant_state"], "present");
+        let requests = present_only.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["approval_request_id"], "apr-grant-present");
+        assert_eq!(requests[0]["grant"]["state"], "present");
+
+        let root_scope = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_scope_session_id": "root-session",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant scope filter");
+
+        assert_eq!(root_scope.payload["matched_count"], 2);
+        assert_eq!(root_scope.payload["returned_count"], 2);
+        assert_eq!(
+            root_scope.payload["filter"]["grant_scope_session_id"],
+            "root-session"
+        );
+        let requests = root_scope.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        assert_eq!(requests.len(), 2);
+        assert!(requests
+            .iter()
+            .all(|item| item["grant"]["scope_session_id"] == "root-session"));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_rejects_unknown_grant_state() {
+        let config = isolated_memory_config("approval-query-list-invalid-grant-state");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-invalid-grant-state",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_state": "broken",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("grant_state should reject unknown values");
+
+        assert_eq!(
+            error,
+            "approval_requests_list_invalid_request: unknown grant_state `broken`"
         );
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -442,6 +442,7 @@ fn execute_approval_requests_list(
     let integrity_summary = approval_request_list_integrity_summary_json(&request_summaries);
     let resolution_summary = approval_request_list_resolution_summary_json(&request_summaries);
     let correlation_summary = approval_request_list_correlation_summary_json(&request_summaries);
+    let session_summary = approval_request_list_session_summary_json(&request_summaries);
     let matched_count = request_summaries.len();
     request_summaries.truncate(request.limit);
     let returned_count = request_summaries.len();
@@ -476,6 +477,7 @@ fn execute_approval_requests_list(
             "integrity_summary": integrity_summary,
             "resolution_summary": resolution_summary,
             "correlation_summary": correlation_summary,
+            "session_summary": session_summary,
             "requests": request_summaries,
         }),
     })
@@ -838,6 +840,105 @@ fn approval_request_list_correlation_summary_json(requests: &[Value]) -> Value {
         "tool_name_counts": tool_name_counts,
         "approval_key_counts": approval_key_counts,
         "rule_id_counts": rule_id_counts,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_list_session_summary_json(requests: &[Value]) -> Value {
+    #[derive(Default)]
+    struct SessionSummaryAccumulator {
+        request_count: usize,
+        pending_count: usize,
+        attention_count: usize,
+        oldest_pending_requested_at: Option<i64>,
+        oldest_pending_age_seconds: Option<i64>,
+        oldest_pending_age_bucket: Option<ApprovalAttentionAgeBucket>,
+    }
+
+    let mut sessions = BTreeMap::<String, SessionSummaryAccumulator>::new();
+    for request in requests {
+        let Some(session_id) = request.get("session_id").and_then(Value::as_str) else {
+            continue;
+        };
+        let session = sessions.entry(session_id.to_owned()).or_default();
+        session.request_count += 1;
+
+        if request
+            .get("execution_integrity")
+            .and_then(|value| value.get("needs_attention"))
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            session.attention_count += 1;
+        }
+
+        let pending_queue = request.get("pending_queue").unwrap_or(&Value::Null);
+        if pending_queue
+            .get("awaiting_decision")
+            .and_then(Value::as_bool)
+            != Some(true)
+        {
+            continue;
+        }
+
+        session.pending_count += 1;
+        let requested_at = approval_request_requested_at(request);
+        session.oldest_pending_requested_at = Some(
+            session
+                .oldest_pending_requested_at
+                .map(|current| current.min(requested_at))
+                .unwrap_or(requested_at),
+        );
+
+        if let Some(age_seconds) = pending_queue.get("age_seconds").and_then(Value::as_i64) {
+            let is_older = session
+                .oldest_pending_age_seconds
+                .map(|current| age_seconds > current)
+                .unwrap_or(true);
+            if is_older {
+                session.oldest_pending_age_seconds = Some(age_seconds);
+                session.oldest_pending_age_bucket =
+                    approval_request_attention_age_bucket(Some(age_seconds));
+            }
+        }
+    }
+
+    let mut sessions = sessions.into_iter().collect::<Vec<_>>();
+    sessions.sort_by(|(left_session_id, left), (right_session_id, right)| {
+        approval_request_session_hotspot_priority(left.oldest_pending_age_bucket)
+            .cmp(&approval_request_session_hotspot_priority(
+                right.oldest_pending_age_bucket,
+            ))
+            .then_with(|| right.pending_count.cmp(&left.pending_count))
+            .then_with(|| right.attention_count.cmp(&left.attention_count))
+            .then_with(|| {
+                right
+                    .oldest_pending_age_seconds
+                    .unwrap_or_default()
+                    .cmp(&left.oldest_pending_age_seconds.unwrap_or_default())
+            })
+            .then_with(|| right.request_count.cmp(&left.request_count))
+            .then_with(|| left_session_id.cmp(right_session_id))
+    });
+
+    let sessions = sessions
+        .into_iter()
+        .map(|(session_id, session)| {
+            json!({
+                "session_id": session_id,
+                "request_count": session.request_count,
+                "pending_count": session.pending_count,
+                "attention_count": session.attention_count,
+                "oldest_pending_requested_at": session.oldest_pending_requested_at,
+                "oldest_pending_age_seconds": session.oldest_pending_age_seconds,
+                "oldest_pending_age_bucket": session.oldest_pending_age_bucket.map(ApprovalAttentionAgeBucket::as_str),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "session_count": sessions.len(),
+        "sessions": sessions,
     })
 }
 
@@ -1418,6 +1519,18 @@ fn approval_request_pending_priority(request: &Value) -> usize {
         Some(ApprovalAttentionAgeBucket::Stale) => 1,
         Some(ApprovalAttentionAgeBucket::Fresh) => 2,
         None => 2,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_session_hotspot_priority(
+    age_bucket: Option<ApprovalAttentionAgeBucket>,
+) -> usize {
+    match age_bucket {
+        Some(ApprovalAttentionAgeBucket::Overdue) => 0,
+        Some(ApprovalAttentionAgeBucket::Stale) => 1,
+        Some(ApprovalAttentionAgeBucket::Fresh) => 2,
+        None => 3,
     }
 }
 
@@ -3266,6 +3379,177 @@ mod tests {
             "apr-pending-stale"
         );
         assert_eq!(stale_requests[0]["pending_queue"]["age_bucket"], "stale");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_summarizes_session_hotspots() {
+        let config = isolated_memory_config("approval-query-list-session-summary");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-hot",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+        seed_session(
+            &repo,
+            "child-busy",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+
+        seed_request(
+            &repo,
+            "apr-root-complete",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-child-hot-pending",
+            "child-hot",
+            "shell.exec",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-child-hot-attention",
+            "child-hot",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-child-busy-pending-a",
+            "child-busy",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+        seed_request(
+            &repo,
+            "apr-child-busy-pending-b",
+            "child-busy",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+        );
+
+        transition_request_status(
+            &repo,
+            "apr-root-complete",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            None,
+        );
+        transition_request_status(
+            &repo,
+            "apr-child-hot-attention",
+            ApprovalRequestStatus::Pending,
+            ApprovalRequestStatus::Executed,
+            Some("tool failed for domain reasons"),
+        );
+
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-root-complete",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append root complete started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "tool_approval_execution_finished".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-root-complete",
+                "resumed_tool_status": "ok",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append root complete finished event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "child-hot".to_owned(),
+            event_kind: "tool_approval_execution_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-child-hot-attention",
+                "replay_decision_persisted": true,
+                "replay_decision_persist_error": null,
+            }),
+        })
+        .expect("append child-hot started event");
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "child-hot".to_owned(),
+            event_kind: "tool_approval_execution_failed".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "approval_request_id": "apr-child-hot-attention",
+                "error": "tool failed for domain reasons",
+                "replay_outcome_persisted": true,
+                "replay_outcome_persist_error": null,
+            }),
+        })
+        .expect("append child-hot failed event");
+
+        let now = test_unix_ts_now();
+        overwrite_request_requested_at(&config, "apr-child-hot-pending", now - 172_800);
+        overwrite_request_requested_at(&config, "apr-child-hot-attention", now - 300);
+        overwrite_request_requested_at(&config, "apr-child-busy-pending-a", now - 7_200);
+        overwrite_request_requested_at(&config, "apr-child-busy-pending-b", now - 60);
+        overwrite_request_requested_at(&config, "apr-root-complete", now - 30);
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for session summary");
+
+        let session_summary = &outcome.payload["session_summary"];
+        assert_eq!(session_summary["session_count"], 3);
+        let sessions = session_summary["sessions"]
+            .as_array()
+            .expect("session summary sessions array");
+        assert_eq!(sessions.len(), 3);
+
+        assert_eq!(sessions[0]["session_id"], "child-hot");
+        assert_eq!(sessions[0]["request_count"], 2);
+        assert_eq!(sessions[0]["pending_count"], 1);
+        assert_eq!(sessions[0]["attention_count"], 1);
+        assert_eq!(sessions[0]["oldest_pending_age_bucket"], "overdue");
+        assert!(
+            sessions[0]["oldest_pending_age_seconds"]
+                .as_i64()
+                .expect("child-hot pending age")
+                >= 172_800
+        );
+
+        assert_eq!(sessions[1]["session_id"], "child-busy");
+        assert_eq!(sessions[1]["request_count"], 2);
+        assert_eq!(sessions[1]["pending_count"], 2);
+        assert_eq!(sessions[1]["attention_count"], 0);
+        assert_eq!(sessions[1]["oldest_pending_age_bucket"], "stale");
+
+        assert_eq!(sessions[2]["session_id"], "root-session");
+        assert_eq!(sessions[2]["request_count"], 1);
+        assert_eq!(sessions[2]["pending_count"], 0);
+        assert_eq!(sessions[2]["attention_count"], 0);
+        assert_eq!(sessions[2]["oldest_pending_requested_at"], Value::Null);
+        assert_eq!(sessions[2]["oldest_pending_age_seconds"], Value::Null);
+        assert_eq!(sessions[2]["oldest_pending_age_bucket"], Value::Null);
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -39,6 +39,7 @@ struct ApprovalRequestsListRequest {
     risk_class: Option<ToolRiskClass>,
     grant_state: Option<ApprovalGrantState>,
     grant_scope_session_id: Option<String>,
+    grant_created_by_session_id: Option<String>,
     pending_age_bucket: Option<ApprovalAttentionAgeBucket>,
     tool_name: Option<String>,
     approval_key: Option<String>,
@@ -407,6 +408,12 @@ fn execute_approval_requests_list(
                 == Some(grant_scope_session_id)
         });
     }
+    if let Some(grant_created_by_session_id) = request.grant_created_by_session_id.as_deref() {
+        request_summaries.retain(|item| {
+            approval_request_grant_created_by_session_id_from_json(item)
+                == Some(grant_created_by_session_id)
+        });
+    }
     if let Some(tool_name) = request.tool_name.as_deref() {
         request_summaries
             .retain(|item| item.get("tool_name").and_then(Value::as_str) == Some(tool_name));
@@ -517,6 +524,7 @@ fn execute_approval_requests_list(
                 "risk_class": request.risk_class.map(tool_risk_class_as_str),
                 "grant_state": request.grant_state.map(ApprovalGrantState::as_str),
                 "grant_scope_session_id": request.grant_scope_session_id,
+                "grant_created_by_session_id": request.grant_created_by_session_id,
                 "pending_age_bucket": request.pending_age_bucket.map(ApprovalAttentionAgeBucket::as_str),
                 "tool_name": request.tool_name,
                 "approval_key": request.approval_key,
@@ -975,6 +983,7 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
         ("lineage_unresolved".to_owned(), 0usize),
     ]);
     let mut scope_session_counts = BTreeMap::<String, usize>::new();
+    let mut created_by_session_counts = BTreeMap::<String, usize>::new();
 
     for request in requests {
         let grant = request.get("grant").unwrap_or(&Value::Null);
@@ -986,11 +995,19 @@ fn approval_request_list_grant_summary_json(requests: &[Value]) -> Value {
                 .entry(scope_session_id.to_owned())
                 .or_default() += 1;
         }
+        if let Some(created_by_session_id) =
+            grant.get("created_by_session_id").and_then(Value::as_str)
+        {
+            *created_by_session_counts
+                .entry(created_by_session_id.to_owned())
+                .or_default() += 1;
+        }
     }
 
     json!({
         "counts_by_state": counts_by_state,
         "scope_session_counts": scope_session_counts,
+        "created_by_session_counts": created_by_session_counts,
     })
 }
 
@@ -1704,6 +1721,14 @@ fn approval_request_grant_scope_session_id_from_json(request: &Value) -> Option<
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn approval_request_grant_created_by_session_id_from_json(request: &Value) -> Option<&str> {
+    request
+        .get("grant")
+        .and_then(|value| value.get("created_by_session_id"))
+        .and_then(Value::as_str)
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn approval_request_decision_from_json(request: &Value) -> Option<ApprovalDecision> {
     request
         .get("resolution")
@@ -1937,6 +1962,10 @@ fn parse_approval_requests_list_request(
         risk_class: optional_payload_tool_risk_class(payload, "risk_class")?,
         grant_state: optional_payload_approval_grant_state(payload, "grant_state")?,
         grant_scope_session_id: optional_payload_string(payload, "grant_scope_session_id"),
+        grant_created_by_session_id: optional_payload_string(
+            payload,
+            "grant_created_by_session_id",
+        ),
         pending_age_bucket: optional_payload_approval_pending_age_bucket(
             payload,
             "pending_age_bucket",
@@ -4675,6 +4704,126 @@ mod tests {
         assert_eq!(
             error,
             "approval_requests_list_invalid_request: unknown grant_state `broken`"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_summarizes_and_filters_runtime_grants_by_creator() {
+        let config = isolated_memory_config("approval-query-list-grant-creator-summary");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+
+        seed_request_with_governance(
+            &repo,
+            "apr-grant-creator-a",
+            "child-session",
+            "delegate_async",
+            "governed_tool_requires_per_call_approval",
+            "Orchestration",
+            "TopologyMutation",
+            "High",
+        );
+        seed_request_with_governance(
+            &repo,
+            "apr-grant-creator-b",
+            "root-session",
+            "session_cancel",
+            "governed_tool_requires_per_call_approval",
+            "App",
+            "Routine",
+            "Elevated",
+        );
+        seed_request_with_governance(
+            &repo,
+            "apr-grant-creator-absent",
+            "root-session",
+            "memory_search",
+            "governed_tool_requires_per_call_approval",
+            "App",
+            "Routine",
+            "Low",
+        );
+
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:delegate_async",
+            Some("operator-alpha"),
+        );
+        seed_runtime_grant(
+            &repo,
+            "root-session",
+            "tool:session_cancel",
+            Some("operator-beta"),
+        );
+
+        let list_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant creator summary");
+
+        let grant_summary = &list_outcome.payload["grant_summary"];
+        assert_eq!(grant_summary["counts_by_state"]["present"], 2);
+        assert_eq!(grant_summary["counts_by_state"]["absent"], 1);
+        assert_eq!(
+            grant_summary["created_by_session_counts"]["operator-alpha"],
+            1
+        );
+        assert_eq!(
+            grant_summary["created_by_session_counts"]["operator-beta"],
+            1
+        );
+        assert_eq!(
+            grant_summary["created_by_session_counts"]
+                .as_object()
+                .expect("creator counts object")
+                .len(),
+            2
+        );
+
+        let filtered_outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_created_by_session_id": "operator-beta",
+                    "limit": 10,
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome for grant creator filter");
+
+        assert_eq!(filtered_outcome.payload["matched_count"], 1);
+        assert_eq!(filtered_outcome.payload["returned_count"], 1);
+        assert_eq!(
+            filtered_outcome.payload["filter"]["grant_created_by_session_id"],
+            "operator-beta"
+        );
+        let requests = filtered_outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["approval_request_id"], "apr-grant-creator-b");
+        assert_eq!(
+            requests[0]["grant"]["created_by_session_id"],
+            "operator-beta"
         );
     }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1,17 +1,30 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
 use loongclaw_contracts::{Capability, ToolCoreOutcome, ToolCoreRequest};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
+use crate::config::{LoongClawConfig, ToolConfig};
+use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::KernelContext;
 
-mod claw_import;
-mod external_skills;
+pub(crate) mod approval;
+mod catalog;
+pub(crate) mod delegate;
 mod file;
 mod kernel_adapter;
+mod memory;
+pub(crate) mod messaging;
 pub mod runtime_config;
+mod session;
 mod shell;
 
+pub use catalog::{
+    delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
+    planned_delegate_child_tool_view, planned_root_tool_view, runtime_tool_view,
+    runtime_tool_view_for_config, tool_catalog, ToolApprovalMode, ToolAvailability, ToolCatalog,
+    ToolDescriptor, ToolExecutionPlane, ToolGovernanceScope, ToolRiskClass, ToolView,
+};
 pub use kernel_adapter::MvpToolAdapter;
 
 /// Execute a tool request, optionally routing through the kernel for
@@ -41,38 +54,233 @@ pub fn execute_tool_core(request: ToolCoreRequest) -> Result<ToolCoreOutcome, St
     execute_tool_core_with_config(request, runtime_config::get_tool_runtime_config())
 }
 
+pub fn execute_app_tool(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+) -> Result<ToolCoreOutcome, String> {
+    execute_app_tool_with_config(
+        request,
+        current_session_id,
+        crate::memory::runtime_config::get_memory_runtime_config(),
+        &crate::config::ToolConfig::default(),
+    )
+}
+
+pub fn execute_app_tool_with_config(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let canonical_name = canonical_tool_name(request.tool_name.as_str());
+    let request = ToolCoreRequest {
+        tool_name: canonical_name.to_owned(),
+        payload: request.payload,
+    };
+    match canonical_name {
+        "approval_request_resolve" => {
+            Err("app_tool_requires_runtime_support: approval_request_resolve".to_owned())
+        }
+        "approval_requests_list" | "approval_request_status" => {
+            approval::execute_approval_tool_with_policies(
+                request,
+                current_session_id,
+                memory_config,
+                tool_config,
+            )
+        }
+        "sessions_list" | "sessions_history" | "session_status" | "session_events"
+        | "session_cancel" | "session_archive" | "session_recover" | "session_unarchive" => {
+            session::execute_session_tool_with_policies(
+                request,
+                current_session_id,
+                memory_config,
+                tool_config,
+            )
+        }
+        "memory_search" => memory::execute_memory_search_tool_with_policies(
+            request.payload,
+            current_session_id,
+            memory_config,
+            tool_config,
+        ),
+        "sessions_send" => Err("app_tool_requires_runtime_support: sessions_send".to_owned()),
+        "session_wait" => Err("app_tool_requires_async_runtime_support: session_wait".to_owned()),
+        "delegate_async" | "delegate" => {
+            Err(format!("app_tool_wrong_execution_plane: {canonical_name}"))
+        }
+        _ => Err(format!(
+            "app_tool_not_found: unknown tool `{}`",
+            request.tool_name
+        )),
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct AppToolRuntimeSupport<'a> {
+    pub app_config: Option<&'a LoongClawConfig>,
+    pub kernel_ctx: Option<&'a KernelContext>,
+    #[cfg(feature = "memory-sqlite")]
+    pub(crate) approval_runtime: Option<Arc<dyn approval::ApprovalResolutionRuntime>>,
+}
+
+#[derive(Clone, Default)]
+pub struct OrchestrationToolRuntimeSupport {
+    pub async_delegate_spawner: Option<Arc<dyn delegate::AsyncDelegateSpawner>>,
+}
+
+pub async fn execute_app_tool_with_runtime_support(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    runtime_support: AppToolRuntimeSupport<'_>,
+) -> Result<ToolCoreOutcome, String> {
+    let canonical_name = canonical_tool_name(request.tool_name.as_str());
+    let request = ToolCoreRequest {
+        tool_name: canonical_name.to_owned(),
+        payload: request.payload,
+    };
+    match canonical_name {
+        "approval_requests_list" | "approval_request_status" | "approval_request_resolve" => {
+            approval::execute_approval_tool_with_runtime_support(
+                request,
+                current_session_id,
+                memory_config,
+                tool_config,
+                #[cfg(feature = "memory-sqlite")]
+                runtime_support.approval_runtime.as_deref(),
+                #[cfg(not(feature = "memory-sqlite"))]
+                None,
+                runtime_support.kernel_ctx,
+            )
+            .await
+        }
+        "sessions_list" | "sessions_history" | "session_status" | "session_events"
+        | "session_cancel" | "session_archive" | "session_recover" | "session_unarchive" => {
+            session::execute_session_tool_with_policies(
+                request,
+                current_session_id,
+                memory_config,
+                tool_config,
+            )
+        }
+        "memory_search" => memory::execute_memory_search_tool_with_policies(
+            request.payload,
+            current_session_id,
+            memory_config,
+            tool_config,
+        ),
+        "session_wait" => {
+            wait_for_session_with_config(
+                request.payload,
+                current_session_id,
+                memory_config,
+                tool_config,
+            )
+            .await
+        }
+        "sessions_send" => {
+            let app_config = runtime_support
+                .app_config
+                .ok_or_else(|| "sessions_send_not_configured".to_owned())?;
+            messaging::execute_sessions_send_with_config(
+                request.payload,
+                current_session_id,
+                memory_config,
+                tool_config,
+                app_config,
+            )
+            .await
+        }
+        "delegate_async" | "delegate" => {
+            Err(format!("app_tool_wrong_execution_plane: {canonical_name}"))
+        }
+        _ => Err(format!(
+            "app_tool_not_found: unknown tool `{}`",
+            request.tool_name
+        )),
+    }
+}
+
+pub async fn execute_orchestration_tool_with_runtime_support(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    runtime_support: OrchestrationToolRuntimeSupport,
+) -> Result<ToolCoreOutcome, String> {
+    let canonical_name = canonical_tool_name(request.tool_name.as_str());
+    let request = ToolCoreRequest {
+        tool_name: canonical_name.to_owned(),
+        payload: request.payload,
+    };
+    match canonical_name {
+        "delegate_async" => {
+            let spawner = runtime_support
+                .async_delegate_spawner
+                .ok_or_else(|| "delegate_async_not_configured".to_owned())?;
+            delegate::execute_delegate_async_with_config(
+                request.payload,
+                current_session_id,
+                memory_config,
+                tool_config,
+                spawner,
+            )
+            .await
+        }
+        "delegate" => Err("orchestration_tool_requires_turn_loop_dispatch: delegate".to_owned()),
+        _ => Err(format!(
+            "orchestration_tool_not_found: unknown tool `{}`",
+            request.tool_name
+        )),
+    }
+}
+
+pub async fn wait_for_session_with_config(
+    payload: Value,
+    current_session_id: &str,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (payload, current_session_id, memory_config, tool_config);
+        return Err(
+            "session tools require sqlite memory support (enable feature `memory-sqlite`)"
+                .to_owned(),
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        if !tool_config.sessions.enabled {
+            return Err("app_tool_disabled: session tools are disabled by config".to_owned());
+        }
+        session::wait_for_session_tool_with_policies(
+            payload,
+            current_session_id,
+            memory_config,
+            tool_config,
+        )
+        .await
+    }
+}
+
 pub fn canonical_tool_name(raw: &str) -> &str {
-    match raw {
-        "claw_import" | "import_claw" => "claw.import",
-        "external_skills_inspect" => "external_skills.inspect",
-        "external_skills_install" => "external_skills.install",
-        "external_skills_invoke" => "external_skills.invoke",
-        "external_skills_list" => "external_skills.list",
-        "external_skills_policy" => "external_skills.policy",
-        "external_skills_fetch" => "external_skills.fetch",
-        "external_skills_remove" => "external_skills.remove",
-        "file_read" => "file.read",
-        "file_write" => "file.write",
-        "shell_exec" | "shell" => "shell.exec",
-        other => other,
+    let catalog = tool_catalog();
+    match catalog.resolve(raw) {
+        Some(descriptor) => descriptor.name,
+        None => raw,
     }
 }
 
 pub fn is_known_tool_name(raw: &str) -> bool {
-    matches!(
-        canonical_tool_name(raw),
-        "claw.import"
-            | "external_skills.inspect"
-            | "external_skills.install"
-            | "external_skills.invoke"
-            | "external_skills.list"
-            | "external_skills.policy"
-            | "external_skills.fetch"
-            | "external_skills.remove"
-            | "shell.exec"
-            | "file.read"
-            | "file.write"
-    )
+    is_known_tool_name_in_view(raw, &runtime_tool_view())
+}
+
+pub fn is_known_tool_name_in_view(raw: &str, view: &ToolView) -> bool {
+    view.contains(canonical_tool_name(raw))
 }
 
 pub fn execute_tool_core_with_config(
@@ -85,28 +293,6 @@ pub fn execute_tool_core_with_config(
         payload: request.payload,
     };
     match canonical_name {
-        "claw.import" => claw_import::execute_claw_import_tool_with_config(request, config),
-        "external_skills.inspect" => {
-            external_skills::execute_external_skills_inspect_tool_with_config(request, config)
-        }
-        "external_skills.install" => {
-            external_skills::execute_external_skills_install_tool_with_config(request, config)
-        }
-        "external_skills.invoke" => {
-            external_skills::execute_external_skills_invoke_tool_with_config(request, config)
-        }
-        "external_skills.list" => {
-            external_skills::execute_external_skills_list_tool_with_config(request, config)
-        }
-        "external_skills.policy" => {
-            external_skills::execute_external_skills_policy_tool_with_config(request, config)
-        }
-        "external_skills.fetch" => {
-            external_skills::execute_external_skills_fetch_tool_with_config(request, config)
-        }
-        "external_skills.remove" => {
-            external_skills::execute_external_skills_remove_tool_with_config(request, config)
-        }
         "shell.exec" => shell::execute_shell_tool_with_config(request, config),
         "file.read" => file::execute_file_read_tool_with_config(request, config),
         "file.write" => file::execute_file_write_tool_with_config(request, config),
@@ -126,80 +312,27 @@ pub struct ToolRegistryEntry {
 
 /// Returns a sorted list of all registered tools, gated by feature flags.
 pub fn tool_registry() -> Vec<ToolRegistryEntry> {
-    let mut entries = vec![
-        ToolRegistryEntry {
-            name: "claw.import",
-            description: "Import legacy Claw configs into native LoongClaw settings",
-        },
-        ToolRegistryEntry {
-            name: "external_skills.fetch",
-            description: "Download external skills artifacts with domain policy and approval guards",
-        },
-        ToolRegistryEntry {
-            name: "external_skills.inspect",
-            description: "Read metadata for an installed external skill",
-        },
-        ToolRegistryEntry {
-            name: "external_skills.install",
-            description: "Install a managed external skill from a local directory or archive",
-        },
-        ToolRegistryEntry {
-            name: "external_skills.invoke",
-            description: "Load an installed external skill into the conversation loop",
-        },
-        ToolRegistryEntry {
-            name: "external_skills.list",
-            description: "List managed external skills available for invocation",
-        },
-        ToolRegistryEntry {
-            name: "external_skills.policy",
-            description: "Read/update external skills domain allow/block policy at runtime",
-        },
-        ToolRegistryEntry {
-            name: "external_skills.remove",
-            description: "Remove an installed external skill from the managed runtime",
-        },
-    ];
-    #[cfg(feature = "tool-file")]
-    {
-        entries.push(ToolRegistryEntry {
-            name: "file.read",
-            description: "Read file contents",
-        });
-        entries.push(ToolRegistryEntry {
-            name: "file.write",
-            description: "Write file contents",
-        });
-    }
-    #[cfg(feature = "tool-shell")]
-    {
-        entries.push(ToolRegistryEntry {
-            name: "shell.exec",
-            description: "Execute shell commands",
-        });
-    }
-    entries.sort_by_key(|entry| entry.name);
-    entries
+    let catalog = tool_catalog();
+    runtime_tool_view()
+        .iter(&catalog)
+        .map(|descriptor| ToolRegistryEntry {
+            name: descriptor.name,
+            description: descriptor.description,
+        })
+        .collect()
 }
 
 /// Produce a deterministic text block listing available tools,
 /// suitable for appending to the system prompt.
 pub fn capability_snapshot() -> String {
-    capability_snapshot_with_config(runtime_config::get_tool_runtime_config())
+    capability_snapshot_for_view(&runtime_tool_view())
 }
 
-pub fn capability_snapshot_with_config(config: &runtime_config::ToolRuntimeConfig) -> String {
-    let entries = tool_registry();
+pub fn capability_snapshot_for_view(view: &ToolView) -> String {
+    let catalog = tool_catalog();
     let mut lines = vec!["[available_tools]".to_owned()];
-    for entry in &entries {
-        lines.push(format!("- {}: {}", entry.name, entry.description));
-    }
-    if let Ok(skill_lines) = external_skills::installed_skill_snapshot_lines_with_config(config)
-        && !skill_lines.is_empty()
-    {
-        lines.push(String::new());
-        lines.push("[available_external_skills]".to_owned());
-        lines.extend(skill_lines);
+    for descriptor in view.iter(&catalog) {
+        lines.push(format!("- {}: {}", descriptor.name, descriptor.description));
     }
     lines.join("\n")
 }
@@ -209,382 +342,33 @@ pub fn capability_snapshot_with_config(config: &runtime_config::ToolRuntimeConfi
 /// The output shape matches OpenAI-compatible `tools=[{type:function,...}]`.
 /// Order is deterministic for stable prompting/tests.
 pub fn provider_tool_definitions() -> Vec<Value> {
-    let mut tools = Vec::new();
-
-    tools.push(json!({
-        "type": "function",
-        "function": {
-            "name": "claw_import",
-            "description": "Import, discover, plan, merge, apply, and rollback legacy Claw workspace migration into native LoongClaw config.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "input_path": {
-                        "type": "string",
-                        "description": "Path to the legacy Claw workspace, config root, or portable import file. Required for all modes except rollback_last_apply."
-                    },
-                    "mode": {
-                        "type": "string",
-                        "enum": [
-                            "plan",
-                            "apply",
-                            "discover",
-                            "plan_many",
-                            "recommend_primary",
-                            "merge_profiles",
-                            "map_external_skills",
-                            "apply_selected",
-                            "rollback_last_apply"
-                        ],
-                        "description": "Migration mode. Defaults to `plan` when omitted."
-                    },
-                    "source": {
-                        "type": "string",
-                        "enum": ["auto", "nanobot", "openclaw", "picoclaw", "zeroclaw", "nanoclaw"],
-                        "description": "Optional source hint for plan/apply modes. Defaults to automatic detection."
-                    },
-                    "source_id": {
-                        "type": "string",
-                        "description": "Selected source identifier for apply_selected mode."
-                    },
-                    "selection_id": {
-                        "type": "string",
-                        "description": "Alias of source_id for apply_selected mode."
-                    },
-                    "primary_source_id": {
-                        "type": "string",
-                        "description": "Primary source identifier for safe profile merge in apply_selected mode."
-                    },
-                    "primary_selection_id": {
-                        "type": "string",
-                        "description": "Alias of primary_source_id for safe profile merge in apply_selected mode."
-                    },
-                    "safe_profile_merge": {
-                        "type": "boolean",
-                        "description": "Enable safe multi-source profile merge in apply_selected mode."
-                    },
-                    "apply_external_skills_plan": {
-                        "type": "boolean",
-                        "description": "When true, apply a generated external-skills mapping addendum into profile_note during apply_selected."
-                    },
-                    "output_path": {
-                        "type": "string",
-                        "description": "Target config path. Required in apply/apply_selected/rollback_last_apply modes."
-                    },
-                    "force": {
-                        "type": "boolean",
-                        "description": "Overwrite an existing target config when applying. Defaults to false."
-                    }
-                },
-                "required": [],
-                "additionalProperties": false
-            }
-        }
-    }));
-
-    tools.push(json!({
-        "type": "function",
-        "function": {
-            "name": "external_skills_policy",
-            "description": "Get, set, or reset runtime policy for external skills downloads (enabled flag, approval gate, domain allowlist/blocklist).",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "enum": ["get", "set", "reset"],
-                        "description": "Policy action. Defaults to `get`."
-                    },
-                    "policy_update_approved": {
-                        "type": "boolean",
-                        "description": "Explicit user authorization for policy updates. Required for `set` and `reset`."
-                    },
-                    "enabled": {
-                        "type": "boolean",
-                        "description": "Whether external skills runtime/download is enabled."
-                    },
-                    "require_download_approval": {
-                        "type": "boolean",
-                        "description": "When true, every external skills download requires explicit approval_granted=true."
-                    },
-                    "allowed_domains": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "Optional domain allowlist (supports exact domains and wildcard forms like *.example.com). Empty list means allow all domains unless blocked."
-                    },
-                    "blocked_domains": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "Optional domain blocklist (supports exact domains and wildcard forms like *.example.com). Blocklist always takes precedence."
-                    }
-                },
-                "required": [],
-                "additionalProperties": false
-            }
-        }
-    }));
-
-    tools.push(json!({
-        "type": "function",
-        "function": {
-            "name": "external_skills_fetch",
-            "description": "Download an external skill artifact with strict domain policy checks and explicit approval gating.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "url": {
-                        "type": "string",
-                        "description": "HTTPS URL to download."
-                    },
-                    "approval_granted": {
-                        "type": "boolean",
-                        "description": "Explicit user authorization for this download. Required when require_download_approval=true."
-                    },
-                    "save_as": {
-                        "type": "string",
-                        "description": "Optional output filename (stored under configured file root / external-skills-downloads)."
-                    },
-                    "max_bytes": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 20971520,
-                        "description": "Maximum download size in bytes. Defaults to 5242880 and is capped at 20971520."
-                    }
-                },
-                "required": ["url"],
-                "additionalProperties": false
-            }
-        }
-    }));
-
-    tools.push(json!({
-        "type": "function",
-        "function": {
-            "name": "external_skills_inspect",
-            "description": "Read metadata and a short preview for an installed external skill.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "skill_id": {
-                        "type": "string",
-                        "description": "Managed external skill identifier."
-                    }
-                },
-                "required": ["skill_id"],
-                "additionalProperties": false
-            }
-        }
-    }));
-
-    tools.push(json!({
-        "type": "function",
-        "function": {
-            "name": "external_skills_install",
-            "description": "Install a managed external skill from a local directory or local .tgz/.tar.gz archive under the configured file root.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Path to a local directory containing SKILL.md or a local .tgz/.tar.gz archive."
-                    },
-                    "skill_id": {
-                        "type": "string",
-                        "description": "Optional explicit managed skill id override."
-                    },
-                    "replace": {
-                        "type": "boolean",
-                        "description": "Replace an existing installed skill with the same id. Defaults to false."
-                    }
-                },
-                "required": ["path"],
-                "additionalProperties": false
-            }
-        }
-    }));
-
-    tools.push(json!({
-        "type": "function",
-        "function": {
-            "name": "external_skills_invoke",
-            "description": "Load an installed external skill's SKILL.md instructions into the conversation loop.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "skill_id": {
-                        "type": "string",
-                        "description": "Managed external skill identifier."
-                    }
-                },
-                "required": ["skill_id"],
-                "additionalProperties": false
-            }
-        }
-    }));
-
-    tools.push(json!({
-        "type": "function",
-        "function": {
-            "name": "external_skills_list",
-            "description": "List managed external skills available for invocation.",
-            "parameters": {
-                "type": "object",
-                "properties": {},
-                "required": [],
-                "additionalProperties": false
-            }
-        }
-    }));
-
-    tools.push(json!({
-        "type": "function",
-        "function": {
-            "name": "external_skills_remove",
-            "description": "Remove an installed external skill from the managed runtime.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "skill_id": {
-                        "type": "string",
-                        "description": "Managed external skill identifier."
-                    }
-                },
-                "required": ["skill_id"],
-                "additionalProperties": false
-            }
-        }
-    }));
-
-    #[cfg(feature = "tool-file")]
-    {
-        tools.push(json!({
-            "type": "function",
-            "function": {
-                "name": "file_read",
-                "description": "Read file contents",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "path": {
-                            "type": "string",
-                            "description": "Path to read (absolute or relative to configured file root)."
-                        },
-                        "max_bytes": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "maximum": 8_388_608,
-                            "description": "Optional read limit in bytes. Defaults to 1048576."
-                        }
-                    },
-                    "required": ["path"],
-                    "additionalProperties": false
-                }
-            }
-        }));
-        tools.push(json!({
-            "type": "function",
-            "function": {
-                "name": "file_write",
-                "description": "Write file contents",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "path": {
-                            "type": "string",
-                            "description": "Path to write (absolute or relative to configured file root)."
-                        },
-                        "content": {
-                            "type": "string",
-                            "description": "File content to write."
-                        },
-                        "create_dirs": {
-                            "type": "boolean",
-                            "description": "Create parent directories when missing. Defaults to true."
-                        }
-                    },
-                    "required": ["path", "content"],
-                    "additionalProperties": false
-                }
-            }
-        }));
-    }
-
-    #[cfg(feature = "tool-shell")]
-    {
-        tools.push(json!({
-            "type": "function",
-            "function": {
-                "name": "shell_exec",
-                "description": "Execute shell commands",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "command": {
-                            "type": "string",
-                            "description": "Executable command name. Must be allowlisted."
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "Optional command arguments."
-                        },
-                        "cwd": {
-                            "type": "string",
-                            "description": "Optional working directory."
-                        }
-                    },
-                    "required": ["command"],
-                    "additionalProperties": false
-                }
-            }
-        }));
-    }
-
-    tools.sort_by(|left, right| tool_function_name(left).cmp(tool_function_name(right)));
-    tools
+    try_provider_tool_definitions_for_view(&runtime_tool_view())
+        .expect("runtime tool view should always be advertisable")
 }
 
-fn tool_function_name(tool: &Value) -> &str {
-    tool.get("function")
-        .and_then(|value| value.get("name"))
-        .and_then(Value::as_str)
-        .unwrap_or("")
+pub fn try_provider_tool_definitions_for_view(view: &ToolView) -> Result<Vec<Value>, String> {
+    let catalog = tool_catalog();
+    let mut tools = Vec::new();
+    for descriptor in view.iter(&catalog) {
+        if descriptor.availability != ToolAvailability::Runtime {
+            return Err(format!(
+                "tool_not_advertisable: `{}` is still planned and cannot be exposed yet",
+                descriptor.name
+            ));
+        }
+        tools.push(descriptor.provider_definition());
+    }
+    Ok(tools)
 }
 
 #[allow(dead_code)]
 fn _shape_examples() -> BTreeMap<&'static str, Value> {
     BTreeMap::from([
         (
-            "claw.import",
-            json!({
-                "input_path": "/tmp/nanobot-workspace",
-                "mode": "plan",
-                "source": "auto"
-            }),
-        ),
-        (
             "shell.exec",
             json!({
                 "command": "echo",
                 "args": ["hello"]
-            }),
-        ),
-        (
-            "external_skills.policy",
-            json!({
-                "action": "set",
-                "policy_update_approved": true,
-                "enabled": true,
-                "require_download_approval": true,
-                "allowed_domains": ["skills.sh"],
-                "blocked_domains": ["*.evil.example"]
-            }),
-        ),
-        (
-            "external_skills.fetch",
-            json!({
-                "url": "https://skills.sh/packages/demo-skill.tar.gz",
-                "approval_granted": true
             }),
         ),
         (
@@ -619,140 +403,107 @@ mod tests {
         assert_eq!(snapshot, snapshot2);
     }
 
-    #[test]
-    fn capability_snapshot_can_include_installed_external_skills() {
-        use std::{
-            fs,
-            path::{Path, PathBuf},
-            time::{SystemTime, UNIX_EPOCH},
-        };
-
-        fn unique_temp_dir(prefix: &str) -> PathBuf {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock should be after epoch")
-                .as_nanos();
-            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
-        }
-
-        fn write_file(root: &Path, relative: &str, content: &str) {
-            let path = root.join(relative);
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).expect("create parent directory");
-            }
-            fs::write(path, content).expect("write fixture");
-        }
-
-        let root = unique_temp_dir("loongclaw-tool-capability-snapshot-skills");
-        fs::create_dir_all(&root).expect("create fixture root");
-        write_file(
-            &root,
-            "skills/demo-skill/SKILL.md",
-            "# Demo Skill\n\nUse this skill for explicit verification.\n",
-        );
-
-        let config = runtime_config::ToolRuntimeConfig {
-            shell_allowlist: BTreeSet::new(),
-            file_root: Some(root.clone()),
-            external_skills: runtime_config::ExternalSkillsRuntimePolicy {
-                enabled: true,
-                require_download_approval: true,
-                allowed_domains: BTreeSet::new(),
-                blocked_domains: BTreeSet::new(),
-                install_root: None,
-                auto_expose_installed: true,
-            },
-        };
-        execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "external_skills.install".to_owned(),
-                payload: json!({
-                    "path": "skills/demo-skill"
-                }),
-            },
-            &config,
-        )
-        .expect("install should succeed");
-
-        let snapshot = capability_snapshot_with_config(&config);
-        assert!(snapshot.contains("[available_external_skills]"));
-        assert!(snapshot.contains(
-            "- demo-skill: installed managed external skill; use external_skills.inspect or external_skills.invoke for details"
-        ));
-
-        fs::remove_dir_all(&root).ok();
-    }
-
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn capability_snapshot_lists_all_tools_when_all_features_enabled() {
         let snapshot = capability_snapshot();
-        assert!(
-            snapshot.contains(
-                "- claw.import: Import legacy Claw configs into native LoongClaw settings"
-            )
-        );
-        assert!(snapshot.contains("- external_skills.fetch: Download external skills artifacts with domain policy and approval guards"));
-        assert!(snapshot.contains("- external_skills.install: Install a managed external skill from a local directory or archive"));
-        assert!(
-            snapshot.contains(
-                "- external_skills.inspect: Read metadata for an installed external skill"
-            )
-        );
         assert!(snapshot.contains(
-            "- external_skills.invoke: Load an installed external skill into the conversation loop"
+            "- approval_request_resolve: Resolve one visible governed tool approval request"
         ));
         assert!(snapshot.contains(
-            "- external_skills.list: List managed external skills available for invocation"
+            "- approval_request_status: Inspect full detail for a visible governed tool approval request"
         ));
-        assert!(snapshot.contains("- external_skills.policy: Read/update external skills domain allow/block policy at runtime"));
         assert!(snapshot.contains(
-            "- external_skills.remove: Remove an installed external skill from the managed runtime"
+            "- approval_requests_list: List visible governed tool approval requests across the current session scope"
+        ));
+        assert!(snapshot.contains("- delegate: Delegate a focused subtask into a child session"));
+        assert!(snapshot.contains(
+            "- delegate_async: Delegate a focused subtask into a background child session"
         ));
         assert!(snapshot.contains("- file.read: Read file contents"));
         assert!(snapshot.contains("- file.write: Write file contents"));
+        assert!(snapshot.contains(
+            "- memory_search: Search visible transcript memory across persisted session turns"
+        ));
         assert!(snapshot.contains("- shell.exec: Execute shell commands"));
+        assert!(
+            snapshot.contains("- sessions_list: List visible sessions and their high-level state")
+        );
+        assert!(
+            snapshot.contains("- sessions_history: Fetch transcript history for a visible session")
+        );
+        assert!(
+            snapshot.contains("- session_status: Inspect the current status of a visible session")
+        );
+        assert!(snapshot.contains(
+            "- session_archive: Archive a visible terminal session from default session listings"
+        ));
+        assert!(
+            snapshot.contains("- session_cancel: Cancel a visible async delegate child session")
+        );
+        assert!(snapshot.contains(
+            "- session_recover: Recover an overdue queued async delegate child session by marking it failed"
+        ));
+        assert!(snapshot
+            .contains("- session_unarchive: Restore a visible archived terminal session to default session listings"));
+        assert!(snapshot
+            .contains("- session_wait: Wait for a visible session to reach a terminal state"));
+        assert!(snapshot.contains("- session_events: Fetch session events for a visible session"));
 
-        // Verify sorted order: claw.import < external_skills.* < file.* < shell.exec
+        // Verify sorted canonical name order.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 11);
-        assert!(lines[0].starts_with("- claw.import"));
-        assert!(lines[1].starts_with("- external_skills.fetch"));
-        assert!(lines[2].starts_with("- external_skills.inspect"));
-        assert!(lines[3].starts_with("- external_skills.install"));
-        assert!(lines[4].starts_with("- external_skills.invoke"));
-        assert!(lines[5].starts_with("- external_skills.list"));
-        assert!(lines[6].starts_with("- external_skills.policy"));
-        assert!(lines[7].starts_with("- external_skills.remove"));
-        assert!(lines[8].starts_with("- file.read"));
-        assert!(lines[9].starts_with("- file.write"));
-        assert!(lines[10].starts_with("- shell.exec"));
+        assert_eq!(lines.len(), 18);
+        assert!(lines[0].starts_with("- approval_request_resolve"));
+        assert!(lines[1].starts_with("- approval_request_status"));
+        assert!(lines[2].starts_with("- approval_requests_list"));
+        assert!(lines[3].starts_with("- delegate"));
+        assert!(lines[4].starts_with("- delegate_async"));
+        assert!(lines[5].starts_with("- file.read"));
+        assert!(lines[6].starts_with("- file.write"));
+        assert!(lines[7].starts_with("- memory_search"));
+        assert!(lines[8].starts_with("- session_archive"));
+        assert!(lines[9].starts_with("- session_cancel"));
+        assert!(lines[10].starts_with("- session_events"));
+        assert!(lines[11].starts_with("- session_recover"));
+        assert!(lines[12].starts_with("- session_status"));
+        assert!(lines[13].starts_with("- session_unarchive"));
+        assert!(lines[14].starts_with("- session_wait"));
+        assert!(lines[15].starts_with("- sessions_history"));
+        assert!(lines[16].starts_with("- sessions_list"));
+        assert!(lines[17].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 11);
+        assert_eq!(entries.len(), 18);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
-        assert!(names.contains(&"claw.import"));
-        assert!(names.contains(&"external_skills.fetch"));
-        assert!(names.contains(&"external_skills.install"));
-        assert!(names.contains(&"external_skills.inspect"));
-        assert!(names.contains(&"external_skills.invoke"));
-        assert!(names.contains(&"external_skills.list"));
-        assert!(names.contains(&"external_skills.policy"));
-        assert!(names.contains(&"external_skills.remove"));
+        assert!(names.contains(&"approval_request_resolve"));
+        assert!(names.contains(&"approval_request_status"));
+        assert!(names.contains(&"approval_requests_list"));
+        assert!(names.contains(&"delegate"));
+        assert!(names.contains(&"delegate_async"));
         assert!(names.contains(&"shell.exec"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
+        assert!(names.contains(&"memory_search"));
+        assert!(names.contains(&"session_archive"));
+        assert!(names.contains(&"session_cancel"));
+        assert!(names.contains(&"session_events"));
+        assert!(names.contains(&"session_recover"));
+        assert!(names.contains(&"session_unarchive"));
+        assert!(names.contains(&"sessions_list"));
+        assert!(names.contains(&"sessions_history"));
+        assert!(names.contains(&"session_status"));
+        assert!(names.contains(&"session_wait"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 11);
+        assert_eq!(defs.len(), 18);
 
         let names: Vec<&str> = defs
             .iter()
@@ -763,17 +514,24 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                "claw_import",
-                "external_skills_fetch",
-                "external_skills_inspect",
-                "external_skills_install",
-                "external_skills_invoke",
-                "external_skills_list",
-                "external_skills_policy",
-                "external_skills_remove",
+                "approval_request_resolve",
+                "approval_request_status",
+                "approval_requests_list",
+                "delegate",
+                "delegate_async",
                 "file_read",
                 "file_write",
-                "shell_exec"
+                "memory_search",
+                "session_archive",
+                "session_cancel",
+                "session_events",
+                "session_recover",
+                "session_status",
+                "session_unarchive",
+                "session_wait",
+                "sessions_history",
+                "sessions_list",
+                "shell_exec",
             ]
         );
 
@@ -782,100 +540,195 @@ mod tests {
             assert_eq!(item["function"]["parameters"]["type"], "object");
         }
 
-        let claw_import = defs
+        let approval_request_resolve = defs
             .iter()
-            .find(|item| {
-                item.get("function")
-                    .and_then(|function| function.get("name"))
-                    .and_then(Value::as_str)
-                    == Some("claw_import")
-            })
-            .expect("claw_import definition should exist");
-        let mode_enum: Vec<&str> =
-            claw_import["function"]["parameters"]["properties"]["mode"]["enum"]
-                .as_array()
-                .expect("mode enum should be an array")
-                .iter()
-                .filter_map(Value::as_str)
-                .collect();
+            .find(|item| item["function"]["name"] == "approval_request_resolve")
+            .expect("approval_request_resolve definition");
+        let approval_request_resolve_properties = approval_request_resolve["function"]
+            ["parameters"]["properties"]
+            .as_object()
+            .expect("approval_request_resolve properties");
+        assert!(approval_request_resolve_properties.contains_key("approval_request_id"));
+        assert!(approval_request_resolve_properties.contains_key("decision"));
+
+        let approval_request_status = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "approval_request_status")
+            .expect("approval_request_status definition");
+        let approval_request_status_properties = approval_request_status["function"]["parameters"]
+            ["properties"]
+            .as_object()
+            .expect("approval_request_status properties");
+        assert!(approval_request_status_properties.contains_key("approval_request_id"));
+
+        let approval_requests_list = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "approval_requests_list")
+            .expect("approval_requests_list definition");
+        let approval_requests_list_properties = approval_requests_list["function"]["parameters"]
+            ["properties"]
+            .as_object()
+            .expect("approval_requests_list properties");
+        assert!(approval_requests_list_properties.contains_key("session_id"));
+        assert!(approval_requests_list_properties.contains_key("status"));
+        assert!(approval_requests_list_properties.contains_key("limit"));
+
+        let session_wait = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_wait")
+            .expect("session_wait definition");
+        let properties = session_wait["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_wait properties");
+        assert!(properties.contains_key("session_id"));
+        assert!(properties.contains_key("session_ids"));
+        assert!(properties.contains_key("timeout_ms"));
+        assert!(properties.contains_key("after_id"));
         assert_eq!(
-            mode_enum,
-            vec![
-                "plan",
-                "apply",
-                "discover",
-                "plan_many",
-                "recommend_primary",
-                "merge_profiles",
-                "map_external_skills",
-                "apply_selected",
-                "rollback_last_apply"
-            ]
-        );
-        assert!(
-            claw_import["function"]["parameters"]["required"]
+            session_wait["function"]["parameters"]["oneOf"]
                 .as_array()
-                .expect("required should be an array")
-                .is_empty()
+                .expect("session_wait oneOf")
+                .len(),
+            2
         );
+
+        let session_recover = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_recover")
+            .expect("session_recover definition");
+        let recover_properties = session_recover["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_recover properties");
+        assert!(recover_properties.contains_key("session_id"));
+        assert!(recover_properties.contains_key("session_ids"));
+        assert!(recover_properties.contains_key("dry_run"));
+        assert_eq!(
+            session_recover["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("session_recover oneOf")
+                .len(),
+            2
+        );
+
+        let session_cancel = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_cancel")
+            .expect("session_cancel definition");
+        let cancel_properties = session_cancel["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_cancel properties");
+        assert!(cancel_properties.contains_key("session_id"));
+        assert!(cancel_properties.contains_key("session_ids"));
+        assert!(cancel_properties.contains_key("dry_run"));
+        assert_eq!(
+            session_cancel["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("session_cancel oneOf")
+                .len(),
+            2
+        );
+
+        let session_archive = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_archive")
+            .expect("session_archive definition");
+        let archive_properties = session_archive["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_archive properties");
+        assert!(archive_properties.contains_key("session_id"));
+        assert!(archive_properties.contains_key("session_ids"));
+        assert!(archive_properties.contains_key("dry_run"));
+        assert_eq!(
+            session_archive["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("session_archive oneOf")
+                .len(),
+            2
+        );
+
+        let session_unarchive = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_unarchive")
+            .expect("session_unarchive definition");
+        let unarchive_properties = session_unarchive["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_unarchive properties");
+        assert!(unarchive_properties.contains_key("session_id"));
+        assert!(unarchive_properties.contains_key("session_ids"));
+        assert!(unarchive_properties.contains_key("dry_run"));
+        assert_eq!(
+            session_unarchive["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("session_unarchive oneOf")
+                .len(),
+            2
+        );
+
+        let session_status = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_status")
+            .expect("session_status definition");
+        let status_properties = session_status["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_status properties");
+        assert!(status_properties.contains_key("session_id"));
+        assert!(status_properties.contains_key("session_ids"));
+        assert_eq!(
+            session_status["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("session_status oneOf")
+                .len(),
+            2
+        );
+
+        let memory_search = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "memory_search")
+            .expect("memory_search definition");
+        let memory_search_properties = memory_search["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("memory_search properties");
+        assert!(memory_search_properties.contains_key("query"));
+        assert!(memory_search_properties.contains_key("session_id"));
+        assert!(memory_search_properties.contains_key("session_ids"));
+        assert!(memory_search_properties.contains_key("limit"));
+        assert!(memory_search_properties.contains_key("excerpt_chars"));
+        assert_eq!(
+            memory_search["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("memory_search oneOf")
+                .len(),
+            3
+        );
+
+        let sessions_list = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "sessions_list")
+            .expect("sessions_list definition");
+        let list_properties = sessions_list["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("sessions_list properties");
+        assert!(list_properties.contains_key("limit"));
+        assert!(list_properties.contains_key("state"));
+        assert!(list_properties.contains_key("kind"));
+        assert!(list_properties.contains_key("parent_session_id"));
+        assert!(list_properties.contains_key("overdue_only"));
+        assert!(list_properties.contains_key("include_archived"));
+        assert!(list_properties.contains_key("include_delegate_lifecycle"));
     }
 
     #[test]
     fn canonical_tool_name_maps_known_aliases() {
-        assert_eq!(canonical_tool_name("claw_import"), "claw.import");
-        assert_eq!(
-            canonical_tool_name("external_skills_policy"),
-            "external_skills.policy"
-        );
-        assert_eq!(
-            canonical_tool_name("external_skills_fetch"),
-            "external_skills.fetch"
-        );
-        assert_eq!(
-            canonical_tool_name("external_skills_install"),
-            "external_skills.install"
-        );
-        assert_eq!(
-            canonical_tool_name("external_skills_list"),
-            "external_skills.list"
-        );
-        assert_eq!(
-            canonical_tool_name("external_skills_inspect"),
-            "external_skills.inspect"
-        );
-        assert_eq!(
-            canonical_tool_name("external_skills_invoke"),
-            "external_skills.invoke"
-        );
-        assert_eq!(
-            canonical_tool_name("external_skills_remove"),
-            "external_skills.remove"
-        );
         assert_eq!(canonical_tool_name("file_read"), "file.read");
         assert_eq!(canonical_tool_name("file_write"), "file.write");
         assert_eq!(canonical_tool_name("shell_exec"), "shell.exec");
         assert_eq!(canonical_tool_name("shell"), "shell.exec");
+        assert_eq!(canonical_tool_name("memory_search"), "memory_search");
         assert_eq!(canonical_tool_name("file.read"), "file.read");
     }
 
     #[test]
     fn is_known_tool_name_accepts_canonical_and_alias_forms() {
-        assert!(is_known_tool_name("claw.import"));
-        assert!(is_known_tool_name("claw_import"));
-        assert!(is_known_tool_name("external_skills.policy"));
-        assert!(is_known_tool_name("external_skills_policy"));
-        assert!(is_known_tool_name("external_skills.fetch"));
-        assert!(is_known_tool_name("external_skills_fetch"));
-        assert!(is_known_tool_name("external_skills.install"));
-        assert!(is_known_tool_name("external_skills_install"));
-        assert!(is_known_tool_name("external_skills.list"));
-        assert!(is_known_tool_name("external_skills_list"));
-        assert!(is_known_tool_name("external_skills.inspect"));
-        assert!(is_known_tool_name("external_skills_inspect"));
-        assert!(is_known_tool_name("external_skills.invoke"));
-        assert!(is_known_tool_name("external_skills_invoke"));
-        assert!(is_known_tool_name("external_skills.remove"));
-        assert!(is_known_tool_name("external_skills_remove"));
         assert!(is_known_tool_name("file.read"));
         assert!(is_known_tool_name("file_read"));
         assert!(is_known_tool_name("file.write"));
@@ -900,719 +753,530 @@ mod tests {
     }
 
     #[test]
-    fn claw_import_plan_mode_returns_nativeized_preview() {
-        use std::{
-            fs,
-            path::{Path, PathBuf},
-            time::{SystemTime, UNIX_EPOCH},
-        };
-
-        fn unique_temp_dir(prefix: &str) -> PathBuf {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock should be after epoch")
-                .as_nanos();
-            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
-        }
-
-        fn write_file(root: &Path, relative: &str, content: &str) {
-            let path = root.join(relative);
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).expect("create parent directory");
-            }
-            fs::write(path, content).expect("write fixture");
-        }
-
-        let root = unique_temp_dir("loongclaw-tool-import-plan");
-        fs::create_dir_all(&root).expect("create fixture root");
-        write_file(
-            &root,
-            "SOUL.md",
-            "# Soul\n\nAlways prefer concise shell output. updated by nanobot.\n",
-        );
-        write_file(
-            &root,
-            "IDENTITY.md",
-            "# Identity\n\n- Motto: your nanobot agent for deploys\n",
-        );
-
-        let config = runtime_config::ToolRuntimeConfig {
-            shell_allowlist: BTreeSet::new(),
-            file_root: Some(root.clone()),
-            external_skills: Default::default(),
-        };
-        let outcome = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "claw.import".to_owned(),
-                payload: json!({
-                    "mode": "plan",
-                    "source": "nanobot",
-                    "input_path": "."
-                }),
-            },
-            &config,
-        )
-        .expect("claw import plan should succeed");
-
-        assert_eq!(outcome.status, "ok");
-        assert_eq!(outcome.payload["tool_name"], "claw.import");
-        assert_eq!(outcome.payload["mode"], "plan");
-        assert_eq!(outcome.payload["source"], "nanobot");
+    fn tool_catalog_marks_core_app_and_orchestration_tools() {
+        let catalog = tool_catalog();
         assert_eq!(
-            outcome.payload["config_preview"]["prompt_pack_id"],
-            "loongclaw-core-v1"
+            catalog
+                .descriptor("file.read")
+                .expect("file.read descriptor")
+                .execution_plane,
+            ToolExecutionPlane::Core
         );
         assert_eq!(
-            outcome.payload["config_preview"]["memory_profile"],
-            "profile_plus_window"
+            catalog
+                .descriptor("sessions_list")
+                .expect("sessions_list descriptor")
+                .execution_plane,
+            ToolExecutionPlane::App
         );
-        assert!(
-            outcome.payload["config_preview"]["system_prompt_addendum"]
-                .as_str()
-                .expect("prompt addendum should exist")
-                .contains("LoongClaw")
+        assert_eq!(
+            catalog
+                .descriptor("delegate")
+                .expect("delegate descriptor")
+                .execution_plane,
+            ToolExecutionPlane::Orchestration
         );
-        assert!(
-            outcome.payload["config_preview"]["profile_note"]
-                .as_str()
-                .expect("profile note should exist")
-                .contains("LoongClaw")
+        assert_eq!(
+            catalog
+                .descriptor("delegate_async")
+                .expect("delegate_async descriptor")
+                .execution_plane,
+            ToolExecutionPlane::Orchestration
         );
-        assert_eq!(outcome.payload["config_written"], false);
-
-        fs::remove_dir_all(&root).ok();
+        assert_eq!(
+            catalog
+                .descriptor("delegate")
+                .expect("delegate descriptor")
+                .availability,
+            ToolAvailability::Runtime
+        );
+        assert_eq!(
+            catalog
+                .descriptor("delegate_async")
+                .expect("delegate_async descriptor")
+                .availability,
+            ToolAvailability::Runtime
+        );
+        assert_eq!(
+            catalog
+                .descriptor("sessions_list")
+                .expect("sessions_list descriptor")
+                .availability,
+            ToolAvailability::Runtime
+        );
     }
 
     #[test]
-    fn claw_import_apply_mode_writes_target_config() {
-        use std::{
-            fs,
-            path::{Path, PathBuf},
-            time::{SystemTime, UNIX_EPOCH},
-        };
+    fn tool_catalog_marks_governance_metadata_for_routine_and_orchestration_tools() {
+        let catalog = tool_catalog();
 
-        fn unique_temp_dir(prefix: &str) -> PathBuf {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock should be after epoch")
-                .as_nanos();
-            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
-        }
+        let sessions_list = catalog
+            .descriptor("sessions_list")
+            .expect("sessions_list descriptor");
+        assert_eq!(sessions_list.governance_scope, ToolGovernanceScope::Routine);
+        assert_eq!(sessions_list.risk_class, ToolRiskClass::Low);
+        assert_eq!(sessions_list.approval_mode, ToolApprovalMode::Never);
 
-        fn write_file(root: &Path, relative: &str, content: &str) {
-            let path = root.join(relative);
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).expect("create parent directory");
-            }
-            fs::write(path, content).expect("write fixture");
-        }
-
-        let root = unique_temp_dir("loongclaw-tool-import-apply");
-        fs::create_dir_all(&root).expect("create fixture root");
-        write_file(
-            &root,
-            "SOUL.md",
-            "# Soul\n\nAlways prefer concise shell output. updated by nanobot.\n",
-        );
-        write_file(
-            &root,
-            "IDENTITY.md",
-            "# Identity\n\n- Motto: your nanobot agent for deploys\n",
-        );
-
-        let output_path = root.join("generated").join("loongclaw.toml");
-        let config = runtime_config::ToolRuntimeConfig {
-            shell_allowlist: BTreeSet::new(),
-            file_root: Some(root.clone()),
-            external_skills: Default::default(),
-        };
-        let outcome = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "claw_import".to_owned(),
-                payload: json!({
-                    "mode": "apply",
-                    "source": "nanobot",
-                    "input_path": ".",
-                    "output_path": "generated/loongclaw.toml",
-                    "force": true
-                }),
-            },
-            &config,
-        )
-        .expect("claw import apply should succeed");
-
-        assert_eq!(outcome.status, "ok");
-        assert_eq!(outcome.payload["mode"], "apply");
-        assert_eq!(outcome.payload["config_written"], true);
+        let approval_request_resolve = catalog
+            .descriptor("approval_request_resolve")
+            .expect("approval_request_resolve descriptor");
         assert_eq!(
-            outcome.payload["next_step"]
-                .as_str()
-                .expect("next_step should be present")
-                .split_whitespace()
-                .next(),
-            Some("loongclaw")
+            approval_request_resolve.governance_scope,
+            ToolGovernanceScope::Routine
         );
+        assert_eq!(approval_request_resolve.risk_class, ToolRiskClass::Low);
         assert_eq!(
-            outcome.payload["output_path"]
-                .as_str()
-                .expect("output path should exist"),
-            fs::canonicalize(&output_path)
-                .expect("output path should canonicalize")
-                .display()
-                .to_string()
+            approval_request_resolve.approval_mode,
+            ToolApprovalMode::Never
         );
 
-        let raw = fs::read_to_string(&output_path).expect("output config should exist");
-        assert!(raw.contains("prompt_pack_id = \"loongclaw-core-v1\""));
-        assert!(raw.contains("profile = \"profile_plus_window\""));
-        assert!(raw.contains("LoongClaw"));
+        let approval_requests_list = catalog
+            .descriptor("approval_requests_list")
+            .expect("approval_requests_list descriptor");
+        assert_eq!(
+            approval_requests_list.governance_scope,
+            ToolGovernanceScope::Routine
+        );
+        assert_eq!(approval_requests_list.risk_class, ToolRiskClass::Low);
+        assert_eq!(
+            approval_requests_list.approval_mode,
+            ToolApprovalMode::Never
+        );
 
-        fs::remove_dir_all(&root).ok();
+        let session_cancel = catalog
+            .descriptor("session_cancel")
+            .expect("session_cancel descriptor");
+        assert_eq!(
+            session_cancel.governance_scope,
+            ToolGovernanceScope::Routine
+        );
+        assert_eq!(session_cancel.risk_class, ToolRiskClass::Elevated);
+        assert_eq!(session_cancel.approval_mode, ToolApprovalMode::PolicyDriven);
+
+        let delegate_async = catalog
+            .descriptor("delegate_async")
+            .expect("delegate_async descriptor");
+        assert_eq!(
+            delegate_async.governance_scope,
+            ToolGovernanceScope::TopologyMutation
+        );
+        assert_eq!(delegate_async.risk_class, ToolRiskClass::High);
+        assert_eq!(delegate_async.approval_mode, ToolApprovalMode::PolicyDriven);
     }
 
     #[test]
-    fn claw_import_discover_mode_returns_detected_sources() {
-        use std::{
-            fs,
-            path::{Path, PathBuf},
-            time::{SystemTime, UNIX_EPOCH},
-        };
-
-        fn unique_temp_dir(prefix: &str) -> PathBuf {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock should be after epoch")
-                .as_nanos();
-            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
-        }
-
-        fn write_file(root: &Path, relative: &str, content: &str) {
-            let path = root.join(relative);
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).expect("create parent directory");
-            }
-            fs::write(path, content).expect("write fixture");
-        }
-
-        let root = unique_temp_dir("loongclaw-tool-import-discover");
-        fs::create_dir_all(&root).expect("create fixture root");
-
-        let openclaw_root = root.join("openclaw-workspace");
-        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
-        write_file(
-            &openclaw_root,
-            "SOUL.md",
-            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
-        );
-        write_file(
-            &openclaw_root,
-            "IDENTITY.md",
-            "# Identity\n\n- Role: Release copilot\n- Priority: stability first\n",
-        );
-
-        let config = runtime_config::ToolRuntimeConfig {
-            shell_allowlist: BTreeSet::new(),
-            file_root: Some(root.clone()),
-            external_skills: Default::default(),
-        };
-        let outcome = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "claw.import".to_owned(),
-                payload: json!({
-                    "mode": "discover",
-                    "input_path": "."
-                }),
-            },
-            &config,
-        )
-        .expect("claw import discover should succeed");
-
-        assert_eq!(outcome.status, "ok");
-        assert_eq!(outcome.payload["mode"], "discover");
-        assert_eq!(outcome.payload["sources"][0]["source_id"], "openclaw");
-
-        fs::remove_dir_all(&root).ok();
+    fn planned_root_tool_view_contains_first_phase_tools() {
+        let view = planned_root_tool_view();
+        assert!(view.contains("file.read"));
+        assert!(view.contains("file.write"));
+        #[cfg(feature = "tool-shell")]
+        assert!(view.contains("shell.exec"));
+        assert!(view.contains("approval_request_resolve"));
+        assert!(view.contains("approval_request_status"));
+        assert!(view.contains("approval_requests_list"));
+        assert!(view.contains("sessions_list"));
+        assert!(view.contains("sessions_history"));
+        assert!(view.contains("session_status"));
+        assert!(view.contains("session_events"));
+        assert!(view.contains("memory_search"));
+        assert!(view.contains("session_archive"));
+        assert!(view.contains("session_cancel"));
+        assert!(view.contains("session_recover"));
+        assert!(view.contains("session_wait"));
+        assert!(view.contains("delegate"));
+        assert!(view.contains("delegate_async"));
     }
 
     #[test]
-    fn claw_import_plan_many_mode_returns_source_summaries_and_recommendation() {
-        use std::{
-            fs,
-            path::{Path, PathBuf},
-            time::{SystemTime, UNIX_EPOCH},
-        };
-
-        fn unique_temp_dir(prefix: &str) -> PathBuf {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock should be after epoch")
-                .as_nanos();
-            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
-        }
-
-        fn write_file(root: &Path, relative: &str, content: &str) {
-            let path = root.join(relative);
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).expect("create parent directory");
-            }
-            fs::write(path, content).expect("write fixture");
-        }
-
-        let root = unique_temp_dir("loongclaw-tool-import-plan-many");
-        fs::create_dir_all(&root).expect("create fixture root");
-
-        let openclaw_root = root.join("openclaw-workspace");
-        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
-        write_file(
-            &openclaw_root,
-            "SOUL.md",
-            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
-        );
-        write_file(
-            &openclaw_root,
-            "IDENTITY.md",
-            "# Identity\n\n- Role: Release copilot\n- Priority: stability first\n",
-        );
-
-        let nanobot_root = root.join("nanobot");
-        fs::create_dir_all(&nanobot_root).expect("create nanobot root");
-        write_file(
-            &nanobot_root,
-            "IDENTITY.md",
-            "# Identity\n\n- Motto: your nanobot agent for deploys\n",
-        );
-
-        let config = runtime_config::ToolRuntimeConfig {
-            shell_allowlist: BTreeSet::new(),
-            file_root: Some(root.clone()),
-            external_skills: Default::default(),
-        };
-        let outcome = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "claw.import".to_owned(),
-                payload: json!({
-                    "mode": "plan_many",
-                    "input_path": "."
-                }),
-            },
-            &config,
-        )
-        .expect("claw import plan_many should succeed");
-
-        assert_eq!(outcome.status, "ok");
-        assert_eq!(outcome.payload["mode"], "plan_many");
-        assert_eq!(outcome.payload["plans"][0]["source_id"], "openclaw");
-        assert_eq!(outcome.payload["recommendation"]["source_id"], "openclaw");
-
-        fs::remove_dir_all(&root).ok();
+    fn runtime_tool_view_includes_delegate_and_session_tools() {
+        let view = runtime_tool_view();
+        assert!(view.contains("approval_request_resolve"));
+        assert!(view.contains("approval_request_status"));
+        assert!(view.contains("approval_requests_list"));
+        assert!(view.contains("delegate"));
+        assert!(view.contains("sessions_list"));
+        assert!(view.contains("sessions_history"));
+        assert!(view.contains("session_status"));
+        assert!(view.contains("session_events"));
+        assert!(view.contains("session_archive"));
+        assert!(view.contains("session_cancel"));
+        assert!(view.contains("session_recover"));
+        assert!(view.contains("session_wait"));
+        assert!(view.contains("delegate_async"));
     }
 
     #[test]
-    fn claw_import_merge_profiles_mode_preserves_prompt_owner() {
-        use std::{
-            fs,
-            path::{Path, PathBuf},
-            time::{SystemTime, UNIX_EPOCH},
-        };
+    fn session_cancel_is_visible_in_root_and_hidden_in_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("session_cancel"));
 
-        fn unique_temp_dir(prefix: &str) -> PathBuf {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock should be after epoch")
-                .as_nanos();
-            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
-        }
+        let child_view = planned_delegate_child_tool_view();
+        assert!(!child_view.contains("session_cancel"));
 
-        fn write_file(root: &Path, relative: &str, content: &str) {
-            let path = root.join(relative);
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).expect("create parent directory");
-            }
-            fs::write(path, content).expect("write fixture");
-        }
-
-        let root = unique_temp_dir("loongclaw-tool-import-merge-profiles");
-        fs::create_dir_all(&root).expect("create fixture root");
-
-        let openclaw_root = root.join("openclaw-workspace");
-        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
-        write_file(
-            &openclaw_root,
-            "SOUL.md",
-            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        let child_with_depth = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
         );
-        write_file(
-            &openclaw_root,
-            "IDENTITY.md",
-            "# Identity\n\n- role: release copilot\n- tone: steady\n",
+        assert!(!child_with_depth.contains("session_cancel"));
+    }
+
+    #[test]
+    fn session_archive_is_visible_in_root_and_hidden_in_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("session_archive"));
+
+        let child_view = planned_delegate_child_tool_view();
+        assert!(!child_view.contains("session_archive"));
+
+        let child_with_depth = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
         );
+        assert!(!child_with_depth.contains("session_archive"));
+    }
 
-        let nanobot_root = root.join("nanobot");
-        fs::create_dir_all(&nanobot_root).expect("create nanobot root");
-        write_file(
-            &nanobot_root,
-            "IDENTITY.md",
-            "# Identity\n\n- role: release copilot\n- region: apac\n",
+    #[test]
+    fn memory_search_is_visible_in_root_and_hidden_in_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("memory_search"));
+
+        let child_view = planned_delegate_child_tool_view();
+        assert!(!child_view.contains("memory_search"));
+
+        let child_with_depth = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
         );
+        assert!(!child_with_depth.contains("memory_search"));
+    }
 
-        let config = runtime_config::ToolRuntimeConfig {
-            shell_allowlist: BTreeSet::new(),
-            file_root: Some(root.clone()),
-            external_skills: Default::default(),
-        };
-        let outcome = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "claw.import".to_owned(),
-                payload: json!({
-                    "mode": "merge_profiles",
-                    "input_path": "."
-                }),
-            },
-            &config,
-        )
-        .expect("claw import merge_profiles should succeed");
+    #[test]
+    fn session_unarchive_is_visible_in_root_and_hidden_in_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("session_unarchive"));
 
-        assert_eq!(outcome.status, "ok");
-        assert_eq!(outcome.payload["mode"], "merge_profiles");
+        let child_view = planned_delegate_child_tool_view();
+        assert!(!child_view.contains("session_unarchive"));
+
+        let child_with_depth = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
+        );
+        assert!(!child_with_depth.contains("session_unarchive"));
+    }
+
+    #[test]
+    fn approval_request_tools_are_visible_in_root_and_hidden_in_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("approval_request_resolve"));
+        assert!(root_view.contains("approval_request_status"));
+        assert!(root_view.contains("approval_requests_list"));
+
+        let child_view = planned_delegate_child_tool_view();
+        assert!(!child_view.contains("approval_request_resolve"));
+        assert!(!child_view.contains("approval_request_status"));
+        assert!(!child_view.contains("approval_requests_list"));
+
+        let child_with_depth = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
+        );
+        assert!(!child_with_depth.contains("approval_request_resolve"));
+        assert!(!child_with_depth.contains("approval_request_status"));
+        assert!(!child_with_depth.contains("approval_requests_list"));
+    }
+
+    #[test]
+    fn runtime_tool_view_for_config_omits_disabled_session_and_delegate_tools() {
+        let mut config = crate::config::ToolConfig::default();
+        config.sessions.enabled = false;
+        config.delegate.enabled = false;
+
+        let view = runtime_tool_view_for_config(&config);
+        assert!(view.contains("file.read"));
+        assert!(view.contains("file.write"));
+        assert!(!view.contains("delegate"));
+        assert!(!view.contains("delegate_async"));
+        assert!(!view.contains("approval_request_resolve"));
+        assert!(!view.contains("approval_request_status"));
+        assert!(!view.contains("approval_requests_list"));
+        assert!(!view.contains("sessions_list"));
+        assert!(!view.contains("sessions_history"));
+        assert!(!view.contains("session_status"));
+        assert!(!view.contains("session_events"));
+        assert!(!view.contains("memory_search"));
+        assert!(!view.contains("session_archive"));
+        assert!(!view.contains("session_recover"));
+        assert!(!view.contains("session_unarchive"));
+        assert!(!view.contains("session_wait"));
+    }
+
+    #[test]
+    fn delegate_child_tool_view_for_config_allows_shell_when_enabled() {
+        let mut config = crate::config::ToolConfig::default();
+        config.delegate.allow_shell_in_child = true;
+
+        let view = delegate_child_tool_view_for_config(&config);
+        assert!(view.contains("file.read"));
+        assert!(view.contains("file.write"));
+        assert!(view.contains("shell.exec"));
+        assert!(!view.contains("delegate"));
+        assert!(!view.contains("sessions_list"));
+        assert!(!view.contains("session_recover"));
+        assert!(!view.contains("session_wait"));
+    }
+
+    #[test]
+    fn delegate_child_tool_view_with_remaining_depth_allows_delegate() {
+        let config = crate::config::ToolConfig::default();
+
+        let view = delegate_child_tool_view_for_config_with_delegate(&config, true);
+        assert!(view.contains("file.read"));
+        assert!(view.contains("file.write"));
+        assert!(view.contains("delegate"));
+        assert!(view.contains("delegate_async"));
+        assert!(view.contains("sessions_history"));
+        assert!(view.contains("session_status"));
+        assert!(!view.contains("sessions_list"));
+    }
+
+    #[test]
+    fn delegate_child_tool_view_default_allowlist_matches_runtime_child_tools() {
+        let config = crate::config::ToolConfig::default();
         assert_eq!(
-            outcome.payload["result"]["prompt_owner_source_id"],
-            "openclaw"
+            config.delegate.child_tool_allowlist,
+            vec!["file.read", "file.write"]
         );
+    }
+
+    #[test]
+    fn child_tool_view_excludes_delegate_and_session_list() {
+        let view = planned_delegate_child_tool_view();
+        assert!(view.contains("file.read"));
+        assert!(view.contains("file.write"));
+        assert!(view.contains("sessions_history"));
+        assert!(view.contains("session_status"));
+        assert!(!view.contains("shell.exec"));
+        assert!(!view.contains("delegate"));
+        assert!(!view.contains("delegate_async"));
+        assert!(!view.contains("sessions_list"));
+        assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_archive"));
+        assert!(!view.contains("session_cancel"));
+        assert!(!view.contains("session_recover"));
+        assert!(!view.contains("session_wait"));
+    }
+
+    #[test]
+    fn child_session_self_inspection_tool_view_includes_status_and_history_only() {
+        let view = planned_delegate_child_tool_view();
+        assert!(view.contains("file.read"));
+        assert!(view.contains("file.write"));
+        assert!(view.contains("sessions_history"));
+        assert!(view.contains("session_status"));
+        assert!(!view.contains("sessions_list"));
+        assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_archive"));
+        assert!(!view.contains("session_cancel"));
+        assert!(!view.contains("session_recover"));
+        assert!(!view.contains("session_wait"));
+        assert!(!view.contains("delegate_async"));
+    }
+
+    #[test]
+    fn delegate_async_is_visible_in_root_and_depth_budgeted_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("delegate_async"));
+
+        let child_allowed = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
+        );
+        assert!(child_allowed.contains("delegate_async"));
+
+        let child_exhausted = planned_delegate_child_tool_view();
+        assert!(!child_exhausted.contains("delegate_async"));
+    }
+
+    #[test]
+    fn provider_tool_definitions_follow_tool_view() {
+        let view = ToolView::from_tool_names(["file.read"]);
+        let defs =
+            try_provider_tool_definitions_for_view(&view).expect("runtime-visible tool schemas");
+        let names: Vec<&str> = defs
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(names, vec!["file_read"]);
+    }
+
+    #[test]
+    fn provider_tool_definitions_include_delegate_when_visible() {
+        let view = ToolView::from_tool_names(["delegate", "delegate_async", "file.read"]);
+        let defs =
+            try_provider_tool_definitions_for_view(&view).expect("runtime-visible tool schemas");
+        let names: Vec<&str> = defs
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(names, vec!["delegate", "delegate_async", "file_read"]);
+    }
+
+    #[cfg(feature = "config-toml")]
+    #[test]
+    fn runtime_tool_view_exposes_sessions_send_only_when_messages_enabled() {
+        let raw = r#"
+[tools.messages]
+enabled = true
+"#;
+        let parsed =
+            toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
+        let root_view = runtime_tool_view_for_config(&parsed.tools);
+        assert!(root_view.contains("sessions_send"));
+
+        let child_view = delegate_child_tool_view_for_config(&parsed.tools);
+        assert!(!child_view.contains("sessions_send"));
+    }
+
+    #[cfg(feature = "config-toml")]
+    #[test]
+    fn provider_tool_definitions_include_sessions_send_when_enabled() {
+        let raw = r#"
+[tools.messages]
+enabled = true
+"#;
+        let parsed =
+            toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
+        let defs =
+            try_provider_tool_definitions_for_view(&runtime_tool_view_for_config(&parsed.tools))
+                .expect("runtime-visible tool schemas");
+        let sessions_send = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "sessions_send")
+            .expect("sessions_send definition");
+        let properties = sessions_send["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("sessions_send properties");
+        assert!(properties.contains_key("session_id"));
+        assert!(properties.contains_key("text"));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn isolated_memory_config(
+        test_name: &str,
+    ) -> crate::memory::runtime_config::MemoryRuntimeConfig {
+        let base = std::env::temp_dir().join(format!(
+            "loongclaw-tools-mod-{test_name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&base).expect("create tools test directory");
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(base.join("memory.sqlite3")),
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn execute_app_tool_runtime_support_routes_session_wait() {
+        let memory_config = isolated_memory_config("runtime-session-wait");
+        let repo =
+            crate::session::repository::SessionRepository::new(&memory_config).expect("repo");
+        repo.create_session(crate::session::repository::NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: crate::session::repository::SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: crate::session::repository::SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(crate::session::repository::NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: crate::session::repository::SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: crate::session::repository::SessionState::Ready,
+        })
+        .expect("create child");
+
+        let outcome = execute_app_tool_with_runtime_support(
+            ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 1
+                }),
+            },
+            "root-session",
+            &memory_config,
+            &crate::config::ToolConfig::default(),
+            AppToolRuntimeSupport::default(),
+        )
+        .await
+        .expect("session_wait outcome");
+
+        assert_eq!(outcome.status, "timeout");
+        assert_eq!(outcome.payload["session"]["session_id"], "child-session");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn execute_app_tool_runtime_support_reports_sessions_send_not_configured() {
+        let memory_config = isolated_memory_config("runtime-sessions-send");
+
+        let error = execute_app_tool_with_runtime_support(
+            ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:123",
+                    "text": "hello"
+                }),
+            },
+            "root-session",
+            &memory_config,
+            &crate::config::ToolConfig::default(),
+            AppToolRuntimeSupport::default(),
+        )
+        .await
+        .expect_err("missing app config should be rejected");
+
         assert!(
-            outcome.payload["result"]["merged_profile_note"]
-                .as_str()
-                .expect("merged profile note should be present")
-                .contains("region: apac")
+            error.contains("sessions_send_not_configured"),
+            "expected sessions_send_not_configured, got: {error}"
         );
-
-        fs::remove_dir_all(&root).ok();
     }
 
-    #[test]
-    fn claw_import_map_external_skills_mode_returns_mapping_plan() {
-        use std::{
-            fs,
-            path::{Path, PathBuf},
-            time::{SystemTime, UNIX_EPOCH},
-        };
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn execute_orchestration_tool_runtime_support_rejects_delegate_without_turn_loop() {
+        let memory_config = isolated_memory_config("runtime-delegate");
 
-        fn unique_temp_dir(prefix: &str) -> PathBuf {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock should be after epoch")
-                .as_nanos();
-            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
-        }
-
-        fn write_file(root: &Path, relative: &str, content: &str) {
-            let path = root.join(relative);
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).expect("create parent directory");
-            }
-            fs::write(path, content).expect("write fixture");
-        }
-
-        let root = unique_temp_dir("loongclaw-tool-import-map-external-skills");
-        fs::create_dir_all(&root).expect("create fixture root");
-        write_file(&root, "SKILLS.md", "# Skills\n\n- custom/skill-a\n");
-        fs::create_dir_all(root.join(".codex/skills")).expect("create codex skills dir");
-
-        let config = runtime_config::ToolRuntimeConfig {
-            shell_allowlist: BTreeSet::new(),
-            file_root: Some(root.clone()),
-            external_skills: Default::default(),
-        };
-        let outcome = execute_tool_core_with_config(
+        let error = execute_orchestration_tool_with_runtime_support(
             ToolCoreRequest {
-                tool_name: "claw.import".to_owned(),
+                tool_name: "delegate".to_owned(),
                 payload: json!({
-                    "mode": "map_external_skills",
-                    "input_path": "."
+                    "task": "research the runtime"
                 }),
             },
-            &config,
+            "root-session",
+            &memory_config,
+            &crate::config::ToolConfig::default(),
+            OrchestrationToolRuntimeSupport::default(),
         )
-        .expect("claw import map_external_skills should succeed");
+        .await
+        .expect_err("delegate should require turn-loop dispatch");
 
-        assert_eq!(outcome.status, "ok");
-        assert_eq!(outcome.payload["mode"], "map_external_skills");
-        assert_eq!(outcome.payload["result"]["artifact_count"], 2);
-        assert_eq!(
-            outcome.payload["result"]["declared_skills"][0],
-            "custom/skill-a"
-        );
-        assert_eq!(
-            outcome.payload["result"]["resolved_skills"][0],
-            "custom/skill-a"
-        );
         assert!(
-            outcome.payload["result"]["profile_note_addendum"]
-                .as_str()
-                .expect("profile note addendum should exist")
-                .contains("Imported External Skills Artifacts")
+            error.contains("orchestration_tool_requires_turn_loop_dispatch: delegate"),
+            "expected delegate turn-loop error, got: {error}"
         );
-
-        fs::remove_dir_all(&root).ok();
-    }
-
-    #[test]
-    fn claw_import_apply_selected_mode_writes_manifest_and_backup() {
-        use std::{
-            fs,
-            path::{Path, PathBuf},
-            time::{SystemTime, UNIX_EPOCH},
-        };
-
-        fn unique_temp_dir(prefix: &str) -> PathBuf {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock should be after epoch")
-                .as_nanos();
-            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
-        }
-
-        fn write_file(root: &Path, relative: &str, content: &str) {
-            let path = root.join(relative);
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).expect("create parent directory");
-            }
-            fs::write(path, content).expect("write fixture");
-        }
-
-        let root = unique_temp_dir("loongclaw-tool-import-apply-selected");
-        fs::create_dir_all(&root).expect("create fixture root");
-
-        let openclaw_root = root.join("openclaw-workspace");
-        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
-        write_file(
-            &openclaw_root,
-            "SOUL.md",
-            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
-        );
-        write_file(
-            &openclaw_root,
-            "IDENTITY.md",
-            "# Identity\n\n- role: release copilot\n- tone: steady\n",
-        );
-
-        let output_path = root.join("loongclaw.toml");
-        let original_body = crate::config::render(&crate::config::LoongClawConfig::default())
-            .expect("render default config");
-        fs::write(&output_path, &original_body).expect("write original config");
-
-        let config = runtime_config::ToolRuntimeConfig {
-            shell_allowlist: BTreeSet::new(),
-            file_root: Some(root.clone()),
-            external_skills: Default::default(),
-        };
-        let outcome = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "claw.import".to_owned(),
-                payload: json!({
-                    "mode": "apply_selected",
-                    "input_path": ".",
-                    "output_path": "loongclaw.toml",
-                    "source_id": "openclaw"
-                }),
-            },
-            &config,
-        )
-        .expect("claw import apply_selected should succeed");
-
-        assert_eq!(outcome.status, "ok");
-        assert_eq!(outcome.payload["mode"], "apply_selected");
-        assert!(
-            Path::new(
-                outcome.payload["result"]["backup_path"]
-                    .as_str()
-                    .expect("backup path should be present")
-            )
-            .exists()
-        );
-        assert!(
-            Path::new(
-                outcome.payload["result"]["manifest_path"]
-                    .as_str()
-                    .expect("manifest path should be present")
-            )
-            .exists()
-        );
-
-        fs::remove_dir_all(&root).ok();
-    }
-
-    #[test]
-    fn claw_import_apply_selected_mode_can_apply_external_skills_plan() {
-        use std::{
-            fs,
-            path::{Path, PathBuf},
-            time::{SystemTime, UNIX_EPOCH},
-        };
-
-        fn unique_temp_dir(prefix: &str) -> PathBuf {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock should be after epoch")
-                .as_nanos();
-            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
-        }
-
-        fn write_file(root: &Path, relative: &str, content: &str) {
-            let path = root.join(relative);
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).expect("create parent directory");
-            }
-            fs::write(path, content).expect("write fixture");
-        }
-
-        let root = unique_temp_dir("loongclaw-tool-import-apply-selected-external");
-        fs::create_dir_all(&root).expect("create fixture root");
-
-        let openclaw_root = root.join("openclaw-workspace");
-        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
-        write_file(
-            &openclaw_root,
-            "SOUL.md",
-            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
-        );
-        write_file(
-            &openclaw_root,
-            "IDENTITY.md",
-            "# Identity\n\n- role: release copilot\n- tone: steady\n",
-        );
-        write_file(&root, "SKILLS.md", "# Skills\n\n- custom/skill-a\n");
-
-        let output_path = root.join("loongclaw.toml");
-
-        let config = runtime_config::ToolRuntimeConfig {
-            shell_allowlist: BTreeSet::new(),
-            file_root: Some(root.clone()),
-            external_skills: Default::default(),
-        };
-        let outcome = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "claw.import".to_owned(),
-                payload: json!({
-                    "mode": "apply_selected",
-                    "input_path": ".",
-                    "output_path": "loongclaw.toml",
-                    "source_id": "openclaw",
-                    "apply_external_skills_plan": true
-                }),
-            },
-            &config,
-        )
-        .expect("claw import apply_selected with external skills should succeed");
-
-        assert_eq!(outcome.status, "ok");
-        assert_eq!(
-            outcome.payload["result"]["external_skill_artifact_count"],
-            1
-        );
-        assert_eq!(
-            outcome.payload["result"]["external_skill_entries_applied"],
-            3
-        );
-        assert!(
-            outcome.payload["result"]["external_skills_manifest_path"]
-                .as_str()
-                .is_some(),
-            "external skills manifest path should exist"
-        );
-        let raw = fs::read_to_string(&output_path).expect("read output config");
-        assert!(raw.contains("Imported External Skills Artifacts"));
-
-        fs::remove_dir_all(&root).ok();
-    }
-
-    #[test]
-    fn claw_import_rollback_last_apply_restores_original_config() {
-        use std::{
-            fs,
-            path::{Path, PathBuf},
-            time::{SystemTime, UNIX_EPOCH},
-        };
-
-        fn unique_temp_dir(prefix: &str) -> PathBuf {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock should be after epoch")
-                .as_nanos();
-            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
-        }
-
-        fn write_file(root: &Path, relative: &str, content: &str) {
-            let path = root.join(relative);
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).expect("create parent directory");
-            }
-            fs::write(path, content).expect("write fixture");
-        }
-
-        let root = unique_temp_dir("loongclaw-tool-import-rollback-selected");
-        fs::create_dir_all(&root).expect("create fixture root");
-
-        let openclaw_root = root.join("openclaw-workspace");
-        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
-        write_file(
-            &openclaw_root,
-            "SOUL.md",
-            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
-        );
-        write_file(
-            &openclaw_root,
-            "IDENTITY.md",
-            "# Identity\n\n- role: release copilot\n- tone: steady\n",
-        );
-
-        let output_path = root.join("loongclaw.toml");
-        let original_body = crate::config::render(&crate::config::LoongClawConfig::default())
-            .expect("render default config");
-        fs::write(&output_path, &original_body).expect("write original config");
-
-        let config = runtime_config::ToolRuntimeConfig {
-            shell_allowlist: BTreeSet::new(),
-            file_root: Some(root.clone()),
-            external_skills: Default::default(),
-        };
-        execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "claw.import".to_owned(),
-                payload: json!({
-                    "mode": "apply_selected",
-                    "input_path": ".",
-                    "output_path": "loongclaw.toml",
-                    "source_id": "openclaw"
-                }),
-            },
-            &config,
-        )
-        .expect("claw import apply_selected should succeed");
-
-        let rollback = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "claw.import".to_owned(),
-                payload: json!({
-                    "mode": "rollback_last_apply",
-                    "output_path": "loongclaw.toml"
-                }),
-            },
-            &config,
-        )
-        .expect("claw import rollback_last_apply should succeed");
-
-        assert_eq!(rollback.status, "ok");
-        assert!(
-            rollback.payload["rolled_back"]
-                .as_bool()
-                .expect("rolled_back flag should exist")
-        );
-        assert_eq!(
-            fs::read_to_string(&output_path).expect("read restored config"),
-            original_body
-        );
-
-        fs::remove_dir_all(&root).ok();
     }
 
     // --- Kernel-routed tool tests ---


### PR DESCRIPTION
## Summary

- derive grant-side attention states from durable grant audit and runtime grant review age
- add grant attention filters, hotspot prioritization, and unified operator attention summaries
- expose a canonical per-request `attention` view with source-tagged execution and grant signals
- this change is needed so approval operators can prioritize stale, risky, or blocked requests from one consistent surface instead of reconstructing that state manually

## Scope

- [ ] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

Scope note: the diff is limited to approval lifecycle attention/query surfaces and their regression coverage, but it changes a core operator workflow across persistence, turn runtime, and tools.

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

Risk note: this changes operator-facing approval prioritization and summary semantics inside the core lifecycle path.

## Validation

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional checks executed:

- [x] `CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 CARGO_TARGET_DIR=target/approval-lifecycle-verify cargo test -p loongclaw-app approval_request_tool_query_ -- --nocapture --test-threads=1`
- [x] `CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 CARGO_TARGET_DIR=target/approval-lifecycle-verify cargo test -p loongclaw-app approval_request_ -- --nocapture --test-threads=1`

## Linked Issues

Closes #128