### PR TITLE
feat(session): land stacked session runtime foundation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         required: true
 
 env:
-  BIN_NAME: loongclawd
+  BIN_NAME: loongclaw
   PACKAGE_NAME: loongclaw
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,6 +1230,7 @@ dependencies = [
  "sha2",
  "tokio",
  "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -2260,7 +2261,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ dependencies = [
  "axum",
  "base64",
  "cbc",
+ "futures-util",
  "loongclaw-contracts",
  "loongclaw-kernel",
  "reqwest",
@@ -1257,12 +1258,14 @@ dependencies = [
 name = "loongclaw-daemon"
 version = "0.1.2"
 dependencies = [
+ "async-trait",
  "base64",
  "chrono",
  "clap",
  "ed25519-dalek",
  "loongclaw-app",
  "loongclaw-bench",
+ "loongclaw-contracts",
  "loongclaw-kernel",
  "loongclaw-spec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ futures-util = "0.3"
 sha2 = "0.10"
 wasmparser = "0.245"
 base64 = "0.22"
+tracing = "0.1"
 ed25519-dalek = "2.2"
 wasmtime = { version = "42.0.1", default-features = false, features = ["std", "runtime", "cranelift"] }
 rusqlite = { version = "0.38", features = ["bundled"] }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ strict policy boundaries, and highly pluggable runtime orchestration.
 ## Workspace Layout
 
 - `crates/kernel` (`loongclaw-kernel`): core architecture contracts and execution kernel.
-- `crates/daemon` (`loongclaw-daemon` / `loongclawd`): runnable daemon wired to kernel policy and runtime controls.
+- `crates/daemon` (`loongclaw-daemon` / `loongclaw`): runnable daemon wired to kernel policy and runtime controls.
 
 ## Core Design
 
@@ -24,7 +24,7 @@ For architecture boundaries, see [Layered Kernel Design](docs/design-docs/layere
 
 - `loongclaw-kernel`: 41 unit tests passing.
 - `loongclaw-daemon`: 135 unit tests passing.
-- `loongclawd` smoke/spec execution verified.
+- `loongclaw` smoke/spec execution verified.
 - `programmatic` pressure benchmark gate (matrix + baseline) verified.
 - `wasm` cache benchmark gate (cold/hot latency + hit/miss) verified.
 
@@ -51,17 +51,17 @@ For architecture boundaries, see [Layered Kernel Design](docs/design-docs/layere
 ```bash
 cargo test -p loongclaw-kernel
 cargo test -p loongclaw-daemon
-cargo run -p loongclaw-daemon --bin loongclawd
-cargo run -p loongclaw-daemon --bin loongclawd -- onboard
-cargo run -p loongclaw-daemon --bin loongclawd -- setup --force
-cargo run -p loongclaw-daemon --bin loongclawd -- doctor --fix
-cargo run -p loongclaw-daemon --bin loongclawd -- list-models --json
-cargo run -p loongclaw-daemon --bin loongclawd -- chat
-cargo run -p loongclaw-daemon --bin loongclawd -- run-spec --spec examples/spec/runtime-extension.json --print-audit
-cargo run -p loongclaw-daemon --bin loongclawd -- run-spec --spec examples/spec/tool-search.json --print-audit
-cargo run -p loongclaw-daemon --bin loongclawd -- run-spec --spec examples/spec/programmatic-tool-call.json --print-audit
-cargo run -p loongclaw-daemon --bin loongclawd -- benchmark-programmatic-pressure --matrix examples/benchmarks/programmatic-pressure-matrix.json --enforce-gate
-cargo run -p loongclaw-daemon --bin loongclawd -- benchmark-wasm-cache --wasm examples/plugins-wasm/secure_echo.wasm --enforce-gate
+cargo run -p loongclaw-daemon --bin loongclaw
+cargo run -p loongclaw-daemon --bin loongclaw -- onboard
+cargo run -p loongclaw-daemon --bin loongclaw -- setup --force
+cargo run -p loongclaw-daemon --bin loongclaw -- doctor --fix
+cargo run -p loongclaw-daemon --bin loongclaw -- list-models --json
+cargo run -p loongclaw-daemon --bin loongclaw -- chat
+cargo run -p loongclaw-daemon --bin loongclaw -- run-spec --spec examples/spec/runtime-extension.json --print-audit
+cargo run -p loongclaw-daemon --bin loongclaw -- run-spec --spec examples/spec/tool-search.json --print-audit
+cargo run -p loongclaw-daemon --bin loongclaw -- run-spec --spec examples/spec/programmatic-tool-call.json --print-audit
+cargo run -p loongclaw-daemon --bin loongclaw -- benchmark-programmatic-pressure --matrix examples/benchmarks/programmatic-pressure-matrix.json --enforce-gate
+cargo run -p loongclaw-daemon --bin loongclaw -- benchmark-wasm-cache --wasm examples/plugins-wasm/secure_echo.wasm --enforce-gate
 ./scripts/benchmark_programmatic_pressure.sh
 ./scripts/benchmark_wasm_cache.sh
 ```
@@ -70,7 +70,7 @@ Optional runtime tuning:
 
 ```bash
 # default = 32, max = 4096
-LOONGCLAW_WASM_CACHE_CAPACITY=64 cargo run -p loongclaw-daemon --bin loongclawd -- benchmark-wasm-cache --enforce-gate
+LOONGCLAW_WASM_CACHE_CAPACITY=64 cargo run -p loongclaw-daemon --bin loongclaw -- benchmark-wasm-cache --enforce-gate
 ```
 
 One-command install from source:
@@ -117,7 +117,7 @@ api_key_env = "MINIMAX_API_KEY"
 Validate config before runtime startup:
 
 ```bash
-loongclawd validate-config --config ~/.loongclaw/config.toml --json --locale en
+loongclaw validate-config --config ~/.loongclaw/config.toml --json --locale en
 ```
 
 `--json` returns stable diagnostic codes and machine-readable message variables
@@ -133,7 +133,7 @@ JSON output includes:
 CI gate example:
 
 ```bash
-loongclawd validate-config --config ~/.loongclaw/config.toml --output problem-json --fail-on-diagnostics
+loongclaw validate-config --config ~/.loongclaw/config.toml --output problem-json --fail-on-diagnostics
 ```
 
 `--fail-on-diagnostics` exits non-zero when diagnostics are present.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -29,9 +29,9 @@ tasks:
   smoke:
     desc: Run representative spec-runner smoke scenarios
     cmds:
-      - cargo run -p loongclaw-daemon --bin loongclawd -- run-spec --spec examples/spec/runtime-extension.json --print-audit
-      - cargo run -p loongclaw-daemon --bin loongclawd -- run-spec --spec examples/spec/tool-search.json --print-audit
-      - cargo run -p loongclaw-daemon --bin loongclawd -- run-spec --spec examples/spec/programmatic-tool-call.json --print-audit
+      - cargo run -p loongclaw-daemon --bin loongclaw -- run-spec --spec examples/spec/runtime-extension.json --print-audit
+      - cargo run -p loongclaw-daemon --bin loongclaw -- run-spec --spec examples/spec/tool-search.json --print-audit
+      - cargo run -p loongclaw-daemon --bin loongclaw -- run-spec --spec examples/spec/programmatic-tool-call.json --print-audit
 
   benchmark:pressure:
     desc: Run programmatic pressure benchmark with gate enforcement

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -29,6 +29,7 @@ reqwest.workspace = true
 sha2.workspace = true
 tokio.workspace = true
 base64.workspace = true
+tracing.workspace = true
 rusqlite = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 aes = { version = "0.8", optional = true }

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -21,6 +21,7 @@ tool-file = []
 loongclaw-contracts = { path = "../contracts" }
 loongclaw-kernel = { path = "../kernel" }
 async-trait.workspace = true
+futures-util.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 toml = { workspace = true, optional = true }

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -33,6 +33,12 @@ pub struct ChannelInboundMessage {
     pub text: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChannelSendReceipt {
+    pub channel: &'static str,
+    pub target: String,
+}
+
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
 #[allow(dead_code)]
 #[async_trait]
@@ -167,6 +173,107 @@ pub async fn run_feishu_channel(
         )
         .await
     }
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+pub(crate) async fn send_text_to_known_session(
+    config: &LoongClawConfig,
+    session_id: &str,
+    text: &str,
+) -> CliResult<ChannelSendReceipt> {
+    let (channel, raw_target) = session_id
+        .trim()
+        .split_once(':')
+        .ok_or_else(|| format!("sessions_send_channel_unsupported: `{session_id}`"))?;
+    let target = raw_target.trim();
+    if target.is_empty() {
+        return Err(format!("sessions_send_channel_unsupported: `{session_id}`"));
+    }
+
+    match channel {
+        "telegram" => {
+            #[cfg(not(feature = "channel-telegram"))]
+            {
+                let _ = config;
+                let _ = text;
+                return Err(
+                    "telegram channel is disabled (enable feature `channel-telegram`)".to_owned(),
+                );
+            }
+
+            #[cfg(feature = "channel-telegram")]
+            {
+                if !config.telegram.enabled {
+                    return Err(
+                        "sessions_send_channel_disabled: telegram channel is disabled by config"
+                            .to_owned(),
+                    );
+                }
+                let chat_id = target.parse::<i64>().map_err(|error| {
+                    format!("sessions_send_invalid_telegram_target: `{target}`: {error}")
+                })?;
+                if !config.telegram.allowed_chat_ids.contains(&chat_id) {
+                    return Err(format!(
+                        "sessions_send_target_not_allowed: telegram target `{chat_id}` is not present in telegram.allowed_chat_ids"
+                    ));
+                }
+                let token = config.telegram.bot_token().ok_or_else(|| {
+                    "telegram bot token missing (set telegram.bot_token or env)".to_owned()
+                })?;
+                let adapter = telegram::TelegramAdapter::new(config, token);
+                adapter.send_text(target, text).await?;
+                return Ok(ChannelSendReceipt {
+                    channel: "telegram",
+                    target: chat_id.to_string(),
+                });
+            }
+        }
+        "feishu" => {
+            #[cfg(not(feature = "channel-feishu"))]
+            {
+                let _ = config;
+                let _ = text;
+                return Err(
+                    "feishu channel is disabled (enable feature `channel-feishu`)".to_owned(),
+                );
+            }
+
+            #[cfg(feature = "channel-feishu")]
+            {
+                if !config.feishu.enabled {
+                    return Err(
+                        "sessions_send_channel_disabled: feishu channel is disabled by config"
+                            .to_owned(),
+                    );
+                }
+                if !config
+                    .feishu
+                    .allowed_chat_ids
+                    .iter()
+                    .any(|allowed| allowed.trim() == target)
+                {
+                    return Err(format!(
+                        "sessions_send_target_not_allowed: feishu target `{target}` is not present in feishu.allowed_chat_ids"
+                    ));
+                }
+                feishu::run_feishu_send(config, target, text, false).await?;
+                return Ok(ChannelSendReceipt {
+                    channel: "feishu",
+                    target: target.to_owned(),
+                });
+            }
+        }
+        _ => Err(format!("sessions_send_channel_unsupported: `{session_id}`")),
+    }
+}
+
+#[cfg(not(any(feature = "channel-telegram", feature = "channel-feishu")))]
+pub(crate) async fn send_text_to_known_session(
+    _config: &crate::config::LoongClawConfig,
+    session_id: &str,
+    _text: &str,
+) -> CliResult<ChannelSendReceipt> {
+    Err(format!("sessions_send_channel_unsupported: `{session_id}`"))
 }
 
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -222,10 +222,10 @@ pub(crate) async fn send_text_to_known_session(
                 })?;
                 let adapter = telegram::TelegramAdapter::new(config, token);
                 adapter.send_text(target, text).await?;
-                return Ok(ChannelSendReceipt {
+                Ok(ChannelSendReceipt {
                     channel: "telegram",
                     target: chat_id.to_string(),
-                });
+                })
             }
         }
         "feishu" => {
@@ -257,10 +257,10 @@ pub(crate) async fn send_text_to_known_session(
                     ));
                 }
                 feishu::run_feishu_send(config, target, text, false).await?;
-                return Ok(ChannelSendReceipt {
+                Ok(ChannelSendReceipt {
                     channel: "feishu",
                     target: target.to_owned(),
-                });
+                })
             }
         }
         _ => Err(format!("sessions_send_channel_unsupported: `{session_id}`")),

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use tokio::time::sleep;
 
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
-use crate::context::{bootstrap_kernel_context, DEFAULT_TOKEN_TTL_S};
+use crate::context::{bootstrap_kernel_context_for_config, DEFAULT_TOKEN_TTL_S};
 use crate::CliResult;
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
 use crate::KernelContext;
@@ -15,7 +15,9 @@ use crate::KernelContext;
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
 use super::config::LoongClawConfig;
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
-use super::conversation::{ConversationTurnLoop, ProviderErrorMode};
+use super::conversation::{ConversationTurnLoop, ProviderErrorMode, SessionContext};
+#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+use crate::tools::runtime_tool_view_for_config;
 
 #[cfg(feature = "channel-feishu")]
 mod feishu;
@@ -59,8 +61,9 @@ pub async fn run_telegram_channel(config_path: Option<&str>, once: bool) -> CliR
             return Err("telegram channel is disabled by config.telegram.enabled=false".to_owned());
         }
         validate_telegram_security_config(&config)?;
-        apply_runtime_env(&config);
-        let kernel_ctx = bootstrap_kernel_context("channel-telegram", DEFAULT_TOKEN_TTL_S)?;
+        crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
+        let kernel_ctx =
+            bootstrap_kernel_context_for_config("channel-telegram", DEFAULT_TOKEN_TTL_S, &config)?;
 
         let token = config.telegram.bot_token().ok_or_else(|| {
             "telegram bot token missing (set telegram.bot_token or env)".to_owned()
@@ -116,7 +119,7 @@ pub async fn run_feishu_send(
         if !config.feishu.enabled {
             return Err("feishu channel is disabled by config.feishu.enabled=false".to_owned());
         }
-        apply_runtime_env(&config);
+        crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
 
         feishu::run_feishu_send(&config, receive_id, text, as_card).await?;
 
@@ -151,8 +154,9 @@ pub async fn run_feishu_channel(
             return Err("feishu channel is disabled by config.feishu.enabled=false".to_owned());
         }
         validate_feishu_security_config(&config)?;
-        apply_runtime_env(&config);
-        let kernel_ctx = bootstrap_kernel_context("channel-feishu", DEFAULT_TOKEN_TTL_S)?;
+        crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
+        let kernel_ctx =
+            bootstrap_kernel_context_for_config("channel-feishu", DEFAULT_TOKEN_TTL_S, &config)?;
 
         feishu::run_feishu_channel(
             &config,
@@ -171,54 +175,19 @@ pub(super) async fn process_inbound_with_provider(
     message: &ChannelInboundMessage,
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<String> {
+    let session_context = SessionContext::root_with_tool_view(
+        &message.session_id,
+        runtime_tool_view_for_config(&config.tools),
+    );
     ConversationTurnLoop::new()
-        .handle_turn(
+        .handle_turn_in_session(
             config,
-            &message.session_id,
+            &session_context,
             &message.text,
             ProviderErrorMode::Propagate,
             kernel_ctx,
         )
         .await
-}
-
-#[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
-fn apply_runtime_env(config: &LoongClawConfig) {
-    std::env::set_var(
-        "LOONGCLAW_SQLITE_PATH",
-        config.memory.resolved_sqlite_path().display().to_string(),
-    );
-    std::env::set_var(
-        "LOONGCLAW_SLIDING_WINDOW",
-        config.memory.sliding_window.to_string(),
-    );
-    std::env::set_var(
-        "LOONGCLAW_SHELL_ALLOWLIST",
-        config.tools.shell_allowlist.join(","),
-    );
-    std::env::set_var(
-        "LOONGCLAW_FILE_ROOT",
-        config.tools.resolved_file_root().display().to_string(),
-    );
-
-    // Populate the typed tool runtime config so executors never hit env vars
-    // on the hot path.  Ignore the error if already initialised.
-    let tool_rt = crate::tools::runtime_config::ToolRuntimeConfig {
-        shell_allowlist: config
-            .tools
-            .shell_allowlist
-            .iter()
-            .map(|s| s.to_ascii_lowercase())
-            .collect(),
-        file_root: Some(config.tools.resolved_file_root()),
-    };
-    let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);
-
-    // Populate the typed memory runtime config (same pattern as tool config).
-    let memory_rt = crate::memory::runtime_config::MemoryRuntimeConfig {
-        sqlite_path: Some(config.memory.resolved_sqlite_path()),
-    };
-    let _ = crate::memory::runtime_config::init_memory_runtime_config(memory_rt);
 }
 
 #[cfg(feature = "channel-telegram")]

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -1,10 +1,11 @@
 use std::io::{self, Write};
 
-use crate::context::{bootstrap_kernel_context, DEFAULT_TOKEN_TTL_S};
+use crate::context::{bootstrap_kernel_context_for_config, DEFAULT_TOKEN_TTL_S};
+use crate::tools::runtime_tool_view_for_config;
 use crate::CliResult;
 
 use super::config::{self, LoongClawConfig};
-use super::conversation::{ConversationTurnLoop, ProviderErrorMode};
+use super::conversation::{ConversationTurnLoop, ProviderErrorMode, SessionContext};
 #[cfg(feature = "memory-sqlite")]
 use super::memory;
 #[cfg(feature = "memory-sqlite")]
@@ -17,8 +18,8 @@ pub async fn run_cli_chat(config_path: Option<&str>, session_hint: Option<&str>)
         return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
     }
 
-    export_runtime_env(&config);
-    let kernel_ctx = bootstrap_kernel_context("cli-chat", DEFAULT_TOKEN_TTL_S)?;
+    crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
+    let kernel_ctx = bootstrap_kernel_context_for_config("cli-chat", DEFAULT_TOKEN_TTL_S, &config)?;
 
     #[cfg(feature = "memory-sqlite")]
     let memory_config = MemoryRuntimeConfig {
@@ -49,6 +50,10 @@ pub async fn run_cli_chat(config_path: Option<&str>, session_hint: Option<&str>)
         .filter(|value| !value.is_empty())
         .unwrap_or("default")
         .to_owned();
+    let session_context = SessionContext::root_with_tool_view(
+        &session_id,
+        runtime_tool_view_for_config(&config.tools),
+    );
     println!("session={session_id} (type /help for commands, /exit to quit)");
     let turn_loop = ConversationTurnLoop::new();
 
@@ -85,9 +90,9 @@ pub async fn run_cli_chat(config_path: Option<&str>, session_hint: Option<&str>)
         }
 
         let assistant_text = turn_loop
-            .handle_turn(
+            .handle_turn_in_session(
                 &config,
-                &session_id,
+                &session_context,
                 input,
                 ProviderErrorMode::InlineMessage,
                 Some(&kernel_ctx),
@@ -144,42 +149,4 @@ fn print_history(
         println!("history unavailable: memory-sqlite feature disabled");
         Ok(())
     }
-}
-
-fn export_runtime_env(config: &LoongClawConfig) {
-    std::env::set_var(
-        "LOONGCLAW_SQLITE_PATH",
-        config.memory.resolved_sqlite_path().display().to_string(),
-    );
-    std::env::set_var(
-        "LOONGCLAW_SLIDING_WINDOW",
-        config.memory.sliding_window.to_string(),
-    );
-    std::env::set_var(
-        "LOONGCLAW_SHELL_ALLOWLIST",
-        config.tools.shell_allowlist.join(","),
-    );
-    std::env::set_var(
-        "LOONGCLAW_FILE_ROOT",
-        config.tools.resolved_file_root().display().to_string(),
-    );
-
-    // Populate the typed tool runtime config so executors never hit env vars
-    // on the hot path.  Ignore the error if already initialised (e.g. tests).
-    let tool_rt = crate::tools::runtime_config::ToolRuntimeConfig {
-        shell_allowlist: config
-            .tools
-            .shell_allowlist
-            .iter()
-            .map(|s| s.to_ascii_lowercase())
-            .collect(),
-        file_root: Some(config.tools.resolved_file_root()),
-    };
-    let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);
-
-    // Populate the typed memory runtime config (same pattern as tool config).
-    let memory_rt = crate::memory::runtime_config::MemoryRuntimeConfig {
-        sqlite_path: Some(config.memory.resolved_sqlite_path()),
-    };
-    let _ = crate::memory::runtime_config::init_memory_runtime_config(memory_rt);
 }

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -17,7 +17,9 @@ pub use runtime::{
 #[allow(unused_imports)]
 pub use shared::expand_path;
 #[allow(unused_imports)]
-pub use tools_memory::{MemoryConfig, ToolConfig};
+pub use tools_memory::{
+    DelegateToolConfig, MemoryConfig, SessionToolConfig, SessionVisibility, ToolConfig,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -18,7 +18,8 @@ pub use runtime::{
 pub use shared::expand_path;
 #[allow(unused_imports)]
 pub use tools_memory::{
-    DelegateToolConfig, MemoryConfig, SessionToolConfig, SessionVisibility, ToolConfig,
+    DelegateToolConfig, MemoryConfig, MessageToolConfig, SessionToolConfig, SessionVisibility,
+    ToolConfig,
 };
 
 #[cfg(test)]

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -144,7 +144,7 @@ pub fn load(path: Option<&str>) -> CliResult<(PathBuf, LoongClawConfig)> {
     let config_path = path.map(expand_path).unwrap_or_else(default_config_path);
     let raw = fs::read_to_string(&config_path).map_err(|error| {
         format!(
-            "failed to read config {}: {error}. run `loongclawd setup` first",
+            "failed to read config {}: {error}. run `loongclaw setup` first",
             config_path.display()
         )
     })?;
@@ -172,7 +172,7 @@ pub fn validate_file_with_locale(
     let config_path = path.map(expand_path).unwrap_or_else(default_config_path);
     let raw = fs::read_to_string(&config_path).map_err(|error| {
         format!(
-            "failed to read config {}: {error}. run `loongclawd setup` first",
+            "failed to read config {}: {error}. run `loongclaw setup` first",
             config_path.display()
         )
     })?;

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -320,14 +320,20 @@ fn template_secret_usage_comment() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn unique_config_path(prefix: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system time should move forward")
             .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{nanos}.toml"))
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "{prefix}-{nanos}-{}-{counter}.toml",
+            std::process::id()
+        ))
     }
 
     #[test]
@@ -562,5 +568,26 @@ api_key_env = "{secret}"
         assert!(error.contains("already exists"));
 
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn tool_config_round_trips_session_and_delegate_settings() {
+        let mut config = LoongClawConfig::default();
+        config.tools.sessions.visibility = crate::config::tools_memory::SessionVisibility::SelfOnly;
+        config.tools.sessions.list_limit = 12;
+        config.tools.sessions.history_limit = 34;
+        config.tools.delegate.enabled = false;
+        config.tools.delegate.max_depth = 2;
+        config.tools.delegate.timeout_seconds = 90;
+        config.tools.delegate.allow_shell_in_child = true;
+        config.tools.delegate.child_tool_allowlist =
+            vec!["file.read".to_owned(), "shell.exec".to_owned()];
+
+        let encoded = encode_toml_config(&config).expect("encode config");
+        let parsed = toml::from_str::<LoongClawConfig>(&encoded).expect("parse encoded config");
+
+        assert_eq!(parsed.tools.sessions, config.tools.sessions);
+        assert_eq!(parsed.tools.delegate, config.tools.delegate);
     }
 }

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -577,6 +577,7 @@ api_key_env = "{secret}"
         config.tools.sessions.visibility = crate::config::tools_memory::SessionVisibility::SelfOnly;
         config.tools.sessions.list_limit = 12;
         config.tools.sessions.history_limit = 34;
+        config.tools.messages.enabled = true;
         config.tools.delegate.enabled = false;
         config.tools.delegate.max_depth = 2;
         config.tools.delegate.timeout_seconds = 90;
@@ -588,6 +589,7 @@ api_key_env = "{secret}"
         let parsed = toml::from_str::<LoongClawConfig>(&encoded).expect("parse encoded config");
 
         assert_eq!(parsed.tools.sessions, config.tools.sessions);
+        assert_eq!(parsed.tools.messages, config.tools.messages);
         assert_eq!(parsed.tools.delegate, config.tools.delegate);
     }
 }

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -39,7 +39,7 @@ pub struct SessionToolConfig {
     pub history_limit: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct MessageToolConfig {
     #[serde(default)]
     pub enabled: bool,
@@ -96,12 +96,6 @@ impl Default for SessionToolConfig {
             list_limit: default_session_list_limit(),
             history_limit: default_session_history_limit(),
         }
-    }
-}
-
-impl Default for MessageToolConfig {
-    fn default() -> Self {
-        Self { enabled: false }
     }
 }
 

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -13,6 +13,8 @@ pub struct ToolConfig {
     #[serde(default)]
     pub sessions: SessionToolConfig,
     #[serde(default)]
+    pub messages: MessageToolConfig,
+    #[serde(default)]
     pub delegate: DelegateToolConfig,
 }
 
@@ -35,6 +37,12 @@ pub struct SessionToolConfig {
     pub list_limit: usize,
     #[serde(default = "default_session_history_limit")]
     pub history_limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageToolConfig {
+    #[serde(default)]
+    pub enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -65,6 +73,7 @@ impl Default for ToolConfig {
             shell_allowlist: default_shell_allowlist(),
             file_root: None,
             sessions: SessionToolConfig::default(),
+            messages: MessageToolConfig::default(),
             delegate: DelegateToolConfig::default(),
         }
     }
@@ -87,6 +96,12 @@ impl Default for SessionToolConfig {
             list_limit: default_session_list_limit(),
             history_limit: default_session_history_limit(),
         }
+    }
+}
+
+impl Default for MessageToolConfig {
+    fn default() -> Self {
+        Self { enabled: false }
     }
 }
 
@@ -172,6 +187,8 @@ mod tests {
         assert_eq!(config.sessions.visibility, SessionVisibility::Children);
         assert_eq!(config.sessions.list_limit, 100);
         assert_eq!(config.sessions.history_limit, 200);
+        assert!(!config.messages.enabled);
+        assert!(!crate::tools::runtime_tool_view_for_config(&config).contains("sessions_send"));
         assert!(config.delegate.enabled);
         assert_eq!(config.delegate.max_depth, 1);
         assert_eq!(config.delegate.timeout_seconds, 60);
@@ -199,5 +216,21 @@ allow_shell_in_child = true
             SessionVisibility::Children
         );
         assert!(parsed.tools.delegate.allow_shell_in_child);
+    }
+
+    #[cfg(feature = "config-toml")]
+    #[test]
+    fn tool_config_parses_messages_enabled() {
+        let raw = r#"
+[tools.messages]
+enabled = true
+"#;
+        let parsed =
+            toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
+        assert!(crate::tools::runtime_tool_view_for_config(&parsed.tools).contains("sessions_send"));
+        assert!(
+            !crate::tools::delegate_child_tool_view_for_config(&parsed.tools)
+                .contains("sessions_send")
+        );
     }
 }

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -4,12 +4,51 @@ use serde::{Deserialize, Serialize};
 
 use super::shared::{default_loongclaw_home, expand_path, DEFAULT_SQLITE_FILE};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ToolConfig {
     #[serde(default = "default_shell_allowlist")]
     pub shell_allowlist: Vec<String>,
     #[serde(default)]
     pub file_root: Option<String>,
+    #[serde(default)]
+    pub sessions: SessionToolConfig,
+    #[serde(default)]
+    pub delegate: DelegateToolConfig,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum SessionVisibility {
+    #[serde(rename = "self")]
+    SelfOnly,
+    #[default]
+    #[serde(rename = "children")]
+    Children,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionToolConfig {
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub visibility: SessionVisibility,
+    #[serde(default = "default_session_list_limit")]
+    pub list_limit: usize,
+    #[serde(default = "default_session_history_limit")]
+    pub history_limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DelegateToolConfig {
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_delegate_max_depth")]
+    pub max_depth: usize,
+    #[serde(default = "default_delegate_timeout_seconds")]
+    pub timeout_seconds: u64,
+    #[serde(default = "default_delegate_child_tool_allowlist")]
+    pub child_tool_allowlist: Vec<String>,
+    #[serde(default)]
+    pub allow_shell_in_child: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -25,6 +64,8 @@ impl Default for ToolConfig {
         Self {
             shell_allowlist: default_shell_allowlist(),
             file_root: None,
+            sessions: SessionToolConfig::default(),
+            delegate: DelegateToolConfig::default(),
         }
     }
 }
@@ -35,6 +76,29 @@ impl ToolConfig {
             return expand_path(path);
         }
         std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    }
+}
+
+impl Default for SessionToolConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+            visibility: SessionVisibility::default(),
+            list_limit: default_session_list_limit(),
+            history_limit: default_session_history_limit(),
+        }
+    }
+}
+
+impl Default for DelegateToolConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+            max_depth: default_delegate_max_depth(),
+            timeout_seconds: default_delegate_timeout_seconds(),
+            child_tool_allowlist: default_delegate_child_tool_allowlist(),
+            allow_shell_in_child: false,
+        }
     }
 }
 
@@ -71,4 +135,69 @@ fn default_shell_allowlist() -> Vec<String> {
 
 const fn default_sliding_window() -> usize {
     12
+}
+
+const fn default_enabled() -> bool {
+    true
+}
+
+const fn default_session_list_limit() -> usize {
+    100
+}
+
+const fn default_session_history_limit() -> usize {
+    200
+}
+
+const fn default_delegate_max_depth() -> usize {
+    1
+}
+
+const fn default_delegate_timeout_seconds() -> u64 {
+    60
+}
+
+fn default_delegate_child_tool_allowlist() -> Vec<String> {
+    vec!["file.read".to_owned(), "file.write".to_owned()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_config_defaults_enable_safe_session_and_delegate_policy() {
+        let config = ToolConfig::default();
+        assert!(config.sessions.enabled);
+        assert_eq!(config.sessions.visibility, SessionVisibility::Children);
+        assert_eq!(config.sessions.list_limit, 100);
+        assert_eq!(config.sessions.history_limit, 200);
+        assert!(config.delegate.enabled);
+        assert_eq!(config.delegate.max_depth, 1);
+        assert_eq!(config.delegate.timeout_seconds, 60);
+        assert!(!config.delegate.allow_shell_in_child);
+        assert_eq!(
+            config.delegate.child_tool_allowlist,
+            vec!["file.read", "file.write",]
+        );
+    }
+
+    #[cfg(feature = "config-toml")]
+    #[test]
+    fn tool_config_parses_children_visibility() {
+        let raw = r#"
+[tools.sessions]
+visibility = "children"
+
+[tools.delegate]
+allow_shell_in_child = true
+"#;
+        let parsed =
+            toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
+        assert_eq!(
+            parsed.tools.sessions.visibility,
+            SessionVisibility::Children
+        );
+        assert!(parsed.tools.delegate.allow_shell_in_child);
+    }
 }

--- a/crates/app/src/context.rs
+++ b/crates/app/src/context.rs
@@ -7,11 +7,13 @@ use loongclaw_kernel::{
     StaticPolicyEngine, SystemClock, VerticalPackManifest,
 };
 
+use crate::config::LoongClawConfig;
+
 /// Default pack identifier used by MVP entry points.
 const MVP_PACK_ID: &str = "dev-automation";
 
 /// Default token TTL (24 hours) for long-running MVP entry points.
-pub(crate) const DEFAULT_TOKEN_TTL_S: u64 = 86400;
+pub const DEFAULT_TOKEN_TTL_S: u64 = 86400;
 
 /// Kernel execution context for policy-gated MVP operations.
 ///
@@ -25,6 +27,13 @@ pub struct KernelContext {
     pub token: CapabilityToken,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct KernelRuntimeConfig {
+    #[cfg(feature = "memory-sqlite")]
+    pub memory: crate::memory::runtime_config::MemoryRuntimeConfig,
+    pub tools: crate::tools::runtime_config::ToolRuntimeConfig,
+}
+
 impl KernelContext {
     pub fn pack_id(&self) -> &str {
         &self.token.pack_id
@@ -35,14 +44,63 @@ impl KernelContext {
     }
 }
 
+impl KernelRuntimeConfig {
+    pub fn from_global_runtime() -> Self {
+        Self {
+            #[cfg(feature = "memory-sqlite")]
+            memory: crate::memory::runtime_config::get_memory_runtime_config().clone(),
+            tools: crate::tools::runtime_config::get_tool_runtime_config().clone(),
+        }
+    }
+
+    pub fn from_config(config: &LoongClawConfig) -> Self {
+        Self {
+            #[cfg(feature = "memory-sqlite")]
+            memory: crate::memory::runtime_config::MemoryRuntimeConfig {
+                sqlite_path: Some(config.memory.resolved_sqlite_path()),
+            },
+            tools: crate::tools::runtime_config::ToolRuntimeConfig {
+                shell_allowlist: config
+                    .tools
+                    .shell_allowlist
+                    .iter()
+                    .map(|value| value.to_ascii_lowercase())
+                    .collect(),
+                file_root: Some(config.tools.resolved_file_root()),
+            },
+        }
+    }
+}
+
 /// Bootstrap a minimal kernel suitable for MVP entry points.
 ///
 /// Registers a default pack manifest with `InvokeTool`, `MemoryRead`, and
 /// `MemoryWrite` capabilities, then issues a long-lived token for the given
 /// `agent_id`.
-pub(crate) fn bootstrap_kernel_context(
+pub fn bootstrap_kernel_context(agent_id: &str, ttl_s: u64) -> Result<KernelContext, String> {
+    bootstrap_kernel_context_with_runtime(
+        agent_id,
+        ttl_s,
+        &KernelRuntimeConfig::from_global_runtime(),
+    )
+}
+
+pub fn bootstrap_kernel_context_for_config(
     agent_id: &str,
     ttl_s: u64,
+    config: &LoongClawConfig,
+) -> Result<KernelContext, String> {
+    bootstrap_kernel_context_with_runtime(
+        agent_id,
+        ttl_s,
+        &KernelRuntimeConfig::from_config(config),
+    )
+}
+
+fn bootstrap_kernel_context_with_runtime(
+    agent_id: &str,
+    ttl_s: u64,
+    runtime: &KernelRuntimeConfig,
 ) -> Result<KernelContext, String> {
     let mut kernel = LoongClawKernel::with_runtime(
         StaticPolicyEngine::default(),
@@ -73,15 +131,17 @@ pub(crate) fn bootstrap_kernel_context(
 
     #[cfg(feature = "memory-sqlite")]
     {
-        let mem_config = crate::memory::runtime_config::get_memory_runtime_config().clone();
-        kernel
-            .register_core_memory_adapter(crate::memory::MvpMemoryAdapter::with_config(mem_config));
+        kernel.register_core_memory_adapter(crate::memory::MvpMemoryAdapter::with_config(
+            runtime.memory.clone(),
+        ));
         kernel
             .set_default_core_memory_adapter("mvp-memory")
             .map_err(|e| format!("set default memory adapter failed: {e}"))?;
     }
 
-    kernel.register_core_tool_adapter(crate::tools::MvpToolAdapter::new());
+    kernel.register_core_tool_adapter(crate::tools::MvpToolAdapter::with_config(
+        runtime.tools.clone(),
+    ));
     kernel
         .set_default_core_tool_adapter("mvp-tools")
         .map_err(|e| format!("set default tool adapter failed: {e}"))?;

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -4,11 +4,14 @@ pub mod turn_engine;
 mod turn_loop;
 
 pub use turn_loop::ConversationTurnLoop;
+#[cfg(feature = "memory-sqlite")]
+pub use turn_loop::{run_delegate_child_turn, run_delegate_child_turn_with_runtime};
 pub type ConversationOrchestrator = ConversationTurnLoop;
 #[allow(unused_imports)]
-pub use runtime::{ConversationRuntime, DefaultConversationRuntime};
+pub use runtime::{ConversationRuntime, DefaultConversationRuntime, SessionContext};
 pub use turn_engine::{
-    ProviderTurn, ToolDecision, ToolIntent, ToolOutcome, TurnEngine, TurnResult,
+    AppToolDispatcher, DefaultAppToolDispatcher, NoopAppToolDispatcher, ProviderTurn, ToolDecision,
+    ToolIntent, ToolOutcome, TurnEngine, TurnResult,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -4,6 +4,10 @@ use async_trait::async_trait;
 use loongclaw_contracts::{Capability, MemoryCoreRequest};
 use serde_json::{json, Value};
 
+use crate::tools::{
+    delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
+    runtime_tool_view, runtime_tool_view_for_config, ToolView,
+};
 use crate::CliResult;
 use crate::KernelContext;
 
@@ -11,16 +15,82 @@ use crate::KernelContext;
 use super::super::memory;
 use super::super::{config::LoongClawConfig, provider};
 use super::turn_engine::ProviderTurn;
+#[cfg(feature = "memory-sqlite")]
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{SessionKind, SessionRepository};
 
 pub struct DefaultConversationRuntime;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionContext {
+    pub session_id: String,
+    pub parent_session_id: Option<String>,
+    pub tool_view: ToolView,
+}
+
+impl SessionContext {
+    pub fn root(session_id: impl Into<String>) -> Self {
+        Self::root_with_tool_view(session_id, runtime_tool_view())
+    }
+
+    pub fn root_with_tool_view(session_id: impl Into<String>, tool_view: ToolView) -> Self {
+        Self {
+            session_id: normalize_session_id(session_id.into()),
+            parent_session_id: None,
+            tool_view,
+        }
+    }
+
+    pub fn child(
+        session_id: impl Into<String>,
+        parent_session_id: impl Into<String>,
+        tool_view: ToolView,
+    ) -> Self {
+        Self {
+            session_id: normalize_session_id(session_id.into()),
+            parent_session_id: Some(normalize_session_id(parent_session_id.into())),
+            tool_view,
+        }
+    }
+}
+
+fn normalize_session_id(session_id: String) -> String {
+    let trimmed = session_id.trim();
+    if trimmed.is_empty() {
+        "default".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
 #[async_trait]
 pub trait ConversationRuntime: Send + Sync {
+    fn session_context(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<SessionContext> {
+        Ok(SessionContext::root_with_tool_view(
+            session_id,
+            self.tool_view(config, session_id, kernel_ctx)?,
+        ))
+    }
+
+    fn tool_view(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<ToolView>;
+
     fn build_messages(
         &self,
         config: &LoongClawConfig,
         session_id: &str,
         include_system_prompt: bool,
+        tool_view: &ToolView,
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<Vec<Value>>;
 
@@ -34,6 +104,7 @@ pub trait ConversationRuntime: Send + Sync {
         &self,
         config: &LoongClawConfig,
         messages: &[Value],
+        tool_view: &ToolView,
     ) -> CliResult<ProviderTurn>;
 
     async fn persist_turn(
@@ -47,6 +118,46 @@ pub trait ConversationRuntime: Send + Sync {
 
 #[async_trait]
 impl ConversationRuntime for DefaultConversationRuntime {
+    fn tool_view(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<ToolView> {
+        #[cfg(feature = "memory-sqlite")]
+        {
+            let memory_config = MemoryRuntimeConfig {
+                sqlite_path: Some(config.memory.resolved_sqlite_path()),
+            };
+            if let Ok(repo) = SessionRepository::new(&memory_config) {
+                if let Some(session) = repo
+                    .load_session(session_id)
+                    .map_err(|error| format!("load session tool-view context failed: {error}"))?
+                {
+                    if session.parent_session_id.is_some() {
+                        let depth = repo.session_lineage_depth(session_id).map_err(|error| {
+                            format!("compute session lineage depth for tool view failed: {error}")
+                        })?;
+                        let allow_nested_delegate = depth < config.tools.delegate.max_depth;
+                        return Ok(delegate_child_tool_view_for_config_with_delegate(
+                            &config.tools,
+                            allow_nested_delegate,
+                        ));
+                    }
+                } else if repo
+                    .load_session_summary_with_legacy_fallback(session_id)
+                    .map_err(|error| {
+                        format!("load legacy session tool-view context failed: {error}")
+                    })?
+                    .is_some_and(|session| session.kind == SessionKind::DelegateChild)
+                {
+                    return Ok(delegate_child_tool_view_for_config(&config.tools));
+                }
+            }
+        }
+        Ok(runtime_tool_view_for_config(&config.tools))
+    }
+
     // TODO(task-11): Route memory window loading through kernel when kernel_ctx is Some.
     // Currently `build_messages_for_session` couples system-prompt construction with
     // memory window loading in a single function. Routing the memory portion through
@@ -58,9 +169,10 @@ impl ConversationRuntime for DefaultConversationRuntime {
         config: &LoongClawConfig,
         session_id: &str,
         include_system_prompt: bool,
+        tool_view: &ToolView,
         _kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<Vec<Value>> {
-        provider::build_messages_for_session(config, session_id, include_system_prompt)
+        provider::build_messages_for_session(config, session_id, include_system_prompt, tool_view)
     }
 
     async fn request_completion(
@@ -75,8 +187,9 @@ impl ConversationRuntime for DefaultConversationRuntime {
         &self,
         config: &LoongClawConfig,
         messages: &[Value],
+        tool_view: &ToolView,
     ) -> CliResult<ProviderTurn> {
-        provider::request_turn(config, messages).await
+        provider::request_turn(config, messages, tool_view).await
     }
 
     async fn persist_turn(

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -814,6 +814,63 @@ async fn child_session_hidden_session_wait_is_rejected_by_default_dispatcher() {
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
+async fn child_session_hidden_session_recover_is_rejected_by_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("child-hidden-session-recover");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_recover".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("child should not execute hidden session_recover");
+
+    assert!(
+        error.contains("tool_not_visible: session_recover"),
+        "expected tool_not_visible for session_recover, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
 async fn child_session_forged_root_tool_view_still_rejects_hidden_sessions_list() {
     let (config, db_path) = isolated_test_config("child-forged-root-view-sessions-list");
     let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1380,6 +1380,127 @@ async fn session_wait_times_out_for_non_terminal_session() {
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
+async fn session_wait_batch_returns_mixed_completed_timeout_and_hidden_results() {
+    let (config, db_path) = isolated_test_config("session-wait-batch");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "completed-child".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Completed".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create completed child");
+    repo.upsert_terminal_outcome(
+        "completed-child",
+        "ok",
+        json!({
+            "child_session_id": "completed-child",
+            "final_output": "done"
+        }),
+    )
+    .expect("upsert terminal outcome");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "running-child".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Running".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create running child");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "hidden-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Hidden".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create hidden root");
+
+    let dispatcher = DefaultAppToolDispatcher::new(memory_config, config.tools.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_ids": ["hidden-root", "completed-child", "running-child"],
+                    "timeout_ms": 10
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait batch outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["tool"], "session_wait");
+    assert_eq!(outcome.payload["current_session_id"], "root-session");
+    assert_eq!(outcome.payload["requested_count"], 3);
+    assert_eq!(outcome.payload["timeout_ms"], 10);
+    assert!(outcome.payload["after_id"].is_null());
+    assert_eq!(outcome.payload["result_counts"]["ok"], 1);
+    assert_eq!(outcome.payload["result_counts"]["timeout"], 1);
+    assert_eq!(outcome.payload["result_counts"]["skipped_not_visible"], 1);
+
+    let results = outcome.payload["results"]
+        .as_array()
+        .expect("batch results array");
+    let ids: Vec<&str> = results
+        .iter()
+        .filter_map(|item| item.get("session_id"))
+        .filter_map(Value::as_str)
+        .collect();
+    assert_eq!(ids, vec!["hidden-root", "completed-child", "running-child"]);
+
+    let hidden = results
+        .iter()
+        .find(|item| item["session_id"] == "hidden-root")
+        .expect("hidden batch result");
+    assert_eq!(hidden["result"], "skipped_not_visible");
+    assert!(hidden["inspection"].is_null());
+    assert!(hidden["message"]
+        .as_str()
+        .expect("hidden message")
+        .contains("visibility_denied"));
+
+    let completed = results
+        .iter()
+        .find(|item| item["session_id"] == "completed-child")
+        .expect("completed batch result");
+    assert_eq!(completed["result"], "ok");
+    assert_eq!(completed["inspection"]["wait_status"], "completed");
+    assert_eq!(completed["inspection"]["session"]["state"], "completed");
+    assert_eq!(completed["inspection"]["terminal_outcome"]["status"], "ok");
+
+    let running = results
+        .iter()
+        .find(|item| item["session_id"] == "running-child")
+        .expect("running batch result");
+    assert_eq!(running["result"], "timeout");
+    assert_eq!(running["inspection"]["wait_status"], "timeout");
+    assert_eq!(running["inspection"]["session"]["state"], "running");
+    assert!(running["inspection"]["terminal_outcome"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
 async fn session_wait_reports_delegate_lifecycle_for_queued_child() {
     let (config, db_path) = isolated_test_config("session-wait-delegate-lifecycle");
     let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -395,6 +395,47 @@ fn isolated_test_config(test_name: &str) -> (LoongClawConfig, PathBuf) {
     (config, db_path)
 }
 
+#[cfg(all(feature = "memory-sqlite", feature = "channel-telegram"))]
+fn spawn_telegram_send_server_once() -> (
+    String,
+    std::sync::mpsc::Receiver<String>,
+    std::thread::JoinHandle<()>,
+) {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind telegram stub");
+    let addr = listener.local_addr().expect("telegram stub addr");
+    let (request_tx, request_rx) = std::sync::mpsc::channel();
+    let server = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut request_buf = [0_u8; 8192];
+            let read = stream
+                .read(&mut request_buf)
+                .expect("read telegram request");
+            request_tx
+                .send(String::from_utf8_lossy(&request_buf[..read]).into_owned())
+                .expect("send telegram request capture");
+            let body = serde_json::to_string(&json!({
+                "ok": true,
+                "result": {
+                    "message_id": 1
+                }
+            }))
+            .expect("serialize telegram stub body");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write telegram response");
+        }
+    });
+    (format!("http://{addr}"), request_rx, server)
+}
+
 #[tokio::test]
 async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
     let runtime = FakeRuntime::new(
@@ -1317,6 +1358,404 @@ async fn session_wait_returns_completed_for_terminal_visible_session() {
     assert_eq!(outcome.payload["terminal_outcome_state"], "present");
     assert!(outcome.payload["terminal_outcome_missing_reason"].is_null());
     assert_eq!(outcome.payload["terminal_outcome"]["status"], "ok");
+}
+
+#[cfg(all(feature = "memory-sqlite", feature = "channel-telegram"))]
+#[tokio::test]
+async fn sessions_send_delivers_to_known_root_channel_session_without_mutating_transcript() {
+    let (base_url, request_rx, server) = spawn_telegram_send_server_once();
+    let (mut config, db_path) = isolated_test_config("sessions-send-telegram-success");
+    config.tools.messages.enabled = true;
+    config.telegram.enabled = true;
+    config.telegram.bot_token = Some("123456:telegram-test-token".to_owned());
+    config.telegram.bot_token_env = None;
+    config.telegram.base_url = base_url;
+    config.telegram.allowed_chat_ids = vec![123];
+
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "controller-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Controller".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create controller root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "telegram:123".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Telegram Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create telegram root");
+    crate::memory::append_turn_direct("telegram:123", "user", "previous inbound", &memory_config)
+        .expect("append prior transcript turn");
+    let before_turns =
+        crate::memory::window_direct("telegram:123", 10, &memory_config).expect("window turns");
+    let before_summary = repo
+        .load_session_summary("telegram:123")
+        .expect("load target summary before send")
+        .expect("target summary before send");
+
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "controller-root",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:123",
+                    "text": "hello root channel"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("sessions_send outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["tool"], "sessions_send");
+    assert_eq!(outcome.payload["session_id"], "telegram:123");
+    assert_eq!(outcome.payload["channel"], "telegram");
+    assert_eq!(outcome.payload["target"], "123");
+    assert_eq!(outcome.payload["delivery"], "sent");
+    assert_eq!(outcome.payload["text_length"], 18);
+
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("telegram request should be captured");
+    assert!(request.starts_with("POST /bot123456:telegram-test-token/sendMessage "));
+    assert!(request.contains("\"chat_id\":123"));
+    assert!(request.contains("\"text\":\"hello root channel\""));
+
+    let after_turns =
+        crate::memory::window_direct("telegram:123", 10, &memory_config).expect("window turns");
+    assert_eq!(after_turns.len(), before_turns.len());
+    assert_eq!(after_turns[0].role, before_turns[0].role);
+    assert_eq!(after_turns[0].content, before_turns[0].content);
+
+    let after_summary = repo
+        .load_session_summary("telegram:123")
+        .expect("load target summary after send")
+        .expect("target summary after send");
+    assert_eq!(after_summary.turn_count, before_summary.turn_count);
+    assert_eq!(after_summary.state, before_summary.state);
+
+    let events = repo
+        .list_recent_events("telegram:123", 10)
+        .expect("list target events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_kind, "session_message_sent");
+    assert_eq!(
+        events[0].actor_session_id.as_deref(),
+        Some("controller-root")
+    );
+    assert_eq!(events[0].payload_json["channel"], "telegram");
+    assert_eq!(events[0].payload_json["target"], "123");
+    assert_eq!(events[0].payload_json["text_length"], 18);
+    assert_eq!(events[0].payload_json["delivery"], "sent");
+    assert!(events[0].payload_json.get("text").is_none());
+
+    server.join().expect("telegram stub join");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn sessions_send_rejects_unknown_target_session() {
+    let (mut config, db_path) = isolated_test_config("sessions-send-unknown-target");
+    config.tools.messages.enabled = true;
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "controller-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Controller".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create controller root");
+
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "controller-root",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:999",
+                    "text": "hello"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("unknown session target must be rejected");
+
+    assert!(
+        error.contains("session_not_found: `telegram:999`"),
+        "expected session_not_found error, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn sessions_send_rejects_delegate_child_target() {
+    let (mut config, db_path) = isolated_test_config("sessions-send-child-target");
+    config.tools.messages.enabled = true;
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "controller-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Controller".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create controller root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "telegram:123".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("controller-root".to_owned()),
+        label: Some("Pretend Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child target");
+
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "controller-root",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:123",
+                    "text": "hello"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("delegate child target must be rejected");
+
+    assert!(
+        error.contains("sessions_send_not_supported") && error.contains("not a root session"),
+        "expected root-session rejection, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn sessions_send_rejects_target_not_in_channel_allowlist() {
+    let (mut config, db_path) = isolated_test_config("sessions-send-disallowed-target");
+    config.tools.messages.enabled = true;
+    config.telegram.enabled = true;
+    config.telegram.bot_token = Some("123456:telegram-test-token".to_owned());
+    config.telegram.bot_token_env = None;
+    config.telegram.allowed_chat_ids = vec![456];
+
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "controller-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Controller".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create controller root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "telegram:123".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Telegram Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create telegram root");
+
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "controller-root",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:123",
+                    "text": "hello"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("disallowed target must be rejected");
+
+    assert!(
+        error.contains("sessions_send_target_not_allowed"),
+        "expected allowlist rejection, got: {error}"
+    );
+}
+
+#[cfg(all(feature = "memory-sqlite", feature = "channel-telegram"))]
+#[tokio::test]
+async fn sessions_send_materializes_legacy_root_session_before_recording_event() {
+    let (base_url, request_rx, server) = spawn_telegram_send_server_once();
+    let (mut config, db_path) = isolated_test_config("sessions-send-legacy-target");
+    config.tools.messages.enabled = true;
+    config.telegram.enabled = true;
+    config.telegram.bot_token = Some("123456:telegram-test-token".to_owned());
+    config.telegram.bot_token_env = None;
+    config.telegram.base_url = base_url;
+    config.telegram.allowed_chat_ids = vec![123];
+
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "controller-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Controller".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create controller root");
+    crate::memory::append_turn_direct("telegram:123", "user", "legacy inbound", &memory_config)
+        .expect("append legacy transcript turn");
+    assert!(repo
+        .load_session("telegram:123")
+        .expect("load target row before send")
+        .is_none());
+    assert!(repo
+        .load_session_summary_with_legacy_fallback("telegram:123")
+        .expect("load legacy summary")
+        .is_some());
+
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "controller-root",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:123",
+                    "text": "hello legacy"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("legacy target sessions_send outcome");
+
+    assert_eq!(outcome.status, "ok");
+    let target_row = repo
+        .load_session("telegram:123")
+        .expect("load target row after send")
+        .expect("target row should be materialized");
+    assert_eq!(
+        target_row.kind,
+        crate::session::repository::SessionKind::Root
+    );
+
+    let events = repo
+        .list_recent_events("telegram:123", 10)
+        .expect("list target events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_kind, "session_message_sent");
+
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("telegram request should be captured");
+    assert!(request.contains("\"text\":\"hello legacy\""));
+
+    server.join().expect("telegram stub join");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_hidden_sessions_send_is_rejected_by_default_dispatcher() {
+    let (mut config, db_path) = isolated_test_config("child-hidden-sessions-send");
+    config.tools.messages.enabled = true;
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::delegate_child_tool_view_for_config(&config.tools),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_send".to_owned(),
+                payload: json!({
+                    "session_id": "telegram:123",
+                    "text": "hello"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("child should not execute hidden sessions_send");
+
+    assert!(
+        error.contains("tool_not_visible: sessions_send"),
+        "expected tool_not_visible for sessions_send, got: {error}"
+    );
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -871,6 +871,208 @@ async fn child_session_hidden_session_recover_is_rejected_by_default_dispatcher(
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
+async fn child_session_hidden_session_cancel_is_rejected_by_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("child-hidden-session-cancel");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_cancel".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("child should not execute hidden session_cancel");
+
+    assert!(
+        error.contains("tool_not_visible: session_cancel"),
+        "expected tool_not_visible for session_cancel, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct CancelRequestingAppToolDispatcher {
+    memory_config: crate::memory::runtime_config::MemoryRuntimeConfig,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl AppToolDispatcher for CancelRequestingAppToolDispatcher {
+    async fn execute_app_tool(
+        &self,
+        session_context: &SessionContext,
+        request: loongclaw_contracts::ToolCoreRequest,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+        if request.tool_name != "session_status" {
+            return Err(format!("unexpected app tool: {}", request.tool_name));
+        }
+        let repo = SessionRepository::new(&self.memory_config)?;
+        repo.transition_session_with_event_if_current(
+            &session_context.session_id,
+            crate::session::repository::TransitionSessionWithEventIfCurrentRequest {
+                expected_state: crate::session::repository::SessionState::Running,
+                next_state: crate::session::repository::SessionState::Running,
+                last_error: None,
+                event_kind: "delegate_cancel_requested".to_owned(),
+                actor_session_id: session_context.parent_session_id.clone(),
+                event_payload_json: json!({
+                    "reference": "running",
+                    "cancel_reason": "operator_requested"
+                }),
+            },
+        )?;
+        Ok(loongclaw_contracts::ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "cancel_requested": true
+            }),
+        })
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_cancel_request_stops_before_next_round() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-cancel");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Inspecting child session".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "session_status".to_owned(),
+                args_json: json!({
+                    "session_id": "child-session"
+                }),
+                source: "provider_tool_call".to_owned(),
+                session_id: "child-session".to_owned(),
+                turn_id: "turn-1".to_owned(),
+                tool_call_id: "call-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        })],
+    );
+
+    let outcome = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &runtime,
+        &CancelRequestingAppToolDispatcher {
+            memory_config: memory_config.clone(),
+        },
+        "child-session",
+        "child task",
+        60,
+        None,
+    )
+    .await
+    .expect("delegate child cancellation outcome");
+
+    assert_eq!(outcome.status, "error");
+    assert_eq!(
+        outcome.payload["error"],
+        "delegate_cancelled: operator_requested"
+    );
+    assert_eq!(
+        *runtime.turn_calls.lock().expect("turn calls lock"),
+        1,
+        "cancel should stop before a second provider round"
+    );
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert_eq!(
+        child.last_error.as_deref(),
+        Some("delegate_cancelled: operator_requested")
+    );
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_cancel_requested"));
+    assert!(event_kinds.contains(&"delegate_cancelled"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "error");
+    assert_eq!(
+        terminal_outcome.payload_json["error"],
+        "delegate_cancelled: operator_requested"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
 async fn child_session_forged_root_tool_view_still_rejects_hidden_sessions_list() {
     let (config, db_path) = isolated_test_config("child-forged-root-view-sessions-list");
     let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
@@ -1254,6 +1456,104 @@ async fn session_wait_reports_delegate_lifecycle_for_queued_child() {
     );
     assert!(outcome.payload["delegate_lifecycle"]["queued_at"].is_number());
     assert!(outcome.payload["delegate_lifecycle"]["started_at"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_reports_pending_cancel_request_for_running_child() {
+    let (config, db_path) = isolated_test_config("session-wait-cancel-requested");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "timeout_seconds": 60
+        }),
+    })
+    .expect("append queued event");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "timeout_seconds": 60
+        }),
+    })
+    .expect("append started event");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_cancel_requested".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "reference": "running",
+            "cancel_reason": "operator_requested"
+        }),
+    })
+    .expect("append cancel requested event");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 10
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "timeout");
+    assert_eq!(outcome.payload["wait_status"], "timeout");
+    assert_eq!(outcome.payload["delegate_lifecycle"]["phase"], "running");
+    assert_eq!(
+        outcome.payload["delegate_lifecycle"]["cancellation"]["state"],
+        "requested"
+    );
+    assert_eq!(
+        outcome.payload["delegate_lifecycle"]["cancellation"]["reference"],
+        "running"
+    );
+    assert_eq!(
+        outcome.payload["delegate_lifecycle"]["cancellation"]["reason"],
+        "operator_requested"
+    );
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -3957,7 +3957,7 @@ async fn handle_turn_with_runtime_uses_session_tool_view_from_runtime() {
             .lock()
             .expect("built tool views lock")
             .as_slice(),
-        &[child_view.clone()]
+        std::slice::from_ref(&child_view)
     );
     assert_eq!(
         runtime

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1,5 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+#[cfg(feature = "memory-sqlite")]
+use std::{fs, path::PathBuf};
 
 use async_trait::async_trait;
 use loongclaw_contracts::{Capability, ExecutionRoute, HarnessKind, MemoryPlaneError};
@@ -7,7 +10,11 @@ use loongclaw_kernel::{
     CoreMemoryAdapter, FixedClock, InMemoryAuditSink, LoongClawKernel, MemoryCoreOutcome,
     MemoryCoreRequest, StaticPolicyEngine, VerticalPackManifest,
 };
+#[cfg(feature = "memory-sqlite")]
+use rusqlite::Connection;
 use serde_json::{json, Value};
+use tokio::sync::{oneshot, Notify};
+use tokio::time::sleep;
 
 use super::super::config::{
     CliChannelConfig, ConversationConfig, FeishuChannelConfig, LoongClawConfig, MemoryConfig,
@@ -16,17 +23,116 @@ use super::super::config::{
 use super::persistence::format_provider_error_reply;
 use super::runtime::DefaultConversationRuntime;
 use super::*;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::SessionRepository;
 use crate::CliResult;
 use crate::KernelContext;
 
+#[cfg(feature = "memory-sqlite")]
+#[derive(Default)]
+struct FakeAsyncDelegateSpawner {
+    requests: Arc<Mutex<Vec<crate::conversation::turn_engine::AsyncDelegateSpawnRequest>>>,
+    spawn_error: Option<String>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl crate::conversation::turn_engine::AsyncDelegateSpawner for FakeAsyncDelegateSpawner {
+    async fn spawn(
+        &self,
+        request: crate::conversation::turn_engine::AsyncDelegateSpawnRequest,
+    ) -> Result<(), String> {
+        self.requests
+            .lock()
+            .expect("async delegate requests lock")
+            .push(request);
+        match &self.spawn_error {
+            Some(error) => Err(error.clone()),
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct PanicAsyncDelegateSpawner;
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl crate::conversation::turn_engine::AsyncDelegateSpawner for PanicAsyncDelegateSpawner {
+    async fn spawn(
+        &self,
+        _request: crate::conversation::turn_engine::AsyncDelegateSpawnRequest,
+    ) -> Result<(), String> {
+        panic!("panic-async-spawn");
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct GatedFakeAsyncDelegateSpawner {
+    requests: Arc<Mutex<Vec<crate::conversation::turn_engine::AsyncDelegateSpawnRequest>>>,
+    request_tx:
+        Mutex<Option<oneshot::Sender<crate::conversation::turn_engine::AsyncDelegateSpawnRequest>>>,
+    release_notify: Arc<Notify>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl GatedFakeAsyncDelegateSpawner {
+    fn new() -> (
+        Self,
+        oneshot::Receiver<crate::conversation::turn_engine::AsyncDelegateSpawnRequest>,
+        Arc<Notify>,
+    ) {
+        let (request_tx, request_rx) = oneshot::channel();
+        let release_notify = Arc::new(Notify::new());
+        (
+            Self {
+                requests: Arc::new(Mutex::new(Vec::new())),
+                request_tx: Mutex::new(Some(request_tx)),
+                release_notify: release_notify.clone(),
+            },
+            request_rx,
+            release_notify,
+        )
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl crate::conversation::turn_engine::AsyncDelegateSpawner for GatedFakeAsyncDelegateSpawner {
+    async fn spawn(
+        &self,
+        request: crate::conversation::turn_engine::AsyncDelegateSpawnRequest,
+    ) -> Result<(), String> {
+        self.requests
+            .lock()
+            .expect("async delegate requests lock")
+            .push(request.clone());
+        let request_tx = self
+            .request_tx
+            .lock()
+            .expect("async delegate request sender lock")
+            .take()
+            .expect("single gated async delegate request sender");
+        request_tx
+            .send(request)
+            .expect("gated async delegate request receiver");
+        self.release_notify.notified().await;
+        Ok(())
+    }
+}
+
 struct FakeRuntime {
     seed_messages: Vec<Value>,
+    tool_view: crate::tools::ToolView,
     completion_responses: Mutex<VecDeque<Result<String, String>>>,
     turn_responses: Mutex<VecDeque<Result<ProviderTurn, String>>>,
     persisted: Mutex<Vec<(String, String, String)>>,
     requested_messages: Mutex<Vec<Value>>,
     turn_requested_messages: Mutex<Vec<Vec<Value>>>,
+    built_tool_views: Mutex<Vec<crate::tools::ToolView>>,
+    turn_requested_tool_views: Mutex<Vec<crate::tools::ToolView>>,
     completion_requested_messages: Mutex<Vec<Vec<Value>>>,
+    turn_delays: Mutex<VecDeque<Duration>>,
     completion_calls: Mutex<usize>,
     turn_calls: Mutex<usize>,
 }
@@ -65,27 +171,68 @@ impl FakeRuntime {
     ) -> Self {
         Self {
             seed_messages,
+            tool_view: crate::tools::runtime_tool_view(),
             completion_responses: Mutex::new(VecDeque::from(completions)),
             turn_responses: Mutex::new(VecDeque::from(turns)),
             persisted: Mutex::new(Vec::new()),
             requested_messages: Mutex::new(Vec::new()),
             turn_requested_messages: Mutex::new(Vec::new()),
+            built_tool_views: Mutex::new(Vec::new()),
+            turn_requested_tool_views: Mutex::new(Vec::new()),
             completion_requested_messages: Mutex::new(Vec::new()),
+            turn_delays: Mutex::new(VecDeque::new()),
             completion_calls: Mutex::new(0),
             turn_calls: Mutex::new(0),
+        }
+    }
+
+    fn with_tool_view(mut self, tool_view: crate::tools::ToolView) -> Self {
+        self.tool_view = tool_view;
+        self
+    }
+
+    fn with_turn_delays(self, delays: Vec<Duration>) -> Self {
+        let runtime = self;
+        *runtime.turn_delays.lock().expect("turn delays lock") = VecDeque::from(delays);
+        runtime
+    }
+}
+
+struct PanicRuntime {
+    tool_view: crate::tools::ToolView,
+}
+
+impl PanicRuntime {
+    fn new() -> Self {
+        Self {
+            tool_view: crate::tools::runtime_tool_view(),
         }
     }
 }
 
 #[async_trait]
 impl ConversationRuntime for FakeRuntime {
+    fn tool_view(
+        &self,
+        _config: &LoongClawConfig,
+        _session_id: &str,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<crate::tools::ToolView> {
+        Ok(self.tool_view.clone())
+    }
+
     fn build_messages(
         &self,
         _config: &LoongClawConfig,
         _session_id: &str,
         _include_system_prompt: bool,
+        tool_view: &crate::tools::ToolView,
         _kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<Vec<Value>> {
+        self.built_tool_views
+            .lock()
+            .expect("built tool views lock")
+            .push(tool_view.clone());
         Ok(self.seed_messages.clone())
     }
 
@@ -113,7 +260,17 @@ impl ConversationRuntime for FakeRuntime {
         &self,
         _config: &LoongClawConfig,
         messages: &[Value],
+        tool_view: &crate::tools::ToolView,
     ) -> CliResult<ProviderTurn> {
+        let delay = {
+            self.turn_delays
+                .lock()
+                .expect("turn delays lock")
+                .pop_front()
+        };
+        if let Some(delay) = delay {
+            sleep(delay).await;
+        }
         let mut calls = self.turn_calls.lock().expect("turn calls lock");
         *calls += 1;
         *self.requested_messages.lock().expect("request lock") = messages.to_vec();
@@ -121,6 +278,10 @@ impl ConversationRuntime for FakeRuntime {
             .lock()
             .expect("turn request lock")
             .push(messages.to_vec());
+        self.turn_requested_tool_views
+            .lock()
+            .expect("turn request tool views lock")
+            .push(tool_view.clone());
         self.turn_responses
             .lock()
             .expect("turn response lock")
@@ -145,6 +306,56 @@ impl ConversationRuntime for FakeRuntime {
     }
 }
 
+#[async_trait]
+impl ConversationRuntime for PanicRuntime {
+    fn tool_view(
+        &self,
+        _config: &LoongClawConfig,
+        _session_id: &str,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<crate::tools::ToolView> {
+        Ok(self.tool_view.clone())
+    }
+
+    fn build_messages(
+        &self,
+        _config: &LoongClawConfig,
+        _session_id: &str,
+        _include_system_prompt: bool,
+        _tool_view: &crate::tools::ToolView,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<Vec<Value>> {
+        Ok(Vec::new())
+    }
+
+    async fn request_completion(
+        &self,
+        _config: &LoongClawConfig,
+        _messages: &[Value],
+    ) -> CliResult<String> {
+        Err("unexpected_completion_call".to_owned())
+    }
+
+    async fn request_turn(
+        &self,
+        _config: &LoongClawConfig,
+        _messages: &[Value],
+        _tool_view: &crate::tools::ToolView,
+    ) -> CliResult<ProviderTurn> {
+        panic!("panic-runtime-request-turn");
+    }
+
+    async fn persist_turn(
+        &self,
+        _session_id: &str,
+        _role: &str,
+        _content: &str,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<()> {
+        Ok(())
+    }
+}
+
 fn test_config() -> LoongClawConfig {
     LoongClawConfig {
         provider: ProviderConfig::default(),
@@ -155,6 +366,33 @@ fn test_config() -> LoongClawConfig {
         memory: MemoryConfig::default(),
         conversation: ConversationConfig::default(),
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn isolated_sqlite_path(test_name: &str) -> String {
+    let base = std::env::temp_dir().join(format!(
+        "loongclaw-conversation-tests-{test_name}-{}",
+        std::process::id()
+    ));
+    let _ = fs::create_dir_all(&base);
+    let db_path = base.join("memory.sqlite3");
+    let _ = fs::remove_file(&db_path);
+    db_path.display().to_string()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn isolated_test_config(test_name: &str) -> (LoongClawConfig, PathBuf) {
+    let base = std::env::temp_dir().join(format!(
+        "loongclaw-conversation-tests-{test_name}-{}",
+        std::process::id()
+    ));
+    let _ = fs::create_dir_all(&base);
+    let db_path = base.join("memory.sqlite3");
+    let _ = fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    (config, db_path)
 }
 
 #[tokio::test]
@@ -200,6 +438,2521 @@ async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
             "assistant".to_owned(),
             "assistant-reply".to_owned(),
         )
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_registers_root_session_metadata() {
+    let runtime = FakeRuntime::new(
+        vec![json!({"role": "system", "content": "sys"})],
+        Ok("assistant-reply".to_owned()),
+    );
+    let mut config = test_config();
+    config.memory.sqlite_path = isolated_sqlite_path("register-root-session");
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "hello",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert_eq!(reply, "assistant-reply");
+
+    let repo = crate::session::repository::SessionRepository::new(
+        &crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+    )
+    .expect("session repository");
+    let session = repo
+        .load_session("root-session")
+        .expect("load session")
+        .expect("session row");
+    assert_eq!(session.kind, crate::session::repository::SessionKind::Root);
+    assert_eq!(session.parent_session_id, None);
+    assert_eq!(
+        session.state,
+        crate::session::repository::SessionState::Ready
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_and_context_registers_child_session_metadata() {
+    let runtime = FakeRuntime::new(
+        vec![json!({"role": "system", "content": "sys"})],
+        Ok("assistant-reply".to_owned()),
+    );
+    let mut config = test_config();
+    config.memory.sqlite_path = isolated_sqlite_path("register-child-session");
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime_and_context(
+            &config,
+            &session_context,
+            "hello",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            &NoopAppToolDispatcher,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert_eq!(reply, "assistant-reply");
+
+    let repo = crate::session::repository::SessionRepository::new(
+        &crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+    )
+    .expect("session repository");
+    let session = repo
+        .load_session("child-session")
+        .expect("load session")
+        .expect("session row");
+    assert_eq!(
+        session.kind,
+        crate::session::repository::SessionKind::DelegateChild
+    );
+    assert_eq!(session.parent_session_id.as_deref(), Some("root-session"));
+    assert_eq!(
+        session.state,
+        crate::session::repository::SessionState::Ready
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn default_runtime_tool_view_for_resumed_child_session_respects_remaining_depth() {
+    let (mut config, db_path) = isolated_test_config("resumed-child-tool-view");
+    config.tools.delegate.max_depth = 2;
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+
+    let runtime = DefaultConversationRuntime;
+    let child_view = runtime
+        .tool_view(&config, "child-session", None)
+        .expect("child tool view");
+    assert!(child_view.contains("delegate"));
+    assert!(child_view.contains("session_status"));
+    assert!(child_view.contains("sessions_history"));
+    assert!(!child_view.contains("sessions_list"));
+
+    config.tools.delegate.max_depth = 1;
+    let exhausted_view = runtime
+        .tool_view(&config, "child-session", None)
+        .expect("exhausted child tool view");
+    assert!(!exhausted_view.contains("delegate"));
+    assert!(exhausted_view.contains("session_status"));
+    assert!(exhausted_view.contains("sessions_history"));
+    assert!(!exhausted_view.contains("sessions_list"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_self_only_can_read_own_status_via_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("child-self-status");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("child self status outcome");
+
+    assert_eq!(outcome.payload["session"]["session_id"], "child-session");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_self_only_can_read_own_history_via_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("child-self-history");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create child");
+    crate::memory::append_turn_direct(
+        "child-session",
+        "user",
+        "hello from child",
+        &crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+    )
+    .expect("append child turn");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_history".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "limit": 10
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("child self history outcome");
+
+    let turns = outcome.payload["turns"].as_array().expect("turns array");
+    assert_eq!(turns.len(), 1);
+    assert_eq!(turns[0]["content"], "hello from child");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_hidden_sessions_list_is_rejected_by_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("child-hidden-sessions-list");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_list".to_owned(),
+                payload: json!({}),
+            },
+            None,
+        )
+        .await
+        .expect_err("child should not execute hidden sessions_list");
+
+    assert!(
+        error.contains("tool_not_visible: sessions_list"),
+        "expected tool_not_visible for sessions_list, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_hidden_session_wait_is_rejected_by_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("child-hidden-session-wait");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 10
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("child should not execute hidden session_wait");
+
+    assert!(
+        error.contains("tool_not_visible: session_wait"),
+        "expected tool_not_visible for session_wait, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_forged_root_tool_view_still_rejects_hidden_sessions_list() {
+    let (config, db_path) = isolated_test_config("child-forged-root-view-sessions-list");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "sessions_list".to_owned(),
+                payload: json!({}),
+            },
+            None,
+        )
+        .await
+        .expect_err("forged child root tool view should not expose sessions_list");
+
+    assert!(
+        error.contains("tool_not_visible: sessions_list"),
+        "expected tool_not_visible for sessions_list, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn depth_exhausted_child_forged_root_tool_view_still_rejects_delegate_async() {
+    let (mut config, db_path) = isolated_test_config("child-forged-root-view-delegate-async");
+    config.tools.delegate.max_depth = 1;
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "delegate_async".to_owned(),
+                payload: json!({
+                    "task": "nested child task",
+                    "timeout_seconds": 5
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("depth exhausted child should not execute forged delegate_async");
+
+    assert!(
+        error.contains("tool_not_visible: delegate_async"),
+        "expected tool_not_visible for delegate_async, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn child_session_self_only_cannot_inspect_descendant_status_via_default_dispatcher() {
+    let (mut config, db_path) = isolated_test_config("child-descendant-denied");
+    config.tools.delegate.max_depth = 2;
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create child");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "grandchild-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("child-session".to_owned()),
+        label: Some("Grandchild".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create grandchild");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::delegate_child_tool_view_for_config_with_delegate(&config.tools, true),
+    );
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "grandchild-session"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("child should not inspect descendant status");
+
+    assert!(
+        error.contains("visibility_denied"),
+        "expected visibility_denied, got: {error}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_returns_completed_for_terminal_visible_session() {
+    let (config, db_path) = isolated_test_config("session-wait-completed");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Completed,
+    })
+    .expect("create child");
+    repo.upsert_terminal_outcome(
+        "child-session",
+        "ok",
+        json!({
+            "child_session_id": "child-session",
+            "final_output": "done"
+        }),
+    )
+    .expect("upsert terminal outcome");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 50
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["wait_status"], "completed");
+    assert_eq!(outcome.payload["session"]["session_id"], "child-session");
+    assert_eq!(outcome.payload["terminal_outcome_state"], "present");
+    assert!(outcome.payload["terminal_outcome_missing_reason"].is_null());
+    assert_eq!(outcome.payload["terminal_outcome"]["status"], "ok");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_times_out_for_non_terminal_session() {
+    let (config, db_path) = isolated_test_config("session-wait-timeout");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 10
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "timeout");
+    assert_eq!(outcome.payload["wait_status"], "timeout");
+    assert_eq!(outcome.payload["session"]["state"], "running");
+    assert_eq!(outcome.payload["terminal_outcome_state"], "not_terminal");
+    assert!(outcome.payload["terminal_outcome_missing_reason"].is_null());
+    assert!(outcome.payload["terminal_outcome"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_reports_delegate_lifecycle_for_queued_child() {
+    let (config, db_path) = isolated_test_config("session-wait-delegate-lifecycle");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "label": "Child",
+            "timeout_seconds": 30
+        }),
+    })
+    .expect("append queued event");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 10
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "timeout");
+    assert_eq!(outcome.payload["wait_status"], "timeout");
+    assert_eq!(outcome.payload["session"]["state"], "ready");
+    assert_eq!(outcome.payload["delegate_lifecycle"]["mode"], "async");
+    assert_eq!(outcome.payload["delegate_lifecycle"]["phase"], "queued");
+    assert_eq!(outcome.payload["delegate_lifecycle"]["timeout_seconds"], 30);
+    assert_eq!(
+        outcome.payload["delegate_lifecycle"]["staleness"]["reference"],
+        "queued"
+    );
+    assert_eq!(
+        outcome.payload["delegate_lifecycle"]["staleness"]["state"],
+        "fresh"
+    );
+    assert!(outcome.payload["delegate_lifecycle"]["queued_at"].is_number());
+    assert!(outcome.payload["delegate_lifecycle"]["started_at"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_reports_missing_terminal_outcome_for_recovered_failed_session() {
+    let (config, db_path) = isolated_test_config("session-wait-recovered-failed");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Failed,
+    })
+    .expect("create child");
+    repo.update_session_state(
+        "child-session",
+        crate::session::repository::SessionState::Failed,
+        Some("opaque_recovery_failure".to_owned()),
+    )
+    .expect("update child status");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_recovery_applied".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "recovery_kind": "async_spawn_failure_persist_failed",
+            "recovered_state": "failed",
+            "recovery_error": "delegate_async_spawn_failure_persist_failed: sqlite_busy; original spawn error: boom",
+            "original_error": "boom"
+        }),
+    })
+    .expect("append failed event");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 50
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["wait_status"], "completed");
+    assert_eq!(outcome.payload["session"]["state"], "failed");
+    assert_eq!(outcome.payload["terminal_outcome_state"], "missing");
+    assert_eq!(
+        outcome.payload["terminal_outcome_missing_reason"],
+        "async_spawn_failure_persist_failed"
+    );
+    assert_eq!(
+        outcome.payload["recovery"]["kind"],
+        "async_spawn_failure_persist_failed"
+    );
+    assert_eq!(
+        outcome.payload["recovery"]["event_kind"],
+        "delegate_recovery_applied"
+    );
+    assert_eq!(outcome.payload["recovery"]["original_error"], "boom");
+    assert_eq!(outcome.payload["recovery"]["source"], "event");
+    assert!(outcome.payload["terminal_outcome"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_synthesizes_recovery_from_last_error_when_event_missing() {
+    let (config, db_path) = isolated_test_config("session-wait-recovery-fallback");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Failed,
+    })
+    .expect("create child");
+    repo.update_session_state(
+        "child-session",
+        crate::session::repository::SessionState::Failed,
+        Some(
+            "delegate_async_spawn_failure_persist_failed: sqlite_busy; original spawn error: boom"
+                .to_owned(),
+        ),
+    )
+    .expect("update child status");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 50
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["wait_status"], "completed");
+    assert_eq!(outcome.payload["terminal_outcome_state"], "missing");
+    assert_eq!(
+        outcome.payload["terminal_outcome_missing_reason"],
+        "async_spawn_failure_persist_failed"
+    );
+    assert_eq!(
+        outcome.payload["recovery"]["kind"],
+        "async_spawn_failure_persist_failed"
+    );
+    assert_eq!(outcome.payload["recovery"]["source"], "last_error");
+    assert_eq!(
+        outcome.payload["recovery"]["recovery_error"],
+        "delegate_async_spawn_failure_persist_failed: sqlite_busy; original spawn error: boom"
+    );
+    assert!(outcome.payload["recovery"]["event_kind"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_synthesizes_unknown_recovery_when_metadata_missing() {
+    let (config, db_path) = isolated_test_config("session-wait-recovery-unknown");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Failed,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 50
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["wait_status"], "completed");
+    assert_eq!(outcome.payload["terminal_outcome_state"], "missing");
+    assert_eq!(
+        outcome.payload["terminal_outcome_missing_reason"],
+        "unknown"
+    );
+    assert_eq!(outcome.payload["recovery"]["kind"], "unknown");
+    assert_eq!(outcome.payload["recovery"]["source"], "none");
+    assert!(outcome.payload["recovery"]["recovery_error"].is_null());
+    assert!(outcome.payload["recovery"]["event_kind"].is_null());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_returns_incremental_events_after_after_id_when_session_completes() {
+    let (config, db_path) = isolated_test_config("session-wait-after-id-completed");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child");
+    let started_event = repo
+        .append_event(crate::session::repository::NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "child task"
+            }),
+        })
+        .expect("append started event");
+
+    let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), config.tools.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let finalize_memory_config = memory_config.clone();
+    let finalize_task = tokio::spawn(async move {
+        sleep(Duration::from_millis(10)).await;
+        let finalize_repo =
+            SessionRepository::new(&finalize_memory_config).expect("finalize session repository");
+        finalize_repo
+            .finalize_session_terminal(
+                "child-session",
+                crate::session::repository::FinalizeSessionTerminalRequest {
+                    state: crate::session::repository::SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({
+                        "turn_count": 1
+                    }),
+                    outcome_status: "ok".to_owned(),
+                    outcome_payload_json: json!({
+                        "child_session_id": "child-session",
+                        "final_output": "done"
+                    }),
+                },
+            )
+            .expect("finalize child session")
+    });
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 100,
+                    "after_id": started_event.id
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    finalize_task.await.expect("join finalize task");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["wait_status"], "completed");
+    assert_eq!(outcome.payload["after_id"], started_event.id);
+    assert_eq!(outcome.payload["session"]["state"], "completed");
+    assert_eq!(outcome.payload["terminal_outcome"]["status"], "ok");
+    let events = outcome.payload["events"]
+        .as_array()
+        .expect("session_wait events array");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["event_kind"], "delegate_completed");
+    assert!(
+        outcome.payload["next_after_id"]
+            .as_i64()
+            .expect("next_after_id")
+            > started_event.id
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_timeout_returns_incremental_events_observed_while_waiting() {
+    let (config, db_path) = isolated_test_config("session-wait-after-id-timeout");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child");
+
+    let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), config.tools.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let append_memory_config = memory_config.clone();
+    let append_task = tokio::spawn(async move {
+        sleep(Duration::from_millis(10)).await;
+        let append_repo =
+            SessionRepository::new(&append_memory_config).expect("append session repository");
+        append_repo
+            .append_event(crate::session::repository::NewSessionEvent {
+                session_id: "child-session".to_owned(),
+                event_kind: "delegate_started".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                payload_json: json!({
+                    "task": "child task"
+                }),
+            })
+            .expect("append started event")
+    });
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 100,
+                    "after_id": 0
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    let started_event = append_task.await.expect("join append task");
+
+    assert_eq!(outcome.status, "timeout");
+    assert_eq!(outcome.payload["wait_status"], "timeout");
+    assert_eq!(outcome.payload["after_id"], 0);
+    assert_eq!(outcome.payload["session"]["state"], "running");
+    assert!(outcome.payload["terminal_outcome"].is_null());
+    let events = outcome.payload["events"]
+        .as_array()
+        .expect("session_wait events array");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["event_kind"], "delegate_started");
+    assert_eq!(events[0]["id"], started_event.id);
+    assert_eq!(outcome.payload["next_after_id"], started_event.id);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_wait_after_id_on_terminal_session_drains_until_terminal_event() {
+    let (config, db_path) = isolated_test_config("session-wait-terminal-drain");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child");
+
+    let mut last_event_id = 0_i64;
+    for index in 0..60 {
+        last_event_id = repo
+            .append_event(crate::session::repository::NewSessionEvent {
+                session_id: "child-session".to_owned(),
+                event_kind: format!("delegate_progress_{index}"),
+                actor_session_id: Some("root-session".to_owned()),
+                payload_json: json!({
+                    "step": index
+                }),
+            })
+            .expect("append progress event")
+            .id;
+    }
+    let finalized = repo
+        .finalize_session_terminal(
+            "child-session",
+            crate::session::repository::FinalizeSessionTerminalRequest {
+                state: crate::session::repository::SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                event_payload_json: json!({
+                    "turn_count": 1
+                }),
+                outcome_status: "ok".to_owned(),
+                outcome_payload_json: json!({
+                    "child_session_id": "child-session",
+                    "final_output": "done"
+                }),
+            },
+        )
+        .expect("finalize child session");
+
+    let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), config.tools.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 100,
+                    "after_id": 0
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["wait_status"], "completed");
+    assert_eq!(outcome.payload["session"]["state"], "completed");
+    let events = outcome.payload["events"]
+        .as_array()
+        .expect("session_wait events array");
+    assert_eq!(events.len(), 61);
+    assert_eq!(events[0]["id"], 1);
+    assert_eq!(
+        events.last().expect("last session_wait event")["event_kind"],
+        "delegate_completed"
+    );
+    assert_eq!(
+        outcome.payload["next_after_id"],
+        finalized.event.id.max(last_event_id)
+    );
+    assert_eq!(outcome.payload["terminal_outcome"]["status"], "ok");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_async_queue_returns_handle_and_records_queued_event() {
+    let (config, db_path) = isolated_test_config("delegate-async-queued");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner::default());
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+        spawner.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "delegate_async".to_owned(),
+                payload: json!({
+                    "task": "child task",
+                    "label": "async-child",
+                    "timeout_seconds": 9
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("delegate_async outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["mode"], "async");
+    assert_eq!(outcome.payload["state"], "queued");
+    assert_eq!(outcome.payload["label"], "async-child");
+    let child_session_id = outcome.payload["child_session_id"]
+        .as_str()
+        .expect("child_session_id")
+        .to_owned();
+    assert!(child_session_id.starts_with("delegate:"));
+
+    let requests = tokio::time::timeout(Duration::from_millis(250), async {
+        loop {
+            let maybe_requests = {
+                let requests = spawner
+                    .requests
+                    .lock()
+                    .expect("async delegate requests lock");
+                (requests.len() == 1).then(|| requests.clone())
+            };
+            if let Some(requests) = maybe_requests {
+                break requests;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("async delegate request should be dispatched");
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].child_session_id, child_session_id);
+    assert_eq!(requests[0].parent_session_id, "root-session");
+    assert_eq!(requests[0].task, "child task");
+    assert_eq!(requests[0].label.as_deref(), Some("async-child"));
+    assert_eq!(requests[0].timeout_seconds, 9);
+
+    let child = repo
+        .load_session_summary(&child_session_id)
+        .expect("load child summary")
+        .expect("child summary");
+    assert_eq!(child.state, crate::session::repository::SessionState::Ready);
+    assert_eq!(child.label.as_deref(), Some("async-child"));
+    let events = repo
+        .list_recent_events(&child_session_id, 10)
+        .expect("list child events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_kind, "delegate_queued");
+    assert!(repo
+        .load_terminal_outcome(&child_session_id)
+        .expect("load terminal outcome")
+        .is_none());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_async_returns_handle_without_waiting_for_spawn_completion() {
+    let (config, db_path) = isolated_test_config("delegate-async-immediate-return");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+
+    let (spawner, request_rx, release_notify) = GatedFakeAsyncDelegateSpawner::new();
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+        Arc::new(spawner),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let queued_dispatcher = dispatcher.clone();
+    let queued_session_context = session_context.clone();
+    let queued_call = tokio::spawn(async move {
+        queued_dispatcher
+            .execute_app_tool(
+                &queued_session_context,
+                loongclaw_contracts::ToolCoreRequest {
+                    tool_name: "delegate_async".to_owned(),
+                    payload: json!({
+                        "task": "child task",
+                        "label": "async-child",
+                        "timeout_seconds": 9
+                    }),
+                },
+                None,
+            )
+            .await
+    });
+
+    let spawn_request = tokio::time::timeout(Duration::from_millis(250), request_rx)
+        .await
+        .expect("delegate_async should dispatch spawn quickly")
+        .expect("gated async delegate spawn request");
+    let queued = tokio::time::timeout(Duration::from_millis(250), queued_call)
+        .await
+        .expect("delegate_async should return handle without waiting for spawn gate")
+        .expect("join queued task")
+        .expect("delegate_async outcome");
+
+    assert_eq!(queued.status, "ok");
+    assert_eq!(queued.payload["mode"], "async");
+    assert_eq!(queued.payload["state"], "queued");
+    assert_eq!(queued.payload["label"], "async-child");
+    let child_session_id = queued.payload["child_session_id"]
+        .as_str()
+        .expect("child_session_id")
+        .to_owned();
+    assert_eq!(spawn_request.child_session_id, child_session_id);
+    assert_eq!(spawn_request.parent_session_id, "root-session");
+    assert_eq!(spawn_request.task, "child task");
+    assert_eq!(spawn_request.label.as_deref(), Some("async-child"));
+    assert_eq!(spawn_request.timeout_seconds, 9);
+
+    let child = repo
+        .load_session_summary(&child_session_id)
+        .expect("load child summary")
+        .expect("child summary");
+    assert_eq!(child.state, crate::session::repository::SessionState::Ready);
+    assert_eq!(child.label.as_deref(), Some("async-child"));
+    let events = repo
+        .list_recent_events(&child_session_id, 10)
+        .expect("list child events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_kind, "delegate_queued");
+    assert!(repo
+        .load_terminal_outcome(&child_session_id)
+        .expect("load terminal outcome")
+        .is_none());
+
+    release_notify.notify_waiters();
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_async_queue_failure_does_not_leave_orphan_child_session() {
+    let (config, db_path) = isolated_test_config("delegate-async-queue-rollback");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner::default());
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+        spawner.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let conn = Connection::open(&db_path).expect("open sqlite connection");
+    conn.execute(
+        "CREATE TRIGGER fail_delegate_queue_event
+         BEFORE INSERT ON session_events
+         BEGIN
+            SELECT RAISE(FAIL, 'forced delegate queue failure');
+         END;",
+        [],
+    )
+    .expect("create session_events failure trigger");
+
+    let error = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "delegate_async".to_owned(),
+                payload: json!({
+                    "task": "child task",
+                    "label": "async-child"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect_err("delegate_async should fail when queued event cannot be written");
+    assert!(error.contains("insert session event failed"));
+
+    let sessions = repo
+        .list_sessions()
+        .expect("list sessions after queue failure");
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].session_id, "root-session");
+    assert_eq!(
+        spawner
+            .requests
+            .lock()
+            .expect("async delegate requests lock")
+            .len(),
+        0
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_async_spawn_failure_is_observable_after_queued_handle_returns() {
+    let (config, db_path) = isolated_test_config("delegate-async-spawn-failed");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner {
+        requests: Arc::new(Mutex::new(Vec::new())),
+        spawn_error: Some("spawn unavailable".to_owned()),
+    });
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+        spawner,
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "delegate_async".to_owned(),
+                payload: json!({
+                    "task": "child task",
+                    "label": "async-child"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("delegate_async outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["mode"], "async");
+    assert_eq!(outcome.payload["state"], "queued");
+    let child_session_id = outcome.payload["child_session_id"]
+        .as_str()
+        .expect("child_session_id");
+
+    let waited = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": child_session_id,
+                    "timeout_ms": 500
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(waited.status, "ok");
+    assert_eq!(waited.payload["wait_status"], "completed");
+    assert_eq!(waited.payload["session"]["state"], "failed");
+    assert_eq!(waited.payload["terminal_outcome"]["status"], "error");
+    assert_eq!(
+        waited.payload["terminal_outcome"]["payload"]["error"],
+        "spawn unavailable"
+    );
+
+    let child = repo
+        .load_session_summary(child_session_id)
+        .expect("load child summary")
+        .expect("child summary");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert_eq!(child.last_error.as_deref(), Some("spawn unavailable"));
+    let events = repo
+        .list_recent_events(child_session_id, 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_queued"));
+    assert!(event_kinds.contains(&"delegate_spawn_failed"));
+    let terminal_outcome = repo
+        .load_terminal_outcome(child_session_id)
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "error");
+    assert_eq!(terminal_outcome.payload_json["error"], "spawn unavailable");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_async_spawn_panic_is_observable_after_queued_handle_returns() {
+    let (config, db_path) = isolated_test_config("delegate-async-spawn-panic");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(config.memory.resolved_sqlite_path()),
+        },
+        config.tools.clone(),
+        Arc::new(PanicAsyncDelegateSpawner),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "delegate_async".to_owned(),
+                payload: json!({
+                    "task": "child task",
+                    "label": "async-child"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("delegate_async outcome");
+
+    assert_eq!(outcome.status, "ok");
+    let child_session_id = outcome.payload["child_session_id"]
+        .as_str()
+        .expect("child_session_id");
+
+    let waited = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": child_session_id,
+                    "timeout_ms": 500
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(waited.status, "ok");
+    assert_eq!(waited.payload["wait_status"], "completed");
+    assert_eq!(waited.payload["session"]["state"], "failed");
+    assert_eq!(waited.payload["terminal_outcome"]["status"], "error");
+    assert_eq!(
+        waited.payload["terminal_outcome"]["payload"]["error"],
+        "delegate_async_spawn_panic: panic-async-spawn"
+    );
+
+    let child = repo
+        .load_session_summary(child_session_id)
+        .expect("load child summary")
+        .expect("child summary");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert_eq!(
+        child.last_error.as_deref(),
+        Some("delegate_async_spawn_panic: panic-async-spawn")
+    );
+    let events = repo
+        .list_recent_events(child_session_id, 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_queued"));
+    assert!(event_kinds.contains(&"delegate_spawn_failed"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_async_spawn_failure_persistence_failure_recovers_to_failed_state() {
+    let (config, db_path) = isolated_test_config("delegate-async-spawn-failure-persistence");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root");
+
+    let conn = Connection::open(&db_path).expect("open sqlite connection");
+    conn.execute(
+        "CREATE TRIGGER fail_async_spawn_terminal_outcome
+         BEFORE INSERT ON session_terminal_outcomes
+         BEGIN
+            SELECT RAISE(FAIL, 'forced async spawn terminal outcome failure');
+         END;",
+        [],
+    )
+    .expect("create terminal outcome failure trigger");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner {
+        requests: Arc::new(Mutex::new(Vec::new())),
+        spawn_error: Some("spawn unavailable".to_owned()),
+    });
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        memory_config.clone(),
+        config.tools.clone(),
+        spawner.clone(),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let outcome = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "delegate_async".to_owned(),
+                payload: json!({
+                    "task": "child task",
+                    "label": "async-child"
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("delegate_async outcome");
+    let child_session_id = outcome.payload["child_session_id"]
+        .as_str()
+        .expect("child_session_id")
+        .to_owned();
+
+    let child = tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            let child = repo
+                .load_session_summary(&child_session_id)
+                .expect("load child summary")
+                .expect("child summary");
+            if child.state == crate::session::repository::SessionState::Failed {
+                break child;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("child should recover to failed state");
+
+    assert!(child
+        .last_error
+        .as_deref()
+        .expect("child last_error")
+        .contains("delegate_async_spawn_failure_persist_failed"));
+    let events = repo
+        .list_recent_events(&child_session_id, 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_queued"));
+    assert!(!event_kinds.contains(&"delegate_spawn_failed"));
+    let recovery_event = events
+        .iter()
+        .find(|event| event.event_kind == "delegate_recovery_applied")
+        .expect("delegate recovery event");
+    assert_eq!(
+        recovery_event.payload_json["recovery_kind"],
+        "async_spawn_failure_persist_failed"
+    );
+    assert_eq!(recovery_event.payload_json["recovered_state"], "failed");
+    assert_eq!(
+        recovery_event.payload_json["original_error"],
+        "spawn unavailable"
+    );
+    assert!(repo
+        .load_terminal_outcome(&child_session_id)
+        .expect("load terminal outcome")
+        .is_none());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_success_persists_terminal_outcome() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-success");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Child final output".to_owned(),
+            tool_intents: vec![],
+            raw_meta: Value::Null,
+        })],
+    );
+
+    let outcome = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "child task",
+        60,
+        None,
+    )
+    .await
+    .expect("delegate child background outcome");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["child_session_id"], "child-session");
+    assert_eq!(outcome.payload["final_output"], "Child final output");
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Completed
+    );
+    assert_eq!(child.last_error, None);
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_completed"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "ok");
+    assert_eq!(
+        terminal_outcome.payload_json["final_output"],
+        "Child final output"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_terminal_finalize_failure_recovers_to_failed_state() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-finalize-failure");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let conn = Connection::open(&db_path).expect("open sqlite connection");
+    conn.execute(
+        "CREATE TRIGGER fail_child_terminal_outcome
+         BEFORE INSERT ON session_terminal_outcomes
+         BEGIN
+            SELECT RAISE(FAIL, 'forced child terminal outcome failure');
+         END;",
+        [],
+    )
+    .expect("create terminal outcome failure trigger");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Child final output".to_owned(),
+            tool_intents: vec![],
+            raw_meta: Value::Null,
+        })],
+    );
+
+    let error = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "child task",
+        60,
+        None,
+    )
+    .await
+    .expect_err("terminal finalize failure should surface as error");
+
+    assert!(
+        error.contains("delegate_terminal_finalize_failed"),
+        "error: {error}"
+    );
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert!(child
+        .last_error
+        .as_deref()
+        .expect("child last_error")
+        .contains("delegate_terminal_finalize_failed"));
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(!event_kinds.contains(&"delegate_completed"));
+    let recovery_event = events
+        .iter()
+        .find(|event| event.event_kind == "delegate_recovery_applied")
+        .expect("delegate recovery event");
+    assert_eq!(
+        recovery_event.payload_json["recovery_kind"],
+        "terminal_finalize_persist_failed"
+    );
+    assert_eq!(recovery_event.payload_json["recovered_state"], "failed");
+    assert_eq!(
+        recovery_event.payload_json["attempted_terminal_event_kind"],
+        "delegate_completed"
+    );
+
+    assert!(repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .is_none());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_terminal_finalize_failure_falls_back_when_recovery_event_persist_fails(
+) {
+    let (config, db_path) =
+        isolated_test_config("delegate-child-background-finalize-recovery-fallback");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let conn = Connection::open(&db_path).expect("open sqlite connection");
+    conn.execute(
+        "CREATE TRIGGER fail_child_terminal_outcome
+         BEFORE INSERT ON session_terminal_outcomes
+         BEGIN
+            SELECT RAISE(FAIL, 'forced child terminal outcome failure');
+         END;",
+        [],
+    )
+    .expect("create terminal outcome failure trigger");
+    conn.execute(
+        "CREATE TRIGGER fail_delegate_recovery_event
+         BEFORE INSERT ON session_events
+         WHEN NEW.event_kind = 'delegate_recovery_applied'
+         BEGIN
+            SELECT RAISE(FAIL, 'forced delegate recovery event failure');
+         END;",
+        [],
+    )
+    .expect("create recovery event failure trigger");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Child final output".to_owned(),
+            tool_intents: vec![],
+            raw_meta: Value::Null,
+        })],
+    );
+
+    let error = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "child task",
+        60,
+        None,
+    )
+    .await
+    .expect_err("terminal finalize failure should surface as error");
+
+    assert!(
+        error.contains("delegate_terminal_recovery_event_failed"),
+        "error: {error}"
+    );
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert!(child
+        .last_error
+        .as_deref()
+        .expect("child last_error")
+        .contains("delegate_terminal_finalize_failed"));
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(!event_kinds.contains(&"delegate_completed"));
+    assert!(!event_kinds.contains(&"delegate_recovery_applied"));
+
+    let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), config.tools.clone());
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::runtime_tool_view_for_config(&config.tools),
+    );
+    let waited = dispatcher
+        .execute_app_tool(
+            &session_context,
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "session_wait".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "timeout_ms": 50
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("session_wait outcome");
+
+    assert_eq!(waited.payload["terminal_outcome_state"], "missing");
+    assert_eq!(
+        waited.payload["terminal_outcome_missing_reason"],
+        "terminal_finalize_persist_failed"
+    );
+    assert_eq!(
+        waited.payload["recovery"]["kind"],
+        "terminal_finalize_persist_failed"
+    );
+    assert_eq!(waited.payload["recovery"]["source"], "last_error");
+    assert!(waited.payload["recovery"]["event_kind"].is_null());
+
+    assert!(repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .is_none());
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_rerun_does_not_overwrite_terminal_outcome() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-rerun");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let first_runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Child final output".to_owned(),
+            tool_intents: vec![],
+            raw_meta: Value::Null,
+        })],
+    );
+
+    let first_outcome = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &first_runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "child task",
+        60,
+        None,
+    )
+    .await
+    .expect("first delegate child background outcome");
+    assert_eq!(first_outcome.status, "ok");
+
+    let second_runtime =
+        FakeRuntime::with_turns(vec![], vec![Err("child runtime failed".to_owned())]);
+
+    let second_error = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &second_runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "child task retry",
+        60,
+        None,
+    )
+    .await
+    .expect_err("rerun should be rejected after terminal completion");
+    assert!(second_error.contains("not runnable"));
+    assert!(second_error.contains("completed"));
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Completed
+    );
+    assert_eq!(child.last_error, None);
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert_eq!(
+        event_kinds
+            .iter()
+            .filter(|kind| **kind == "delegate_started")
+            .count(),
+        1
+    );
+    assert_eq!(
+        event_kinds
+            .iter()
+            .filter(|kind| **kind == "delegate_completed")
+            .count(),
+        1
+    );
+    assert!(!event_kinds.contains(&"delegate_failed"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "ok");
+    assert_eq!(
+        terminal_outcome.payload_json["final_output"],
+        "Child final output"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_failure_persists_terminal_outcome() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-failure");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let runtime = FakeRuntime::with_turns(vec![], vec![Err("child runtime failed".to_owned())]);
+
+    let outcome = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "child task",
+        60,
+        None,
+    )
+    .await
+    .expect("delegate child background outcome");
+
+    assert_eq!(outcome.status, "error");
+    assert_eq!(outcome.payload["child_session_id"], "child-session");
+    assert_eq!(outcome.payload["error"], "child runtime failed");
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert_eq!(child.last_error.as_deref(), Some("child runtime failed"));
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_failed"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "error");
+    assert_eq!(
+        terminal_outcome.payload_json["error"],
+        "child runtime failed"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_timeout_persists_terminal_outcome() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-timeout");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Too slow".to_owned(),
+            tool_intents: vec![],
+            raw_meta: Value::Null,
+        })],
+    )
+    .with_turn_delays(vec![Duration::from_millis(1_100)]);
+
+    let outcome = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &runtime,
+        &NoopAppToolDispatcher,
+        "child-session",
+        "slow child task",
+        1,
+        None,
+    )
+    .await
+    .expect("delegate child background outcome");
+
+    assert_eq!(outcome.status, "timeout");
+    assert_eq!(outcome.payload["child_session_id"], "child-session");
+    assert_eq!(outcome.payload["error"], "delegate_timeout");
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::TimedOut
+    );
+    assert_eq!(child.last_error.as_deref(), Some("delegate_timeout"));
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_timed_out"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "timeout");
+    assert_eq!(terminal_outcome.payload_json["error"], "delegate_timeout");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_background_panic_persists_failed_terminal_outcome() {
+    let (config, db_path) = isolated_test_config("delegate-child-background-panic");
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    };
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("bg-child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let outcome = super::run_delegate_child_turn_with_runtime(
+        &ConversationTurnLoop::new(),
+        &config,
+        &PanicRuntime::new(),
+        &NoopAppToolDispatcher,
+        "child-session",
+        "panic child task",
+        60,
+        None,
+    )
+    .await
+    .expect("delegate child panic outcome");
+
+    assert_eq!(outcome.status, "error");
+    assert_eq!(outcome.payload["child_session_id"], "child-session");
+    assert_eq!(
+        outcome.payload["error"],
+        "delegate_child_panic: panic-runtime-request-turn"
+    );
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert_eq!(
+        child.last_error.as_deref(),
+        Some("delegate_child_panic: panic-runtime-request-turn")
+    );
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_failed"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "error");
+    assert_eq!(
+        terminal_outcome.payload_json["error"],
+        "delegate_child_panic: panic-runtime-request-turn"
     );
 }
 
@@ -259,6 +3012,839 @@ async fn handle_turn_with_runtime_inline_mode_returns_synthetic_reply_and_persis
             "[provider_error] timeout".to_owned(),
         )
     );
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_uses_session_tool_view_from_runtime() {
+    let child_view = crate::tools::planned_delegate_child_tool_view();
+    let runtime = FakeRuntime::new(vec![], Ok("assistant-reply".to_owned()))
+        .with_tool_view(child_view.clone());
+    let turn_loop = ConversationTurnLoop::new();
+
+    let reply = turn_loop
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-child",
+            "hello",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert_eq!(reply, "assistant-reply");
+    assert_eq!(
+        runtime
+            .built_tool_views
+            .lock()
+            .expect("built tool views lock")
+            .as_slice(),
+        &[child_view.clone()]
+    );
+    assert_eq!(
+        runtime
+            .turn_requested_tool_views
+            .lock()
+            .expect("turn request tool views lock")
+            .as_slice(),
+        &[child_view]
+    );
+}
+
+#[tokio::test]
+async fn conversation_turn_uses_tool_view_from_session_context() {
+    let runtime = FakeRuntime::new(vec![], Ok("assistant-reply".to_owned()));
+    let turn_loop = ConversationTurnLoop::new();
+    let child_context = crate::conversation::SessionContext::child(
+        "delegate:child-1",
+        "root-session",
+        crate::tools::planned_delegate_child_tool_view(),
+    );
+
+    let reply = turn_loop
+        .handle_turn_with_runtime_and_context(
+            &test_config(),
+            &child_context,
+            "hello",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            &crate::conversation::NoopAppToolDispatcher,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert_eq!(reply, "assistant-reply");
+    assert_eq!(
+        runtime
+            .built_tool_views
+            .lock()
+            .expect("built tool views lock")
+            .as_slice(),
+        &[crate::tools::planned_delegate_child_tool_view()]
+    );
+    assert_eq!(
+        runtime
+            .turn_requested_tool_views
+            .lock()
+            .expect("turn request tool views lock")
+            .as_slice(),
+        &[crate::tools::planned_delegate_child_tool_view()]
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_executes_session_tools_via_default_dispatcher() {
+    let (config, db_path) = isolated_test_config("default-session-tools");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Listing sessions.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "sessions_list".to_owned(),
+                args_json: json!({}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "root-session".to_owned(),
+                turn_id: "turn-session-tools".to_owned(),
+                tool_call_id: "call-session-tools".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        })],
+    );
+    let turn_loop = ConversationTurnLoop::new();
+
+    let reply = turn_loop
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert!(
+        reply.contains("\"current_session_id\":\"root-session\""),
+        "reply should contain session tool payload, got: {reply}"
+    );
+    assert!(
+        reply.contains("\"session_id\":\"root-session\""),
+        "reply should list the registered root session, got: {reply}"
+    );
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    let session = repo
+        .load_session("root-session")
+        .expect("load session")
+        .expect("root session row");
+    assert_eq!(session.session_id, "root-session");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_creates_child_session_and_returns_structured_result() {
+    let (config, db_path) = isolated_test_config("delegate-happy-path");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "child task",
+                        "label": "research-subtask"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Child final output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert!(
+        reply.contains("\"label\":\"research-subtask\""),
+        "reply: {reply}"
+    );
+    assert!(
+        reply.contains("\"final_output\":\"Child final output\""),
+        "reply: {reply}"
+    );
+    assert!(
+        reply.contains("\"child_session_id\":\"delegate:"),
+        "reply: {reply}"
+    );
+
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    let child = repo
+        .list_visible_sessions("root-session")
+        .expect("list visible sessions")
+        .into_iter()
+        .find(|session| session.parent_session_id.as_deref() == Some("root-session"))
+        .expect("child session summary");
+    assert_eq!(
+        child.kind,
+        crate::session::repository::SessionKind::DelegateChild
+    );
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Completed
+    );
+    assert_eq!(child.label.as_deref(), Some("research-subtask"));
+
+    let events = repo
+        .list_recent_events(&child.session_id, 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_completed"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome(&child.session_id)
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "ok");
+    assert_eq!(
+        terminal_outcome.payload_json["final_output"],
+        "Child final output"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_start_failure_does_not_leave_orphan_child_session() {
+    let (config, db_path) = isolated_test_config("delegate-start-rollback");
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+    })
+    .expect("session repository");
+    let conn = Connection::open(&db_path).expect("open sqlite connection");
+    conn.execute(
+        "CREATE TRIGGER fail_delegate_started_event
+         BEFORE INSERT ON session_events
+         WHEN NEW.event_kind = 'delegate_started'
+         BEGIN
+            SELECT RAISE(FAIL, 'forced delegate started failure');
+         END;",
+        [],
+    )
+    .expect("create delegate_started failure trigger");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Delegating.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "delegate".to_owned(),
+                args_json: json!({
+                    "task": "child task",
+                    "label": "research-subtask"
+                }),
+                source: "provider_tool_call".to_owned(),
+                session_id: "root-session".to_owned(),
+                turn_id: "turn-delegate-parent".to_owned(),
+                tool_call_id: "call-delegate-parent".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        })],
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn should surface tool error");
+
+    assert!(
+        reply.contains("insert session event failed"),
+        "reply: {reply}"
+    );
+
+    let sessions = repo
+        .list_sessions()
+        .expect("list sessions after delegate start failure");
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].session_id, "root-session");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_uses_restricted_tool_view() {
+    let (config, _db_path) = isolated_test_config("delegate-child-tool-view");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "child task",
+                        "label": "child-view"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Child output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert_eq!(
+        runtime
+            .turn_requested_tool_views
+            .lock()
+            .expect("turn request tool views lock")
+            .as_slice(),
+        &[
+            crate::tools::runtime_tool_view(),
+            crate::tools::planned_delegate_child_tool_view(),
+        ]
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_tool_view_allows_shell_when_config_enabled() {
+    let (mut config, _db_path) = isolated_test_config("delegate-child-shell");
+    config.tools.delegate.allow_shell_in_child = true;
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "child task",
+                        "label": "child-shell"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Child output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    let requested = runtime
+        .turn_requested_tool_views
+        .lock()
+        .expect("turn request tool views lock");
+    assert_eq!(requested.len(), 2);
+    assert!(requested[1].contains("shell.exec"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_timeout_sets_child_session_to_timed_out() {
+    let (config, db_path) = isolated_test_config("delegate-timeout");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "slow child task",
+                        "label": "timeout-child",
+                        "timeout_seconds": 1
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Too slow".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    )
+    .with_turn_delays(vec![Duration::ZERO, Duration::from_millis(1_100)]);
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert!(reply.contains("[timeout]"), "reply: {reply}");
+    assert!(
+        reply.contains("\"error\":\"delegate_timeout\""),
+        "reply: {reply}"
+    );
+
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    let child = repo
+        .list_visible_sessions("root-session")
+        .expect("list visible sessions")
+        .into_iter()
+        .find(|session| session.parent_session_id.as_deref() == Some("root-session"))
+        .expect("child session summary");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::TimedOut
+    );
+    assert_eq!(child.last_error.as_deref(), Some("delegate_timeout"));
+
+    let events = repo
+        .list_recent_events(&child.session_id, 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_timed_out"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome(&child.session_id)
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "timeout");
+    assert_eq!(terminal_outcome.payload_json["error"], "delegate_timeout");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_terminal_outcome_persists_for_failed_child() {
+    let (config, db_path) = isolated_test_config("delegate-failed-terminal-outcome");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "failing child task",
+                        "label": "failed-child"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Err("child runtime failed".to_owned()),
+        ],
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert!(reply.contains("[error]"), "reply: {reply}");
+    assert!(
+        reply.contains("\"error\":\"child runtime failed\""),
+        "reply: {reply}"
+    );
+
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    let child = repo
+        .list_visible_sessions("root-session")
+        .expect("list visible sessions")
+        .into_iter()
+        .find(|session| session.parent_session_id.as_deref() == Some("root-session"))
+        .expect("child session summary");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Failed
+    );
+    assert_eq!(child.label.as_deref(), Some("failed-child"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome(&child.session_id)
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "error");
+    assert_eq!(
+        terminal_outcome.payload_json["error"],
+        "child runtime failed"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_cannot_reenter_delegate() {
+    let (config, _db_path) = isolated_test_config("delegate-reenter");
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "show raw json tool output",
+                        "label": "nested-child"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Trying nested delegate.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({"task": "nested"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "delegate:child".to_owned(),
+                    turn_id: "turn-delegate-child".to_owned(),
+                    tool_call_id: "call-delegate-child".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success");
+
+    assert!(
+        reply.contains("tool_not_visible: delegate"),
+        "reply should surface nested delegate denial, got: {reply}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_child_can_reenter_when_max_depth_allows() {
+    let (mut config, db_path) = isolated_test_config("delegate-nested-allowed");
+    config.tools.delegate.max_depth = 2;
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating from root.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "show raw json tool output",
+                        "label": "child"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-root".to_owned(),
+                    tool_call_id: "call-root".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Delegating from child.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "final grandchild task",
+                        "label": "grandchild"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "delegate:child-runtime".to_owned(),
+                    turn_id: "turn-child".to_owned(),
+                    tool_call_id: "call-child".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Grandchild final output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("nested delegate success");
+
+    assert!(
+        reply.contains("Grandchild final output"),
+        "reply should include nested delegate final output, got: {reply}"
+    );
+
+    let requested = runtime
+        .turn_requested_tool_views
+        .lock()
+        .expect("turn request tool views lock");
+    assert_eq!(requested.len(), 3);
+    assert!(requested[1].contains("delegate"));
+    assert!(!requested[2].contains("delegate"));
+
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    let visible = repo
+        .list_visible_sessions("root-session")
+        .expect("visible sessions");
+    let descendant_ids: Vec<&str> = visible
+        .iter()
+        .map(|session| session.session_id.as_str())
+        .collect();
+    assert!(descendant_ids.contains(&"root-session"));
+    assert!(
+        visible.len() >= 3,
+        "expected root, child, grandchild; got: {visible:?}"
+    );
+    assert!(
+        visible
+            .iter()
+            .any(|session| session.parent_session_id.as_deref() == Some("root-session")),
+        "expected direct child session in visible set: {visible:?}"
+    );
+    assert!(
+        visible
+            .iter()
+            .any(|session| session.parent_session_id.is_some()
+                && session.parent_session_id.as_deref() != Some("root-session")),
+        "expected descendant grandchild session in visible set: {visible:?}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn delegate_returns_depth_exceeded_when_nested_delegate_exceeds_max_depth() {
+    let (mut config, db_path) = isolated_test_config("delegate-depth-exceeded");
+    config.tools.delegate.max_depth = 1;
+    let repo = SessionRepository::new(&crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    })
+    .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let runtime = FakeRuntime::with_turns(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Trying nested delegate despite depth.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "delegate".to_owned(),
+                args_json: json!({
+                    "task": "nested",
+                    "label": "too-deep"
+                }),
+                source: "provider_tool_call".to_owned(),
+                session_id: "delegate:stale-child".to_owned(),
+                turn_id: "turn-child".to_owned(),
+                tool_call_id: "call-child".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        })],
+    );
+    let session_context = SessionContext::child(
+        "delegate:stale-child",
+        "root-session",
+        crate::tools::delegate_child_tool_view_for_config_with_delegate(&config.tools, true),
+    );
+
+    let reply = ConversationTurnLoop::new()
+        .handle_turn_with_runtime_and_context(
+            &config,
+            &session_context,
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            &DefaultAppToolDispatcher::new(
+                crate::memory::runtime_config::MemoryRuntimeConfig {
+                    sqlite_path: Some(config.memory.resolved_sqlite_path()),
+                },
+                config.tools.clone(),
+            ),
+            None,
+        )
+        .await
+        .expect("depth exceeded reply");
+
+    assert!(
+        reply.contains("delegate_depth_exceeded"),
+        "reply should surface depth enforcement, got: {reply}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_denies_tool_outside_session_tool_view() {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Trying a shell command.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "shell.exec".to_owned(),
+                args_json: json!({"command": "echo", "args": ["blocked by tool view"]}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-child".to_owned(),
+                turn_id: "turn-child".to_owned(),
+                tool_call_id: "call-child".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        })],
+        Vec::new(),
+    )
+    .with_tool_view(crate::tools::planned_delegate_child_tool_view());
+    let turn_loop = ConversationTurnLoop::new();
+
+    let reply = turn_loop
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-child",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("turn should return denied raw reply");
+
+    assert!(
+        reply.contains("tool_not_visible: shell.exec"),
+        "reply should surface tool-view denial, got: {reply}"
+    );
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1446,6 +5032,34 @@ fn turn_engine_unknown_tool_returns_tool_denied() {
 }
 
 #[test]
+fn turn_engine_known_tool_outside_tool_view_returns_tool_denied() {
+    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "shell.exec".to_owned(),
+            args_json: serde_json::json!({"command": "echo", "args": ["hello"]}),
+            source: "provider_tool_call".to_owned(),
+            session_id: "s-child".to_owned(),
+            turn_id: "t-child".to_owned(),
+            tool_call_id: "c-child".to_owned(),
+        }],
+        raw_meta: serde_json::Value::Null,
+    };
+
+    let result =
+        engine.evaluate_turn_in_view(&turn, &crate::tools::planned_delegate_child_tool_view());
+    match result {
+        TurnResult::ToolDenied(reason) => {
+            assert!(reason.contains("tool_not_visible"), "reason: {reason}")
+        }
+        other => panic!("expected ToolDenied, got {:?}", other),
+    }
+}
+
+#[test]
 fn turn_engine_exceeding_max_steps_returns_denied() {
     use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
     let engine = TurnEngine::new(1);
@@ -1625,6 +5239,81 @@ async fn turn_engine_executes_known_tool_with_kernel() {
             }
         }
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_routes_app_tools_through_dispatcher() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct RecordingAppDispatcher {
+        calls: Mutex<Vec<(String, String)>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for RecordingAppDispatcher {
+        async fn execute_app_tool(
+            &self,
+            session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _kernel_ctx: Option<&KernelContext>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.calls.lock().expect("dispatcher calls lock").push((
+                session_context.session_id.clone(),
+                request.tool_name.clone(),
+            ));
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "session_id": session_context.session_id,
+                    "tool_name": request.tool_name,
+                }),
+            })
+        }
+    }
+
+    let dispatcher = RecordingAppDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "sessions_list".to_owned(),
+            args_json: json!({}),
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-app-1".to_owned(),
+            tool_call_id: "call-app-1".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context(&turn, &session_context, &dispatcher, None)
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            assert!(
+                text.contains("\"tool_name\":\"sessions_list\""),
+                "expected dispatcher payload in output, got: {text}"
+            );
+        }
+        other => panic!("expected FinalText, got: {other:?}"),
+    }
+
+    assert_eq!(
+        dispatcher
+            .calls
+            .lock()
+            .expect("dispatcher calls lock")
+            .as_slice(),
+        &[("root-session".to_owned(), "sessions_list".to_owned())]
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1876,6 +5565,22 @@ async fn persist_turn_routes_through_kernel_when_context_provided() {
         has_memory_plane,
         "audit should contain memory plane invocation"
     );
+}
+
+#[test]
+fn default_runtime_build_messages_respects_restricted_tool_view() {
+    let runtime = DefaultConversationRuntime;
+    let view = crate::tools::ToolView::from_tool_names(["file.read"]);
+
+    let messages = runtime
+        .build_messages(&test_config(), "noop-session", true, &view, None)
+        .expect("build messages");
+
+    assert!(!messages.is_empty());
+    let system_content = messages[0]["content"].as_str().expect("system content");
+    assert!(system_content.contains("- file.read: Read file contents"));
+    assert!(!system_content.contains("- file.write: Write file contents"));
+    assert!(!system_content.contains("- shell.exec: Execute shell commands"));
 }
 
 #[cfg(not(feature = "memory-sqlite"))]

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -14,7 +14,7 @@ use loongclaw_contracts::{Capability, KernelError, ToolCoreOutcome, ToolCoreRequ
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::config::{SessionVisibility, ToolConfig};
+use crate::config::{LoongClawConfig, SessionVisibility, ToolConfig};
 use crate::context::KernelContext;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
@@ -339,6 +339,7 @@ impl AppToolDispatcher for NoopAppToolDispatcher {
 pub struct DefaultAppToolDispatcher {
     memory_config: MemoryRuntimeConfig,
     tool_config: ToolConfig,
+    app_config: Option<Arc<LoongClawConfig>>,
     async_delegate_spawner: Option<Arc<dyn AsyncDelegateSpawner>>,
 }
 
@@ -347,6 +348,16 @@ impl DefaultAppToolDispatcher {
         Self {
             memory_config,
             tool_config,
+            app_config: None,
+            async_delegate_spawner: None,
+        }
+    }
+
+    pub fn with_config(memory_config: MemoryRuntimeConfig, config: LoongClawConfig) -> Self {
+        Self {
+            memory_config,
+            tool_config: config.tools.clone(),
+            app_config: Some(Arc::new(config)),
             async_delegate_spawner: None,
         }
     }
@@ -359,6 +370,23 @@ impl DefaultAppToolDispatcher {
         Self {
             memory_config,
             tool_config,
+            app_config: None,
+            async_delegate_spawner,
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    pub fn production_with_config(
+        memory_config: MemoryRuntimeConfig,
+        config: LoongClawConfig,
+    ) -> Self {
+        let async_delegate_spawner = SubprocessAsyncDelegateSpawner::from_current_process()
+            .ok()
+            .map(|spawner| Arc::new(spawner) as Arc<dyn AsyncDelegateSpawner>);
+        Self {
+            memory_config,
+            tool_config: config.tools.clone(),
+            app_config: Some(Arc::new(config)),
             async_delegate_spawner,
         }
     }
@@ -371,6 +399,7 @@ impl DefaultAppToolDispatcher {
         Self {
             memory_config,
             tool_config,
+            app_config: None,
             async_delegate_spawner: Some(async_delegate_spawner),
         }
     }
@@ -510,6 +539,27 @@ impl DefaultAppToolDispatcher {
             delegate_request.timeout_seconds,
         ))
     }
+
+    #[cfg(feature = "memory-sqlite")]
+    async fn execute_sessions_send(
+        &self,
+        session_context: &SessionContext,
+        payload: serde_json::Value,
+    ) -> Result<ToolCoreOutcome, String> {
+        let app_config = self
+            .app_config
+            .as_ref()
+            .ok_or_else(|| "sessions_send_not_configured".to_owned())?;
+        let effective_tool_config = self.effective_tool_config_for_session(session_context);
+        crate::tools::messaging::execute_sessions_send_with_config(
+            payload,
+            &session_context.session_id,
+            &self.memory_config,
+            &effective_tool_config,
+            app_config.as_ref(),
+        )
+        .await
+    }
 }
 
 impl Default for DefaultAppToolDispatcher {
@@ -545,6 +595,12 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                 &effective_tool_config,
             )
             .await;
+        }
+        #[cfg(feature = "memory-sqlite")]
+        if canonical_tool_name == "sessions_send" {
+            return self
+                .execute_sessions_send(session_context, request.payload)
+                .await;
         }
         #[cfg(feature = "memory-sqlite")]
         if canonical_tool_name == "delegate_async" {

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -313,7 +313,7 @@ fn spawn_async_delegate_detached(
                 label,
                 error.clone(),
             ) {
-                eprintln!(
+                tracing::error!(
                     "error: async delegate spawn failure persistence failed for `{child_session_id}`: {finalize_error}; original spawn error: {error}"
                 );
             }
@@ -407,10 +407,10 @@ impl DefaultAppToolDispatcher {
     pub fn runtime() -> Self {
         #[cfg(feature = "memory-sqlite")]
         {
-            return Self::production(
+            Self::production(
                 crate::memory::runtime_config::get_memory_runtime_config().clone(),
                 ToolConfig::default(),
-            );
+            )
         }
         #[cfg(not(feature = "memory-sqlite"))]
         Self::new(
@@ -734,9 +734,9 @@ impl TurnEngine {
         // Execute each tool intent through the kernel
         let mut outputs = Vec::new();
         for intent in &turn.tool_intents {
-            let descriptor = catalog
-                .resolve(&intent.tool_name)
-                .expect("tool descriptor should remain resolvable after validation");
+            let Some(descriptor) = catalog.resolve(&intent.tool_name) else {
+                return TurnResult::ToolDenied(format!("tool_not_found: {}", intent.tool_name));
+            };
             let request = ToolCoreRequest {
                 tool_name: descriptor.name.to_owned(),
                 payload: intent.args_json.clone(),

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -798,12 +798,12 @@ mod tests {
         };
 
         let plan = build_async_delegate_subprocess_plan(
-            std::path::Path::new("/tmp/loongclawd"),
+            std::path::Path::new("/tmp/loongclaw"),
             Some("/tmp/loongclaw.toml"),
             &request,
         );
 
-        assert_eq!(plan.program, std::path::PathBuf::from("/tmp/loongclawd"));
+        assert_eq!(plan.program, std::path::PathBuf::from("/tmp/loongclaw"));
         assert_eq!(
             plan.args,
             vec![

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1,9 +1,30 @@
+use async_trait::async_trait;
+use futures_util::FutureExt;
+use std::any::Any;
 use std::collections::BTreeSet;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+#[cfg(feature = "memory-sqlite")]
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+};
 
-use loongclaw_contracts::{Capability, KernelError, ToolCoreRequest};
+use loongclaw_contracts::{Capability, KernelError, ToolCoreOutcome, ToolCoreRequest};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
+use crate::config::{SessionVisibility, ToolConfig};
 use crate::context::KernelContext;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::recovery::{build_async_spawn_failure_recovery_payload, RECOVERY_EVENT_KIND};
+use crate::tools::{
+    delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
+    runtime_tool_view, runtime_tool_view_for_config, tool_catalog, ToolExecutionKind, ToolView,
+};
+
+use super::runtime::SessionContext;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProviderTurn {
@@ -49,6 +70,497 @@ pub enum TurnResult {
     ProviderError(String),
 }
 
+#[async_trait]
+pub trait AppToolDispatcher: Send + Sync {
+    async fn execute_app_tool(
+        &self,
+        session_context: &SessionContext,
+        request: ToolCoreRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ToolCoreOutcome, String>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AsyncDelegateSpawnRequest {
+    pub child_session_id: String,
+    pub parent_session_id: String,
+    pub task: String,
+    pub label: Option<String>,
+    pub timeout_seconds: u64,
+}
+
+#[async_trait]
+pub trait AsyncDelegateSpawner: Send + Sync {
+    async fn spawn(&self, request: AsyncDelegateSpawnRequest) -> Result<(), String>;
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AsyncDelegateSubprocessPlan {
+    program: PathBuf,
+    args: Vec<String>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_async_delegate_subprocess_plan(
+    executable_path: &Path,
+    config_path: Option<&str>,
+    request: &AsyncDelegateSpawnRequest,
+) -> AsyncDelegateSubprocessPlan {
+    let mut args = vec!["run-turn".to_owned()];
+    if let Some(config_path) = config_path.map(str::trim).filter(|value| !value.is_empty()) {
+        args.push("--config".to_owned());
+        args.push(config_path.to_owned());
+    }
+    args.extend([
+        "--session".to_owned(),
+        request.child_session_id.clone(),
+        "--input".to_owned(),
+        request.task.clone(),
+        "--timeout-seconds".to_owned(),
+        request.timeout_seconds.to_string(),
+        "--delegate-child".to_owned(),
+    ]);
+    AsyncDelegateSubprocessPlan {
+        program: executable_path.to_path_buf(),
+        args,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone)]
+struct SubprocessAsyncDelegateSpawner {
+    executable_path: PathBuf,
+    config_path: Option<String>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl SubprocessAsyncDelegateSpawner {
+    fn from_current_process() -> Result<Self, String> {
+        let executable_path = std::env::current_exe().map_err(|error| {
+            format!("resolve current executable for async delegate failed: {error}")
+        })?;
+        let config_path = std::env::var("LOONGCLAW_CONFIG_PATH")
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty());
+        Ok(Self {
+            executable_path,
+            config_path,
+        })
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl AsyncDelegateSpawner for SubprocessAsyncDelegateSpawner {
+    async fn spawn(&self, request: AsyncDelegateSpawnRequest) -> Result<(), String> {
+        let plan = build_async_delegate_subprocess_plan(
+            &self.executable_path,
+            self.config_path.as_deref(),
+            &request,
+        );
+        let mut command = tokio::process::Command::new(&plan.program);
+        command.args(&plan.args);
+        command.stdin(Stdio::null());
+        command.stdout(Stdio::null());
+        command.stderr(Stdio::null());
+        let child = command
+            .spawn()
+            .map_err(|error| format!("spawn async delegate subprocess failed: {error}"))?;
+        drop(child);
+        Ok(())
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn finalize_async_delegate_spawn_failure(
+    memory_config: &MemoryRuntimeConfig,
+    child_session_id: &str,
+    parent_session_id: &str,
+    label: Option<String>,
+    error: String,
+) -> Result<(), String> {
+    let repo = crate::session::repository::SessionRepository::new(memory_config)?;
+    let outcome = crate::tools::delegate::delegate_error_outcome(
+        child_session_id.to_owned(),
+        label,
+        error.clone(),
+        0,
+    );
+    repo.finalize_session_terminal(
+        child_session_id,
+        crate::session::repository::FinalizeSessionTerminalRequest {
+            state: crate::session::repository::SessionState::Failed,
+            last_error: Some(error.clone()),
+            event_kind: "delegate_spawn_failed".to_owned(),
+            actor_session_id: Some(parent_session_id.to_owned()),
+            event_payload_json: json!({
+                "error": error,
+            }),
+            outcome_status: outcome.status,
+            outcome_payload_json: outcome.payload,
+        },
+    )?;
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn finalize_async_delegate_spawn_failure_with_recovery(
+    memory_config: &MemoryRuntimeConfig,
+    child_session_id: &str,
+    parent_session_id: &str,
+    label: Option<String>,
+    error: String,
+) -> Result<(), String> {
+    let recovery_label = label.clone();
+    match finalize_async_delegate_spawn_failure(
+        memory_config,
+        child_session_id,
+        parent_session_id,
+        label,
+        error.clone(),
+    ) {
+        Ok(()) => Ok(()),
+        Err(finalize_error) => {
+            let repo = crate::session::repository::SessionRepository::new(memory_config)?;
+            let recovery_error = format!(
+                "delegate_async_spawn_failure_persist_failed: {finalize_error}; original spawn error: {error}"
+            );
+            match repo.transition_session_with_event_if_current(
+                child_session_id,
+                crate::session::repository::TransitionSessionWithEventIfCurrentRequest {
+                    expected_state: crate::session::repository::SessionState::Ready,
+                    next_state: crate::session::repository::SessionState::Failed,
+                    last_error: Some(recovery_error.clone()),
+                    event_kind: RECOVERY_EVENT_KIND.to_owned(),
+                    actor_session_id: Some(parent_session_id.to_owned()),
+                    event_payload_json: build_async_spawn_failure_recovery_payload(
+                        recovery_label.as_deref(),
+                        &error,
+                        &recovery_error,
+                    ),
+                },
+            ) {
+                Ok(Some(_)) => Ok(()),
+                Ok(None) => {
+                    let current_state = repo
+                        .load_session(child_session_id)?
+                        .map(|session| session.state.as_str().to_owned())
+                        .unwrap_or_else(|| "missing".to_owned());
+                    Err(format!(
+                        "{recovery_error}; delegate_async_spawn_recovery_skipped_from_state: {current_state}"
+                    ))
+                }
+                Err(recovery_event_error) => match repo.update_session_state_if_current(
+                    child_session_id,
+                    crate::session::repository::SessionState::Ready,
+                    crate::session::repository::SessionState::Failed,
+                    Some(recovery_error.clone()),
+                ) {
+                    Ok(Some(_)) => Ok(()),
+                    Ok(None) => {
+                        let current_state = repo
+                            .load_session(child_session_id)?
+                            .map(|session| session.state.as_str().to_owned())
+                            .unwrap_or_else(|| "missing".to_owned());
+                        Err(format!(
+                            "{recovery_error}; delegate_async_spawn_recovery_skipped_from_state: {current_state}"
+                        ))
+                    }
+                    Err(mark_error) => Err(format!(
+                        "{recovery_error}; delegate_async_spawn_recovery_failed: {mark_error}; delegate_async_spawn_recovery_event_failed: {recovery_event_error}"
+                    )),
+                },
+            }
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn format_async_delegate_spawn_panic(panic_payload: Box<dyn Any + Send>) -> String {
+    let panic_payload = match panic_payload.downcast::<String>() {
+        Ok(message) => return format!("delegate_async_spawn_panic: {}", *message),
+        Err(panic_payload) => panic_payload,
+    };
+    match panic_payload.downcast::<&'static str>() {
+        Ok(message) => format!("delegate_async_spawn_panic: {}", *message),
+        Err(_) => "delegate_async_spawn_panic".to_owned(),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn spawn_async_delegate_detached(
+    runtime_handle: tokio::runtime::Handle,
+    memory_config: MemoryRuntimeConfig,
+    spawner: Arc<dyn AsyncDelegateSpawner>,
+    request: AsyncDelegateSpawnRequest,
+) {
+    let child_session_id = request.child_session_id.clone();
+    let parent_session_id = request.parent_session_id.clone();
+    let label = request.label.clone();
+    runtime_handle.spawn(async move {
+        let spawn_failure = match AssertUnwindSafe(spawner.spawn(request)).catch_unwind().await {
+            Ok(Ok(())) => None,
+            Ok(Err(error)) => Some(error),
+            Err(panic_payload) => Some(format_async_delegate_spawn_panic(panic_payload)),
+        };
+        if let Some(error) = spawn_failure {
+            if let Err(finalize_error) = finalize_async_delegate_spawn_failure_with_recovery(
+                &memory_config,
+                &child_session_id,
+                &parent_session_id,
+                label,
+                error.clone(),
+            ) {
+                eprintln!(
+                    "error: async delegate spawn failure persistence failed for `{child_session_id}`: {finalize_error}; original spawn error: {error}"
+                );
+            }
+        }
+    });
+}
+
+pub struct NoopAppToolDispatcher;
+
+#[async_trait]
+impl AppToolDispatcher for NoopAppToolDispatcher {
+    async fn execute_app_tool(
+        &self,
+        _session_context: &SessionContext,
+        request: ToolCoreRequest,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ToolCoreOutcome, String> {
+        Err(format!("app_tool_not_implemented: {}", request.tool_name))
+    }
+}
+
+#[derive(Clone)]
+pub struct DefaultAppToolDispatcher {
+    memory_config: MemoryRuntimeConfig,
+    tool_config: ToolConfig,
+    async_delegate_spawner: Option<Arc<dyn AsyncDelegateSpawner>>,
+}
+
+impl DefaultAppToolDispatcher {
+    pub fn new(memory_config: MemoryRuntimeConfig, tool_config: ToolConfig) -> Self {
+        Self {
+            memory_config,
+            tool_config,
+            async_delegate_spawner: None,
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    pub fn production(memory_config: MemoryRuntimeConfig, tool_config: ToolConfig) -> Self {
+        let async_delegate_spawner = SubprocessAsyncDelegateSpawner::from_current_process()
+            .ok()
+            .map(|spawner| Arc::new(spawner) as Arc<dyn AsyncDelegateSpawner>);
+        Self {
+            memory_config,
+            tool_config,
+            async_delegate_spawner,
+        }
+    }
+
+    pub fn with_async_delegate_spawner(
+        memory_config: MemoryRuntimeConfig,
+        tool_config: ToolConfig,
+        async_delegate_spawner: Arc<dyn AsyncDelegateSpawner>,
+    ) -> Self {
+        Self {
+            memory_config,
+            tool_config,
+            async_delegate_spawner: Some(async_delegate_spawner),
+        }
+    }
+
+    pub fn runtime() -> Self {
+        #[cfg(feature = "memory-sqlite")]
+        {
+            return Self::production(
+                crate::memory::runtime_config::get_memory_runtime_config().clone(),
+                ToolConfig::default(),
+            );
+        }
+        #[cfg(not(feature = "memory-sqlite"))]
+        Self::new(
+            crate::memory::runtime_config::get_memory_runtime_config().clone(),
+            ToolConfig::default(),
+        )
+    }
+
+    fn effective_tool_config_for_session(&self, session_context: &SessionContext) -> ToolConfig {
+        let mut tool_config = self.tool_config.clone();
+        if session_context.parent_session_id.is_some() {
+            tool_config.sessions.visibility = SessionVisibility::SelfOnly;
+        }
+        tool_config
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn effective_tool_view_for_session(
+        &self,
+        session_context: &SessionContext,
+    ) -> Result<ToolView, String> {
+        let repo = crate::session::repository::SessionRepository::new(&self.memory_config)?;
+        if let Some(session) = repo.load_session(&session_context.session_id)? {
+            if session.parent_session_id.is_some() {
+                let depth = repo
+                    .session_lineage_depth(&session_context.session_id)
+                    .map_err(|error| {
+                        format!("compute session lineage depth for dispatcher tool view failed: {error}")
+                    })?;
+                let allow_nested_delegate = depth < self.tool_config.delegate.max_depth;
+                return Ok(delegate_child_tool_view_for_config_with_delegate(
+                    &self.tool_config,
+                    allow_nested_delegate,
+                ));
+            }
+            return Ok(runtime_tool_view_for_config(&self.tool_config));
+        }
+        if repo
+            .load_session_summary_with_legacy_fallback(&session_context.session_id)?
+            .is_some_and(|session| {
+                session.kind == crate::session::repository::SessionKind::DelegateChild
+            })
+        {
+            return Ok(delegate_child_tool_view_for_config(&self.tool_config));
+        }
+        Ok(runtime_tool_view_for_config(&self.tool_config))
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    fn effective_tool_view_for_session(
+        &self,
+        _session_context: &SessionContext,
+    ) -> Result<ToolView, String> {
+        Ok(runtime_tool_view_for_config(&self.tool_config))
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    async fn execute_delegate_async(
+        &self,
+        session_context: &SessionContext,
+        payload: serde_json::Value,
+    ) -> Result<ToolCoreOutcome, String> {
+        if !self.tool_config.delegate.enabled {
+            return Err("app_tool_disabled: delegate is disabled by config".to_owned());
+        }
+
+        let delegate_request = crate::tools::delegate::parse_delegate_request_with_default_timeout(
+            &payload,
+            self.tool_config.delegate.timeout_seconds,
+        )?;
+        let spawner = self
+            .async_delegate_spawner
+            .as_ref()
+            .ok_or_else(|| "delegate_async_not_configured".to_owned())?;
+        let runtime_handle = tokio::runtime::Handle::try_current()
+            .map_err(|error| format!("delegate_async_runtime_unavailable: {error}"))?;
+        let repo = crate::session::repository::SessionRepository::new(&self.memory_config)?;
+        let current_depth = repo.session_lineage_depth(&session_context.session_id)?;
+        let next_child_depth = current_depth.saturating_add(1);
+        if next_child_depth > self.tool_config.delegate.max_depth {
+            return Err(format!(
+                "delegate_depth_exceeded: next child depth {next_child_depth} exceeds configured max_depth {}",
+                self.tool_config.delegate.max_depth
+            ));
+        }
+
+        let child_session_id = crate::tools::delegate::next_delegate_session_id();
+        let child_label = delegate_request.label.clone();
+        repo.create_session_with_event(
+            crate::session::repository::CreateSessionWithEventRequest {
+                session: crate::session::repository::NewSessionRecord {
+                    session_id: child_session_id.clone(),
+                    kind: crate::session::repository::SessionKind::DelegateChild,
+                    parent_session_id: Some(session_context.session_id.clone()),
+                    label: child_label.clone(),
+                    state: crate::session::repository::SessionState::Ready,
+                },
+                event_kind: "delegate_queued".to_owned(),
+                actor_session_id: Some(session_context.session_id.clone()),
+                event_payload_json: json!({
+                    "task": delegate_request.task.clone(),
+                    "label": child_label.clone(),
+                    "timeout_seconds": delegate_request.timeout_seconds,
+                }),
+            },
+        )?;
+
+        let spawn_request = AsyncDelegateSpawnRequest {
+            child_session_id: child_session_id.clone(),
+            parent_session_id: session_context.session_id.clone(),
+            task: delegate_request.task,
+            label: child_label.clone(),
+            timeout_seconds: delegate_request.timeout_seconds,
+        };
+
+        spawn_async_delegate_detached(
+            runtime_handle,
+            self.memory_config.clone(),
+            Arc::clone(spawner),
+            spawn_request,
+        );
+
+        Ok(crate::tools::delegate::delegate_async_queued_outcome(
+            child_session_id,
+            delegate_request.label,
+            delegate_request.timeout_seconds,
+        ))
+    }
+}
+
+impl Default for DefaultAppToolDispatcher {
+    fn default() -> Self {
+        Self::runtime()
+    }
+}
+
+#[async_trait]
+impl AppToolDispatcher for DefaultAppToolDispatcher {
+    async fn execute_app_tool(
+        &self,
+        session_context: &SessionContext,
+        request: ToolCoreRequest,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> Result<ToolCoreOutcome, String> {
+        let canonical_tool_name = crate::tools::canonical_tool_name(request.tool_name.as_str());
+        let effective_tool_view = self.effective_tool_view_for_session(session_context)?;
+        if let Some(descriptor) = tool_catalog().descriptor(canonical_tool_name) {
+            if descriptor.execution_kind == ToolExecutionKind::App
+                && (!session_context.tool_view.contains(descriptor.name)
+                    || !effective_tool_view.contains(descriptor.name))
+            {
+                return Err(format!("tool_not_visible: {}", descriptor.name));
+            }
+        }
+        let effective_tool_config = self.effective_tool_config_for_session(session_context);
+        if canonical_tool_name == "session_wait" {
+            return crate::tools::wait_for_session_with_config(
+                request.payload,
+                &session_context.session_id,
+                &self.memory_config,
+                &effective_tool_config,
+            )
+            .await;
+        }
+        #[cfg(feature = "memory-sqlite")]
+        if canonical_tool_name == "delegate_async" {
+            return self
+                .execute_delegate_async(session_context, request.payload)
+                .await;
+        }
+        crate::tools::execute_app_tool_with_config(
+            request,
+            &session_context.session_id,
+            &self.memory_config,
+            &effective_tool_config,
+        )
+    }
+}
+
 /// Single orchestration boundary for tool-call evaluation and execution.
 ///
 /// `evaluate_turn` performs synchronous validation (no execution).
@@ -65,6 +577,18 @@ impl TurnEngine {
     /// Evaluate a provider turn and produce a deterministic result.
     /// Does NOT execute tools — just validates and gates.
     pub fn evaluate_turn(&self, turn: &ProviderTurn) -> TurnResult {
+        self.evaluate_turn_in_view(turn, &runtime_tool_view())
+    }
+
+    pub fn evaluate_turn_in_view(&self, turn: &ProviderTurn, tool_view: &ToolView) -> TurnResult {
+        self.evaluate_turn_in_context(turn, &session_context_from_turn(turn, tool_view.clone()))
+    }
+
+    pub fn evaluate_turn_in_context(
+        &self,
+        turn: &ProviderTurn,
+        session_context: &SessionContext,
+    ) -> TurnResult {
         // No tool intents → just return the text
         if turn.tool_intents.is_empty() {
             return TurnResult::FinalText(turn.assistant_text.clone());
@@ -76,9 +600,13 @@ impl TurnEngine {
         }
 
         // Check each tool intent
+        let catalog = tool_catalog();
         for intent in &turn.tool_intents {
-            if !crate::tools::is_known_tool_name(&intent.tool_name) {
+            let Some(descriptor) = catalog.resolve(&intent.tool_name) else {
                 return TurnResult::ToolDenied(format!("tool_not_found: {}", intent.tool_name));
+            };
+            if !session_context.tool_view.contains(descriptor.name) {
+                return TurnResult::ToolDenied(format!("tool_not_visible: {}", intent.tool_name));
             }
         }
 
@@ -100,6 +628,32 @@ impl TurnEngine {
         turn: &ProviderTurn,
         kernel_ctx: Option<&KernelContext>,
     ) -> TurnResult {
+        self.execute_turn_in_view(turn, &runtime_tool_view(), kernel_ctx)
+            .await
+    }
+
+    pub async fn execute_turn_in_view(
+        &self,
+        turn: &ProviderTurn,
+        tool_view: &ToolView,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> TurnResult {
+        self.execute_turn_in_context(
+            turn,
+            &session_context_from_turn(turn, tool_view.clone()),
+            &DefaultAppToolDispatcher::runtime(),
+            kernel_ctx,
+        )
+        .await
+    }
+
+    pub async fn execute_turn_in_context<D: AppToolDispatcher + ?Sized>(
+        &self,
+        turn: &ProviderTurn,
+        session_context: &SessionContext,
+        app_dispatcher: &D,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> TurnResult {
         // No tool intents → just return the text
         if turn.tool_intents.is_empty() {
             return TurnResult::FinalText(turn.assistant_text.clone());
@@ -111,46 +665,112 @@ impl TurnEngine {
         }
 
         // Check each tool intent is known
+        let catalog = tool_catalog();
         for intent in &turn.tool_intents {
-            if !crate::tools::is_known_tool_name(&intent.tool_name) {
+            let Some(descriptor) = catalog.resolve(&intent.tool_name) else {
                 return TurnResult::ToolDenied(format!("tool_not_found: {}", intent.tool_name));
+            };
+            if !session_context.tool_view.contains(descriptor.name) {
+                return TurnResult::ToolDenied(format!("tool_not_visible: {}", intent.tool_name));
             }
         }
-
-        // Require kernel context for execution
-        let ctx = match kernel_ctx {
-            Some(ctx) => ctx,
-            None => return TurnResult::ToolDenied("no_kernel_context".to_owned()),
-        };
 
         // Execute each tool intent through the kernel
         let mut outputs = Vec::new();
         for intent in &turn.tool_intents {
+            let descriptor = catalog
+                .resolve(&intent.tool_name)
+                .expect("tool descriptor should remain resolvable after validation");
             let request = ToolCoreRequest {
-                tool_name: intent.tool_name.clone(),
+                tool_name: descriptor.name.to_owned(),
                 payload: intent.args_json.clone(),
             };
-            let caps = BTreeSet::from([Capability::InvokeTool]);
-            match ctx
-                .kernel
-                .execute_tool_core(ctx.pack_id(), &ctx.token, &caps, None, request)
-                .await
-            {
-                Ok(outcome) => {
-                    outputs.push(format!("[{}] {}", outcome.status, outcome.payload));
-                }
-                Err(e) => {
-                    // Classify by error variant, not by Display string
-                    return match &e {
-                        KernelError::Policy(_) | KernelError::PackCapabilityBoundary { .. } => {
-                            TurnResult::ToolDenied(format!("{e}"))
-                        }
-                        _ => TurnResult::ToolError(format!("{e}")),
+            match descriptor.execution_kind {
+                ToolExecutionKind::Core => {
+                    let ctx = match kernel_ctx {
+                        Some(ctx) => ctx,
+                        None => return TurnResult::ToolDenied("no_kernel_context".to_owned()),
                     };
+                    let caps = BTreeSet::from([Capability::InvokeTool]);
+                    match ctx
+                        .kernel
+                        .execute_tool_core(ctx.pack_id(), &ctx.token, &caps, None, request)
+                        .await
+                    {
+                        Ok(outcome) => {
+                            outputs.push(format!("[{}] {}", outcome.status, outcome.payload));
+                        }
+                        Err(e) => {
+                            return match &e {
+                                KernelError::Policy(_)
+                                | KernelError::PackCapabilityBoundary { .. } => {
+                                    TurnResult::ToolDenied(format!("{e}"))
+                                }
+                                _ => TurnResult::ToolError(format!("{e}")),
+                            };
+                        }
+                    }
                 }
+                ToolExecutionKind::App => match app_dispatcher
+                    .execute_app_tool(session_context, request, kernel_ctx)
+                    .await
+                {
+                    Ok(outcome) => {
+                        outputs.push(format!("[{}] {}", outcome.status, outcome.payload));
+                    }
+                    Err(error) => return TurnResult::ToolError(error),
+                },
             }
         }
 
         TurnResult::FinalText(outputs.join("\n"))
     }
+}
+
+#[cfg(all(test, feature = "memory-sqlite"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delegate_async_subprocess_plan_includes_config_path_and_delegate_child_flag() {
+        let request = AsyncDelegateSpawnRequest {
+            child_session_id: "delegate:child-1".to_owned(),
+            parent_session_id: "root-session".to_owned(),
+            task: "child task".to_owned(),
+            label: Some("research".to_owned()),
+            timeout_seconds: 19,
+        };
+
+        let plan = build_async_delegate_subprocess_plan(
+            std::path::Path::new("/tmp/loongclawd"),
+            Some("/tmp/loongclaw.toml"),
+            &request,
+        );
+
+        assert_eq!(plan.program, std::path::PathBuf::from("/tmp/loongclawd"));
+        assert_eq!(
+            plan.args,
+            vec![
+                "run-turn",
+                "--config",
+                "/tmp/loongclaw.toml",
+                "--session",
+                "delegate:child-1",
+                "--input",
+                "child task",
+                "--timeout-seconds",
+                "19",
+                "--delegate-child",
+            ]
+        );
+    }
+}
+
+fn session_context_from_turn(turn: &ProviderTurn, tool_view: ToolView) -> SessionContext {
+    let session_id = turn
+        .tool_intents
+        .first()
+        .map(|intent| intent.session_id.as_str())
+        .unwrap_or("default");
+    SessionContext::root_with_tool_view(session_id, tool_view)
 }

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -28,6 +28,11 @@ use crate::session::repository::{
     CreateSessionWithEventRequest, NewSessionRecord, SessionKind, SessionRepository, SessionState,
     TransitionSessionWithEventIfCurrentRequest,
 };
+#[cfg(feature = "memory-sqlite")]
+use crate::session::{
+    delegate_cancelled_error, parse_delegate_cancelled_reason, DELEGATE_CANCELLED_EVENT_KIND,
+    DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED, DELEGATE_CANCEL_REQUESTED_EVENT_KIND,
+};
 use crate::tools::runtime_tool_view_for_config;
 
 #[derive(Default)]
@@ -142,6 +147,15 @@ impl ConversationTurnLoop {
         );
 
         for round_index in 0..policy.max_rounds {
+            #[cfg(feature = "memory-sqlite")]
+            if session_context.parent_session_id.is_some() {
+                if let Some(cancel_reason) =
+                    load_delegate_child_cancel_request(config, session_context)?
+                {
+                    return Err(delegate_cancelled_error(&cancel_reason));
+                }
+            }
+
             let turn = match runtime.request_turn(config, &messages, tool_view).await {
                 Ok(turn) => turn,
                 Err(error) => {
@@ -582,6 +596,30 @@ fn load_delegate_child_execution_context(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn load_delegate_child_cancel_request(
+    config: &LoongClawConfig,
+    session_context: &SessionContext,
+) -> Result<Option<String>, String> {
+    let repo = SessionRepository::new(&memory_runtime_config_for(config))?;
+    let recent_events = repo.list_recent_events(&session_context.session_id, 1)?;
+    let Some(event) = recent_events.last() else {
+        return Ok(None);
+    };
+    if event.event_kind != DELEGATE_CANCEL_REQUESTED_EVENT_KIND {
+        return Ok(None);
+    }
+    let reason = event
+        .payload_json
+        .get("cancel_reason")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED)
+        .to_owned();
+    Ok(Some(reason))
+}
+
+#[cfg(feature = "memory-sqlite")]
 async fn run_started_delegate_child_turn_with_runtime<R, D>(
     turn_loop: &ConversationTurnLoop,
     config: &LoongClawConfig,
@@ -661,18 +699,35 @@ where
                 error.clone(),
                 duration_ms,
             );
+            let (event_kind, event_payload_json) =
+                if let Some(cancel_reason) = parse_delegate_cancelled_reason(&error) {
+                    (
+                        DELEGATE_CANCELLED_EVENT_KIND.to_owned(),
+                        json!({
+                            "error": error,
+                            "duration_ms": duration_ms,
+                            "cancel_reason": cancel_reason,
+                            "reference": "running",
+                        }),
+                    )
+                } else {
+                    (
+                        "delegate_failed".to_owned(),
+                        json!({
+                            "error": error,
+                            "duration_ms": duration_ms,
+                        }),
+                    )
+                };
             finalize_delegate_child_terminal_with_recovery(
                 &repo,
                 child_session_id,
                 crate::session::repository::FinalizeSessionTerminalRequest {
                     state: SessionState::Failed,
                     last_error: Some(error.clone()),
-                    event_kind: "delegate_failed".to_owned(),
+                    event_kind,
                     actor_session_id: Some(child_execution.parent_session_id.clone()),
-                    event_payload_json: json!({
-                        "error": error,
-                        "duration_ms": duration_ms,
-                    }),
+                    event_payload_json,
                     outcome_status: outcome.status.clone(),
                     outcome_payload_json: outcome.payload.clone(),
                 },

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -462,9 +462,9 @@ fn ensure_session_registered(
 fn default_app_tool_dispatcher(config: &LoongClawConfig) -> DefaultAppToolDispatcher {
     #[cfg(feature = "memory-sqlite")]
     {
-        return DefaultAppToolDispatcher::production(
+        return DefaultAppToolDispatcher::production_with_config(
             memory_runtime_config_for(config),
-            config.tools.clone(),
+            config.clone(),
         );
     }
     #[cfg(not(feature = "memory-sqlite"))]

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -462,10 +462,10 @@ fn ensure_session_registered(
 fn default_app_tool_dispatcher(config: &LoongClawConfig) -> DefaultAppToolDispatcher {
     #[cfg(feature = "memory-sqlite")]
     {
-        return DefaultAppToolDispatcher::production_with_config(
+        DefaultAppToolDispatcher::production_with_config(
             memory_runtime_config_for(config),
             config.clone(),
-        );
+        )
     }
     #[cfg(not(feature = "memory-sqlite"))]
     DefaultAppToolDispatcher::new(memory_runtime_config_for(config), config.tools.clone())

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -1,16 +1,34 @@
+use async_trait::async_trait;
+use futures_util::FutureExt;
+use std::any::Any;
 use std::collections::VecDeque;
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::panic::AssertUnwindSafe;
+use std::time::{Duration, Instant};
 
 use serde_json::{json, Value};
+use tokio::time::timeout;
 
 use crate::CliResult;
 use crate::KernelContext;
 
 use super::super::config::LoongClawConfig;
 use super::persistence::{format_provider_error_reply, persist_error_turns, persist_success_turns};
-use super::runtime::{ConversationRuntime, DefaultConversationRuntime};
-use super::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+use super::runtime::{ConversationRuntime, DefaultConversationRuntime, SessionContext};
+use super::turn_engine::{
+    AppToolDispatcher, DefaultAppToolDispatcher, ProviderTurn, ToolIntent, TurnEngine, TurnResult,
+};
 use super::ProviderErrorMode;
+
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::recovery::{build_terminal_finalize_recovery_payload, RECOVERY_EVENT_KIND};
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{
+    CreateSessionWithEventRequest, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    TransitionSessionWithEventIfCurrentRequest,
+};
+use crate::tools::runtime_tool_view_for_config;
 
 #[derive(Default)]
 pub struct ConversationTurnLoop;
@@ -31,9 +49,32 @@ impl ConversationTurnLoop {
         error_mode: ProviderErrorMode,
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<String> {
+        let session_context = SessionContext::root_with_tool_view(
+            session_id,
+            runtime_tool_view_for_config(&config.tools),
+        );
+        self.handle_turn_in_session(config, &session_context, user_input, error_mode, kernel_ctx)
+            .await
+    }
+
+    pub async fn handle_turn_in_session(
+        &self,
+        config: &LoongClawConfig,
+        session_context: &SessionContext,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<String> {
         let runtime = DefaultConversationRuntime;
-        self.handle_turn_with_runtime(
-            config, session_id, user_input, error_mode, &runtime, kernel_ctx,
+        let app_dispatcher = default_app_tool_dispatcher(config);
+        self.handle_turn_with_runtime_and_context(
+            config,
+            session_context,
+            user_input,
+            error_mode,
+            &runtime,
+            &app_dispatcher,
+            kernel_ctx,
         )
         .await
     }
@@ -47,7 +88,46 @@ impl ConversationTurnLoop {
         runtime: &R,
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<String> {
-        let mut messages = runtime.build_messages(config, session_id, true, kernel_ctx)?;
+        let session_context = runtime.session_context(config, session_id, kernel_ctx)?;
+        let app_dispatcher = default_app_tool_dispatcher(config);
+        self.handle_turn_with_runtime_and_context(
+            config,
+            &session_context,
+            user_input,
+            error_mode,
+            runtime,
+            &app_dispatcher,
+            kernel_ctx,
+        )
+        .await
+    }
+
+    pub async fn handle_turn_with_runtime_and_context<
+        R: ConversationRuntime + ?Sized,
+        D: AppToolDispatcher + ?Sized,
+    >(
+        &self,
+        config: &LoongClawConfig,
+        session_context: &SessionContext,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        runtime: &R,
+        app_dispatcher: &D,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> CliResult<String> {
+        #[cfg(feature = "memory-sqlite")]
+        ensure_session_registered(config, session_context)?;
+
+        let turn_loop_dispatcher = TurnLoopAppToolDispatcher {
+            turn_loop: self,
+            config,
+            runtime,
+            fallback: app_dispatcher,
+        };
+        let session_id = session_context.session_id.as_str();
+        let tool_view = &session_context.tool_view;
+        let mut messages =
+            runtime.build_messages(config, session_id, true, tool_view, kernel_ctx)?;
         messages.push(json!({
             "role": "user",
             "content": user_input,
@@ -62,7 +142,7 @@ impl ConversationTurnLoop {
         );
 
         for round_index in 0..policy.max_rounds {
-            let turn = match runtime.request_turn(config, &messages).await {
+            let turn = match runtime.request_turn(config, &messages, tool_view).await {
                 Ok(turn) => turn,
                 Err(error) => {
                     return match error_mode {
@@ -86,7 +166,7 @@ impl ConversationTurnLoop {
                 had_tool_intents.then(|| tool_name_signature(&turn.tool_intents));
 
             let turn_result = TurnEngine::new(policy.max_tool_steps_per_round)
-                .execute_turn(&turn, kernel_ctx)
+                .execute_turn_in_context(&turn, session_context, &turn_loop_dispatcher, kernel_ctx)
                 .await;
             let loop_supervisor_verdict = if let (Some(signature), Some(name_signature)) = (
                 current_tool_signature.as_deref(),
@@ -301,6 +381,521 @@ impl ConversationTurnLoop {
         persist_success_turns(runtime, session_id, user_input, &reply, kernel_ctx).await?;
         Ok(reply)
     }
+}
+
+struct TurnLoopAppToolDispatcher<'a, R: ?Sized, D: ?Sized> {
+    turn_loop: &'a ConversationTurnLoop,
+    config: &'a LoongClawConfig,
+    runtime: &'a R,
+    fallback: &'a D,
+}
+
+#[async_trait]
+impl<R, D> AppToolDispatcher for TurnLoopAppToolDispatcher<'_, R, D>
+where
+    R: ConversationRuntime + ?Sized,
+    D: AppToolDispatcher + ?Sized,
+{
+    async fn execute_app_tool(
+        &self,
+        session_context: &SessionContext,
+        request: loongclaw_contracts::ToolCoreRequest,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+        match request.tool_name.as_str() {
+            "delegate" => {
+                execute_delegate_tool(
+                    self.turn_loop,
+                    self.config,
+                    self.runtime,
+                    self.fallback,
+                    session_context,
+                    request.payload,
+                    kernel_ctx,
+                )
+                .await
+            }
+            _ => {
+                self.fallback
+                    .execute_app_tool(session_context, request, kernel_ctx)
+                    .await
+            }
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn ensure_session_registered(
+    config: &LoongClawConfig,
+    session_context: &SessionContext,
+) -> CliResult<()> {
+    let repo = SessionRepository::new(&memory_runtime_config_for(config))?;
+    let kind = if session_context.parent_session_id.is_some() {
+        SessionKind::DelegateChild
+    } else {
+        SessionKind::Root
+    };
+    let _ = repo.ensure_session(NewSessionRecord {
+        session_id: session_context.session_id.clone(),
+        kind,
+        parent_session_id: session_context.parent_session_id.clone(),
+        label: None,
+        state: SessionState::Ready,
+    })?;
+    Ok(())
+}
+
+fn default_app_tool_dispatcher(config: &LoongClawConfig) -> DefaultAppToolDispatcher {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        return DefaultAppToolDispatcher::production(
+            memory_runtime_config_for(config),
+            config.tools.clone(),
+        );
+    }
+    #[cfg(not(feature = "memory-sqlite"))]
+    DefaultAppToolDispatcher::new(memory_runtime_config_for(config), config.tools.clone())
+}
+
+fn memory_runtime_config_for(config: &LoongClawConfig) -> MemoryRuntimeConfig {
+    MemoryRuntimeConfig {
+        sqlite_path: Some(config.memory.resolved_sqlite_path()),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub async fn run_delegate_child_turn(
+    turn_loop: &ConversationTurnLoop,
+    config: &LoongClawConfig,
+    child_session_id: &str,
+    user_input: &str,
+    timeout_seconds: u64,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+    let runtime = DefaultConversationRuntime;
+    let app_dispatcher = default_app_tool_dispatcher(config);
+    run_delegate_child_turn_with_runtime(
+        turn_loop,
+        config,
+        &runtime,
+        &app_dispatcher,
+        child_session_id,
+        user_input,
+        timeout_seconds,
+        kernel_ctx,
+    )
+    .await
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub async fn run_delegate_child_turn_with_runtime<R, D>(
+    turn_loop: &ConversationTurnLoop,
+    config: &LoongClawConfig,
+    runtime: &R,
+    fallback: &D,
+    child_session_id: &str,
+    user_input: &str,
+    timeout_seconds: u64,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String>
+where
+    R: ConversationRuntime + ?Sized,
+    D: AppToolDispatcher + ?Sized,
+{
+    let repo = SessionRepository::new(&memory_runtime_config_for(config))?;
+    let child_execution = load_delegate_child_execution_context(&repo, config, child_session_id)?;
+
+    if repo
+        .transition_session_with_event_if_current(
+            child_session_id,
+            TransitionSessionWithEventIfCurrentRequest {
+                expected_state: SessionState::Ready,
+                next_state: SessionState::Running,
+                last_error: None,
+                event_kind: "delegate_started".to_owned(),
+                actor_session_id: Some(child_execution.parent_session_id.clone()),
+                event_payload_json: json!({
+                    "task": user_input,
+                    "label": child_execution.child_label.clone(),
+                    "timeout_seconds": timeout_seconds,
+                }),
+            },
+        )?
+        .is_none()
+    {
+        let latest_child_session = repo
+            .load_session(child_session_id)?
+            .ok_or_else(|| format!("delegate child session `{child_session_id}` not found"))?;
+        return Err(format!(
+            "delegate child session `{child_session_id}` is not runnable from state `{}`",
+            latest_child_session.state.as_str()
+        ));
+    }
+
+    run_started_delegate_child_turn_with_runtime(
+        turn_loop,
+        config,
+        runtime,
+        fallback,
+        child_session_id,
+        user_input,
+        timeout_seconds,
+        kernel_ctx,
+        child_execution,
+    )
+    .await
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct DelegateChildExecutionContext {
+    parent_session_id: String,
+    child_label: Option<String>,
+    child_can_delegate: bool,
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_delegate_child_execution_context(
+    repo: &SessionRepository,
+    config: &LoongClawConfig,
+    child_session_id: &str,
+) -> Result<DelegateChildExecutionContext, String> {
+    let child_session = repo
+        .load_session(child_session_id)?
+        .ok_or_else(|| format!("delegate child session `{child_session_id}` not found"))?;
+    if child_session.kind != SessionKind::DelegateChild {
+        return Err(format!(
+            "session `{child_session_id}` is not a delegate child session"
+        ));
+    }
+    let parent_session_id = child_session.parent_session_id.clone().ok_or_else(|| {
+        format!("delegate child session `{child_session_id}` is missing parent_session_id")
+    })?;
+    let child_label = child_session.label.clone();
+    let child_depth = repo.session_lineage_depth(child_session_id)?;
+    let child_can_delegate = child_depth < config.tools.delegate.max_depth;
+
+    Ok(DelegateChildExecutionContext {
+        parent_session_id,
+        child_label,
+        child_can_delegate,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn run_started_delegate_child_turn_with_runtime<R, D>(
+    turn_loop: &ConversationTurnLoop,
+    config: &LoongClawConfig,
+    runtime: &R,
+    fallback: &D,
+    child_session_id: &str,
+    user_input: &str,
+    timeout_seconds: u64,
+    kernel_ctx: Option<&KernelContext>,
+    child_execution: DelegateChildExecutionContext,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String>
+where
+    R: ConversationRuntime + ?Sized,
+    D: AppToolDispatcher + ?Sized,
+{
+    let repo = SessionRepository::new(&memory_runtime_config_for(config))?;
+    let child_context = SessionContext::child(
+        child_session_id.to_owned(),
+        child_execution.parent_session_id.clone(),
+        crate::tools::delegate_child_tool_view_for_config_with_delegate(
+            &config.tools,
+            child_execution.child_can_delegate,
+        ),
+    );
+    let start = Instant::now();
+    let child_result = timeout(Duration::from_secs(timeout_seconds), async {
+        AssertUnwindSafe(turn_loop.handle_turn_with_runtime_and_context(
+            config,
+            &child_context,
+            user_input,
+            ProviderErrorMode::Propagate,
+            runtime,
+            fallback,
+            kernel_ctx,
+        ))
+        .catch_unwind()
+        .await
+    })
+    .await;
+    let duration_ms = start.elapsed().as_millis() as u64;
+
+    match child_result {
+        Ok(Ok(Ok(final_output))) => {
+            let turn_count = repo
+                .load_session_summary(child_session_id)?
+                .map(|session| session.turn_count)
+                .unwrap_or_default();
+            let outcome = crate::tools::delegate::delegate_success_outcome(
+                child_session_id.to_owned(),
+                child_execution.child_label,
+                final_output,
+                turn_count,
+                duration_ms,
+            );
+            finalize_delegate_child_terminal_with_recovery(
+                &repo,
+                child_session_id,
+                crate::session::repository::FinalizeSessionTerminalRequest {
+                    state: SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some(child_execution.parent_session_id.clone()),
+                    event_payload_json: json!({
+                        "turn_count": turn_count,
+                        "duration_ms": duration_ms,
+                    }),
+                    outcome_status: outcome.status.clone(),
+                    outcome_payload_json: outcome.payload.clone(),
+                },
+            )?;
+            Ok(outcome)
+        }
+        Ok(Ok(Err(error))) => {
+            let outcome = crate::tools::delegate::delegate_error_outcome(
+                child_session_id.to_owned(),
+                child_execution.child_label,
+                error.clone(),
+                duration_ms,
+            );
+            finalize_delegate_child_terminal_with_recovery(
+                &repo,
+                child_session_id,
+                crate::session::repository::FinalizeSessionTerminalRequest {
+                    state: SessionState::Failed,
+                    last_error: Some(error.clone()),
+                    event_kind: "delegate_failed".to_owned(),
+                    actor_session_id: Some(child_execution.parent_session_id.clone()),
+                    event_payload_json: json!({
+                        "error": error,
+                        "duration_ms": duration_ms,
+                    }),
+                    outcome_status: outcome.status.clone(),
+                    outcome_payload_json: outcome.payload.clone(),
+                },
+            )?;
+            Ok(outcome)
+        }
+        Ok(Err(panic_payload)) => {
+            let panic_error = format_delegate_child_panic(panic_payload);
+            let outcome = crate::tools::delegate::delegate_error_outcome(
+                child_session_id.to_owned(),
+                child_execution.child_label,
+                panic_error.clone(),
+                duration_ms,
+            );
+            finalize_delegate_child_terminal_with_recovery(
+                &repo,
+                child_session_id,
+                crate::session::repository::FinalizeSessionTerminalRequest {
+                    state: SessionState::Failed,
+                    last_error: Some(panic_error.clone()),
+                    event_kind: "delegate_failed".to_owned(),
+                    actor_session_id: Some(child_execution.parent_session_id.clone()),
+                    event_payload_json: json!({
+                        "error": panic_error,
+                        "duration_ms": duration_ms,
+                    }),
+                    outcome_status: outcome.status.clone(),
+                    outcome_payload_json: outcome.payload.clone(),
+                },
+            )?;
+            Ok(outcome)
+        }
+        Err(_) => {
+            let timeout_error = "delegate_timeout".to_owned();
+            let outcome = crate::tools::delegate::delegate_timeout_outcome(
+                child_session_id.to_owned(),
+                child_execution.child_label,
+                duration_ms,
+            );
+            finalize_delegate_child_terminal_with_recovery(
+                &repo,
+                child_session_id,
+                crate::session::repository::FinalizeSessionTerminalRequest {
+                    state: SessionState::TimedOut,
+                    last_error: Some(timeout_error.clone()),
+                    event_kind: "delegate_timed_out".to_owned(),
+                    actor_session_id: Some(child_execution.parent_session_id.clone()),
+                    event_payload_json: json!({
+                        "error": timeout_error,
+                        "duration_ms": duration_ms,
+                    }),
+                    outcome_status: outcome.status.clone(),
+                    outcome_payload_json: outcome.payload.clone(),
+                },
+            )?;
+            Ok(outcome)
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn finalize_delegate_child_terminal_with_recovery(
+    repo: &SessionRepository,
+    child_session_id: &str,
+    request: crate::session::repository::FinalizeSessionTerminalRequest,
+) -> Result<(), String> {
+    let recovery_request = request.clone();
+    match repo.finalize_session_terminal(child_session_id, request) {
+        Ok(_) => Ok(()),
+        Err(finalize_error) => {
+            let recovery_error = format!("delegate_terminal_finalize_failed: {finalize_error}");
+            match repo.transition_session_with_event_if_current(
+                child_session_id,
+                TransitionSessionWithEventIfCurrentRequest {
+                    expected_state: SessionState::Running,
+                    next_state: SessionState::Failed,
+                    last_error: Some(recovery_error.clone()),
+                    event_kind: RECOVERY_EVENT_KIND.to_owned(),
+                    actor_session_id: recovery_request.actor_session_id.clone(),
+                    event_payload_json: build_terminal_finalize_recovery_payload(
+                        &recovery_request,
+                        &recovery_error,
+                    ),
+                },
+            ) {
+                Ok(Some(_)) => Err(recovery_error),
+                Ok(None) => {
+                    delegate_terminal_recovery_skipped_error(repo, child_session_id, recovery_error)
+                }
+                Err(recovery_event_error) => match repo.update_session_state_if_current(
+                    child_session_id,
+                    SessionState::Running,
+                    SessionState::Failed,
+                    Some(recovery_error.clone()),
+                ) {
+                    Ok(Some(_)) => Err(format!(
+                        "{recovery_error}; delegate_terminal_recovery_event_failed: {recovery_event_error}"
+                    )),
+                    Ok(None) => delegate_terminal_recovery_skipped_error(
+                        repo,
+                        child_session_id,
+                        recovery_error,
+                    ),
+                    Err(mark_error) => Err(format!(
+                        "{recovery_error}; delegate_terminal_recovery_failed: {mark_error}"
+                    )),
+                },
+            }
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn delegate_terminal_recovery_skipped_error(
+    repo: &SessionRepository,
+    child_session_id: &str,
+    recovery_error: String,
+) -> Result<(), String> {
+    let current_state = repo
+        .load_session(child_session_id)?
+        .map(|session| session.state.as_str().to_owned())
+        .unwrap_or_else(|| "missing".to_owned());
+    Err(format!(
+        "{recovery_error}; delegate_terminal_recovery_skipped_from_state: {current_state}"
+    ))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn format_delegate_child_panic(panic_payload: Box<dyn Any + Send>) -> String {
+    let panic_payload = match panic_payload.downcast::<String>() {
+        Ok(message) => return format!("delegate_child_panic: {}", *message),
+        Err(panic_payload) => panic_payload,
+    };
+    match panic_payload.downcast::<&'static str>() {
+        Ok(message) => format!("delegate_child_panic: {}", *message),
+        Err(_) => "delegate_child_panic".to_owned(),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn execute_delegate_tool<R, D>(
+    turn_loop: &ConversationTurnLoop,
+    config: &LoongClawConfig,
+    runtime: &R,
+    fallback: &D,
+    session_context: &SessionContext,
+    payload: Value,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String>
+where
+    R: ConversationRuntime + ?Sized,
+    D: AppToolDispatcher + ?Sized,
+{
+    if !config.tools.delegate.enabled {
+        return Err("app_tool_disabled: delegate is disabled by config".to_owned());
+    }
+
+    let delegate_request = crate::tools::delegate::parse_delegate_request_with_default_timeout(
+        &payload,
+        config.tools.delegate.timeout_seconds,
+    )?;
+    let child_session_id = crate::tools::delegate::next_delegate_session_id();
+    let repo = SessionRepository::new(&memory_runtime_config_for(config))?;
+    let current_depth = repo.session_lineage_depth(&session_context.session_id)?;
+    let next_child_depth = current_depth.saturating_add(1);
+    if next_child_depth > config.tools.delegate.max_depth {
+        return Err(format!(
+            "delegate_depth_exceeded: next child depth {next_child_depth} exceeds configured max_depth {}",
+            config.tools.delegate.max_depth
+        ));
+    }
+    let child_label = delegate_request.label.clone();
+    let child_can_delegate = next_child_depth < config.tools.delegate.max_depth;
+
+    repo.create_session_with_event(CreateSessionWithEventRequest {
+        session: NewSessionRecord {
+            session_id: child_session_id.clone(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some(session_context.session_id.clone()),
+            label: child_label.clone(),
+            state: SessionState::Running,
+        },
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some(session_context.session_id.clone()),
+        event_payload_json: json!({
+            "task": delegate_request.task,
+            "label": child_label.clone(),
+            "timeout_seconds": delegate_request.timeout_seconds,
+        }),
+    })?;
+    run_started_delegate_child_turn_with_runtime(
+        turn_loop,
+        config,
+        runtime,
+        fallback,
+        &child_session_id,
+        &delegate_request.task,
+        delegate_request.timeout_seconds,
+        kernel_ctx,
+        DelegateChildExecutionContext {
+            parent_session_id: session_context.session_id.clone(),
+            child_label,
+            child_can_delegate,
+        },
+    )
+    .await
+}
+
+#[cfg(not(feature = "memory-sqlite"))]
+async fn execute_delegate_tool<R, D>(
+    _turn_loop: &ConversationTurnLoop,
+    _config: &LoongClawConfig,
+    _runtime: &R,
+    _fallback: &D,
+    _session_context: &SessionContext,
+    _payload: Value,
+    _kernel_ctx: Option<&KernelContext>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String>
+where
+    R: ConversationRuntime + ?Sized,
+    D: AppToolDispatcher + ?Sized,
+{
+    Err("delegate requires sqlite memory support (enable feature `memory-sqlite`)".to_owned())
 }
 
 fn append_tool_followup_messages(

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -5,6 +5,8 @@ pub mod context;
 pub mod conversation;
 pub mod memory;
 pub mod provider;
+pub mod runtime_env;
+pub mod session;
 pub mod tools;
 
 pub use context::KernelContext;

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -299,8 +299,13 @@ mod tests {
             .expect("append first match");
         append_turn_direct("session-b", "assistant", "no relevant text here", &config)
             .expect("append unrelated turn");
-        append_turn_direct("session-a", "assistant", "latest timeout budget update", &config)
-            .expect("append latest match");
+        append_turn_direct(
+            "session-a",
+            "assistant",
+            "latest timeout budget update",
+            &config,
+        )
+        .expect("append latest match");
 
         let matches = search_transcript_direct(
             &["session-a".to_owned(), "session-b".to_owned()],
@@ -344,12 +349,16 @@ mod tests {
             sqlite_path: Some(db_path.clone()),
         };
 
-        append_turn_direct("session-a", "user", "archive inventory", &config)
-            .expect("append turn");
+        append_turn_direct("session-a", "user", "archive inventory", &config).expect("append turn");
 
-        let matches =
-            search_transcript_direct(&["session-a".to_owned()], "timeout budget", 20, 120, &config)
-                .expect("search transcript");
+        let matches = search_transcript_direct(
+            &["session-a".to_owned()],
+            "timeout budget",
+            20,
+            120,
+            &config,
+        )
+        .expect("search transcript");
 
         assert!(matches.is_empty(), "non-matching turns should be excluded");
 

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -11,7 +11,7 @@ mod sqlite;
 
 pub use kernel_adapter::MvpMemoryAdapter;
 #[cfg(feature = "memory-sqlite")]
-pub use sqlite::ConversationTurn;
+pub use sqlite::{ConversationTurn, TranscriptSearchMatch};
 
 pub fn execute_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
     execute_memory_core_with_config(request, runtime_config::get_memory_runtime_config())
@@ -115,6 +115,17 @@ pub fn ensure_memory_db_ready(
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<PathBuf, String> {
     sqlite::ensure_memory_db_ready(path, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn search_transcript_direct(
+    session_ids: &[String],
+    query: &str,
+    limit: usize,
+    excerpt_chars: usize,
+    config: &runtime_config::MemoryRuntimeConfig,
+) -> Result<Vec<TranscriptSearchMatch>, String> {
+    sqlite::search_transcript_direct(session_ids, query, limit, excerpt_chars, config)
 }
 
 #[cfg(test)]
@@ -262,6 +273,130 @@ mod tests {
         assert_eq!(turns.len(), 1);
         assert_eq!(turns[0].role, "user");
         assert_eq!(turns[0].content, "hello from transcript");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn search_transcript_direct_returns_recent_matching_turns() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-test-memory-search-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&tmp);
+        let db_path = tmp.join("search.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+        };
+
+        append_turn_direct("session-a", "user", "first timeout budget note", &config)
+            .expect("append first match");
+        append_turn_direct("session-b", "assistant", "no relevant text here", &config)
+            .expect("append unrelated turn");
+        append_turn_direct("session-a", "assistant", "latest timeout budget update", &config)
+            .expect("append latest match");
+
+        let matches = search_transcript_direct(
+            &["session-a".to_owned(), "session-b".to_owned()],
+            "timeout budget",
+            20,
+            120,
+            &config,
+        )
+        .expect("search transcript");
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].session_id, "session-a");
+        assert_eq!(matches[0].role, "assistant");
+        assert!(
+            matches[0].content_snippet.contains("timeout budget"),
+            "snippet should contain query"
+        );
+        assert!(
+            matches[0].turn_id > matches[1].turn_id,
+            "results should be newest first"
+        );
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn search_transcript_direct_excludes_non_matching_turns() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-test-memory-search-miss-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&tmp);
+        let db_path = tmp.join("search-miss.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+        };
+
+        append_turn_direct("session-a", "user", "archive inventory", &config)
+            .expect("append turn");
+
+        let matches =
+            search_transcript_direct(&["session-a".to_owned()], "timeout budget", 20, 120, &config)
+                .expect("search transcript");
+
+        assert!(matches.is_empty(), "non-matching turns should be excluded");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn search_transcript_direct_clamps_limit_and_excerpt() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-test-memory-search-clamp-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&tmp);
+        let db_path = tmp.join("search-clamp.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+        };
+        let long_prefix = "prefix ".repeat(20);
+        let long_suffix = " suffix".repeat(20);
+        let long_match = format!("{long_prefix}timeout budget{long_suffix}");
+
+        append_turn_direct("session-a", "user", "timeout budget alpha", &config)
+            .expect("append alpha");
+        append_turn_direct("session-a", "assistant", "timeout budget beta", &config)
+            .expect("append beta");
+        append_turn_direct("session-a", "assistant", &long_match, &config)
+            .expect("append long match");
+
+        let matches =
+            search_transcript_direct(&["session-a".to_owned()], "timeout budget", 0, 12, &config)
+                .expect("search transcript");
+
+        assert_eq!(matches.len(), 1, "limit should clamp to at least one");
+        assert!(
+            matches[0].content_snippet.len() <= 406,
+            "excerpt should clamp instead of returning the full long content"
+        );
+        assert!(
+            matches[0].content_snippet.contains("timeout budget"),
+            "snippet should preserve the matching phrase"
+        );
 
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir(&tmp);

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -216,4 +216,54 @@ mod tests {
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir(&tmp);
     }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn transcript_window_excludes_session_events() {
+        use std::fs;
+
+        use crate::session::repository::{
+            NewSessionEvent, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+        };
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-test-memory-session-events-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&tmp);
+        let db_path = tmp.join("session-events.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+        };
+
+        let repo = SessionRepository::new(&config).expect("session repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "session-a".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Session A".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create session");
+        repo.append_event(NewSessionEvent {
+            session_id: "session-a".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: None,
+            payload_json: json!({"note": "control-plane event"}),
+        })
+        .expect("append session event");
+
+        append_turn_direct("session-a", "user", "hello from transcript", &config)
+            .expect("append transcript turn");
+
+        let turns = window_direct("session-a", 10, &config).expect("window turns");
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].role, "user");
+        assert_eq!(turns[0].content, "hello from transcript");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir(&tmp);
+    }
 }

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -255,7 +255,9 @@ pub(super) fn search_transcript_direct(
     );
 
     let mut params = Vec::with_capacity(session_ids.len() + 2);
-    params.push(rusqlite::types::Value::from(format!("%{normalized_query}%")));
+    params.push(rusqlite::types::Value::from(format!(
+        "%{normalized_query}%"
+    )));
     params.extend(
         session_ids
             .iter()
@@ -285,8 +287,7 @@ pub(super) fn search_transcript_direct(
 
     let mut matches = Vec::new();
     for row in rows {
-        matches
-            .push(row.map_err(|error| format!("decode transcript search row failed: {error}"))?);
+        matches.push(row.map_err(|error| format!("decode transcript search row failed: {error}"))?);
     }
     Ok(matches)
 }

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -17,6 +17,15 @@ pub struct ConversationTurn {
     pub ts: i64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranscriptSearchMatch {
+    pub turn_id: i64,
+    pub session_id: String,
+    pub role: String,
+    pub content_snippet: String,
+    pub ts: i64,
+}
+
 pub(super) fn append_turn(
     request: MemoryCoreRequest,
     config: &MemoryRuntimeConfig,
@@ -206,6 +215,82 @@ pub(super) fn window_direct(
         .map_err(|error| format!("decode memory turns failed: {error}"))
 }
 
+pub(super) fn search_transcript_direct(
+    session_ids: &[String],
+    query: &str,
+    limit: usize,
+    excerpt_chars: usize,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<TranscriptSearchMatch>, String> {
+    if session_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let normalized_query = query.trim();
+    if normalized_query.is_empty() {
+        return Err("memory.search_transcript requires a non-empty query".to_owned());
+    }
+
+    let search_limit = clamp_search_limit(limit);
+    let excerpt_limit = clamp_excerpt_chars(excerpt_chars);
+    let path = resolve_db_path(config);
+    ensure_sqlite_schema(&path)?;
+    let conn = rusqlite::Connection::open(&path)
+        .map_err(|error| format!("open sqlite memory db failed: {error}"))?;
+
+    let mut session_placeholders = Vec::with_capacity(session_ids.len());
+    for offset in 0..session_ids.len() {
+        session_placeholders.push(format!("?{}", offset + 2));
+    }
+    let limit_placeholder = session_ids.len() + 2;
+    let sql = format!(
+        "SELECT id, session_id, role, content, ts
+         FROM turns
+         WHERE content LIKE ?1
+           AND session_id IN ({})
+         ORDER BY ts DESC, id DESC
+         LIMIT ?{}",
+        session_placeholders.join(", "),
+        limit_placeholder
+    );
+
+    let mut params = Vec::with_capacity(session_ids.len() + 2);
+    params.push(rusqlite::types::Value::from(format!("%{normalized_query}%")));
+    params.extend(
+        session_ids
+            .iter()
+            .cloned()
+            .map(rusqlite::types::Value::from),
+    );
+    params.push(rusqlite::types::Value::from(search_limit as i64));
+
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|error| format!("prepare transcript search query failed: {error}"))?;
+    let rows = stmt
+        .query_map(
+            rusqlite::params_from_iter(params),
+            |row| -> rusqlite::Result<TranscriptSearchMatch> {
+                let content: String = row.get(3)?;
+                Ok(TranscriptSearchMatch {
+                    turn_id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    role: row.get(2)?,
+                    content_snippet: build_excerpt(&content, normalized_query, excerpt_limit),
+                    ts: row.get(4)?,
+                })
+            },
+        )
+        .map_err(|error| format!("query transcript search failed: {error}"))?;
+
+    let mut matches = Vec::new();
+    for row in rows {
+        matches
+            .push(row.map_err(|error| format!("decode transcript search row failed: {error}"))?);
+    }
+    Ok(matches)
+}
+
 pub(super) fn ensure_memory_db_ready(
     path: Option<PathBuf>,
     config: &MemoryRuntimeConfig,
@@ -225,6 +310,47 @@ fn default_window_size() -> usize {
 
 fn default_window_size_u64() -> u64 {
     default_window_size() as u64
+}
+
+fn clamp_search_limit(limit: usize) -> usize {
+    limit.clamp(1, 100)
+}
+
+fn clamp_excerpt_chars(excerpt_chars: usize) -> usize {
+    excerpt_chars.clamp(40, 400)
+}
+
+fn build_excerpt(content: &str, query: &str, excerpt_chars: usize) -> String {
+    if content.chars().count() <= excerpt_chars {
+        return content.to_owned();
+    }
+
+    let content_lower = content.to_lowercase();
+    let query_lower = query.to_lowercase();
+    let match_start = content_lower.find(&query_lower).unwrap_or(0);
+    let match_end = match_start.saturating_add(query_lower.len());
+
+    let mut start = match_start.saturating_sub(excerpt_chars / 2);
+    let mut end = start.saturating_add(excerpt_chars).min(content.len());
+    if end < match_end {
+        end = match_end.min(content.len());
+        start = end.saturating_sub(excerpt_chars);
+    }
+    while start > 0 && !content.is_char_boundary(start) {
+        start -= 1;
+    }
+    while end < content.len() && !content.is_char_boundary(end) {
+        end += 1;
+    }
+
+    let mut snippet = content[start..end].to_owned();
+    if start > 0 {
+        snippet.insert_str(0, "...");
+    }
+    if end < content.len() {
+        snippet.push_str("...");
+    }
+    snippet
 }
 
 fn unix_ts_now() -> i64 {

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -261,6 +261,34 @@ fn ensure_sqlite_schema(path: &PathBuf) -> Result<(), String> {
           ts INTEGER NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_turns_session_id ON turns(session_id, id);
+        CREATE TABLE IF NOT EXISTS sessions(
+          session_id TEXT PRIMARY KEY,
+          kind TEXT NOT NULL,
+          parent_session_id TEXT NULL,
+          label TEXT NULL,
+          state TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          last_error TEXT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id
+          ON sessions(parent_session_id, updated_at, session_id);
+        CREATE TABLE IF NOT EXISTS session_events(
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          session_id TEXT NOT NULL,
+          event_kind TEXT NOT NULL,
+          actor_session_id TEXT NULL,
+          payload_json TEXT NOT NULL,
+          ts INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_session_events_session_id
+          ON session_events(session_id, id);
+        CREATE TABLE IF NOT EXISTS session_terminal_outcomes(
+          session_id TEXT PRIMARY KEY,
+          status TEXT NOT NULL,
+          payload_json TEXT NOT NULL,
+          recorded_at INTEGER NOT NULL
+        );
         ",
     )
     .map_err(|error| format!("initialize sqlite memory schema failed: {error}"))?;

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -1138,6 +1138,7 @@ mod tests {
             expected.push("file_read");
             expected.push("file_write");
         }
+        expected.push("memory_search");
         expected.push("session_archive");
         expected.push("session_cancel");
         expected.push("session_events");
@@ -1264,6 +1265,37 @@ mod tests {
             .collect();
 
         assert!(names.contains(&"session_archive"));
+    }
+
+    #[test]
+    fn memory_search_appears_in_root_turn_request_body() {
+        let config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        let tool_definitions = crate::tools::provider_tool_definitions();
+        let body = build_turn_request_body(
+            &config,
+            &[],
+            "model-latest",
+            CompletionPayloadMode::default_for(&config.provider),
+            true,
+            &tool_definitions,
+        );
+        let tools = body["tools"].as_array().expect("tools array");
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+
+        assert!(names.contains(&"memory_search"));
     }
 
     #[test]

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -1139,6 +1139,7 @@ mod tests {
             expected.push("file_write");
         }
         expected.push("session_events");
+        expected.push("session_recover");
         expected.push("session_status");
         expected.push("session_wait");
         expected.push("sessions_history");
@@ -1189,6 +1190,7 @@ mod tests {
         assert!(names.contains(&"file_read"));
         assert!(names.contains(&"file_write"));
         assert!(!names.contains(&"session_events"));
+        assert!(!names.contains(&"session_recover"));
         assert!(names.contains(&"session_status"));
         assert!(names.contains(&"sessions_history"));
         assert!(!names.contains(&"session_wait"));

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -1138,6 +1138,7 @@ mod tests {
             expected.push("file_read");
             expected.push("file_write");
         }
+        expected.push("session_cancel");
         expected.push("session_events");
         expected.push("session_recover");
         expected.push("session_status");
@@ -1190,6 +1191,7 @@ mod tests {
         assert!(names.contains(&"file_read"));
         assert!(names.contains(&"file_write"));
         assert!(!names.contains(&"session_events"));
+        assert!(!names.contains(&"session_cancel"));
         assert!(!names.contains(&"session_recover"));
         assert!(names.contains(&"session_status"));
         assert!(names.contains(&"sessions_history"));
@@ -1198,6 +1200,37 @@ mod tests {
         assert!(!names.contains(&"delegate"));
         assert!(!names.contains(&"delegate_async"));
         assert!(!names.contains(&"sessions_list"));
+    }
+
+    #[test]
+    fn session_cancel_appears_in_root_turn_request_body() {
+        let config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        let tool_definitions = crate::tools::provider_tool_definitions();
+        let body = build_turn_request_body(
+            &config,
+            &[],
+            "model-latest",
+            CompletionPayloadMode::default_for(&config.provider),
+            true,
+            &tool_definitions,
+        );
+        let tools = body["tools"].as_array().expect("tools array");
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+
+        assert!(names.contains(&"session_cancel"));
     }
 
     #[test]

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -1143,6 +1143,7 @@ mod tests {
         expected.push("session_events");
         expected.push("session_recover");
         expected.push("session_status");
+        expected.push("session_unarchive");
         expected.push("session_wait");
         expected.push("sessions_history");
         expected.push("sessions_list");
@@ -1263,6 +1264,37 @@ mod tests {
             .collect();
 
         assert!(names.contains(&"session_archive"));
+    }
+
+    #[test]
+    fn session_unarchive_appears_in_root_turn_request_body() {
+        let config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        let tool_definitions = crate::tools::provider_tool_definitions();
+        let body = build_turn_request_body(
+            &config,
+            &[],
+            "model-latest",
+            CompletionPayloadMode::default_for(&config.provider),
+            true,
+            &tool_definitions,
+        );
+        let tools = body["tools"].as_array().expect("tools array");
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+
+        assert!(names.contains(&"session_unarchive"));
     }
 
     #[test]

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -1138,6 +1138,7 @@ mod tests {
             expected.push("file_read");
             expected.push("file_write");
         }
+        expected.push("session_archive");
         expected.push("session_cancel");
         expected.push("session_events");
         expected.push("session_recover");
@@ -1231,6 +1232,37 @@ mod tests {
             .collect();
 
         assert!(names.contains(&"session_cancel"));
+    }
+
+    #[test]
+    fn session_archive_appears_in_root_turn_request_body() {
+        let config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        let tool_definitions = crate::tools::provider_tool_definitions();
+        let body = build_turn_request_body(
+            &config,
+            &[],
+            "model-latest",
+            CompletionPayloadMode::default_for(&config.provider),
+            true,
+            &tool_definitions,
+        );
+        let tools = body["tools"].as_array().expect("tools array");
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+
+        assert!(names.contains(&"session_archive"));
     }
 
     #[test]

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use serde_json::{json, Value};
 use tokio::time::sleep;
 
+use crate::tools::ToolView;
 use crate::CliResult;
 
 use super::config::{LoongClawConfig, ProviderConfig, ProviderKind, ReasoningEffort};
@@ -19,11 +20,12 @@ pub fn build_messages_for_session(
     config: &LoongClawConfig,
     session_id: &str,
     include_system_prompt: bool,
+    tool_view: &ToolView,
 ) -> CliResult<Vec<Value>> {
     let mut messages = Vec::new();
     if include_system_prompt {
         let system = config.cli.system_prompt.trim();
-        let snapshot = super::tools::capability_snapshot();
+        let snapshot = super::tools::capability_snapshot_for_view(tool_view);
         let content = if system.is_empty() {
             snapshot
         } else {
@@ -98,6 +100,7 @@ pub async fn request_completion(config: &LoongClawConfig, messages: &[Value]) ->
 pub async fn request_turn(
     config: &LoongClawConfig,
     messages: &[Value],
+    tool_view: &ToolView,
 ) -> CliResult<crate::conversation::turn_engine::ProviderTurn> {
     validate_provider_configuration(config)?;
     validate_provider_feature_gate(config)?;
@@ -114,6 +117,7 @@ pub async fn request_turn(
         match request_turn_with_model(
             config,
             messages,
+            tool_view,
             model,
             auto_model_mode,
             &endpoint,
@@ -681,6 +685,7 @@ async fn request_completion_with_model(
 async fn request_turn_with_model(
     config: &LoongClawConfig,
     messages: &[Value],
+    tool_view: &ToolView,
     model: &str,
     auto_model_mode: bool,
     endpoint: &str,
@@ -692,7 +697,11 @@ async fn request_turn_with_model(
     let mut backoff_ms = request_policy.initial_backoff_ms;
     let mut payload_mode = CompletionPayloadMode::default_for(&config.provider);
     let mut tried_payload_modes = vec![payload_mode];
-    let tool_definitions = super::tools::provider_tool_definitions();
+    let tool_definitions = super::tools::try_provider_tool_definitions_for_view(tool_view)
+        .map_err(|message| ModelRequestError {
+            message,
+            try_next_model: false,
+        })?;
     let mut include_tool_schema = !tool_definitions.is_empty();
 
     loop {
@@ -895,8 +904,13 @@ mod tests {
             conversation: crate::config::ConversationConfig::default(),
         };
 
-        let messages =
-            build_messages_for_session(&config, "noop-session", true).expect("build messages");
+        let messages = build_messages_for_session(
+            &config,
+            "noop-session",
+            true,
+            &crate::tools::runtime_tool_view(),
+        )
+        .expect("build messages");
         assert!(!messages.is_empty());
         assert_eq!(messages[0]["role"], "system");
     }
@@ -913,8 +927,13 @@ mod tests {
             conversation: crate::config::ConversationConfig::default(),
         };
 
-        let messages =
-            build_messages_for_session(&config, "noop-session", true).expect("build messages");
+        let messages = build_messages_for_session(
+            &config,
+            "noop-session",
+            true,
+            &crate::tools::runtime_tool_view(),
+        )
+        .expect("build messages");
         assert!(!messages.is_empty());
         let system_content = messages[0]["content"].as_str().expect("system content");
         assert!(
@@ -933,6 +952,29 @@ mod tests {
             system_content.contains("- file.write: Write file contents"),
             "system prompt should list file.write tool"
         );
+    }
+
+    #[test]
+    fn build_messages_respect_restricted_tool_view() {
+        let config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        let view = crate::tools::ToolView::from_tool_names(["file.read"]);
+
+        let messages = build_messages_for_session(&config, "noop-session", true, &view)
+            .expect("build messages");
+        assert!(!messages.is_empty());
+        let system_content = messages[0]["content"].as_str().expect("system content");
+        assert!(system_content.contains("[available_tools]"));
+        assert!(system_content.contains("- file.read: Read file contents"));
+        assert!(!system_content.contains("- file.write: Write file contents"));
+        assert!(!system_content.contains("- shell.exec: Execute shell commands"));
     }
 
     #[test]
@@ -1089,11 +1131,18 @@ mod tests {
             .collect();
 
         let mut expected = Vec::new();
+        expected.push("delegate");
+        expected.push("delegate_async");
         #[cfg(feature = "tool-file")]
         {
             expected.push("file_read");
             expected.push("file_write");
         }
+        expected.push("session_events");
+        expected.push("session_status");
+        expected.push("session_wait");
+        expected.push("sessions_history");
+        expected.push("sessions_list");
         #[cfg(feature = "tool-shell")]
         {
             expected.push("shell_exec");
@@ -1101,6 +1150,82 @@ mod tests {
 
         assert_eq!(names, expected);
         assert_eq!(body["tool_choice"], "auto");
+    }
+
+    #[test]
+    fn build_turn_request_body_respects_restricted_tool_view() {
+        let config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        let view = crate::tools::planned_delegate_child_tool_view();
+        let tool_definitions =
+            crate::tools::try_provider_tool_definitions_for_view(&view).expect("tool defs");
+
+        let body = build_turn_request_body(
+            &config,
+            &[],
+            "model-latest",
+            CompletionPayloadMode::default_for(&config.provider),
+            true,
+            &tool_definitions,
+        );
+        let tools = body
+            .get("tools")
+            .and_then(|value| value.as_array())
+            .expect("tools array in turn body");
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+
+        assert!(names.contains(&"file_read"));
+        assert!(names.contains(&"file_write"));
+        assert!(!names.contains(&"session_events"));
+        assert!(names.contains(&"session_status"));
+        assert!(names.contains(&"sessions_history"));
+        assert!(!names.contains(&"session_wait"));
+        assert!(!names.contains(&"shell_exec"));
+        assert!(!names.contains(&"delegate"));
+        assert!(!names.contains(&"delegate_async"));
+        assert!(!names.contains(&"sessions_list"));
+    }
+
+    #[test]
+    fn delegate_async_appears_in_root_turn_request_body() {
+        let config = LoongClawConfig {
+            provider: ProviderConfig::default(),
+            cli: crate::config::CliChannelConfig::default(),
+            telegram: crate::config::TelegramChannelConfig::default(),
+            feishu: FeishuChannelConfig::default(),
+            tools: ToolConfig::default(),
+            memory: MemoryConfig::default(),
+            conversation: crate::config::ConversationConfig::default(),
+        };
+        let tool_definitions = crate::tools::provider_tool_definitions();
+        let body = build_turn_request_body(
+            &config,
+            &[],
+            "model-latest",
+            CompletionPayloadMode::default_for(&config.provider),
+            true,
+            &tool_definitions,
+        );
+        let tools = body["tools"].as_array().expect("tools array");
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(names.contains(&"delegate_async"));
     }
 
     #[test]

--- a/crates/app/src/runtime_env.rs
+++ b/crates/app/src/runtime_env.rs
@@ -1,0 +1,69 @@
+use std::path::Path;
+
+use crate::config::LoongClawConfig;
+
+pub fn initialize_runtime_environment(
+    config: &LoongClawConfig,
+    resolved_config_path: Option<&Path>,
+) {
+    if let Some(path) = resolved_config_path {
+        std::env::set_var("LOONGCLAW_CONFIG_PATH", path.display().to_string());
+    }
+    std::env::set_var(
+        "LOONGCLAW_SQLITE_PATH",
+        config.memory.resolved_sqlite_path().display().to_string(),
+    );
+    std::env::set_var(
+        "LOONGCLAW_SLIDING_WINDOW",
+        config.memory.sliding_window.to_string(),
+    );
+    std::env::set_var(
+        "LOONGCLAW_SHELL_ALLOWLIST",
+        config.tools.shell_allowlist.join(","),
+    );
+    std::env::set_var(
+        "LOONGCLAW_FILE_ROOT",
+        config.tools.resolved_file_root().display().to_string(),
+    );
+
+    let tool_rt = crate::tools::runtime_config::ToolRuntimeConfig {
+        shell_allowlist: config
+            .tools
+            .shell_allowlist
+            .iter()
+            .map(|s| s.to_ascii_lowercase())
+            .collect(),
+        file_root: Some(config.tools.resolved_file_root()),
+    };
+    let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);
+
+    let memory_rt = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(config.memory.resolved_sqlite_path()),
+    };
+    let _ = crate::memory::runtime_config::init_memory_runtime_config(memory_rt);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_path_env_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    #[test]
+    fn initialize_runtime_environment_exports_config_path() {
+        let _guard = config_path_env_lock().lock().expect("env lock");
+        std::env::remove_var("LOONGCLAW_CONFIG_PATH");
+
+        let config = LoongClawConfig::default();
+        let config_path = std::env::temp_dir().join("loongclaw-runtime-env-config.toml");
+        initialize_runtime_environment(&config, Some(&config_path));
+        let exported = std::env::var("LOONGCLAW_CONFIG_PATH").expect("config path env");
+
+        assert_eq!(exported, config_path.display().to_string());
+
+        std::env::remove_var("LOONGCLAW_CONFIG_PATH");
+    }
+}

--- a/crates/app/src/session/mod.rs
+++ b/crates/app/src/session/mod.rs
@@ -106,4 +106,24 @@ mod recovery_tests {
         assert!(recovery.event_kind.is_empty());
         assert_eq!(recovery.recovery_error, None);
     }
+
+    #[test]
+    fn observe_missing_recovery_infers_running_async_overdue_from_last_error() {
+        let recovery = observe_missing_recovery(
+            &[],
+            Some(
+                "delegate_async_running_overdue_marked_failed: running delegate child exceeded timeout after 91s (threshold 30s)",
+            ),
+        );
+
+        assert_eq!(recovery.source, "last_error");
+        assert_eq!(recovery.kind, "running_async_overdue_marked_failed");
+        assert!(recovery.event_kind.is_empty());
+        assert_eq!(
+            recovery.recovery_error.as_deref(),
+            Some(
+                "delegate_async_running_overdue_marked_failed: running delegate child exceeded timeout after 91s (threshold 30s)",
+            )
+        );
+    }
 }

--- a/crates/app/src/session/mod.rs
+++ b/crates/app/src/session/mod.rs
@@ -4,6 +4,26 @@ pub mod recovery;
 #[cfg(feature = "memory-sqlite")]
 pub mod repository;
 
+pub(crate) const DELEGATE_CANCEL_REQUESTED_EVENT_KIND: &str = "delegate_cancel_requested";
+pub(crate) const DELEGATE_CANCELLED_EVENT_KIND: &str = "delegate_cancelled";
+pub(crate) const DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED: &str = "operator_requested";
+pub(crate) const DELEGATE_CANCELLED_ERROR_PREFIX: &str = "delegate_cancelled:";
+
+pub(crate) fn delegate_cancelled_error(reason: &str) -> String {
+    format!(
+        "{DELEGATE_CANCELLED_ERROR_PREFIX} {}",
+        reason.trim().trim_matches(':')
+    )
+}
+
+pub(crate) fn parse_delegate_cancelled_reason(error: &str) -> Option<String> {
+    error
+        .strip_prefix(DELEGATE_CANCELLED_ERROR_PREFIX)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 #[cfg(all(test, feature = "memory-sqlite"))]
 mod recovery_tests {
     use serde_json::json;

--- a/crates/app/src/session/mod.rs
+++ b/crates/app/src/session/mod.rs
@@ -1,0 +1,89 @@
+#[cfg(feature = "memory-sqlite")]
+pub mod recovery;
+
+#[cfg(feature = "memory-sqlite")]
+pub mod repository;
+
+#[cfg(all(test, feature = "memory-sqlite"))]
+mod recovery_tests {
+    use serde_json::json;
+
+    use crate::session::repository::{
+        FinalizeSessionTerminalRequest, SessionEventRecord, SessionState,
+    };
+
+    use super::recovery::{
+        build_async_spawn_failure_recovery_payload, build_terminal_finalize_recovery_payload,
+        observe_missing_recovery, RECOVERY_EVENT_KIND,
+        RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED,
+        RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED, RECOVERY_KIND_UNKNOWN,
+        RECOVERY_SOURCE_EVENT, RECOVERY_SOURCE_NONE,
+    };
+
+    #[test]
+    fn build_terminal_finalize_recovery_payload_uses_shared_schema() {
+        let payload = build_terminal_finalize_recovery_payload(
+            &FinalizeSessionTerminalRequest {
+                state: SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                event_payload_json: json!({"turn_count": 1}),
+                outcome_status: "ok".to_owned(),
+                outcome_payload_json: json!({"final_output": "done"}),
+            },
+            "delegate_terminal_finalize_failed: database busy",
+        );
+
+        assert_eq!(
+            payload["recovery_kind"],
+            RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED
+        );
+        assert_eq!(payload["recovered_state"], "failed");
+        assert_eq!(
+            payload["attempted_terminal_event_kind"],
+            "delegate_completed"
+        );
+        assert_eq!(payload["attempted_outcome_status"], "ok");
+    }
+
+    #[test]
+    fn observe_missing_recovery_prefers_structured_event() {
+        let recovery = observe_missing_recovery(
+            &[SessionEventRecord {
+                id: 1,
+                session_id: "child-session".to_owned(),
+                event_kind: RECOVERY_EVENT_KIND.to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                payload_json: build_async_spawn_failure_recovery_payload(
+                    Some("child"),
+                    "spawn unavailable",
+                    "delegate_async_spawn_failure_persist_failed: sqlite_busy; original spawn error: spawn unavailable",
+                ),
+                ts: 42,
+            }],
+            Some("delegate_terminal_finalize_failed: ignored because event wins"),
+        );
+
+        assert_eq!(recovery.source, RECOVERY_SOURCE_EVENT);
+        assert_eq!(
+            recovery.kind,
+            RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED
+        );
+        assert_eq!(recovery.event_kind, RECOVERY_EVENT_KIND);
+        assert_eq!(
+            recovery.original_error.as_deref(),
+            Some("spawn unavailable")
+        );
+    }
+
+    #[test]
+    fn observe_missing_recovery_returns_unknown_none_when_no_metadata_exists() {
+        let recovery = observe_missing_recovery(&[], None);
+
+        assert_eq!(recovery.source, RECOVERY_SOURCE_NONE);
+        assert_eq!(recovery.kind, RECOVERY_KIND_UNKNOWN);
+        assert!(recovery.event_kind.is_empty());
+        assert_eq!(recovery.recovery_error, None);
+    }
+}

--- a/crates/app/src/session/recovery.rs
+++ b/crates/app/src/session/recovery.rs
@@ -12,9 +12,12 @@ pub(crate) const RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED: &str =
     "terminal_finalize_persist_failed";
 pub(crate) const RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED: &str =
     "async_spawn_failure_persist_failed";
+pub(crate) const RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED: &str =
+    "queued_async_overdue_marked_failed";
 
 const TERMINAL_FINALIZE_LAST_ERROR_PREFIX: &str = "delegate_terminal_finalize_failed:";
 const ASYNC_SPAWN_PERSIST_LAST_ERROR_PREFIX: &str = "delegate_async_spawn_failure_persist_failed:";
+const QUEUED_ASYNC_OVERDUE_LAST_ERROR_PREFIX: &str = "delegate_async_queued_overdue_marked_failed:";
 
 const RECOVERY_KIND_FIELD: &str = "recovery_kind";
 const RECOVERED_STATE_FIELD: &str = "recovered_state";
@@ -61,6 +64,27 @@ pub(crate) fn build_async_spawn_failure_recovery_payload(
         RECOVERY_ERROR_FIELD: recovery_error,
         ORIGINAL_ERROR_FIELD: original_error,
         "label": label,
+    })
+}
+
+pub(crate) fn build_queued_async_overdue_recovery_payload(
+    label: Option<&str>,
+    queued_at: i64,
+    elapsed_seconds: u64,
+    timeout_seconds: u64,
+    deadline_at: i64,
+    recovery_error: &str,
+) -> Value {
+    json!({
+        RECOVERY_KIND_FIELD: RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
+        RECOVERED_STATE_FIELD: "failed",
+        RECOVERY_ERROR_FIELD: recovery_error,
+        "label": label,
+        "queued_at": queued_at,
+        "elapsed_seconds": elapsed_seconds,
+        "timeout_seconds": timeout_seconds,
+        "deadline_at": deadline_at,
+        "reference": "queued",
     })
 }
 
@@ -166,6 +190,9 @@ fn recovery_kind_from_last_error(last_error: Option<&str>) -> &'static str {
         }
         Some(last_error) if last_error.starts_with(ASYNC_SPAWN_PERSIST_LAST_ERROR_PREFIX) => {
             RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED
+        }
+        Some(last_error) if last_error.starts_with(QUEUED_ASYNC_OVERDUE_LAST_ERROR_PREFIX) => {
+            RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED
         }
         Some(_) | None => RECOVERY_KIND_UNKNOWN,
     }

--- a/crates/app/src/session/recovery.rs
+++ b/crates/app/src/session/recovery.rs
@@ -14,10 +14,14 @@ pub(crate) const RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED: &str =
     "async_spawn_failure_persist_failed";
 pub(crate) const RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED: &str =
     "queued_async_overdue_marked_failed";
+pub(crate) const RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED: &str =
+    "running_async_overdue_marked_failed";
 
 const TERMINAL_FINALIZE_LAST_ERROR_PREFIX: &str = "delegate_terminal_finalize_failed:";
 const ASYNC_SPAWN_PERSIST_LAST_ERROR_PREFIX: &str = "delegate_async_spawn_failure_persist_failed:";
 const QUEUED_ASYNC_OVERDUE_LAST_ERROR_PREFIX: &str = "delegate_async_queued_overdue_marked_failed:";
+const RUNNING_ASYNC_OVERDUE_LAST_ERROR_PREFIX: &str =
+    "delegate_async_running_overdue_marked_failed:";
 
 const RECOVERY_KIND_FIELD: &str = "recovery_kind";
 const RECOVERED_STATE_FIELD: &str = "recovered_state";
@@ -85,6 +89,30 @@ pub(crate) fn build_queued_async_overdue_recovery_payload(
         "timeout_seconds": timeout_seconds,
         "deadline_at": deadline_at,
         "reference": "queued",
+    })
+}
+
+pub(crate) fn build_running_async_overdue_recovery_payload(
+    label: Option<&str>,
+    queued_at: Option<i64>,
+    started_at: Option<i64>,
+    reference: &str,
+    elapsed_seconds: u64,
+    timeout_seconds: u64,
+    deadline_at: i64,
+    recovery_error: &str,
+) -> Value {
+    json!({
+        RECOVERY_KIND_FIELD: RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED,
+        RECOVERED_STATE_FIELD: "failed",
+        RECOVERY_ERROR_FIELD: recovery_error,
+        "label": label,
+        "queued_at": queued_at,
+        "started_at": started_at,
+        "elapsed_seconds": elapsed_seconds,
+        "timeout_seconds": timeout_seconds,
+        "deadline_at": deadline_at,
+        "reference": reference,
     })
 }
 
@@ -193,6 +221,9 @@ fn recovery_kind_from_last_error(last_error: Option<&str>) -> &'static str {
         }
         Some(last_error) if last_error.starts_with(QUEUED_ASYNC_OVERDUE_LAST_ERROR_PREFIX) => {
             RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED
+        }
+        Some(last_error) if last_error.starts_with(RUNNING_ASYNC_OVERDUE_LAST_ERROR_PREFIX) => {
+            RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED
         }
         Some(_) | None => RECOVERY_KIND_UNKNOWN,
     }

--- a/crates/app/src/session/recovery.rs
+++ b/crates/app/src/session/recovery.rs
@@ -1,0 +1,172 @@
+use serde_json::{json, Value};
+
+use crate::session::repository::{FinalizeSessionTerminalRequest, SessionEventRecord};
+
+pub(crate) const RECOVERY_EVENT_KIND: &str = "delegate_recovery_applied";
+pub(crate) const RECOVERY_SOURCE_EVENT: &str = "event";
+pub(crate) const RECOVERY_SOURCE_LAST_ERROR: &str = "last_error";
+pub(crate) const RECOVERY_SOURCE_NONE: &str = "none";
+
+pub(crate) const RECOVERY_KIND_UNKNOWN: &str = "unknown";
+pub(crate) const RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED: &str =
+    "terminal_finalize_persist_failed";
+pub(crate) const RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED: &str =
+    "async_spawn_failure_persist_failed";
+
+const TERMINAL_FINALIZE_LAST_ERROR_PREFIX: &str = "delegate_terminal_finalize_failed:";
+const ASYNC_SPAWN_PERSIST_LAST_ERROR_PREFIX: &str = "delegate_async_spawn_failure_persist_failed:";
+
+const RECOVERY_KIND_FIELD: &str = "recovery_kind";
+const RECOVERED_STATE_FIELD: &str = "recovered_state";
+const RECOVERY_ERROR_FIELD: &str = "recovery_error";
+const ORIGINAL_ERROR_FIELD: &str = "original_error";
+const ATTEMPTED_TERMINAL_EVENT_KIND_FIELD: &str = "attempted_terminal_event_kind";
+const ATTEMPTED_OUTCOME_STATUS_FIELD: &str = "attempted_outcome_status";
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SessionRecoveryRecord {
+    pub source: String,
+    pub kind: String,
+    pub event_kind: String,
+    pub recovered_state: Option<String>,
+    pub recovery_error: Option<String>,
+    pub original_error: Option<String>,
+    pub attempted_terminal_event_kind: Option<String>,
+    pub attempted_outcome_status: Option<String>,
+    pub ts: i64,
+}
+
+pub(crate) fn build_terminal_finalize_recovery_payload(
+    request: &FinalizeSessionTerminalRequest,
+    recovery_error: &str,
+) -> Value {
+    json!({
+        RECOVERY_KIND_FIELD: RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED,
+        RECOVERED_STATE_FIELD: "failed",
+        RECOVERY_ERROR_FIELD: recovery_error,
+        ATTEMPTED_TERMINAL_EVENT_KIND_FIELD: request.event_kind,
+        ATTEMPTED_OUTCOME_STATUS_FIELD: request.outcome_status,
+        "attempted_last_error": request.last_error,
+    })
+}
+
+pub(crate) fn build_async_spawn_failure_recovery_payload(
+    label: Option<&str>,
+    original_error: &str,
+    recovery_error: &str,
+) -> Value {
+    json!({
+        RECOVERY_KIND_FIELD: RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED,
+        RECOVERED_STATE_FIELD: "failed",
+        RECOVERY_ERROR_FIELD: recovery_error,
+        ORIGINAL_ERROR_FIELD: original_error,
+        "label": label,
+    })
+}
+
+pub(crate) fn observe_missing_recovery(
+    recent_events: &[SessionEventRecord],
+    last_error: Option<&str>,
+) -> SessionRecoveryRecord {
+    recent_events
+        .iter()
+        .rev()
+        .find_map(parse_recovery_event)
+        .unwrap_or_else(|| synthesize_recovery_from_last_error(last_error))
+}
+
+pub(crate) fn recovery_json(recovery: SessionRecoveryRecord) -> Value {
+    json!({
+        "source": recovery.source,
+        "kind": recovery.kind,
+        "event_kind": if recovery.event_kind.is_empty() {
+            Value::Null
+        } else {
+            Value::String(recovery.event_kind)
+        },
+        "recovered_state": recovery.recovered_state,
+        "recovery_error": recovery.recovery_error,
+        "original_error": recovery.original_error,
+        "attempted_terminal_event_kind": recovery.attempted_terminal_event_kind,
+        "attempted_outcome_status": recovery.attempted_outcome_status,
+        "ts": if recovery.ts == 0 { Value::Null } else { Value::from(recovery.ts) },
+    })
+}
+
+fn parse_recovery_event(event: &SessionEventRecord) -> Option<SessionRecoveryRecord> {
+    if event.event_kind != RECOVERY_EVENT_KIND {
+        return None;
+    }
+    let kind = event
+        .payload_json
+        .get(RECOVERY_KIND_FIELD)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_owned();
+    Some(SessionRecoveryRecord {
+        source: RECOVERY_SOURCE_EVENT.to_owned(),
+        kind,
+        event_kind: event.event_kind.clone(),
+        recovered_state: event
+            .payload_json
+            .get(RECOVERED_STATE_FIELD)
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        recovery_error: event
+            .payload_json
+            .get(RECOVERY_ERROR_FIELD)
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        original_error: event
+            .payload_json
+            .get(ORIGINAL_ERROR_FIELD)
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        attempted_terminal_event_kind: event
+            .payload_json
+            .get(ATTEMPTED_TERMINAL_EVENT_KIND_FIELD)
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        attempted_outcome_status: event
+            .payload_json
+            .get(ATTEMPTED_OUTCOME_STATUS_FIELD)
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        ts: event.ts,
+    })
+}
+
+fn synthesize_recovery_from_last_error(last_error: Option<&str>) -> SessionRecoveryRecord {
+    let recovery_error = last_error
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    SessionRecoveryRecord {
+        source: if recovery_error.is_some() {
+            RECOVERY_SOURCE_LAST_ERROR.to_owned()
+        } else {
+            RECOVERY_SOURCE_NONE.to_owned()
+        },
+        kind: recovery_kind_from_last_error(recovery_error.as_deref()).to_owned(),
+        event_kind: String::new(),
+        recovered_state: None,
+        recovery_error,
+        original_error: None,
+        attempted_terminal_event_kind: None,
+        attempted_outcome_status: None,
+        ts: 0,
+    }
+}
+
+fn recovery_kind_from_last_error(last_error: Option<&str>) -> &'static str {
+    match last_error {
+        Some(last_error) if last_error.starts_with(TERMINAL_FINALIZE_LAST_ERROR_PREFIX) => {
+            RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED
+        }
+        Some(last_error) if last_error.starts_with(ASYNC_SPAWN_PERSIST_LAST_ERROR_PREFIX) => {
+            RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED
+        }
+        Some(_) | None => RECOVERY_KIND_UNKNOWN,
+    }
+}

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -695,6 +695,15 @@ impl SessionRepository {
         Self::list_events_after_with_conn(&conn, &session_id, after_id, limit)
     }
 
+    pub fn list_delegate_lifecycle_events(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<SessionEventRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        Self::list_delegate_lifecycle_events_with_conn(&conn, &session_id)
+    }
+
     pub fn load_terminal_outcome(
         &self,
         session_id: &str,
@@ -1082,6 +1091,45 @@ impl SessionRepository {
         let mut events = Vec::new();
         for row in rows {
             let raw = row.map_err(|error| format!("decode session event row failed: {error}"))?;
+            events.push(SessionEventRecord::try_from_raw(raw)?);
+        }
+        Ok(events)
+    }
+
+    fn list_delegate_lifecycle_events_with_conn(
+        conn: &Connection,
+        session_id: &str,
+    ) -> Result<Vec<SessionEventRecord>, String> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, session_id, event_kind, actor_session_id, payload_json, ts
+                 FROM session_events
+                 WHERE session_id = ?1
+                   AND event_kind IN (
+                        'delegate_queued',
+                        'delegate_started',
+                        'delegate_cancel_requested'
+                   )
+                 ORDER BY id ASC",
+            )
+            .map_err(|error| format!("prepare delegate lifecycle event query failed: {error}"))?;
+        let rows = stmt
+            .query_map(params![session_id], |row| {
+                Ok(RawSessionEventRecord {
+                    id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    event_kind: row.get(2)?,
+                    actor_session_id: row.get(3)?,
+                    payload_json: row.get(4)?,
+                    ts: row.get(5)?,
+                })
+            })
+            .map_err(|error| format!("query delegate lifecycle events failed: {error}"))?;
+
+        let mut events = Vec::new();
+        for row in rows {
+            let raw = row
+                .map_err(|error| format!("decode delegate lifecycle event row failed: {error}"))?;
             events.push(SessionEventRecord::try_from_raw(raw)?);
         }
         Ok(events)

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -562,10 +562,22 @@ impl SessionRepository {
                     MAX(t.ts) AS last_turn_at
                  FROM sessions s
                  LEFT JOIN (
-                    SELECT session_id, MAX(ts) AS archived_at
-                    FROM session_events
-                    WHERE event_kind = 'session_archived'
-                    GROUP BY session_id
+                    SELECT
+                        latest.session_id,
+                        CASE
+                            WHEN latest.event_kind = 'session_archived' THEN latest.ts
+                            ELSE NULL
+                        END AS archived_at
+                    FROM (
+                        SELECT se.session_id, se.event_kind, se.ts
+                        FROM session_events se
+                        JOIN (
+                            SELECT session_id, MAX(id) AS latest_id
+                            FROM session_events
+                            WHERE event_kind IN ('session_archived', 'session_unarchived')
+                            GROUP BY session_id
+                        ) selected ON selected.latest_id = se.id
+                    ) latest
                  ) archived ON archived.session_id = s.session_id
                  JOIN visible v ON v.session_id = s.session_id
                  LEFT JOIN turns t ON t.session_id = s.session_id
@@ -994,10 +1006,22 @@ impl SessionRepository {
                     MAX(t.ts) AS last_turn_at
                  FROM sessions s
                  LEFT JOIN (
-                    SELECT session_id, MAX(ts) AS archived_at
-                    FROM session_events
-                    WHERE event_kind = 'session_archived'
-                    GROUP BY session_id
+                    SELECT
+                        latest.session_id,
+                        CASE
+                            WHEN latest.event_kind = 'session_archived' THEN latest.ts
+                            ELSE NULL
+                        END AS archived_at
+                    FROM (
+                        SELECT se.session_id, se.event_kind, se.ts
+                        FROM session_events se
+                        JOIN (
+                            SELECT session_id, MAX(id) AS latest_id
+                            FROM session_events
+                            WHERE event_kind IN ('session_archived', 'session_unarchived')
+                            GROUP BY session_id
+                        ) selected ON selected.latest_id = se.id
+                    ) latest
                  ) archived ON archived.session_id = s.session_id
                  LEFT JOIN turns t ON t.session_id = s.session_id
                  WHERE s.session_id = ?1

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -824,6 +824,101 @@ impl SessionRepository {
         })
     }
 
+    pub fn finalize_session_terminal_if_current(
+        &self,
+        session_id: &str,
+        expected_state: SessionState,
+        request: FinalizeSessionTerminalRequest,
+    ) -> Result<Option<FinalizeSessionTerminalResult>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let event_kind = normalize_required_text(&request.event_kind, "event_kind")?;
+        let outcome_status = normalize_required_text(&request.outcome_status, "outcome_status")?;
+        let actor_session_id = normalize_optional_text(request.actor_session_id);
+        let last_error = normalize_optional_text(request.last_error);
+        let event_payload_json = request.event_payload_json;
+        let outcome_payload_json = request.outcome_payload_json;
+        let encoded_event_payload = serde_json::to_string(&event_payload_json)
+            .map_err(|error| format!("encode session terminal event payload failed: {error}"))?;
+        let encoded_outcome_payload = serde_json::to_string(&outcome_payload_json)
+            .map_err(|error| format!("encode session terminal outcome payload failed: {error}"))?;
+        let ts = unix_ts_now();
+
+        let mut conn = self.open_connection()?;
+        let tx = conn.transaction().map_err(|error| {
+            format!("open conditional session terminal transaction failed: {error}")
+        })?;
+        let affected = tx
+            .execute(
+                "UPDATE sessions
+                 SET state = ?3, updated_at = ?4, last_error = ?5
+                 WHERE session_id = ?1 AND state = ?2",
+                params![
+                    session_id,
+                    expected_state.as_str(),
+                    request.state.as_str(),
+                    ts,
+                    last_error.clone(),
+                ],
+            )
+            .map_err(|error| {
+                format!("conditionally update session state in terminal finalize failed: {error}")
+            })?;
+        if affected == 0 {
+            return Ok(None);
+        }
+        tx.execute(
+            "INSERT INTO session_events(
+                session_id, event_kind, actor_session_id, payload_json, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                session_id,
+                event_kind,
+                actor_session_id.clone(),
+                encoded_event_payload,
+                ts
+            ],
+        )
+        .map_err(|error| format!("insert conditional session terminal event failed: {error}"))?;
+        let event_id = tx.last_insert_rowid();
+        tx.execute(
+            "INSERT INTO session_terminal_outcomes(session_id, status, payload_json, recorded_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(session_id) DO UPDATE SET
+                status = excluded.status,
+                payload_json = excluded.payload_json,
+                recorded_at = excluded.recorded_at",
+            params![session_id, outcome_status, encoded_outcome_payload, ts],
+        )
+        .map_err(|error| {
+            format!("upsert session terminal outcome in conditional finalize failed: {error}")
+        })?;
+        tx.commit().map_err(|error| {
+            format!("commit conditional session terminal finalize failed: {error}")
+        })?;
+
+        let session = self.load_session(&session_id)?.ok_or_else(|| {
+            format!("session `{session_id}` missing after conditional terminal finalize")
+        })?;
+
+        Ok(Some(FinalizeSessionTerminalResult {
+            session,
+            event: SessionEventRecord {
+                id: event_id,
+                session_id: session_id.clone(),
+                event_kind,
+                actor_session_id,
+                payload_json: event_payload_json,
+                ts,
+            },
+            terminal_outcome: SessionTerminalOutcomeRecord {
+                session_id,
+                status: outcome_status,
+                payload_json: outcome_payload_json,
+                recorded_at: ts,
+            },
+        }))
+    }
+
     pub fn append_event(&self, event: NewSessionEvent) -> Result<SessionEventRecord, String> {
         let session_id = normalize_required_text(&event.session_id, "session_id")?;
         let event_kind = normalize_required_text(&event.event_kind, "event_kind")?;
@@ -1976,6 +2071,124 @@ mod tests {
             .expect("terminal outcome row");
         assert_eq!(outcome.status, "timeout");
         assert_eq!(outcome.payload_json["error"], "delegate_timeout");
+    }
+
+    #[test]
+    fn finalize_session_terminal_if_current_writes_state_event_and_outcome_when_state_matches() {
+        let config = isolated_memory_config("finalize-session-terminal-if-current");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+
+        let finalized = repo
+            .finalize_session_terminal_if_current(
+                "child-session",
+                SessionState::Ready,
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::Failed,
+                    last_error: Some("delegate_timeout".to_owned()),
+                    event_kind: "delegate_recovery_applied".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({
+                        "kind": "queued_async_overdue_marked_failed",
+                        "reference": "queued"
+                    }),
+                    outcome_status: "error".to_owned(),
+                    outcome_payload_json: json!({
+                        "error": "delegate_timeout"
+                    }),
+                },
+            )
+            .expect("conditionally finalize session")
+            .expect("conditional finalize result");
+
+        assert_eq!(finalized.session.state, SessionState::Failed);
+        assert_eq!(
+            finalized.session.last_error.as_deref(),
+            Some("delegate_timeout")
+        );
+        assert_eq!(finalized.event.event_kind, "delegate_recovery_applied");
+        assert_eq!(finalized.terminal_outcome.status, "error");
+
+        let child = repo
+            .load_session("child-session")
+            .expect("load child session")
+            .expect("child session row");
+        assert_eq!(child.state, SessionState::Failed);
+        assert_eq!(child.last_error.as_deref(), Some("delegate_timeout"));
+
+        let events = repo
+            .list_recent_events("child-session", 10)
+            .expect("list child events");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_kind, "delegate_recovery_applied");
+
+        let outcome = repo
+            .load_terminal_outcome("child-session")
+            .expect("load terminal outcome")
+            .expect("terminal outcome row");
+        assert_eq!(outcome.status, "error");
+        assert_eq!(outcome.payload_json["error"], "delegate_timeout");
+    }
+
+    #[test]
+    fn finalize_session_terminal_if_current_writes_nothing_when_state_does_not_match() {
+        let config = isolated_memory_config("finalize-session-terminal-if-current-noop");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+
+        let finalized = repo
+            .finalize_session_terminal_if_current(
+                "child-session",
+                SessionState::Ready,
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::Failed,
+                    last_error: Some("delegate_timeout".to_owned()),
+                    event_kind: "delegate_recovery_applied".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({
+                        "kind": "queued_async_overdue_marked_failed",
+                        "reference": "queued"
+                    }),
+                    outcome_status: "error".to_owned(),
+                    outcome_payload_json: json!({
+                        "error": "delegate_timeout"
+                    }),
+                },
+            )
+            .expect("conditionally finalize session");
+
+        assert!(finalized.is_none());
+
+        let child = repo
+            .load_session("child-session")
+            .expect("load child session")
+            .expect("child session row");
+        assert_eq!(child.state, SessionState::Running);
+        assert!(child.last_error.is_none());
+
+        let events = repo
+            .list_recent_events("child-session", 10)
+            .expect("list child events");
+        assert!(events.is_empty());
+
+        let outcome = repo
+            .load_terminal_outcome("child-session")
+            .expect("load terminal outcome");
+        assert!(outcome.is_none());
     }
 
     #[test]

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -1,0 +1,2065 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde_json::Value;
+
+use crate::memory;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionKind {
+    Root,
+    DelegateChild,
+}
+
+impl SessionKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Root => "root",
+            Self::DelegateChild => "delegate_child",
+        }
+    }
+
+    fn from_db(value: &str) -> Result<Self, String> {
+        match value {
+            "root" => Ok(Self::Root),
+            "delegate_child" => Ok(Self::DelegateChild),
+            _ => Err(format!("unknown session kind `{value}`")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionState {
+    Ready,
+    Running,
+    Completed,
+    Failed,
+    TimedOut,
+}
+
+impl SessionState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::TimedOut => "timed_out",
+        }
+    }
+
+    fn from_db(value: &str) -> Result<Self, String> {
+        match value {
+            "ready" => Ok(Self::Ready),
+            "running" => Ok(Self::Running),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            "timed_out" => Ok(Self::TimedOut),
+            _ => Err(format!("unknown session state `{value}`")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionRecord {
+    pub session_id: String,
+    pub kind: SessionKind,
+    pub parent_session_id: Option<String>,
+    pub label: Option<String>,
+    pub state: SessionState,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionEventRecord {
+    pub id: i64,
+    pub session_id: String,
+    pub event_kind: String,
+    pub actor_session_id: Option<String>,
+    pub payload_json: Value,
+    pub ts: i64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionTerminalOutcomeRecord {
+    pub session_id: String,
+    pub status: String,
+    pub payload_json: Value,
+    pub recorded_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionSummaryRecord {
+    pub session_id: String,
+    pub kind: SessionKind,
+    pub parent_session_id: Option<String>,
+    pub label: Option<String>,
+    pub state: SessionState,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub turn_count: usize,
+    pub last_turn_at: Option<i64>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionObservationRecord {
+    pub session: SessionSummaryRecord,
+    pub terminal_outcome: Option<SessionTerminalOutcomeRecord>,
+    pub recent_events: Vec<SessionEventRecord>,
+    pub tail_events: Vec<SessionEventRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewSessionRecord {
+    pub session_id: String,
+    pub kind: SessionKind,
+    pub parent_session_id: Option<String>,
+    pub label: Option<String>,
+    pub state: SessionState,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NewSessionEvent {
+    pub session_id: String,
+    pub event_kind: String,
+    pub actor_session_id: Option<String>,
+    pub payload_json: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateSessionWithEventRequest {
+    pub session: NewSessionRecord,
+    pub event_kind: String,
+    pub actor_session_id: Option<String>,
+    pub event_payload_json: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateSessionWithEventResult {
+    pub session: SessionRecord,
+    pub event: SessionEventRecord,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FinalizeSessionTerminalRequest {
+    pub state: SessionState,
+    pub last_error: Option<String>,
+    pub event_kind: String,
+    pub actor_session_id: Option<String>,
+    pub event_payload_json: Value,
+    pub outcome_status: String,
+    pub outcome_payload_json: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FinalizeSessionTerminalResult {
+    pub session: SessionRecord,
+    pub event: SessionEventRecord,
+    pub terminal_outcome: SessionTerminalOutcomeRecord,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TransitionSessionWithEventIfCurrentRequest {
+    pub expected_state: SessionState,
+    pub next_state: SessionState,
+    pub last_error: Option<String>,
+    pub event_kind: String,
+    pub actor_session_id: Option<String>,
+    pub event_payload_json: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TransitionSessionWithEventResult {
+    pub session: SessionRecord,
+    pub event: SessionEventRecord,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionRepository {
+    db_path: PathBuf,
+}
+
+impl SessionRepository {
+    pub fn new(config: &MemoryRuntimeConfig) -> Result<Self, String> {
+        let db_path = memory::ensure_memory_db_ready(config.sqlite_path.clone(), config)?;
+        Ok(Self { db_path })
+    }
+
+    pub fn create_session(&self, record: NewSessionRecord) -> Result<SessionRecord, String> {
+        let session_id = normalize_required_text(&record.session_id, "session_id")?;
+        let parent_session_id = normalize_optional_text(record.parent_session_id);
+        let label = normalize_optional_text(record.label);
+        let ts = unix_ts_now();
+        let conn = self.open_connection()?;
+        conn.execute(
+            "INSERT INTO sessions(
+                session_id, kind, parent_session_id, label, state, created_at, updated_at, last_error
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL)",
+            params![
+                session_id,
+                record.kind.as_str(),
+                parent_session_id,
+                label,
+                record.state.as_str(),
+                ts,
+                ts,
+            ],
+        )
+        .map_err(|error| format!("insert session row failed: {error}"))?;
+
+        self.load_session(&session_id)?
+            .ok_or_else(|| format!("session row `{session_id}` disappeared after insert"))
+    }
+
+    pub fn ensure_session(&self, record: NewSessionRecord) -> Result<SessionRecord, String> {
+        let session_id = normalize_required_text(&record.session_id, "session_id")?;
+        if let Some(existing) = self.load_session(&session_id)? {
+            return Ok(existing);
+        }
+
+        match self.create_session(record) {
+            Ok(created) => Ok(created),
+            Err(error) if error.contains("UNIQUE constraint failed") => self
+                .load_session(&session_id)?
+                .ok_or_else(|| format!("session `{session_id}` missing after concurrent insert")),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub fn create_session_with_event(
+        &self,
+        request: CreateSessionWithEventRequest,
+    ) -> Result<CreateSessionWithEventResult, String> {
+        let session_id = normalize_required_text(&request.session.session_id, "session_id")?;
+        let parent_session_id = normalize_optional_text(request.session.parent_session_id);
+        let label = normalize_optional_text(request.session.label);
+        let event_kind = normalize_required_text(&request.event_kind, "event_kind")?;
+        let actor_session_id = normalize_optional_text(request.actor_session_id);
+        let event_payload_json = request.event_payload_json;
+        let encoded_event_payload = serde_json::to_string(&event_payload_json)
+            .map_err(|error| format!("encode session event payload failed: {error}"))?;
+        let ts = unix_ts_now();
+
+        let mut conn = self.open_connection()?;
+        let tx = conn
+            .transaction()
+            .map_err(|error| format!("open session create transaction failed: {error}"))?;
+        tx.execute(
+            "INSERT INTO sessions(
+                session_id, kind, parent_session_id, label, state, created_at, updated_at, last_error
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL)",
+            params![
+                session_id,
+                request.session.kind.as_str(),
+                parent_session_id,
+                label,
+                request.session.state.as_str(),
+                ts,
+                ts,
+            ],
+        )
+        .map_err(|error| format!("insert session row failed: {error}"))?;
+        tx.execute(
+            "INSERT INTO session_events(
+                session_id, event_kind, actor_session_id, payload_json, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                session_id,
+                event_kind,
+                actor_session_id.clone(),
+                encoded_event_payload,
+                ts
+            ],
+        )
+        .map_err(|error| format!("insert session event failed: {error}"))?;
+        let event_id = tx.last_insert_rowid();
+        tx.commit()
+            .map_err(|error| format!("commit session create transaction failed: {error}"))?;
+
+        let session = self
+            .load_session(&session_id)?
+            .ok_or_else(|| format!("session `{session_id}` disappeared after insert"))?;
+
+        Ok(CreateSessionWithEventResult {
+            session,
+            event: SessionEventRecord {
+                id: event_id,
+                session_id,
+                event_kind,
+                actor_session_id,
+                payload_json: event_payload_json,
+                ts,
+            },
+        })
+    }
+
+    pub fn load_session(&self, session_id: &str) -> Result<Option<SessionRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        let raw = conn
+            .query_row(
+                "SELECT session_id, kind, parent_session_id, label, state, created_at, updated_at, last_error
+                 FROM sessions
+                 WHERE session_id = ?1",
+                params![session_id],
+                |row| {
+                    Ok(RawSessionRecord {
+                        session_id: row.get(0)?,
+                        kind: row.get(1)?,
+                        parent_session_id: row.get(2)?,
+                        label: row.get(3)?,
+                        state: row.get(4)?,
+                        created_at: row.get(5)?,
+                        updated_at: row.get(6)?,
+                        last_error: row.get(7)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|error| format!("load session row failed: {error}"))?;
+        raw.map(SessionRecord::try_from_raw).transpose()
+    }
+
+    pub fn load_session_summary(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SessionSummaryRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        Self::load_session_summary_with_conn(&conn, &session_id)
+    }
+
+    pub fn load_session_summary_with_legacy_fallback(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SessionSummaryRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        Self::load_session_summary_with_legacy_fallback_with_conn(&conn, &session_id)
+    }
+
+    pub fn load_session_observation(
+        &self,
+        session_id: &str,
+        recent_event_limit: usize,
+        tail_after_id: Option<i64>,
+        tail_page_limit: usize,
+    ) -> Result<Option<SessionObservationRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let mut conn = self.open_connection()?;
+        let tx = conn
+            .transaction()
+            .map_err(|error| format!("open session observation transaction failed: {error}"))?;
+        let observation = Self::load_session_observation_with_conn(
+            &tx,
+            &session_id,
+            recent_event_limit,
+            tail_after_id,
+            tail_page_limit,
+        )?;
+        tx.commit()
+            .map_err(|error| format!("commit session observation transaction failed: {error}"))?;
+        Ok(observation)
+    }
+
+    pub fn update_session_state(
+        &self,
+        session_id: &str,
+        state: SessionState,
+        last_error: Option<String>,
+    ) -> Result<SessionRecord, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        let affected = conn
+            .execute(
+                "UPDATE sessions
+                 SET state = ?2, updated_at = ?3, last_error = ?4
+                 WHERE session_id = ?1",
+                params![
+                    session_id,
+                    state.as_str(),
+                    unix_ts_now(),
+                    normalize_optional_text(last_error),
+                ],
+            )
+            .map_err(|error| format!("update session state failed: {error}"))?;
+        if affected == 0 {
+            return Err(format!("session `{session_id}` not found"));
+        }
+        self.load_session(&session_id)?
+            .ok_or_else(|| format!("session `{session_id}` missing after update"))
+    }
+
+    pub fn update_session_state_if_current(
+        &self,
+        session_id: &str,
+        expected_state: SessionState,
+        next_state: SessionState,
+        last_error: Option<String>,
+    ) -> Result<Option<SessionRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        let affected = conn
+            .execute(
+                "UPDATE sessions
+                 SET state = ?3, updated_at = ?4, last_error = ?5
+                 WHERE session_id = ?1 AND state = ?2",
+                params![
+                    session_id,
+                    expected_state.as_str(),
+                    next_state.as_str(),
+                    unix_ts_now(),
+                    normalize_optional_text(last_error),
+                ],
+            )
+            .map_err(|error| format!("conditionally update session state failed: {error}"))?;
+        if affected == 0 {
+            return Ok(None);
+        }
+        self.load_session(&session_id)?
+            .map(Some)
+            .ok_or_else(|| format!("session `{session_id}` missing after conditional update"))
+    }
+
+    pub fn transition_session_with_event_if_current(
+        &self,
+        session_id: &str,
+        request: TransitionSessionWithEventIfCurrentRequest,
+    ) -> Result<Option<TransitionSessionWithEventResult>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let event_kind = normalize_required_text(&request.event_kind, "event_kind")?;
+        let actor_session_id = normalize_optional_text(request.actor_session_id);
+        let last_error = normalize_optional_text(request.last_error);
+        let event_payload_json = request.event_payload_json;
+        let encoded_event_payload = serde_json::to_string(&event_payload_json)
+            .map_err(|error| format!("encode session transition event payload failed: {error}"))?;
+        let ts = unix_ts_now();
+
+        let mut conn = self.open_connection()?;
+        let tx = conn
+            .transaction()
+            .map_err(|error| format!("open session transition transaction failed: {error}"))?;
+        let affected = tx
+            .execute(
+                "UPDATE sessions
+                 SET state = ?3, updated_at = ?4, last_error = ?5
+                 WHERE session_id = ?1 AND state = ?2",
+                params![
+                    session_id,
+                    request.expected_state.as_str(),
+                    request.next_state.as_str(),
+                    ts,
+                    last_error.clone(),
+                ],
+            )
+            .map_err(|error| {
+                format!("conditionally update session state in transition failed: {error}")
+            })?;
+        if affected == 0 {
+            return Ok(None);
+        }
+        tx.execute(
+            "INSERT INTO session_events(
+                session_id, event_kind, actor_session_id, payload_json, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                session_id,
+                event_kind,
+                actor_session_id.clone(),
+                encoded_event_payload,
+                ts
+            ],
+        )
+        .map_err(|error| format!("insert session transition event failed: {error}"))?;
+        let event_id = tx.last_insert_rowid();
+        tx.commit()
+            .map_err(|error| format!("commit session transition failed: {error}"))?;
+
+        let session = self.load_session(&session_id)?.ok_or_else(|| {
+            format!("session `{session_id}` missing after conditional transition")
+        })?;
+
+        Ok(Some(TransitionSessionWithEventResult {
+            session,
+            event: SessionEventRecord {
+                id: event_id,
+                session_id,
+                event_kind,
+                actor_session_id,
+                payload_json: event_payload_json,
+                ts,
+            },
+        }))
+    }
+
+    pub fn list_sessions(&self) -> Result<Vec<SessionRecord>, String> {
+        let conn = self.open_connection()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT session_id, kind, parent_session_id, label, state, created_at, updated_at, last_error
+                 FROM sessions
+                 ORDER BY updated_at DESC, session_id ASC",
+            )
+            .map_err(|error| format!("prepare session list query failed: {error}"))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(RawSessionRecord {
+                    session_id: row.get(0)?,
+                    kind: row.get(1)?,
+                    parent_session_id: row.get(2)?,
+                    label: row.get(3)?,
+                    state: row.get(4)?,
+                    created_at: row.get(5)?,
+                    updated_at: row.get(6)?,
+                    last_error: row.get(7)?,
+                })
+            })
+            .map_err(|error| format!("query session list failed: {error}"))?;
+
+        let mut sessions = Vec::new();
+        for row in rows {
+            let raw = row.map_err(|error| format!("decode session row failed: {error}"))?;
+            sessions.push(SessionRecord::try_from_raw(raw)?);
+        }
+        Ok(sessions)
+    }
+
+    pub fn list_visible_sessions(
+        &self,
+        current_session_id: &str,
+    ) -> Result<Vec<SessionSummaryRecord>, String> {
+        let current_session_id = normalize_required_text(current_session_id, "current_session_id")?;
+        let conn = self.open_connection()?;
+        let mut stmt = conn
+            .prepare(
+                "WITH RECURSIVE visible(session_id) AS (
+                    SELECT session_id
+                    FROM sessions
+                    WHERE session_id = ?1
+                    UNION
+                    SELECT s.session_id
+                    FROM sessions s
+                    JOIN visible v ON s.parent_session_id = v.session_id
+                 )
+                 SELECT
+                    s.session_id,
+                    s.kind,
+                    s.parent_session_id,
+                    s.label,
+                    s.state,
+                    s.created_at,
+                    s.updated_at,
+                    s.last_error,
+                    COUNT(t.id) AS turn_count,
+                    MAX(t.ts) AS last_turn_at
+                 FROM sessions s
+                 JOIN visible v ON v.session_id = s.session_id
+                 LEFT JOIN turns t ON t.session_id = s.session_id
+                 GROUP BY
+                    s.session_id,
+                    s.kind,
+                    s.parent_session_id,
+                    s.label,
+                    s.state,
+                    s.created_at,
+                    s.updated_at,
+                    s.last_error
+                 ORDER BY s.updated_at DESC, s.session_id ASC",
+            )
+            .map_err(|error| format!("prepare visible session query failed: {error}"))?;
+        let rows = stmt
+            .query_map(params![current_session_id], |row| {
+                Ok(RawSessionSummaryRecord {
+                    session_id: row.get(0)?,
+                    kind: row.get(1)?,
+                    parent_session_id: row.get(2)?,
+                    label: row.get(3)?,
+                    state: row.get(4)?,
+                    created_at: row.get(5)?,
+                    updated_at: row.get(6)?,
+                    last_error: row.get(7)?,
+                    turn_count: row.get(8)?,
+                    last_turn_at: row.get(9)?,
+                })
+            })
+            .map_err(|error| format!("query visible sessions failed: {error}"))?;
+
+        let mut sessions = Vec::new();
+        for row in rows {
+            let raw = row.map_err(|error| format!("decode visible session row failed: {error}"))?;
+            sessions.push(SessionSummaryRecord::try_from_raw(raw)?);
+        }
+        if !sessions
+            .iter()
+            .any(|session| session.session_id == current_session_id)
+        {
+            if let Some(legacy) = self.infer_legacy_session_summary(&current_session_id)? {
+                sessions.push(legacy);
+                sort_session_summaries(&mut sessions);
+            }
+        }
+        Ok(sessions)
+    }
+
+    pub fn is_session_visible(
+        &self,
+        current_session_id: &str,
+        target_session_id: &str,
+    ) -> Result<bool, String> {
+        let current_session_id = normalize_required_text(current_session_id, "current_session_id")?;
+        let target_session_id = normalize_required_text(target_session_id, "target_session_id")?;
+        if current_session_id == target_session_id {
+            return Ok(true);
+        }
+
+        let mut seen = BTreeSet::new();
+        let mut next_session_id = Some(target_session_id);
+        while let Some(session_id) = next_session_id {
+            if !seen.insert(session_id.to_owned()) {
+                return Err(format!(
+                    "session_lineage_cycle_detected: `{session_id}` reappeared while checking visibility"
+                ));
+            }
+            let session = match self.load_session(&session_id)? {
+                Some(session) => session,
+                None => return Ok(false),
+            };
+            match session.parent_session_id {
+                Some(parent_session_id) if parent_session_id == current_session_id => {
+                    return Ok(true);
+                }
+                Some(parent_session_id) => next_session_id = Some(parent_session_id),
+                None => return Ok(false),
+            }
+        }
+        Ok(false)
+    }
+
+    pub fn session_lineage_depth(&self, session_id: &str) -> Result<usize, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let mut seen = BTreeSet::new();
+        let mut depth = 0usize;
+        let mut next_session_id = Some(session_id);
+
+        while let Some(current_session_id) = next_session_id {
+            if !seen.insert(current_session_id.clone()) {
+                return Err(format!(
+                    "session_lineage_cycle_detected: `{current_session_id}` reappeared while computing lineage depth"
+                ));
+            }
+            let session = match self.load_session(&current_session_id)? {
+                Some(session) => session,
+                None if depth == 0 => return Ok(0),
+                None => {
+                    return Err(format!(
+                        "session_lineage_broken: missing parent row for `{current_session_id}`"
+                    ));
+                }
+            };
+            match session.parent_session_id {
+                Some(parent_session_id) => {
+                    depth += 1;
+                    next_session_id = Some(parent_session_id);
+                }
+                None => return Ok(depth),
+            }
+        }
+
+        Ok(depth)
+    }
+
+    pub fn list_recent_events(
+        &self,
+        session_id: &str,
+        limit: usize,
+    ) -> Result<Vec<SessionEventRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        Self::list_recent_events_with_conn(&conn, &session_id, limit)
+    }
+
+    pub fn list_events_after(
+        &self,
+        session_id: &str,
+        after_id: i64,
+        limit: usize,
+    ) -> Result<Vec<SessionEventRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        Self::list_events_after_with_conn(&conn, &session_id, after_id, limit)
+    }
+
+    pub fn load_terminal_outcome(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SessionTerminalOutcomeRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        Self::load_terminal_outcome_with_conn(&conn, &session_id)
+    }
+
+    pub fn upsert_terminal_outcome(
+        &self,
+        session_id: &str,
+        status: &str,
+        payload_json: Value,
+    ) -> Result<SessionTerminalOutcomeRecord, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let status = normalize_required_text(status, "status")?;
+        if self.load_session(&session_id)?.is_none() {
+            return Err(format!("session `{session_id}` not found"));
+        }
+
+        let encoded_payload = serde_json::to_string(&payload_json)
+            .map_err(|error| format!("encode session terminal outcome payload failed: {error}"))?;
+        let recorded_at = unix_ts_now();
+        let conn = self.open_connection()?;
+        conn.execute(
+            "INSERT INTO session_terminal_outcomes(session_id, status, payload_json, recorded_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(session_id) DO UPDATE SET
+                status = excluded.status,
+                payload_json = excluded.payload_json,
+                recorded_at = excluded.recorded_at",
+            params![session_id, status, encoded_payload, recorded_at],
+        )
+        .map_err(|error| format!("upsert session terminal outcome failed: {error}"))?;
+
+        Ok(SessionTerminalOutcomeRecord {
+            session_id,
+            status,
+            payload_json,
+            recorded_at,
+        })
+    }
+
+    pub fn finalize_session_terminal(
+        &self,
+        session_id: &str,
+        request: FinalizeSessionTerminalRequest,
+    ) -> Result<FinalizeSessionTerminalResult, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let event_kind = normalize_required_text(&request.event_kind, "event_kind")?;
+        let outcome_status = normalize_required_text(&request.outcome_status, "outcome_status")?;
+        let actor_session_id = normalize_optional_text(request.actor_session_id);
+        let last_error = normalize_optional_text(request.last_error);
+        let event_payload_json = request.event_payload_json;
+        let outcome_payload_json = request.outcome_payload_json;
+        let encoded_event_payload = serde_json::to_string(&event_payload_json)
+            .map_err(|error| format!("encode session terminal event payload failed: {error}"))?;
+        let encoded_outcome_payload = serde_json::to_string(&outcome_payload_json)
+            .map_err(|error| format!("encode session terminal outcome payload failed: {error}"))?;
+        let ts = unix_ts_now();
+
+        let mut conn = self.open_connection()?;
+        let tx = conn
+            .transaction()
+            .map_err(|error| format!("open session terminal transaction failed: {error}"))?;
+        let affected = tx
+            .execute(
+                "UPDATE sessions
+                 SET state = ?2, updated_at = ?3, last_error = ?4
+                 WHERE session_id = ?1",
+                params![session_id, request.state.as_str(), ts, last_error.clone(),],
+            )
+            .map_err(|error| {
+                format!("update session state in terminal finalize failed: {error}")
+            })?;
+        if affected == 0 {
+            return Err(format!("session `{session_id}` not found"));
+        }
+        tx.execute(
+            "INSERT INTO session_events(
+                session_id, event_kind, actor_session_id, payload_json, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                session_id,
+                event_kind,
+                actor_session_id.clone(),
+                encoded_event_payload,
+                ts
+            ],
+        )
+        .map_err(|error| format!("insert session terminal event failed: {error}"))?;
+        let event_id = tx.last_insert_rowid();
+        tx.execute(
+            "INSERT INTO session_terminal_outcomes(session_id, status, payload_json, recorded_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(session_id) DO UPDATE SET
+                status = excluded.status,
+                payload_json = excluded.payload_json,
+                recorded_at = excluded.recorded_at",
+            params![session_id, outcome_status, encoded_outcome_payload, ts],
+        )
+        .map_err(|error| format!("upsert session terminal outcome in finalize failed: {error}"))?;
+        tx.commit()
+            .map_err(|error| format!("commit session terminal finalize failed: {error}"))?;
+
+        let session = self
+            .load_session(&session_id)?
+            .ok_or_else(|| format!("session `{session_id}` missing after terminal finalize"))?;
+
+        Ok(FinalizeSessionTerminalResult {
+            session,
+            event: SessionEventRecord {
+                id: event_id,
+                session_id: session_id.clone(),
+                event_kind,
+                actor_session_id,
+                payload_json: event_payload_json,
+                ts,
+            },
+            terminal_outcome: SessionTerminalOutcomeRecord {
+                session_id,
+                status: outcome_status,
+                payload_json: outcome_payload_json,
+                recorded_at: ts,
+            },
+        })
+    }
+
+    pub fn append_event(&self, event: NewSessionEvent) -> Result<SessionEventRecord, String> {
+        let session_id = normalize_required_text(&event.session_id, "session_id")?;
+        let event_kind = normalize_required_text(&event.event_kind, "event_kind")?;
+        if self.load_session(&session_id)?.is_none() {
+            return Err(format!("session `{session_id}` not found"));
+        }
+
+        let ts = unix_ts_now();
+        let payload_json = serde_json::to_string(&event.payload_json)
+            .map_err(|error| format!("encode session event payload failed: {error}"))?;
+        let actor_session_id = normalize_optional_text(event.actor_session_id);
+
+        let conn = self.open_connection()?;
+        conn.execute(
+            "INSERT INTO session_events(
+                session_id, event_kind, actor_session_id, payload_json, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![session_id, event_kind, actor_session_id, payload_json, ts],
+        )
+        .map_err(|error| format!("insert session event failed: {error}"))?;
+
+        Ok(SessionEventRecord {
+            id: conn.last_insert_rowid(),
+            session_id,
+            event_kind,
+            actor_session_id,
+            payload_json: event.payload_json,
+            ts,
+        })
+    }
+
+    fn open_connection(&self) -> Result<Connection, String> {
+        Connection::open(&self.db_path)
+            .map_err(|error| format!("open session repository sqlite db failed: {error}"))
+    }
+
+    fn load_session_summary_with_conn(
+        conn: &Connection,
+        session_id: &str,
+    ) -> Result<Option<SessionSummaryRecord>, String> {
+        let raw = conn
+            .query_row(
+                "SELECT
+                    s.session_id,
+                    s.kind,
+                    s.parent_session_id,
+                    s.label,
+                    s.state,
+                    s.created_at,
+                    s.updated_at,
+                    s.last_error,
+                    COUNT(t.id) AS turn_count,
+                    MAX(t.ts) AS last_turn_at
+                 FROM sessions s
+                 LEFT JOIN turns t ON t.session_id = s.session_id
+                 WHERE s.session_id = ?1
+                 GROUP BY
+                    s.session_id,
+                    s.kind,
+                    s.parent_session_id,
+                    s.label,
+                    s.state,
+                    s.created_at,
+                    s.updated_at,
+                    s.last_error",
+                params![session_id],
+                |row| {
+                    Ok(RawSessionSummaryRecord {
+                        session_id: row.get(0)?,
+                        kind: row.get(1)?,
+                        parent_session_id: row.get(2)?,
+                        label: row.get(3)?,
+                        state: row.get(4)?,
+                        created_at: row.get(5)?,
+                        updated_at: row.get(6)?,
+                        last_error: row.get(7)?,
+                        turn_count: row.get(8)?,
+                        last_turn_at: row.get(9)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|error| format!("load session summary failed: {error}"))?;
+        raw.map(SessionSummaryRecord::try_from_raw).transpose()
+    }
+
+    fn load_session_summary_with_legacy_fallback_with_conn(
+        conn: &Connection,
+        session_id: &str,
+    ) -> Result<Option<SessionSummaryRecord>, String> {
+        if let Some(summary) = Self::load_session_summary_with_conn(conn, session_id)? {
+            return Ok(Some(summary));
+        }
+        Self::infer_legacy_session_summary_with_conn(conn, session_id)
+    }
+
+    fn list_recent_events_with_conn(
+        conn: &Connection,
+        session_id: &str,
+        limit: usize,
+    ) -> Result<Vec<SessionEventRecord>, String> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, session_id, event_kind, actor_session_id, payload_json, ts
+                 FROM session_events
+                 WHERE session_id = ?1
+                 ORDER BY id DESC
+                 LIMIT ?2",
+            )
+            .map_err(|error| format!("prepare session event query failed: {error}"))?;
+        let rows = stmt
+            .query_map(params![session_id, limit as i64], |row| {
+                Ok(RawSessionEventRecord {
+                    id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    event_kind: row.get(2)?,
+                    actor_session_id: row.get(3)?,
+                    payload_json: row.get(4)?,
+                    ts: row.get(5)?,
+                })
+            })
+            .map_err(|error| format!("query session events failed: {error}"))?;
+
+        let mut events = Vec::new();
+        for row in rows {
+            let raw = row.map_err(|error| format!("decode session event row failed: {error}"))?;
+            events.push(SessionEventRecord::try_from_raw(raw)?);
+        }
+        events.reverse();
+        Ok(events)
+    }
+
+    fn list_events_after_with_conn(
+        conn: &Connection,
+        session_id: &str,
+        after_id: i64,
+        limit: usize,
+    ) -> Result<Vec<SessionEventRecord>, String> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, session_id, event_kind, actor_session_id, payload_json, ts
+                 FROM session_events
+                 WHERE session_id = ?1 AND id > ?2
+                 ORDER BY id ASC
+                 LIMIT ?3",
+            )
+            .map_err(|error| format!("prepare session event tail query failed: {error}"))?;
+        let rows = stmt
+            .query_map(params![session_id, after_id, limit as i64], |row| {
+                Ok(RawSessionEventRecord {
+                    id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    event_kind: row.get(2)?,
+                    actor_session_id: row.get(3)?,
+                    payload_json: row.get(4)?,
+                    ts: row.get(5)?,
+                })
+            })
+            .map_err(|error| format!("query session event tail failed: {error}"))?;
+
+        let mut events = Vec::new();
+        for row in rows {
+            let raw = row.map_err(|error| format!("decode session event row failed: {error}"))?;
+            events.push(SessionEventRecord::try_from_raw(raw)?);
+        }
+        Ok(events)
+    }
+
+    fn load_terminal_outcome_with_conn(
+        conn: &Connection,
+        session_id: &str,
+    ) -> Result<Option<SessionTerminalOutcomeRecord>, String> {
+        let raw = conn
+            .query_row(
+                "SELECT session_id, status, payload_json, recorded_at
+                 FROM session_terminal_outcomes
+                 WHERE session_id = ?1",
+                params![session_id],
+                |row| {
+                    Ok(RawSessionTerminalOutcomeRecord {
+                        session_id: row.get(0)?,
+                        status: row.get(1)?,
+                        payload_json: row.get(2)?,
+                        recorded_at: row.get(3)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|error| format!("load session terminal outcome failed: {error}"))?;
+        raw.map(SessionTerminalOutcomeRecord::try_from_raw)
+            .transpose()
+    }
+
+    fn drain_events_after_with_conn(
+        conn: &Connection,
+        session_id: &str,
+        after_id: i64,
+        page_limit: usize,
+    ) -> Result<Vec<SessionEventRecord>, String> {
+        if page_limit == 0 {
+            return Ok(Vec::new());
+        }
+        let mut next_after_id = after_id.max(0);
+        let mut events = Vec::new();
+        loop {
+            let page =
+                Self::list_events_after_with_conn(conn, session_id, next_after_id, page_limit)?;
+            if page.is_empty() {
+                break;
+            }
+            next_after_id = page.last().map(|event| event.id).unwrap_or(next_after_id);
+            events.extend(page);
+        }
+        Ok(events)
+    }
+
+    fn load_session_observation_with_conn(
+        conn: &Connection,
+        session_id: &str,
+        recent_event_limit: usize,
+        tail_after_id: Option<i64>,
+        tail_page_limit: usize,
+    ) -> Result<Option<SessionObservationRecord>, String> {
+        let Some(session) =
+            Self::load_session_summary_with_legacy_fallback_with_conn(conn, session_id)?
+        else {
+            return Ok(None);
+        };
+        let recent_events =
+            Self::list_recent_events_with_conn(conn, session_id, recent_event_limit)?;
+        let terminal_outcome = Self::load_terminal_outcome_with_conn(conn, session_id)?;
+        let tail_events = match tail_after_id {
+            Some(after_id) => Self::drain_events_after_with_conn(
+                conn,
+                session_id,
+                after_id.max(0),
+                tail_page_limit,
+            )?,
+            None => Vec::new(),
+        };
+        Ok(Some(SessionObservationRecord {
+            session,
+            terminal_outcome,
+            recent_events,
+            tail_events,
+        }))
+    }
+
+    fn infer_legacy_session_summary(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SessionSummaryRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        Self::infer_legacy_session_summary_with_conn(&conn, &session_id)
+    }
+
+    fn infer_legacy_session_summary_with_conn(
+        conn: &Connection,
+        session_id: &str,
+    ) -> Result<Option<SessionSummaryRecord>, String> {
+        let aggregate = conn
+            .query_row(
+                "SELECT MIN(ts), MAX(ts), COUNT(id)
+                 FROM turns
+                 WHERE session_id = ?1",
+                params![session_id],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<i64>>(0)?,
+                        row.get::<_, Option<i64>>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                },
+            )
+            .map_err(|error| format!("load legacy session aggregate failed: {error}"))?;
+        let (created_at, updated_at, turn_count) = aggregate;
+        if turn_count <= 0 {
+            return Ok(None);
+        }
+
+        let created_at = created_at.unwrap_or_default();
+        let updated_at = updated_at.unwrap_or(created_at);
+        let kind = infer_legacy_session_kind(session_id);
+        Ok(Some(SessionSummaryRecord {
+            session_id: session_id.to_owned(),
+            kind,
+            parent_session_id: None,
+            label: None,
+            state: SessionState::Ready,
+            created_at,
+            updated_at,
+            turn_count: turn_count.max(0) as usize,
+            last_turn_at: Some(updated_at),
+            last_error: None,
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct RawSessionRecord {
+    session_id: String,
+    kind: String,
+    parent_session_id: Option<String>,
+    label: Option<String>,
+    state: String,
+    created_at: i64,
+    updated_at: i64,
+    last_error: Option<String>,
+}
+
+#[derive(Debug)]
+struct RawSessionSummaryRecord {
+    session_id: String,
+    kind: String,
+    parent_session_id: Option<String>,
+    label: Option<String>,
+    state: String,
+    created_at: i64,
+    updated_at: i64,
+    last_error: Option<String>,
+    turn_count: i64,
+    last_turn_at: Option<i64>,
+}
+
+#[derive(Debug)]
+struct RawSessionEventRecord {
+    id: i64,
+    session_id: String,
+    event_kind: String,
+    actor_session_id: Option<String>,
+    payload_json: String,
+    ts: i64,
+}
+
+#[derive(Debug)]
+struct RawSessionTerminalOutcomeRecord {
+    session_id: String,
+    status: String,
+    payload_json: String,
+    recorded_at: i64,
+}
+
+impl SessionRecord {
+    fn try_from_raw(raw: RawSessionRecord) -> Result<Self, String> {
+        Ok(Self {
+            session_id: raw.session_id,
+            kind: SessionKind::from_db(&raw.kind)?,
+            parent_session_id: raw.parent_session_id,
+            label: raw.label,
+            state: SessionState::from_db(&raw.state)?,
+            created_at: raw.created_at,
+            updated_at: raw.updated_at,
+            last_error: raw.last_error,
+        })
+    }
+}
+
+impl SessionSummaryRecord {
+    fn try_from_raw(raw: RawSessionSummaryRecord) -> Result<Self, String> {
+        Ok(Self {
+            session_id: raw.session_id,
+            kind: SessionKind::from_db(&raw.kind)?,
+            parent_session_id: raw.parent_session_id,
+            label: raw.label,
+            state: SessionState::from_db(&raw.state)?,
+            created_at: raw.created_at,
+            updated_at: raw.updated_at,
+            turn_count: raw.turn_count.max(0) as usize,
+            last_turn_at: raw.last_turn_at,
+            last_error: raw.last_error,
+        })
+    }
+}
+
+impl SessionEventRecord {
+    fn try_from_raw(raw: RawSessionEventRecord) -> Result<Self, String> {
+        Ok(Self {
+            id: raw.id,
+            session_id: raw.session_id,
+            event_kind: raw.event_kind,
+            actor_session_id: raw.actor_session_id,
+            payload_json: serde_json::from_str(&raw.payload_json)
+                .map_err(|error| format!("decode session event payload failed: {error}"))?,
+            ts: raw.ts,
+        })
+    }
+}
+
+impl SessionTerminalOutcomeRecord {
+    fn try_from_raw(raw: RawSessionTerminalOutcomeRecord) -> Result<Self, String> {
+        Ok(Self {
+            session_id: raw.session_id,
+            status: raw.status,
+            payload_json: serde_json::from_str(&raw.payload_json).map_err(|error| {
+                format!("decode session terminal outcome payload failed: {error}")
+            })?,
+            recorded_at: raw.recorded_at,
+        })
+    }
+}
+
+fn normalize_required_text(value: &str, field_name: &str) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(format!("session repository requires {field_name}"));
+    }
+    Ok(trimmed.to_owned())
+}
+
+fn normalize_optional_text(value: Option<String>) -> Option<String> {
+    value.and_then(|raw| {
+        let trimmed = raw.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_owned())
+    })
+}
+
+fn unix_ts_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or_default()
+}
+
+fn infer_legacy_session_kind(session_id: &str) -> SessionKind {
+    if session_id.starts_with("delegate:") {
+        SessionKind::DelegateChild
+    } else {
+        SessionKind::Root
+    }
+}
+
+fn sort_session_summaries(sessions: &mut [SessionSummaryRecord]) {
+    sessions.sort_by(|left, right| {
+        right
+            .updated_at
+            .cmp(&left.updated_at)
+            .then_with(|| left.session_id.cmp(&right.session_id))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+
+    use crate::memory::append_turn_direct;
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+
+    use super::*;
+
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        let base = std::env::temp_dir().join(format!(
+            "loongclaw-session-repository-{test_name}-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&base);
+        let db_path = base.join("memory.sqlite3");
+        let _ = fs::remove_file(&db_path);
+        MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+        }
+    }
+
+    #[test]
+    fn session_repository_creates_and_loads_session_rows() {
+        let config = isolated_memory_config("create-load");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let created = repo
+            .create_session(NewSessionRecord {
+                session_id: "root-session".to_owned(),
+                kind: SessionKind::Root,
+                parent_session_id: None,
+                label: Some("Root".to_owned()),
+                state: SessionState::Ready,
+            })
+            .expect("create session");
+
+        assert_eq!(created.session_id, "root-session");
+        assert_eq!(created.kind, SessionKind::Root);
+        assert_eq!(created.state, SessionState::Ready);
+
+        let loaded = repo
+            .load_session("root-session")
+            .expect("load session")
+            .expect("session row");
+        assert_eq!(loaded.session_id, "root-session");
+        assert_eq!(loaded.label.as_deref(), Some("Root"));
+        assert_eq!(loaded.parent_session_id, None);
+    }
+
+    #[test]
+    fn session_repository_updates_state_and_last_error() {
+        let config = isolated_memory_config("update-state");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create session");
+
+        let updated = repo
+            .update_session_state(
+                "child-session",
+                SessionState::Failed,
+                Some("tool timeout".to_owned()),
+            )
+            .expect("update session state");
+        assert_eq!(updated.state, SessionState::Failed);
+        assert_eq!(updated.last_error.as_deref(), Some("tool timeout"));
+    }
+
+    #[test]
+    fn session_repository_conditional_state_update_requires_expected_state() {
+        let config = isolated_memory_config("update-state-if-current");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create session");
+
+        let updated = repo
+            .update_session_state_if_current(
+                "child-session",
+                SessionState::Ready,
+                SessionState::Running,
+                None,
+            )
+            .expect("conditional update should succeed");
+        assert!(updated.is_none());
+
+        let loaded = repo
+            .load_session("child-session")
+            .expect("load session")
+            .expect("session row");
+        assert_eq!(loaded.state, SessionState::Completed);
+    }
+
+    #[test]
+    fn transition_session_with_event_if_current_writes_state_and_event_together() {
+        let config = isolated_memory_config("transition-session-with-event");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+
+        let transitioned = repo
+            .transition_session_with_event_if_current(
+                "child-session",
+                TransitionSessionWithEventIfCurrentRequest {
+                    expected_state: SessionState::Ready,
+                    next_state: SessionState::Running,
+                    last_error: None,
+                    event_kind: "delegate_started".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({
+                        "task": "child task",
+                        "timeout_seconds": 60
+                    }),
+                },
+            )
+            .expect("transition session with event")
+            .expect("transition result");
+
+        assert_eq!(transitioned.session.state, SessionState::Running);
+        assert_eq!(transitioned.session.last_error, None);
+        assert_eq!(transitioned.event.event_kind, "delegate_started");
+        assert_eq!(
+            transitioned.event.actor_session_id.as_deref(),
+            Some("root-session")
+        );
+
+        let child = repo
+            .load_session("child-session")
+            .expect("load child")
+            .expect("child row");
+        assert_eq!(child.state, SessionState::Running);
+
+        let events = repo
+            .list_recent_events("child-session", 10)
+            .expect("list events");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_kind, "delegate_started");
+    }
+
+    #[test]
+    fn transition_session_with_event_if_current_rolls_back_state_when_event_insert_fails() {
+        let config = isolated_memory_config("transition-session-with-event-rollback");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+
+        let conn = repo.open_connection().expect("open connection");
+        conn.execute("DROP TABLE session_events", [])
+            .expect("drop session_events table");
+
+        let error = repo
+            .transition_session_with_event_if_current(
+                "child-session",
+                TransitionSessionWithEventIfCurrentRequest {
+                    expected_state: SessionState::Ready,
+                    next_state: SessionState::Running,
+                    last_error: None,
+                    event_kind: "delegate_started".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({
+                        "task": "child task",
+                        "timeout_seconds": 60
+                    }),
+                },
+            )
+            .expect_err("transition should fail when event insert fails");
+        assert!(error.contains("insert session transition event failed"));
+
+        let child = repo
+            .load_session("child-session")
+            .expect("load child")
+            .expect("child row");
+        assert_eq!(child.state, SessionState::Ready);
+
+        let events_error = repo
+            .list_recent_events("child-session", 10)
+            .expect_err("list events should fail after dropping table");
+        assert!(events_error.contains("prepare session event query failed"));
+    }
+
+    #[test]
+    fn session_repository_ensure_session_is_idempotent() {
+        let config = isolated_memory_config("ensure-session");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        let first = repo
+            .ensure_session(NewSessionRecord {
+                session_id: "root-session".to_owned(),
+                kind: SessionKind::Root,
+                parent_session_id: None,
+                label: Some("Root".to_owned()),
+                state: SessionState::Ready,
+            })
+            .expect("ensure root session");
+        let second = repo
+            .ensure_session(NewSessionRecord {
+                session_id: "root-session".to_owned(),
+                kind: SessionKind::DelegateChild,
+                parent_session_id: Some("other-parent".to_owned()),
+                label: Some("Ignored".to_owned()),
+                state: SessionState::Failed,
+            })
+            .expect("ensure existing session");
+
+        assert_eq!(first.session_id, second.session_id);
+        assert_eq!(second.kind, SessionKind::Root);
+        assert_eq!(second.parent_session_id, None);
+        assert_eq!(second.label.as_deref(), Some("Root"));
+        assert_eq!(repo.list_sessions().expect("list sessions").len(), 1);
+    }
+
+    #[test]
+    fn create_session_with_event_writes_session_and_event_together() {
+        let config = isolated_memory_config("create-session-with-event");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        let created = repo
+            .create_session_with_event(CreateSessionWithEventRequest {
+                session: NewSessionRecord {
+                    session_id: "child-session".to_owned(),
+                    kind: SessionKind::DelegateChild,
+                    parent_session_id: Some("root-session".to_owned()),
+                    label: Some("Child".to_owned()),
+                    state: SessionState::Ready,
+                },
+                event_kind: "delegate_queued".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                event_payload_json: json!({
+                    "task": "child task",
+                    "timeout_seconds": 60
+                }),
+            })
+            .expect("create session with queued event");
+
+        assert_eq!(created.session.state, SessionState::Ready);
+        assert_eq!(
+            created.session.parent_session_id.as_deref(),
+            Some("root-session")
+        );
+        assert_eq!(created.event.event_kind, "delegate_queued");
+        assert_eq!(
+            created.event.actor_session_id.as_deref(),
+            Some("root-session")
+        );
+
+        let sessions = repo.list_sessions().expect("list sessions");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, "child-session");
+
+        let events = repo
+            .list_recent_events("child-session", 10)
+            .expect("list child events");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_kind, "delegate_queued");
+    }
+
+    #[test]
+    fn create_session_with_event_rolls_back_session_when_event_insert_fails() {
+        let config = isolated_memory_config("create-session-with-event-rollback");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let conn = repo.open_connection().expect("open connection");
+        conn.execute(
+            "CREATE TRIGGER fail_create_session_event
+             BEFORE INSERT ON session_events
+             BEGIN
+                SELECT RAISE(FAIL, 'forced create session event failure');
+             END;",
+            [],
+        )
+        .expect("create session event failure trigger");
+
+        let error = repo
+            .create_session_with_event(CreateSessionWithEventRequest {
+                session: NewSessionRecord {
+                    session_id: "child-session".to_owned(),
+                    kind: SessionKind::DelegateChild,
+                    parent_session_id: Some("root-session".to_owned()),
+                    label: Some("Child".to_owned()),
+                    state: SessionState::Ready,
+                },
+                event_kind: "delegate_queued".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                event_payload_json: json!({
+                    "task": "child task",
+                    "timeout_seconds": 60
+                }),
+            })
+            .expect_err("create session with event should fail when event insert fails");
+        assert!(error.contains("insert session event failed"));
+
+        assert!(repo
+            .load_session("child-session")
+            .expect("load child after rollback")
+            .is_none());
+    }
+
+    #[test]
+    fn session_repository_lists_parent_child_relationships() {
+        let config = isolated_memory_config("list-relationships");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({"depth": 1}),
+        })
+        .expect("append event");
+
+        let sessions = repo.list_sessions().expect("list sessions");
+        assert_eq!(sessions.len(), 2);
+        let child = sessions
+            .iter()
+            .find(|session| session.session_id == "child-session")
+            .expect("child session");
+        assert_eq!(child.parent_session_id.as_deref(), Some("root-session"));
+        assert_eq!(child.kind, SessionKind::DelegateChild);
+    }
+
+    #[test]
+    fn list_visible_sessions_infers_legacy_rows_from_turn_history_without_backfill() {
+        let config = isolated_memory_config("legacy-visible-sessions");
+        append_turn_direct("telegram:123", "user", "hello", &config).expect("append user turn");
+        append_turn_direct("telegram:123", "assistant", "world", &config)
+            .expect("append assistant turn");
+
+        let repo = SessionRepository::new(&config).expect("repository");
+        let sessions = repo
+            .list_visible_sessions("telegram:123")
+            .expect("list visible sessions");
+
+        assert_eq!(sessions.len(), 1);
+        let session = &sessions[0];
+        assert_eq!(session.session_id, "telegram:123");
+        assert_eq!(session.kind, SessionKind::Root);
+        assert_eq!(session.parent_session_id, None);
+        assert_eq!(session.turn_count, 2);
+        assert!(session.last_turn_at.is_some());
+
+        assert!(repo
+            .load_session("telegram:123")
+            .expect("load legacy session")
+            .is_none());
+        assert!(repo
+            .list_sessions()
+            .expect("list concrete sessions")
+            .is_empty());
+    }
+
+    #[test]
+    fn inferred_legacy_session_kind_uses_known_prefixes() {
+        let config = isolated_memory_config("legacy-kind-prefixes");
+        append_turn_direct("delegate:legacy-child", "assistant", "done", &config)
+            .expect("append delegate turn");
+        append_turn_direct("telegram:456", "user", "ping", &config).expect("append telegram turn");
+
+        let repo = SessionRepository::new(&config).expect("repository");
+        let delegate_session = repo
+            .list_visible_sessions("delegate:legacy-child")
+            .expect("list delegate legacy session")
+            .into_iter()
+            .find(|session| session.session_id == "delegate:legacy-child")
+            .expect("delegate legacy session");
+        assert_eq!(delegate_session.kind, SessionKind::DelegateChild);
+
+        let telegram_session = repo
+            .list_visible_sessions("telegram:456")
+            .expect("list telegram legacy session")
+            .into_iter()
+            .find(|session| session.session_id == "telegram:456")
+            .expect("telegram legacy session");
+        assert_eq!(telegram_session.kind, SessionKind::Root);
+    }
+
+    #[test]
+    fn session_lineage_depth_counts_root_child_and_grandchild() {
+        let config = isolated_memory_config("lineage-depth");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.create_session(NewSessionRecord {
+            session_id: "grandchild-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("child-session".to_owned()),
+            label: Some("Grandchild".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create grandchild");
+
+        assert_eq!(
+            repo.session_lineage_depth("root-session")
+                .expect("root depth"),
+            0
+        );
+        assert_eq!(
+            repo.session_lineage_depth("child-session")
+                .expect("child depth"),
+            1
+        );
+        assert_eq!(
+            repo.session_lineage_depth("grandchild-session")
+                .expect("grandchild depth"),
+            2
+        );
+    }
+
+    #[test]
+    fn list_visible_sessions_includes_descendant_delegate_chain() {
+        let config = isolated_memory_config("descendant-visibility");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.create_session(NewSessionRecord {
+            session_id: "grandchild-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("child-session".to_owned()),
+            label: Some("Grandchild".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create grandchild");
+
+        let visible = repo
+            .list_visible_sessions("root-session")
+            .expect("visible sessions");
+        let ids: Vec<&str> = visible
+            .iter()
+            .map(|session| session.session_id.as_str())
+            .collect();
+        assert!(ids.contains(&"root-session"));
+        assert!(ids.contains(&"child-session"));
+        assert!(ids.contains(&"grandchild-session"));
+        assert!(repo
+            .is_session_visible("root-session", "grandchild-session")
+            .expect("root should see grandchild"));
+    }
+
+    #[test]
+    fn session_terminal_outcome_round_trips_payload() {
+        let config = isolated_memory_config("terminal-outcome-round-trip");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create child");
+
+        repo.upsert_terminal_outcome(
+            "child-session",
+            "ok",
+            json!({
+                "child_session_id": "child-session",
+                "final_output": "done",
+                "duration_ms": 12
+            }),
+        )
+        .expect("upsert terminal outcome");
+
+        let outcome = repo
+            .load_terminal_outcome("child-session")
+            .expect("load terminal outcome")
+            .expect("terminal outcome row");
+
+        assert_eq!(outcome.session_id, "child-session");
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload_json["final_output"], "done");
+        assert!(outcome.recorded_at > 0);
+    }
+
+    #[test]
+    fn session_terminal_outcome_upsert_replaces_existing_row() {
+        let config = isolated_memory_config("terminal-outcome-upsert");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Failed,
+        })
+        .expect("create child");
+
+        repo.upsert_terminal_outcome(
+            "child-session",
+            "error",
+            json!({
+                "error": "first"
+            }),
+        )
+        .expect("upsert first terminal outcome");
+        repo.upsert_terminal_outcome(
+            "child-session",
+            "timeout",
+            json!({
+                "error": "delegate_timeout"
+            }),
+        )
+        .expect("upsert second terminal outcome");
+
+        let outcome = repo
+            .load_terminal_outcome("child-session")
+            .expect("load terminal outcome")
+            .expect("terminal outcome row");
+        assert_eq!(outcome.status, "timeout");
+        assert_eq!(outcome.payload_json["error"], "delegate_timeout");
+    }
+
+    #[test]
+    fn finalize_session_terminal_writes_state_event_and_outcome_together() {
+        let config = isolated_memory_config("finalize-session-terminal");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+
+        let finalized = repo
+            .finalize_session_terminal(
+                "child-session",
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({
+                        "turn_count": 2,
+                        "duration_ms": 15
+                    }),
+                    outcome_status: "ok".to_owned(),
+                    outcome_payload_json: json!({
+                        "child_session_id": "child-session",
+                        "final_output": "done",
+                        "turn_count": 2,
+                        "duration_ms": 15
+                    }),
+                },
+            )
+            .expect("finalize session");
+
+        assert_eq!(finalized.session.state, SessionState::Completed);
+        assert_eq!(finalized.session.last_error, None);
+        assert_eq!(finalized.event.event_kind, "delegate_completed");
+        assert_eq!(
+            finalized.event.actor_session_id.as_deref(),
+            Some("root-session")
+        );
+        assert_eq!(finalized.terminal_outcome.status, "ok");
+        assert_eq!(finalized.session.updated_at, finalized.event.ts);
+        assert_eq!(finalized.event.ts, finalized.terminal_outcome.recorded_at);
+
+        let child = repo
+            .load_session("child-session")
+            .expect("load child session")
+            .expect("child session row");
+        assert_eq!(child.state, SessionState::Completed);
+
+        let events = repo
+            .list_recent_events("child-session", 10)
+            .expect("list child events");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_kind, "delegate_completed");
+
+        let outcome = repo
+            .load_terminal_outcome("child-session")
+            .expect("load terminal outcome")
+            .expect("terminal outcome row");
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload_json["final_output"], "done");
+    }
+
+    #[test]
+    fn finalize_session_terminal_replaces_previous_outcome_payload() {
+        let config = isolated_memory_config("finalize-session-terminal-upsert");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+
+        repo.finalize_session_terminal(
+            "child-session",
+            FinalizeSessionTerminalRequest {
+                state: SessionState::Failed,
+                last_error: Some("first".to_owned()),
+                event_kind: "delegate_failed".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                event_payload_json: json!({
+                    "error": "first"
+                }),
+                outcome_status: "error".to_owned(),
+                outcome_payload_json: json!({
+                    "error": "first"
+                }),
+            },
+        )
+        .expect("finalize first terminal state");
+
+        let finalized = repo
+            .finalize_session_terminal(
+                "child-session",
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::TimedOut,
+                    last_error: Some("delegate_timeout".to_owned()),
+                    event_kind: "delegate_timed_out".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({
+                        "error": "delegate_timeout"
+                    }),
+                    outcome_status: "timeout".to_owned(),
+                    outcome_payload_json: json!({
+                        "error": "delegate_timeout"
+                    }),
+                },
+            )
+            .expect("finalize second terminal state");
+
+        assert_eq!(finalized.session.state, SessionState::TimedOut);
+        assert_eq!(
+            finalized.session.last_error.as_deref(),
+            Some("delegate_timeout")
+        );
+        assert_eq!(finalized.terminal_outcome.status, "timeout");
+        assert_eq!(
+            finalized.terminal_outcome.payload_json["error"],
+            "delegate_timeout"
+        );
+
+        let outcome = repo
+            .load_terminal_outcome("child-session")
+            .expect("load terminal outcome")
+            .expect("terminal outcome row");
+        assert_eq!(outcome.status, "timeout");
+        assert_eq!(outcome.payload_json["error"], "delegate_timeout");
+    }
+
+    #[test]
+    fn load_session_observation_drains_tail_after_cursor_through_terminal_event() {
+        let config = isolated_memory_config("session-observation-tail-drain");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+
+        for index in 0..60 {
+            repo.append_event(NewSessionEvent {
+                session_id: "child-session".to_owned(),
+                event_kind: format!("delegate_progress_{index}"),
+                actor_session_id: Some("root-session".to_owned()),
+                payload_json: json!({
+                    "step": index
+                }),
+            })
+            .expect("append progress event");
+        }
+        repo.finalize_session_terminal(
+            "child-session",
+            FinalizeSessionTerminalRequest {
+                state: SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                event_payload_json: json!({
+                    "turn_count": 1
+                }),
+                outcome_status: "ok".to_owned(),
+                outcome_payload_json: json!({
+                    "child_session_id": "child-session",
+                    "final_output": "done"
+                }),
+            },
+        )
+        .expect("finalize child");
+
+        let observation = repo
+            .load_session_observation("child-session", 5, Some(0), 50)
+            .expect("load session observation")
+            .expect("session observation");
+
+        assert_eq!(observation.session.state, SessionState::Completed);
+        assert_eq!(
+            observation
+                .terminal_outcome
+                .as_ref()
+                .expect("terminal outcome")
+                .status,
+            "ok"
+        );
+        assert_eq!(observation.tail_events.len(), 61);
+        assert_eq!(
+            observation
+                .tail_events
+                .first()
+                .expect("first tail event")
+                .id,
+            1
+        );
+        assert_eq!(
+            observation
+                .tail_events
+                .last()
+                .expect("last tail event")
+                .event_kind,
+            "delegate_completed"
+        );
+        assert_eq!(observation.recent_events.len(), 5);
+        assert_eq!(
+            observation
+                .recent_events
+                .last()
+                .expect("last recent event")
+                .event_kind,
+            "delegate_completed"
+        );
+    }
+}

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -102,6 +102,7 @@ pub struct SessionSummaryRecord {
     pub state: SessionState,
     pub created_at: i64,
     pub updated_at: i64,
+    pub archived_at: Option<i64>,
     pub turn_count: usize,
     pub last_turn_at: Option<i64>,
     pub last_error: Option<String>,
@@ -556,9 +557,16 @@ impl SessionRepository {
                     s.created_at,
                     s.updated_at,
                     s.last_error,
+                    archived.archived_at,
                     COUNT(t.id) AS turn_count,
                     MAX(t.ts) AS last_turn_at
                  FROM sessions s
+                 LEFT JOIN (
+                    SELECT session_id, MAX(ts) AS archived_at
+                    FROM session_events
+                    WHERE event_kind = 'session_archived'
+                    GROUP BY session_id
+                 ) archived ON archived.session_id = s.session_id
                  JOIN visible v ON v.session_id = s.session_id
                  LEFT JOIN turns t ON t.session_id = s.session_id
                  GROUP BY
@@ -569,7 +577,8 @@ impl SessionRepository {
                     s.state,
                     s.created_at,
                     s.updated_at,
-                    s.last_error
+                    s.last_error,
+                    archived.archived_at
                  ORDER BY s.updated_at DESC, s.session_id ASC",
             )
             .map_err(|error| format!("prepare visible session query failed: {error}"))?;
@@ -584,8 +593,9 @@ impl SessionRepository {
                     created_at: row.get(5)?,
                     updated_at: row.get(6)?,
                     last_error: row.get(7)?,
-                    turn_count: row.get(8)?,
-                    last_turn_at: row.get(9)?,
+                    archived_at: row.get(8)?,
+                    turn_count: row.get(9)?,
+                    last_turn_at: row.get(10)?,
                 })
             })
             .map_err(|error| format!("query visible sessions failed: {error}"))?;
@@ -979,9 +989,16 @@ impl SessionRepository {
                     s.created_at,
                     s.updated_at,
                     s.last_error,
+                    archived.archived_at,
                     COUNT(t.id) AS turn_count,
                     MAX(t.ts) AS last_turn_at
                  FROM sessions s
+                 LEFT JOIN (
+                    SELECT session_id, MAX(ts) AS archived_at
+                    FROM session_events
+                    WHERE event_kind = 'session_archived'
+                    GROUP BY session_id
+                 ) archived ON archived.session_id = s.session_id
                  LEFT JOIN turns t ON t.session_id = s.session_id
                  WHERE s.session_id = ?1
                  GROUP BY
@@ -992,7 +1009,8 @@ impl SessionRepository {
                     s.state,
                     s.created_at,
                     s.updated_at,
-                    s.last_error",
+                    s.last_error,
+                    archived.archived_at",
                 params![session_id],
                 |row| {
                     Ok(RawSessionSummaryRecord {
@@ -1004,8 +1022,9 @@ impl SessionRepository {
                         created_at: row.get(5)?,
                         updated_at: row.get(6)?,
                         last_error: row.get(7)?,
-                        turn_count: row.get(8)?,
-                        last_turn_at: row.get(9)?,
+                        archived_at: row.get(8)?,
+                        turn_count: row.get(9)?,
+                        last_turn_at: row.get(10)?,
                     })
                 },
             )
@@ -1259,6 +1278,7 @@ impl SessionRepository {
             state: SessionState::Ready,
             created_at,
             updated_at,
+            archived_at: None,
             turn_count: turn_count.max(0) as usize,
             last_turn_at: Some(updated_at),
             last_error: None,
@@ -1288,6 +1308,7 @@ struct RawSessionSummaryRecord {
     created_at: i64,
     updated_at: i64,
     last_error: Option<String>,
+    archived_at: Option<i64>,
     turn_count: i64,
     last_turn_at: Option<i64>,
 }
@@ -1335,6 +1356,7 @@ impl SessionSummaryRecord {
             state: SessionState::from_db(&raw.state)?,
             created_at: raw.created_at,
             updated_at: raw.updated_at,
+            archived_at: raw.archived_at,
             turn_count: raw.turn_count.max(0) as usize,
             last_turn_at: raw.last_turn_at,
             last_error: raw.last_error,

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -323,9 +323,7 @@ fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> boo
     match tool_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
         | "session_archive" | "session_cancel" | "session_recover" | "session_unarchive"
-        | "session_wait" => {
-            config.sessions.enabled
-        }
+        | "session_wait" => config.sessions.enabled,
         "sessions_send" => config.messages.enabled,
         "delegate" | "delegate_async" => config.delegate.enabled,
         _ => true,

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -187,6 +187,15 @@ pub fn tool_catalog() -> ToolCatalog {
         provider_definition_builder: session_archive_definition,
     });
     descriptors.push(ToolDescriptor {
+        name: "session_unarchive",
+        provider_name: "session_unarchive",
+        aliases: &[],
+        description: "Restore a visible archived terminal session to default session listings",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: session_unarchive_definition,
+    });
+    descriptors.push(ToolDescriptor {
         name: "session_cancel",
         provider_name: "session_cancel",
         aliases: &[],
@@ -313,7 +322,8 @@ pub fn delegate_child_tool_view_for_config_with_delegate(
 fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> bool {
     match tool_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_archive" | "session_cancel" | "session_recover" | "session_wait" => {
+        | "session_archive" | "session_cancel" | "session_recover" | "session_unarchive"
+        | "session_wait" => {
             config.sessions.enabled
         }
         "sessions_send" => config.messages.enabled,
@@ -607,6 +617,42 @@ fn session_archive_definition(descriptor: &ToolDescriptor) -> Value {
                     "dry_run": {
                         "type": "boolean",
                         "description": "When true, preview which targets are archivable without mutating state."
+                    }
+                },
+                "oneOf": [
+                    { "required": ["session_id"] },
+                    { "required": ["session_ids"] }
+                ],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn session_unarchive_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Visible archived terminal session identifier to restore to default listings."
+                    },
+                    "session_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "Visible archived terminal session identifiers to restore in one request."
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "When true, preview which targets are unarchivable without mutating state."
                     }
                 },
                 "oneOf": [

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -397,7 +397,36 @@ fn sessions_list_definition(descriptor: &ToolDescriptor) -> Value {
             "description": descriptor.description,
             "parameters": {
                 "type": "object",
-                "properties": {},
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 200,
+                        "description": "Maximum visible sessions to return after filtering."
+                    },
+                    "state": {
+                        "type": "string",
+                        "enum": ["ready", "running", "completed", "failed", "timed_out"],
+                        "description": "Optional lifecycle state filter."
+                    },
+                    "kind": {
+                        "type": "string",
+                        "enum": ["root", "delegate_child"],
+                        "description": "Optional session kind filter."
+                    },
+                    "parent_session_id": {
+                        "type": "string",
+                        "description": "Optional direct parent session filter."
+                    },
+                    "overdue_only": {
+                        "type": "boolean",
+                        "description": "When true, only return async delegate children whose lifecycle staleness is overdue."
+                    },
+                    "include_delegate_lifecycle": {
+                        "type": "boolean",
+                        "description": "When true, include normalized delegate lifecycle metadata for returned sessions."
+                    }
+                },
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -180,6 +180,15 @@ pub fn tool_catalog() -> ToolCatalog {
         provider_definition_builder: session_recover_definition,
     });
     descriptors.push(ToolDescriptor {
+        name: "session_cancel",
+        provider_name: "session_cancel",
+        aliases: &[],
+        description: "Cancel a visible async delegate child session",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: session_cancel_definition,
+    });
+    descriptors.push(ToolDescriptor {
         name: "session_wait",
         provider_name: "session_wait",
         aliases: &[],
@@ -288,7 +297,7 @@ pub fn delegate_child_tool_view_for_config_with_delegate(
 fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> bool {
     match tool_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_recover" | "session_wait" => config.sessions.enabled,
+        | "session_cancel" | "session_recover" | "session_wait" => config.sessions.enabled,
         "delegate" | "delegate_async" => config.delegate.enabled,
         _ => true,
     }
@@ -487,6 +496,27 @@ fn session_recover_definition(descriptor: &ToolDescriptor) -> Value {
                     "session_id": {
                         "type": "string",
                         "description": "Visible delegate child session identifier to recover when it is still queued and overdue."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn session_cancel_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Visible async delegate child session identifier to cancel."
                     }
                 },
                 "required": ["session_id"],

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -171,6 +171,15 @@ pub fn tool_catalog() -> ToolCatalog {
         provider_definition_builder: session_status_definition,
     });
     descriptors.push(ToolDescriptor {
+        name: "session_recover",
+        provider_name: "session_recover",
+        aliases: &[],
+        description: "Recover an overdue queued async delegate child session by marking it failed",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: session_recover_definition,
+    });
+    descriptors.push(ToolDescriptor {
         name: "session_wait",
         provider_name: "session_wait",
         aliases: &[],
@@ -279,7 +288,7 @@ pub fn delegate_child_tool_view_for_config_with_delegate(
 fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> bool {
     match tool_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_wait" => config.sessions.enabled,
+        | "session_recover" | "session_wait" => config.sessions.enabled,
         "delegate" | "delegate_async" => config.delegate.enabled,
         _ => true,
     }
@@ -457,6 +466,27 @@ fn session_status_definition(descriptor: &ToolDescriptor) -> Value {
                     "session_id": {
                         "type": "string",
                         "description": "Visible session identifier to inspect."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn session_recover_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Visible delegate child session identifier to recover when it is still queued and overdue."
                     }
                 },
                 "required": ["session_id"],

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -609,6 +609,14 @@ fn session_wait_definition(descriptor: &ToolDescriptor) -> Value {
                         "type": "string",
                         "description": "Visible session identifier to wait on."
                     },
+                    "session_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "Visible session identifiers to wait on in one request."
+                    },
                     "after_id": {
                         "type": "integer",
                         "description": "Optional event cursor. When present, the response also returns session events with id greater than this value."
@@ -620,7 +628,10 @@ fn session_wait_definition(descriptor: &ToolDescriptor) -> Value {
                         "description": "Bounded wait timeout in milliseconds."
                     }
                 },
-                "required": ["session_id"],
+                "oneOf": [
+                    { "required": ["session_id"] },
+                    { "required": ["session_ids"] }
+                ],
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -595,9 +595,24 @@ fn session_archive_definition(descriptor: &ToolDescriptor) -> Value {
                     "session_id": {
                         "type": "string",
                         "description": "Visible terminal session identifier to archive."
+                    },
+                    "session_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "Visible terminal session identifiers to archive in one request."
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "When true, preview which targets are archivable without mutating state."
                     }
                 },
-                "required": ["session_id"],
+                "oneOf": [
+                    { "required": ["session_id"] },
+                    { "required": ["session_ids"] }
+                ],
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -524,10 +524,25 @@ fn session_recover_definition(descriptor: &ToolDescriptor) -> Value {
                 "properties": {
                     "session_id": {
                         "type": "string",
-                        "description": "Visible delegate child session identifier to recover when it is still queued and overdue."
+                        "description": "Visible delegate child session identifier to recover."
+                    },
+                    "session_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "Visible delegate child session identifiers to recover in one request."
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "When true, preview which targets are recoverable without mutating state."
                     }
                 },
-                "required": ["session_id"],
+                "oneOf": [
+                    { "required": ["session_id"] },
+                    { "required": ["session_ids"] }
+                ],
                 "additionalProperties": false
             }
         }
@@ -546,9 +561,24 @@ fn session_cancel_definition(descriptor: &ToolDescriptor) -> Value {
                     "session_id": {
                         "type": "string",
                         "description": "Visible async delegate child session identifier to cancel."
+                    },
+                    "session_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "Visible async delegate child session identifiers to cancel in one request."
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "When true, preview which targets are cancellable without mutating state."
                     }
                 },
-                "required": ["session_id"],
+                "oneOf": [
+                    { "required": ["session_id"] },
+                    { "required": ["session_ids"] }
+                ],
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -148,7 +148,7 @@ pub fn tool_catalog() -> ToolCatalog {
         description: "Fetch session events for a visible session",
         execution_kind: ToolExecutionKind::App,
         availability: ToolAvailability::Runtime,
-            provider_definition_builder: session_events_definition,
+        provider_definition_builder: session_events_definition,
     });
     descriptors.push(ToolDescriptor {
         name: "memory_search",

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -315,7 +315,9 @@ pub fn delegate_child_tool_view_for_config_with_delegate(
 fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> bool {
     match tool_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_archive" | "session_cancel" | "session_recover" | "session_wait" => config.sessions.enabled,
+        | "session_archive" | "session_cancel" | "session_recover" | "session_wait" => {
+            config.sessions.enabled
+        }
         "sessions_send" => config.messages.enabled,
         "delegate" | "delegate_async" => config.delegate.enabled,
         _ => true,

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -29,9 +29,7 @@ pub struct ToolDescriptor {
 
 impl ToolDescriptor {
     pub fn matches_name(&self, raw: &str) -> bool {
-        self.name == raw
-            || self.provider_name == raw
-            || self.aliases.iter().any(|alias| *alias == raw)
+        self.name == raw || self.provider_name == raw || self.aliases.contains(&raw)
     }
 
     pub fn provider_definition(&self) -> Value {

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -148,7 +148,16 @@ pub fn tool_catalog() -> ToolCatalog {
         description: "Fetch session events for a visible session",
         execution_kind: ToolExecutionKind::App,
         availability: ToolAvailability::Runtime,
-        provider_definition_builder: session_events_definition,
+            provider_definition_builder: session_events_definition,
+    });
+    descriptors.push(ToolDescriptor {
+        name: "memory_search",
+        provider_name: "memory_search",
+        aliases: &[],
+        description: "Search visible transcript memory across persisted session turns",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: memory_search_definition,
     });
     descriptors.push(ToolDescriptor {
         name: "sessions_history",
@@ -322,8 +331,8 @@ pub fn delegate_child_tool_view_for_config_with_delegate(
 fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> bool {
     match tool_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_archive" | "session_cancel" | "session_recover" | "session_unarchive"
-        | "session_wait" => config.sessions.enabled,
+        | "memory_search" | "session_archive" | "session_cancel" | "session_recover"
+        | "session_unarchive" | "session_wait" => config.sessions.enabled,
         "sessions_send" => config.messages.enabled,
         "delegate" | "delegate_async" => config.delegate.enabled,
         _ => true,
@@ -485,6 +494,56 @@ fn sessions_history_definition(descriptor: &ToolDescriptor) -> Value {
                     }
                 },
                 "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn memory_search_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Non-empty transcript text to search for within visible session memory."
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional visible session identifier to search exclusively."
+                    },
+                    "session_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "Optional visible session identifiers to search in one request."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "description": "Maximum transcript matches to return."
+                    },
+                    "excerpt_chars": {
+                        "type": "integer",
+                        "minimum": 40,
+                        "maximum": 400,
+                        "description": "Approximate match snippet length in characters."
+                    }
+                },
+                "required": ["query"],
+                "oneOf": [
+                    { "required": ["query", "session_id"] },
+                    { "required": ["query", "session_ids"] },
+                    { "required": ["query"] }
+                ],
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1,0 +1,560 @@
+use std::collections::BTreeSet;
+
+use serde_json::{json, Value};
+
+use crate::config::ToolConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolExecutionKind {
+    Core,
+    App,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolAvailability {
+    Runtime,
+    Planned,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ToolDescriptor {
+    pub name: &'static str,
+    pub provider_name: &'static str,
+    pub aliases: &'static [&'static str],
+    pub description: &'static str,
+    pub execution_kind: ToolExecutionKind,
+    pub availability: ToolAvailability,
+    provider_definition_builder: fn(&ToolDescriptor) -> Value,
+}
+
+impl ToolDescriptor {
+    pub fn matches_name(&self, raw: &str) -> bool {
+        self.name == raw
+            || self.provider_name == raw
+            || self.aliases.iter().any(|alias| *alias == raw)
+    }
+
+    pub fn provider_definition(&self) -> Value {
+        (self.provider_definition_builder)(self)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ToolView {
+    allowed_names: BTreeSet<String>,
+}
+
+impl ToolView {
+    pub fn from_tool_names<I, S>(names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self {
+            allowed_names: names
+                .into_iter()
+                .map(|name| name.as_ref().to_owned())
+                .collect(),
+        }
+    }
+
+    pub fn contains(&self, tool_name: &str) -> bool {
+        self.allowed_names.contains(tool_name)
+    }
+
+    pub fn iter<'a>(
+        &'a self,
+        catalog: &'a ToolCatalog,
+    ) -> impl Iterator<Item = &'a ToolDescriptor> + 'a {
+        catalog
+            .descriptors
+            .iter()
+            .filter(move |descriptor| self.contains(descriptor.name))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolCatalog {
+    descriptors: Vec<ToolDescriptor>,
+}
+
+impl ToolCatalog {
+    pub fn descriptor(&self, tool_name: &str) -> Option<&ToolDescriptor> {
+        self.descriptors
+            .iter()
+            .find(|descriptor| descriptor.name == tool_name)
+    }
+
+    pub fn resolve(&self, raw_tool_name: &str) -> Option<&ToolDescriptor> {
+        self.descriptors
+            .iter()
+            .find(|descriptor| descriptor.matches_name(raw_tool_name))
+    }
+
+    pub fn descriptors(&self) -> &[ToolDescriptor] {
+        &self.descriptors
+    }
+}
+
+pub fn tool_catalog() -> ToolCatalog {
+    let mut descriptors = Vec::new();
+
+    #[cfg(feature = "tool-file")]
+    {
+        descriptors.push(ToolDescriptor {
+            name: "file.read",
+            provider_name: "file_read",
+            aliases: &[],
+            description: "Read file contents",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            provider_definition_builder: file_read_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "file.write",
+            provider_name: "file_write",
+            aliases: &[],
+            description: "Write file contents",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            provider_definition_builder: file_write_definition,
+        });
+    }
+
+    #[cfg(feature = "tool-shell")]
+    {
+        descriptors.push(ToolDescriptor {
+            name: "shell.exec",
+            provider_name: "shell_exec",
+            aliases: &["shell"],
+            description: "Execute shell commands",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            provider_definition_builder: shell_exec_definition,
+        });
+    }
+
+    descriptors.push(ToolDescriptor {
+        name: "sessions_list",
+        provider_name: "sessions_list",
+        aliases: &[],
+        description: "List visible sessions and their high-level state",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: sessions_list_definition,
+    });
+    descriptors.push(ToolDescriptor {
+        name: "session_events",
+        provider_name: "session_events",
+        aliases: &[],
+        description: "Fetch session events for a visible session",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: session_events_definition,
+    });
+    descriptors.push(ToolDescriptor {
+        name: "sessions_history",
+        provider_name: "sessions_history",
+        aliases: &[],
+        description: "Fetch transcript history for a visible session",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: sessions_history_definition,
+    });
+    descriptors.push(ToolDescriptor {
+        name: "session_status",
+        provider_name: "session_status",
+        aliases: &[],
+        description: "Inspect the current status of a visible session",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: session_status_definition,
+    });
+    descriptors.push(ToolDescriptor {
+        name: "session_wait",
+        provider_name: "session_wait",
+        aliases: &[],
+        description: "Wait for a visible session to reach a terminal state",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: session_wait_definition,
+    });
+    descriptors.push(ToolDescriptor {
+        name: "delegate",
+        provider_name: "delegate",
+        aliases: &[],
+        description: "Delegate a focused subtask into a child session",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: delegate_definition,
+    });
+    descriptors.push(ToolDescriptor {
+        name: "delegate_async",
+        provider_name: "delegate_async",
+        aliases: &[],
+        description: "Delegate a focused subtask into a background child session",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: delegate_async_definition,
+    });
+
+    descriptors.sort_by(|left, right| left.name.cmp(right.name));
+
+    ToolCatalog { descriptors }
+}
+
+pub fn runtime_tool_view() -> ToolView {
+    runtime_tool_view_for_config(&ToolConfig::default())
+}
+
+pub fn runtime_tool_view_for_config(config: &ToolConfig) -> ToolView {
+    let catalog = tool_catalog();
+    ToolView::from_tool_names(
+        catalog
+            .descriptors()
+            .iter()
+            .filter(|descriptor| descriptor.availability == ToolAvailability::Runtime)
+            .filter(|descriptor| tool_is_enabled_for_runtime_view(descriptor.name, config))
+            .map(|descriptor| descriptor.name),
+    )
+}
+
+pub fn planned_root_tool_view() -> ToolView {
+    let catalog = tool_catalog();
+    ToolView::from_tool_names(
+        catalog
+            .descriptors()
+            .iter()
+            .map(|descriptor| descriptor.name),
+    )
+}
+
+pub fn planned_delegate_child_tool_view() -> ToolView {
+    delegate_child_tool_view_for_config(&ToolConfig::default())
+}
+
+pub fn delegate_child_tool_view_for_config(config: &ToolConfig) -> ToolView {
+    delegate_child_tool_view_for_config_with_delegate(config, false)
+}
+
+pub fn delegate_child_tool_view_for_config_with_delegate(
+    config: &ToolConfig,
+    allow_delegate: bool,
+) -> ToolView {
+    let catalog = tool_catalog();
+    let mut names = vec!["session_status", "sessions_history"];
+    let allowlist = BTreeSet::<&str>::from_iter(
+        config
+            .delegate
+            .child_tool_allowlist
+            .iter()
+            .map(String::as_str),
+    );
+
+    for descriptor in catalog.descriptors().iter().filter(|descriptor| {
+        descriptor.execution_kind == ToolExecutionKind::Core
+            && descriptor.availability == ToolAvailability::Runtime
+    }) {
+        match descriptor.name {
+            "shell.exec" =>
+            {
+                #[cfg(feature = "tool-shell")]
+                if config.delegate.allow_shell_in_child {
+                    names.push(descriptor.name);
+                }
+            }
+            name if allowlist.contains(name) => names.push(name),
+            _ => {}
+        }
+    }
+
+    if allow_delegate && config.delegate.enabled {
+        names.push("delegate");
+        names.push("delegate_async");
+    }
+
+    ToolView::from_tool_names(names)
+}
+
+fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> bool {
+    match tool_name {
+        "sessions_list" | "sessions_history" | "session_status" | "session_events"
+        | "session_wait" => config.sessions.enabled,
+        "delegate" | "delegate_async" => config.delegate.enabled,
+        _ => true,
+    }
+}
+
+fn file_read_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to read (absolute or relative to configured file root)."
+                    },
+                    "max_bytes": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 8_388_608,
+                        "description": "Optional read limit in bytes. Defaults to 1048576."
+                    }
+                },
+                "required": ["path"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn file_write_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to write (absolute or relative to configured file root)."
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "File content to write."
+                    },
+                    "create_dirs": {
+                        "type": "boolean",
+                        "description": "Create parent directories when missing. Defaults to true."
+                    }
+                },
+                "required": ["path", "content"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn shell_exec_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "Executable command name. Must be allowlisted."
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional command arguments."
+                    },
+                    "cwd": {
+                        "type": "string",
+                        "description": "Optional working directory."
+                    }
+                },
+                "required": ["command"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn sessions_list_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn sessions_history_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Visible session identifier to inspect."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 200,
+                        "description": "Maximum transcript entries to return."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn session_events_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Visible session identifier to inspect."
+                    },
+                    "after_id": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Optional event id cursor; when present only newer events are returned."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 200,
+                        "description": "Maximum event rows to return."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn session_status_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Visible session identifier to inspect."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn session_wait_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Visible session identifier to wait on."
+                    },
+                    "after_id": {
+                        "type": "integer",
+                        "description": "Optional event cursor. When present, the response also returns session events with id greater than this value."
+                    },
+                    "timeout_ms": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 30000,
+                        "description": "Bounded wait timeout in milliseconds."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn delegate_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "task": {
+                        "type": "string",
+                        "description": "Focused subtask to run in a child session."
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "Optional human-readable label for the child session."
+                    },
+                    "timeout_seconds": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 600,
+                        "description": "Optional timeout for the delegated task."
+                    }
+                },
+                "required": ["task"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn delegate_async_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "task": {
+                        "type": "string",
+                        "description": "Focused subtask to run in a background child session."
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "Optional human-readable label for the child session."
+                    },
+                    "timeout_seconds": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 600,
+                        "description": "Optional timeout for the delegated task."
+                    }
+                },
+                "required": ["task"],
+                "additionalProperties": false
+            }
+        }
+    })
+}

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -504,9 +504,20 @@ fn session_status_definition(descriptor: &ToolDescriptor) -> Value {
                     "session_id": {
                         "type": "string",
                         "description": "Visible session identifier to inspect."
+                    },
+                    "session_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "Visible session identifiers to inspect in one request."
                     }
                 },
-                "required": ["session_id"],
+                "oneOf": [
+                    { "required": ["session_id"] },
+                    { "required": ["session_ids"] }
+                ],
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -198,6 +198,15 @@ pub fn tool_catalog() -> ToolCatalog {
         provider_definition_builder: session_wait_definition,
     });
     descriptors.push(ToolDescriptor {
+        name: "sessions_send",
+        provider_name: "sessions_send",
+        aliases: &[],
+        description: "Send an outbound text message to a known channel-backed root session",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: sessions_send_definition,
+    });
+    descriptors.push(ToolDescriptor {
         name: "delegate",
         provider_name: "delegate",
         aliases: &[],
@@ -298,6 +307,7 @@ fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> boo
     match tool_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
         | "session_cancel" | "session_recover" | "session_wait" => config.sessions.enabled,
+        "sessions_send" => config.messages.enabled,
         "delegate" | "delegate_async" => config.delegate.enabled,
         _ => true,
     }
@@ -632,6 +642,31 @@ fn session_wait_definition(descriptor: &ToolDescriptor) -> Value {
                     { "required": ["session_id"] },
                     { "required": ["session_ids"] }
                 ],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn sessions_send_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Known Telegram or Feishu root session identifier to receive the outbound text message."
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "Outbound plain-text message content."
+                    }
+                },
+                "required": ["session_id", "text"],
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -180,6 +180,15 @@ pub fn tool_catalog() -> ToolCatalog {
         provider_definition_builder: session_recover_definition,
     });
     descriptors.push(ToolDescriptor {
+        name: "session_archive",
+        provider_name: "session_archive",
+        aliases: &[],
+        description: "Archive a visible terminal session from default session listings",
+        execution_kind: ToolExecutionKind::App,
+        availability: ToolAvailability::Runtime,
+        provider_definition_builder: session_archive_definition,
+    });
+    descriptors.push(ToolDescriptor {
         name: "session_cancel",
         provider_name: "session_cancel",
         aliases: &[],
@@ -306,7 +315,7 @@ pub fn delegate_child_tool_view_for_config_with_delegate(
 fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> bool {
     match tool_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_cancel" | "session_recover" | "session_wait" => config.sessions.enabled,
+        | "session_archive" | "session_cancel" | "session_recover" | "session_wait" => config.sessions.enabled,
         "sessions_send" => config.messages.enabled,
         "delegate" | "delegate_async" => config.delegate.enabled,
         _ => true,
@@ -431,6 +440,10 @@ fn sessions_list_definition(descriptor: &ToolDescriptor) -> Value {
                     "overdue_only": {
                         "type": "boolean",
                         "description": "When true, only return async delegate children whose lifecycle staleness is overdue."
+                    },
+                    "include_archived": {
+                        "type": "boolean",
+                        "description": "When true, include archived visible sessions in the returned list."
                     },
                     "include_delegate_lifecycle": {
                         "type": "boolean",
@@ -564,6 +577,27 @@ fn session_recover_definition(descriptor: &ToolDescriptor) -> Value {
                     { "required": ["session_id"] },
                     { "required": ["session_ids"] }
                 ],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn session_archive_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Visible terminal session identifier to archive."
+                    }
+                },
+                "required": ["session_id"],
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/delegate.rs
+++ b/crates/app/src/tools/delegate.rs
@@ -1,0 +1,162 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use loongclaw_contracts::ToolCoreOutcome;
+use serde_json::{json, Value};
+
+#[cfg(test)]
+pub const DEFAULT_TIMEOUT_SECONDS: u64 = 60;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DelegateRequest {
+    pub task: String,
+    pub label: Option<String>,
+    pub timeout_seconds: u64,
+}
+
+#[cfg(test)]
+pub fn parse_delegate_request(payload: &Value) -> Result<DelegateRequest, String> {
+    parse_delegate_request_with_default_timeout(payload, DEFAULT_TIMEOUT_SECONDS)
+}
+
+pub fn parse_delegate_request_with_default_timeout(
+    payload: &Value,
+    default_timeout_seconds: u64,
+) -> Result<DelegateRequest, String> {
+    let task = required_payload_string(payload, "task")?;
+    let label = payload
+        .get("label")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|label| !label.is_empty())
+        .map(ToOwned::to_owned);
+    let timeout_seconds = payload
+        .get("timeout_seconds")
+        .and_then(Value::as_u64)
+        .unwrap_or(default_timeout_seconds);
+
+    Ok(DelegateRequest {
+        task,
+        label,
+        timeout_seconds,
+    })
+}
+
+pub fn next_delegate_session_id() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default();
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("delegate:{now_ms:x}{counter:x}")
+}
+
+pub fn delegate_success_outcome(
+    child_session_id: String,
+    label: Option<String>,
+    final_output: String,
+    turn_count: usize,
+    duration_ms: u64,
+) -> ToolCoreOutcome {
+    ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "child_session_id": child_session_id,
+            "label": label,
+            "final_output": final_output,
+            "turn_count": turn_count,
+            "duration_ms": duration_ms,
+        }),
+    }
+}
+
+pub fn delegate_async_queued_outcome(
+    child_session_id: String,
+    label: Option<String>,
+    timeout_seconds: u64,
+) -> ToolCoreOutcome {
+    ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "child_session_id": child_session_id,
+            "label": label,
+            "mode": "async",
+            "state": "queued",
+            "timeout_seconds": timeout_seconds,
+        }),
+    }
+}
+
+pub fn delegate_timeout_outcome(
+    child_session_id: String,
+    label: Option<String>,
+    duration_ms: u64,
+) -> ToolCoreOutcome {
+    ToolCoreOutcome {
+        status: "timeout".to_owned(),
+        payload: json!({
+            "child_session_id": child_session_id,
+            "label": label,
+            "duration_ms": duration_ms,
+            "error": "delegate_timeout",
+        }),
+    }
+}
+
+pub fn delegate_error_outcome(
+    child_session_id: String,
+    label: Option<String>,
+    error: String,
+    duration_ms: u64,
+) -> ToolCoreOutcome {
+    ToolCoreOutcome {
+        status: "error".to_owned(),
+        payload: json!({
+            "child_session_id": child_session_id,
+            "label": label,
+            "duration_ms": duration_ms,
+            "error": error,
+        }),
+    }
+}
+
+fn required_payload_string(payload: &Value, field: &str) -> Result<String, String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| format!("delegate tool requires payload.{field}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_delegate_request_requires_task() {
+        let error =
+            parse_delegate_request(&json!({})).expect_err("missing task should be rejected");
+        assert!(error.contains("payload.task"), "error: {error}");
+    }
+
+    #[test]
+    fn parse_delegate_request_uses_defaults() {
+        let request = parse_delegate_request(&json!({
+            "task": "research"
+        }))
+        .expect("delegate request");
+        assert_eq!(request.task, "research");
+        assert_eq!(request.label, None);
+        assert_eq!(request.timeout_seconds, DEFAULT_TIMEOUT_SECONDS);
+    }
+
+    #[test]
+    fn delegate_session_ids_use_expected_prefix() {
+        let session_id = next_delegate_session_id();
+        assert!(session_id.starts_with("delegate:"));
+    }
+}

--- a/crates/app/src/tools/memory.rs
+++ b/crates/app/src/tools/memory.rs
@@ -81,8 +81,9 @@ pub(crate) fn execute_memory_search_tool_with_policies(
             "limit": request.limit.clamp(1, 100),
             "truncated": false,
         });
-        let returned_count = payload["matches"]
-            .as_array()
+        let returned_count = payload
+            .get("matches")
+            .and_then(Value::as_array)
             .map(Vec::len)
             .unwrap_or_default();
 
@@ -299,8 +300,10 @@ mod tests {
     }
 
     fn skipped_target<'a>(payload: &'a Value, session_id: &str) -> &'a Value {
-        payload["scope"]["skipped_targets"]
-            .as_array()
+        payload
+            .get("scope")
+            .and_then(|scope| scope.get("skipped_targets"))
+            .and_then(Value::as_array)
             .expect("skipped_targets array")
             .iter()
             .find(|item| item.get("session_id").and_then(Value::as_str) == Some(session_id))
@@ -399,10 +402,19 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        assert_eq!(outcome.payload["scope"]["mode"], "visible");
-        assert_eq!(outcome.payload["returned_count"], 2);
-        let matches = outcome.payload["matches"]
-            .as_array()
+        let scope = outcome.payload.get("scope").expect("scope payload");
+        assert_eq!(scope.get("mode").and_then(Value::as_str), Some("visible"));
+        assert_eq!(
+            outcome
+                .payload
+                .get("returned_count")
+                .and_then(Value::as_u64),
+            Some(2)
+        );
+        let matches = outcome
+            .payload
+            .get("matches")
+            .and_then(Value::as_array)
             .expect("matches array");
         let session_ids: Vec<&str> = matches
             .iter()
@@ -510,15 +522,26 @@ mod tests {
         )
         .expect("batch memory_search outcome");
 
-        assert_eq!(outcome.payload["scope"]["mode"], "batch");
-        assert_eq!(outcome.payload["returned_count"], 1);
+        let scope = outcome.payload.get("scope").expect("scope payload");
+        assert_eq!(scope.get("mode").and_then(Value::as_str), Some("batch"));
         assert_eq!(
-            skipped_target(&outcome.payload, "hidden-root")["result"],
-            "skipped_not_visible"
+            outcome
+                .payload
+                .get("returned_count")
+                .and_then(Value::as_u64),
+            Some(1)
         );
         assert_eq!(
-            skipped_target(&outcome.payload, "missing-session")["result"],
-            "skipped_not_found"
+            skipped_target(&outcome.payload, "hidden-root")
+                .get("result")
+                .and_then(Value::as_str),
+            Some("skipped_not_visible")
+        );
+        assert_eq!(
+            skipped_target(&outcome.payload, "missing-session")
+                .get("result")
+                .and_then(Value::as_str),
+            Some("skipped_not_found")
         );
     }
 
@@ -566,11 +589,19 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        let matches = outcome.payload["matches"]
-            .as_array()
+        let matches = outcome
+            .payload
+            .get("matches")
+            .and_then(Value::as_array)
             .expect("matches array");
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0]["session_id"], "archived-child");
+        assert_eq!(
+            matches
+                .first()
+                .and_then(|item| item.get("session_id"))
+                .and_then(Value::as_str),
+            Some("archived-child")
+        );
     }
 
     #[test]
@@ -599,10 +630,22 @@ mod tests {
         )
         .expect("legacy memory_search outcome");
 
-        assert_eq!(outcome.payload["returned_count"], 1);
         assert_eq!(
-            outcome.payload["matches"][0]["session_id"],
-            "delegate:legacy-child"
+            outcome
+                .payload
+                .get("returned_count")
+                .and_then(Value::as_u64),
+            Some(1)
+        );
+        assert_eq!(
+            outcome
+                .payload
+                .get("matches")
+                .and_then(Value::as_array)
+                .and_then(|matches| matches.first())
+                .and_then(|item| item.get("session_id"))
+                .and_then(Value::as_str),
+            Some("delegate:legacy-child")
         );
     }
 
@@ -643,8 +686,10 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        let matches = outcome.payload["matches"]
-            .as_array()
+        let matches = outcome
+            .payload
+            .get("matches")
+            .and_then(Value::as_array)
             .expect("matches array");
         assert!(
             matches.is_empty(),

--- a/crates/app/src/tools/memory.rs
+++ b/crates/app/src/tools/memory.rs
@@ -1,10 +1,10 @@
 use loongclaw_contracts::ToolCoreOutcome;
 use serde_json::{json, Value};
 
-use crate::config::ToolConfig;
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::config::SessionVisibility;
+use crate::config::ToolConfig;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::SessionRepository;
 
@@ -115,7 +115,10 @@ fn parse_memory_search_request(payload: Value) -> Result<MemorySearchRequest, St
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned);
-    let session_ids = object.get("session_ids").map(parse_session_ids).transpose()?;
+    let session_ids = object
+        .get("session_ids")
+        .map(parse_session_ids)
+        .transpose()?;
     if session_id.is_some() && session_ids.is_some() {
         return Err(
             "memory_search_invalid_request: session_id and session_ids are mutually exclusive"
@@ -127,10 +130,7 @@ fn parse_memory_search_request(payload: Value) -> Result<MemorySearchRequest, St
         query,
         session_id,
         session_ids,
-        limit: object
-            .get("limit")
-            .and_then(Value::as_u64)
-            .unwrap_or(20) as usize,
+        limit: object.get("limit").and_then(Value::as_u64).unwrap_or(20) as usize,
         excerpt_chars: object
             .get("excerpt_chars")
             .and_then(Value::as_u64)
@@ -169,7 +169,12 @@ fn resolve_search_scope(
     tool_config: &ToolConfig,
 ) -> Result<(&'static str, Vec<String>, Vec<Value>), String> {
     if let Some(session_id) = &request.session_id {
-        ensure_target_visible(repo, current_session_id, session_id, tool_config.sessions.visibility)?;
+        ensure_target_visible(
+            repo,
+            current_session_id,
+            session_id,
+            tool_config.sessions.visibility,
+        )?;
         return Ok(("single", vec![session_id.clone()], Vec::new()));
     }
 
@@ -250,7 +255,9 @@ fn classify_target_visibility(
 
     let is_visible = match visibility {
         SessionVisibility::SelfOnly => false,
-        SessionVisibility::Children => repo.is_session_visible(current_session_id, target_session_id)?,
+        SessionVisibility::Children => {
+            repo.is_session_visible(current_session_id, target_session_id)?
+        }
     };
     if is_visible {
         Ok(TargetVisibility::Visible)
@@ -369,8 +376,13 @@ mod tests {
 
         append_turn_direct("root-session", "user", "timeout budget root", &config)
             .expect("append root turn");
-        append_turn_direct("child-session", "assistant", "timeout budget child", &config)
-            .expect("append child turn");
+        append_turn_direct(
+            "child-session",
+            "assistant",
+            "timeout budget child",
+            &config,
+        )
+        .expect("append child turn");
         append_turn_direct("other-root", "assistant", "timeout budget hidden", &config)
             .expect("append hidden turn");
 
@@ -389,7 +401,9 @@ mod tests {
 
         assert_eq!(outcome.payload["scope"]["mode"], "visible");
         assert_eq!(outcome.payload["returned_count"], 2);
-        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        let matches = outcome.payload["matches"]
+            .as_array()
+            .expect("matches array");
         let session_ids: Vec<&str> = matches
             .iter()
             .filter_map(|item| item.get("session_id"))
@@ -474,8 +488,13 @@ mod tests {
         })
         .expect("create hidden");
 
-        append_turn_direct("child-session", "assistant", "timeout budget child", &config)
-            .expect("append child turn");
+        append_turn_direct(
+            "child-session",
+            "assistant",
+            "timeout budget child",
+            &config,
+        )
+        .expect("append child turn");
 
         let outcome = execute_app_tool_with_config(
             ToolCoreRequest {
@@ -525,8 +544,13 @@ mod tests {
             state: SessionState::Ready,
         })
         .expect("create archived child");
-        append_turn_direct("archived-child", "assistant", "restore inventory marker", &config)
-            .expect("append archived turn");
+        append_turn_direct(
+            "archived-child",
+            "assistant",
+            "restore inventory marker",
+            &config,
+        )
+        .expect("append archived turn");
         archive_completed_session(&repo, "archived-child", "root-session");
 
         let outcome = execute_app_tool_with_config(
@@ -542,7 +566,9 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        let matches = outcome.payload["matches"]
+            .as_array()
+            .expect("matches array");
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0]["session_id"], "archived-child");
     }
@@ -574,7 +600,10 @@ mod tests {
         .expect("legacy memory_search outcome");
 
         assert_eq!(outcome.payload["returned_count"], 1);
-        assert_eq!(outcome.payload["matches"][0]["session_id"], "delegate:legacy-child");
+        assert_eq!(
+            outcome.payload["matches"][0]["session_id"],
+            "delegate:legacy-child"
+        );
     }
 
     #[test]
@@ -614,7 +643,12 @@ mod tests {
         )
         .expect("memory_search outcome");
 
-        let matches = outcome.payload["matches"].as_array().expect("matches array");
-        assert!(matches.is_empty(), "session events should not be searchable transcript hits");
+        let matches = outcome.payload["matches"]
+            .as_array()
+            .expect("matches array");
+        assert!(
+            matches.is_empty(),
+            "session events should not be searchable transcript hits"
+        );
     }
 }

--- a/crates/app/src/tools/memory.rs
+++ b/crates/app/src/tools/memory.rs
@@ -1,0 +1,620 @@
+use loongclaw_contracts::ToolCoreOutcome;
+use serde_json::{json, Value};
+
+use crate::config::ToolConfig;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::config::SessionVisibility;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::SessionRepository;
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MemorySearchRequest {
+    query: String,
+    session_id: Option<String>,
+    session_ids: Option<Vec<String>>,
+    limit: usize,
+    excerpt_chars: usize,
+}
+
+pub(crate) fn execute_memory_search_tool_with_policies(
+    payload: Value,
+    current_session_id: &str,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (payload, current_session_id, memory_config, tool_config);
+        return Err(
+            "memory_search requires sqlite memory support (enable feature `memory-sqlite`)"
+                .to_owned(),
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        if !tool_config.sessions.enabled {
+            return Err("app_tool_disabled: session tools are disabled by config".to_owned());
+        }
+
+        let request = parse_memory_search_request(payload)?;
+        let repo = SessionRepository::new(memory_config)?;
+        let (mode, searched_session_ids, skipped_targets) =
+            resolve_search_scope(&repo, current_session_id, &request, tool_config)?;
+
+        let matches = crate::memory::search_transcript_direct(
+            &searched_session_ids,
+            &request.query,
+            request.limit,
+            request.excerpt_chars,
+            memory_config,
+        )?;
+        let mut payload = json!({
+            "query": request.query,
+            "scope": {
+                "mode": mode,
+                "current_session_id": current_session_id,
+                "searched_session_ids": searched_session_ids,
+                "searched_session_count": searched_session_ids.len(),
+                "skipped_targets": skipped_targets,
+            },
+            "matches": matches
+                .into_iter()
+                .map(|item| {
+                    json!({
+                        "session_id": item.session_id,
+                        "turn_id": item.turn_id,
+                        "role": item.role,
+                        "ts": item.ts,
+                        "content_snippet": item.content_snippet,
+                        "match": {
+                            "query": request.query,
+                            "match_kind": "substring",
+                            "excerpt_chars": request.excerpt_chars.clamp(40, 400),
+                        }
+                    })
+                })
+                .collect::<Vec<_>>(),
+            "returned_count": 0,
+            "limit": request.limit.clamp(1, 100),
+            "truncated": false,
+        });
+        let returned_count = payload["matches"]
+            .as_array()
+            .map(Vec::len)
+            .unwrap_or_default();
+
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("returned_count".to_owned(), json!(returned_count));
+        }
+
+        Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload,
+        })
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_memory_search_request(payload: Value) -> Result<MemorySearchRequest, String> {
+    let object = payload
+        .as_object()
+        .ok_or_else(|| "memory_search_invalid_request: payload must be an object".to_owned())?;
+    let query = object
+        .get("query")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "memory_search_invalid_request: query is required".to_owned())?
+        .to_owned();
+    let session_id = object
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let session_ids = object.get("session_ids").map(parse_session_ids).transpose()?;
+    if session_id.is_some() && session_ids.is_some() {
+        return Err(
+            "memory_search_invalid_request: session_id and session_ids are mutually exclusive"
+                .to_owned(),
+        );
+    }
+
+    Ok(MemorySearchRequest {
+        query,
+        session_id,
+        session_ids,
+        limit: object
+            .get("limit")
+            .and_then(Value::as_u64)
+            .unwrap_or(20) as usize,
+        excerpt_chars: object
+            .get("excerpt_chars")
+            .and_then(Value::as_u64)
+            .unwrap_or(120) as usize,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_session_ids(value: &Value) -> Result<Vec<String>, String> {
+    let items = value.as_array().ok_or_else(|| {
+        "memory_search_invalid_request: session_ids must be an array of strings".to_owned()
+    })?;
+    if items.is_empty() {
+        return Err("memory_search_invalid_request: session_ids cannot be empty".to_owned());
+    }
+
+    let mut session_ids = Vec::with_capacity(items.len());
+    for item in items {
+        let session_id = item
+            .as_str()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                "memory_search_invalid_request: session_ids must be non-empty strings".to_owned()
+            })?;
+        session_ids.push(session_id.to_owned());
+    }
+    Ok(session_ids)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn resolve_search_scope(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    request: &MemorySearchRequest,
+    tool_config: &ToolConfig,
+) -> Result<(&'static str, Vec<String>, Vec<Value>), String> {
+    if let Some(session_id) = &request.session_id {
+        ensure_target_visible(repo, current_session_id, session_id, tool_config.sessions.visibility)?;
+        return Ok(("single", vec![session_id.clone()], Vec::new()));
+    }
+
+    if let Some(session_ids) = &request.session_ids {
+        let mut visible = Vec::new();
+        let mut skipped = Vec::new();
+        for session_id in session_ids {
+            match classify_target_visibility(
+                repo,
+                current_session_id,
+                session_id,
+                tool_config.sessions.visibility,
+            )? {
+                TargetVisibility::Visible => visible.push(session_id.clone()),
+                TargetVisibility::NotVisible(message) => skipped.push(json!({
+                    "session_id": session_id,
+                    "result": "skipped_not_visible",
+                    "message": message,
+                })),
+                TargetVisibility::NotFound(message) => skipped.push(json!({
+                    "session_id": session_id,
+                    "result": "skipped_not_found",
+                    "message": message,
+                })),
+            }
+        }
+        return Ok(("batch", visible, skipped));
+    }
+
+    let visible_sessions = repo.list_visible_sessions(current_session_id)?;
+    Ok((
+        "visible",
+        visible_sessions
+            .into_iter()
+            .map(|session| session.session_id)
+            .collect(),
+        Vec::new(),
+    ))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn ensure_target_visible(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    target_session_id: &str,
+    visibility: SessionVisibility,
+) -> Result<(), String> {
+    match classify_target_visibility(repo, current_session_id, target_session_id, visibility)? {
+        TargetVisibility::Visible => Ok(()),
+        TargetVisibility::NotVisible(message) => Err(message),
+        TargetVisibility::NotFound(message) => Err(message),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+enum TargetVisibility {
+    Visible,
+    NotVisible(String),
+    NotFound(String),
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn classify_target_visibility(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    target_session_id: &str,
+    visibility: SessionVisibility,
+) -> Result<TargetVisibility, String> {
+    let summary = repo.load_session_summary_with_legacy_fallback(target_session_id)?;
+    if summary.is_none() {
+        return Ok(TargetVisibility::NotFound(format!(
+            "session_not_found: `{target_session_id}`"
+        )));
+    }
+    if current_session_id == target_session_id {
+        return Ok(TargetVisibility::Visible);
+    }
+
+    let is_visible = match visibility {
+        SessionVisibility::SelfOnly => false,
+        SessionVisibility::Children => repo.is_session_visible(current_session_id, target_session_id)?,
+    };
+    if is_visible {
+        Ok(TargetVisibility::Visible)
+    } else {
+        Ok(TargetVisibility::NotVisible(format!(
+            "visibility_denied: session `{target_session_id}` is not visible from `{current_session_id}`"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use loongclaw_contracts::ToolCoreRequest;
+    use serde_json::{json, Value};
+
+    use crate::config::ToolConfig;
+    use crate::memory::append_turn_direct;
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::repository::{
+        FinalizeSessionTerminalRequest, NewSessionEvent, NewSessionRecord, SessionKind,
+        SessionRepository, SessionState, TransitionSessionWithEventIfCurrentRequest,
+    };
+
+    use super::super::execute_app_tool_with_config;
+
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        let base = std::env::temp_dir().join(format!(
+            "loongclaw-memory-tool-{test_name}-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&base);
+        let db_path = base.join("memory.sqlite3");
+        let _ = fs::remove_file(&db_path);
+        MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+        }
+    }
+
+    fn skipped_target<'a>(payload: &'a Value, session_id: &str) -> &'a Value {
+        payload["scope"]["skipped_targets"]
+            .as_array()
+            .expect("skipped_targets array")
+            .iter()
+            .find(|item| item.get("session_id").and_then(Value::as_str) == Some(session_id))
+            .unwrap_or_else(|| panic!("missing skipped target `{session_id}`"))
+    }
+
+    fn archive_completed_session(
+        repo: &SessionRepository,
+        session_id: &str,
+        actor_session_id: &str,
+    ) {
+        repo.finalize_session_terminal(
+            session_id,
+            FinalizeSessionTerminalRequest {
+                state: SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some(actor_session_id.to_owned()),
+                event_payload_json: json!({}),
+                outcome_status: "completed".to_owned(),
+                outcome_payload_json: json!({}),
+            },
+        )
+        .expect("finalize completed");
+        repo.transition_session_with_event_if_current(
+            session_id,
+            TransitionSessionWithEventIfCurrentRequest {
+                expected_state: SessionState::Completed,
+                next_state: SessionState::Completed,
+                last_error: None,
+                event_kind: "session_archived".to_owned(),
+                actor_session_id: Some(actor_session_id.to_owned()),
+                event_payload_json: json!({
+                    "previous_state": "completed",
+                    "hides_from_sessions_list": true
+                }),
+            },
+        )
+        .expect("archive session")
+        .expect("archive transition result");
+    }
+
+    #[test]
+    fn memory_search_searches_visible_scope_by_default() {
+        let config = isolated_memory_config("visible-scope");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.create_session(NewSessionRecord {
+            session_id: "other-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Other".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create other root");
+
+        append_turn_direct("root-session", "user", "timeout budget root", &config)
+            .expect("append root turn");
+        append_turn_direct("child-session", "assistant", "timeout budget child", &config)
+            .expect("append child turn");
+        append_turn_direct("other-root", "assistant", "timeout budget hidden", &config)
+            .expect("append hidden turn");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget"
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("memory_search outcome");
+
+        assert_eq!(outcome.payload["scope"]["mode"], "visible");
+        assert_eq!(outcome.payload["returned_count"], 2);
+        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        let session_ids: Vec<&str> = matches
+            .iter()
+            .filter_map(|item| item.get("session_id"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(session_ids.contains(&"root-session"));
+        assert!(session_ids.contains(&"child-session"));
+        assert!(!session_ids.contains(&"other-root"));
+    }
+
+    #[test]
+    fn memory_search_rejects_invisible_single_target() {
+        let config = isolated_memory_config("single-target-visibility");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "other-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Other".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create other");
+
+        let error = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget",
+                    "session_id": "other-root"
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect_err("hidden single target should fail");
+
+        assert!(
+            error.contains("visibility_denied"),
+            "expected visibility_denied, got: {error}"
+        );
+    }
+
+    #[test]
+    fn memory_search_batch_reports_skipped_targets() {
+        let config = isolated_memory_config("batch-skips");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.create_session(NewSessionRecord {
+            session_id: "hidden-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Hidden".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create hidden");
+
+        append_turn_direct("child-session", "assistant", "timeout budget child", &config)
+            .expect("append child turn");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget",
+                    "session_ids": ["child-session", "hidden-root", "missing-session"]
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("batch memory_search outcome");
+
+        assert_eq!(outcome.payload["scope"]["mode"], "batch");
+        assert_eq!(outcome.payload["returned_count"], 1);
+        assert_eq!(
+            skipped_target(&outcome.payload, "hidden-root")["result"],
+            "skipped_not_visible"
+        );
+        assert_eq!(
+            skipped_target(&outcome.payload, "missing-session")["result"],
+            "skipped_not_found"
+        );
+    }
+
+    #[test]
+    fn memory_search_includes_archived_visible_sessions() {
+        let config = isolated_memory_config("archived-visible");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "archived-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Archived".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create archived child");
+        append_turn_direct("archived-child", "assistant", "restore inventory marker", &config)
+            .expect("append archived turn");
+        archive_completed_session(&repo, "archived-child", "root-session");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "restore inventory marker"
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("memory_search outcome");
+
+        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0]["session_id"], "archived-child");
+    }
+
+    #[test]
+    fn memory_search_supports_legacy_current_session_transcript() {
+        let config = isolated_memory_config("legacy-current");
+        let tool_config = ToolConfig::default();
+
+        append_turn_direct(
+            "delegate:legacy-child",
+            "assistant",
+            "legacy timeout budget note",
+            &config,
+        )
+        .expect("append legacy turn");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget"
+                }),
+            },
+            "delegate:legacy-child",
+            &config,
+            &tool_config,
+        )
+        .expect("legacy memory_search outcome");
+
+        assert_eq!(outcome.payload["returned_count"], 1);
+        assert_eq!(outcome.payload["matches"][0]["session_id"], "delegate:legacy-child");
+    }
+
+    #[test]
+    fn memory_search_does_not_return_session_events() {
+        let config = isolated_memory_config("ignores-events");
+        let repo = SessionRepository::new(&config).expect("repository");
+        let tool_config = ToolConfig::default();
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.append_event(NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "delegate_progress".to_owned(),
+            actor_session_id: None,
+            payload_json: json!({
+                "note": "timeout budget appears only in control-plane event"
+            }),
+        })
+        .expect("append control event");
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "timeout budget"
+                }),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("memory_search outcome");
+
+        let matches = outcome.payload["matches"].as_array().expect("matches array");
+        assert!(matches.is_empty(), "session events should not be searchable transcript hits");
+    }
+}

--- a/crates/app/src/tools/messaging.rs
+++ b/crates/app/src/tools/messaging.rs
@@ -1,0 +1,110 @@
+use loongclaw_contracts::ToolCoreOutcome;
+use serde_json::{json, Value};
+
+use crate::config::{LoongClawConfig, ToolConfig};
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{
+    NewSessionEvent, NewSessionRecord, SessionKind, SessionRepository,
+};
+
+const SESSION_MESSAGE_SENT_EVENT_KIND: &str = "session_message_sent";
+
+pub(crate) async fn execute_sessions_send_with_config(
+    payload: Value,
+    current_session_id: &str,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    app_config: &LoongClawConfig,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (
+            payload,
+            current_session_id,
+            memory_config,
+            tool_config,
+            app_config,
+        );
+        return Err(
+            "session tools require sqlite memory support (enable feature `memory-sqlite`)"
+                .to_owned(),
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        if !tool_config.messages.enabled {
+            return Err("app_tool_disabled: messaging tools are disabled by config".to_owned());
+        }
+
+        let session_id = required_payload_string(&payload, "session_id")?;
+        let text = required_payload_text(&payload)?;
+        let text_length = text.chars().count();
+
+        let repo = SessionRepository::new(memory_config)?;
+        let target_summary = repo
+            .load_session_summary_with_legacy_fallback(&session_id)?
+            .ok_or_else(|| format!("session_not_found: `{session_id}`"))?;
+        if target_summary.kind != SessionKind::Root {
+            return Err(format!(
+                "sessions_send_not_supported: session `{session_id}` is not a root session"
+            ));
+        }
+        if repo.load_session(&session_id)?.is_none() {
+            let _ = repo.ensure_session(NewSessionRecord {
+                session_id: target_summary.session_id.clone(),
+                kind: target_summary.kind,
+                parent_session_id: target_summary.parent_session_id.clone(),
+                label: target_summary.label.clone(),
+                state: target_summary.state,
+            })?;
+        }
+
+        let receipt =
+            crate::channel::send_text_to_known_session(app_config, &session_id, &text).await?;
+        repo.append_event(NewSessionEvent {
+            session_id: session_id.clone(),
+            event_kind: SESSION_MESSAGE_SENT_EVENT_KIND.to_owned(),
+            actor_session_id: Some(current_session_id.to_owned()),
+            payload_json: json!({
+                "channel": receipt.channel,
+                "target": receipt.target,
+                "text_length": text_length,
+                "delivery": "sent",
+            }),
+        })?;
+
+        Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "tool": "sessions_send",
+                "session_id": session_id,
+                "channel": receipt.channel,
+                "target": receipt.target,
+                "text_length": text_length,
+                "delivery": "sent",
+            }),
+        })
+    }
+}
+
+fn required_payload_string(payload: &Value, field: &str) -> Result<String, String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| format!("sessions_send requires payload.{field}"))
+}
+
+fn required_payload_text(payload: &Value) -> Result<String, String> {
+    payload
+        .get("text")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| "sessions_send requires payload.text".to_owned())
+}

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -9,6 +9,7 @@ mod catalog;
 pub(crate) mod delegate;
 mod file;
 mod kernel_adapter;
+pub(crate) mod messaging;
 pub mod runtime_config;
 mod session;
 mod shell;

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -74,7 +74,7 @@ pub fn execute_app_tool_with_config(
     };
     match canonical_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_recover" => session::execute_session_tool_with_policies(
+        | "session_cancel" | "session_recover" => session::execute_session_tool_with_policies(
             request,
             current_session_id,
             memory_config,
@@ -410,6 +410,9 @@ mod tests {
         assert!(
             snapshot.contains("- session_status: Inspect the current status of a visible session")
         );
+        assert!(
+            snapshot.contains("- session_cancel: Cancel a visible async delegate child session")
+        );
         assert!(snapshot.contains(
             "- session_recover: Recover an overdue queued async delegate child session by marking it failed"
         ));
@@ -419,31 +422,33 @@ mod tests {
 
         // Verify sorted canonical name order.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 11);
+        assert_eq!(lines.len(), 12);
         assert!(lines[0].starts_with("- delegate"));
         assert!(lines[1].starts_with("- delegate_async"));
         assert!(lines[2].starts_with("- file.read"));
         assert!(lines[3].starts_with("- file.write"));
-        assert!(lines[4].starts_with("- session_events"));
-        assert!(lines[5].starts_with("- session_recover"));
-        assert!(lines[6].starts_with("- session_status"));
-        assert!(lines[7].starts_with("- session_wait"));
-        assert!(lines[8].starts_with("- sessions_history"));
-        assert!(lines[9].starts_with("- sessions_list"));
-        assert!(lines[10].starts_with("- shell.exec"));
+        assert!(lines[4].starts_with("- session_cancel"));
+        assert!(lines[5].starts_with("- session_events"));
+        assert!(lines[6].starts_with("- session_recover"));
+        assert!(lines[7].starts_with("- session_status"));
+        assert!(lines[8].starts_with("- session_wait"));
+        assert!(lines[9].starts_with("- sessions_history"));
+        assert!(lines[10].starts_with("- sessions_list"));
+        assert!(lines[11].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 11);
+        assert_eq!(entries.len(), 12);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"delegate"));
         assert!(names.contains(&"delegate_async"));
         assert!(names.contains(&"shell.exec"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
+        assert!(names.contains(&"session_cancel"));
         assert!(names.contains(&"session_events"));
         assert!(names.contains(&"session_recover"));
         assert!(names.contains(&"sessions_list"));
@@ -456,7 +461,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 11);
+        assert_eq!(defs.len(), 12);
 
         let names: Vec<&str> = defs
             .iter()
@@ -471,6 +476,7 @@ mod tests {
                 "delegate_async",
                 "file_read",
                 "file_write",
+                "session_cancel",
                 "session_events",
                 "session_recover",
                 "session_status",
@@ -505,6 +511,15 @@ mod tests {
             .as_object()
             .expect("session_recover properties");
         assert!(recover_properties.contains_key("session_id"));
+
+        let session_cancel = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_cancel")
+            .expect("session_cancel definition");
+        let cancel_properties = session_cancel["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_cancel properties");
+        assert!(cancel_properties.contains_key("session_id"));
     }
 
     #[test]
@@ -599,6 +614,7 @@ mod tests {
         assert!(view.contains("sessions_history"));
         assert!(view.contains("session_status"));
         assert!(view.contains("session_events"));
+        assert!(view.contains("session_cancel"));
         assert!(view.contains("session_recover"));
         assert!(view.contains("session_wait"));
         assert!(view.contains("delegate"));
@@ -613,9 +629,25 @@ mod tests {
         assert!(view.contains("sessions_history"));
         assert!(view.contains("session_status"));
         assert!(view.contains("session_events"));
+        assert!(view.contains("session_cancel"));
         assert!(view.contains("session_recover"));
         assert!(view.contains("session_wait"));
         assert!(view.contains("delegate_async"));
+    }
+
+    #[test]
+    fn session_cancel_is_visible_in_root_and_hidden_in_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("session_cancel"));
+
+        let child_view = planned_delegate_child_tool_view();
+        assert!(!child_view.contains("session_cancel"));
+
+        let child_with_depth = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
+        );
+        assert!(!child_with_depth.contains("session_cancel"));
     }
 
     #[test]
@@ -687,6 +719,7 @@ mod tests {
         assert!(!view.contains("delegate_async"));
         assert!(!view.contains("sessions_list"));
         assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_cancel"));
         assert!(!view.contains("session_recover"));
         assert!(!view.contains("session_wait"));
     }
@@ -700,6 +733,7 @@ mod tests {
         assert!(view.contains("session_status"));
         assert!(!view.contains("sessions_list"));
         assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_cancel"));
         assert!(!view.contains("session_recover"));
         assert!(!view.contains("session_wait"));
         assert!(!view.contains("delegate_async"));

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use loongclaw_contracts::{Capability, ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{json, Value};
-use tokio::time::{sleep, Duration, Instant};
 
 use crate::KernelContext;
 
@@ -109,149 +108,14 @@ pub async fn wait_for_session_with_config(
         if !tool_config.sessions.enabled {
             return Err("app_tool_disabled: session tools are disabled by config".to_owned());
         }
-
-        let target_session_id = payload
-            .get("session_id")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| "session tool requires payload.session_id".to_owned())?
-            .to_owned();
-        let after_id = payload.get("after_id").and_then(Value::as_i64);
-        let timeout_ms = payload
-            .get("timeout_ms")
-            .and_then(Value::as_u64)
-            .unwrap_or(1_000)
-            .clamp(1, 30_000);
-        let event_limit = tool_config.sessions.history_limit.min(50);
-        let started_at = Instant::now();
-        let mut next_after_id = after_id.unwrap_or(0).max(0);
-        let mut observed_events = Vec::new();
-
-        loop {
-            let observation = session::observe_visible_session_with_policies(
-                &target_session_id,
-                current_session_id,
-                memory_config,
-                tool_config,
-                5,
-                after_id.map(|_| next_after_id),
-                event_limit,
-            )?;
-            let snapshot = observation.inspection;
-            if let Some(last_tail_event_id) = observation.tail_events.last().map(|event| event.id) {
-                next_after_id = last_tail_event_id;
-            }
-            observed_events.extend(observation.tail_events);
-            let is_terminal = session::session_state_is_terminal(snapshot.session.state);
-            if is_terminal {
-                return Ok(wait_outcome(
-                    "ok",
-                    snapshot,
-                    after_id,
-                    timeout_ms,
-                    match after_id {
-                        Some(_) => observed_events,
-                        None => Vec::new(),
-                    },
-                    next_after_id,
-                ));
-            }
-
-            let elapsed_ms = started_at.elapsed().as_millis() as u64;
-            if elapsed_ms >= timeout_ms {
-                return Ok(ToolCoreOutcome {
-                    status: "timeout".to_owned(),
-                    payload: wait_payload(
-                        snapshot,
-                        "timeout",
-                        after_id,
-                        timeout_ms,
-                        match after_id {
-                            Some(_) => observed_events,
-                            None => Vec::new(),
-                        },
-                        next_after_id,
-                    ),
-                });
-            }
-
-            let remaining_ms = timeout_ms - elapsed_ms;
-            sleep(Duration::from_millis(remaining_ms.min(25))).await;
-        }
+        session::wait_for_session_tool_with_policies(
+            payload,
+            current_session_id,
+            memory_config,
+            tool_config,
+        )
+        .await
     }
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn wait_outcome(
-    status: &str,
-    snapshot: session::SessionInspectionSnapshot,
-    after_id: Option<i64>,
-    timeout_ms: u64,
-    observed_events: Vec<crate::session::repository::SessionEventRecord>,
-    next_after_id: i64,
-) -> ToolCoreOutcome {
-    ToolCoreOutcome {
-        status: status.to_owned(),
-        payload: wait_payload(
-            snapshot,
-            if status == "ok" {
-                "completed"
-            } else {
-                "timeout"
-            },
-            after_id,
-            timeout_ms,
-            observed_events,
-            next_after_id,
-        ),
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn wait_payload(
-    snapshot: session::SessionInspectionSnapshot,
-    wait_status: &str,
-    after_id: Option<i64>,
-    timeout_ms: u64,
-    observed_events: Vec<crate::session::repository::SessionEventRecord>,
-    next_after_id: i64,
-) -> Value {
-    let next_after_id = match after_id {
-        Some(_) => next_after_id,
-        None => snapshot
-            .recent_events
-            .last()
-            .map(|event| event.id)
-            .unwrap_or(0),
-    };
-    let events = match after_id {
-        Some(_) => observed_events,
-        None => snapshot.recent_events.clone(),
-    };
-    let mut payload = session::session_inspection_payload(snapshot);
-    if let Some(object) = payload.as_object_mut() {
-        object.insert(
-            "wait_status".to_owned(),
-            Value::String(wait_status.to_owned()),
-        );
-        object.insert("timeout_ms".to_owned(), Value::from(timeout_ms));
-        object.insert(
-            "after_id".to_owned(),
-            after_id.map(Value::from).unwrap_or(Value::Null),
-        );
-        object.insert("next_after_id".to_owned(), Value::from(next_after_id));
-        object.insert(
-            "events".to_owned(),
-            Value::Array(
-                events
-                    .into_iter()
-                    .map(session::session_event_json)
-                    .collect::<Vec<_>>(),
-            ),
-        );
-    }
-    payload
 }
 
 pub fn canonical_tool_name(raw: &str) -> &str {
@@ -500,8 +364,16 @@ mod tests {
             .as_object()
             .expect("session_wait properties");
         assert!(properties.contains_key("session_id"));
+        assert!(properties.contains_key("session_ids"));
         assert!(properties.contains_key("timeout_ms"));
         assert!(properties.contains_key("after_id"));
+        assert_eq!(
+            session_wait["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("session_wait oneOf")
+                .len(),
+            2
+        );
 
         let session_recover = defs
             .iter()

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -73,14 +73,13 @@ pub fn execute_app_tool_with_config(
         payload: request.payload,
     };
     match canonical_name {
-        "sessions_list" | "sessions_history" | "session_status" | "session_events" => {
-            session::execute_session_tool_with_policies(
-                request,
-                current_session_id,
-                memory_config,
-                tool_config,
-            )
-        }
+        "sessions_list" | "sessions_history" | "session_status" | "session_events"
+        | "session_recover" => session::execute_session_tool_with_policies(
+            request,
+            current_session_id,
+            memory_config,
+            tool_config,
+        ),
         "session_wait" => Err("app_tool_not_implemented: session_wait".to_owned()),
         "delegate" => Err("app_tool_not_implemented: delegate".to_owned()),
         _ => Err(format!(
@@ -411,30 +410,34 @@ mod tests {
         assert!(
             snapshot.contains("- session_status: Inspect the current status of a visible session")
         );
+        assert!(snapshot.contains(
+            "- session_recover: Recover an overdue queued async delegate child session by marking it failed"
+        ));
         assert!(snapshot
             .contains("- session_wait: Wait for a visible session to reach a terminal state"));
         assert!(snapshot.contains("- session_events: Fetch session events for a visible session"));
 
         // Verify sorted canonical name order.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 10);
+        assert_eq!(lines.len(), 11);
         assert!(lines[0].starts_with("- delegate"));
         assert!(lines[1].starts_with("- delegate_async"));
         assert!(lines[2].starts_with("- file.read"));
         assert!(lines[3].starts_with("- file.write"));
         assert!(lines[4].starts_with("- session_events"));
-        assert!(lines[5].starts_with("- session_status"));
-        assert!(lines[6].starts_with("- session_wait"));
-        assert!(lines[7].starts_with("- sessions_history"));
-        assert!(lines[8].starts_with("- sessions_list"));
-        assert!(lines[9].starts_with("- shell.exec"));
+        assert!(lines[5].starts_with("- session_recover"));
+        assert!(lines[6].starts_with("- session_status"));
+        assert!(lines[7].starts_with("- session_wait"));
+        assert!(lines[8].starts_with("- sessions_history"));
+        assert!(lines[9].starts_with("- sessions_list"));
+        assert!(lines[10].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 10);
+        assert_eq!(entries.len(), 11);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"delegate"));
         assert!(names.contains(&"delegate_async"));
@@ -442,6 +445,7 @@ mod tests {
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
         assert!(names.contains(&"session_events"));
+        assert!(names.contains(&"session_recover"));
         assert!(names.contains(&"sessions_list"));
         assert!(names.contains(&"sessions_history"));
         assert!(names.contains(&"session_status"));
@@ -452,7 +456,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 10);
+        assert_eq!(defs.len(), 11);
 
         let names: Vec<&str> = defs
             .iter()
@@ -468,6 +472,7 @@ mod tests {
                 "file_read",
                 "file_write",
                 "session_events",
+                "session_recover",
                 "session_status",
                 "session_wait",
                 "sessions_history",
@@ -491,6 +496,15 @@ mod tests {
         assert!(properties.contains_key("session_id"));
         assert!(properties.contains_key("timeout_ms"));
         assert!(properties.contains_key("after_id"));
+
+        let session_recover = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_recover")
+            .expect("session_recover definition");
+        let recover_properties = session_recover["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_recover properties");
+        assert!(recover_properties.contains_key("session_id"));
     }
 
     #[test]
@@ -585,6 +599,7 @@ mod tests {
         assert!(view.contains("sessions_history"));
         assert!(view.contains("session_status"));
         assert!(view.contains("session_events"));
+        assert!(view.contains("session_recover"));
         assert!(view.contains("session_wait"));
         assert!(view.contains("delegate"));
         assert!(view.contains("delegate_async"));
@@ -598,6 +613,7 @@ mod tests {
         assert!(view.contains("sessions_history"));
         assert!(view.contains("session_status"));
         assert!(view.contains("session_events"));
+        assert!(view.contains("session_recover"));
         assert!(view.contains("session_wait"));
         assert!(view.contains("delegate_async"));
     }
@@ -617,6 +633,7 @@ mod tests {
         assert!(!view.contains("sessions_history"));
         assert!(!view.contains("session_status"));
         assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_recover"));
         assert!(!view.contains("session_wait"));
     }
 
@@ -631,6 +648,7 @@ mod tests {
         assert!(view.contains("shell.exec"));
         assert!(!view.contains("delegate"));
         assert!(!view.contains("sessions_list"));
+        assert!(!view.contains("session_recover"));
         assert!(!view.contains("session_wait"));
     }
 
@@ -669,6 +687,7 @@ mod tests {
         assert!(!view.contains("delegate_async"));
         assert!(!view.contains("sessions_list"));
         assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_recover"));
         assert!(!view.contains("session_wait"));
     }
 
@@ -681,6 +700,7 @@ mod tests {
         assert!(view.contains("session_status"));
         assert!(!view.contains("sessions_list"));
         assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_recover"));
         assert!(!view.contains("session_wait"));
         assert!(!view.contains("delegate_async"));
     }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -74,7 +74,7 @@ pub fn execute_app_tool_with_config(
     };
     match canonical_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_cancel" | "session_archive" | "session_recover" => {
+        | "session_cancel" | "session_archive" | "session_recover" | "session_unarchive" => {
             session::execute_session_tool_with_policies(
                 request,
                 current_session_id,
@@ -292,12 +292,14 @@ mod tests {
             "- session_recover: Recover an overdue queued async delegate child session by marking it failed"
         ));
         assert!(snapshot
+            .contains("- session_unarchive: Restore a visible archived terminal session to default session listings"));
+        assert!(snapshot
             .contains("- session_wait: Wait for a visible session to reach a terminal state"));
         assert!(snapshot.contains("- session_events: Fetch session events for a visible session"));
 
         // Verify sorted canonical name order.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 13);
+        assert_eq!(lines.len(), 14);
         assert!(lines[0].starts_with("- delegate"));
         assert!(lines[1].starts_with("- delegate_async"));
         assert!(lines[2].starts_with("- file.read"));
@@ -307,17 +309,18 @@ mod tests {
         assert!(lines[6].starts_with("- session_events"));
         assert!(lines[7].starts_with("- session_recover"));
         assert!(lines[8].starts_with("- session_status"));
-        assert!(lines[9].starts_with("- session_wait"));
-        assert!(lines[10].starts_with("- sessions_history"));
-        assert!(lines[11].starts_with("- sessions_list"));
-        assert!(lines[12].starts_with("- shell.exec"));
+        assert!(lines[9].starts_with("- session_unarchive"));
+        assert!(lines[10].starts_with("- session_wait"));
+        assert!(lines[11].starts_with("- sessions_history"));
+        assert!(lines[12].starts_with("- sessions_list"));
+        assert!(lines[13].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 13);
+        assert_eq!(entries.len(), 14);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"delegate"));
         assert!(names.contains(&"delegate_async"));
@@ -328,6 +331,7 @@ mod tests {
         assert!(names.contains(&"session_cancel"));
         assert!(names.contains(&"session_events"));
         assert!(names.contains(&"session_recover"));
+        assert!(names.contains(&"session_unarchive"));
         assert!(names.contains(&"sessions_list"));
         assert!(names.contains(&"sessions_history"));
         assert!(names.contains(&"session_status"));
@@ -338,7 +342,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 13);
+        assert_eq!(defs.len(), 14);
 
         let names: Vec<&str> = defs
             .iter()
@@ -358,6 +362,7 @@ mod tests {
                 "session_events",
                 "session_recover",
                 "session_status",
+                "session_unarchive",
                 "session_wait",
                 "sessions_history",
                 "sessions_list",
@@ -439,6 +444,24 @@ mod tests {
             session_archive["function"]["parameters"]["oneOf"]
                 .as_array()
                 .expect("session_archive oneOf")
+                .len(),
+            2
+        );
+
+        let session_unarchive = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_unarchive")
+            .expect("session_unarchive definition");
+        let unarchive_properties = session_unarchive["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_unarchive properties");
+        assert!(unarchive_properties.contains_key("session_id"));
+        assert!(unarchive_properties.contains_key("session_ids"));
+        assert!(unarchive_properties.contains_key("dry_run"));
+        assert_eq!(
+            session_unarchive["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("session_unarchive oneOf")
                 .len(),
             2
         );
@@ -622,6 +645,21 @@ mod tests {
     }
 
     #[test]
+    fn session_unarchive_is_visible_in_root_and_hidden_in_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("session_unarchive"));
+
+        let child_view = planned_delegate_child_tool_view();
+        assert!(!child_view.contains("session_unarchive"));
+
+        let child_with_depth = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
+        );
+        assert!(!child_with_depth.contains("session_unarchive"));
+    }
+
+    #[test]
     fn runtime_tool_view_for_config_omits_disabled_session_and_delegate_tools() {
         let mut config = crate::config::ToolConfig::default();
         config.sessions.enabled = false;
@@ -638,6 +676,7 @@ mod tests {
         assert!(!view.contains("session_events"));
         assert!(!view.contains("session_archive"));
         assert!(!view.contains("session_recover"));
+        assert!(!view.contains("session_unarchive"));
         assert!(!view.contains("session_wait"));
     }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -520,6 +520,20 @@ mod tests {
             .as_object()
             .expect("session_cancel properties");
         assert!(cancel_properties.contains_key("session_id"));
+
+        let sessions_list = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "sessions_list")
+            .expect("sessions_list definition");
+        let list_properties = sessions_list["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("sessions_list properties");
+        assert!(list_properties.contains_key("limit"));
+        assert!(list_properties.contains_key("state"));
+        assert!(list_properties.contains_key("kind"));
+        assert!(list_properties.contains_key("parent_session_id"));
+        assert!(list_properties.contains_key("overdue_only"));
+        assert!(list_properties.contains_key("include_delegate_lifecycle"));
     }
 
     #[test]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -74,12 +74,14 @@ pub fn execute_app_tool_with_config(
     };
     match canonical_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_cancel" | "session_archive" | "session_recover" => session::execute_session_tool_with_policies(
-            request,
-            current_session_id,
-            memory_config,
-            tool_config,
-        ),
+        | "session_cancel" | "session_archive" | "session_recover" => {
+            session::execute_session_tool_with_policies(
+                request,
+                current_session_id,
+                memory_config,
+                tool_config,
+            )
+        }
         "sessions_send" => Err("app_tool_not_implemented: sessions_send".to_owned()),
         "session_wait" => Err("app_tool_not_implemented: session_wait".to_owned()),
         "delegate" => Err("app_tool_not_implemented: delegate".to_owned()),

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -74,7 +74,7 @@ pub fn execute_app_tool_with_config(
     };
     match canonical_name {
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_cancel" | "session_recover" => session::execute_session_tool_with_policies(
+        | "session_cancel" | "session_archive" | "session_recover" => session::execute_session_tool_with_policies(
             request,
             current_session_id,
             memory_config,

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -2,14 +2,24 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use loongclaw_contracts::{Capability, ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{json, Value};
+use tokio::time::{sleep, Duration, Instant};
 
 use crate::KernelContext;
 
+mod catalog;
+pub(crate) mod delegate;
 mod file;
 mod kernel_adapter;
 pub mod runtime_config;
+mod session;
 mod shell;
 
+pub use catalog::{
+    delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
+    planned_delegate_child_tool_view, planned_root_tool_view, runtime_tool_view,
+    runtime_tool_view_for_config, tool_catalog, ToolAvailability, ToolCatalog, ToolDescriptor,
+    ToolExecutionKind, ToolView,
+};
 pub use kernel_adapter::MvpToolAdapter;
 
 /// Execute a tool request, optionally routing through the kernel for
@@ -39,20 +49,226 @@ pub fn execute_tool_core(request: ToolCoreRequest) -> Result<ToolCoreOutcome, St
     execute_tool_core_with_config(request, runtime_config::get_tool_runtime_config())
 }
 
+pub fn execute_app_tool(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+) -> Result<ToolCoreOutcome, String> {
+    execute_app_tool_with_config(
+        request,
+        current_session_id,
+        crate::memory::runtime_config::get_memory_runtime_config(),
+        &crate::config::ToolConfig::default(),
+    )
+}
+
+pub fn execute_app_tool_with_config(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    memory_config: &crate::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &crate::config::ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let canonical_name = canonical_tool_name(request.tool_name.as_str());
+    let request = ToolCoreRequest {
+        tool_name: canonical_name.to_owned(),
+        payload: request.payload,
+    };
+    match canonical_name {
+        "sessions_list" | "sessions_history" | "session_status" | "session_events" => {
+            session::execute_session_tool_with_policies(
+                request,
+                current_session_id,
+                memory_config,
+                tool_config,
+            )
+        }
+        "session_wait" => Err("app_tool_not_implemented: session_wait".to_owned()),
+        "delegate" => Err("app_tool_not_implemented: delegate".to_owned()),
+        _ => Err(format!(
+            "app_tool_not_found: unknown tool `{}`",
+            request.tool_name
+        )),
+    }
+}
+
+pub async fn wait_for_session_with_config(
+    payload: Value,
+    current_session_id: &str,
+    memory_config: &crate::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &crate::config::ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (payload, current_session_id, memory_config, tool_config);
+        return Err(
+            "session tools require sqlite memory support (enable feature `memory-sqlite`)"
+                .to_owned(),
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        if !tool_config.sessions.enabled {
+            return Err("app_tool_disabled: session tools are disabled by config".to_owned());
+        }
+
+        let target_session_id = payload
+            .get("session_id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| "session tool requires payload.session_id".to_owned())?
+            .to_owned();
+        let after_id = payload.get("after_id").and_then(Value::as_i64);
+        let timeout_ms = payload
+            .get("timeout_ms")
+            .and_then(Value::as_u64)
+            .unwrap_or(1_000)
+            .clamp(1, 30_000);
+        let event_limit = tool_config.sessions.history_limit.min(50);
+        let started_at = Instant::now();
+        let mut next_after_id = after_id.unwrap_or(0).max(0);
+        let mut observed_events = Vec::new();
+
+        loop {
+            let observation = session::observe_visible_session_with_policies(
+                &target_session_id,
+                current_session_id,
+                memory_config,
+                tool_config,
+                5,
+                after_id.map(|_| next_after_id),
+                event_limit,
+            )?;
+            let snapshot = observation.inspection;
+            if let Some(last_tail_event_id) = observation.tail_events.last().map(|event| event.id) {
+                next_after_id = last_tail_event_id;
+            }
+            observed_events.extend(observation.tail_events);
+            let is_terminal = session::session_state_is_terminal(snapshot.session.state);
+            if is_terminal {
+                return Ok(wait_outcome(
+                    "ok",
+                    snapshot,
+                    after_id,
+                    timeout_ms,
+                    match after_id {
+                        Some(_) => observed_events,
+                        None => Vec::new(),
+                    },
+                    next_after_id,
+                ));
+            }
+
+            let elapsed_ms = started_at.elapsed().as_millis() as u64;
+            if elapsed_ms >= timeout_ms {
+                return Ok(ToolCoreOutcome {
+                    status: "timeout".to_owned(),
+                    payload: wait_payload(
+                        snapshot,
+                        "timeout",
+                        after_id,
+                        timeout_ms,
+                        match after_id {
+                            Some(_) => observed_events,
+                            None => Vec::new(),
+                        },
+                        next_after_id,
+                    ),
+                });
+            }
+
+            let remaining_ms = timeout_ms - elapsed_ms;
+            sleep(Duration::from_millis(remaining_ms.min(25))).await;
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn wait_outcome(
+    status: &str,
+    snapshot: session::SessionInspectionSnapshot,
+    after_id: Option<i64>,
+    timeout_ms: u64,
+    observed_events: Vec<crate::session::repository::SessionEventRecord>,
+    next_after_id: i64,
+) -> ToolCoreOutcome {
+    ToolCoreOutcome {
+        status: status.to_owned(),
+        payload: wait_payload(
+            snapshot,
+            if status == "ok" {
+                "completed"
+            } else {
+                "timeout"
+            },
+            after_id,
+            timeout_ms,
+            observed_events,
+            next_after_id,
+        ),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn wait_payload(
+    snapshot: session::SessionInspectionSnapshot,
+    wait_status: &str,
+    after_id: Option<i64>,
+    timeout_ms: u64,
+    observed_events: Vec<crate::session::repository::SessionEventRecord>,
+    next_after_id: i64,
+) -> Value {
+    let next_after_id = match after_id {
+        Some(_) => next_after_id,
+        None => snapshot
+            .recent_events
+            .last()
+            .map(|event| event.id)
+            .unwrap_or(0),
+    };
+    let events = match after_id {
+        Some(_) => observed_events,
+        None => snapshot.recent_events.clone(),
+    };
+    let mut payload = session::session_inspection_payload(snapshot);
+    if let Some(object) = payload.as_object_mut() {
+        object.insert(
+            "wait_status".to_owned(),
+            Value::String(wait_status.to_owned()),
+        );
+        object.insert("timeout_ms".to_owned(), Value::from(timeout_ms));
+        object.insert(
+            "after_id".to_owned(),
+            after_id.map(Value::from).unwrap_or(Value::Null),
+        );
+        object.insert("next_after_id".to_owned(), Value::from(next_after_id));
+        object.insert(
+            "events".to_owned(),
+            Value::Array(
+                events
+                    .into_iter()
+                    .map(session::session_event_json)
+                    .collect::<Vec<_>>(),
+            ),
+        );
+    }
+    payload
+}
+
 pub fn canonical_tool_name(raw: &str) -> &str {
-    match raw {
-        "file_read" => "file.read",
-        "file_write" => "file.write",
-        "shell_exec" | "shell" => "shell.exec",
-        other => other,
+    let catalog = tool_catalog();
+    match catalog.resolve(raw) {
+        Some(descriptor) => descriptor.name,
+        None => raw,
     }
 }
 
 pub fn is_known_tool_name(raw: &str) -> bool {
-    matches!(
-        canonical_tool_name(raw),
-        "shell.exec" | "file.read" | "file.write"
-    )
+    is_known_tool_name_in_view(raw, &runtime_tool_view())
+}
+
+pub fn is_known_tool_name_in_view(raw: &str, view: &ToolView) -> bool {
+    view.contains(canonical_tool_name(raw))
 }
 
 pub fn execute_tool_core_with_config(
@@ -84,35 +300,27 @@ pub struct ToolRegistryEntry {
 
 /// Returns a sorted list of all registered tools, gated by feature flags.
 pub fn tool_registry() -> Vec<ToolRegistryEntry> {
-    let mut entries = Vec::new();
-    #[cfg(feature = "tool-file")]
-    {
-        entries.push(ToolRegistryEntry {
-            name: "file.read",
-            description: "Read file contents",
-        });
-        entries.push(ToolRegistryEntry {
-            name: "file.write",
-            description: "Write file contents",
-        });
-    }
-    #[cfg(feature = "tool-shell")]
-    {
-        entries.push(ToolRegistryEntry {
-            name: "shell.exec",
-            description: "Execute shell commands",
-        });
-    }
-    entries
+    let catalog = tool_catalog();
+    runtime_tool_view()
+        .iter(&catalog)
+        .map(|descriptor| ToolRegistryEntry {
+            name: descriptor.name,
+            description: descriptor.description,
+        })
+        .collect()
 }
 
 /// Produce a deterministic text block listing available tools,
 /// suitable for appending to the system prompt.
 pub fn capability_snapshot() -> String {
-    let entries = tool_registry();
+    capability_snapshot_for_view(&runtime_tool_view())
+}
+
+pub fn capability_snapshot_for_view(view: &ToolView) -> String {
+    let catalog = tool_catalog();
     let mut lines = vec!["[available_tools]".to_owned()];
-    for entry in &entries {
-        lines.push(format!("- {}: {}", entry.name, entry.description));
+    for descriptor in view.iter(&catalog) {
+        lines.push(format!("- {}: {}", descriptor.name, descriptor.description));
     }
     lines.join("\n")
 }
@@ -122,94 +330,23 @@ pub fn capability_snapshot() -> String {
 /// The output shape matches OpenAI-compatible `tools=[{type:function,...}]`.
 /// Order is deterministic for stable prompting/tests.
 pub fn provider_tool_definitions() -> Vec<Value> {
+    try_provider_tool_definitions_for_view(&runtime_tool_view())
+        .expect("runtime tool view should always be advertisable")
+}
+
+pub fn try_provider_tool_definitions_for_view(view: &ToolView) -> Result<Vec<Value>, String> {
+    let catalog = tool_catalog();
     let mut tools = Vec::new();
-
-    #[cfg(feature = "tool-file")]
-    {
-        tools.push(json!({
-            "type": "function",
-            "function": {
-                "name": "file_read",
-                "description": "Read file contents",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "path": {
-                            "type": "string",
-                            "description": "Path to read (absolute or relative to configured file root)."
-                        },
-                        "max_bytes": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "maximum": 8_388_608,
-                            "description": "Optional read limit in bytes. Defaults to 1048576."
-                        }
-                    },
-                    "required": ["path"],
-                    "additionalProperties": false
-                }
-            }
-        }));
-        tools.push(json!({
-            "type": "function",
-            "function": {
-                "name": "file_write",
-                "description": "Write file contents",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "path": {
-                            "type": "string",
-                            "description": "Path to write (absolute or relative to configured file root)."
-                        },
-                        "content": {
-                            "type": "string",
-                            "description": "File content to write."
-                        },
-                        "create_dirs": {
-                            "type": "boolean",
-                            "description": "Create parent directories when missing. Defaults to true."
-                        }
-                    },
-                    "required": ["path", "content"],
-                    "additionalProperties": false
-                }
-            }
-        }));
+    for descriptor in view.iter(&catalog) {
+        if descriptor.availability != ToolAvailability::Runtime {
+            return Err(format!(
+                "tool_not_advertisable: `{}` is still planned and cannot be exposed yet",
+                descriptor.name
+            ));
+        }
+        tools.push(descriptor.provider_definition());
     }
-
-    #[cfg(feature = "tool-shell")]
-    {
-        tools.push(json!({
-            "type": "function",
-            "function": {
-                "name": "shell_exec",
-                "description": "Execute shell commands",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "command": {
-                            "type": "string",
-                            "description": "Executable command name. Must be allowlisted."
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "Optional command arguments."
-                        },
-                        "cwd": {
-                            "type": "string",
-                            "description": "Optional working directory."
-                        }
-                    },
-                    "required": ["command"],
-                    "additionalProperties": false
-                }
-            }
-        }));
-    }
-
-    tools
+    Ok(tools)
 }
 
 #[allow(dead_code)]
@@ -258,34 +395,64 @@ mod tests {
     #[test]
     fn capability_snapshot_lists_all_tools_when_all_features_enabled() {
         let snapshot = capability_snapshot();
+        assert!(snapshot.contains("- delegate: Delegate a focused subtask into a child session"));
+        assert!(snapshot.contains(
+            "- delegate_async: Delegate a focused subtask into a background child session"
+        ));
         assert!(snapshot.contains("- file.read: Read file contents"));
         assert!(snapshot.contains("- file.write: Write file contents"));
         assert!(snapshot.contains("- shell.exec: Execute shell commands"));
+        assert!(
+            snapshot.contains("- sessions_list: List visible sessions and their high-level state")
+        );
+        assert!(
+            snapshot.contains("- sessions_history: Fetch transcript history for a visible session")
+        );
+        assert!(
+            snapshot.contains("- session_status: Inspect the current status of a visible session")
+        );
+        assert!(snapshot
+            .contains("- session_wait: Wait for a visible session to reach a terminal state"));
+        assert!(snapshot.contains("- session_events: Fetch session events for a visible session"));
 
-        // Verify sorted order: file.read < file.write < shell.exec
+        // Verify sorted canonical name order.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 3);
-        assert!(lines[0].starts_with("- file.read"));
-        assert!(lines[1].starts_with("- file.write"));
-        assert!(lines[2].starts_with("- shell.exec"));
+        assert_eq!(lines.len(), 10);
+        assert!(lines[0].starts_with("- delegate"));
+        assert!(lines[1].starts_with("- delegate_async"));
+        assert!(lines[2].starts_with("- file.read"));
+        assert!(lines[3].starts_with("- file.write"));
+        assert!(lines[4].starts_with("- session_events"));
+        assert!(lines[5].starts_with("- session_status"));
+        assert!(lines[6].starts_with("- session_wait"));
+        assert!(lines[7].starts_with("- sessions_history"));
+        assert!(lines[8].starts_with("- sessions_list"));
+        assert!(lines[9].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 3);
+        assert_eq!(entries.len(), 10);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
+        assert!(names.contains(&"delegate"));
+        assert!(names.contains(&"delegate_async"));
         assert!(names.contains(&"shell.exec"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
+        assert!(names.contains(&"session_events"));
+        assert!(names.contains(&"sessions_list"));
+        assert!(names.contains(&"sessions_history"));
+        assert!(names.contains(&"session_status"));
+        assert!(names.contains(&"session_wait"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 3);
+        assert_eq!(defs.len(), 10);
 
         let names: Vec<&str> = defs
             .iter()
@@ -293,12 +460,37 @@ mod tests {
             .filter_map(|function| function.get("name"))
             .filter_map(Value::as_str)
             .collect();
-        assert_eq!(names, vec!["file_read", "file_write", "shell_exec"]);
+        assert_eq!(
+            names,
+            vec![
+                "delegate",
+                "delegate_async",
+                "file_read",
+                "file_write",
+                "session_events",
+                "session_status",
+                "session_wait",
+                "sessions_history",
+                "sessions_list",
+                "shell_exec",
+            ]
+        );
 
         for item in &defs {
             assert_eq!(item["type"], "function");
             assert_eq!(item["function"]["parameters"]["type"], "object");
         }
+
+        let session_wait = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_wait")
+            .expect("session_wait definition");
+        let properties = session_wait["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_wait properties");
+        assert!(properties.contains_key("session_id"));
+        assert!(properties.contains_key("timeout_ms"));
+        assert!(properties.contains_key("after_id"));
     }
 
     #[test]
@@ -333,6 +525,207 @@ mod tests {
             err.contains("tool_not_found"),
             "error should contain tool_not_found, got: {err}"
         );
+    }
+
+    #[test]
+    fn tool_catalog_marks_core_and_app_tools() {
+        let catalog = tool_catalog();
+        assert_eq!(
+            catalog
+                .descriptor("file.read")
+                .expect("file.read descriptor")
+                .execution_kind,
+            ToolExecutionKind::Core
+        );
+        assert_eq!(
+            catalog
+                .descriptor("delegate")
+                .expect("delegate descriptor")
+                .execution_kind,
+            ToolExecutionKind::App
+        );
+        assert_eq!(
+            catalog
+                .descriptor("delegate_async")
+                .expect("delegate_async descriptor")
+                .execution_kind,
+            ToolExecutionKind::App
+        );
+        assert_eq!(
+            catalog
+                .descriptor("delegate")
+                .expect("delegate descriptor")
+                .availability,
+            ToolAvailability::Runtime
+        );
+        assert_eq!(
+            catalog
+                .descriptor("delegate_async")
+                .expect("delegate_async descriptor")
+                .availability,
+            ToolAvailability::Runtime
+        );
+        assert_eq!(
+            catalog
+                .descriptor("sessions_list")
+                .expect("sessions_list descriptor")
+                .availability,
+            ToolAvailability::Runtime
+        );
+    }
+
+    #[test]
+    fn planned_root_tool_view_contains_first_phase_tools() {
+        let view = planned_root_tool_view();
+        assert!(view.contains("file.read"));
+        assert!(view.contains("file.write"));
+        #[cfg(feature = "tool-shell")]
+        assert!(view.contains("shell.exec"));
+        assert!(view.contains("sessions_list"));
+        assert!(view.contains("sessions_history"));
+        assert!(view.contains("session_status"));
+        assert!(view.contains("session_events"));
+        assert!(view.contains("session_wait"));
+        assert!(view.contains("delegate"));
+        assert!(view.contains("delegate_async"));
+    }
+
+    #[test]
+    fn runtime_tool_view_includes_delegate_and_session_tools() {
+        let view = runtime_tool_view();
+        assert!(view.contains("delegate"));
+        assert!(view.contains("sessions_list"));
+        assert!(view.contains("sessions_history"));
+        assert!(view.contains("session_status"));
+        assert!(view.contains("session_events"));
+        assert!(view.contains("session_wait"));
+        assert!(view.contains("delegate_async"));
+    }
+
+    #[test]
+    fn runtime_tool_view_for_config_omits_disabled_session_and_delegate_tools() {
+        let mut config = crate::config::ToolConfig::default();
+        config.sessions.enabled = false;
+        config.delegate.enabled = false;
+
+        let view = runtime_tool_view_for_config(&config);
+        assert!(view.contains("file.read"));
+        assert!(view.contains("file.write"));
+        assert!(!view.contains("delegate"));
+        assert!(!view.contains("delegate_async"));
+        assert!(!view.contains("sessions_list"));
+        assert!(!view.contains("sessions_history"));
+        assert!(!view.contains("session_status"));
+        assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_wait"));
+    }
+
+    #[test]
+    fn delegate_child_tool_view_for_config_allows_shell_when_enabled() {
+        let mut config = crate::config::ToolConfig::default();
+        config.delegate.allow_shell_in_child = true;
+
+        let view = delegate_child_tool_view_for_config(&config);
+        assert!(view.contains("file.read"));
+        assert!(view.contains("file.write"));
+        assert!(view.contains("shell.exec"));
+        assert!(!view.contains("delegate"));
+        assert!(!view.contains("sessions_list"));
+        assert!(!view.contains("session_wait"));
+    }
+
+    #[test]
+    fn delegate_child_tool_view_with_remaining_depth_allows_delegate() {
+        let config = crate::config::ToolConfig::default();
+
+        let view = delegate_child_tool_view_for_config_with_delegate(&config, true);
+        assert!(view.contains("file.read"));
+        assert!(view.contains("file.write"));
+        assert!(view.contains("delegate"));
+        assert!(view.contains("delegate_async"));
+        assert!(view.contains("sessions_history"));
+        assert!(view.contains("session_status"));
+        assert!(!view.contains("sessions_list"));
+    }
+
+    #[test]
+    fn delegate_child_tool_view_default_allowlist_matches_runtime_child_tools() {
+        let config = crate::config::ToolConfig::default();
+        assert_eq!(
+            config.delegate.child_tool_allowlist,
+            vec!["file.read", "file.write"]
+        );
+    }
+
+    #[test]
+    fn child_tool_view_excludes_delegate_and_session_list() {
+        let view = planned_delegate_child_tool_view();
+        assert!(view.contains("file.read"));
+        assert!(view.contains("file.write"));
+        assert!(view.contains("sessions_history"));
+        assert!(view.contains("session_status"));
+        assert!(!view.contains("shell.exec"));
+        assert!(!view.contains("delegate"));
+        assert!(!view.contains("delegate_async"));
+        assert!(!view.contains("sessions_list"));
+        assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_wait"));
+    }
+
+    #[test]
+    fn child_session_self_inspection_tool_view_includes_status_and_history_only() {
+        let view = planned_delegate_child_tool_view();
+        assert!(view.contains("file.read"));
+        assert!(view.contains("file.write"));
+        assert!(view.contains("sessions_history"));
+        assert!(view.contains("session_status"));
+        assert!(!view.contains("sessions_list"));
+        assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_wait"));
+        assert!(!view.contains("delegate_async"));
+    }
+
+    #[test]
+    fn delegate_async_is_visible_in_root_and_depth_budgeted_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("delegate_async"));
+
+        let child_allowed = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
+        );
+        assert!(child_allowed.contains("delegate_async"));
+
+        let child_exhausted = planned_delegate_child_tool_view();
+        assert!(!child_exhausted.contains("delegate_async"));
+    }
+
+    #[test]
+    fn provider_tool_definitions_follow_tool_view() {
+        let view = ToolView::from_tool_names(["file.read"]);
+        let defs =
+            try_provider_tool_definitions_for_view(&view).expect("runtime-visible tool schemas");
+        let names: Vec<&str> = defs
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(names, vec!["file_read"]);
+    }
+
+    #[test]
+    fn provider_tool_definitions_include_delegate_when_visible() {
+        let view = ToolView::from_tool_names(["delegate", "delegate_async", "file.read"]);
+        let defs =
+            try_provider_tool_definitions_for_view(&view).expect("runtime-visible tool schemas");
+        let names: Vec<&str> = defs
+            .iter()
+            .filter_map(|item| item.get("function"))
+            .filter_map(|function| function.get("name"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(names, vec!["delegate", "delegate_async", "file_read"]);
     }
 
     // --- Kernel-routed tool tests ---

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -511,6 +511,15 @@ mod tests {
             .as_object()
             .expect("session_recover properties");
         assert!(recover_properties.contains_key("session_id"));
+        assert!(recover_properties.contains_key("session_ids"));
+        assert!(recover_properties.contains_key("dry_run"));
+        assert_eq!(
+            session_recover["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("session_recover oneOf")
+                .len(),
+            2
+        );
 
         let session_cancel = defs
             .iter()
@@ -520,6 +529,15 @@ mod tests {
             .as_object()
             .expect("session_cancel properties");
         assert!(cancel_properties.contains_key("session_id"));
+        assert!(cancel_properties.contains_key("session_ids"));
+        assert!(cancel_properties.contains_key("dry_run"));
+        assert_eq!(
+            session_cancel["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("session_cancel oneOf")
+                .len(),
+            2
+        );
 
         let sessions_list = defs
             .iter()

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -197,8 +197,12 @@ pub fn capability_snapshot_for_view(view: &ToolView) -> String {
 /// The output shape matches OpenAI-compatible `tools=[{type:function,...}]`.
 /// Order is deterministic for stable prompting/tests.
 pub fn provider_tool_definitions() -> Vec<Value> {
-    try_provider_tool_definitions_for_view(&runtime_tool_view())
-        .expect("runtime tool view should always be advertisable")
+    let catalog = tool_catalog();
+    runtime_tool_view()
+        .iter(&catalog)
+        .filter(|descriptor| descriptor.availability == ToolAvailability::Runtime)
+        .map(ToolDescriptor::provider_definition)
+        .collect()
 }
 
 pub fn try_provider_tool_definitions_for_view(view: &ToolView) -> Result<Vec<Value>, String> {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -9,6 +9,7 @@ mod catalog;
 pub(crate) mod delegate;
 mod file;
 mod kernel_adapter;
+mod memory;
 pub(crate) mod messaging;
 pub mod runtime_config;
 mod session;
@@ -82,6 +83,12 @@ pub fn execute_app_tool_with_config(
                 tool_config,
             )
         }
+        "memory_search" => memory::execute_memory_search_tool_with_policies(
+            request.payload,
+            current_session_id,
+            memory_config,
+            tool_config,
+        ),
         "sessions_send" => Err("app_tool_not_implemented: sessions_send".to_owned()),
         "session_wait" => Err("app_tool_not_implemented: session_wait".to_owned()),
         "delegate" => Err("app_tool_not_implemented: delegate".to_owned()),

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -79,6 +79,7 @@ pub fn execute_app_tool_with_config(
             memory_config,
             tool_config,
         ),
+        "sessions_send" => Err("app_tool_not_implemented: sessions_send".to_owned()),
         "session_wait" => Err("app_tool_not_implemented: session_wait".to_owned()),
         "delegate" => Err("app_tool_not_implemented: delegate".to_owned()),
         _ => Err(format!(
@@ -701,6 +702,45 @@ mod tests {
             .filter_map(Value::as_str)
             .collect();
         assert_eq!(names, vec!["delegate", "delegate_async", "file_read"]);
+    }
+
+    #[cfg(feature = "config-toml")]
+    #[test]
+    fn runtime_tool_view_exposes_sessions_send_only_when_messages_enabled() {
+        let raw = r#"
+[tools.messages]
+enabled = true
+"#;
+        let parsed =
+            toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
+        let root_view = runtime_tool_view_for_config(&parsed.tools);
+        assert!(root_view.contains("sessions_send"));
+
+        let child_view = delegate_child_tool_view_for_config(&parsed.tools);
+        assert!(!child_view.contains("sessions_send"));
+    }
+
+    #[cfg(feature = "config-toml")]
+    #[test]
+    fn provider_tool_definitions_include_sessions_send_when_enabled() {
+        let raw = r#"
+[tools.messages]
+enabled = true
+"#;
+        let parsed =
+            toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
+        let defs =
+            try_provider_tool_definitions_for_view(&runtime_tool_view_for_config(&parsed.tools))
+                .expect("runtime-visible tool schemas");
+        let sessions_send = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "sessions_send")
+            .expect("sessions_send definition");
+        let properties = sessions_send["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("sessions_send properties");
+        assert!(properties.contains_key("session_id"));
+        assert!(properties.contains_key("text"));
     }
 
     // --- Kernel-routed tool tests ---

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -539,6 +539,23 @@ mod tests {
             2
         );
 
+        let session_status = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_status")
+            .expect("session_status definition");
+        let status_properties = session_status["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_status properties");
+        assert!(status_properties.contains_key("session_id"));
+        assert!(status_properties.contains_key("session_ids"));
+        assert_eq!(
+            session_status["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("session_status oneOf")
+                .len(),
+            2
+        );
+
         let sessions_list = defs
             .iter()
             .find(|item| item["function"]["name"] == "sessions_list")

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -427,9 +427,14 @@ mod tests {
             .as_object()
             .expect("session_archive properties");
         assert!(archive_properties.contains_key("session_id"));
+        assert!(archive_properties.contains_key("session_ids"));
+        assert!(archive_properties.contains_key("dry_run"));
         assert_eq!(
-            session_archive["function"]["parameters"]["required"],
-            json!(["session_id"])
+            session_archive["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("session_archive oneOf")
+                .len(),
+            2
         );
 
         let session_status = defs

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -276,6 +276,9 @@ mod tests {
         assert!(
             snapshot.contains("- session_status: Inspect the current status of a visible session")
         );
+        assert!(snapshot.contains(
+            "- session_archive: Archive a visible terminal session from default session listings"
+        ));
         assert!(
             snapshot.contains("- session_cancel: Cancel a visible async delegate child session")
         );
@@ -288,32 +291,34 @@ mod tests {
 
         // Verify sorted canonical name order.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 12);
+        assert_eq!(lines.len(), 13);
         assert!(lines[0].starts_with("- delegate"));
         assert!(lines[1].starts_with("- delegate_async"));
         assert!(lines[2].starts_with("- file.read"));
         assert!(lines[3].starts_with("- file.write"));
-        assert!(lines[4].starts_with("- session_cancel"));
-        assert!(lines[5].starts_with("- session_events"));
-        assert!(lines[6].starts_with("- session_recover"));
-        assert!(lines[7].starts_with("- session_status"));
-        assert!(lines[8].starts_with("- session_wait"));
-        assert!(lines[9].starts_with("- sessions_history"));
-        assert!(lines[10].starts_with("- sessions_list"));
-        assert!(lines[11].starts_with("- shell.exec"));
+        assert!(lines[4].starts_with("- session_archive"));
+        assert!(lines[5].starts_with("- session_cancel"));
+        assert!(lines[6].starts_with("- session_events"));
+        assert!(lines[7].starts_with("- session_recover"));
+        assert!(lines[8].starts_with("- session_status"));
+        assert!(lines[9].starts_with("- session_wait"));
+        assert!(lines[10].starts_with("- sessions_history"));
+        assert!(lines[11].starts_with("- sessions_list"));
+        assert!(lines[12].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 12);
+        assert_eq!(entries.len(), 13);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"delegate"));
         assert!(names.contains(&"delegate_async"));
         assert!(names.contains(&"shell.exec"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
+        assert!(names.contains(&"session_archive"));
         assert!(names.contains(&"session_cancel"));
         assert!(names.contains(&"session_events"));
         assert!(names.contains(&"session_recover"));
@@ -327,7 +332,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 12);
+        assert_eq!(defs.len(), 13);
 
         let names: Vec<&str> = defs
             .iter()
@@ -342,6 +347,7 @@ mod tests {
                 "delegate_async",
                 "file_read",
                 "file_write",
+                "session_archive",
                 "session_cancel",
                 "session_events",
                 "session_recover",
@@ -413,6 +419,19 @@ mod tests {
             2
         );
 
+        let session_archive = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "session_archive")
+            .expect("session_archive definition");
+        let archive_properties = session_archive["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("session_archive properties");
+        assert!(archive_properties.contains_key("session_id"));
+        assert_eq!(
+            session_archive["function"]["parameters"]["required"],
+            json!(["session_id"])
+        );
+
         let session_status = defs
             .iter()
             .find(|item| item["function"]["name"] == "session_status")
@@ -442,6 +461,7 @@ mod tests {
         assert!(list_properties.contains_key("kind"));
         assert!(list_properties.contains_key("parent_session_id"));
         assert!(list_properties.contains_key("overdue_only"));
+        assert!(list_properties.contains_key("include_archived"));
         assert!(list_properties.contains_key("include_delegate_lifecycle"));
     }
 
@@ -537,6 +557,7 @@ mod tests {
         assert!(view.contains("sessions_history"));
         assert!(view.contains("session_status"));
         assert!(view.contains("session_events"));
+        assert!(view.contains("session_archive"));
         assert!(view.contains("session_cancel"));
         assert!(view.contains("session_recover"));
         assert!(view.contains("session_wait"));
@@ -552,6 +573,7 @@ mod tests {
         assert!(view.contains("sessions_history"));
         assert!(view.contains("session_status"));
         assert!(view.contains("session_events"));
+        assert!(view.contains("session_archive"));
         assert!(view.contains("session_cancel"));
         assert!(view.contains("session_recover"));
         assert!(view.contains("session_wait"));
@@ -574,6 +596,21 @@ mod tests {
     }
 
     #[test]
+    fn session_archive_is_visible_in_root_and_hidden_in_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("session_archive"));
+
+        let child_view = planned_delegate_child_tool_view();
+        assert!(!child_view.contains("session_archive"));
+
+        let child_with_depth = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
+        );
+        assert!(!child_with_depth.contains("session_archive"));
+    }
+
+    #[test]
     fn runtime_tool_view_for_config_omits_disabled_session_and_delegate_tools() {
         let mut config = crate::config::ToolConfig::default();
         config.sessions.enabled = false;
@@ -588,6 +625,7 @@ mod tests {
         assert!(!view.contains("sessions_history"));
         assert!(!view.contains("session_status"));
         assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_archive"));
         assert!(!view.contains("session_recover"));
         assert!(!view.contains("session_wait"));
     }
@@ -642,6 +680,7 @@ mod tests {
         assert!(!view.contains("delegate_async"));
         assert!(!view.contains("sessions_list"));
         assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_archive"));
         assert!(!view.contains("session_cancel"));
         assert!(!view.contains("session_recover"));
         assert!(!view.contains("session_wait"));
@@ -656,6 +695,7 @@ mod tests {
         assert!(view.contains("session_status"));
         assert!(!view.contains("sessions_list"));
         assert!(!view.contains("session_events"));
+        assert!(!view.contains("session_archive"));
         assert!(!view.contains("session_cancel"));
         assert!(!view.contains("session_recover"));
         assert!(!view.contains("session_wait"));

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -279,6 +279,9 @@ mod tests {
         ));
         assert!(snapshot.contains("- file.read: Read file contents"));
         assert!(snapshot.contains("- file.write: Write file contents"));
+        assert!(snapshot.contains(
+            "- memory_search: Search visible transcript memory across persisted session turns"
+        ));
         assert!(snapshot.contains("- shell.exec: Execute shell commands"));
         assert!(
             snapshot.contains("- sessions_list: List visible sessions and their high-level state")
@@ -306,34 +309,36 @@ mod tests {
 
         // Verify sorted canonical name order.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 14);
+        assert_eq!(lines.len(), 15);
         assert!(lines[0].starts_with("- delegate"));
         assert!(lines[1].starts_with("- delegate_async"));
         assert!(lines[2].starts_with("- file.read"));
         assert!(lines[3].starts_with("- file.write"));
-        assert!(lines[4].starts_with("- session_archive"));
-        assert!(lines[5].starts_with("- session_cancel"));
-        assert!(lines[6].starts_with("- session_events"));
-        assert!(lines[7].starts_with("- session_recover"));
-        assert!(lines[8].starts_with("- session_status"));
-        assert!(lines[9].starts_with("- session_unarchive"));
-        assert!(lines[10].starts_with("- session_wait"));
-        assert!(lines[11].starts_with("- sessions_history"));
-        assert!(lines[12].starts_with("- sessions_list"));
-        assert!(lines[13].starts_with("- shell.exec"));
+        assert!(lines[4].starts_with("- memory_search"));
+        assert!(lines[5].starts_with("- session_archive"));
+        assert!(lines[6].starts_with("- session_cancel"));
+        assert!(lines[7].starts_with("- session_events"));
+        assert!(lines[8].starts_with("- session_recover"));
+        assert!(lines[9].starts_with("- session_status"));
+        assert!(lines[10].starts_with("- session_unarchive"));
+        assert!(lines[11].starts_with("- session_wait"));
+        assert!(lines[12].starts_with("- sessions_history"));
+        assert!(lines[13].starts_with("- sessions_list"));
+        assert!(lines[14].starts_with("- shell.exec"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 14);
+        assert_eq!(entries.len(), 15);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"delegate"));
         assert!(names.contains(&"delegate_async"));
         assert!(names.contains(&"shell.exec"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
+        assert!(names.contains(&"memory_search"));
         assert!(names.contains(&"session_archive"));
         assert!(names.contains(&"session_cancel"));
         assert!(names.contains(&"session_events"));
@@ -349,7 +354,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 14);
+        assert_eq!(defs.len(), 15);
 
         let names: Vec<&str> = defs
             .iter()
@@ -364,6 +369,7 @@ mod tests {
                 "delegate_async",
                 "file_read",
                 "file_write",
+                "memory_search",
                 "session_archive",
                 "session_cancel",
                 "session_events",
@@ -490,6 +496,26 @@ mod tests {
             2
         );
 
+        let memory_search = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "memory_search")
+            .expect("memory_search definition");
+        let memory_search_properties = memory_search["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("memory_search properties");
+        assert!(memory_search_properties.contains_key("query"));
+        assert!(memory_search_properties.contains_key("session_id"));
+        assert!(memory_search_properties.contains_key("session_ids"));
+        assert!(memory_search_properties.contains_key("limit"));
+        assert!(memory_search_properties.contains_key("excerpt_chars"));
+        assert_eq!(
+            memory_search["function"]["parameters"]["oneOf"]
+                .as_array()
+                .expect("memory_search oneOf")
+                .len(),
+            3
+        );
+
         let sessions_list = defs
             .iter()
             .find(|item| item["function"]["name"] == "sessions_list")
@@ -512,6 +538,7 @@ mod tests {
         assert_eq!(canonical_tool_name("file_write"), "file.write");
         assert_eq!(canonical_tool_name("shell_exec"), "shell.exec");
         assert_eq!(canonical_tool_name("shell"), "shell.exec");
+        assert_eq!(canonical_tool_name("memory_search"), "memory_search");
         assert_eq!(canonical_tool_name("file.read"), "file.read");
     }
 
@@ -598,6 +625,7 @@ mod tests {
         assert!(view.contains("sessions_history"));
         assert!(view.contains("session_status"));
         assert!(view.contains("session_events"));
+        assert!(view.contains("memory_search"));
         assert!(view.contains("session_archive"));
         assert!(view.contains("session_cancel"));
         assert!(view.contains("session_recover"));
@@ -652,6 +680,21 @@ mod tests {
     }
 
     #[test]
+    fn memory_search_is_visible_in_root_and_hidden_in_child_views() {
+        let root_view = runtime_tool_view();
+        assert!(root_view.contains("memory_search"));
+
+        let child_view = planned_delegate_child_tool_view();
+        assert!(!child_view.contains("memory_search"));
+
+        let child_with_depth = delegate_child_tool_view_for_config_with_delegate(
+            &crate::config::ToolConfig::default(),
+            true,
+        );
+        assert!(!child_with_depth.contains("memory_search"));
+    }
+
+    #[test]
     fn session_unarchive_is_visible_in_root_and_hidden_in_child_views() {
         let root_view = runtime_tool_view();
         assert!(root_view.contains("session_unarchive"));
@@ -681,6 +724,7 @@ mod tests {
         assert!(!view.contains("sessions_history"));
         assert!(!view.contains("session_status"));
         assert!(!view.contains("session_events"));
+        assert!(!view.contains("memory_search"));
         assert!(!view.contains("session_archive"));
         assert!(!view.contains("session_recover"));
         assert!(!view.contains("session_unarchive"));

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -9,8 +9,10 @@ use crate::memory;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::session::recovery::{
-    build_queued_async_overdue_recovery_payload, observe_missing_recovery, recovery_json,
-    SessionRecoveryRecord, RECOVERY_EVENT_KIND, RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
+    build_queued_async_overdue_recovery_payload, build_running_async_overdue_recovery_payload,
+    observe_missing_recovery, recovery_json, SessionRecoveryRecord, RECOVERY_EVENT_KIND,
+    RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
+    RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED,
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::session::{
@@ -73,7 +75,11 @@ struct SessionDelegateCancellationRecord {
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SessionRecoverPlan {
-    queued_at: i64,
+    expected_state: SessionState,
+    recovery_kind: &'static str,
+    reference: &'static str,
+    queued_at: Option<i64>,
+    started_at: Option<i64>,
     elapsed_seconds: u64,
     timeout_seconds: u64,
     deadline_at: i64,
@@ -284,32 +290,49 @@ fn execute_session_recover(
         10,
     )?;
     let recover_plan = build_session_recover_plan(&snapshot, current_unix_ts())?;
-    let recovery_error = format!(
-        "delegate_async_queued_overdue_marked_failed: queued delegate child exceeded timeout after {}s (threshold {}s)",
-        recover_plan.elapsed_seconds, recover_plan.timeout_seconds
-    );
+    let recovery_error = session_recovery_error(&recover_plan);
     let outcome = crate::tools::delegate::delegate_error_outcome(
         snapshot.session.session_id.clone(),
         snapshot.session.label.clone(),
         recovery_error.clone(),
         recover_plan.elapsed_seconds.saturating_mul(1_000),
     );
+    let event_payload_json = match recover_plan.recovery_kind {
+        RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED => {
+            build_queued_async_overdue_recovery_payload(
+                snapshot.session.label.as_deref(),
+                recover_plan
+                    .queued_at
+                    .expect("queued async overdue recovery requires queued_at"),
+                recover_plan.elapsed_seconds,
+                recover_plan.timeout_seconds,
+                recover_plan.deadline_at,
+                &recovery_error,
+            )
+        }
+        RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED => {
+            build_running_async_overdue_recovery_payload(
+                snapshot.session.label.as_deref(),
+                recover_plan.queued_at,
+                recover_plan.started_at,
+                recover_plan.reference,
+                recover_plan.elapsed_seconds,
+                recover_plan.timeout_seconds,
+                recover_plan.deadline_at,
+                &recovery_error,
+            )
+        }
+        other => unreachable!("unsupported session recovery kind `{other}`"),
+    };
     let finalized = repo.finalize_session_terminal_if_current(
         &target_session_id,
-        SessionState::Ready,
+        recover_plan.expected_state,
         crate::session::repository::FinalizeSessionTerminalRequest {
             state: SessionState::Failed,
             last_error: Some(recovery_error.clone()),
             event_kind: RECOVERY_EVENT_KIND.to_owned(),
             actor_session_id: Some(current_session_id.to_owned()),
-            event_payload_json: build_queued_async_overdue_recovery_payload(
-                snapshot.session.label.as_deref(),
-                recover_plan.queued_at,
-                recover_plan.elapsed_seconds,
-                recover_plan.timeout_seconds,
-                recover_plan.deadline_at,
-                &recovery_error,
-            ),
+            event_payload_json,
             outcome_status: outcome.status.clone(),
             outcome_payload_json: outcome.payload.clone(),
         },
@@ -335,10 +358,10 @@ fn execute_session_recover(
         object.insert(
             "recovery_action".to_owned(),
             json!({
-                "kind": RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
-                "previous_state": "ready",
+                "kind": recover_plan.recovery_kind,
+                "previous_state": recover_plan.expected_state.as_str(),
                 "next_state": "failed",
-                "reference": "queued",
+                "reference": recover_plan.reference,
                 "elapsed_seconds": recover_plan.elapsed_seconds,
                 "timeout_seconds": recover_plan.timeout_seconds,
                 "deadline_at": recover_plan.deadline_at,
@@ -645,21 +668,12 @@ fn build_session_recover_plan(
             snapshot.session.session_id
         )
             })?;
-    if lifecycle.mode != "async"
-        || lifecycle.phase != "queued"
-        || snapshot.session.state != SessionState::Ready
-    {
+    if lifecycle.mode != "async" {
         return Err(format!(
-            "session_recover_not_recoverable: session `{}` is not an overdue queued async child",
+            "session_recover_not_recoverable: session `{}` is not an overdue async child",
             snapshot.session.session_id
         ));
     }
-    let queued_at = lifecycle.queued_at.ok_or_else(|| {
-        format!(
-            "session_recover_not_recoverable: session `{}` is missing queued timestamp",
-            snapshot.session.session_id
-        )
-    })?;
     let staleness = lifecycle.staleness.ok_or_else(|| {
         format!(
             "session_recover_not_recoverable: session `{}` is missing staleness metadata",
@@ -679,12 +693,55 @@ fn build_session_recover_plan(
         )
     })?;
 
-    Ok(SessionRecoverPlan {
-        queued_at,
-        elapsed_seconds: staleness.elapsed_seconds,
-        timeout_seconds,
-        deadline_at: staleness.deadline_at,
-    })
+    match (snapshot.session.state, lifecycle.phase) {
+        (SessionState::Ready, "queued") => {
+            let queued_at = lifecycle.queued_at.ok_or_else(|| {
+                format!(
+                    "session_recover_not_recoverable: session `{}` is missing queued timestamp",
+                    snapshot.session.session_id
+                )
+            })?;
+            Ok(SessionRecoverPlan {
+                expected_state: SessionState::Ready,
+                recovery_kind: RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
+                reference: "queued",
+                queued_at: Some(queued_at),
+                started_at: lifecycle.started_at,
+                elapsed_seconds: staleness.elapsed_seconds,
+                timeout_seconds,
+                deadline_at: staleness.deadline_at,
+            })
+        }
+        (SessionState::Running, "running") => Ok(SessionRecoverPlan {
+            expected_state: SessionState::Running,
+            recovery_kind: RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED,
+            reference: staleness.reference,
+            queued_at: lifecycle.queued_at,
+            started_at: lifecycle.started_at,
+            elapsed_seconds: staleness.elapsed_seconds,
+            timeout_seconds,
+            deadline_at: staleness.deadline_at,
+        }),
+        _ => Err(format!(
+            "session_recover_not_recoverable: session `{}` is not an overdue async child",
+            snapshot.session.session_id
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_recovery_error(plan: &SessionRecoverPlan) -> String {
+    match plan.recovery_kind {
+        RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED => format!(
+            "delegate_async_queued_overdue_marked_failed: queued delegate child exceeded timeout after {}s (threshold {}s)",
+            plan.elapsed_seconds, plan.timeout_seconds
+        ),
+        RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED => format!(
+            "delegate_async_running_overdue_marked_failed: running delegate child exceeded timeout after {}s (threshold {}s)",
+            plan.elapsed_seconds, plan.timeout_seconds
+        ),
+        other => unreachable!("unsupported session recovery kind `{other}`"),
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1580,7 +1637,97 @@ mod tests {
     }
 
     #[test]
-    fn session_recover_rejects_running_child() {
+    fn session_recover_marks_overdue_running_async_child_failed() {
+        let config = isolated_memory_config("session-recover-running-overdue");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 30
+            }),
+        })
+        .expect("append queued event");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 30
+            }),
+        })
+        .expect("append started event");
+        overwrite_session_event_ts(
+            &config,
+            "child-session",
+            "delegate_queued",
+            super::current_unix_ts() - 120,
+        );
+        overwrite_session_event_ts(
+            &config,
+            "child-session",
+            "delegate_started",
+            super::current_unix_ts() - 90,
+        );
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_recover".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_recover outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["session"]["state"], "failed");
+        assert_eq!(outcome.payload["delegate_lifecycle"]["phase"], "failed");
+        assert!(outcome.payload["delegate_lifecycle"]["staleness"].is_null());
+        assert_eq!(outcome.payload["terminal_outcome_state"], "present");
+        assert_eq!(outcome.payload["terminal_outcome"]["status"], "error");
+        assert_eq!(
+            outcome.payload["recovery_action"]["kind"],
+            "running_async_overdue_marked_failed"
+        );
+        assert_eq!(
+            outcome.payload["recovery_action"]["previous_state"],
+            "running"
+        );
+        assert_eq!(outcome.payload["recovery_action"]["reference"], "started");
+        assert_eq!(
+            outcome.payload["recent_events"]
+                .as_array()
+                .expect("recent events array")
+                .last()
+                .expect("latest recent event")["event_kind"],
+            "delegate_recovery_applied"
+        );
+    }
+
+    #[test]
+    fn session_recover_rejects_fresh_running_child() {
         let config = isolated_memory_config("session-recover-running");
         let repo = SessionRepository::new(&config).expect("repository");
         repo.create_session(NewSessionRecord {

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -717,11 +717,7 @@ fn execute_session_unarchive(
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
     if request.use_legacy_single_response() {
-        let target_session_id = request
-            .target
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_session_id(&request.target.session_ids)?;
         let repo = SessionRepository::new(config)?;
         ensure_visible(
             &repo,

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -8,7 +8,10 @@ use crate::config::{SessionVisibility, ToolConfig};
 use crate::memory;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
-use crate::session::recovery::{observe_missing_recovery, recovery_json, SessionRecoveryRecord};
+use crate::session::recovery::{
+    build_queued_async_overdue_recovery_payload, observe_missing_recovery, recovery_json,
+    SessionRecoveryRecord, RECOVERY_EVENT_KIND, RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
+};
 
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
@@ -52,6 +55,15 @@ struct SessionDelegateStalenessRecord {
     deadline_at: i64,
 }
 
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionRecoverPlan {
+    queued_at: i64,
+    elapsed_seconds: u64,
+    timeout_seconds: u64,
+    deadline_at: i64,
+}
+
 #[cfg(test)]
 pub fn execute_session_tool_with_config(
     request: ToolCoreRequest,
@@ -91,6 +103,9 @@ pub fn execute_session_tool_with_policies(
             }
             "session_status" => {
                 execute_session_status(request.payload, current_session_id, config, tool_config)
+            }
+            "session_recover" => {
+                execute_session_recover(request.payload, current_session_id, config, tool_config)
             }
             other => Err(format!(
                 "app_tool_not_found: unknown session tool `{other}`"
@@ -218,6 +233,97 @@ fn execute_session_status(
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: session_inspection_payload(snapshot),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_session_recover(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let target_session_id = required_payload_string(&payload, "session_id")?;
+    let repo = SessionRepository::new(config)?;
+    ensure_visible(
+        &repo,
+        current_session_id,
+        &target_session_id,
+        tool_config.sessions.visibility,
+    )?;
+    let snapshot = inspect_visible_session_with_policies(
+        &target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    )?;
+    let recover_plan = build_session_recover_plan(&snapshot, current_unix_ts())?;
+    let recovery_error = format!(
+        "delegate_async_queued_overdue_marked_failed: queued delegate child exceeded timeout after {}s (threshold {}s)",
+        recover_plan.elapsed_seconds, recover_plan.timeout_seconds
+    );
+    let outcome = crate::tools::delegate::delegate_error_outcome(
+        snapshot.session.session_id.clone(),
+        snapshot.session.label.clone(),
+        recovery_error.clone(),
+        recover_plan.elapsed_seconds.saturating_mul(1_000),
+    );
+    let finalized = repo.finalize_session_terminal_if_current(
+        &target_session_id,
+        SessionState::Ready,
+        crate::session::repository::FinalizeSessionTerminalRequest {
+            state: SessionState::Failed,
+            last_error: Some(recovery_error.clone()),
+            event_kind: RECOVERY_EVENT_KIND.to_owned(),
+            actor_session_id: Some(current_session_id.to_owned()),
+            event_payload_json: build_queued_async_overdue_recovery_payload(
+                snapshot.session.label.as_deref(),
+                recover_plan.queued_at,
+                recover_plan.elapsed_seconds,
+                recover_plan.timeout_seconds,
+                recover_plan.deadline_at,
+                &recovery_error,
+            ),
+            outcome_status: outcome.status.clone(),
+            outcome_payload_json: outcome.payload.clone(),
+        },
+    )?;
+    if finalized.is_none() {
+        let latest = repo
+            .load_session_summary_with_legacy_fallback(&target_session_id)?
+            .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
+        return Err(format!(
+            "session_recover_state_changed: session `{target_session_id}` is no longer recoverable from state `{}`",
+            latest.state.as_str()
+        ));
+    }
+    let recovered_snapshot = inspect_visible_session_with_policies(
+        &target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    )?;
+    let mut payload = session_inspection_payload(recovered_snapshot);
+    if let Some(object) = payload.as_object_mut() {
+        object.insert(
+            "recovery_action".to_owned(),
+            json!({
+                "kind": RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
+                "previous_state": "ready",
+                "next_state": "failed",
+                "reference": "queued",
+                "elapsed_seconds": recover_plan.elapsed_seconds,
+                "timeout_seconds": recover_plan.timeout_seconds,
+                "deadline_at": recover_plan.deadline_at,
+            }),
+        );
+    }
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload,
     })
 }
 
@@ -351,6 +457,73 @@ fn session_terminal_outcome_missing_reason(
     recovery: Option<&SessionRecoveryRecord>,
 ) -> Option<String> {
     recovery.map(|recovery| recovery.kind.clone())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_session_recover_plan(
+    snapshot: &SessionInspectionSnapshot,
+    now_ts: i64,
+) -> Result<SessionRecoverPlan, String> {
+    if snapshot.session.kind != SessionKind::DelegateChild {
+        return Err(format!(
+            "session_recover_not_supported: session `{}` is not a delegate child",
+            snapshot.session.session_id
+        ));
+    }
+    if snapshot.terminal_outcome.is_some() || session_state_is_terminal(snapshot.session.state) {
+        return Err(format!(
+            "session_recover_not_recoverable: session `{}` is already terminal",
+            snapshot.session.session_id
+        ));
+    }
+    let lifecycle =
+        session_delegate_lifecycle_at(&snapshot.session, snapshot.recent_events.as_slice(), now_ts)
+            .ok_or_else(|| {
+                format!(
+            "session_recover_not_recoverable: session `{}` is missing delegate lifecycle metadata",
+            snapshot.session.session_id
+        )
+            })?;
+    if lifecycle.mode != "async"
+        || lifecycle.phase != "queued"
+        || snapshot.session.state != SessionState::Ready
+    {
+        return Err(format!(
+            "session_recover_not_recoverable: session `{}` is not an overdue queued async child",
+            snapshot.session.session_id
+        ));
+    }
+    let queued_at = lifecycle.queued_at.ok_or_else(|| {
+        format!(
+            "session_recover_not_recoverable: session `{}` is missing queued timestamp",
+            snapshot.session.session_id
+        )
+    })?;
+    let staleness = lifecycle.staleness.ok_or_else(|| {
+        format!(
+            "session_recover_not_recoverable: session `{}` is missing staleness metadata",
+            snapshot.session.session_id
+        )
+    })?;
+    if staleness.state != "overdue" {
+        return Err(format!(
+            "session_recover_not_recoverable: session `{}` is not overdue",
+            snapshot.session.session_id
+        ));
+    }
+    let timeout_seconds = lifecycle.timeout_seconds.ok_or_else(|| {
+        format!(
+            "session_recover_not_recoverable: session `{}` is missing timeout metadata",
+            snapshot.session.session_id
+        )
+    })?;
+
+    Ok(SessionRecoverPlan {
+        queued_at,
+        elapsed_seconds: staleness.elapsed_seconds,
+        timeout_seconds,
+        deadline_at: staleness.deadline_at,
+    })
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -581,6 +754,7 @@ mod tests {
     use std::fs;
 
     use loongclaw_contracts::ToolCoreRequest;
+    use rusqlite::params;
     use serde_json::{json, Value};
 
     use crate::config::{SessionVisibility, ToolConfig};
@@ -604,6 +778,28 @@ mod tests {
         MemoryRuntimeConfig {
             sqlite_path: Some(db_path),
         }
+    }
+
+    fn overwrite_session_event_ts(
+        config: &MemoryRuntimeConfig,
+        session_id: &str,
+        event_kind: &str,
+        ts: i64,
+    ) {
+        let db_path = config
+            .sqlite_path
+            .as_ref()
+            .expect("sqlite path for session tools test");
+        let conn = rusqlite::Connection::open(db_path).expect("open sqlite db");
+        let updated = conn
+            .execute(
+                "UPDATE session_events
+                 SET ts = ?3
+                 WHERE session_id = ?1 AND event_kind = ?2",
+                params![session_id, event_kind, ts],
+            )
+            .expect("update session event ts");
+        assert!(updated > 0, "expected at least one updated event row");
     }
 
     #[test]
@@ -1017,6 +1213,184 @@ mod tests {
         assert_eq!(outcome.payload["recovery"]["source"], "none");
         assert!(outcome.payload["recovery"]["recovery_error"].is_null());
         assert!(outcome.payload["recovery"]["event_kind"].is_null());
+    }
+
+    #[test]
+    fn session_recover_marks_overdue_queued_async_child_failed() {
+        let config = isolated_memory_config("session-recover-overdue");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "label": "Child",
+                "timeout_seconds": 30
+            }),
+        })
+        .expect("append queued event");
+        overwrite_session_event_ts(
+            &config,
+            "child-session",
+            "delegate_queued",
+            super::current_unix_ts() - 90,
+        );
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_recover".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_recover outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["session"]["state"], "failed");
+        assert_eq!(outcome.payload["delegate_lifecycle"]["phase"], "failed");
+        assert!(outcome.payload["delegate_lifecycle"]["staleness"].is_null());
+        assert_eq!(outcome.payload["terminal_outcome_state"], "present");
+        assert_eq!(outcome.payload["terminal_outcome"]["status"], "error");
+        assert_eq!(
+            outcome.payload["recovery_action"]["kind"],
+            "queued_async_overdue_marked_failed"
+        );
+        assert_eq!(
+            outcome.payload["recent_events"]
+                .as_array()
+                .expect("recent events array")
+                .last()
+                .expect("latest recent event")["event_kind"],
+            "delegate_recovery_applied"
+        );
+    }
+
+    #[test]
+    fn session_recover_rejects_fresh_queued_child() {
+        let config = isolated_memory_config("session-recover-fresh");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append queued event");
+
+        let error = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_recover".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect_err("fresh queued child should be rejected");
+
+        assert!(
+            error.contains("session_recover_not_recoverable"),
+            "expected recoverability rejection, got: {error}"
+        );
+    }
+
+    #[test]
+    fn session_recover_rejects_running_child() {
+        let config = isolated_memory_config("session-recover-running");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 30
+            }),
+        })
+        .expect("append queued event");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 30
+            }),
+        })
+        .expect("append started event");
+
+        let error = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_recover".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect_err("running child should be rejected");
+
+        assert!(
+            error.contains("session_recover_not_recoverable"),
+            "expected recoverability rejection, got: {error}"
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -12,6 +12,11 @@ use crate::session::recovery::{
     build_queued_async_overdue_recovery_payload, observe_missing_recovery, recovery_json,
     SessionRecoveryRecord, RECOVERY_EVENT_KIND, RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
 };
+#[cfg(feature = "memory-sqlite")]
+use crate::session::{
+    delegate_cancelled_error, DELEGATE_CANCELLED_EVENT_KIND,
+    DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED, DELEGATE_CANCEL_REQUESTED_EVENT_KIND,
+};
 
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
@@ -43,6 +48,7 @@ struct SessionDelegateLifecycleRecord {
     started_at: Option<i64>,
     timeout_seconds: Option<u64>,
     staleness: Option<SessionDelegateStalenessRecord>,
+    cancellation: Option<SessionDelegateCancellationRecord>,
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -57,11 +63,27 @@ struct SessionDelegateStalenessRecord {
 
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionDelegateCancellationRecord {
+    state: &'static str,
+    reference: String,
+    requested_at: i64,
+    reason: String,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct SessionRecoverPlan {
     queued_at: i64,
     elapsed_seconds: u64,
     timeout_seconds: u64,
     deadline_at: i64,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SessionCancelPlan {
+    Queued,
+    Running,
 }
 
 #[cfg(test)]
@@ -103,6 +125,9 @@ pub fn execute_session_tool_with_policies(
             }
             "session_status" => {
                 execute_session_status(request.payload, current_session_id, config, tool_config)
+            }
+            "session_cancel" => {
+                execute_session_cancel(request.payload, current_session_id, config, tool_config)
             }
             "session_recover" => {
                 execute_session_recover(request.payload, current_session_id, config, tool_config)
@@ -328,6 +353,142 @@ fn execute_session_recover(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn execute_session_cancel(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let target_session_id = required_payload_string(&payload, "session_id")?;
+    let repo = SessionRepository::new(config)?;
+    ensure_visible(
+        &repo,
+        current_session_id,
+        &target_session_id,
+        tool_config.sessions.visibility,
+    )?;
+    let snapshot = inspect_visible_session_with_policies(
+        &target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    )?;
+
+    match build_session_cancel_plan(&snapshot)? {
+        SessionCancelPlan::Queued => {
+            let cancel_error = delegate_cancelled_error(DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED);
+            let outcome = crate::tools::delegate::delegate_error_outcome(
+                snapshot.session.session_id.clone(),
+                snapshot.session.label.clone(),
+                cancel_error.clone(),
+                0,
+            );
+            let finalized = repo.finalize_session_terminal_if_current(
+                &target_session_id,
+                SessionState::Ready,
+                crate::session::repository::FinalizeSessionTerminalRequest {
+                    state: SessionState::Failed,
+                    last_error: Some(cancel_error),
+                    event_kind: DELEGATE_CANCELLED_EVENT_KIND.to_owned(),
+                    actor_session_id: Some(current_session_id.to_owned()),
+                    event_payload_json: json!({
+                        "reference": "queued",
+                        "cancel_reason": DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED,
+                    }),
+                    outcome_status: outcome.status.clone(),
+                    outcome_payload_json: outcome.payload.clone(),
+                },
+            )?;
+            if finalized.is_none() {
+                let latest = repo
+                    .load_session_summary_with_legacy_fallback(&target_session_id)?
+                    .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
+                return Err(format!(
+                    "session_cancel_state_changed: session `{target_session_id}` is no longer cancellable from state `{}`",
+                    latest.state.as_str()
+                ));
+            }
+
+            let cancelled_snapshot = inspect_visible_session_with_policies(
+                &target_session_id,
+                current_session_id,
+                config,
+                tool_config,
+                10,
+            )?;
+            let mut response_payload = session_inspection_payload(cancelled_snapshot);
+            if let Some(object) = response_payload.as_object_mut() {
+                object.insert(
+                    "cancel_action".to_owned(),
+                    json!({
+                        "kind": "queued_async_cancelled",
+                        "previous_state": "ready",
+                        "next_state": "failed",
+                        "reference": "queued",
+                        "reason": DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED,
+                    }),
+                );
+            }
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: response_payload,
+            })
+        }
+        SessionCancelPlan::Running => {
+            let requested = repo.transition_session_with_event_if_current(
+                &target_session_id,
+                crate::session::repository::TransitionSessionWithEventIfCurrentRequest {
+                    expected_state: SessionState::Running,
+                    next_state: SessionState::Running,
+                    last_error: None,
+                    event_kind: DELEGATE_CANCEL_REQUESTED_EVENT_KIND.to_owned(),
+                    actor_session_id: Some(current_session_id.to_owned()),
+                    event_payload_json: json!({
+                        "reference": "running",
+                        "cancel_reason": DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED,
+                    }),
+                },
+            )?;
+            if requested.is_none() {
+                let latest = repo
+                    .load_session_summary_with_legacy_fallback(&target_session_id)?
+                    .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
+                return Err(format!(
+                    "session_cancel_state_changed: session `{target_session_id}` is no longer cancellable from state `{}`",
+                    latest.state.as_str()
+                ));
+            }
+
+            let requested_snapshot = inspect_visible_session_with_policies(
+                &target_session_id,
+                current_session_id,
+                config,
+                tool_config,
+                10,
+            )?;
+            let mut response_payload = session_inspection_payload(requested_snapshot);
+            if let Some(object) = response_payload.as_object_mut() {
+                object.insert(
+                    "cancel_action".to_owned(),
+                    json!({
+                        "kind": "running_async_cancel_requested",
+                        "previous_state": "running",
+                        "next_state": "running",
+                        "reference": "running",
+                        "reason": DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED,
+                    }),
+                );
+            }
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: response_payload,
+            })
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
 pub(super) fn inspect_visible_session_with_policies(
     target_session_id: &str,
     current_session_id: &str,
@@ -527,6 +688,49 @@ fn build_session_recover_plan(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn build_session_cancel_plan(
+    snapshot: &SessionInspectionSnapshot,
+) -> Result<SessionCancelPlan, String> {
+    if snapshot.session.kind != SessionKind::DelegateChild {
+        return Err(format!(
+            "session_cancel_not_supported: session `{}` is not a delegate child",
+            snapshot.session.session_id
+        ));
+    }
+    if snapshot.terminal_outcome.is_some() || session_state_is_terminal(snapshot.session.state) {
+        return Err(format!(
+            "session_cancel_not_cancellable: session `{}` is already terminal",
+            snapshot.session.session_id
+        ));
+    }
+    let lifecycle = session_delegate_lifecycle_at(
+        &snapshot.session,
+        snapshot.recent_events.as_slice(),
+        current_unix_ts(),
+    )
+    .ok_or_else(|| {
+        format!(
+            "session_cancel_not_cancellable: session `{}` is missing delegate lifecycle metadata",
+            snapshot.session.session_id
+        )
+    })?;
+    if lifecycle.mode != "async" {
+        return Err(format!(
+            "session_cancel_not_supported: session `{}` is not an async delegate child",
+            snapshot.session.session_id
+        ));
+    }
+    match (snapshot.session.state, lifecycle.phase) {
+        (SessionState::Ready, "queued") => Ok(SessionCancelPlan::Queued),
+        (SessionState::Running, "running") => Ok(SessionCancelPlan::Running),
+        _ => Err(format!(
+            "session_cancel_not_cancellable: session `{}` is not queued or running",
+            snapshot.session.session_id
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn session_delegate_lifecycle_at(
     session: &SessionSummaryRecord,
     recent_events: &[SessionEventRecord],
@@ -540,6 +744,7 @@ fn session_delegate_lifecycle_at(
     let mut started_at = None;
     let mut queued_timeout_seconds = None;
     let mut started_timeout_seconds = None;
+    let mut cancellation = None;
     for event in recent_events {
         match event.event_kind.as_str() {
             "delegate_queued" => {
@@ -555,6 +760,28 @@ fn session_delegate_lifecycle_at(
                     .payload_json
                     .get("timeout_seconds")
                     .and_then(Value::as_u64);
+            }
+            DELEGATE_CANCEL_REQUESTED_EVENT_KIND => {
+                let reason = event
+                    .payload_json
+                    .get("cancel_reason")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or(DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED)
+                    .to_owned();
+                let reference = event
+                    .payload_json
+                    .get("reference")
+                    .and_then(Value::as_str)
+                    .filter(|value| *value == "running")
+                    .unwrap_or("running");
+                cancellation = Some(SessionDelegateCancellationRecord {
+                    state: "requested",
+                    reference: reference.to_owned(),
+                    requested_at: event.ts,
+                    reason,
+                });
             }
             _ => {}
         }
@@ -601,6 +828,11 @@ fn session_delegate_lifecycle_at(
         started_at,
         timeout_seconds,
         staleness,
+        cancellation: if session.state == SessionState::Running {
+            cancellation
+        } else {
+            None
+        },
     })
 }
 
@@ -639,6 +871,9 @@ fn session_delegate_lifecycle_json(lifecycle: SessionDelegateLifecycleRecord) ->
         "started_at": lifecycle.started_at,
         "timeout_seconds": lifecycle.timeout_seconds,
         "staleness": lifecycle.staleness.map(session_delegate_staleness_json),
+        "cancellation": lifecycle
+            .cancellation
+            .map(session_delegate_cancellation_json),
     })
 }
 
@@ -650,6 +885,16 @@ fn session_delegate_staleness_json(staleness: SessionDelegateStalenessRecord) ->
         "elapsed_seconds": staleness.elapsed_seconds,
         "threshold_seconds": staleness.threshold_seconds,
         "deadline_at": staleness.deadline_at,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_delegate_cancellation_json(cancellation: SessionDelegateCancellationRecord) -> Value {
+    json!({
+        "state": cancellation.state,
+        "reference": cancellation.reference,
+        "requested_at": cancellation.requested_at,
+        "reason": cancellation.reason,
     })
 }
 
@@ -1390,6 +1635,218 @@ mod tests {
         assert!(
             error.contains("session_recover_not_recoverable"),
             "expected recoverability rejection, got: {error}"
+        );
+    }
+
+    #[test]
+    fn session_cancel_cancels_queued_async_child() {
+        let config = isolated_memory_config("session-cancel-queued");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append queued event");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_cancel".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_cancel outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["session"]["state"], "failed");
+        assert_eq!(outcome.payload["terminal_outcome_state"], "present");
+        assert_eq!(outcome.payload["terminal_outcome"]["status"], "error");
+        assert_eq!(
+            outcome.payload["cancel_action"]["kind"],
+            "queued_async_cancelled"
+        );
+        assert_eq!(
+            outcome.payload["recent_events"]
+                .as_array()
+                .expect("recent events array")
+                .last()
+                .expect("latest recent event")["event_kind"],
+            "delegate_cancelled"
+        );
+    }
+
+    #[test]
+    fn session_cancel_requests_running_async_child_cancellation() {
+        let config = isolated_memory_config("session-cancel-running");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append queued event");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append started event");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_cancel".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_cancel outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["session"]["state"], "running");
+        assert_eq!(outcome.payload["terminal_outcome_state"], "not_terminal");
+        assert_eq!(
+            outcome.payload["cancel_action"]["kind"],
+            "running_async_cancel_requested"
+        );
+        assert_eq!(
+            outcome.payload["recent_events"]
+                .as_array()
+                .expect("recent events array")
+                .last()
+                .expect("latest recent event")["event_kind"],
+            "delegate_cancel_requested"
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["cancellation"]["state"],
+            "requested"
+        );
+    }
+
+    #[test]
+    fn session_cancel_requested_state_is_visible_in_session_status() {
+        let config = isolated_memory_config("session-cancel-status");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append queued event");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append started event");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_cancel_requested".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "reference": "running",
+                "cancel_reason": "operator_requested"
+            }),
+        })
+        .expect("append cancel requested event");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["cancellation"]["state"],
+            "requested"
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["cancellation"]["reference"],
+            "running"
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["cancellation"]["reason"],
+            "operator_requested"
         );
     }
 

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -3,6 +3,8 @@ use std::{
     collections::BTreeMap,
     time::{SystemTime, UNIX_EPOCH},
 };
+#[cfg(feature = "memory-sqlite")]
+use tokio::time::{sleep, Duration, Instant};
 
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{json, Value};
@@ -152,6 +154,16 @@ struct SessionBatchResultRecord {
     inspection: Option<Value>,
 }
 
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq)]
+struct SessionWaitTargetState {
+    index: usize,
+    session_id: String,
+    next_after_id: i64,
+    observed_events: Vec<SessionEventRecord>,
+    latest_inspection: Option<SessionInspectionSnapshot>,
+}
+
 #[cfg(test)]
 pub fn execute_session_tool_with_config(
     request: ToolCoreRequest,
@@ -205,6 +217,51 @@ pub fn execute_session_tool_with_policies(
             )),
         }
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) async fn wait_for_session_tool_with_policies(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let request = parse_session_target_request(&payload)?;
+    let after_id = payload.get("after_id").and_then(Value::as_i64);
+    let timeout_ms = payload
+        .get("timeout_ms")
+        .and_then(Value::as_u64)
+        .unwrap_or(1_000)
+        .clamp(1, 30_000);
+    let event_limit = tool_config.sessions.history_limit.min(50);
+
+    if request.legacy_single {
+        let target_session_id = request
+            .session_ids
+            .first()
+            .expect("legacy single request requires one session id");
+        return wait_for_single_session_with_policies(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            after_id,
+            timeout_ms,
+            event_limit,
+        )
+        .await;
+    }
+
+    wait_for_session_batch_with_policies(
+        request.session_ids,
+        current_session_id,
+        config,
+        tool_config,
+        after_id,
+        timeout_ms,
+        event_limit,
+    )
+    .await
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -563,6 +620,231 @@ pub(super) fn inspect_visible_session_with_policies(
         0,
     )?
     .inspection)
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn wait_for_single_session_with_policies(
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    after_id: Option<i64>,
+    timeout_ms: u64,
+    event_limit: usize,
+) -> Result<ToolCoreOutcome, String> {
+    let started_at = Instant::now();
+    let mut next_after_id = after_id.unwrap_or(0).max(0);
+    let mut observed_events = Vec::new();
+
+    loop {
+        let observation = observe_visible_session_with_policies(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            event_limit,
+            after_id.map(|_| next_after_id),
+            event_limit,
+        )?;
+        let snapshot = observation.inspection;
+        if let Some(last_tail_event_id) = observation.tail_events.last().map(|event| event.id) {
+            next_after_id = last_tail_event_id;
+        }
+        observed_events.extend(observation.tail_events);
+        if session_state_is_terminal(snapshot.session.state) {
+            return Ok(wait_outcome(
+                "ok",
+                snapshot,
+                after_id,
+                timeout_ms,
+                if after_id.is_some() {
+                    observed_events
+                } else {
+                    Vec::new()
+                },
+                next_after_id,
+            ));
+        }
+
+        let elapsed_ms = started_at.elapsed().as_millis() as u64;
+        if elapsed_ms >= timeout_ms {
+            return Ok(ToolCoreOutcome {
+                status: "timeout".to_owned(),
+                payload: wait_payload(
+                    snapshot,
+                    "timeout",
+                    after_id,
+                    timeout_ms,
+                    if after_id.is_some() {
+                        observed_events
+                    } else {
+                        Vec::new()
+                    },
+                    next_after_id,
+                ),
+            });
+        }
+
+        let remaining_ms = timeout_ms - elapsed_ms;
+        sleep(Duration::from_millis(remaining_ms.min(25))).await;
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn wait_for_session_batch_with_policies(
+    target_session_ids: Vec<String>,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    after_id: Option<i64>,
+    timeout_ms: u64,
+    event_limit: usize,
+) -> Result<ToolCoreOutcome, String> {
+    let repo = SessionRepository::new(config)?;
+    let mut results = vec![None; target_session_ids.len()];
+    let mut pending = Vec::new();
+    for (index, target_session_id) in target_session_ids.into_iter().enumerate() {
+        if let Err(error) = ensure_visible(
+            &repo,
+            current_session_id,
+            &target_session_id,
+            tool_config.sessions.visibility,
+        ) {
+            results[index] = Some(session_batch_result(
+                target_session_id,
+                "skipped_not_visible",
+                Some(error),
+                None,
+                None,
+            ));
+            continue;
+        }
+        pending.push(SessionWaitTargetState {
+            index,
+            session_id: target_session_id,
+            next_after_id: after_id.unwrap_or(0).max(0),
+            observed_events: Vec::new(),
+            latest_inspection: None,
+        });
+    }
+    drop(repo);
+
+    let started_at = Instant::now();
+    loop {
+        let mut next_pending = Vec::with_capacity(pending.len());
+        for mut target in pending.into_iter() {
+            let observation = match observe_visible_session_with_policies(
+                &target.session_id,
+                current_session_id,
+                config,
+                tool_config,
+                event_limit,
+                after_id.map(|_| target.next_after_id),
+                event_limit,
+            ) {
+                Ok(observation) => observation,
+                Err(error) if is_session_visibility_skip_error(&error) => {
+                    results[target.index] = Some(session_batch_result(
+                        target.session_id,
+                        "skipped_not_visible",
+                        Some(error),
+                        None,
+                        None,
+                    ));
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            let snapshot = observation.inspection;
+            if let Some(last_tail_event_id) = observation.tail_events.last().map(|event| event.id) {
+                target.next_after_id = last_tail_event_id;
+            }
+            target.observed_events.extend(observation.tail_events);
+            target.latest_inspection = Some(snapshot.clone());
+            if session_state_is_terminal(snapshot.session.state) {
+                results[target.index] = Some(session_batch_result(
+                    target.session_id,
+                    "ok",
+                    None,
+                    None,
+                    Some(wait_payload(
+                        snapshot,
+                        "completed",
+                        after_id,
+                        timeout_ms,
+                        if after_id.is_some() {
+                            std::mem::take(&mut target.observed_events)
+                        } else {
+                            Vec::new()
+                        },
+                        target.next_after_id,
+                    )),
+                ));
+                continue;
+            }
+            next_pending.push(target);
+        }
+        pending = next_pending;
+
+        if pending.is_empty() {
+            return Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: session_wait_batch_payload(
+                    current_session_id,
+                    after_id,
+                    timeout_ms,
+                    results
+                        .into_iter()
+                        .map(|result| result.expect("batch wait result"))
+                        .collect::<Vec<_>>(),
+                ),
+            });
+        }
+
+        let elapsed_ms = started_at.elapsed().as_millis() as u64;
+        if elapsed_ms >= timeout_ms {
+            for mut target in pending.into_iter() {
+                let snapshot = target
+                    .latest_inspection
+                    .take()
+                    .expect("pending batch wait target inspection");
+                results[target.index] = Some(session_batch_result(
+                    target.session_id,
+                    "timeout",
+                    None,
+                    None,
+                    Some(wait_payload(
+                        snapshot,
+                        "timeout",
+                        after_id,
+                        timeout_ms,
+                        if after_id.is_some() {
+                            target.observed_events
+                        } else {
+                            Vec::new()
+                        },
+                        target.next_after_id,
+                    )),
+                ));
+            }
+
+            return Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: session_wait_batch_payload(
+                    current_session_id,
+                    after_id,
+                    timeout_ms,
+                    results
+                        .into_iter()
+                        .map(|result| result.expect("batch wait result"))
+                        .collect::<Vec<_>>(),
+                ),
+            });
+        }
+
+        let remaining_ms = timeout_ms - elapsed_ms;
+        sleep(Duration::from_millis(remaining_ms.min(25))).await;
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1732,6 +2014,33 @@ fn session_batch_payload_with_optional_dry_run(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn session_wait_batch_payload(
+    current_session_id: &str,
+    after_id: Option<i64>,
+    timeout_ms: u64,
+    results: Vec<SessionBatchResultRecord>,
+) -> Value {
+    let mut payload = session_batch_payload_without_dry_run(
+        "session_wait",
+        current_session_id,
+        results.len(),
+        results,
+    );
+    payload
+        .as_object_mut()
+        .expect("session wait batch payload object")
+        .insert("timeout_ms".to_owned(), Value::from(timeout_ms));
+    payload
+        .as_object_mut()
+        .expect("session wait batch payload object")
+        .insert(
+            "after_id".to_owned(),
+            after_id.map(Value::from).unwrap_or(Value::Null),
+        );
+    payload
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn session_batch_result(
     session_id: String,
     result: &'static str,
@@ -1746,6 +2055,78 @@ fn session_batch_result(
         action,
         inspection,
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn wait_outcome(
+    status: &str,
+    snapshot: SessionInspectionSnapshot,
+    after_id: Option<i64>,
+    timeout_ms: u64,
+    observed_events: Vec<SessionEventRecord>,
+    next_after_id: i64,
+) -> ToolCoreOutcome {
+    ToolCoreOutcome {
+        status: status.to_owned(),
+        payload: wait_payload(
+            snapshot,
+            if status == "ok" {
+                "completed"
+            } else {
+                "timeout"
+            },
+            after_id,
+            timeout_ms,
+            observed_events,
+            next_after_id,
+        ),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn wait_payload(
+    snapshot: SessionInspectionSnapshot,
+    wait_status: &str,
+    after_id: Option<i64>,
+    timeout_ms: u64,
+    observed_events: Vec<SessionEventRecord>,
+    next_after_id: i64,
+) -> Value {
+    let next_after_id = match after_id {
+        Some(_) => next_after_id,
+        None => snapshot
+            .recent_events
+            .last()
+            .map(|event| event.id)
+            .unwrap_or(0),
+    };
+    let events = match after_id {
+        Some(_) => observed_events,
+        None => snapshot.recent_events.clone(),
+    };
+    let mut payload = session_inspection_payload(snapshot);
+    if let Some(object) = payload.as_object_mut() {
+        object.insert(
+            "wait_status".to_owned(),
+            Value::String(wait_status.to_owned()),
+        );
+        object.insert("timeout_ms".to_owned(), Value::from(timeout_ms));
+        object.insert(
+            "after_id".to_owned(),
+            after_id.map(Value::from).unwrap_or(Value::Null),
+        );
+        object.insert("next_after_id".to_owned(), Value::from(next_after_id));
+        object.insert(
+            "events".to_owned(),
+            Value::Array(
+                events
+                    .into_iter()
+                    .map(session_event_json)
+                    .collect::<Vec<_>>(),
+            ),
+        );
+    }
+    payload
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -5343,18 +5343,12 @@ mod tests {
         assert_eq!(outcome.payload["dry_run"], true);
         assert_eq!(outcome.payload["requested_count"], 4);
         assert_eq!(outcome.payload["result_counts"]["would_apply"], 1);
-        assert_eq!(
-            outcome.payload["result_counts"]["skipped_not_archived"],
-            1
-        );
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_archived"], 1);
         assert_eq!(
             outcome.payload["result_counts"]["skipped_not_archivable"],
             1
         );
-        assert_eq!(
-            outcome.payload["result_counts"]["skipped_not_visible"],
-            1
-        );
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_visible"], 1);
 
         let ready = batch_result(&outcome.payload, "ready-to-unarchive");
         assert_eq!(ready["result"], "would_apply");
@@ -5470,18 +5464,12 @@ mod tests {
         assert_eq!(outcome.payload["dry_run"], false);
         assert_eq!(outcome.payload["requested_count"], 4);
         assert_eq!(outcome.payload["result_counts"]["applied"], 1);
-        assert_eq!(
-            outcome.payload["result_counts"]["skipped_not_archived"],
-            1
-        );
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_archived"], 1);
         assert_eq!(
             outcome.payload["result_counts"]["skipped_not_archivable"],
             1
         );
-        assert_eq!(
-            outcome.payload["result_counts"]["skipped_not_visible"],
-            1
-        );
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_visible"], 1);
 
         let ready = batch_result(&outcome.payload, "ready-to-unarchive");
         assert_eq!(ready["result"], "applied");

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -145,6 +145,12 @@ struct SessionArchivePlan {
 }
 
 #[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionUnarchivePlan {
+    expected_state: SessionState,
+}
+
+#[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq)]
 struct SessionToolActionOutcome {
     inspection: Value,
@@ -249,6 +255,9 @@ pub fn execute_session_tool_with_policies(
             }
             "session_archive" => {
                 execute_session_archive(request.payload, current_session_id, config, tool_config)
+            }
+            "session_unarchive" => {
+                execute_session_unarchive(request.payload, current_session_id, config, tool_config)
             }
             "session_recover" => {
                 execute_session_recover(request.payload, current_session_id, config, tool_config)
@@ -700,6 +709,57 @@ fn execute_session_archive(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn execute_session_unarchive(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let request = parse_session_mutation_request(&payload)?;
+    if request.use_legacy_single_response() {
+        let target_session_id = request
+            .target
+            .session_ids
+            .first()
+            .expect("legacy single request requires one session id");
+        let repo = SessionRepository::new(config)?;
+        ensure_visible(
+            &repo,
+            current_session_id,
+            target_session_id,
+            tool_config.sessions.visibility,
+        )?;
+        let snapshot = inspect_visible_session_with_policies(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            10,
+        )?;
+        let unarchive_plan = build_session_unarchive_plan(&snapshot)?;
+        let outcome = apply_session_unarchive_plan(
+            &repo,
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            &snapshot,
+            &unarchive_plan,
+        )?;
+        let mut payload = outcome.inspection;
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("unarchive_action".to_owned(), outcome.action);
+        }
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload,
+        });
+    }
+
+    Err("session_unarchive_batch_not_implemented".to_owned())
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn build_session_archive_plan(
     snapshot: &SessionInspectionSnapshot,
 ) -> Result<SessionArchivePlan, String> {
@@ -717,6 +777,28 @@ fn build_session_archive_plan(
     }
 
     Ok(SessionArchivePlan {
+        expected_state: snapshot.session.state,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_session_unarchive_plan(
+    snapshot: &SessionInspectionSnapshot,
+) -> Result<SessionUnarchivePlan, String> {
+    if !session_state_is_terminal(snapshot.session.state) {
+        return Err(format!(
+            "session_unarchive_not_archivable: session `{}` is not terminal",
+            snapshot.session.session_id
+        ));
+    }
+    if snapshot.session.archived_at.is_none() {
+        return Err(format!(
+            "session_unarchive_not_unarchivable: session `{}` is not archived",
+            snapshot.session.session_id
+        ));
+    }
+
+    Ok(SessionUnarchivePlan {
         expected_state: snapshot.session.state,
     })
 }
@@ -765,6 +847,53 @@ fn apply_session_archive_plan(
     Ok(SessionToolActionOutcome {
         inspection: session_inspection_payload(archived_snapshot),
         action: session_archive_action_json(archive_plan),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn apply_session_unarchive_plan(
+    repo: &SessionRepository,
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    snapshot: &SessionInspectionSnapshot,
+    unarchive_plan: &SessionUnarchivePlan,
+) -> Result<SessionToolActionOutcome, String> {
+    let transitioned = repo.transition_session_with_event_if_current(
+        target_session_id,
+        crate::session::repository::TransitionSessionWithEventIfCurrentRequest {
+            expected_state: unarchive_plan.expected_state,
+            next_state: unarchive_plan.expected_state,
+            last_error: snapshot.session.last_error.clone(),
+            event_kind: "session_unarchived".to_owned(),
+            actor_session_id: Some(current_session_id.to_owned()),
+            event_payload_json: json!({
+                "previous_state": unarchive_plan.expected_state.as_str(),
+                "restores_to_sessions_list": true,
+            }),
+        },
+    )?;
+    if transitioned.is_none() {
+        let latest = repo
+            .load_session_summary_with_legacy_fallback(target_session_id)?
+            .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
+        return Err(format!(
+            "session_unarchive_state_changed: session `{target_session_id}` is no longer unarchivable from state `{}`",
+            latest.state.as_str()
+        ));
+    }
+
+    let unarchived_snapshot = inspect_visible_session_with_policies(
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    )?;
+    Ok(SessionToolActionOutcome {
+        inspection: session_inspection_payload(unarchived_snapshot),
+        action: session_unarchive_action_json(unarchive_plan),
     })
 }
 
@@ -891,6 +1020,16 @@ fn session_archive_action_json(plan: &SessionArchivePlan) -> Value {
         "previous_state": plan.expected_state.as_str(),
         "next_state": plan.expected_state.as_str(),
         "hides_from_sessions_list": true,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_unarchive_action_json(plan: &SessionUnarchivePlan) -> Value {
+    json!({
+        "kind": "session_unarchived",
+        "previous_state": plan.expected_state.as_str(),
+        "next_state": plan.expected_state.as_str(),
+        "restores_to_sessions_list": true,
     })
 }
 
@@ -4891,6 +5030,94 @@ mod tests {
 
         assert_eq!(status.payload["session"]["archived"], true);
         assert!(status.payload["session"]["archived_at"].is_number());
+    }
+
+    #[test]
+    fn session_unarchive_restores_archived_terminal_visible_session() {
+        let config = isolated_memory_config("session-unarchive-single");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+        repo.finalize_session_terminal(
+            "child-session",
+            FinalizeSessionTerminalRequest {
+                state: SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                event_payload_json: json!({
+                    "result": "ok"
+                }),
+                outcome_status: "ok".to_owned(),
+                outcome_payload_json: json!({
+                    "child_session_id": "child-session",
+                    "result": "ok"
+                }),
+            },
+        )
+        .expect("finalize child");
+        execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("archive child");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_unarchive".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_unarchive outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["session"]["session_id"], "child-session");
+        assert_eq!(outcome.payload["session"]["state"], "completed");
+        assert_eq!(outcome.payload["session"]["archived"], false);
+        assert!(outcome.payload["session"]["archived_at"].is_null());
+        assert_eq!(
+            outcome.payload["unarchive_action"]["kind"],
+            "session_unarchived"
+        );
+
+        let status = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(status.payload["session"]["archived"], false);
+        assert!(status.payload["session"]["archived_at"].is_null());
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -32,6 +32,7 @@ pub(super) struct SessionInspectionSnapshot {
     pub session: SessionSummaryRecord,
     pub terminal_outcome: Option<SessionTerminalOutcomeRecord>,
     pub recent_events: Vec<SessionEventRecord>,
+    pub delegate_events: Vec<SessionEventRecord>,
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -70,6 +71,24 @@ struct SessionDelegateCancellationRecord {
     reference: String,
     requested_at: i64,
     reason: String,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionsListRequest {
+    limit: usize,
+    state: Option<SessionState>,
+    kind: Option<SessionKind>,
+    parent_session_id: Option<String>,
+    overdue_only: bool,
+    include_delegate_lifecycle: bool,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl SessionsListRequest {
+    fn effective_include_delegate_lifecycle(&self) -> bool {
+        self.include_delegate_lifecycle || self.overdue_only
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -122,7 +141,9 @@ pub fn execute_session_tool_with_policies(
             return Err("app_tool_disabled: session tools are disabled by config".to_owned());
         }
         match request.tool_name.as_str() {
-            "sessions_list" => execute_sessions_list(current_session_id, config, tool_config),
+            "sessions_list" => {
+                execute_sessions_list(request.payload, current_session_id, config, tool_config)
+            }
             "session_events" => {
                 execute_session_events(request.payload, current_session_id, config, tool_config)
             }
@@ -147,21 +168,69 @@ pub fn execute_session_tool_with_policies(
 
 #[cfg(feature = "memory-sqlite")]
 fn execute_sessions_list(
+    payload: Value,
     current_session_id: &str,
     config: &MemoryRuntimeConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let repo = SessionRepository::new(config)?;
+    let request = parse_sessions_list_request(&payload, tool_config)?;
+    let include_delegate_lifecycle = request.effective_include_delegate_lifecycle();
+    let now_ts = current_unix_ts();
     let mut sessions = repo.list_visible_sessions(current_session_id)?;
     if tool_config.sessions.visibility == SessionVisibility::SelfOnly {
         sessions.retain(|session| session.session_id == current_session_id);
     }
-    sessions.truncate(tool_config.sessions.list_limit);
+    if let Some(state) = request.state {
+        sessions.retain(|session| session.state == state);
+    }
+    if let Some(kind) = request.kind {
+        sessions.retain(|session| session.kind == kind);
+    }
+    if let Some(parent_session_id) = request.parent_session_id.as_deref() {
+        sessions.retain(|session| session.parent_session_id.as_deref() == Some(parent_session_id));
+    }
+
+    let mut listed_sessions = Vec::new();
+    for session in sessions {
+        let delegate_lifecycle = if include_delegate_lifecycle {
+            let delegate_events = load_delegate_lifecycle_events(&repo, &session)?;
+            session_delegate_lifecycle_at(&session, delegate_events.as_slice(), now_ts)
+        } else {
+            None
+        };
+        if request.overdue_only
+            && !delegate_lifecycle
+                .as_ref()
+                .and_then(|lifecycle| lifecycle.staleness.as_ref())
+                .map(|staleness| staleness.state == "overdue")
+                .unwrap_or(false)
+        {
+            continue;
+        }
+        listed_sessions.push((session, delegate_lifecycle));
+    }
+
+    let matched_count = listed_sessions.len();
+    listed_sessions.truncate(request.limit);
+    let returned_count = listed_sessions.len();
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
             "current_session_id": current_session_id,
-            "sessions": sessions.into_iter().map(session_summary_json).collect::<Vec<_>>(),
+            "filters": sessions_list_filters_json(&request),
+            "matched_count": matched_count,
+            "returned_count": returned_count,
+            "sessions": listed_sessions
+                .into_iter()
+                .map(|(session, delegate_lifecycle)| {
+                    session_summary_json_with_delegate_lifecycle(
+                        session,
+                        delegate_lifecycle,
+                        include_delegate_lifecycle,
+                    )
+                })
+                .collect::<Vec<_>>(),
         }),
     })
 }
@@ -562,15 +631,28 @@ pub(super) fn observe_visible_session_with_policies(
             tail_page_limit,
         )?
         .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
+    let delegate_events = load_delegate_lifecycle_events(&repo, &session)?;
 
     Ok(SessionObservationSnapshot {
         inspection: SessionInspectionSnapshot {
             session,
             terminal_outcome,
             recent_events,
+            delegate_events,
         },
         tail_events,
     })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_delegate_lifecycle_events(
+    repo: &SessionRepository,
+    session: &SessionSummaryRecord,
+) -> Result<Vec<SessionEventRecord>, String> {
+    if session.kind != SessionKind::DelegateChild {
+        return Ok(Vec::new());
+    }
+    repo.list_delegate_lifecycle_events(&session.session_id)
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -587,7 +669,7 @@ pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) ->
         session_terminal_outcome_state(snapshot.session.state, snapshot.terminal_outcome.is_some());
     let delegate_lifecycle = session_delegate_lifecycle_at(
         &snapshot.session,
-        snapshot.recent_events.as_slice(),
+        snapshot.delegate_events.as_slice(),
         current_unix_ts(),
     );
     let recovery = match terminal_outcome_state {
@@ -660,14 +742,17 @@ fn build_session_recover_plan(
             snapshot.session.session_id
         ));
     }
-    let lifecycle =
-        session_delegate_lifecycle_at(&snapshot.session, snapshot.recent_events.as_slice(), now_ts)
-            .ok_or_else(|| {
-                format!(
+    let lifecycle = session_delegate_lifecycle_at(
+        &snapshot.session,
+        snapshot.delegate_events.as_slice(),
+        now_ts,
+    )
+    .ok_or_else(|| {
+        format!(
             "session_recover_not_recoverable: session `{}` is missing delegate lifecycle metadata",
             snapshot.session.session_id
         )
-            })?;
+    })?;
     if lifecycle.mode != "async" {
         return Err(format!(
             "session_recover_not_recoverable: session `{}` is not an overdue async child",
@@ -762,7 +847,7 @@ fn build_session_cancel_plan(
     }
     let lifecycle = session_delegate_lifecycle_at(
         &snapshot.session,
-        snapshot.recent_events.as_slice(),
+        snapshot.delegate_events.as_slice(),
         current_unix_ts(),
     )
     .ok_or_else(|| {
@@ -1012,6 +1097,86 @@ fn optional_payload_limit(payload: &Value, field: &str, default: usize, max: usi
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn parse_sessions_list_request(
+    payload: &Value,
+    tool_config: &ToolConfig,
+) -> Result<SessionsListRequest, String> {
+    Ok(SessionsListRequest {
+        limit: optional_payload_limit(
+            payload,
+            "limit",
+            tool_config.sessions.list_limit,
+            tool_config.sessions.list_limit,
+        ),
+        state: optional_payload_session_state(payload, "state")?,
+        kind: optional_payload_session_kind(payload, "kind")?,
+        parent_session_id: optional_payload_string(payload, "parent_session_id"),
+        overdue_only: payload
+            .get("overdue_only")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        include_delegate_lifecycle: payload
+            .get("include_delegate_lifecycle")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_session_state(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<SessionState>, String> {
+    let Some(raw) = optional_payload_string(payload, field) else {
+        return Ok(None);
+    };
+    match raw.as_str() {
+        "ready" => Ok(Some(SessionState::Ready)),
+        "running" => Ok(Some(SessionState::Running)),
+        "completed" => Ok(Some(SessionState::Completed)),
+        "failed" => Ok(Some(SessionState::Failed)),
+        "timed_out" => Ok(Some(SessionState::TimedOut)),
+        _ => Err(format!("invalid session tool payload.{field}: `{raw}`")),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_session_kind(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<SessionKind>, String> {
+    let Some(raw) = optional_payload_string(payload, field) else {
+        return Ok(None);
+    };
+    match raw.as_str() {
+        "root" => Ok(Some(SessionKind::Root)),
+        "delegate_child" => Ok(Some(SessionKind::DelegateChild)),
+        _ => Err(format!("invalid session tool payload.{field}: `{raw}`")),
+    }
+}
+
+fn optional_payload_string(payload: &Value, field: &str) -> Option<String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn sessions_list_filters_json(request: &SessionsListRequest) -> Value {
+    json!({
+        "limit": request.limit,
+        "state": request.state.map(SessionState::as_str),
+        "kind": request.kind.map(SessionKind::as_str),
+        "parent_session_id": request.parent_session_id.clone(),
+        "overdue_only": request.overdue_only,
+        "include_delegate_lifecycle": request.effective_include_delegate_lifecycle(),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn session_summary_json(session: SessionSummaryRecord) -> Value {
     json!({
         "session_id": session.session_id,
@@ -1025,6 +1190,27 @@ fn session_summary_json(session: SessionSummaryRecord) -> Value {
         "last_turn_at": session.last_turn_at,
         "last_error": session.last_error,
     })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_summary_json_with_delegate_lifecycle(
+    session: SessionSummaryRecord,
+    delegate_lifecycle: Option<SessionDelegateLifecycleRecord>,
+    include_delegate_lifecycle: bool,
+) -> Value {
+    let mut payload = session_summary_json(session);
+    if include_delegate_lifecycle {
+        payload
+            .as_object_mut()
+            .expect("session summary json object")
+            .insert(
+                "delegate_lifecycle".to_owned(),
+                delegate_lifecycle
+                    .map(session_delegate_lifecycle_json)
+                    .unwrap_or(Value::Null),
+            );
+    }
+    payload
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1206,6 +1392,185 @@ mod tests {
             .filter_map(Value::as_str)
             .collect();
         assert_eq!(ids, vec!["root-session"]);
+    }
+
+    #[test]
+    fn sessions_list_filters_visible_sessions_by_state_kind_and_parent() {
+        let config = isolated_memory_config("sessions-list-filtered");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-running".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Running Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create running child");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-completed".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Completed Child".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create completed child");
+        repo.create_session(NewSessionRecord {
+            session_id: "grandchild-running".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("child-running".to_owned()),
+            label: Some("Grandchild".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create grandchild");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "sessions_list".to_owned(),
+                payload: json!({
+                    "state": "running",
+                    "kind": "delegate_child",
+                    "parent_session_id": "root-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("sessions_list outcome");
+
+        let sessions = outcome.payload["sessions"]
+            .as_array()
+            .expect("sessions array");
+        let ids: Vec<&str> = sessions
+            .iter()
+            .filter_map(|item: &Value| item.get("session_id"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(ids, vec!["child-running"]);
+        assert_eq!(outcome.payload["matched_count"], 1);
+        assert_eq!(outcome.payload["returned_count"], 1);
+    }
+
+    #[test]
+    fn sessions_list_overdue_only_uses_lifecycle_anchor_events() {
+        let config = isolated_memory_config("sessions-list-overdue-only");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "overdue-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Overdue".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create overdue child");
+        repo.create_session(NewSessionRecord {
+            session_id: "fresh-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Fresh".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create fresh child");
+
+        repo.append_event(NewSessionEvent {
+            session_id: "overdue-child".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({ "timeout_seconds": 30 }),
+        })
+        .expect("append overdue queued");
+        repo.append_event(NewSessionEvent {
+            session_id: "overdue-child".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({ "timeout_seconds": 30 }),
+        })
+        .expect("append overdue started");
+        overwrite_session_event_ts(
+            &config,
+            "overdue-child",
+            "delegate_queued",
+            super::current_unix_ts() - 120,
+        );
+        overwrite_session_event_ts(
+            &config,
+            "overdue-child",
+            "delegate_started",
+            super::current_unix_ts() - 90,
+        );
+        for step in 0..20 {
+            repo.append_event(NewSessionEvent {
+                session_id: "overdue-child".to_owned(),
+                event_kind: format!("delegate_progress_{step}"),
+                actor_session_id: Some("root-session".to_owned()),
+                payload_json: json!({ "step": step }),
+            })
+            .expect("append overdue progress");
+        }
+
+        repo.append_event(NewSessionEvent {
+            session_id: "fresh-child".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({ "timeout_seconds": 300 }),
+        })
+        .expect("append fresh queued");
+        repo.append_event(NewSessionEvent {
+            session_id: "fresh-child".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({ "timeout_seconds": 300 }),
+        })
+        .expect("append fresh started");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "sessions_list".to_owned(),
+                payload: json!({
+                    "kind": "delegate_child",
+                    "overdue_only": true
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("sessions_list outcome");
+
+        let sessions = outcome.payload["sessions"]
+            .as_array()
+            .expect("sessions array");
+        let ids: Vec<&str> = sessions
+            .iter()
+            .filter_map(|item: &Value| item.get("session_id"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(ids, vec!["overdue-child"]);
+        assert_eq!(outcome.payload["matched_count"], 1);
+        assert_eq!(sessions[0]["delegate_lifecycle"]["mode"], "async");
+        assert_eq!(sessions[0]["delegate_lifecycle"]["phase"], "running");
+        assert_eq!(
+            sessions[0]["delegate_lifecycle"]["staleness"]["state"],
+            "overdue"
+        );
+        assert_eq!(
+            sessions[0]["delegate_lifecycle"]["staleness"]["reference"],
+            "started"
+        );
     }
 
     #[test]
@@ -2096,6 +2461,88 @@ mod tests {
         );
         assert!(outcome.payload["delegate_lifecycle"]["queued_at"].is_number());
         assert!(outcome.payload["delegate_lifecycle"]["started_at"].is_null());
+    }
+
+    #[test]
+    fn session_status_uses_delegate_lifecycle_anchor_events_when_recent_window_is_noisy() {
+        let config = isolated_memory_config("session-status-lifecycle-noisy-window");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({ "timeout_seconds": 30 }),
+        })
+        .expect("append queued event");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({ "timeout_seconds": 30 }),
+        })
+        .expect("append started event");
+        overwrite_session_event_ts(
+            &config,
+            "child-session",
+            "delegate_queued",
+            super::current_unix_ts() - 120,
+        );
+        overwrite_session_event_ts(
+            &config,
+            "child-session",
+            "delegate_started",
+            super::current_unix_ts() - 90,
+        );
+        for step in 0..20 {
+            repo.append_event(NewSessionEvent {
+                session_id: "child-session".to_owned(),
+                event_kind: format!("delegate_progress_{step}"),
+                actor_session_id: Some("root-session".to_owned()),
+                payload_json: json!({ "step": step }),
+            })
+            .expect("append progress event");
+        }
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(outcome.payload["delegate_lifecycle"]["mode"], "async");
+        assert_eq!(outcome.payload["delegate_lifecycle"]["phase"], "running");
+        assert_eq!(outcome.payload["delegate_lifecycle"]["timeout_seconds"], 30);
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["staleness"]["reference"],
+            "started"
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["staleness"]["state"],
+            "overdue"
+        );
+        assert!(outcome.payload["delegate_lifecycle"]["started_at"].is_number());
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "memory-sqlite")]
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    collections::BTreeMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{json, Value};
@@ -93,6 +96,21 @@ impl SessionsListRequest {
 
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionMutationRequest {
+    session_ids: Vec<String>,
+    dry_run: bool,
+    legacy_single: bool,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl SessionMutationRequest {
+    fn use_legacy_single_response(&self) -> bool {
+        self.legacy_single && !self.dry_run
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct SessionRecoverPlan {
     expected_state: SessionState,
     recovery_kind: &'static str,
@@ -109,6 +127,23 @@ struct SessionRecoverPlan {
 enum SessionCancelPlan {
     Queued,
     Running,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq)]
+struct SessionToolActionOutcome {
+    inspection: Value,
+    action: Value,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq)]
+struct SessionBatchResultRecord {
+    session_id: String,
+    result: &'static str,
+    message: Option<String>,
+    action: Option<Value>,
+    inspection: Option<Value>,
 }
 
 #[cfg(test)]
@@ -343,104 +378,66 @@ fn execute_session_recover(
     config: &MemoryRuntimeConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    let target_session_id = required_payload_string(&payload, "session_id")?;
-    let repo = SessionRepository::new(config)?;
-    ensure_visible(
-        &repo,
-        current_session_id,
-        &target_session_id,
-        tool_config.sessions.visibility,
-    )?;
-    let snapshot = inspect_visible_session_with_policies(
-        &target_session_id,
-        current_session_id,
-        config,
-        tool_config,
-        10,
-    )?;
-    let recover_plan = build_session_recover_plan(&snapshot, current_unix_ts())?;
-    let recovery_error = session_recovery_error(&recover_plan);
-    let outcome = crate::tools::delegate::delegate_error_outcome(
-        snapshot.session.session_id.clone(),
-        snapshot.session.label.clone(),
-        recovery_error.clone(),
-        recover_plan.elapsed_seconds.saturating_mul(1_000),
-    );
-    let event_payload_json = match recover_plan.recovery_kind {
-        RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED => {
-            build_queued_async_overdue_recovery_payload(
-                snapshot.session.label.as_deref(),
-                recover_plan
-                    .queued_at
-                    .expect("queued async overdue recovery requires queued_at"),
-                recover_plan.elapsed_seconds,
-                recover_plan.timeout_seconds,
-                recover_plan.deadline_at,
-                &recovery_error,
-            )
+    let request = parse_session_mutation_request(&payload)?;
+    if request.use_legacy_single_response() {
+        let target_session_id = request
+            .session_ids
+            .first()
+            .expect("legacy single request requires one session id");
+        let repo = SessionRepository::new(config)?;
+        ensure_visible(
+            &repo,
+            current_session_id,
+            target_session_id,
+            tool_config.sessions.visibility,
+        )?;
+        let snapshot = inspect_visible_session_with_policies(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            10,
+        )?;
+        let recover_plan = build_session_recover_plan(&snapshot, current_unix_ts())?;
+        let outcome = apply_session_recover_plan(
+            &repo,
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            &snapshot,
+            &recover_plan,
+        )?;
+        let mut payload = outcome.inspection;
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("recovery_action".to_owned(), outcome.action);
         }
-        RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED => {
-            build_running_async_overdue_recovery_payload(
-                snapshot.session.label.as_deref(),
-                recover_plan.queued_at,
-                recover_plan.started_at,
-                recover_plan.reference,
-                recover_plan.elapsed_seconds,
-                recover_plan.timeout_seconds,
-                recover_plan.deadline_at,
-                &recovery_error,
-            )
-        }
-        other => unreachable!("unsupported session recovery kind `{other}`"),
-    };
-    let finalized = repo.finalize_session_terminal_if_current(
-        &target_session_id,
-        recover_plan.expected_state,
-        crate::session::repository::FinalizeSessionTerminalRequest {
-            state: SessionState::Failed,
-            last_error: Some(recovery_error.clone()),
-            event_kind: RECOVERY_EVENT_KIND.to_owned(),
-            actor_session_id: Some(current_session_id.to_owned()),
-            event_payload_json,
-            outcome_status: outcome.status.clone(),
-            outcome_payload_json: outcome.payload.clone(),
-        },
-    )?;
-    if finalized.is_none() {
-        let latest = repo
-            .load_session_summary_with_legacy_fallback(&target_session_id)?
-            .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
-        return Err(format!(
-            "session_recover_state_changed: session `{target_session_id}` is no longer recoverable from state `{}`",
-            latest.state.as_str()
-        ));
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload,
+        });
     }
-    let recovered_snapshot = inspect_visible_session_with_policies(
-        &target_session_id,
-        current_session_id,
-        config,
-        tool_config,
-        10,
-    )?;
-    let mut payload = session_inspection_payload(recovered_snapshot);
-    if let Some(object) = payload.as_object_mut() {
-        object.insert(
-            "recovery_action".to_owned(),
-            json!({
-                "kind": recover_plan.recovery_kind,
-                "previous_state": recover_plan.expected_state.as_str(),
-                "next_state": "failed",
-                "reference": recover_plan.reference,
-                "elapsed_seconds": recover_plan.elapsed_seconds,
-                "timeout_seconds": recover_plan.timeout_seconds,
-                "deadline_at": recover_plan.deadline_at,
-            }),
-        );
+
+    let mut results = Vec::with_capacity(request.session_ids.len());
+    for target_session_id in &request.session_ids {
+        results.push(execute_session_recover_batch_result(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            request.dry_run,
+        )?);
     }
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
-        payload,
+        payload: session_batch_payload(
+            "session_recover",
+            current_session_id,
+            request.dry_run,
+            request.session_ids.len(),
+            results,
+        ),
     })
 }
 
@@ -451,133 +448,67 @@ fn execute_session_cancel(
     config: &MemoryRuntimeConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    let target_session_id = required_payload_string(&payload, "session_id")?;
-    let repo = SessionRepository::new(config)?;
-    ensure_visible(
-        &repo,
-        current_session_id,
-        &target_session_id,
-        tool_config.sessions.visibility,
-    )?;
-    let snapshot = inspect_visible_session_with_policies(
-        &target_session_id,
-        current_session_id,
-        config,
-        tool_config,
-        10,
-    )?;
-
-    match build_session_cancel_plan(&snapshot)? {
-        SessionCancelPlan::Queued => {
-            let cancel_error = delegate_cancelled_error(DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED);
-            let outcome = crate::tools::delegate::delegate_error_outcome(
-                snapshot.session.session_id.clone(),
-                snapshot.session.label.clone(),
-                cancel_error.clone(),
-                0,
-            );
-            let finalized = repo.finalize_session_terminal_if_current(
-                &target_session_id,
-                SessionState::Ready,
-                crate::session::repository::FinalizeSessionTerminalRequest {
-                    state: SessionState::Failed,
-                    last_error: Some(cancel_error),
-                    event_kind: DELEGATE_CANCELLED_EVENT_KIND.to_owned(),
-                    actor_session_id: Some(current_session_id.to_owned()),
-                    event_payload_json: json!({
-                        "reference": "queued",
-                        "cancel_reason": DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED,
-                    }),
-                    outcome_status: outcome.status.clone(),
-                    outcome_payload_json: outcome.payload.clone(),
-                },
-            )?;
-            if finalized.is_none() {
-                let latest = repo
-                    .load_session_summary_with_legacy_fallback(&target_session_id)?
-                    .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
-                return Err(format!(
-                    "session_cancel_state_changed: session `{target_session_id}` is no longer cancellable from state `{}`",
-                    latest.state.as_str()
-                ));
-            }
-
-            let cancelled_snapshot = inspect_visible_session_with_policies(
-                &target_session_id,
-                current_session_id,
-                config,
-                tool_config,
-                10,
-            )?;
-            let mut response_payload = session_inspection_payload(cancelled_snapshot);
-            if let Some(object) = response_payload.as_object_mut() {
-                object.insert(
-                    "cancel_action".to_owned(),
-                    json!({
-                        "kind": "queued_async_cancelled",
-                        "previous_state": "ready",
-                        "next_state": "failed",
-                        "reference": "queued",
-                        "reason": DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED,
-                    }),
-                );
-            }
-            Ok(ToolCoreOutcome {
-                status: "ok".to_owned(),
-                payload: response_payload,
-            })
+    let request = parse_session_mutation_request(&payload)?;
+    if request.use_legacy_single_response() {
+        let target_session_id = request
+            .session_ids
+            .first()
+            .expect("legacy single request requires one session id");
+        let repo = SessionRepository::new(config)?;
+        ensure_visible(
+            &repo,
+            current_session_id,
+            target_session_id,
+            tool_config.sessions.visibility,
+        )?;
+        let snapshot = inspect_visible_session_with_policies(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            10,
+        )?;
+        let cancel_plan = build_session_cancel_plan(&snapshot)?;
+        let outcome = apply_session_cancel_plan(
+            &repo,
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            &snapshot,
+            cancel_plan,
+        )?;
+        let mut payload = outcome.inspection;
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("cancel_action".to_owned(), outcome.action);
         }
-        SessionCancelPlan::Running => {
-            let requested = repo.transition_session_with_event_if_current(
-                &target_session_id,
-                crate::session::repository::TransitionSessionWithEventIfCurrentRequest {
-                    expected_state: SessionState::Running,
-                    next_state: SessionState::Running,
-                    last_error: None,
-                    event_kind: DELEGATE_CANCEL_REQUESTED_EVENT_KIND.to_owned(),
-                    actor_session_id: Some(current_session_id.to_owned()),
-                    event_payload_json: json!({
-                        "reference": "running",
-                        "cancel_reason": DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED,
-                    }),
-                },
-            )?;
-            if requested.is_none() {
-                let latest = repo
-                    .load_session_summary_with_legacy_fallback(&target_session_id)?
-                    .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
-                return Err(format!(
-                    "session_cancel_state_changed: session `{target_session_id}` is no longer cancellable from state `{}`",
-                    latest.state.as_str()
-                ));
-            }
-
-            let requested_snapshot = inspect_visible_session_with_policies(
-                &target_session_id,
-                current_session_id,
-                config,
-                tool_config,
-                10,
-            )?;
-            let mut response_payload = session_inspection_payload(requested_snapshot);
-            if let Some(object) = response_payload.as_object_mut() {
-                object.insert(
-                    "cancel_action".to_owned(),
-                    json!({
-                        "kind": "running_async_cancel_requested",
-                        "previous_state": "running",
-                        "next_state": "running",
-                        "reference": "running",
-                        "reason": DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED,
-                    }),
-                );
-            }
-            Ok(ToolCoreOutcome {
-                status: "ok".to_owned(),
-                payload: response_payload,
-            })
-        }
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload,
+        });
     }
+
+    let mut results = Vec::with_capacity(request.session_ids.len());
+    for target_session_id in &request.session_ids {
+        results.push(execute_session_cancel_batch_result(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            request.dry_run,
+        )?);
+    }
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: session_batch_payload(
+            "session_cancel",
+            current_session_id,
+            request.dry_run,
+            request.session_ids.len(),
+            results,
+        ),
+    })
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -726,6 +657,202 @@ fn session_terminal_outcome_missing_reason(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn execute_session_recover_batch_result(
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    dry_run: bool,
+) -> Result<SessionBatchResultRecord, String> {
+    let repo = SessionRepository::new(config)?;
+    if let Err(error) = ensure_visible(
+        &repo,
+        current_session_id,
+        target_session_id,
+        tool_config.sessions.visibility,
+    ) {
+        return Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "skipped_not_visible",
+            Some(error),
+            None,
+            None,
+        ));
+    }
+
+    let snapshot = match inspect_visible_session_with_policies(
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    ) {
+        Ok(snapshot) => snapshot,
+        Err(error) if is_session_visibility_skip_error(&error) => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_visible",
+                Some(error),
+                None,
+                None,
+            ));
+        }
+        Err(error) => return Err(error),
+    };
+    let inspection = session_inspection_payload(snapshot.clone());
+    let recover_plan = match build_session_recover_plan(&snapshot, current_unix_ts()) {
+        Ok(plan) => plan,
+        Err(error) => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_recoverable",
+                Some(error),
+                None,
+                Some(inspection),
+            ));
+        }
+    };
+    let action = session_recovery_action_json(&recover_plan);
+    if dry_run {
+        return Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "would_apply",
+            None,
+            Some(action),
+            Some(inspection),
+        ));
+    }
+
+    match apply_session_recover_plan(
+        &repo,
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        &snapshot,
+        &recover_plan,
+    ) {
+        Ok(outcome) => Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "applied",
+            None,
+            Some(outcome.action),
+            Some(outcome.inspection),
+        )),
+        Err(error) if error.starts_with("session_recover_state_changed:") => {
+            Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_state_changed",
+                Some(error),
+                Some(action),
+                inspect_visible_session_with_policies(
+                    target_session_id,
+                    current_session_id,
+                    config,
+                    tool_config,
+                    10,
+                )
+                .ok()
+                .map(session_inspection_payload),
+            ))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn apply_session_recover_plan(
+    repo: &SessionRepository,
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    snapshot: &SessionInspectionSnapshot,
+    recover_plan: &SessionRecoverPlan,
+) -> Result<SessionToolActionOutcome, String> {
+    let recovery_error = session_recovery_error(recover_plan);
+    let outcome = crate::tools::delegate::delegate_error_outcome(
+        snapshot.session.session_id.clone(),
+        snapshot.session.label.clone(),
+        recovery_error.clone(),
+        recover_plan.elapsed_seconds.saturating_mul(1_000),
+    );
+    let event_payload_json = match recover_plan.recovery_kind {
+        RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED => {
+            build_queued_async_overdue_recovery_payload(
+                snapshot.session.label.as_deref(),
+                recover_plan
+                    .queued_at
+                    .expect("queued async overdue recovery requires queued_at"),
+                recover_plan.elapsed_seconds,
+                recover_plan.timeout_seconds,
+                recover_plan.deadline_at,
+                &recovery_error,
+            )
+        }
+        RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED => {
+            build_running_async_overdue_recovery_payload(
+                snapshot.session.label.as_deref(),
+                recover_plan.queued_at,
+                recover_plan.started_at,
+                recover_plan.reference,
+                recover_plan.elapsed_seconds,
+                recover_plan.timeout_seconds,
+                recover_plan.deadline_at,
+                &recovery_error,
+            )
+        }
+        other => unreachable!("unsupported session recovery kind `{other}`"),
+    };
+    let finalized = repo.finalize_session_terminal_if_current(
+        target_session_id,
+        recover_plan.expected_state,
+        crate::session::repository::FinalizeSessionTerminalRequest {
+            state: SessionState::Failed,
+            last_error: Some(recovery_error.clone()),
+            event_kind: RECOVERY_EVENT_KIND.to_owned(),
+            actor_session_id: Some(current_session_id.to_owned()),
+            event_payload_json,
+            outcome_status: outcome.status.clone(),
+            outcome_payload_json: outcome.payload.clone(),
+        },
+    )?;
+    if finalized.is_none() {
+        let latest = repo
+            .load_session_summary_with_legacy_fallback(target_session_id)?
+            .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
+        return Err(format!(
+            "session_recover_state_changed: session `{target_session_id}` is no longer recoverable from state `{}`",
+            latest.state.as_str()
+        ));
+    }
+    let recovered_snapshot = inspect_visible_session_with_policies(
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    )?;
+    Ok(SessionToolActionOutcome {
+        inspection: session_inspection_payload(recovered_snapshot),
+        action: session_recovery_action_json(recover_plan),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_recovery_action_json(plan: &SessionRecoverPlan) -> Value {
+    json!({
+        "kind": plan.recovery_kind,
+        "previous_state": plan.expected_state.as_str(),
+        "next_state": "failed",
+        "reference": plan.reference,
+        "elapsed_seconds": plan.elapsed_seconds,
+        "timeout_seconds": plan.timeout_seconds,
+        "deadline_at": plan.deadline_at,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn build_session_recover_plan(
     snapshot: &SessionInspectionSnapshot,
     now_ts: i64,
@@ -826,6 +953,227 @@ fn session_recovery_error(plan: &SessionRecoverPlan) -> String {
             plan.elapsed_seconds, plan.timeout_seconds
         ),
         other => unreachable!("unsupported session recovery kind `{other}`"),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_session_cancel_batch_result(
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    dry_run: bool,
+) -> Result<SessionBatchResultRecord, String> {
+    let repo = SessionRepository::new(config)?;
+    if let Err(error) = ensure_visible(
+        &repo,
+        current_session_id,
+        target_session_id,
+        tool_config.sessions.visibility,
+    ) {
+        return Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "skipped_not_visible",
+            Some(error),
+            None,
+            None,
+        ));
+    }
+
+    let snapshot = match inspect_visible_session_with_policies(
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    ) {
+        Ok(snapshot) => snapshot,
+        Err(error) if is_session_visibility_skip_error(&error) => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_visible",
+                Some(error),
+                None,
+                None,
+            ));
+        }
+        Err(error) => return Err(error),
+    };
+    let inspection = session_inspection_payload(snapshot.clone());
+    let cancel_plan = match build_session_cancel_plan(&snapshot) {
+        Ok(plan) => plan,
+        Err(error) => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_cancellable",
+                Some(error),
+                None,
+                Some(inspection),
+            ));
+        }
+    };
+    let action = session_cancel_action_json(&cancel_plan);
+    if dry_run {
+        return Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "would_apply",
+            None,
+            Some(action),
+            Some(inspection),
+        ));
+    }
+
+    match apply_session_cancel_plan(
+        &repo,
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        &snapshot,
+        cancel_plan,
+    ) {
+        Ok(outcome) => Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "applied",
+            None,
+            Some(outcome.action),
+            Some(outcome.inspection),
+        )),
+        Err(error) if error.starts_with("session_cancel_state_changed:") => {
+            Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_state_changed",
+                Some(error),
+                Some(action),
+                inspect_visible_session_with_policies(
+                    target_session_id,
+                    current_session_id,
+                    config,
+                    tool_config,
+                    10,
+                )
+                .ok()
+                .map(session_inspection_payload),
+            ))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn apply_session_cancel_plan(
+    repo: &SessionRepository,
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    snapshot: &SessionInspectionSnapshot,
+    cancel_plan: SessionCancelPlan,
+) -> Result<SessionToolActionOutcome, String> {
+    match cancel_plan {
+        SessionCancelPlan::Queued => {
+            let cancel_error = delegate_cancelled_error(DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED);
+            let outcome = crate::tools::delegate::delegate_error_outcome(
+                snapshot.session.session_id.clone(),
+                snapshot.session.label.clone(),
+                cancel_error.clone(),
+                0,
+            );
+            let finalized = repo.finalize_session_terminal_if_current(
+                target_session_id,
+                SessionState::Ready,
+                crate::session::repository::FinalizeSessionTerminalRequest {
+                    state: SessionState::Failed,
+                    last_error: Some(cancel_error),
+                    event_kind: DELEGATE_CANCELLED_EVENT_KIND.to_owned(),
+                    actor_session_id: Some(current_session_id.to_owned()),
+                    event_payload_json: json!({
+                        "reference": "queued",
+                        "cancel_reason": DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED,
+                    }),
+                    outcome_status: outcome.status.clone(),
+                    outcome_payload_json: outcome.payload.clone(),
+                },
+            )?;
+            if finalized.is_none() {
+                let latest = repo
+                    .load_session_summary_with_legacy_fallback(target_session_id)?
+                    .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
+                return Err(format!(
+                    "session_cancel_state_changed: session `{target_session_id}` is no longer cancellable from state `{}`",
+                    latest.state.as_str()
+                ));
+            }
+
+            let cancelled_snapshot = inspect_visible_session_with_policies(
+                target_session_id,
+                current_session_id,
+                config,
+                tool_config,
+                10,
+            )?;
+            Ok(SessionToolActionOutcome {
+                inspection: session_inspection_payload(cancelled_snapshot),
+                action: session_cancel_action_json(&SessionCancelPlan::Queued),
+            })
+        }
+        SessionCancelPlan::Running => {
+            let requested = repo.transition_session_with_event_if_current(
+                target_session_id,
+                crate::session::repository::TransitionSessionWithEventIfCurrentRequest {
+                    expected_state: SessionState::Running,
+                    next_state: SessionState::Running,
+                    last_error: None,
+                    event_kind: DELEGATE_CANCEL_REQUESTED_EVENT_KIND.to_owned(),
+                    actor_session_id: Some(current_session_id.to_owned()),
+                    event_payload_json: json!({
+                        "reference": "running",
+                        "cancel_reason": DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED,
+                    }),
+                },
+            )?;
+            if requested.is_none() {
+                let latest = repo
+                    .load_session_summary_with_legacy_fallback(target_session_id)?
+                    .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
+                return Err(format!(
+                    "session_cancel_state_changed: session `{target_session_id}` is no longer cancellable from state `{}`",
+                    latest.state.as_str()
+                ));
+            }
+
+            let requested_snapshot = inspect_visible_session_with_policies(
+                target_session_id,
+                current_session_id,
+                config,
+                tool_config,
+                10,
+            )?;
+            Ok(SessionToolActionOutcome {
+                inspection: session_inspection_payload(requested_snapshot),
+                action: session_cancel_action_json(&SessionCancelPlan::Running),
+            })
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_cancel_action_json(plan: &SessionCancelPlan) -> Value {
+    match plan {
+        SessionCancelPlan::Queued => json!({
+            "kind": "queued_async_cancelled",
+            "previous_state": "ready",
+            "next_state": "failed",
+            "reference": "queued",
+            "reason": DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED,
+        }),
+        SessionCancelPlan::Running => json!({
+            "kind": "running_async_cancel_requested",
+            "previous_state": "running",
+            "next_state": "running",
+            "reference": "running",
+            "reason": DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED,
+        }),
     }
 }
 
@@ -1088,6 +1436,36 @@ fn normalize_required_session_id(session_id: &str) -> Result<String, String> {
     Ok(trimmed.to_owned())
 }
 
+#[cfg(feature = "memory-sqlite")]
+fn parse_session_mutation_request(payload: &Value) -> Result<SessionMutationRequest, String> {
+    let single = optional_payload_string(payload, "session_id");
+    let batch = optional_payload_string_array(payload, "session_ids")?;
+    let dry_run = payload
+        .get("dry_run")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    match (single, batch) {
+        (Some(session_id), None) => Ok(SessionMutationRequest {
+            session_ids: vec![normalize_required_session_id(&session_id)?],
+            dry_run,
+            legacy_single: true,
+        }),
+        (None, Some(session_ids)) => Ok(SessionMutationRequest {
+            session_ids,
+            dry_run,
+            legacy_single: false,
+        }),
+        (Some(_), Some(_)) => Err(
+            "session tool requires exactly one of payload.session_id or payload.session_ids"
+                .to_owned(),
+        ),
+        (None, None) => {
+            Err("session tool requires payload.session_id or payload.session_ids".to_owned())
+        }
+    }
+}
+
 fn optional_payload_limit(payload: &Value, field: &str, default: usize, max: usize) -> usize {
     payload
         .get(field)
@@ -1162,6 +1540,97 @@ fn optional_payload_string(payload: &Value, field: &str) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_string_array(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<Vec<String>>, String> {
+    let Some(value) = payload.get(field) else {
+        return Ok(None);
+    };
+    let values = value.as_array().ok_or_else(|| {
+        format!("session tool requires payload.{field} to be a non-empty array of strings")
+    })?;
+    if values.is_empty() {
+        return Err(format!(
+            "session tool requires payload.{field} to be a non-empty array of strings"
+        ));
+    }
+
+    let mut session_ids = Vec::with_capacity(values.len());
+    for value in values {
+        let Some(session_id) = value.as_str() else {
+            return Err(format!(
+                "session tool requires payload.{field} to be a non-empty array of strings"
+            ));
+        };
+        let trimmed = session_id.trim();
+        if trimmed.is_empty() {
+            return Err(format!(
+                "session tool requires payload.{field} to be a non-empty array of strings"
+            ));
+        }
+        session_ids.push(trimmed.to_owned());
+    }
+    Ok(Some(session_ids))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_batch_payload(
+    tool: &str,
+    current_session_id: &str,
+    dry_run: bool,
+    requested_count: usize,
+    results: Vec<SessionBatchResultRecord>,
+) -> Value {
+    let mut result_counts = BTreeMap::<&'static str, usize>::new();
+    for result in &results {
+        *result_counts.entry(result.result).or_default() += 1;
+    }
+
+    json!({
+        "tool": tool,
+        "current_session_id": current_session_id,
+        "dry_run": dry_run,
+        "requested_count": requested_count,
+        "result_counts": result_counts,
+        "results": results.into_iter().map(session_batch_result_json).collect::<Vec<_>>(),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_batch_result(
+    session_id: String,
+    result: &'static str,
+    message: Option<String>,
+    action: Option<Value>,
+    inspection: Option<Value>,
+) -> SessionBatchResultRecord {
+    SessionBatchResultRecord {
+        session_id,
+        result,
+        message,
+        action,
+        inspection,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_batch_result_json(result: SessionBatchResultRecord) -> Value {
+    json!({
+        "session_id": result.session_id,
+        "result": result.result,
+        "message": result.message,
+        "action": result.action,
+        "inspection": result.inspection,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn is_session_visibility_skip_error(error: &str) -> bool {
+    error.starts_with("visibility_denied:") || error.starts_with("session_not_found:")
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1288,6 +1757,15 @@ mod tests {
             )
             .expect("update session event ts");
         assert!(updated > 0, "expected at least one updated event row");
+    }
+
+    fn batch_result<'a>(payload: &'a Value, session_id: &str) -> &'a Value {
+        payload["results"]
+            .as_array()
+            .expect("results array")
+            .iter()
+            .find(|item| item.get("session_id").and_then(Value::as_str) == Some(session_id))
+            .unwrap_or_else(|| panic!("missing batch result for session `{session_id}`"))
     }
 
     #[test]
@@ -2151,6 +2629,315 @@ mod tests {
     }
 
     #[test]
+    fn session_recover_batch_dry_run_reports_mixed_results_without_mutation() {
+        let config = isolated_memory_config("session-recover-batch-dry-run");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "overdue-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Overdue".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create overdue child");
+        repo.create_session(NewSessionRecord {
+            session_id: "fresh-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Fresh".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create fresh child");
+        repo.create_session(NewSessionRecord {
+            session_id: "hidden-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Hidden".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create hidden root");
+        repo.append_event(NewSessionEvent {
+            session_id: "overdue-child".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 30
+            }),
+        })
+        .expect("append overdue queued");
+        repo.append_event(NewSessionEvent {
+            session_id: "fresh-child".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append fresh queued");
+        overwrite_session_event_ts(
+            &config,
+            "overdue-child",
+            "delegate_queued",
+            super::current_unix_ts() - 90,
+        );
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_recover".to_owned(),
+                payload: json!({
+                    "session_ids": ["overdue-child", "fresh-child", "hidden-root"],
+                    "dry_run": true
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_recover batch dry_run outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool"], "session_recover");
+        assert_eq!(outcome.payload["dry_run"], true);
+        assert_eq!(outcome.payload["requested_count"], 3);
+        assert_eq!(outcome.payload["result_counts"]["would_apply"], 1);
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_recoverable"],
+            1
+        );
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_visible"], 1);
+
+        let overdue = batch_result(&outcome.payload, "overdue-child");
+        assert_eq!(overdue["result"], "would_apply");
+        assert_eq!(
+            overdue["action"]["kind"],
+            "queued_async_overdue_marked_failed"
+        );
+        assert_eq!(overdue["inspection"]["session"]["state"], "ready");
+
+        let fresh = batch_result(&outcome.payload, "fresh-child");
+        assert_eq!(fresh["result"], "skipped_not_recoverable");
+        assert!(fresh["message"]
+            .as_str()
+            .expect("fresh batch message")
+            .contains("session_recover_not_recoverable"));
+        assert_eq!(fresh["inspection"]["session"]["state"], "ready");
+
+        let hidden = batch_result(&outcome.payload, "hidden-root");
+        assert_eq!(hidden["result"], "skipped_not_visible");
+        assert!(hidden["message"]
+            .as_str()
+            .expect("hidden batch message")
+            .contains("visibility_denied"));
+        assert!(hidden["inspection"].is_null());
+
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("overdue-child")
+                .expect("load overdue summary")
+                .expect("overdue session")
+                .state,
+            SessionState::Ready
+        );
+        assert!(repo
+            .load_terminal_outcome("overdue-child")
+            .expect("load overdue outcome")
+            .is_none());
+    }
+
+    #[test]
+    fn session_recover_batch_apply_reports_partial_success() {
+        let config = isolated_memory_config("session-recover-batch-apply");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "queued-overdue".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Queued Overdue".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create queued overdue");
+        repo.create_session(NewSessionRecord {
+            session_id: "running-overdue".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Running Overdue".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create running overdue");
+        repo.create_session(NewSessionRecord {
+            session_id: "fresh-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Fresh".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create fresh child");
+        repo.append_event(NewSessionEvent {
+            session_id: "queued-overdue".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "queued work",
+                "timeout_seconds": 30
+            }),
+        })
+        .expect("append queued overdue event");
+        repo.append_event(NewSessionEvent {
+            session_id: "running-overdue".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "running work",
+                "timeout_seconds": 30
+            }),
+        })
+        .expect("append running queued event");
+        repo.append_event(NewSessionEvent {
+            session_id: "running-overdue".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "running work",
+                "timeout_seconds": 30
+            }),
+        })
+        .expect("append running started event");
+        repo.append_event(NewSessionEvent {
+            session_id: "fresh-child".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "fresh work",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append fresh event");
+        overwrite_session_event_ts(
+            &config,
+            "queued-overdue",
+            "delegate_queued",
+            super::current_unix_ts() - 90,
+        );
+        overwrite_session_event_ts(
+            &config,
+            "running-overdue",
+            "delegate_queued",
+            super::current_unix_ts() - 120,
+        );
+        overwrite_session_event_ts(
+            &config,
+            "running-overdue",
+            "delegate_started",
+            super::current_unix_ts() - 90,
+        );
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_recover".to_owned(),
+                payload: json!({
+                    "session_ids": ["queued-overdue", "running-overdue", "fresh-child"]
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_recover batch apply outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool"], "session_recover");
+        assert_eq!(outcome.payload["dry_run"], false);
+        assert_eq!(outcome.payload["requested_count"], 3);
+        assert_eq!(outcome.payload["result_counts"]["applied"], 2);
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_recoverable"],
+            1
+        );
+
+        let queued = batch_result(&outcome.payload, "queued-overdue");
+        assert_eq!(queued["result"], "applied");
+        assert_eq!(queued["inspection"]["session"]["state"], "failed");
+        assert_eq!(
+            queued["action"]["kind"],
+            "queued_async_overdue_marked_failed"
+        );
+        assert_eq!(
+            queued["inspection"]["delegate_lifecycle"]["phase"],
+            "failed"
+        );
+
+        let running = batch_result(&outcome.payload, "running-overdue");
+        assert_eq!(running["result"], "applied");
+        assert_eq!(running["inspection"]["session"]["state"], "failed");
+        assert_eq!(
+            running["action"]["kind"],
+            "running_async_overdue_marked_failed"
+        );
+        assert_eq!(running["action"]["reference"], "started");
+        assert_eq!(
+            running["inspection"]["recent_events"]
+                .as_array()
+                .expect("running recent events")
+                .last()
+                .expect("running latest event")["event_kind"],
+            "delegate_recovery_applied"
+        );
+
+        let fresh = batch_result(&outcome.payload, "fresh-child");
+        assert_eq!(fresh["result"], "skipped_not_recoverable");
+        assert_eq!(fresh["inspection"]["session"]["state"], "ready");
+
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("queued-overdue")
+                .expect("load queued summary")
+                .expect("queued session")
+                .state,
+            SessionState::Failed
+        );
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("running-overdue")
+                .expect("load running summary")
+                .expect("running session")
+                .state,
+            SessionState::Failed
+        );
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("fresh-child")
+                .expect("load fresh summary")
+                .expect("fresh session")
+                .state,
+            SessionState::Ready
+        );
+        assert!(repo
+            .load_terminal_outcome("queued-overdue")
+            .expect("load queued outcome")
+            .is_some());
+        assert!(repo
+            .load_terminal_outcome("running-overdue")
+            .expect("load running outcome")
+            .is_some());
+        assert!(repo
+            .load_terminal_outcome("fresh-child")
+            .expect("load fresh outcome")
+            .is_none());
+    }
+
+    #[test]
     fn session_cancel_cancels_queued_async_child() {
         let config = isolated_memory_config("session-cancel-queued");
         let repo = SessionRepository::new(&config).expect("repository");
@@ -2283,6 +3070,282 @@ mod tests {
             outcome.payload["delegate_lifecycle"]["cancellation"]["state"],
             "requested"
         );
+    }
+
+    #[test]
+    fn session_cancel_batch_dry_run_reports_mixed_results_without_mutation() {
+        let config = isolated_memory_config("session-cancel-batch-dry-run");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "queued-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Queued".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create queued child");
+        repo.create_session(NewSessionRecord {
+            session_id: "running-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Running".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create running child");
+        repo.create_session(NewSessionRecord {
+            session_id: "completed-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Completed".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create completed child");
+        repo.create_session(NewSessionRecord {
+            session_id: "hidden-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Hidden".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create hidden root");
+        repo.append_event(NewSessionEvent {
+            session_id: "queued-child".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "queued work",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append queued child event");
+        repo.append_event(NewSessionEvent {
+            session_id: "running-child".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "running work",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append running queued event");
+        repo.append_event(NewSessionEvent {
+            session_id: "running-child".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "running work",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append running started event");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_cancel".to_owned(),
+                payload: json!({
+                    "session_ids": ["queued-child", "running-child", "completed-child", "hidden-root"],
+                    "dry_run": true
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_cancel batch dry_run outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool"], "session_cancel");
+        assert_eq!(outcome.payload["dry_run"], true);
+        assert_eq!(outcome.payload["requested_count"], 4);
+        assert_eq!(outcome.payload["result_counts"]["would_apply"], 2);
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_cancellable"],
+            1
+        );
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_visible"], 1);
+
+        let queued = batch_result(&outcome.payload, "queued-child");
+        assert_eq!(queued["result"], "would_apply");
+        assert_eq!(queued["action"]["kind"], "queued_async_cancelled");
+        assert_eq!(queued["inspection"]["session"]["state"], "ready");
+
+        let running = batch_result(&outcome.payload, "running-child");
+        assert_eq!(running["result"], "would_apply");
+        assert_eq!(running["action"]["kind"], "running_async_cancel_requested");
+        assert_eq!(running["inspection"]["session"]["state"], "running");
+
+        let completed = batch_result(&outcome.payload, "completed-child");
+        assert_eq!(completed["result"], "skipped_not_cancellable");
+        assert_eq!(completed["inspection"]["session"]["state"], "completed");
+
+        let hidden = batch_result(&outcome.payload, "hidden-root");
+        assert_eq!(hidden["result"], "skipped_not_visible");
+        assert!(hidden["inspection"].is_null());
+
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("queued-child")
+                .expect("load queued summary")
+                .expect("queued session")
+                .state,
+            SessionState::Ready
+        );
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("running-child")
+                .expect("load running summary")
+                .expect("running session")
+                .state,
+            SessionState::Running
+        );
+        assert!(repo
+            .load_terminal_outcome("queued-child")
+            .expect("load queued outcome")
+            .is_none());
+    }
+
+    #[test]
+    fn session_cancel_batch_apply_reports_partial_success() {
+        let config = isolated_memory_config("session-cancel-batch-apply");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "queued-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Queued".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create queued child");
+        repo.create_session(NewSessionRecord {
+            session_id: "running-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Running".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create running child");
+        repo.create_session(NewSessionRecord {
+            session_id: "completed-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Completed".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create completed child");
+        repo.append_event(NewSessionEvent {
+            session_id: "queued-child".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "queued work",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append queued child event");
+        repo.append_event(NewSessionEvent {
+            session_id: "running-child".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "running work",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append running queued event");
+        repo.append_event(NewSessionEvent {
+            session_id: "running-child".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "running work",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append running started event");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_cancel".to_owned(),
+                payload: json!({
+                    "session_ids": ["queued-child", "running-child", "completed-child"]
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_cancel batch apply outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool"], "session_cancel");
+        assert_eq!(outcome.payload["dry_run"], false);
+        assert_eq!(outcome.payload["requested_count"], 3);
+        assert_eq!(outcome.payload["result_counts"]["applied"], 2);
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_cancellable"],
+            1
+        );
+
+        let queued = batch_result(&outcome.payload, "queued-child");
+        assert_eq!(queued["result"], "applied");
+        assert_eq!(queued["inspection"]["session"]["state"], "failed");
+        assert_eq!(queued["action"]["kind"], "queued_async_cancelled");
+        assert_eq!(
+            queued["inspection"]["recent_events"]
+                .as_array()
+                .expect("queued recent events")
+                .last()
+                .expect("queued latest event")["event_kind"],
+            "delegate_cancelled"
+        );
+
+        let running = batch_result(&outcome.payload, "running-child");
+        assert_eq!(running["result"], "applied");
+        assert_eq!(running["inspection"]["session"]["state"], "running");
+        assert_eq!(running["action"]["kind"], "running_async_cancel_requested");
+        assert_eq!(
+            running["inspection"]["delegate_lifecycle"]["cancellation"]["state"],
+            "requested"
+        );
+
+        let completed = batch_result(&outcome.payload, "completed-child");
+        assert_eq!(completed["result"], "skipped_not_cancellable");
+        assert_eq!(completed["inspection"]["session"]["state"], "completed");
+
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("queued-child")
+                .expect("load queued summary")
+                .expect("queued session")
+                .state,
+            SessionState::Failed
+        );
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("running-child")
+                .expect("load running summary")
+                .expect("running session")
+                .state,
+            SessionState::Running
+        );
+        assert!(repo
+            .load_terminal_outcome("queued-child")
+            .expect("load queued outcome")
+            .is_some());
+        assert!(repo
+            .load_terminal_outcome("running-child")
+            .expect("load running outcome")
+            .is_none());
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -756,7 +756,27 @@ fn execute_session_unarchive(
         });
     }
 
-    Err("session_unarchive_batch_not_implemented".to_owned())
+    let mut results = Vec::with_capacity(request.target.session_ids.len());
+    for target_session_id in &request.target.session_ids {
+        results.push(execute_session_unarchive_batch_result(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            request.dry_run,
+        )?);
+    }
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: session_batch_payload(
+            "session_unarchive",
+            current_session_id,
+            request.dry_run,
+            request.target.session_ids.len(),
+            results,
+        ),
+    })
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -895,6 +915,119 @@ fn apply_session_unarchive_plan(
         inspection: session_inspection_payload(unarchived_snapshot),
         action: session_unarchive_action_json(unarchive_plan),
     })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_session_unarchive_batch_result(
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    dry_run: bool,
+) -> Result<SessionBatchResultRecord, String> {
+    let repo = SessionRepository::new(config)?;
+    if let Err(error) = ensure_visible(
+        &repo,
+        current_session_id,
+        target_session_id,
+        tool_config.sessions.visibility,
+    ) {
+        return Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "skipped_not_visible",
+            Some(error),
+            None,
+            None,
+        ));
+    }
+
+    let snapshot = match inspect_visible_session_with_policies(
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    ) {
+        Ok(snapshot) => snapshot,
+        Err(error) if is_session_visibility_skip_error(&error) => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_visible",
+                Some(error),
+                None,
+                None,
+            ));
+        }
+        Err(error) => return Err(error),
+    };
+    let inspection = session_inspection_payload(snapshot.clone());
+    let unarchive_plan = match build_session_unarchive_plan(&snapshot) {
+        Ok(plan) => plan,
+        Err(error) if error.starts_with("session_unarchive_not_unarchivable:") => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_archived",
+                Some(error),
+                None,
+                Some(inspection),
+            ));
+        }
+        Err(error) => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_archivable",
+                Some(error),
+                None,
+                Some(inspection),
+            ));
+        }
+    };
+    let action = session_unarchive_action_json(&unarchive_plan);
+    if dry_run {
+        return Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "would_apply",
+            None,
+            Some(action),
+            Some(inspection),
+        ));
+    }
+
+    match apply_session_unarchive_plan(
+        &repo,
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        &snapshot,
+        &unarchive_plan,
+    ) {
+        Ok(outcome) => Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "applied",
+            None,
+            Some(outcome.action),
+            Some(outcome.inspection),
+        )),
+        Err(error) if error.starts_with("session_unarchive_state_changed:") => {
+            Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_state_changed",
+                Some(error),
+                Some(action),
+                inspect_visible_session_with_policies(
+                    target_session_id,
+                    current_session_id,
+                    config,
+                    tool_config,
+                    10,
+                )
+                .ok()
+                .map(session_inspection_payload),
+            ))
+        }
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -5118,6 +5251,277 @@ mod tests {
 
         assert_eq!(status.payload["session"]["archived"], false);
         assert!(status.payload["session"]["archived_at"].is_null());
+    }
+
+    #[test]
+    fn session_unarchive_batch_dry_run_reports_mixed_results_without_mutation() {
+        let config = isolated_memory_config("session-unarchive-batch-dry-run");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "ready-to-unarchive".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Archived".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create archivable child");
+        repo.create_session(NewSessionRecord {
+            session_id: "already-visible".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Visible".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create visible child");
+        repo.create_session(NewSessionRecord {
+            session_id: "running-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Running".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create running child");
+        repo.create_session(NewSessionRecord {
+            session_id: "hidden-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Hidden".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create hidden root");
+
+        for session_id in ["ready-to-unarchive", "already-visible"] {
+            repo.finalize_session_terminal(
+                session_id,
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({ "result": "ok" }),
+                    outcome_status: "ok".to_owned(),
+                    outcome_payload_json: json!({ "child_session_id": session_id }),
+                },
+            )
+            .expect("finalize child");
+        }
+        execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_id": "ready-to-unarchive"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("archive ready-to-unarchive child");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_unarchive".to_owned(),
+                payload: json!({
+                    "session_ids": ["ready-to-unarchive", "already-visible", "running-child", "hidden-root"],
+                    "dry_run": true
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_unarchive batch dry_run outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool"], "session_unarchive");
+        assert_eq!(outcome.payload["dry_run"], true);
+        assert_eq!(outcome.payload["requested_count"], 4);
+        assert_eq!(outcome.payload["result_counts"]["would_apply"], 1);
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_archived"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_archivable"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_visible"],
+            1
+        );
+
+        let ready = batch_result(&outcome.payload, "ready-to-unarchive");
+        assert_eq!(ready["result"], "would_apply");
+        assert_eq!(ready["inspection"]["session"]["archived"], true);
+        assert_eq!(ready["action"]["kind"], "session_unarchived");
+
+        let visible = batch_result(&outcome.payload, "already-visible");
+        assert_eq!(visible["result"], "skipped_not_archived");
+        assert_eq!(visible["inspection"]["session"]["archived"], false);
+
+        let running = batch_result(&outcome.payload, "running-child");
+        assert_eq!(running["result"], "skipped_not_archivable");
+        assert_eq!(running["inspection"]["session"]["state"], "running");
+
+        let hidden = batch_result(&outcome.payload, "hidden-root");
+        assert_eq!(hidden["result"], "skipped_not_visible");
+        assert!(hidden["inspection"].is_null());
+
+        assert!(repo
+            .load_session_summary_with_legacy_fallback("ready-to-unarchive")
+            .expect("load archived summary")
+            .expect("archived session")
+            .archived_at
+            .is_some());
+    }
+
+    #[test]
+    fn session_unarchive_batch_apply_reports_partial_success() {
+        let config = isolated_memory_config("session-unarchive-batch-apply");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "ready-to-unarchive".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Archived".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create archivable child");
+        repo.create_session(NewSessionRecord {
+            session_id: "already-visible".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Visible".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create visible child");
+        repo.create_session(NewSessionRecord {
+            session_id: "running-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Running".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create running child");
+        repo.create_session(NewSessionRecord {
+            session_id: "hidden-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Hidden".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create hidden root");
+
+        for session_id in ["ready-to-unarchive", "already-visible"] {
+            repo.finalize_session_terminal(
+                session_id,
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({ "result": "ok" }),
+                    outcome_status: "ok".to_owned(),
+                    outcome_payload_json: json!({ "child_session_id": session_id }),
+                },
+            )
+            .expect("finalize child");
+        }
+        execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_id": "ready-to-unarchive"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("archive ready-to-unarchive child");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_unarchive".to_owned(),
+                payload: json!({
+                    "session_ids": ["ready-to-unarchive", "already-visible", "running-child", "hidden-root"]
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_unarchive batch apply outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool"], "session_unarchive");
+        assert_eq!(outcome.payload["dry_run"], false);
+        assert_eq!(outcome.payload["requested_count"], 4);
+        assert_eq!(outcome.payload["result_counts"]["applied"], 1);
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_archived"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_archivable"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_visible"],
+            1
+        );
+
+        let ready = batch_result(&outcome.payload, "ready-to-unarchive");
+        assert_eq!(ready["result"], "applied");
+        assert_eq!(ready["inspection"]["session"]["archived"], false);
+        assert_eq!(ready["action"]["kind"], "session_unarchived");
+        assert_eq!(
+            ready["inspection"]["recent_events"]
+                .as_array()
+                .expect("ready recent events")
+                .last()
+                .expect("ready latest event")["event_kind"],
+            "session_unarchived"
+        );
+
+        let visible = batch_result(&outcome.payload, "already-visible");
+        assert_eq!(visible["result"], "skipped_not_archived");
+        assert_eq!(visible["inspection"]["session"]["archived"], false);
+
+        let running = batch_result(&outcome.payload, "running-child");
+        assert_eq!(running["result"], "skipped_not_archivable");
+        assert_eq!(running["inspection"]["session"]["state"], "running");
+
+        let hidden = batch_result(&outcome.payload, "hidden-root");
+        assert_eq!(hidden["result"], "skipped_not_visible");
+        assert!(hidden["inspection"].is_null());
+
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("ready-to-unarchive")
+                .expect("load ready summary")
+                .expect("ready session")
+                .archived_at,
+            None
+        );
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("already-visible")
+                .expect("load visible summary")
+                .expect("visible session")
+                .archived_at,
+            None
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -86,6 +86,7 @@ struct SessionsListRequest {
     kind: Option<SessionKind>,
     parent_session_id: Option<String>,
     overdue_only: bool,
+    include_archived: bool,
     include_delegate_lifecycle: bool,
 }
 
@@ -296,6 +297,9 @@ fn execute_sessions_list(
     }
     if let Some(parent_session_id) = request.parent_session_id.as_deref() {
         sessions.retain(|session| session.parent_session_id.as_deref() == Some(parent_session_id));
+    }
+    if !request.include_archived {
+        sessions.retain(|session| session.archived_at.is_none());
     }
 
     let mut listed_sessions = Vec::new();
@@ -2011,6 +2015,10 @@ fn parse_sessions_list_request(
             .get("overdue_only")
             .and_then(Value::as_bool)
             .unwrap_or(false),
+        include_archived: payload
+            .get("include_archived")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
         include_delegate_lifecycle: payload
             .get("include_delegate_lifecycle")
             .and_then(Value::as_bool)
@@ -2297,6 +2305,7 @@ fn sessions_list_filters_json(request: &SessionsListRequest) -> Value {
         "kind": request.kind.map(SessionKind::as_str),
         "parent_session_id": request.parent_session_id.clone(),
         "overdue_only": request.overdue_only,
+        "include_archived": request.include_archived,
         "include_delegate_lifecycle": request.effective_include_delegate_lifecycle(),
     })
 }
@@ -2592,6 +2601,153 @@ mod tests {
         assert_eq!(ids, vec!["child-running"]);
         assert_eq!(outcome.payload["matched_count"], 1);
         assert_eq!(outcome.payload["returned_count"], 1);
+    }
+
+    #[test]
+    fn sessions_list_excludes_archived_sessions_by_default() {
+        let config = isolated_memory_config("sessions-list-excludes-archived");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "archived-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Archived".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create archived child");
+        repo.create_session(NewSessionRecord {
+            session_id: "visible-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Visible".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create visible child");
+        for session_id in ["archived-child", "visible-child"] {
+            repo.finalize_session_terminal(
+                session_id,
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({ "result": "ok" }),
+                    outcome_status: "ok".to_owned(),
+                    outcome_payload_json: json!({ "child_session_id": session_id }),
+                },
+            )
+            .expect("finalize child");
+        }
+
+        execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_id": "archived-child"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("archive child");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "sessions_list".to_owned(),
+                payload: json!({}),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("sessions_list outcome");
+
+        let sessions = outcome.payload["sessions"]
+            .as_array()
+            .expect("sessions array");
+        let ids: Vec<&str> = sessions
+            .iter()
+            .filter_map(|item: &Value| item.get("session_id"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(ids.contains(&"root-session"));
+        assert!(ids.contains(&"visible-child"));
+        assert!(!ids.contains(&"archived-child"));
+    }
+
+    #[test]
+    fn sessions_list_can_include_archived_sessions_when_requested() {
+        let config = isolated_memory_config("sessions-list-include-archived");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "archived-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Archived".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create archived child");
+        repo.finalize_session_terminal(
+            "archived-child",
+            FinalizeSessionTerminalRequest {
+                state: SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                event_payload_json: json!({ "result": "ok" }),
+                outcome_status: "ok".to_owned(),
+                outcome_payload_json: json!({ "child_session_id": "archived-child" }),
+            },
+        )
+        .expect("finalize child");
+        execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_id": "archived-child"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("archive child");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "sessions_list".to_owned(),
+                payload: json!({
+                    "include_archived": true
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("sessions_list outcome");
+
+        let archived = outcome.payload["sessions"]
+            .as_array()
+            .expect("sessions array")
+            .iter()
+            .find(|item| item["session_id"] == "archived-child")
+            .expect("archived session");
+        assert_eq!(outcome.payload["filters"]["include_archived"], true);
+        assert_eq!(archived["archived"], true);
+        assert!(archived["archived_at"].is_number());
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -96,16 +96,22 @@ impl SessionsListRequest {
 
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct SessionMutationRequest {
+struct SessionTargetRequest {
     session_ids: Vec<String>,
-    dry_run: bool,
     legacy_single: bool,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionMutationRequest {
+    target: SessionTargetRequest,
+    dry_run: bool,
 }
 
 #[cfg(feature = "memory-sqlite")]
 impl SessionMutationRequest {
     fn use_legacy_single_response(&self) -> bool {
-        self.legacy_single && !self.dry_run
+        self.target.legacy_single && !self.dry_run
     }
 }
 
@@ -356,18 +362,44 @@ fn execute_session_status(
     config: &MemoryRuntimeConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    let target_session_id = required_payload_string(&payload, "session_id")?;
-    let snapshot = inspect_visible_session_with_policies(
-        &target_session_id,
-        current_session_id,
-        config,
-        tool_config,
-        5,
-    )?;
+    let request = parse_session_target_request(&payload)?;
+    if request.legacy_single {
+        let target_session_id = request
+            .session_ids
+            .first()
+            .expect("legacy single request requires one session id");
+        let snapshot = inspect_visible_session_with_policies(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            5,
+        )?;
+
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: session_inspection_payload(snapshot),
+        });
+    }
+
+    let mut results = Vec::with_capacity(request.session_ids.len());
+    for target_session_id in &request.session_ids {
+        results.push(execute_session_status_batch_result(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+        )?);
+    }
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
-        payload: session_inspection_payload(snapshot),
+        payload: session_batch_payload_without_dry_run(
+            "session_status",
+            current_session_id,
+            request.session_ids.len(),
+            results,
+        ),
     })
 }
 
@@ -381,6 +413,7 @@ fn execute_session_recover(
     let request = parse_session_mutation_request(&payload)?;
     if request.use_legacy_single_response() {
         let target_session_id = request
+            .target
             .session_ids
             .first()
             .expect("legacy single request requires one session id");
@@ -418,8 +451,8 @@ fn execute_session_recover(
         });
     }
 
-    let mut results = Vec::with_capacity(request.session_ids.len());
-    for target_session_id in &request.session_ids {
+    let mut results = Vec::with_capacity(request.target.session_ids.len());
+    for target_session_id in &request.target.session_ids {
         results.push(execute_session_recover_batch_result(
             target_session_id,
             current_session_id,
@@ -435,7 +468,7 @@ fn execute_session_recover(
             "session_recover",
             current_session_id,
             request.dry_run,
-            request.session_ids.len(),
+            request.target.session_ids.len(),
             results,
         ),
     })
@@ -451,6 +484,7 @@ fn execute_session_cancel(
     let request = parse_session_mutation_request(&payload)?;
     if request.use_legacy_single_response() {
         let target_session_id = request
+            .target
             .session_ids
             .first()
             .expect("legacy single request requires one session id");
@@ -488,8 +522,8 @@ fn execute_session_cancel(
         });
     }
 
-    let mut results = Vec::with_capacity(request.session_ids.len());
-    for target_session_id in &request.session_ids {
+    let mut results = Vec::with_capacity(request.target.session_ids.len());
+    for target_session_id in &request.target.session_ids {
         results.push(execute_session_cancel_batch_result(
             target_session_id,
             current_session_id,
@@ -505,7 +539,7 @@ fn execute_session_cancel(
             "session_cancel",
             current_session_id,
             request.dry_run,
-            request.session_ids.len(),
+            request.target.session_ids.len(),
             results,
         ),
     })
@@ -654,6 +688,58 @@ fn session_terminal_outcome_missing_reason(
     recovery: Option<&SessionRecoveryRecord>,
 ) -> Option<String> {
     recovery.map(|recovery| recovery.kind.clone())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_session_status_batch_result(
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<SessionBatchResultRecord, String> {
+    let repo = SessionRepository::new(config)?;
+    if let Err(error) = ensure_visible(
+        &repo,
+        current_session_id,
+        target_session_id,
+        tool_config.sessions.visibility,
+    ) {
+        return Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "skipped_not_visible",
+            Some(error),
+            None,
+            None,
+        ));
+    }
+
+    let snapshot = match inspect_visible_session_with_policies(
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        5,
+    ) {
+        Ok(snapshot) => snapshot,
+        Err(error) if is_session_visibility_skip_error(&error) => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_visible",
+                Some(error),
+                None,
+                None,
+            ));
+        }
+        Err(error) => return Err(error),
+    };
+
+    Ok(session_batch_result(
+        target_session_id.to_owned(),
+        "ok",
+        None,
+        None,
+        Some(session_inspection_payload(snapshot)),
+    ))
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1437,23 +1523,17 @@ fn normalize_required_session_id(session_id: &str) -> Result<String, String> {
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn parse_session_mutation_request(payload: &Value) -> Result<SessionMutationRequest, String> {
+fn parse_session_target_request(payload: &Value) -> Result<SessionTargetRequest, String> {
     let single = optional_payload_string(payload, "session_id");
     let batch = optional_payload_string_array(payload, "session_ids")?;
-    let dry_run = payload
-        .get("dry_run")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
 
     match (single, batch) {
-        (Some(session_id), None) => Ok(SessionMutationRequest {
+        (Some(session_id), None) => Ok(SessionTargetRequest {
             session_ids: vec![normalize_required_session_id(&session_id)?],
-            dry_run,
             legacy_single: true,
         }),
-        (None, Some(session_ids)) => Ok(SessionMutationRequest {
+        (None, Some(session_ids)) => Ok(SessionTargetRequest {
             session_ids,
-            dry_run,
             legacy_single: false,
         }),
         (Some(_), Some(_)) => Err(
@@ -1464,6 +1544,18 @@ fn parse_session_mutation_request(payload: &Value) -> Result<SessionMutationRequ
             Err("session tool requires payload.session_id or payload.session_ids".to_owned())
         }
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_session_mutation_request(payload: &Value) -> Result<SessionMutationRequest, String> {
+    let dry_run = payload
+        .get("dry_run")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    Ok(SessionMutationRequest {
+        target: parse_session_target_request(payload)?,
+        dry_run,
+    })
 }
 
 fn optional_payload_limit(payload: &Value, field: &str, default: usize, max: usize) -> usize {
@@ -1585,19 +1677,58 @@ fn session_batch_payload(
     requested_count: usize,
     results: Vec<SessionBatchResultRecord>,
 ) -> Value {
+    session_batch_payload_with_optional_dry_run(
+        tool,
+        current_session_id,
+        requested_count,
+        results,
+        Some(dry_run),
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_batch_payload_without_dry_run(
+    tool: &str,
+    current_session_id: &str,
+    requested_count: usize,
+    results: Vec<SessionBatchResultRecord>,
+) -> Value {
+    session_batch_payload_with_optional_dry_run(
+        tool,
+        current_session_id,
+        requested_count,
+        results,
+        None,
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_batch_payload_with_optional_dry_run(
+    tool: &str,
+    current_session_id: &str,
+    requested_count: usize,
+    results: Vec<SessionBatchResultRecord>,
+    dry_run: Option<bool>,
+) -> Value {
     let mut result_counts = BTreeMap::<&'static str, usize>::new();
     for result in &results {
         *result_counts.entry(result.result).or_default() += 1;
     }
 
-    json!({
+    let mut payload = json!({
         "tool": tool,
         "current_session_id": current_session_id,
-        "dry_run": dry_run,
         "requested_count": requested_count,
         "result_counts": result_counts,
         "results": results.into_iter().map(session_batch_result_json).collect::<Vec<_>>(),
-    })
+    });
+    if let Some(dry_run) = dry_run {
+        payload
+            .as_object_mut()
+            .expect("session batch payload object")
+            .insert("dry_run".to_owned(), Value::Bool(dry_run));
+    }
+    payload
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -3738,6 +3869,99 @@ mod tests {
             "grandchild-session"
         );
         assert_eq!(outcome.payload["session"]["kind"], "delegate_child");
+    }
+
+    #[test]
+    fn session_status_batch_returns_mixed_visible_and_hidden_results() {
+        let config = isolated_memory_config("session-status-batch");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+        repo.create_session(NewSessionRecord {
+            session_id: "grandchild-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("child-session".to_owned()),
+            label: Some("Grandchild".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create grandchild");
+        repo.create_session(NewSessionRecord {
+            session_id: "hidden-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Hidden".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create hidden root");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_ids": ["hidden-root", "grandchild-session", "child-session"]
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status batch outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool"], "session_status");
+        assert_eq!(outcome.payload["requested_count"], 3);
+        assert_eq!(outcome.payload["result_counts"]["ok"], 2);
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_visible"], 1);
+
+        let results = outcome.payload["results"]
+            .as_array()
+            .expect("batch results array");
+        let ids: Vec<&str> = results
+            .iter()
+            .filter_map(|item| item.get("session_id"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["hidden-root", "grandchild-session", "child-session"]
+        );
+
+        let hidden = batch_result(&outcome.payload, "hidden-root");
+        assert_eq!(hidden["result"], "skipped_not_visible");
+        assert!(hidden["inspection"].is_null());
+        assert!(hidden["message"]
+            .as_str()
+            .expect("hidden message")
+            .contains("visibility_denied"));
+
+        let grandchild = batch_result(&outcome.payload, "grandchild-session");
+        assert_eq!(grandchild["result"], "ok");
+        assert_eq!(grandchild["inspection"]["session"]["state"], "completed");
+        assert_eq!(
+            grandchild["inspection"]["session"]["session_id"],
+            "grandchild-session"
+        );
+
+        let child = batch_result(&outcome.payload, "child-session");
+        assert_eq!(child["result"], "ok");
+        assert_eq!(child["inspection"]["session"]["state"], "running");
+        assert_eq!(
+            child["inspection"]["terminal_outcome_state"],
+            "not_terminal"
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -623,49 +623,66 @@ fn execute_session_archive(
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
-    if !request.use_legacy_single_response() {
-        return Err(
-            "session_archive batch mode is not implemented yet; use payload.session_id"
-                .to_owned(),
-        );
+    if request.use_legacy_single_response() {
+        let target_session_id = request
+            .target
+            .session_ids
+            .first()
+            .expect("legacy single request requires one session id");
+        let repo = SessionRepository::new(config)?;
+        ensure_visible(
+            &repo,
+            current_session_id,
+            target_session_id,
+            tool_config.sessions.visibility,
+        )?;
+        let snapshot = inspect_visible_session_with_policies(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            10,
+        )?;
+        let archive_plan = build_session_archive_plan(&snapshot)?;
+        let outcome = apply_session_archive_plan(
+            &repo,
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            &snapshot,
+            &archive_plan,
+        )?;
+        let mut payload = outcome.inspection;
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("archive_action".to_owned(), outcome.action);
+        }
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload,
+        });
     }
 
-    let target_session_id = request
-        .target
-        .session_ids
-        .first()
-        .expect("legacy single request requires one session id");
-    let repo = SessionRepository::new(config)?;
-    ensure_visible(
-        &repo,
-        current_session_id,
-        target_session_id,
-        tool_config.sessions.visibility,
-    )?;
-    let snapshot = inspect_visible_session_with_policies(
-        target_session_id,
-        current_session_id,
-        config,
-        tool_config,
-        10,
-    )?;
-    let archive_plan = build_session_archive_plan(&snapshot)?;
-    let outcome = apply_session_archive_plan(
-        &repo,
-        target_session_id,
-        current_session_id,
-        config,
-        tool_config,
-        &snapshot,
-        &archive_plan,
-    )?;
-    let mut payload = outcome.inspection;
-    if let Some(object) = payload.as_object_mut() {
-        object.insert("archive_action".to_owned(), outcome.action);
+    let mut results = Vec::with_capacity(request.target.session_ids.len());
+    for target_session_id in &request.target.session_ids {
+        results.push(execute_session_archive_batch_result(
+            target_session_id,
+            current_session_id,
+            config,
+            tool_config,
+            request.dry_run,
+        )?);
     }
+
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
-        payload,
+        payload: session_batch_payload(
+            "session_archive",
+            current_session_id,
+            request.dry_run,
+            request.target.session_ids.len(),
+            results,
+        ),
     })
 }
 
@@ -736,6 +753,121 @@ fn apply_session_archive_plan(
         inspection: session_inspection_payload(archived_snapshot),
         action: session_archive_action_json(archive_plan),
     })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_session_archive_batch_result(
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    dry_run: bool,
+) -> Result<SessionBatchResultRecord, String> {
+    let repo = SessionRepository::new(config)?;
+    if let Err(error) = ensure_visible(
+        &repo,
+        current_session_id,
+        target_session_id,
+        tool_config.sessions.visibility,
+    ) {
+        return Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "skipped_not_visible",
+            Some(error),
+            None,
+            None,
+        ));
+    }
+
+    let snapshot = match inspect_visible_session_with_policies(
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    ) {
+        Ok(snapshot) => snapshot,
+        Err(error) if is_session_visibility_skip_error(&error) => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_visible",
+                Some(error),
+                None,
+                None,
+            ));
+        }
+        Err(error) => return Err(error),
+    };
+    let inspection = session_inspection_payload(snapshot.clone());
+    let archive_plan = match build_session_archive_plan(&snapshot) {
+        Ok(plan) => plan,
+        Err(error) if error.starts_with("session_archive_not_archivable:")
+            && error.contains("already archived") =>
+        {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_already_archived",
+                Some(error),
+                None,
+                Some(inspection),
+            ));
+        }
+        Err(error) => {
+            return Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_not_archivable",
+                Some(error),
+                None,
+                Some(inspection),
+            ));
+        }
+    };
+    let action = session_archive_action_json(&archive_plan);
+    if dry_run {
+        return Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "would_apply",
+            None,
+            Some(action),
+            Some(inspection),
+        ));
+    }
+
+    match apply_session_archive_plan(
+        &repo,
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        &snapshot,
+        &archive_plan,
+    ) {
+        Ok(outcome) => Ok(session_batch_result(
+            target_session_id.to_owned(),
+            "applied",
+            None,
+            Some(outcome.action),
+            Some(outcome.inspection),
+        )),
+        Err(error) if error.starts_with("session_archive_state_changed:") => {
+            Ok(session_batch_result(
+                target_session_id.to_owned(),
+                "skipped_state_changed",
+                Some(error),
+                Some(action),
+                inspect_visible_session_with_policies(
+                    target_session_id,
+                    current_session_id,
+                    config,
+                    tool_config,
+                    10,
+                )
+                .ok()
+                .map(session_inspection_payload),
+            ))
+        }
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -4720,6 +4852,241 @@ mod tests {
 
         assert_eq!(status.payload["session"]["archived"], true);
         assert!(status.payload["session"]["archived_at"].is_number());
+    }
+
+    #[test]
+    fn session_archive_batch_dry_run_reports_mixed_results_without_mutation() {
+        let config = isolated_memory_config("session-archive-batch-dry-run");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "ready-to-archive".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Ready".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create archivable child");
+        repo.create_session(NewSessionRecord {
+            session_id: "already-archived".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Archived".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create archived child");
+        repo.create_session(NewSessionRecord {
+            session_id: "running-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Running".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create running child");
+
+        for session_id in ["ready-to-archive", "already-archived"] {
+            repo.finalize_session_terminal(
+                session_id,
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({ "result": "ok" }),
+                    outcome_status: "ok".to_owned(),
+                    outcome_payload_json: json!({ "child_session_id": session_id }),
+                },
+            )
+            .expect("finalize child");
+        }
+        execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_id": "already-archived"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("archive already-archived child");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_ids": ["ready-to-archive", "already-archived", "running-child"],
+                    "dry_run": true
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_archive batch dry_run outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool"], "session_archive");
+        assert_eq!(outcome.payload["dry_run"], true);
+        assert_eq!(outcome.payload["requested_count"], 3);
+        assert_eq!(outcome.payload["result_counts"]["would_apply"], 1);
+        assert_eq!(outcome.payload["result_counts"]["skipped_already_archived"], 1);
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_archivable"], 1);
+
+        let ready = batch_result(&outcome.payload, "ready-to-archive");
+        assert_eq!(ready["result"], "would_apply");
+        assert_eq!(ready["inspection"]["session"]["archived"], false);
+        assert_eq!(ready["action"]["kind"], "session_archived");
+
+        let archived = batch_result(&outcome.payload, "already-archived");
+        assert_eq!(archived["result"], "skipped_already_archived");
+        assert_eq!(archived["inspection"]["session"]["archived"], true);
+
+        let running = batch_result(&outcome.payload, "running-child");
+        assert_eq!(running["result"], "skipped_not_archivable");
+        assert_eq!(running["inspection"]["session"]["state"], "running");
+
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("ready-to-archive")
+                .expect("load ready summary")
+                .expect("ready session")
+                .archived_at,
+            None
+        );
+    }
+
+    #[test]
+    fn session_archive_batch_apply_reports_partial_success() {
+        let config = isolated_memory_config("session-archive-batch-apply");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "ready-to-archive".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Ready".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create archivable child");
+        repo.create_session(NewSessionRecord {
+            session_id: "already-archived".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Archived".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create archived child");
+        repo.create_session(NewSessionRecord {
+            session_id: "running-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Running".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create running child");
+
+        for session_id in ["ready-to-archive", "already-archived"] {
+            repo.finalize_session_terminal(
+                session_id,
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({ "result": "ok" }),
+                    outcome_status: "ok".to_owned(),
+                    outcome_payload_json: json!({ "child_session_id": session_id }),
+                },
+            )
+            .expect("finalize child");
+        }
+        execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_id": "already-archived"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("archive already-archived child");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_ids": ["ready-to-archive", "already-archived", "running-child"]
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_archive batch apply outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool"], "session_archive");
+        assert_eq!(outcome.payload["dry_run"], false);
+        assert_eq!(outcome.payload["requested_count"], 3);
+        assert_eq!(outcome.payload["result_counts"]["applied"], 1);
+        assert_eq!(outcome.payload["result_counts"]["skipped_already_archived"], 1);
+        assert_eq!(outcome.payload["result_counts"]["skipped_not_archivable"], 1);
+
+        let ready = batch_result(&outcome.payload, "ready-to-archive");
+        assert_eq!(ready["result"], "applied");
+        assert_eq!(ready["inspection"]["session"]["archived"], true);
+        assert_eq!(ready["action"]["kind"], "session_archived");
+        assert_eq!(
+            ready["inspection"]["recent_events"]
+                .as_array()
+                .expect("ready recent events")
+                .last()
+                .expect("ready latest event")["event_kind"],
+            "session_archived"
+        );
+
+        let archived = batch_result(&outcome.payload, "already-archived");
+        assert_eq!(archived["result"], "skipped_already_archived");
+        assert_eq!(archived["inspection"]["session"]["archived"], true);
+
+        let running = batch_result(&outcome.payload, "running-child");
+        assert_eq!(running["result"], "skipped_not_archivable");
+        assert_eq!(running["inspection"]["session"]["state"], "running");
+
+        assert!(
+            repo.load_session_summary_with_legacy_fallback("ready-to-archive")
+                .expect("load ready summary")
+                .expect("ready session")
+                .archived_at
+                .is_some()
+        );
+        assert!(
+            repo.load_session_summary_with_legacy_fallback("already-archived")
+                .expect("load archived summary")
+                .expect("archived session")
+                .archived_at
+                .is_some()
+        );
+        assert_eq!(
+            repo.load_session_summary_with_legacy_fallback("running-child")
+                .expect("load running summary")
+                .expect("running session")
+                .archived_at,
+            None
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -801,8 +801,9 @@ fn execute_session_archive_batch_result(
     let inspection = session_inspection_payload(snapshot.clone());
     let archive_plan = match build_session_archive_plan(&snapshot) {
         Ok(plan) => plan,
-        Err(error) if error.starts_with("session_archive_not_archivable:")
-            && error.contains("already archived") =>
+        Err(error)
+            if error.starts_with("session_archive_not_archivable:")
+                && error.contains("already archived") =>
         {
             return Ok(session_batch_result(
                 target_session_id.to_owned(),
@@ -4836,7 +4837,10 @@ mod tests {
         assert_eq!(outcome.payload["session"]["state"], "completed");
         assert_eq!(outcome.payload["session"]["archived"], true);
         assert!(outcome.payload["session"]["archived_at"].is_number());
-        assert_eq!(outcome.payload["archive_action"]["kind"], "session_archived");
+        assert_eq!(
+            outcome.payload["archive_action"]["kind"],
+            "session_archived"
+        );
 
         let status = execute_session_tool_with_config(
             ToolCoreRequest {
@@ -4936,8 +4940,14 @@ mod tests {
         assert_eq!(outcome.payload["dry_run"], true);
         assert_eq!(outcome.payload["requested_count"], 3);
         assert_eq!(outcome.payload["result_counts"]["would_apply"], 1);
-        assert_eq!(outcome.payload["result_counts"]["skipped_already_archived"], 1);
-        assert_eq!(outcome.payload["result_counts"]["skipped_not_archivable"], 1);
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_already_archived"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_archivable"],
+            1
+        );
 
         let ready = batch_result(&outcome.payload, "ready-to-archive");
         assert_eq!(ready["result"], "would_apply");
@@ -5042,8 +5052,14 @@ mod tests {
         assert_eq!(outcome.payload["dry_run"], false);
         assert_eq!(outcome.payload["requested_count"], 3);
         assert_eq!(outcome.payload["result_counts"]["applied"], 1);
-        assert_eq!(outcome.payload["result_counts"]["skipped_already_archived"], 1);
-        assert_eq!(outcome.payload["result_counts"]["skipped_not_archivable"], 1);
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_already_archived"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["result_counts"]["skipped_not_archivable"],
+            1
+        );
 
         let ready = batch_result(&outcome.payload, "ready-to-archive");
         assert_eq!(ready["result"], "applied");
@@ -5066,20 +5082,18 @@ mod tests {
         assert_eq!(running["result"], "skipped_not_archivable");
         assert_eq!(running["inspection"]["session"]["state"], "running");
 
-        assert!(
-            repo.load_session_summary_with_legacy_fallback("ready-to-archive")
-                .expect("load ready summary")
-                .expect("ready session")
-                .archived_at
-                .is_some()
-        );
-        assert!(
-            repo.load_session_summary_with_legacy_fallback("already-archived")
-                .expect("load archived summary")
-                .expect("archived session")
-                .archived_at
-                .is_some()
-        );
+        assert!(repo
+            .load_session_summary_with_legacy_fallback("ready-to-archive")
+            .expect("load ready summary")
+            .expect("ready session")
+            .archived_at
+            .is_some());
+        assert!(repo
+            .load_session_summary_with_legacy_fallback("already-archived")
+            .expect("load archived summary")
+            .expect("archived session")
+            .archived_at
+            .is_some());
         assert_eq!(
             repo.load_session_summary_with_legacy_fallback("running-child")
                 .expect("load running summary")

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -1,0 +1,1337 @@
+#[cfg(feature = "memory-sqlite")]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+use serde_json::{json, Value};
+
+use crate::config::{SessionVisibility, ToolConfig};
+use crate::memory;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::recovery::{observe_missing_recovery, recovery_json, SessionRecoveryRecord};
+
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{
+    SessionEventRecord, SessionKind, SessionObservationRecord, SessionRepository, SessionState,
+    SessionSummaryRecord, SessionTerminalOutcomeRecord,
+};
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct SessionInspectionSnapshot {
+    pub session: SessionSummaryRecord,
+    pub terminal_outcome: Option<SessionTerminalOutcomeRecord>,
+    pub recent_events: Vec<SessionEventRecord>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct SessionObservationSnapshot {
+    pub inspection: SessionInspectionSnapshot,
+    pub tail_events: Vec<SessionEventRecord>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionDelegateLifecycleRecord {
+    mode: &'static str,
+    phase: &'static str,
+    queued_at: Option<i64>,
+    started_at: Option<i64>,
+    timeout_seconds: Option<u64>,
+    staleness: Option<SessionDelegateStalenessRecord>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionDelegateStalenessRecord {
+    state: &'static str,
+    reference: &'static str,
+    elapsed_seconds: u64,
+    threshold_seconds: u64,
+    deadline_at: i64,
+}
+
+#[cfg(test)]
+pub fn execute_session_tool_with_config(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    execute_session_tool_with_policies(request, current_session_id, config, &ToolConfig::default())
+}
+
+pub fn execute_session_tool_with_policies(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (request, current_session_id, config, tool_config);
+        return Err(
+            "session tools require sqlite memory support (enable feature `memory-sqlite`)"
+                .to_owned(),
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        if !tool_config.sessions.enabled {
+            return Err("app_tool_disabled: session tools are disabled by config".to_owned());
+        }
+        match request.tool_name.as_str() {
+            "sessions_list" => execute_sessions_list(current_session_id, config, tool_config),
+            "session_events" => {
+                execute_session_events(request.payload, current_session_id, config, tool_config)
+            }
+            "sessions_history" => {
+                execute_sessions_history(request.payload, current_session_id, config, tool_config)
+            }
+            "session_status" => {
+                execute_session_status(request.payload, current_session_id, config, tool_config)
+            }
+            other => Err(format!(
+                "app_tool_not_found: unknown session tool `{other}`"
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_sessions_list(
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let repo = SessionRepository::new(config)?;
+    let mut sessions = repo.list_visible_sessions(current_session_id)?;
+    if tool_config.sessions.visibility == SessionVisibility::SelfOnly {
+        sessions.retain(|session| session.session_id == current_session_id);
+    }
+    sessions.truncate(tool_config.sessions.list_limit);
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "current_session_id": current_session_id,
+            "sessions": sessions.into_iter().map(session_summary_json).collect::<Vec<_>>(),
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_session_events(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let target_session_id = required_payload_string(&payload, "session_id")?;
+    let default_limit = tool_config.sessions.history_limit.min(50);
+    let limit = optional_payload_limit(
+        &payload,
+        "limit",
+        default_limit,
+        tool_config.sessions.history_limit,
+    );
+    let after_id = payload.get("after_id").and_then(Value::as_i64);
+    let repo = SessionRepository::new(config)?;
+    ensure_visible(
+        &repo,
+        current_session_id,
+        &target_session_id,
+        tool_config.sessions.visibility,
+    )?;
+    let events = match after_id {
+        Some(after_id) => repo.list_events_after(&target_session_id, after_id.max(0), limit)?,
+        None => repo.list_recent_events(&target_session_id, limit)?,
+    };
+    let next_after_id = events
+        .last()
+        .map(|event| event.id)
+        .unwrap_or(after_id.unwrap_or(0));
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "session_id": target_session_id,
+            "after_id": after_id,
+            "limit": limit,
+            "next_after_id": next_after_id,
+            "events": events.into_iter().map(session_event_json).collect::<Vec<_>>(),
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_sessions_history(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let target_session_id = required_payload_string(&payload, "session_id")?;
+    let default_limit = tool_config.sessions.history_limit.min(50);
+    let limit = optional_payload_limit(
+        &payload,
+        "limit",
+        default_limit,
+        tool_config.sessions.history_limit,
+    );
+    let repo = SessionRepository::new(config)?;
+    ensure_visible(
+        &repo,
+        current_session_id,
+        &target_session_id,
+        tool_config.sessions.visibility,
+    )?;
+    let turns = memory::window_direct(&target_session_id, limit, config)
+        .map_err(|error| format!("load session transcript failed: {error}"))?;
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "session_id": target_session_id,
+            "limit": limit,
+            "turns": turns,
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_session_status(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let target_session_id = required_payload_string(&payload, "session_id")?;
+    let snapshot = inspect_visible_session_with_policies(
+        &target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        5,
+    )?;
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: session_inspection_payload(snapshot),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) fn inspect_visible_session_with_policies(
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    recent_event_limit: usize,
+) -> Result<SessionInspectionSnapshot, String> {
+    Ok(observe_visible_session_with_policies(
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        recent_event_limit,
+        None,
+        0,
+    )?
+    .inspection)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) fn observe_visible_session_with_policies(
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    recent_event_limit: usize,
+    tail_after_id: Option<i64>,
+    tail_page_limit: usize,
+) -> Result<SessionObservationSnapshot, String> {
+    let target_session_id = normalize_required_session_id(target_session_id)?;
+    let repo = SessionRepository::new(config)?;
+    ensure_visible(
+        &repo,
+        current_session_id,
+        &target_session_id,
+        tool_config.sessions.visibility,
+    )?;
+    let SessionObservationRecord {
+        session,
+        terminal_outcome,
+        recent_events,
+        tail_events,
+    } = repo
+        .load_session_observation(
+            &target_session_id,
+            recent_event_limit,
+            tail_after_id,
+            tail_page_limit,
+        )?
+        .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
+
+    Ok(SessionObservationSnapshot {
+        inspection: SessionInspectionSnapshot {
+            session,
+            terminal_outcome,
+            recent_events,
+        },
+        tail_events,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) fn session_state_is_terminal(state: SessionState) -> bool {
+    matches!(
+        state,
+        SessionState::Completed | SessionState::Failed | SessionState::TimedOut
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) -> Value {
+    let terminal_outcome_state =
+        session_terminal_outcome_state(snapshot.session.state, snapshot.terminal_outcome.is_some());
+    let delegate_lifecycle = session_delegate_lifecycle_at(
+        &snapshot.session,
+        snapshot.recent_events.as_slice(),
+        current_unix_ts(),
+    );
+    let recovery = match terminal_outcome_state {
+        "missing" => Some(observe_missing_recovery(
+            snapshot.recent_events.as_slice(),
+            snapshot.session.last_error.as_deref(),
+        )),
+        _ => None,
+    };
+    let terminal_outcome_missing_reason = match terminal_outcome_state {
+        "missing" => session_terminal_outcome_missing_reason(recovery.as_ref()),
+        _ => None,
+    };
+    json!({
+        "session": {
+            "session_id": snapshot.session.session_id,
+            "kind": snapshot.session.kind.as_str(),
+            "parent_session_id": snapshot.session.parent_session_id,
+            "label": snapshot.session.label,
+            "state": snapshot.session.state.as_str(),
+            "created_at": snapshot.session.created_at,
+            "updated_at": snapshot.session.updated_at,
+            "last_error": snapshot.session.last_error,
+        },
+        "terminal_outcome_state": terminal_outcome_state,
+        "terminal_outcome_missing_reason": terminal_outcome_missing_reason,
+        "delegate_lifecycle": delegate_lifecycle.map(session_delegate_lifecycle_json),
+        "recovery": recovery.map(recovery_json),
+        "terminal_outcome": snapshot.terminal_outcome.map(session_terminal_outcome_json),
+        "recent_events": snapshot
+            .recent_events
+            .into_iter()
+            .map(session_event_json)
+            .collect::<Vec<_>>(),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_terminal_outcome_state(state: SessionState, has_terminal_outcome: bool) -> &'static str {
+    if has_terminal_outcome {
+        "present"
+    } else if session_state_is_terminal(state) {
+        "missing"
+    } else {
+        "not_terminal"
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_terminal_outcome_missing_reason(
+    recovery: Option<&SessionRecoveryRecord>,
+) -> Option<String> {
+    recovery.map(|recovery| recovery.kind.clone())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_delegate_lifecycle_at(
+    session: &SessionSummaryRecord,
+    recent_events: &[SessionEventRecord],
+    now_ts: i64,
+) -> Option<SessionDelegateLifecycleRecord> {
+    if session.kind != SessionKind::DelegateChild {
+        return None;
+    }
+
+    let mut queued_at = None;
+    let mut started_at = None;
+    let mut queued_timeout_seconds = None;
+    let mut started_timeout_seconds = None;
+    for event in recent_events {
+        match event.event_kind.as_str() {
+            "delegate_queued" => {
+                queued_at = Some(event.ts);
+                queued_timeout_seconds = event
+                    .payload_json
+                    .get("timeout_seconds")
+                    .and_then(Value::as_u64);
+            }
+            "delegate_started" => {
+                started_at = Some(event.ts);
+                started_timeout_seconds = event
+                    .payload_json
+                    .get("timeout_seconds")
+                    .and_then(Value::as_u64);
+            }
+            _ => {}
+        }
+    }
+
+    if session.parent_session_id.is_none() && queued_at.is_none() && started_at.is_none() {
+        return None;
+    }
+
+    let phase = match session.state {
+        SessionState::Ready => "queued",
+        SessionState::Running => "running",
+        SessionState::Completed => "completed",
+        SessionState::Failed => "failed",
+        SessionState::TimedOut => "timed_out",
+    };
+    let timeout_seconds = started_timeout_seconds.or(queued_timeout_seconds);
+    let mode = if queued_at.is_some() || matches!(session.state, SessionState::Ready) {
+        "async"
+    } else {
+        "inline"
+    };
+    let staleness = match session.state {
+        SessionState::Ready => {
+            session_delegate_staleness_at("queued", queued_at, timeout_seconds, now_ts)
+        }
+        SessionState::Running => session_delegate_staleness_at(
+            if started_at.is_some() {
+                "started"
+            } else {
+                "queued"
+            },
+            started_at.or(queued_at),
+            timeout_seconds,
+            now_ts,
+        ),
+        SessionState::Completed | SessionState::Failed | SessionState::TimedOut => None,
+    };
+
+    Some(SessionDelegateLifecycleRecord {
+        mode,
+        phase,
+        queued_at,
+        started_at,
+        timeout_seconds,
+        staleness,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_delegate_staleness_at(
+    reference: &'static str,
+    reference_at: Option<i64>,
+    timeout_seconds: Option<u64>,
+    now_ts: i64,
+) -> Option<SessionDelegateStalenessRecord> {
+    let reference_at = reference_at?;
+    let threshold_seconds = timeout_seconds?;
+    let elapsed_seconds = now_ts.saturating_sub(reference_at).max(0) as u64;
+    let deadline_at = reference_at.saturating_add(threshold_seconds.min(i64::MAX as u64) as i64);
+    let state = if elapsed_seconds > threshold_seconds {
+        "overdue"
+    } else {
+        "fresh"
+    };
+
+    Some(SessionDelegateStalenessRecord {
+        state,
+        reference,
+        elapsed_seconds,
+        threshold_seconds,
+        deadline_at,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_delegate_lifecycle_json(lifecycle: SessionDelegateLifecycleRecord) -> Value {
+    json!({
+        "mode": lifecycle.mode,
+        "phase": lifecycle.phase,
+        "queued_at": lifecycle.queued_at,
+        "started_at": lifecycle.started_at,
+        "timeout_seconds": lifecycle.timeout_seconds,
+        "staleness": lifecycle.staleness.map(session_delegate_staleness_json),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_delegate_staleness_json(staleness: SessionDelegateStalenessRecord) -> Value {
+    json!({
+        "state": staleness.state,
+        "reference": staleness.reference,
+        "elapsed_seconds": staleness.elapsed_seconds,
+        "threshold_seconds": staleness.threshold_seconds,
+        "deadline_at": staleness.deadline_at,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn current_unix_ts() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or_default()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn ensure_visible(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    target_session_id: &str,
+    visibility: SessionVisibility,
+) -> Result<(), String> {
+    let is_visible = match visibility {
+        SessionVisibility::SelfOnly => current_session_id == target_session_id,
+        SessionVisibility::Children => {
+            repo.is_session_visible(current_session_id, target_session_id)?
+        }
+    };
+    if is_visible {
+        return Ok(());
+    }
+    Err(format!(
+        "visibility_denied: session `{target_session_id}` is not visible from `{current_session_id}`"
+    ))
+}
+
+fn required_payload_string(payload: &Value, field: &str) -> Result<String, String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| format!("session tool requires payload.{field}"))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn normalize_required_session_id(session_id: &str) -> Result<String, String> {
+    let trimmed = session_id.trim();
+    if trimmed.is_empty() {
+        return Err("session tool requires payload.session_id".to_owned());
+    }
+    Ok(trimmed.to_owned())
+}
+
+fn optional_payload_limit(payload: &Value, field: &str, default: usize, max: usize) -> usize {
+    payload
+        .get(field)
+        .and_then(Value::as_u64)
+        .map(|value| value.clamp(1, max as u64) as usize)
+        .unwrap_or(default)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_summary_json(session: SessionSummaryRecord) -> Value {
+    json!({
+        "session_id": session.session_id,
+        "kind": session.kind.as_str(),
+        "parent_session_id": session.parent_session_id,
+        "label": session.label,
+        "state": session.state.as_str(),
+        "created_at": session.created_at,
+        "updated_at": session.updated_at,
+        "turn_count": session.turn_count,
+        "last_turn_at": session.last_turn_at,
+        "last_error": session.last_error,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) fn session_event_json(event: SessionEventRecord) -> Value {
+    json!({
+        "id": event.id,
+        "session_id": event.session_id,
+        "event_kind": event.event_kind,
+        "actor_session_id": event.actor_session_id,
+        "payload_json": event.payload_json,
+        "ts": event.ts,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_terminal_outcome_json(
+    outcome: crate::session::repository::SessionTerminalOutcomeRecord,
+) -> Value {
+    json!({
+        "session_id": outcome.session_id,
+        "status": outcome.status,
+        "payload": outcome.payload_json,
+        "recorded_at": outcome.recorded_at,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use loongclaw_contracts::ToolCoreRequest;
+    use serde_json::{json, Value};
+
+    use crate::config::{SessionVisibility, ToolConfig};
+    use crate::memory::append_turn_direct;
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::repository::{
+        NewSessionEvent, NewSessionRecord, SessionEventRecord, SessionKind, SessionRepository,
+        SessionState, SessionSummaryRecord,
+    };
+
+    use super::{execute_session_tool_with_config, execute_session_tool_with_policies};
+
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        let base = std::env::temp_dir().join(format!(
+            "loongclaw-session-tools-{test_name}-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&base);
+        let db_path = base.join("memory.sqlite3");
+        let _ = fs::remove_file(&db_path);
+        MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+        }
+    }
+
+    #[test]
+    fn sessions_list_returns_current_session_and_children() {
+        let config = isolated_memory_config("sessions-list");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+        repo.create_session(NewSessionRecord {
+            session_id: "other-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Other".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create other");
+
+        append_turn_direct("root-session", "user", "root turn", &config).expect("append root turn");
+        append_turn_direct("child-session", "assistant", "child turn", &config)
+            .expect("append child turn");
+        append_turn_direct("other-session", "user", "other turn", &config)
+            .expect("append other turn");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "sessions_list".to_owned(),
+                payload: json!({}),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("sessions_list outcome");
+
+        let sessions = outcome.payload["sessions"]
+            .as_array()
+            .expect("sessions array");
+        let ids: Vec<&str> = sessions
+            .iter()
+            .filter_map(|item: &Value| item.get("session_id"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(ids.contains(&"root-session"));
+        assert!(ids.contains(&"child-session"));
+        assert!(!ids.contains(&"other-session"));
+    }
+
+    #[test]
+    fn sessions_list_respects_self_visibility_policy() {
+        let config = isolated_memory_config("sessions-list-self-only");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+
+        let mut tool_config = ToolConfig::default();
+        tool_config.sessions.visibility = SessionVisibility::SelfOnly;
+
+        let outcome = execute_session_tool_with_policies(
+            ToolCoreRequest {
+                tool_name: "sessions_list".to_owned(),
+                payload: json!({}),
+            },
+            "root-session",
+            &config,
+            &tool_config,
+        )
+        .expect("sessions_list outcome");
+
+        let sessions = outcome.payload["sessions"]
+            .as_array()
+            .expect("sessions array");
+        let ids: Vec<&str> = sessions
+            .iter()
+            .filter_map(|item: &Value| item.get("session_id"))
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(ids, vec!["root-session"]);
+    }
+
+    #[test]
+    fn sessions_history_returns_transcript_without_control_events() {
+        let config = isolated_memory_config("sessions-history");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_completed".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({"status": "ok"}),
+        })
+        .expect("append event");
+
+        append_turn_direct("child-session", "user", "hello", &config).expect("append user turn");
+        append_turn_direct("child-session", "assistant", "world", &config)
+            .expect("append assistant turn");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "sessions_history".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "limit": 10
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("sessions_history outcome");
+
+        let turns = outcome.payload["turns"].as_array().expect("turns array");
+        assert_eq!(turns.len(), 2);
+        assert_eq!(turns[0]["role"], "user");
+        assert_eq!(turns[0]["content"], "hello");
+        assert_eq!(turns[1]["role"], "assistant");
+        assert_eq!(turns[1]["content"], "world");
+    }
+
+    #[test]
+    fn session_status_returns_state_and_last_error() {
+        let config = isolated_memory_config("session-status");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Failed,
+        })
+        .expect("create child");
+        repo.update_session_state(
+            "child-session",
+            SessionState::Failed,
+            Some("delegate_timeout".to_owned()),
+        )
+        .expect("update child status");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_failed".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({"error": "delegate_timeout"}),
+        })
+        .expect("append event");
+        repo.upsert_terminal_outcome(
+            "child-session",
+            "error",
+            json!({
+                "child_session_id": "child-session",
+                "error": "delegate_timeout",
+                "duration_ms": 12
+            }),
+        )
+        .expect("upsert terminal outcome");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(outcome.payload["session"]["session_id"], "child-session");
+        assert_eq!(outcome.payload["session"]["state"], "failed");
+        assert_eq!(outcome.payload["session"]["last_error"], "delegate_timeout");
+        assert_eq!(outcome.payload["terminal_outcome_state"], "present");
+        assert!(outcome.payload["terminal_outcome_missing_reason"].is_null());
+        assert_eq!(outcome.payload["terminal_outcome"]["status"], "error");
+        assert_eq!(
+            outcome.payload["terminal_outcome"]["payload"]["error"],
+            "delegate_timeout"
+        );
+        let recent_events = outcome.payload["recent_events"]
+            .as_array()
+            .expect("recent_events array");
+        assert_eq!(recent_events.len(), 1);
+        assert_eq!(recent_events[0]["event_kind"], "delegate_failed");
+    }
+
+    #[test]
+    fn session_status_reports_missing_terminal_outcome_for_recovered_failed_session() {
+        let config = isolated_memory_config("session-status-recovered-failed");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Failed,
+        })
+        .expect("create child");
+        repo.update_session_state(
+            "child-session",
+            SessionState::Failed,
+            Some("opaque_recovery_failure".to_owned()),
+        )
+        .expect("update child status");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_recovery_applied".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "recovery_kind": "terminal_finalize_persist_failed",
+                "recovered_state": "failed",
+                "recovery_error": "delegate_terminal_finalize_failed: database busy",
+                "attempted_terminal_event_kind": "delegate_completed",
+                "attempted_outcome_status": "ok"
+            }),
+        })
+        .expect("append event");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(outcome.payload["session"]["session_id"], "child-session");
+        assert_eq!(outcome.payload["session"]["state"], "failed");
+        assert_eq!(
+            outcome.payload["session"]["last_error"],
+            "opaque_recovery_failure"
+        );
+        assert_eq!(outcome.payload["terminal_outcome_state"], "missing");
+        assert_eq!(
+            outcome.payload["terminal_outcome_missing_reason"],
+            "terminal_finalize_persist_failed"
+        );
+        assert_eq!(
+            outcome.payload["recovery"]["kind"],
+            "terminal_finalize_persist_failed"
+        );
+        assert_eq!(
+            outcome.payload["recovery"]["event_kind"],
+            "delegate_recovery_applied"
+        );
+        assert_eq!(
+            outcome.payload["recovery"]["recovery_error"],
+            "delegate_terminal_finalize_failed: database busy"
+        );
+        assert_eq!(
+            outcome.payload["recovery"]["attempted_terminal_event_kind"],
+            "delegate_completed"
+        );
+        assert_eq!(outcome.payload["recovery"]["source"], "event");
+        assert!(outcome.payload["terminal_outcome"].is_null());
+    }
+
+    #[test]
+    fn session_status_synthesizes_recovery_from_last_error_when_event_missing() {
+        let config = isolated_memory_config("session-status-recovery-fallback");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Failed,
+        })
+        .expect("create child");
+        repo.update_session_state(
+            "child-session",
+            SessionState::Failed,
+            Some("delegate_terminal_finalize_failed: database busy".to_owned()),
+        )
+        .expect("update child status");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(outcome.payload["terminal_outcome_state"], "missing");
+        assert_eq!(
+            outcome.payload["terminal_outcome_missing_reason"],
+            "terminal_finalize_persist_failed"
+        );
+        assert_eq!(
+            outcome.payload["recovery"]["kind"],
+            "terminal_finalize_persist_failed"
+        );
+        assert_eq!(outcome.payload["recovery"]["source"], "last_error");
+        assert_eq!(
+            outcome.payload["recovery"]["recovery_error"],
+            "delegate_terminal_finalize_failed: database busy"
+        );
+        assert!(outcome.payload["recovery"]["event_kind"].is_null());
+    }
+
+    #[test]
+    fn session_status_synthesizes_unknown_recovery_when_metadata_missing() {
+        let config = isolated_memory_config("session-status-recovery-unknown");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Failed,
+        })
+        .expect("create child");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(outcome.payload["terminal_outcome_state"], "missing");
+        assert_eq!(
+            outcome.payload["terminal_outcome_missing_reason"],
+            "unknown"
+        );
+        assert_eq!(outcome.payload["recovery"]["kind"], "unknown");
+        assert_eq!(outcome.payload["recovery"]["source"], "none");
+        assert!(outcome.payload["recovery"]["recovery_error"].is_null());
+        assert!(outcome.payload["recovery"]["event_kind"].is_null());
+    }
+
+    #[test]
+    fn session_delegate_lifecycle_marks_overdue_queued_child() {
+        let session = SessionSummaryRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+            created_at: 100,
+            updated_at: 100,
+            turn_count: 0,
+            last_turn_at: None,
+            last_error: None,
+        };
+        let events = vec![SessionEventRecord {
+            id: 1,
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 30
+            }),
+            ts: 100,
+        }];
+
+        let lifecycle = super::session_delegate_lifecycle_at(&session, &events, 140)
+            .expect("delegate lifecycle");
+
+        assert_eq!(lifecycle.mode, "async");
+        assert_eq!(lifecycle.phase, "queued");
+        assert_eq!(lifecycle.queued_at, Some(100));
+        assert_eq!(lifecycle.started_at, None);
+        assert_eq!(lifecycle.timeout_seconds, Some(30));
+        let staleness = lifecycle.staleness.expect("staleness");
+        assert_eq!(staleness.state, "overdue");
+        assert_eq!(staleness.reference, "queued");
+        assert_eq!(staleness.elapsed_seconds, 40);
+        assert_eq!(staleness.threshold_seconds, 30);
+        assert_eq!(staleness.deadline_at, 130);
+    }
+
+    #[test]
+    fn session_status_includes_delegate_lifecycle_for_queued_child() {
+        let config = isolated_memory_config("session-status-delegate-lifecycle");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "label": "Child",
+                "timeout_seconds": 60
+            }),
+        })
+        .expect("append queued event");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(outcome.payload["delegate_lifecycle"]["mode"], "async");
+        assert_eq!(outcome.payload["delegate_lifecycle"]["phase"], "queued");
+        assert_eq!(outcome.payload["delegate_lifecycle"]["timeout_seconds"], 60);
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["staleness"]["reference"],
+            "queued"
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["staleness"]["state"],
+            "fresh"
+        );
+        assert!(outcome.payload["delegate_lifecycle"]["queued_at"].is_number());
+        assert!(outcome.payload["delegate_lifecycle"]["started_at"].is_null());
+    }
+
+    #[test]
+    fn session_tools_reject_invisible_sessions() {
+        let config = isolated_memory_config("session-visibility");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "other-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Other".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create other");
+
+        let error = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "other-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect_err("invisible session should be rejected");
+
+        assert!(
+            error.contains("visibility_denied"),
+            "expected visibility_denied, got: {error}"
+        );
+    }
+
+    #[test]
+    fn session_status_returns_inferred_legacy_current_session_without_backfill() {
+        let config = isolated_memory_config("legacy-session-status");
+        append_turn_direct("delegate:legacy-child", "user", "hello", &config)
+            .expect("append user turn");
+        append_turn_direct("delegate:legacy-child", "assistant", "done", &config)
+            .expect("append assistant turn");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "delegate:legacy-child"
+                }),
+            },
+            "delegate:legacy-child",
+            &config,
+        )
+        .expect("legacy session_status outcome");
+
+        assert_eq!(
+            outcome.payload["session"]["session_id"],
+            "delegate:legacy-child"
+        );
+        assert_eq!(outcome.payload["session"]["kind"], "delegate_child");
+        assert_eq!(outcome.payload["session"]["state"], "ready");
+        assert_eq!(outcome.payload["terminal_outcome_state"], "not_terminal");
+        assert!(outcome.payload["terminal_outcome_missing_reason"].is_null());
+        assert!(outcome.payload["delegate_lifecycle"].is_null());
+        assert!(outcome.payload["terminal_outcome"].is_null());
+        assert_eq!(
+            outcome.payload["recent_events"]
+                .as_array()
+                .expect("recent_events array")
+                .len(),
+            0
+        );
+
+        let repo = SessionRepository::new(&config).expect("repository");
+        assert!(repo
+            .load_session("delegate:legacy-child")
+            .expect("load legacy session")
+            .is_none());
+    }
+
+    #[test]
+    fn session_status_allows_visible_descendant_delegate_session() {
+        let config = isolated_memory_config("descendant-session-status");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create child");
+        repo.create_session(NewSessionRecord {
+            session_id: "grandchild-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("child-session".to_owned()),
+            label: Some("Grandchild".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create grandchild");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "grandchild-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("descendant session_status outcome");
+
+        assert_eq!(
+            outcome.payload["session"]["session_id"],
+            "grandchild-session"
+        );
+        assert_eq!(outcome.payload["session"]["kind"], "delegate_child");
+    }
+
+    #[test]
+    fn session_events_returns_ordered_tail_and_respects_after_id() {
+        let config = isolated_memory_config("session-events");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+
+        let first = repo
+            .append_event(NewSessionEvent {
+                session_id: "child-session".to_owned(),
+                event_kind: "delegate_started".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                payload_json: json!({"step": 1}),
+            })
+            .expect("append first event");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_progress".to_owned(),
+            actor_session_id: Some("child-session".to_owned()),
+            payload_json: json!({"step": 2}),
+        })
+        .expect("append second event");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_completed".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({"step": 3}),
+        })
+        .expect("append third event");
+
+        let full = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_events".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "limit": 10
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_events outcome");
+        let full_events = full.payload["events"].as_array().expect("events array");
+        assert_eq!(full_events.len(), 3);
+        assert_eq!(full_events[0]["event_kind"], "delegate_started");
+        assert_eq!(full_events[1]["event_kind"], "delegate_progress");
+        assert_eq!(full_events[2]["event_kind"], "delegate_completed");
+
+        let incremental = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_events".to_owned(),
+                payload: json!({
+                    "session_id": "child-session",
+                    "after_id": first.id,
+                    "limit": 10
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("incremental session_events outcome");
+        let incremental_events = incremental.payload["events"]
+            .as_array()
+            .expect("incremental events array");
+        assert_eq!(incremental_events.len(), 2);
+        assert_eq!(incremental_events[0]["event_kind"], "delegate_progress");
+        assert_eq!(incremental_events[1]["event_kind"], "delegate_completed");
+    }
+}

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -138,6 +138,12 @@ enum SessionCancelPlan {
 }
 
 #[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionArchivePlan {
+    expected_state: SessionState,
+}
+
+#[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq)]
 struct SessionToolActionOutcome {
     inspection: Value,
@@ -208,6 +214,9 @@ pub fn execute_session_tool_with_policies(
             }
             "session_cancel" => {
                 execute_session_cancel(request.payload, current_session_id, config, tool_config)
+            }
+            "session_archive" => {
+                execute_session_archive(request.payload, current_session_id, config, tool_config)
             }
             "session_recover" => {
                 execute_session_recover(request.payload, current_session_id, config, tool_config)
@@ -603,6 +612,139 @@ fn execute_session_cancel(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn execute_session_archive(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let request = parse_session_mutation_request(&payload)?;
+    if !request.use_legacy_single_response() {
+        return Err(
+            "session_archive batch mode is not implemented yet; use payload.session_id"
+                .to_owned(),
+        );
+    }
+
+    let target_session_id = request
+        .target
+        .session_ids
+        .first()
+        .expect("legacy single request requires one session id");
+    let repo = SessionRepository::new(config)?;
+    ensure_visible(
+        &repo,
+        current_session_id,
+        target_session_id,
+        tool_config.sessions.visibility,
+    )?;
+    let snapshot = inspect_visible_session_with_policies(
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    )?;
+    let archive_plan = build_session_archive_plan(&snapshot)?;
+    let outcome = apply_session_archive_plan(
+        &repo,
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        &snapshot,
+        &archive_plan,
+    )?;
+    let mut payload = outcome.inspection;
+    if let Some(object) = payload.as_object_mut() {
+        object.insert("archive_action".to_owned(), outcome.action);
+    }
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_session_archive_plan(
+    snapshot: &SessionInspectionSnapshot,
+) -> Result<SessionArchivePlan, String> {
+    if snapshot.session.archived_at.is_some() {
+        return Err(format!(
+            "session_archive_not_archivable: session `{}` is already archived",
+            snapshot.session.session_id
+        ));
+    }
+    if !session_state_is_terminal(snapshot.session.state) {
+        return Err(format!(
+            "session_archive_not_archivable: session `{}` is not terminal",
+            snapshot.session.session_id
+        ));
+    }
+
+    Ok(SessionArchivePlan {
+        expected_state: snapshot.session.state,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn apply_session_archive_plan(
+    repo: &SessionRepository,
+    target_session_id: &str,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    snapshot: &SessionInspectionSnapshot,
+    archive_plan: &SessionArchivePlan,
+) -> Result<SessionToolActionOutcome, String> {
+    let transitioned = repo.transition_session_with_event_if_current(
+        target_session_id,
+        crate::session::repository::TransitionSessionWithEventIfCurrentRequest {
+            expected_state: archive_plan.expected_state,
+            next_state: archive_plan.expected_state,
+            last_error: snapshot.session.last_error.clone(),
+            event_kind: "session_archived".to_owned(),
+            actor_session_id: Some(current_session_id.to_owned()),
+            event_payload_json: json!({
+                "previous_state": archive_plan.expected_state.as_str(),
+                "hides_from_sessions_list": true,
+            }),
+        },
+    )?;
+    if transitioned.is_none() {
+        let latest = repo
+            .load_session_summary_with_legacy_fallback(target_session_id)?
+            .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
+        return Err(format!(
+            "session_archive_state_changed: session `{target_session_id}` is no longer archivable from state `{}`",
+            latest.state.as_str()
+        ));
+    }
+
+    let archived_snapshot = inspect_visible_session_with_policies(
+        target_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        10,
+    )?;
+    Ok(SessionToolActionOutcome {
+        inspection: session_inspection_payload(archived_snapshot),
+        action: session_archive_action_json(archive_plan),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_archive_action_json(plan: &SessionArchivePlan) -> Value {
+    json!({
+        "kind": "session_archived",
+        "previous_state": plan.expected_state.as_str(),
+        "next_state": plan.expected_state.as_str(),
+        "hides_from_sessions_list": true,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
 pub(super) fn inspect_visible_session_with_policies(
     target_session_id: &str,
     current_session_id: &str,
@@ -939,6 +1081,8 @@ pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) ->
             "state": snapshot.session.state.as_str(),
             "created_at": snapshot.session.created_at,
             "updated_at": snapshot.session.updated_at,
+            "archived": snapshot.session.archived_at.is_some(),
+            "archived_at": snapshot.session.archived_at,
             "last_error": snapshot.session.last_error,
         },
         "terminal_outcome_state": terminal_outcome_state,
@@ -2167,6 +2311,8 @@ fn session_summary_json(session: SessionSummaryRecord) -> Value {
         "state": session.state.as_str(),
         "created_at": session.created_at,
         "updated_at": session.updated_at,
+        "archived": session.archived_at.is_some(),
+        "archived_at": session.archived_at,
         "turn_count": session.turn_count,
         "last_turn_at": session.last_turn_at,
         "last_error": session.last_error,
@@ -2230,8 +2376,8 @@ mod tests {
     use crate::memory::append_turn_direct;
     use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::{
-        NewSessionEvent, NewSessionRecord, SessionEventRecord, SessionKind, SessionRepository,
-        SessionState, SessionSummaryRecord,
+        FinalizeSessionTerminalRequest, NewSessionEvent, NewSessionRecord, SessionEventRecord,
+        SessionKind, SessionRepository, SessionState, SessionSummaryRecord,
     };
 
     use super::{execute_session_tool_with_config, execute_session_tool_with_policies};
@@ -3947,6 +4093,7 @@ mod tests {
             state: SessionState::Ready,
             created_at: 100,
             updated_at: 100,
+            archived_at: None,
             turn_count: 0,
             last_turn_at: None,
             last_error: None,
@@ -4343,6 +4490,80 @@ mod tests {
             child["inspection"]["terminal_outcome_state"],
             "not_terminal"
         );
+    }
+
+    #[test]
+    fn session_archive_archives_terminal_visible_session() {
+        let config = isolated_memory_config("session-archive-single");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+        repo.finalize_session_terminal(
+            "child-session",
+            FinalizeSessionTerminalRequest {
+                state: SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                event_payload_json: json!({
+                    "result": "ok"
+                }),
+                outcome_status: "ok".to_owned(),
+                outcome_payload_json: json!({
+                    "child_session_id": "child-session",
+                    "result": "ok"
+                }),
+            },
+        )
+        .expect("finalize child");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_archive outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["session"]["session_id"], "child-session");
+        assert_eq!(outcome.payload["session"]["state"], "completed");
+        assert_eq!(outcome.payload["session"]["archived"], true);
+        assert!(outcome.payload["session"]["archived_at"].is_number());
+        assert_eq!(outcome.payload["archive_action"]["kind"], "session_archived");
+
+        let status = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(status.payload["session"]["archived"], true);
+        assert!(status.payload["session"]["archived_at"].is_number());
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -171,6 +171,37 @@ struct SessionWaitTargetState {
     latest_inspection: Option<SessionInspectionSnapshot>,
 }
 
+#[cfg(feature = "memory-sqlite")]
+fn set_session_batch_result(
+    results: &mut [Option<SessionBatchResultRecord>],
+    index: usize,
+    result: SessionBatchResultRecord,
+) -> Result<(), String> {
+    let Some(slot) = results.get_mut(index) else {
+        return Err(format!(
+            "session_wait_internal_error: result slot `{index}` is out of bounds"
+        ));
+    };
+    *slot = Some(result);
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn collect_session_batch_results(
+    results: Vec<Option<SessionBatchResultRecord>>,
+) -> Result<Vec<SessionBatchResultRecord>, String> {
+    let mut collected = Vec::with_capacity(results.len());
+    for (index, result) in results.into_iter().enumerate() {
+        let Some(result) = result else {
+            return Err(format!(
+                "session_wait_internal_error: missing batch result at index `{index}`"
+            ));
+        };
+        collected.push(result);
+    }
+    Ok(collected)
+}
+
 #[cfg(test)]
 pub fn execute_session_tool_with_config(
     request: ToolCoreRequest,
@@ -246,10 +277,7 @@ pub(super) async fn wait_for_session_tool_with_policies(
     let event_limit = tool_config.sessions.history_limit.min(50);
 
     if request.legacy_single {
-        let target_session_id = request
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_session_id(&request.session_ids)?;
         return wait_for_single_session_with_policies(
             target_session_id,
             current_session_id,
@@ -434,10 +462,7 @@ fn execute_session_status(
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_target_request(&payload)?;
     if request.legacy_single {
-        let target_session_id = request
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_session_id(&request.session_ids)?;
         let snapshot = inspect_visible_session_with_policies(
             target_session_id,
             current_session_id,
@@ -482,11 +507,7 @@ fn execute_session_recover(
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
     if request.use_legacy_single_response() {
-        let target_session_id = request
-            .target
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_session_id(&request.target.session_ids)?;
         let repo = SessionRepository::new(config)?;
         ensure_visible(
             &repo,
@@ -553,11 +574,7 @@ fn execute_session_cancel(
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
     if request.use_legacy_single_response() {
-        let target_session_id = request
-            .target
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_session_id(&request.target.session_ids)?;
         let repo = SessionRepository::new(config)?;
         ensure_visible(
             &repo,
@@ -624,11 +641,7 @@ fn execute_session_archive(
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
     if request.use_legacy_single_response() {
-        let target_session_id = request
-            .target
-            .session_ids
-            .first()
-            .expect("legacy single request requires one session id");
+        let target_session_id = legacy_single_session_id(&request.target.session_ids)?;
         let repo = SessionRepository::new(config)?;
         ensure_visible(
             &repo,
@@ -989,13 +1002,17 @@ async fn wait_for_session_batch_with_policies(
             &target_session_id,
             tool_config.sessions.visibility,
         ) {
-            results[index] = Some(session_batch_result(
-                target_session_id,
-                "skipped_not_visible",
-                Some(error),
-                None,
-                None,
-            ));
+            set_session_batch_result(
+                &mut results,
+                index,
+                session_batch_result(
+                    target_session_id,
+                    "skipped_not_visible",
+                    Some(error),
+                    None,
+                    None,
+                ),
+            )?;
             continue;
         }
         pending.push(SessionWaitTargetState {
@@ -1023,13 +1040,17 @@ async fn wait_for_session_batch_with_policies(
             ) {
                 Ok(observation) => observation,
                 Err(error) if is_session_visibility_skip_error(&error) => {
-                    results[target.index] = Some(session_batch_result(
-                        target.session_id,
-                        "skipped_not_visible",
-                        Some(error),
-                        None,
-                        None,
-                    ));
+                    set_session_batch_result(
+                        &mut results,
+                        target.index,
+                        session_batch_result(
+                            target.session_id,
+                            "skipped_not_visible",
+                            Some(error),
+                            None,
+                            None,
+                        ),
+                    )?;
                     continue;
                 }
                 Err(error) => return Err(error),
@@ -1041,24 +1062,28 @@ async fn wait_for_session_batch_with_policies(
             target.observed_events.extend(observation.tail_events);
             target.latest_inspection = Some(snapshot.clone());
             if session_state_is_terminal(snapshot.session.state) {
-                results[target.index] = Some(session_batch_result(
-                    target.session_id,
-                    "ok",
-                    None,
-                    None,
-                    Some(wait_payload(
-                        snapshot,
-                        "completed",
-                        after_id,
-                        timeout_ms,
-                        if after_id.is_some() {
-                            std::mem::take(&mut target.observed_events)
-                        } else {
-                            Vec::new()
-                        },
-                        target.next_after_id,
-                    )),
-                ));
+                set_session_batch_result(
+                    &mut results,
+                    target.index,
+                    session_batch_result(
+                        target.session_id,
+                        "ok",
+                        None,
+                        None,
+                        Some(wait_payload(
+                            snapshot,
+                            "completed",
+                            after_id,
+                            timeout_ms,
+                            if after_id.is_some() {
+                                std::mem::take(&mut target.observed_events)
+                            } else {
+                                Vec::new()
+                            },
+                            target.next_after_id,
+                        )),
+                    ),
+                )?;
                 continue;
             }
             next_pending.push(target);
@@ -1066,16 +1091,14 @@ async fn wait_for_session_batch_with_policies(
         pending = next_pending;
 
         if pending.is_empty() {
+            let results = collect_session_batch_results(results)?;
             return Ok(ToolCoreOutcome {
                 status: "ok".to_owned(),
                 payload: session_wait_batch_payload(
                     current_session_id,
                     after_id,
                     timeout_ms,
-                    results
-                        .into_iter()
-                        .map(|result| result.expect("batch wait result"))
-                        .collect::<Vec<_>>(),
+                    results,
                 ),
             });
         }
@@ -1083,40 +1106,44 @@ async fn wait_for_session_batch_with_policies(
         let elapsed_ms = started_at.elapsed().as_millis() as u64;
         if elapsed_ms >= timeout_ms {
             for mut target in pending.into_iter() {
-                let snapshot = target
-                    .latest_inspection
-                    .take()
-                    .expect("pending batch wait target inspection");
-                results[target.index] = Some(session_batch_result(
-                    target.session_id,
-                    "timeout",
-                    None,
-                    None,
-                    Some(wait_payload(
-                        snapshot,
+                let snapshot = target.latest_inspection.take().ok_or_else(|| {
+                    format!(
+                        "session_wait_internal_error: missing pending inspection for `{}`",
+                        target.session_id
+                    )
+                })?;
+                set_session_batch_result(
+                    &mut results,
+                    target.index,
+                    session_batch_result(
+                        target.session_id,
                         "timeout",
-                        after_id,
-                        timeout_ms,
-                        if after_id.is_some() {
-                            target.observed_events
-                        } else {
-                            Vec::new()
-                        },
-                        target.next_after_id,
-                    )),
-                ));
+                        None,
+                        None,
+                        Some(wait_payload(
+                            snapshot,
+                            "timeout",
+                            after_id,
+                            timeout_ms,
+                            if after_id.is_some() {
+                                target.observed_events
+                            } else {
+                                Vec::new()
+                            },
+                            target.next_after_id,
+                        )),
+                    ),
+                )?;
             }
 
+            let results = collect_session_batch_results(results)?;
             return Ok(ToolCoreOutcome {
                 status: "ok".to_owned(),
                 payload: session_wait_batch_payload(
                     current_session_id,
                     after_id,
                     timeout_ms,
-                    results
-                        .into_iter()
-                        .map(|result| result.expect("batch wait result"))
-                        .collect::<Vec<_>>(),
+                    results,
                 ),
             });
         }
@@ -1428,11 +1455,14 @@ fn apply_session_recover_plan(
     );
     let event_payload_json = match recover_plan.recovery_kind {
         RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED => {
+            let Some(queued_at) = recover_plan.queued_at else {
+                return Err(format!(
+                    "session_recover_not_recoverable: session `{target_session_id}` is missing queued timestamp"
+                ));
+            };
             build_queued_async_overdue_recovery_payload(
                 snapshot.session.label.as_deref(),
-                recover_plan
-                    .queued_at
-                    .expect("queued async overdue recovery requires queued_at"),
+                queued_at,
                 recover_plan.elapsed_seconds,
                 recover_plan.timeout_seconds,
                 recover_plan.deadline_at,
@@ -1451,7 +1481,11 @@ fn apply_session_recover_plan(
                 &recovery_error,
             )
         }
-        other => unreachable!("unsupported session recovery kind `{other}`"),
+        other => {
+            return Err(format!(
+                "session_recover_not_supported: unsupported recovery kind `{other}`"
+            ));
+        }
     };
     let finalized = repo.finalize_session_terminal_if_current(
         target_session_id,
@@ -1601,7 +1635,7 @@ fn session_recovery_error(plan: &SessionRecoverPlan) -> String {
             "delegate_async_running_overdue_marked_failed: running delegate child exceeded timeout after {}s (threshold {}s)",
             plan.elapsed_seconds, plan.timeout_seconds
         ),
-        other => unreachable!("unsupported session recovery kind `{other}`"),
+        other => format!("session_recover_unsupported_kind: unsupported session recovery kind `{other}`"),
     }
 }
 
@@ -2121,6 +2155,13 @@ fn parse_session_mutation_request(payload: &Value) -> Result<SessionMutationRequ
     })
 }
 
+#[cfg(feature = "memory-sqlite")]
+fn legacy_single_session_id(session_ids: &[String]) -> Result<&str, String> {
+    session_ids.first().map(String::as_str).ok_or_else(|| {
+        "session_tool_internal_error: legacy single request missing session id".to_owned()
+    })
+}
+
 fn optional_payload_limit(payload: &Value, field: &str, default: usize, max: usize) -> usize {
     payload
         .get(field)
@@ -2290,10 +2331,9 @@ fn session_batch_payload_with_optional_dry_run(
         "results": results.into_iter().map(session_batch_result_json).collect::<Vec<_>>(),
     });
     if let Some(dry_run) = dry_run {
-        payload
-            .as_object_mut()
-            .expect("session batch payload object")
-            .insert("dry_run".to_owned(), Value::Bool(dry_run));
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("dry_run".to_owned(), Value::Bool(dry_run));
+        }
     }
     payload
 }
@@ -2311,17 +2351,13 @@ fn session_wait_batch_payload(
         results.len(),
         results,
     );
-    payload
-        .as_object_mut()
-        .expect("session wait batch payload object")
-        .insert("timeout_ms".to_owned(), Value::from(timeout_ms));
-    payload
-        .as_object_mut()
-        .expect("session wait batch payload object")
-        .insert(
+    if let Some(object) = payload.as_object_mut() {
+        object.insert("timeout_ms".to_owned(), Value::from(timeout_ms));
+        object.insert(
             "after_id".to_owned(),
             after_id.map(Value::from).unwrap_or(Value::Null),
         );
+    }
     payload
 }
 
@@ -2469,15 +2505,14 @@ fn session_summary_json_with_delegate_lifecycle(
 ) -> Value {
     let mut payload = session_summary_json(session);
     if include_delegate_lifecycle {
-        payload
-            .as_object_mut()
-            .expect("session summary json object")
-            .insert(
+        if let Some(object) = payload.as_object_mut() {
+            object.insert(
                 "delegate_lifecycle".to_owned(),
                 delegate_lifecycle
                     .map(session_delegate_lifecycle_json)
                     .unwrap_or(Value::Null),
             );
+        }
     }
     payload
 }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -30,7 +30,7 @@ tokio.workspace = true
 chrono.workspace = true
 
 [[bin]]
-name = "loongclawd"
+name = "loongclaw"
 path = "src/main.rs"
 
 [dev-dependencies]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -34,8 +34,10 @@ name = "loongclawd"
 path = "src/main.rs"
 
 [dev-dependencies]
+async-trait.workspace = true
 base64.workspace = true
 ed25519-dalek.workspace = true
+loongclaw-contracts = { path = "../contracts" }
 sha2.workspace = true
 wat = "1"
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -38,7 +38,7 @@ const PUBLIC_GITHUB_REPO: &str = "loongclaw-ai/loongclaw";
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "loongclawd",
+    name = "loongclaw",
     about = "LoongClaw low-level runtime daemon",
     version
 )]
@@ -612,7 +612,7 @@ fn run_setup_cli(output: Option<&str>, force: bool) -> CliResult<()> {
     {
         println!("setup complete\n- config: {}", path.display());
     }
-    println!("next step: loongclawd chat --config {}", path.display());
+    println!("next step: loongclaw chat --config {}", path.display());
     Ok(())
 }
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -203,6 +203,19 @@ enum Commands {
         #[arg(long)]
         session: Option<String>,
     },
+    /// Execute exactly one conversation turn and exit
+    RunTurn {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long)]
+        session: String,
+        #[arg(long)]
+        input: String,
+        #[arg(long)]
+        timeout_seconds: Option<u64>,
+        #[arg(long, default_value_t = false)]
+        delegate_child: bool,
+    },
     /// Run Telegram channel polling/response loop
     TelegramServe {
         #[arg(long)]
@@ -237,6 +250,18 @@ enum ValidateConfigOutput {
     Text,
     Json,
     ProblemJson,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct RunTurnDelegateOutcome {
+    status: String,
+    payload: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum RunTurnResult {
+    Reply(String),
+    DelegateOutcome(RunTurnDelegateOutcome),
 }
 
 #[tokio::main]
@@ -352,6 +377,22 @@ async fn main() {
         Commands::ListModels { config, json } => run_list_models_cli(config.as_deref(), json).await,
         Commands::Chat { config, session } => {
             run_chat_cli(config.as_deref(), session.as_deref()).await
+        }
+        Commands::RunTurn {
+            config,
+            session,
+            input,
+            timeout_seconds,
+            delegate_child,
+        } => {
+            run_turn_cli(
+                config.as_deref(),
+                &session,
+                &input,
+                timeout_seconds,
+                delegate_child,
+            )
+            .await
         }
         Commands::TelegramServe { config, once } => {
             run_telegram_serve_cli(config.as_deref(), once).await
@@ -702,6 +743,92 @@ async fn run_list_models_cli(config_path: Option<&str>, as_json: bool) -> CliRes
 
 async fn run_chat_cli(config_path: Option<&str>, session: Option<&str>) -> CliResult<()> {
     mvp::chat::run_cli_chat(config_path, session).await
+}
+
+fn resolve_run_turn_config_path(config_path: Option<&str>) -> Option<String> {
+    config_path
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            std::env::var("LOONGCLAW_CONFIG_PATH")
+                .ok()
+                .map(|value| value.trim().to_owned())
+                .filter(|value| !value.is_empty())
+        })
+}
+
+async fn run_turn_cli(
+    config_path: Option<&str>,
+    session: &str,
+    input: &str,
+    timeout_seconds: Option<u64>,
+    delegate_child: bool,
+) -> CliResult<()> {
+    let result =
+        execute_run_turn(config_path, session, input, timeout_seconds, delegate_child).await?;
+
+    match result {
+        RunTurnResult::Reply(reply) => {
+            println!("{reply}");
+        }
+        RunTurnResult::DelegateOutcome(outcome) => {
+            let payload = json!({
+                "status": outcome.status,
+                "payload": outcome.payload,
+            });
+            let pretty = serde_json::to_string_pretty(&payload).map_err(|error| {
+                format!("serialize run-turn delegate-child output failed: {error}")
+            })?;
+            println!("{pretty}");
+        }
+    }
+    Ok(())
+}
+
+async fn execute_run_turn(
+    config_path: Option<&str>,
+    session: &str,
+    input: &str,
+    timeout_seconds: Option<u64>,
+    delegate_child: bool,
+) -> CliResult<RunTurnResult> {
+    let resolved_config_path = resolve_run_turn_config_path(config_path);
+    let (resolved_path, config) = mvp::config::load(resolved_config_path.as_deref())?;
+    mvp::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
+    let kernel_ctx = mvp::context::bootstrap_kernel_context_for_config(
+        "daemon-run-turn",
+        mvp::context::DEFAULT_TOKEN_TTL_S,
+        &config,
+    )?;
+
+    if delegate_child {
+        let timeout_seconds = timeout_seconds.unwrap_or(config.tools.delegate.timeout_seconds);
+        let outcome = mvp::conversation::run_delegate_child_turn(
+            &mvp::conversation::ConversationTurnLoop::new(),
+            &config,
+            session,
+            input,
+            timeout_seconds,
+            Some(&kernel_ctx),
+        )
+        .await?;
+        return Ok(RunTurnResult::DelegateOutcome(RunTurnDelegateOutcome {
+            status: outcome.status,
+            payload: outcome.payload,
+        }));
+    }
+
+    let reply = mvp::conversation::ConversationTurnLoop::new()
+        .handle_turn(
+            &config,
+            session,
+            input,
+            mvp::conversation::ProviderErrorMode::Propagate,
+            Some(&kernel_ctx),
+        )
+        .await?;
+    Ok(RunTurnResult::Reply(reply))
 }
 
 async fn run_telegram_serve_cli(config_path: Option<&str>, once: bool) -> CliResult<()> {

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -145,7 +145,7 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
     }
     #[cfg(feature = "memory-sqlite")]
     println!("- sqlite memory: {}", memory_path.display());
-    println!("next step: loongclawd chat --config {}", path.display());
+    println!("next step: loongclaw chat --config {}", path.display());
     Ok(())
 }
 

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::await_holding_lock, clippy::expect_used)]
+
 use super::*;
 use clap::Parser;
 use std::path::PathBuf;

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -153,7 +153,7 @@ fn resolve_validate_output_rejects_conflicting_json_and_output_flags() {
 #[test]
 fn run_turn_command_parses_delegate_child_and_timeout() {
     let cli = Cli::try_parse_from([
-        "loongclawd",
+        "loongclaw",
         "run-turn",
         "--config",
         "/tmp/worker.toml",

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -1,4 +1,92 @@
 use super::*;
+use clap::Parser;
+use std::path::PathBuf;
+
+fn run_turn_env_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+fn run_turn_test_dir(test_name: &str) -> PathBuf {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("loongclaw-run-turn-{test_name}-{unique}"));
+    fs::create_dir_all(&dir).expect("create run-turn test dir");
+    dir
+}
+
+fn spawn_openai_turn_server_once(reply_text: &str) -> (String, std::thread::JoinHandle<()>) {
+    spawn_openai_turn_server_once_with_delay(reply_text, std::time::Duration::ZERO)
+}
+
+fn spawn_openai_turn_server_once_with_delay(
+    reply_text: &str,
+    response_delay: std::time::Duration,
+) -> (String, std::thread::JoinHandle<()>) {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider stub");
+    let addr = listener.local_addr().expect("local provider addr");
+    let reply_text = reply_text.to_owned();
+    let server = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut request_buf = [0_u8; 8192];
+            let _ = stream.read(&mut request_buf);
+            if !response_delay.is_zero() {
+                std::thread::sleep(response_delay);
+            }
+            let body = serde_json::to_string(&json!({
+                "choices": [{
+                    "message": {
+                        "content": reply_text
+                    }
+                }]
+            }))
+            .expect("serialize provider stub body");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+    (format!("http://{addr}"), server)
+}
+
+fn write_run_turn_config(
+    test_name: &str,
+    base_url: &str,
+) -> (PathBuf, mvp::memory::runtime_config::MemoryRuntimeConfig) {
+    let dir = run_turn_test_dir(test_name);
+    let config_path = dir.join("loongclaw.toml");
+    let db_path = dir.join("memory.sqlite3");
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.model = "stub-model".to_owned();
+    config.provider.base_url = base_url.to_owned();
+    config.provider.endpoint = Some(format!("{base_url}/v1/chat/completions"));
+    config.provider.models_endpoint = Some(format!("{base_url}/v1/models"));
+    config.provider.api_key = Some("test-api-key".to_owned());
+    config.provider.api_key_env = None;
+    config.provider.retry_max_attempts = 1;
+    config.memory.sqlite_path = db_path.display().to_string();
+
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write run-turn config");
+
+    (
+        config_path,
+        mvp::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+        },
+    )
+}
 
 fn approval_test_operation(tool_name: &str, payload: Value) -> OperationSpec {
     OperationSpec::ToolCore {
@@ -58,4 +146,423 @@ fn resolve_validate_output_rejects_conflicting_json_and_output_flags() {
     let error = resolve_validate_output(true, Some(ValidateConfigOutput::Json))
         .expect_err("conflicting flags should fail");
     assert!(error.contains("conflicts"));
+}
+
+#[test]
+fn run_turn_command_parses_delegate_child_and_timeout() {
+    let cli = Cli::try_parse_from([
+        "loongclawd",
+        "run-turn",
+        "--config",
+        "/tmp/worker.toml",
+        "--session",
+        "delegate:child-1",
+        "--input",
+        "child task",
+        "--timeout-seconds",
+        "17",
+        "--delegate-child",
+    ])
+    .expect("parse run-turn command");
+
+    match cli.command.expect("command") {
+        Commands::RunTurn {
+            config,
+            session,
+            input,
+            timeout_seconds,
+            delegate_child,
+        } => {
+            assert_eq!(config.as_deref(), Some("/tmp/worker.toml"));
+            assert_eq!(session, "delegate:child-1");
+            assert_eq!(input, "child task");
+            assert_eq!(timeout_seconds, Some(17));
+            assert!(delegate_child);
+        }
+        other => panic!("unexpected command: {other:?}"),
+    }
+}
+
+#[test]
+fn resolve_run_turn_config_path_prefers_explicit_arg_over_env() {
+    let _guard = run_turn_env_lock().lock().expect("env lock");
+    std::env::set_var("LOONGCLAW_CONFIG_PATH", "/tmp/from-env.toml");
+
+    let resolved = resolve_run_turn_config_path(Some("/tmp/from-arg.toml"));
+
+    assert_eq!(resolved.as_deref(), Some("/tmp/from-arg.toml"));
+    std::env::remove_var("LOONGCLAW_CONFIG_PATH");
+}
+
+#[test]
+fn resolve_run_turn_config_path_uses_env_when_arg_missing() {
+    let _guard = run_turn_env_lock().lock().expect("env lock");
+    std::env::set_var("LOONGCLAW_CONFIG_PATH", "/tmp/from-env.toml");
+
+    let resolved = resolve_run_turn_config_path(None);
+
+    assert_eq!(resolved.as_deref(), Some("/tmp/from-env.toml"));
+    std::env::remove_var("LOONGCLAW_CONFIG_PATH");
+}
+
+#[tokio::test]
+async fn execute_run_turn_returns_root_reply_and_persists_turns() {
+    let _guard = run_turn_env_lock().lock().expect("env lock");
+    let (base_url, server) = spawn_openai_turn_server_once("Root daemon reply");
+    let (config_path, memory_config) = write_run_turn_config("root", &base_url);
+
+    let result = execute_run_turn(
+        Some(config_path.to_string_lossy().as_ref()),
+        "root-session",
+        "hello from root",
+        None,
+        false,
+    )
+    .await
+    .expect("execute run-turn root");
+
+    server.join().expect("join provider stub");
+
+    match result {
+        RunTurnResult::Reply(reply) => assert_eq!(reply, "Root daemon reply"),
+        other => panic!("unexpected run-turn result: {other:?}"),
+    }
+
+    let turns = mvp::memory::window_direct("root-session", 10, &memory_config)
+        .expect("load root session turns");
+    assert_eq!(turns.len(), 2);
+    assert_eq!(turns[0].role, "user");
+    assert_eq!(turns[0].content, "hello from root");
+    assert_eq!(turns[1].role, "assistant");
+    assert_eq!(turns[1].content, "Root daemon reply");
+
+    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    let root = repo
+        .load_session("root-session")
+        .expect("load root session")
+        .expect("root session row");
+    assert_eq!(root.kind, mvp::session::repository::SessionKind::Root);
+}
+
+#[tokio::test]
+async fn execute_run_turn_uses_current_memory_runtime_for_each_config() {
+    let _guard = run_turn_env_lock().lock().expect("env lock");
+    let (base_url_a, server_a) = spawn_openai_turn_server_once("First config reply");
+    let (config_path_a, memory_config_a) = write_run_turn_config("root-config-a", &base_url_a);
+
+    let result_a = execute_run_turn(
+        Some(config_path_a.to_string_lossy().as_ref()),
+        "root-session-a",
+        "hello from config a",
+        None,
+        false,
+    )
+    .await
+    .expect("execute run-turn root config a");
+
+    server_a.join().expect("join provider stub a");
+
+    match result_a {
+        RunTurnResult::Reply(reply) => assert_eq!(reply, "First config reply"),
+        other => panic!("unexpected first run-turn result: {other:?}"),
+    }
+
+    let (base_url_b, server_b) = spawn_openai_turn_server_once("Second config reply");
+    let (config_path_b, memory_config_b) = write_run_turn_config("root-config-b", &base_url_b);
+
+    let result_b = execute_run_turn(
+        Some(config_path_b.to_string_lossy().as_ref()),
+        "root-session-b",
+        "hello from config b",
+        None,
+        false,
+    )
+    .await
+    .expect("execute run-turn root config b");
+
+    server_b.join().expect("join provider stub b");
+
+    match result_b {
+        RunTurnResult::Reply(reply) => assert_eq!(reply, "Second config reply"),
+        other => panic!("unexpected second run-turn result: {other:?}"),
+    }
+
+    let turns_a = mvp::memory::window_direct("root-session-a", 10, &memory_config_a)
+        .expect("load root session turns for config a");
+    assert_eq!(turns_a.len(), 2);
+    assert_eq!(turns_a[0].content, "hello from config a");
+    assert_eq!(turns_a[1].content, "First config reply");
+
+    let turns_b = mvp::memory::window_direct("root-session-b", 10, &memory_config_b)
+        .expect("load root session turns for config b");
+    assert_eq!(turns_b.len(), 2);
+    assert_eq!(turns_b[0].content, "hello from config b");
+    assert_eq!(turns_b[1].content, "Second config reply");
+}
+
+#[tokio::test]
+async fn execute_run_turn_completes_delegate_child_session() {
+    let _guard = run_turn_env_lock().lock().expect("env lock");
+    let (base_url, server) = spawn_openai_turn_server_once("Child daemon reply");
+    let (config_path, memory_config) = write_run_turn_config("delegate-child", &base_url);
+    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("async-child".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let result = execute_run_turn(
+        Some(config_path.to_string_lossy().as_ref()),
+        "child-session",
+        "child task",
+        Some(5),
+        true,
+    )
+    .await
+    .expect("execute run-turn delegate child");
+
+    server.join().expect("join provider stub");
+
+    match result {
+        RunTurnResult::DelegateOutcome(outcome) => {
+            assert_eq!(outcome.status, "ok");
+            assert_eq!(outcome.payload["child_session_id"], "child-session");
+            assert_eq!(outcome.payload["final_output"], "Child daemon reply");
+        }
+        other => panic!("unexpected run-turn result: {other:?}"),
+    }
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        mvp::session::repository::SessionState::Completed
+    );
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_completed"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "ok");
+    assert_eq!(
+        terminal_outcome.payload_json["final_output"],
+        "Child daemon reply"
+    );
+}
+
+#[tokio::test]
+async fn execute_run_turn_fails_delegate_child_session_on_provider_error() {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let _guard = run_turn_env_lock().lock().expect("env lock");
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider stub");
+    let addr = listener.local_addr().expect("local provider addr");
+    let server = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut request_buf = [0_u8; 8192];
+            let _ = stream.read(&mut request_buf);
+            let body = serde_json::to_string(&json!({
+                "error": {
+                    "message": "stub failure"
+                }
+            }))
+            .expect("serialize provider stub error body");
+            let response = format!(
+                "HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+
+    let (config_path, memory_config) =
+        write_run_turn_config("delegate-child-failure", &format!("http://{addr}"));
+    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("async-child".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let result = execute_run_turn(
+        Some(config_path.to_string_lossy().as_ref()),
+        "child-session",
+        "failing child task",
+        Some(5),
+        true,
+    )
+    .await
+    .expect("execute run-turn delegate child failure");
+
+    server.join().expect("join provider stub");
+
+    match result {
+        RunTurnResult::DelegateOutcome(outcome) => {
+            assert_eq!(outcome.status, "error");
+            assert_eq!(outcome.payload["child_session_id"], "child-session");
+            let error = outcome.payload["error"]
+                .as_str()
+                .expect("delegate failure error string");
+            assert!(
+                error.contains("provider returned status 500"),
+                "error: {error}"
+            );
+        }
+        other => panic!("unexpected run-turn result: {other:?}"),
+    }
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(child.state, mvp::session::repository::SessionState::Failed);
+    assert!(
+        child
+            .last_error
+            .as_deref()
+            .expect("child last_error")
+            .contains("provider returned status 500"),
+        "last_error: {:?}",
+        child.last_error
+    );
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_failed"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "error");
+    assert!(
+        terminal_outcome.payload_json["error"]
+            .as_str()
+            .expect("terminal outcome error")
+            .contains("provider returned status 500"),
+        "terminal_error: {}",
+        terminal_outcome.payload_json["error"]
+    );
+}
+
+#[tokio::test]
+async fn execute_run_turn_times_out_delegate_child_session() {
+    let _guard = run_turn_env_lock().lock().expect("env lock");
+    let (base_url, server) = spawn_openai_turn_server_once_with_delay(
+        "Too slow",
+        std::time::Duration::from_millis(1_200),
+    );
+    let (config_path, memory_config) = write_run_turn_config("delegate-child-timeout", &base_url);
+    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("async-child".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let result = execute_run_turn(
+        Some(config_path.to_string_lossy().as_ref()),
+        "child-session",
+        "slow child task",
+        Some(1),
+        true,
+    )
+    .await
+    .expect("execute run-turn delegate child timeout");
+
+    server.join().expect("join provider stub");
+
+    match result {
+        RunTurnResult::DelegateOutcome(outcome) => {
+            assert_eq!(outcome.status, "timeout");
+            assert_eq!(outcome.payload["child_session_id"], "child-session");
+            assert_eq!(outcome.payload["error"], "delegate_timeout");
+        }
+        other => panic!("unexpected run-turn result: {other:?}"),
+    }
+
+    let child = repo
+        .load_session("child-session")
+        .expect("load child session")
+        .expect("child session row");
+    assert_eq!(
+        child.state,
+        mvp::session::repository::SessionState::TimedOut
+    );
+    assert_eq!(child.last_error.as_deref(), Some("delegate_timeout"));
+
+    let events = repo
+        .list_recent_events("child-session", 10)
+        .expect("list child events");
+    let event_kinds: Vec<&str> = events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect();
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_timed_out"));
+
+    let terminal_outcome = repo
+        .load_terminal_outcome("child-session")
+        .expect("load terminal outcome")
+        .expect("terminal outcome row");
+    assert_eq!(terminal_outcome.status, "timeout");
+    assert_eq!(terminal_outcome.payload_json["error"], "delegate_timeout");
 }

--- a/crates/daemon/tests/delegate_async_observability.rs
+++ b/crates/daemon/tests/delegate_async_observability.rs
@@ -1,3 +1,9 @@
+#![allow(
+    clippy::await_holding_lock,
+    clippy::expect_used,
+    clippy::indexing_slicing
+)]
+
 use async_trait::async_trait;
 use loongclaw_app as mvp;
 use loongclaw_contracts::ToolCoreRequest;
@@ -304,7 +310,7 @@ impl AsyncDelegateSpawner for GatedAsyncDelegateSpawner {
             .ok_or_else(|| "gated async delegate spawn request already captured".to_owned())?;
         request_tx
             .send(request.clone())
-            .map_err(|_| "gated async delegate spawn receiver dropped".to_owned())?;
+            .map_err(|_send_error| "gated async delegate spawn receiver dropped".to_owned())?;
         self.launch_notify.notified().await;
         self.inner.spawn(request).await
     }

--- a/crates/daemon/tests/delegate_async_observability.rs
+++ b/crates/daemon/tests/delegate_async_observability.rs
@@ -215,7 +215,7 @@ fn write_delegate_async_config(
 }
 
 fn resolve_daemon_binary_path() -> PathBuf {
-    if let Ok(path) = std::env::var("CARGO_BIN_EXE_loongclawd") {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_loongclaw") {
         let resolved = PathBuf::from(path);
         if resolved.is_file() {
             return resolved;
@@ -227,7 +227,7 @@ fn resolve_daemon_binary_path() -> PathBuf {
         .parent()
         .and_then(|path| path.parent())
         .expect("integration test executable should live under target/debug/deps");
-    let fallback = target_debug_dir.join("loongclawd");
+    let fallback = target_debug_dir.join("loongclaw");
     assert!(
         fallback.is_file(),
         "daemon binary not found via env or fallback path: {}",

--- a/crates/daemon/tests/delegate_async_observability.rs
+++ b/crates/daemon/tests/delegate_async_observability.rs
@@ -1,0 +1,1476 @@
+use async_trait::async_trait;
+use loongclaw_app as mvp;
+use loongclaw_contracts::ToolCoreRequest;
+use serde_json::{json, Value};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::{oneshot, Notify};
+
+use mvp::conversation::turn_engine::{AsyncDelegateSpawnRequest, AsyncDelegateSpawner};
+use mvp::conversation::{AppToolDispatcher, DefaultAppToolDispatcher, SessionContext};
+
+fn integration_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn integration_test_dir(test_name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("loongclaw-daemon-integ-{test_name}-{unique}"));
+    fs::create_dir_all(&dir).expect("create integration test dir");
+    dir
+}
+
+fn spawn_openai_turn_server_once_with_delay(
+    reply_text: &str,
+    response_delay: Duration,
+) -> (String, std::thread::JoinHandle<()>) {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider stub");
+    let addr = listener.local_addr().expect("local provider addr");
+    let reply_text = reply_text.to_owned();
+    let server = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut request_buf = [0_u8; 8192];
+            let _ = stream.read(&mut request_buf);
+            if !response_delay.is_zero() {
+                std::thread::sleep(response_delay);
+            }
+            let body = serde_json::to_string(&json!({
+                "choices": [{
+                    "message": {
+                        "content": reply_text
+                    }
+                }]
+            }))
+            .expect("serialize provider stub body");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+    (format!("http://{addr}"), server)
+}
+
+fn spawn_openai_turn_server_once_with_response_gate(
+    reply_text: &str,
+) -> (
+    String,
+    oneshot::Receiver<()>,
+    oneshot::Sender<()>,
+    std::thread::JoinHandle<()>,
+) {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider stub");
+    let addr = listener.local_addr().expect("local provider addr");
+    let reply_text = reply_text.to_owned();
+    let (request_seen_tx, request_seen_rx) = oneshot::channel();
+    let (release_response_tx, release_response_rx) = oneshot::channel();
+    let server = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut request_buf = [0_u8; 8192];
+            let _ = stream.read(&mut request_buf);
+            let _ = request_seen_tx.send(());
+            release_response_rx
+                .blocking_recv()
+                .expect("release provider stub response");
+            let body = serde_json::to_string(&json!({
+                "choices": [{
+                    "message": {
+                        "content": reply_text
+                    }
+                }]
+            }))
+            .expect("serialize provider stub body");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+    (
+        format!("http://{addr}"),
+        request_seen_rx,
+        release_response_tx,
+        server,
+    )
+}
+
+fn spawn_openai_error_server_once(
+    status_code: u16,
+    body: Value,
+) -> (String, std::thread::JoinHandle<()>) {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider stub");
+    let addr = listener.local_addr().expect("local provider addr");
+    let server = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut request_buf = [0_u8; 8192];
+            let _ = stream.read(&mut request_buf);
+            let body = serde_json::to_string(&body).expect("serialize provider stub error body");
+            let response = format!(
+                "HTTP/1.1 {status_code} Stub Error\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+    (format!("http://{addr}"), server)
+}
+
+fn spawn_openai_error_server_once_with_response_gate(
+    status_code: u16,
+    body: Value,
+) -> (
+    String,
+    oneshot::Receiver<()>,
+    oneshot::Sender<()>,
+    std::thread::JoinHandle<()>,
+) {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider stub");
+    let addr = listener.local_addr().expect("local provider addr");
+    let (request_seen_tx, request_seen_rx) = oneshot::channel();
+    let (release_response_tx, release_response_rx) = oneshot::channel();
+    let server = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut request_buf = [0_u8; 8192];
+            let _ = stream.read(&mut request_buf);
+            let _ = request_seen_tx.send(());
+            release_response_rx
+                .blocking_recv()
+                .expect("release provider stub error response");
+            let body = serde_json::to_string(&body).expect("serialize provider stub error body");
+            let response = format!(
+                "HTTP/1.1 {status_code} Stub Error\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+    (
+        format!("http://{addr}"),
+        request_seen_rx,
+        release_response_tx,
+        server,
+    )
+}
+
+fn write_delegate_async_config(
+    test_name: &str,
+    base_url: &str,
+) -> (
+    PathBuf,
+    mvp::config::LoongClawConfig,
+    mvp::memory::runtime_config::MemoryRuntimeConfig,
+) {
+    let dir = integration_test_dir(test_name);
+    let config_path = dir.join("loongclaw.toml");
+    let db_path = dir.join("memory.sqlite3");
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.model = "stub-model".to_owned();
+    config.provider.base_url = base_url.to_owned();
+    config.provider.endpoint = Some(format!("{base_url}/v1/chat/completions"));
+    config.provider.models_endpoint = Some(format!("{base_url}/v1/models"));
+    config.provider.api_key = Some("test-api-key".to_owned());
+    config.provider.api_key_env = None;
+    config.provider.retry_max_attempts = 1;
+    config.memory.sqlite_path = db_path.display().to_string();
+
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write integration config");
+
+    let memory_config = mvp::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+    };
+    (config_path, config, memory_config)
+}
+
+fn resolve_daemon_binary_path() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_loongclawd") {
+        let resolved = PathBuf::from(path);
+        if resolved.is_file() {
+            return resolved;
+        }
+    }
+
+    let current_exe = std::env::current_exe().expect("resolve current integration test executable");
+    let target_debug_dir = current_exe
+        .parent()
+        .and_then(|path| path.parent())
+        .expect("integration test executable should live under target/debug/deps");
+    let fallback = target_debug_dir.join("loongclawd");
+    assert!(
+        fallback.is_file(),
+        "daemon binary not found via env or fallback path: {}",
+        fallback.display()
+    );
+    fallback
+}
+
+#[derive(Debug, Clone)]
+struct BinaryAsyncDelegateSpawner {
+    daemon_bin: PathBuf,
+    config_path: PathBuf,
+}
+
+#[async_trait]
+impl AsyncDelegateSpawner for BinaryAsyncDelegateSpawner {
+    async fn spawn(&self, request: AsyncDelegateSpawnRequest) -> Result<(), String> {
+        let mut command = tokio::process::Command::new(&self.daemon_bin);
+        command.args([
+            "run-turn",
+            "--config",
+            self.config_path
+                .to_str()
+                .ok_or_else(|| "non-utf8 config path".to_owned())?,
+            "--session",
+            &request.child_session_id,
+            "--input",
+            &request.task,
+            "--timeout-seconds",
+            &request.timeout_seconds.to_string(),
+            "--delegate-child",
+        ]);
+        command.stdin(Stdio::null());
+        command.stdout(Stdio::null());
+        command.stderr(Stdio::null());
+        let child = command
+            .spawn()
+            .map_err(|error| format!("spawn daemon delegate subprocess failed: {error}"))?;
+        drop(child);
+        Ok(())
+    }
+}
+
+struct GatedAsyncDelegateSpawner {
+    inner: BinaryAsyncDelegateSpawner,
+    request_tx: Mutex<Option<oneshot::Sender<AsyncDelegateSpawnRequest>>>,
+    launch_notify: Arc<Notify>,
+}
+
+impl GatedAsyncDelegateSpawner {
+    fn new(
+        inner: BinaryAsyncDelegateSpawner,
+    ) -> (
+        Self,
+        oneshot::Receiver<AsyncDelegateSpawnRequest>,
+        Arc<Notify>,
+    ) {
+        let (request_tx, request_rx) = oneshot::channel();
+        let launch_notify = Arc::new(Notify::new());
+        (
+            Self {
+                inner,
+                request_tx: Mutex::new(Some(request_tx)),
+                launch_notify: launch_notify.clone(),
+            },
+            request_rx,
+            launch_notify,
+        )
+    }
+}
+
+#[async_trait]
+impl AsyncDelegateSpawner for GatedAsyncDelegateSpawner {
+    async fn spawn(&self, request: AsyncDelegateSpawnRequest) -> Result<(), String> {
+        let request_tx = self
+            .request_tx
+            .lock()
+            .expect("gated request sender lock")
+            .take()
+            .ok_or_else(|| "gated async delegate spawn request already captured".to_owned())?;
+        request_tx
+            .send(request.clone())
+            .map_err(|_| "gated async delegate spawn receiver dropped".to_owned())?;
+        self.launch_notify.notified().await;
+        self.inner.spawn(request).await
+    }
+}
+
+async fn execute_root_tool(
+    dispatcher: &DefaultAppToolDispatcher,
+    session_context: &SessionContext,
+    tool_name: &str,
+    payload: Value,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+    dispatcher
+        .execute_app_tool(
+            session_context,
+            ToolCoreRequest {
+                tool_name: tool_name.to_owned(),
+                payload,
+            },
+            None,
+        )
+        .await
+}
+
+async fn wait_for_session_event(
+    dispatcher: &DefaultAppToolDispatcher,
+    session_context: &SessionContext,
+    child_session_id: &str,
+    expected_event_kind: &str,
+    timeout: Duration,
+) -> loongclaw_contracts::ToolCoreOutcome {
+    let started = tokio::time::Instant::now();
+    loop {
+        let outcome = execute_root_tool(
+            dispatcher,
+            session_context,
+            "session_events",
+            json!({
+                "session_id": child_session_id,
+                "limit": 10
+            }),
+        )
+        .await
+        .expect("session_events outcome");
+        let found = outcome.payload["events"]
+            .as_array()
+            .expect("events array")
+            .iter()
+            .any(|event| event["event_kind"] == expected_event_kind);
+        if found {
+            return outcome;
+        }
+        assert!(
+            started.elapsed() < timeout,
+            "timed out waiting for event `{expected_event_kind}` for child session `{child_session_id}`"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn assert_queued_tail_and_get_after_id(
+    dispatcher: &DefaultAppToolDispatcher,
+    session_context: &SessionContext,
+    child_session_id: &str,
+) -> i64 {
+    let queued_tail = execute_root_tool(
+        dispatcher,
+        session_context,
+        "session_events",
+        json!({
+            "session_id": child_session_id,
+            "after_id": 0,
+            "limit": 10
+        }),
+    )
+    .await
+    .expect("queued tail session_events outcome");
+    assert_eq!(queued_tail.status, "ok");
+    assert_eq!(
+        queued_tail.payload["after_id"]
+            .as_i64()
+            .expect("queued after_id"),
+        0
+    );
+    let queued_events = queued_tail.payload["events"]
+        .as_array()
+        .expect("queued events array");
+    assert_eq!(queued_events.len(), 1);
+    assert_eq!(queued_events[0]["event_kind"], "delegate_queued");
+    let queued_after_id = queued_events[0]
+        .as_object()
+        .and_then(|_| queued_events[0]["id"].as_i64())
+        .expect("queued event id");
+    assert_eq!(
+        queued_tail.payload["next_after_id"]
+            .as_i64()
+            .expect("queued next_after_id"),
+        queued_after_id
+    );
+    queued_after_id
+}
+
+async fn assert_empty_tail(
+    dispatcher: &DefaultAppToolDispatcher,
+    session_context: &SessionContext,
+    child_session_id: &str,
+    after_id: i64,
+) {
+    let empty_tail = execute_root_tool(
+        dispatcher,
+        session_context,
+        "session_events",
+        json!({
+            "session_id": child_session_id,
+            "after_id": after_id,
+            "limit": 10
+        }),
+    )
+    .await
+    .expect("empty tail session_events outcome");
+    assert_eq!(empty_tail.status, "ok");
+    assert!(empty_tail.payload["events"]
+        .as_array()
+        .expect("empty events array")
+        .is_empty());
+    assert_eq!(
+        empty_tail.payload["next_after_id"]
+            .as_i64()
+            .expect("empty next_after_id"),
+        after_id
+    );
+}
+
+async fn assert_incremental_tail_contains_only(
+    dispatcher: &DefaultAppToolDispatcher,
+    session_context: &SessionContext,
+    child_session_id: &str,
+    after_id: i64,
+    expected_event_kind: &str,
+) -> i64 {
+    let tail = execute_root_tool(
+        dispatcher,
+        session_context,
+        "session_events",
+        json!({
+            "session_id": child_session_id,
+            "after_id": after_id,
+            "limit": 10
+        }),
+    )
+    .await
+    .expect("incremental tail session_events outcome");
+    assert_eq!(tail.status, "ok");
+    assert_eq!(
+        tail.payload["after_id"]
+            .as_i64()
+            .expect("incremental after_id"),
+        after_id
+    );
+    let events = tail.payload["events"]
+        .as_array()
+        .expect("incremental events array");
+    assert!(!events.is_empty());
+    assert!(events
+        .iter()
+        .all(|event| event["id"].as_i64().expect("incremental event id") > after_id));
+    assert!(events
+        .iter()
+        .all(|event| event["event_kind"] == expected_event_kind));
+    let next_after_id = tail.payload["next_after_id"]
+        .as_i64()
+        .expect("incremental next_after_id");
+    assert!(next_after_id > after_id);
+    next_after_id
+}
+
+#[tokio::test]
+async fn delegate_async_real_subprocess_is_observable_via_session_tools() {
+    let _guard = integration_env_lock().lock().expect("env lock");
+    let (base_url, server) = spawn_openai_turn_server_once_with_delay(
+        "Async child final output",
+        Duration::from_millis(400),
+    );
+    let (config_path, config, memory_config) =
+        write_delegate_async_config("delegate-async-observability", &base_url);
+    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let daemon_bin = resolve_daemon_binary_path();
+    let spawner = std::sync::Arc::new(BinaryAsyncDelegateSpawner {
+        daemon_bin,
+        config_path: config_path.clone(),
+    });
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        memory_config.clone(),
+        config.tools.clone(),
+        spawner,
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        mvp::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let queued = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "delegate_async",
+        json!({
+            "task": "child task",
+            "label": "async-child",
+            "timeout_seconds": 5
+        }),
+    )
+    .await
+    .expect("delegate_async queued outcome");
+
+    assert_eq!(queued.status, "ok");
+    assert_eq!(queued.payload["mode"], "async");
+    assert_eq!(queued.payload["state"], "queued");
+    let child_session_id = queued.payload["child_session_id"]
+        .as_str()
+        .expect("child session id")
+        .to_owned();
+
+    let initial_status = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_status",
+        json!({
+            "session_id": child_session_id
+        }),
+    )
+    .await
+    .expect("initial session_status outcome");
+    assert_eq!(initial_status.status, "ok");
+    assert_eq!(
+        initial_status.payload["session"]["session_id"],
+        child_session_id
+    );
+    assert!(matches!(
+        initial_status.payload["session"]["state"].as_str(),
+        Some("ready") | Some("running") | Some("completed")
+    ));
+
+    let started_events = wait_for_session_event(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        "delegate_started",
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(started_events.status, "ok");
+
+    let running_status = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_status",
+        json!({
+            "session_id": child_session_id
+        }),
+    )
+    .await
+    .expect("running session_status outcome");
+    assert_eq!(running_status.status, "ok");
+    assert_eq!(
+        running_status.payload["session"]["session_id"],
+        child_session_id
+    );
+    assert!(matches!(
+        running_status.payload["session"]["state"].as_str(),
+        Some("running") | Some("completed")
+    ));
+    assert!(running_status.payload["recent_events"]
+        .as_array()
+        .expect("recent_events array")
+        .iter()
+        .any(|event| event["event_kind"] == "delegate_started"));
+
+    let waited = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_wait",
+        json!({
+            "session_id": child_session_id,
+            "timeout_ms": 5_000
+        }),
+    )
+    .await
+    .expect("session_wait outcome");
+    assert_eq!(waited.status, "ok");
+    assert_eq!(waited.payload["wait_status"], "completed");
+    assert_eq!(waited.payload["session"]["state"], "completed");
+    assert_eq!(waited.payload["terminal_outcome"]["status"], "ok");
+    assert_eq!(
+        waited.payload["terminal_outcome"]["payload"]["final_output"],
+        "Async child final output"
+    );
+
+    let final_events = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_events",
+        json!({
+            "session_id": child_session_id,
+            "limit": 10
+        }),
+    )
+    .await
+    .expect("final session_events outcome");
+    assert_eq!(final_events.status, "ok");
+    let event_kinds: Vec<&str> = final_events.payload["events"]
+        .as_array()
+        .expect("events array")
+        .iter()
+        .map(|event| event["event_kind"].as_str().expect("event kind"))
+        .collect();
+    assert!(event_kinds.contains(&"delegate_queued"));
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_completed"));
+
+    server.join().expect("join provider stub");
+}
+
+#[tokio::test]
+async fn delegate_async_real_subprocess_session_events_after_id_is_incremental() {
+    let _guard = integration_env_lock().lock().expect("env lock");
+    let (base_url, provider_request_rx, release_response_tx, server) =
+        spawn_openai_turn_server_once_with_response_gate("Async child tail output");
+    let (config_path, config, memory_config) =
+        write_delegate_async_config("delegate-async-observability-tail", &base_url);
+    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let daemon_bin = resolve_daemon_binary_path();
+    let (spawner, request_rx, launch_notify) =
+        GatedAsyncDelegateSpawner::new(BinaryAsyncDelegateSpawner {
+            daemon_bin,
+            config_path: config_path.clone(),
+        });
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        memory_config.clone(),
+        config.tools.clone(),
+        Arc::new(spawner),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        mvp::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let queued_dispatcher = dispatcher.clone();
+    let queued_session_context = session_context.clone();
+    let queued_call = tokio::spawn(async move {
+        execute_root_tool(
+            &queued_dispatcher,
+            &queued_session_context,
+            "delegate_async",
+            json!({
+                "task": "child task tail",
+                "label": "async-child-tail",
+                "timeout_seconds": 5
+            }),
+        )
+        .await
+    });
+
+    let queued = tokio::time::timeout(Duration::from_millis(250), queued_call)
+        .await
+        .expect("delegate_async should return queued handle before child launch")
+        .expect("join delegate_async queued task")
+        .expect("delegate_async queued outcome");
+    assert_eq!(queued.status, "ok");
+    assert_eq!(queued.payload["mode"], "async");
+    assert_eq!(queued.payload["state"], "queued");
+
+    let spawn_request = tokio::time::timeout(Duration::from_secs(5), request_rx)
+        .await
+        .expect("timed out waiting for gated spawn request")
+        .expect("gated spawn request");
+    let child_session_id = spawn_request.child_session_id.clone();
+    assert_eq!(spawn_request.parent_session_id, "root-session");
+    assert_eq!(spawn_request.task, "child task tail");
+    assert_eq!(spawn_request.label.as_deref(), Some("async-child-tail"));
+    assert_eq!(spawn_request.timeout_seconds, 5);
+    assert_eq!(queued.payload["child_session_id"], child_session_id);
+
+    let queued_after_id =
+        assert_queued_tail_and_get_after_id(&dispatcher, &session_context, &child_session_id).await;
+    assert_empty_tail(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        queued_after_id,
+    )
+    .await;
+
+    launch_notify.notify_one();
+
+    tokio::time::timeout(Duration::from_secs(5), provider_request_rx)
+        .await
+        .expect("timed out waiting for provider request")
+        .expect("provider request signal");
+
+    let started_after_id = assert_incremental_tail_contains_only(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        queued_after_id,
+        "delegate_started",
+    )
+    .await;
+
+    release_response_tx
+        .send(())
+        .expect("release provider response");
+
+    let waited = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_wait",
+        json!({
+            "session_id": child_session_id,
+            "timeout_ms": 5_000
+        }),
+    )
+    .await
+    .expect("tail session_wait outcome");
+    assert_eq!(waited.status, "ok");
+    assert_eq!(waited.payload["wait_status"], "completed");
+    assert_eq!(waited.payload["session"]["state"], "completed");
+    assert_eq!(
+        waited.payload["terminal_outcome"]["payload"]["final_output"],
+        "Async child tail output"
+    );
+
+    let completed_after_id = assert_incremental_tail_contains_only(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        started_after_id,
+        "delegate_completed",
+    )
+    .await;
+
+    assert_empty_tail(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        completed_after_id,
+    )
+    .await;
+
+    server.join().expect("join provider stub");
+}
+
+#[tokio::test]
+async fn delegate_async_real_subprocess_session_wait_returns_incremental_events_after_id() {
+    let _guard = integration_env_lock().lock().expect("env lock");
+    let (base_url, provider_request_rx, release_response_tx, server) =
+        spawn_openai_turn_server_once_with_response_gate("Async child wait tail output");
+    let (config_path, config, memory_config) =
+        write_delegate_async_config("delegate-async-observability-wait-tail", &base_url);
+    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let daemon_bin = resolve_daemon_binary_path();
+    let (spawner, request_rx, launch_notify) =
+        GatedAsyncDelegateSpawner::new(BinaryAsyncDelegateSpawner {
+            daemon_bin,
+            config_path: config_path.clone(),
+        });
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        memory_config.clone(),
+        config.tools.clone(),
+        Arc::new(spawner),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        mvp::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let queued_dispatcher = dispatcher.clone();
+    let queued_session_context = session_context.clone();
+    let queued_call = tokio::spawn(async move {
+        execute_root_tool(
+            &queued_dispatcher,
+            &queued_session_context,
+            "delegate_async",
+            json!({
+                "task": "child task wait tail",
+                "label": "async-child-wait-tail",
+                "timeout_seconds": 5
+            }),
+        )
+        .await
+    });
+
+    let queued = tokio::time::timeout(Duration::from_millis(250), queued_call)
+        .await
+        .expect("delegate_async should return queued handle before child launch")
+        .expect("join delegate_async queued task")
+        .expect("delegate_async queued outcome");
+    assert_eq!(queued.status, "ok");
+    assert_eq!(queued.payload["mode"], "async");
+    assert_eq!(queued.payload["state"], "queued");
+
+    let spawn_request = tokio::time::timeout(Duration::from_secs(5), request_rx)
+        .await
+        .expect("timed out waiting for gated spawn request")
+        .expect("gated spawn request");
+    let child_session_id = spawn_request.child_session_id.clone();
+    assert_eq!(spawn_request.parent_session_id, "root-session");
+    assert_eq!(spawn_request.task, "child task wait tail");
+    assert_eq!(
+        spawn_request.label.as_deref(),
+        Some("async-child-wait-tail")
+    );
+    assert_eq!(spawn_request.timeout_seconds, 5);
+    assert_eq!(queued.payload["child_session_id"], child_session_id);
+
+    let queued_after_id =
+        assert_queued_tail_and_get_after_id(&dispatcher, &session_context, &child_session_id).await;
+    assert_empty_tail(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        queued_after_id,
+    )
+    .await;
+
+    launch_notify.notify_one();
+
+    tokio::time::timeout(Duration::from_secs(5), provider_request_rx)
+        .await
+        .expect("timed out waiting for provider request")
+        .expect("provider request signal");
+
+    let wait_dispatcher = dispatcher.clone();
+    let wait_session_context = session_context.clone();
+    let wait_child_session_id = child_session_id.clone();
+    let wait_task = tokio::spawn(async move {
+        execute_root_tool(
+            &wait_dispatcher,
+            &wait_session_context,
+            "session_wait",
+            json!({
+                "session_id": wait_child_session_id,
+                "timeout_ms": 5_000,
+                "after_id": queued_after_id
+            }),
+        )
+        .await
+    });
+
+    release_response_tx
+        .send(())
+        .expect("release provider response");
+
+    let waited = wait_task
+        .await
+        .expect("join session_wait task")
+        .expect("session_wait outcome");
+    assert_eq!(waited.status, "ok");
+    assert_eq!(waited.payload["wait_status"], "completed");
+    assert_eq!(waited.payload["after_id"], queued_after_id);
+    assert_eq!(waited.payload["session"]["state"], "completed");
+    assert_eq!(waited.payload["terminal_outcome"]["status"], "ok");
+    assert_eq!(
+        waited.payload["terminal_outcome"]["payload"]["final_output"],
+        "Async child wait tail output"
+    );
+    let events = waited.payload["events"]
+        .as_array()
+        .expect("session_wait events array");
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["event_kind"], "delegate_started");
+    assert_eq!(events[1]["event_kind"], "delegate_completed");
+    let wait_next_after_id = waited.payload["next_after_id"]
+        .as_i64()
+        .expect("session_wait next_after_id");
+    assert_eq!(
+        wait_next_after_id,
+        events[1]["id"]
+            .as_i64()
+            .expect("completed event id from session_wait")
+    );
+    assert!(wait_next_after_id > queued_after_id);
+
+    assert_empty_tail(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        wait_next_after_id,
+    )
+    .await;
+
+    server.join().expect("join provider stub");
+}
+
+#[tokio::test]
+async fn delegate_async_real_subprocess_failure_session_events_after_id_is_incremental() {
+    let _guard = integration_env_lock().lock().expect("env lock");
+    let (base_url, provider_request_rx, release_response_tx, server) =
+        spawn_openai_error_server_once_with_response_gate(
+            500,
+            json!({
+                "error": {
+                    "message": "stub failure"
+                }
+            }),
+        );
+    let (config_path, config, memory_config) =
+        write_delegate_async_config("delegate-async-observability-failure-tail", &base_url);
+    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let daemon_bin = resolve_daemon_binary_path();
+    let (spawner, request_rx, launch_notify) =
+        GatedAsyncDelegateSpawner::new(BinaryAsyncDelegateSpawner {
+            daemon_bin,
+            config_path: config_path.clone(),
+        });
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        memory_config.clone(),
+        config.tools.clone(),
+        Arc::new(spawner),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        mvp::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let queued_dispatcher = dispatcher.clone();
+    let queued_session_context = session_context.clone();
+    let queued_call = tokio::spawn(async move {
+        execute_root_tool(
+            &queued_dispatcher,
+            &queued_session_context,
+            "delegate_async",
+            json!({
+                "task": "child task failure tail",
+                "label": "async-child-failure-tail",
+                "timeout_seconds": 5
+            }),
+        )
+        .await
+    });
+
+    let queued = tokio::time::timeout(Duration::from_millis(250), queued_call)
+        .await
+        .expect("delegate_async should return queued handle before child launch")
+        .expect("join delegate_async queued task")
+        .expect("delegate_async queued outcome");
+    assert_eq!(queued.status, "ok");
+    assert_eq!(queued.payload["mode"], "async");
+    assert_eq!(queued.payload["state"], "queued");
+
+    let spawn_request = tokio::time::timeout(Duration::from_secs(5), request_rx)
+        .await
+        .expect("timed out waiting for gated spawn request")
+        .expect("gated spawn request");
+    let child_session_id = spawn_request.child_session_id.clone();
+    assert_eq!(spawn_request.parent_session_id, "root-session");
+    assert_eq!(spawn_request.task, "child task failure tail");
+    assert_eq!(
+        spawn_request.label.as_deref(),
+        Some("async-child-failure-tail")
+    );
+    assert_eq!(spawn_request.timeout_seconds, 5);
+    assert_eq!(queued.payload["child_session_id"], child_session_id);
+
+    let queued_after_id =
+        assert_queued_tail_and_get_after_id(&dispatcher, &session_context, &child_session_id).await;
+    assert_empty_tail(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        queued_after_id,
+    )
+    .await;
+
+    launch_notify.notify_one();
+
+    tokio::time::timeout(Duration::from_secs(5), provider_request_rx)
+        .await
+        .expect("timed out waiting for provider request")
+        .expect("provider request signal");
+
+    let started_after_id = assert_incremental_tail_contains_only(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        queued_after_id,
+        "delegate_started",
+    )
+    .await;
+
+    release_response_tx
+        .send(())
+        .expect("release provider error response");
+
+    let waited = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_wait",
+        json!({
+            "session_id": child_session_id,
+            "timeout_ms": 5_000
+        }),
+    )
+    .await
+    .expect("failure tail session_wait outcome");
+    assert_eq!(waited.status, "ok");
+    assert_eq!(waited.payload["wait_status"], "completed");
+    assert_eq!(waited.payload["session"]["state"], "failed");
+    assert_eq!(waited.payload["terminal_outcome"]["status"], "error");
+    assert!(waited.payload["terminal_outcome"]["payload"]["error"]
+        .as_str()
+        .expect("failure tail error")
+        .contains("provider returned status 500"));
+
+    let failed_after_id = assert_incremental_tail_contains_only(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        started_after_id,
+        "delegate_failed",
+    )
+    .await;
+
+    assert_empty_tail(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        failed_after_id,
+    )
+    .await;
+
+    server.join().expect("join provider stub");
+}
+
+#[tokio::test]
+async fn delegate_async_real_subprocess_failure_is_observable_via_session_tools() {
+    let _guard = integration_env_lock().lock().expect("env lock");
+    let (base_url, server) = spawn_openai_error_server_once(
+        500,
+        json!({
+            "error": {
+                "message": "stub failure"
+            }
+        }),
+    );
+    let (config_path, config, memory_config) =
+        write_delegate_async_config("delegate-async-observability-failure", &base_url);
+    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let daemon_bin = resolve_daemon_binary_path();
+    let spawner = std::sync::Arc::new(BinaryAsyncDelegateSpawner {
+        daemon_bin,
+        config_path: config_path.clone(),
+    });
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        memory_config.clone(),
+        config.tools.clone(),
+        spawner,
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        mvp::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let queued = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "delegate_async",
+        json!({
+            "task": "child task failure",
+            "label": "async-child-failure",
+            "timeout_seconds": 5
+        }),
+    )
+    .await
+    .expect("delegate_async queued outcome");
+
+    assert_eq!(queued.status, "ok");
+    let child_session_id = queued.payload["child_session_id"]
+        .as_str()
+        .expect("child session id")
+        .to_owned();
+
+    let failed_events = wait_for_session_event(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        "delegate_failed",
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(failed_events.status, "ok");
+
+    let status = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_status",
+        json!({
+            "session_id": child_session_id
+        }),
+    )
+    .await
+    .expect("failure session_status outcome");
+    assert_eq!(status.status, "ok");
+    assert_eq!(status.payload["session"]["state"], "failed");
+    assert_eq!(status.payload["terminal_outcome"]["status"], "error");
+    assert!(status.payload["terminal_outcome"]["payload"]["error"]
+        .as_str()
+        .expect("terminal error")
+        .contains("provider returned status 500"));
+
+    let waited = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_wait",
+        json!({
+            "session_id": child_session_id,
+            "timeout_ms": 5_000
+        }),
+    )
+    .await
+    .expect("failure session_wait outcome");
+    assert_eq!(waited.status, "ok");
+    assert_eq!(waited.payload["wait_status"], "completed");
+    assert_eq!(waited.payload["session"]["state"], "failed");
+    assert_eq!(waited.payload["terminal_outcome"]["status"], "error");
+    assert!(waited.payload["terminal_outcome"]["payload"]["error"]
+        .as_str()
+        .expect("waited terminal error")
+        .contains("provider returned status 500"));
+
+    let final_events = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_events",
+        json!({
+            "session_id": child_session_id,
+            "limit": 10
+        }),
+    )
+    .await
+    .expect("final failure session_events outcome");
+    assert_eq!(final_events.status, "ok");
+    let event_kinds: Vec<&str> = final_events.payload["events"]
+        .as_array()
+        .expect("events array")
+        .iter()
+        .map(|event| event["event_kind"].as_str().expect("event kind"))
+        .collect();
+    assert!(event_kinds.contains(&"delegate_queued"));
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_failed"));
+
+    server.join().expect("join provider stub");
+}
+
+#[tokio::test]
+async fn delegate_async_real_subprocess_timeout_session_events_after_id_is_incremental() {
+    let _guard = integration_env_lock().lock().expect("env lock");
+    let (base_url, provider_request_rx, release_response_tx, server) =
+        spawn_openai_turn_server_once_with_response_gate("Too slow");
+    let (config_path, config, memory_config) =
+        write_delegate_async_config("delegate-async-observability-timeout-tail", &base_url);
+    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let daemon_bin = resolve_daemon_binary_path();
+    let (spawner, request_rx, launch_notify) =
+        GatedAsyncDelegateSpawner::new(BinaryAsyncDelegateSpawner {
+            daemon_bin,
+            config_path: config_path.clone(),
+        });
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        memory_config.clone(),
+        config.tools.clone(),
+        Arc::new(spawner),
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        mvp::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let queued_dispatcher = dispatcher.clone();
+    let queued_session_context = session_context.clone();
+    let queued_call = tokio::spawn(async move {
+        execute_root_tool(
+            &queued_dispatcher,
+            &queued_session_context,
+            "delegate_async",
+            json!({
+                "task": "child task timeout tail",
+                "label": "async-child-timeout-tail",
+                "timeout_seconds": 1
+            }),
+        )
+        .await
+    });
+
+    let queued = tokio::time::timeout(Duration::from_millis(250), queued_call)
+        .await
+        .expect("delegate_async should return queued handle before child launch")
+        .expect("join delegate_async queued task")
+        .expect("delegate_async queued outcome");
+    assert_eq!(queued.status, "ok");
+    assert_eq!(queued.payload["mode"], "async");
+    assert_eq!(queued.payload["state"], "queued");
+
+    let spawn_request = tokio::time::timeout(Duration::from_secs(5), request_rx)
+        .await
+        .expect("timed out waiting for gated spawn request")
+        .expect("gated spawn request");
+    let child_session_id = spawn_request.child_session_id.clone();
+    assert_eq!(spawn_request.parent_session_id, "root-session");
+    assert_eq!(spawn_request.task, "child task timeout tail");
+    assert_eq!(
+        spawn_request.label.as_deref(),
+        Some("async-child-timeout-tail")
+    );
+    assert_eq!(spawn_request.timeout_seconds, 1);
+    assert_eq!(queued.payload["child_session_id"], child_session_id);
+
+    let queued_after_id =
+        assert_queued_tail_and_get_after_id(&dispatcher, &session_context, &child_session_id).await;
+    assert_empty_tail(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        queued_after_id,
+    )
+    .await;
+
+    launch_notify.notify_one();
+
+    tokio::time::timeout(Duration::from_secs(5), provider_request_rx)
+        .await
+        .expect("timed out waiting for provider request")
+        .expect("provider request signal");
+
+    let started_after_id = assert_incremental_tail_contains_only(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        queued_after_id,
+        "delegate_started",
+    )
+    .await;
+
+    let waited = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_wait",
+        json!({
+            "session_id": child_session_id,
+            "timeout_ms": 5_000
+        }),
+    )
+    .await
+    .expect("timeout tail session_wait outcome");
+    assert_eq!(waited.status, "ok");
+    assert_eq!(waited.payload["wait_status"], "completed");
+    assert_eq!(waited.payload["session"]["state"], "timed_out");
+    assert_eq!(waited.payload["terminal_outcome"]["status"], "timeout");
+    assert_eq!(
+        waited.payload["terminal_outcome"]["payload"]["error"],
+        "delegate_timeout"
+    );
+
+    let timed_out_after_id = assert_incremental_tail_contains_only(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        started_after_id,
+        "delegate_timed_out",
+    )
+    .await;
+
+    assert_empty_tail(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        timed_out_after_id,
+    )
+    .await;
+
+    release_response_tx
+        .send(())
+        .expect("release provider response after timeout");
+    server.join().expect("join provider stub");
+}
+
+#[tokio::test]
+async fn delegate_async_real_subprocess_timeout_is_observable_via_session_tools() {
+    let _guard = integration_env_lock().lock().expect("env lock");
+    let (base_url, server) =
+        spawn_openai_turn_server_once_with_delay("Too slow", Duration::from_millis(1_200));
+    let (config_path, config, memory_config) =
+        write_delegate_async_config("delegate-async-observability-timeout", &base_url);
+    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let daemon_bin = resolve_daemon_binary_path();
+    let spawner = std::sync::Arc::new(BinaryAsyncDelegateSpawner {
+        daemon_bin,
+        config_path: config_path.clone(),
+    });
+    let dispatcher = DefaultAppToolDispatcher::with_async_delegate_spawner(
+        memory_config.clone(),
+        config.tools.clone(),
+        spawner,
+    );
+    let session_context = SessionContext::root_with_tool_view(
+        "root-session",
+        mvp::tools::runtime_tool_view_for_config(&config.tools),
+    );
+
+    let queued = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "delegate_async",
+        json!({
+            "task": "child task timeout",
+            "label": "async-child-timeout",
+            "timeout_seconds": 1
+        }),
+    )
+    .await
+    .expect("delegate_async queued outcome");
+
+    assert_eq!(queued.status, "ok");
+    let child_session_id = queued.payload["child_session_id"]
+        .as_str()
+        .expect("child session id")
+        .to_owned();
+
+    let timed_out_events = wait_for_session_event(
+        &dispatcher,
+        &session_context,
+        &child_session_id,
+        "delegate_timed_out",
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(timed_out_events.status, "ok");
+
+    let status = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_status",
+        json!({
+            "session_id": child_session_id
+        }),
+    )
+    .await
+    .expect("timeout session_status outcome");
+    assert_eq!(status.status, "ok");
+    assert_eq!(status.payload["session"]["state"], "timed_out");
+    assert_eq!(status.payload["terminal_outcome"]["status"], "timeout");
+    assert_eq!(
+        status.payload["terminal_outcome"]["payload"]["error"],
+        "delegate_timeout"
+    );
+
+    let waited = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_wait",
+        json!({
+            "session_id": child_session_id,
+            "timeout_ms": 5_000
+        }),
+    )
+    .await
+    .expect("timeout session_wait outcome");
+    assert_eq!(waited.status, "ok");
+    assert_eq!(waited.payload["wait_status"], "completed");
+    assert_eq!(waited.payload["session"]["state"], "timed_out");
+    assert_eq!(waited.payload["terminal_outcome"]["status"], "timeout");
+    assert_eq!(
+        waited.payload["terminal_outcome"]["payload"]["error"],
+        "delegate_timeout"
+    );
+
+    let final_events = execute_root_tool(
+        &dispatcher,
+        &session_context,
+        "session_events",
+        json!({
+            "session_id": child_session_id,
+            "limit": 10
+        }),
+    )
+    .await
+    .expect("final timeout session_events outcome");
+    assert_eq!(final_events.status, "ok");
+    let event_kinds: Vec<&str> = final_events.payload["events"]
+        .as_array()
+        .expect("events array")
+        .iter()
+        .map(|event| event["event_kind"].as_str().expect("event kind"))
+        .collect();
+    assert!(event_kinds.contains(&"delegate_queued"));
+    assert!(event_kinds.contains(&"delegate_started"));
+    assert!(event_kinds.contains(&"delegate_timed_out"));
+
+    server.join().expect("join provider stub");
+}

--- a/docs/plans/2026-03-11-loongclaw-onboarding-design.md
+++ b/docs/plans/2026-03-11-loongclaw-onboarding-design.md
@@ -1,0 +1,775 @@
+# LoongClaw Onboarding Redesign
+
+**Date:** 2026-03-11
+
+**Status:** Approved design for `alpha-test`
+
+**Scope:** Redesign `loongclawd onboard` and the first `chat` entry experience so onboarding feels like a product journey instead of a linear config wizard.
+
+---
+
+## 1. Product Goal
+
+`loongclawd onboard` should help a first-time user reach a successful first chat in 60 to 90 seconds.
+
+The command should no longer behave like a sequence of free-form prompts. It should behave like a guided operator console with:
+
+- clear next actions
+- strong but restrained branding
+- explicit trust and safety boundaries
+- recoverable error paths
+- a direct handoff into `chat`
+
+This redesign targets the current CLI architecture in:
+
+- `crates/daemon/src/onboard_cli.rs`
+- `crates/app/src/chat.rs`
+
+The `alpha-test` implementation should stay lightweight. It should not introduce a heavy full-screen TUI framework unless later work proves that need.
+
+---
+
+## 2. Design Intent
+
+The onboarding visual direction is:
+
+`Warm Operator Console`
+
+This means:
+
+- professional and trustworthy, not playful
+- branded, but not decorative
+- compact and readable on normal terminals
+- able to degrade cleanly on narrow terminals and low-color environments
+
+The visual identity should use the LoongClaw brand palette:
+
+- primary accent: `#b1231c`
+- warm highlight: `#fcf5e2`
+
+The accent color should frame action and identity. It should not be reused as the generic warning or error color.
+
+---
+
+## 3. Core Principles
+
+### 3.1 One Strong Thing Per Screen
+
+Each screen gets one primary job:
+
+- welcome establishes tone
+- trust establishes boundaries
+- provider chooses route
+- credential resolves auth
+- model confirms runtime target
+- preflight confirms readiness
+- success launches chat
+
+### 3.2 Fast Happy Path, Rich Recovery Paths
+
+The default path should be short. Recovery paths should be available without dumping the user into raw config editing.
+
+### 3.3 Default First, Editable Later
+
+Advanced customization should exist, but should not compete with first-run success.
+
+### 3.4 Status Before Explanation
+
+Users should see the current state before reading detail text.
+
+Examples:
+
+- `[ok] OPENAI_API_KEY is available`
+- `[!] model probe was skipped`
+- `[x] memory path is not writable`
+
+### 3.5 Every Warning Needs a Next Action
+
+Warnings and failures must always pair with a recoverable action:
+
+- retry
+- use fallback
+- switch provider
+- save and finish later
+
+### 3.6 Branding Frames Action
+
+Logo, color, and spacing should improve perceived quality without pushing the real action below the fold.
+
+---
+
+## 4. Command Boundary
+
+The redesign assumes these command roles:
+
+- `setup`
+  - generate a default config template
+  - bootstrap memory path
+  - useful for users who want a file first
+- `onboard`
+  - guided first-run setup
+  - the primary entry for first-time CLI users
+  - owns provider selection, credential readiness, model selection, preflight, and success handoff
+- `doctor`
+  - diagnostics and optional repair
+  - referenced by onboarding, but not embedded deeply in the alpha flow
+- `chat`
+  - day-to-day interaction entrypoint
+  - should feel like a continuation of onboarding when launched from `onboard`
+
+---
+
+## 5. Banner and Version Strategy
+
+### 5.1 Banner Family
+
+The onboarding banner uses three responsive variants.
+
+Wide, default when the terminal width is at least 80 columns:
+
+```text
+██╗      ██████╗  ██████╗ ███╗   ██╗ ██████╗  ██████╗██╗      █████╗ ██╗    ██╗
+██║     ██╔═══██╗██╔═══██╗████╗  ██║██╔════╝ ██╔════╝██║     ██╔══██╗██║    ██║
+██║     ██║   ██║██║   ██║██╔██╗ ██║██║  ███╗██║     ██║     ███████║██║ █╗ ██║
+██║     ██║   ██║██║   ██║██║╚██╗██║██║   ██║██║     ██║     ██╔══██║██║███╗██║
+███████╗╚██████╔╝╚██████╔╝██║ ╚████║╚██████╔╝╚██████╗███████╗██║  ██║╚███╔███╔╝
+╚══════╝ ╚═════╝  ╚═════╝ ╚═╝  ╚═══╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝
+```
+
+Split, when width is between 46 and 79 columns:
+
+```text
+██╗      ██████╗  ██████╗ ███╗   ██╗ ██████╗
+██║     ██╔═══██╗██╔═══██╗████╗  ██║██╔════╝
+██║     ██║   ██║██║   ██║██╔██╗ ██║██║  ███╗
+██║     ██║   ██║██║   ██║██║╚██╗██║██║   ██║
+███████╗╚██████╔╝╚██████╔╝██║ ╚████║╚██████╔╝
+╚══════╝ ╚═════╝  ╚═════╝ ╚═╝  ╚═══╝ ╚═════╝
+
+██████╗██╗      █████╗ ██╗    ██╗
+██╔════╝██║     ██╔══██╗██║    ██║
+██║     ██║     ███████║██║ █╗ ██║
+██║     ██║     ██╔══██║██║███╗██║
+╚██████╗███████╗██║  ██║╚███╔███╔╝
+╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝
+```
+
+Plain, when width is below 46 columns:
+
+```text
+LOONGCLAW
+```
+
+### 5.2 Version and Channel Line
+
+Version information always stays on a single line under the banner.
+
+Release builds:
+
+```text
+v0.1.2
+```
+
+Development builds:
+
+```text
+v0.1.2 · alpha-test · 1a2b3c4
+```
+
+Rules:
+
+- release builds display only semantic version
+- development builds display semantic version, channel or branch, and short git SHA
+- if branch metadata is missing, fallback to `dev`
+- if SHA is missing, omit only the SHA portion
+- version text should visually read lighter than the banner
+
+---
+
+## 6. Visual System
+
+### 6.1 Color Roles
+
+- `#b1231c`
+  - banner
+  - current selection arrow
+  - current step or short key emphasis
+- `#fcf5e2`
+  - version line
+  - hero subtitle
+  - selected summary highlights on success or review screens
+- default terminal foreground
+  - body text
+  - descriptions
+  - most list content
+
+State colors should not reuse the primary brand red:
+
+- success: green family
+- warning: warm orange or yellow family
+- danger: darker red or fallback terminal error color
+- info: muted or neutral highlight
+
+### 6.2 Layout Rules
+
+- left-align all body content
+- keep only one blank line between content blocks
+- avoid full-width heavy borders
+- use spacing and headings before decorative separators
+- keep the first actionable control visible on the first screen height where possible
+
+### 6.3 Footer Hints
+
+Footer hints should collapse by available width and by available actions.
+
+Wide:
+
+```text
+Enter confirm  j/k move  1-9 quick pick  ? details  b back  q quit
+```
+
+Medium:
+
+```text
+Enter confirm  ? details  b back  q quit
+```
+
+Narrow:
+
+```text
+Enter  b  q
+```
+
+---
+
+## 7. Screen Flow
+
+### 7.1 Screen Order
+
+Primary path:
+
+1. Welcome
+2. Trust
+3. Provider
+4. Credential
+5. Model
+6. Advanced
+7. Preflight
+8. Success
+9. Launch chat
+
+Conditional screens:
+
+- Existing config found
+- Custom env var
+- Review config summary
+
+### 7.2 Welcome
+
+Purpose:
+
+- establish product feel
+- communicate speed
+- reassure users that advanced settings can be changed later
+
+Reference layout:
+
+```text
+<LOONGCLAW banner>
+
+v0.1.2 · alpha-test · 1a2b3c4
+trusted local agent runtime
+
+We'll set up your provider, verify local paths,
+and start your first chat.
+
+This usually takes under 90 seconds.
+You can change advanced settings later.
+
+> Continue
+  Exit
+```
+
+### 7.3 Trust
+
+Purpose:
+
+- set safety boundary before auth or model selection
+- make trust specific to real local paths
+
+Reference layout:
+
+```text
+Workspace trust
+
+LoongClaw may read local files and invoke allowed tools.
+Use it only in a workspace you trust.
+
+Workspace: /Users/chum/project
+File root:  /Users/chum/project
+Tool mode:  allowlisted shell + file tools
+
+> I trust this workspace
+  Exit
+```
+
+Optional detail panel on `?`:
+
+```text
+Prompts, local files, and enabled tools can affect runtime behavior.
+If this workspace is untrusted, stop here.
+```
+
+### 7.4 Existing Config Found
+
+Purpose:
+
+- prevent destructive overwrite behavior
+- make backup the default choice
+
+Reference layout:
+
+```text
+Existing configuration found
+
+Config path: ~/.loongclaw/config.toml
+
+Choose how to continue.
+
+> Back up existing config
+  Replace existing config
+  Review current config path
+  Exit
+```
+
+### 7.5 Provider
+
+Purpose:
+
+- remove free-form provider entry
+- surface current machine readiness
+
+Grouping order:
+
+1. Ready now
+2. Popular
+3. Regional
+4. Local
+
+Reference layout:
+
+```text
+2/6 Choose a provider
+
+Ready now
+> OpenAI        [ready] OPENAI_API_KEY found
+  Kimi Coding   [ready] KIMI_CODING_API_KEY found
+
+Popular
+  Anthropic     [missing] ANTHROPIC_API_KEY
+  OpenRouter    [missing] OPENROUTER_API_KEY
+
+Regional
+  Kimi          [missing] MOONSHOT_API_KEY
+  Volcengine    [missing] ARK_API_KEY
+  Zhipu         [missing] ZHIPU_API_KEY
+  Minimax       [missing] MINIMAX_API_KEY
+  DeepSeek      [missing] DEEPSEEK_API_KEY
+  ZAI           [missing] ZAI_API_KEY
+
+Local
+  Ollama        [local] no API key required
+```
+
+### 7.6 Credential
+
+Purpose:
+
+- resolve auth before model probing
+- keep missing credentials recoverable
+
+States:
+
+- default env found
+- default env missing
+- local provider, no key required
+
+Reference layout when env is missing:
+
+```text
+3/6 Provider credential
+
+Provider: Anthropic
+Expected env var: ANTHROPIC_API_KEY
+Status: [!] not found
+
+Set the variable in your shell and return here.
+You can also choose a custom env var name.
+
+> Re-check
+  Use a different env var name
+  Switch provider
+  Save and finish later
+```
+
+### 7.7 Custom Env Var
+
+Purpose:
+
+- let advanced users remap credential env names without pushing that burden onto everyone
+
+Reference layout:
+
+```text
+Custom env var name
+
+Default: ANTHROPIC_API_KEY
+
+Env var name: [MY_TEAM_ANTHROPIC_KEY]
+
+We'll look for this variable in the current environment.
+
+> Save and re-check
+  Back
+```
+
+### 7.8 Model
+
+Purpose:
+
+- pick a usable model
+- avoid making probe failure a fatal first-run event
+
+States:
+
+- probe succeeded
+- probe failed
+- probe skipped
+- local provider connectivity check
+
+Reference layout when probe fails:
+
+```text
+4/6 Choose a model
+
+Provider: OpenAI
+Credential: [ok]
+Model probe: [!] request failed
+
+We'll use a default model for now.
+You can retry, switch provider, or continue with the default.
+
+> Use default: gpt-5
+  Retry probe
+  Enter manually
+  Switch provider
+```
+
+### 7.9 Advanced
+
+Purpose:
+
+- keep high-value customization available
+- keep low-value complexity out of the happy path
+
+Default gate:
+
+```text
+5/6 Advanced options
+
+Use defaults for:
+- system prompt
+- file root
+- shell allowlist
+- sqlite memory path
+
+> Use defaults
+  Customize now
+```
+
+Alpha-stage customization surface:
+
+- system prompt
+- file root
+
+Do not expose shell allowlist and sqlite path editing in the first alpha redesign.
+
+### 7.10 Preflight
+
+Purpose:
+
+- summarize readiness using product language instead of raw diagnostic output
+
+Groups:
+
+- Ready
+- Needs attention
+- Optional
+
+Reference layout:
+
+```text
+6/6 Preflight
+
+Ready
+  [ok] OPENAI_API_KEY is available
+  [ok] model is set to gpt-5
+  [ok] memory path is writable
+  [ok] tool file root is writable
+
+Optional
+  [i] shell allowlist still uses defaults
+      You can tune this later with doctor.
+
+> Start chat now
+  Review config
+  Save and exit
+```
+
+### 7.11 Review Config Summary
+
+Purpose:
+
+- show the effective configuration in human-readable form
+- avoid dumping raw TOML into the first-run flow
+
+Reference layout:
+
+```text
+Configuration summary
+
+Provider     OpenAI
+Model        gpt-5
+Credential   OPENAI_API_KEY
+File root    /Users/chum/project
+Memory       ~/.loongclaw/memory.sqlite3
+
+> Start chat now
+  Show config path
+  Back
+```
+
+### 7.12 Success
+
+Purpose:
+
+- transition from setup mindset into usage mindset
+
+Reference layout:
+
+```text
+Ready to chat
+
+Config:   ~/.loongclaw/config.toml
+Provider: OpenAI
+Model:    gpt-5
+Memory:   ~/.loongclaw/memory.sqlite3
+
+Try asking:
+- Summarize the current repository
+- Explain which tools are enabled
+- Help me tune the shell allowlist
+
+> Start chat now
+  Review config path
+  Exit
+```
+
+### 7.13 Chat First Screen
+
+Purpose:
+
+- preserve continuity from onboarding to usage
+
+Reference layout:
+
+```text
+loongclaw // session default
+provider openai   model gpt-5   memory on
+
+/help commands   /history memory   /exit quit
+
+Try one:
+- summarize this repository
+- inspect the current config
+- explain the enabled tools
+
+you>
+```
+
+---
+
+## 8. Interaction Model
+
+All onboarding screens should share the same core controls.
+
+- `Enter`
+  - confirm current selection
+- `Up/Down`
+  - move selection
+- `j/k`
+  - move selection
+- `1-9`
+  - quick pick when meaningful
+- `b`
+  - go back
+- `q`
+  - exit onboarding
+- `?`
+  - show contextual explanation or provider detail
+
+Text input should appear only on screens that require actual value entry, such as custom env var name, system prompt, or file root.
+
+---
+
+## 9. State Semantics
+
+Onboarding state should use product-level semantics, not just raw diagnostic codes.
+
+User-facing markers:
+
+- `[ok]`
+- `[!]`
+- `[x]`
+- `[i]`
+
+Meaning:
+
+- `[ok]`
+  - ready or verified
+- `[!]`
+  - caution or fallback path available
+- `[x]`
+  - blocking issue for first success
+- `[i]`
+  - informational or optional refinement
+
+Rules:
+
+- all status messages must include an object and a conclusion
+- all blocking states must pair with a next action
+- warnings should not be colored like brand accent
+
+---
+
+## 10. Recovery Paths
+
+The redesign should make recovery a first-class product feature.
+
+Credential missing should support:
+
+- re-check
+- use a different env var name
+- switch provider
+- save and finish later
+
+Model probe failure should support:
+
+- use default model
+- retry probe
+- enter manually
+- switch provider
+
+File root validation failure should support:
+
+- retry
+- choose another root
+- reset to workspace root
+- save and exit
+
+Existing config should support:
+
+- backup existing config
+- replace existing config
+- review config path
+- exit
+
+---
+
+## 11. Accessibility and Terminal Degradation
+
+The experience must remain usable when:
+
+- colors are disabled
+- `NO_COLOR` is set
+- Unicode banner rendering is poor
+- terminal width is narrow
+
+Therefore:
+
+- the interface cannot rely on color alone
+- all screens must remain understandable with plain text markers
+- the banner must fall back from wide to split to plain
+- footer hints must collapse by width
+
+---
+
+## 12. Acceptance Criteria
+
+The redesign is complete when:
+
+- a standard 80-column terminal displays the wide banner without wrapping
+- a 46 to 79-column terminal displays the split banner without clipping
+- a narrow terminal falls back cleanly to plain text branding
+- the happy path requires no free-form provider entry
+- credentials are resolved before model probing
+- model probe failure still allows a first-chat path
+- preflight groups output into `Ready`, `Needs attention`, and `Optional`
+- onboarding no longer defaults to destructive overwrite when config already exists
+- success flow offers direct transition into chat
+- the first chat screen includes contextual summary and starter prompts
+- release builds and development builds are visually distinguishable
+
+---
+
+## 13. Alpha Implementation Priority
+
+### P0
+
+- responsive onboarding banner family
+- single-line release and development version display
+- welcome screen
+- trust screen
+- non-destructive existing-config handling
+- provider selection UI with readiness grouping
+- credential-before-model flow
+- model fallback flow
+- grouped preflight summary
+- success screen with direct chat handoff
+- upgraded chat first screen
+
+### P1
+
+- contextual `? details`
+- advanced customization menu for system prompt and file root
+- configuration summary screen
+- width-aware footer hints
+- improved local-provider connectivity path for Ollama
+
+### P2
+
+- richer doctor integration
+- model recommendation refinement
+- resume unfinished onboarding
+- more context-sensitive starter prompts
+
+### Explicit Non-Goals for Alpha
+
+- heavy full-screen TUI framework
+- animated welcome screen
+- inline full config editor
+- exposing every low-level runtime knob during onboarding
+
+---
+
+## 14. Summary
+
+This redesign keeps LoongClaw grounded in its existing CLI architecture while dramatically improving perceived quality, safety clarity, and first-run usability.
+
+The result should feel like a disciplined local agent console:
+
+- branded
+- trustworthy
+- fast
+- flexible
+- hard to misuse

--- a/docs/plans/2026-03-11-loongclaw-onboarding-design.md
+++ b/docs/plans/2026-03-11-loongclaw-onboarding-design.md
@@ -4,13 +4,13 @@
 
 **Status:** Approved design for `alpha-test`
 
-**Scope:** Redesign `loongclawd onboard` and the first `chat` entry experience so onboarding feels like a product journey instead of a linear config wizard.
+**Scope:** Redesign `loongclaw onboard` and the first `chat` entry experience so onboarding feels like a product journey instead of a linear config wizard.
 
 ---
 
 ## 1. Product Goal
 
-`loongclawd onboard` should help a first-time user reach a successful first chat in 60 to 90 seconds.
+`loongclaw onboard` should help a first-time user reach a successful first chat in 60 to 90 seconds.
 
 The command should no longer behave like a sequence of free-form prompts. It should behave like a guided operator console with:
 

--- a/docs/plans/2026-03-11-loongclaw-onboarding-implementation-plan.md
+++ b/docs/plans/2026-03-11-loongclaw-onboarding-implementation-plan.md
@@ -1,0 +1,578 @@
+# LoongClaw Onboarding Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Rework `loongclawd onboard` into a guided, width-aware first-run flow that reaches a successful first chat with clearer safety, provider, credential, model, and handoff UX.
+
+**Architecture:** Keep the implementation in the existing line-oriented CLI architecture instead of introducing a heavy TUI framework. Add small rendering helpers for banner selection, footer hints, stateful menus, grouped summaries, and development build labeling, then connect onboarding success directly to improved chat startup messaging.
+
+**Tech Stack:** Rust, Clap, existing `loongclaw-app` config/provider helpers, daemon unit tests, inline app unit tests, optional lightweight terminal-width/build-metadata helpers.
+
+---
+
+### Task 1: Introduce Onboarding Presentation Primitives
+
+**Files:**
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Test: `crates/daemon/src/tests/onboard_cli.rs`
+- Optional Modify: `crates/daemon/Cargo.toml`
+- Optional Modify: `Cargo.toml`
+
+**Step 1: Write the failing tests for presentation helpers**
+
+Add daemon tests that assert:
+
+- development label formatting produces `vX.Y.Z · branch · sha`
+- release label formatting produces only `vX.Y.Z`
+- banner selection chooses wide, split, and plain variants by width
+- footer hints collapse by width
+
+Suggested test names:
+
+```rust
+#[test]
+fn format_build_label_for_release_build() {}
+
+#[test]
+fn format_build_label_for_dev_build() {}
+
+#[test]
+fn select_banner_variant_uses_split_logo_for_medium_width() {}
+
+#[test]
+fn footer_hints_collapse_for_narrow_width() {}
+```
+
+**Step 2: Run the daemon tests to confirm they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon onboard_cli -- --nocapture
+```
+
+Expected: new tests fail because the helper functions do not exist yet.
+
+**Step 3: Add minimal presentation helpers**
+
+Implement small helpers in `crates/daemon/src/onboard_cli.rs` for:
+
+- terminal width detection or width injection for testability
+- build label formatting
+- banner variant selection
+- footer hint rendering
+- plain text fallback when color or Unicode is unavailable
+
+Prefer isolated pure functions so they are easy to unit test.
+
+**Step 4: Re-run the daemon tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon onboard_cli -- --nocapture
+```
+
+Expected: the new presentation tests pass.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/daemon/src/onboard_cli.rs crates/daemon/src/tests/onboard_cli.rs crates/daemon/Cargo.toml Cargo.toml
+git commit -m "feat: add onboarding presentation helpers"
+```
+
+Expected: one focused commit for width-aware presentation primitives.
+
+---
+
+### Task 2: Replace Free-Form Provider Entry with Stateful Provider Selection
+
+**Files:**
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Test: `crates/daemon/src/tests/onboard_cli.rs`
+
+**Step 1: Write the failing tests for provider grouping and readiness**
+
+Add tests that assert:
+
+- providers with detected env vars are promoted into `Ready now`
+- `Ollama` is marked as local
+- supported providers are rendered in product-defined order instead of raw enum order
+- provider detail rows include status labels
+
+Suggested test names:
+
+```rust
+#[test]
+fn provider_menu_promotes_ready_providers() {}
+
+#[test]
+fn provider_menu_marks_ollama_as_local() {}
+
+#[test]
+fn provider_menu_uses_product_display_order() {}
+```
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon provider_menu -- --nocapture
+```
+
+Expected: failures because the grouping and render helpers are not implemented.
+
+**Step 3: Implement a provider menu model**
+
+Add internal structs or enums in `crates/daemon/src/onboard_cli.rs` for:
+
+- provider display section
+- provider readiness state
+- provider menu item
+- provider detail text
+
+Update onboarding flow to use a numbered or cursor-based selection model instead of `prompt_with_default("Provider", ...)`.
+
+**Step 4: Re-run daemon tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon onboard_cli -- --nocapture
+```
+
+Expected: provider grouping tests pass and older parsing tests continue to pass.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/daemon/src/onboard_cli.rs crates/daemon/src/tests/onboard_cli.rs
+git commit -m "feat: add guided provider selection for onboarding"
+```
+
+Expected: provider selection is now structured and test-covered.
+
+---
+
+### Task 3: Reorder Credential and Model Flow with Recovery Paths
+
+**Files:**
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Test: `crates/daemon/src/tests/onboard_cli.rs`
+
+**Step 1: Write failing tests for first-run recovery behavior**
+
+Add tests that assert:
+
+- credential checks happen before model selection
+- missing credentials produce recoverable user-facing state
+- model probe failures can fall back to default model
+- skipped model probe is classified as optional, not fatal
+
+Suggested test names:
+
+```rust
+#[tokio::test]
+async fn preflight_treats_missing_credentials_as_attention() {}
+
+#[tokio::test]
+async fn preflight_allows_default_model_after_probe_failure() {}
+
+#[test]
+fn onboarding_step_order_places_credentials_before_models() {}
+```
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon onboard_cli -- --nocapture
+```
+
+Expected: failures that show step order and preflight semantics need rework.
+
+**Step 3: Implement the reordered flow**
+
+Update `run_onboard_cli` and helper functions to:
+
+- prompt for provider first
+- resolve or confirm credential state second
+- defer model selection until credentials are ready or a fallback route is chosen
+- support model fallback when probe fails
+- support a `save and finish later` exit path without misreporting success
+
+**Step 4: Re-run daemon tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon onboard_cli -- --nocapture
+```
+
+Expected: reordered-flow and fallback tests pass.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/daemon/src/onboard_cli.rs crates/daemon/src/tests/onboard_cli.rs
+git commit -m "feat: add recoverable credential and model onboarding flow"
+```
+
+Expected: one focused commit that improves first-run success rate.
+
+---
+
+### Task 4: Replace Flat Preflight Output with Product-Level Summary Screens
+
+**Files:**
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Test: `crates/daemon/src/tests/onboard_cli.rs`
+
+**Step 1: Write failing tests for grouped preflight output**
+
+Add tests that assert preflight items are classified into:
+
+- `Ready`
+- `Needs attention`
+- `Optional`
+
+Suggested test names:
+
+```rust
+#[test]
+fn group_preflight_checks_separates_ready_attention_and_optional() {}
+
+#[test]
+fn missing_credentials_are_grouped_as_attention() {}
+
+#[test]
+fn skipped_model_probe_is_grouped_as_optional() {}
+```
+
+**Step 2: Run the daemon tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon onboard_cli -- --nocapture
+```
+
+Expected: failures because grouped summary helpers are not implemented.
+
+**Step 3: Implement grouped preflight rendering**
+
+Refactor or extend:
+
+- `OnboardCheck`
+- `run_preflight_checks`
+- `print_preflight_checks`
+
+So the user-facing output summarizes readiness by group and pairs blocking items with next actions.
+
+Add an explicit summary helper rather than overloading the current flat table formatter.
+
+**Step 4: Re-run daemon tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon onboard_cli -- --nocapture
+```
+
+Expected: preflight grouping tests pass and legacy tests remain green.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/daemon/src/onboard_cli.rs crates/daemon/src/tests/onboard_cli.rs
+git commit -m "feat: add grouped onboarding preflight summary"
+```
+
+Expected: onboarding diagnostics now read like product guidance instead of raw logs.
+
+---
+
+### Task 5: Make Existing Config Handling Safe and Reviewable
+
+**Files:**
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Test: `crates/daemon/src/tests/onboard_cli.rs`
+
+**Step 1: Write failing tests for existing-config behavior**
+
+Add tests that assert:
+
+- backup is the default recommended path when config already exists
+- overwrite remains explicit
+- config review summary can be derived before final write
+
+Suggested test names:
+
+```rust
+#[test]
+fn existing_config_flow_prefers_backup_language() {}
+
+#[test]
+fn backup_path_uses_timestamped_suffix() {}
+
+#[test]
+fn config_summary_reports_provider_model_and_paths() {}
+```
+
+**Step 2: Run the daemon tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon onboard_cli -- --nocapture
+```
+
+Expected: some tests fail because summary helpers or safer default wording are missing.
+
+**Step 3: Implement safer existing-config and summary helpers**
+
+Refactor:
+
+- `resolve_force_write`
+- `resolve_backup_path`
+
+Add a non-destructive review summary helper for:
+
+- provider
+- model
+- credential env
+- config path
+- memory path
+- file root
+
+**Step 4: Re-run daemon tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon onboard_cli -- --nocapture
+```
+
+Expected: config safety and summary tests pass.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/daemon/src/onboard_cli.rs crates/daemon/src/tests/onboard_cli.rs
+git commit -m "feat: make onboarding config writes safer"
+```
+
+Expected: existing configurations are handled explicitly and safely.
+
+---
+
+### Task 6: Upgrade Chat Startup Messaging and First-Run Handoff
+
+**Files:**
+- Modify: `crates/app/src/chat.rs`
+- Test: `crates/app/src/chat.rs`
+- Optional Modify: `README.md`
+
+**Step 1: Write failing unit tests for chat intro helpers**
+
+Add inline unit tests in `crates/app/src/chat.rs` for pure helpers that format:
+
+- startup summary line
+- starter prompt suggestions
+- help copy
+
+Suggested test names:
+
+```rust
+#[test]
+fn format_chat_intro_includes_provider_model_and_memory_state() {}
+
+#[test]
+fn starter_prompts_include_repository_hint_when_relevant() {}
+
+#[test]
+fn help_copy_lists_primary_commands() {}
+```
+
+**Step 2: Run the app tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app chat -- --nocapture
+```
+
+Expected: failures because these helper functions do not exist yet.
+
+**Step 3: Implement chat intro helpers**
+
+Refactor `run_cli_chat` and `print_help` so chat startup:
+
+- summarizes session, provider, model, and memory state
+- includes three suggested starter prompts
+- remains readable in plain text terminals
+
+Keep the actual prompt loop unchanged except for the first-run output.
+
+**Step 4: Re-run the app tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app chat -- --nocapture
+```
+
+Expected: new chat intro tests pass.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/app/src/chat.rs README.md
+git commit -m "feat: improve chat startup guidance"
+```
+
+Expected: onboarding success can hand off into a more informative chat surface.
+
+---
+
+### Task 7: Update CLI Documentation to Recommend Onboarding
+
+**Files:**
+- Modify: `README.md`
+- Optional Modify: `docs/product-specs/index.md`
+
+**Step 1: Write the minimal docs changes**
+
+Update the quick-start sequence so first-time users are guided toward:
+
+```text
+loongclawd onboard
+```
+
+before manually running `chat`.
+
+**Step 2: Review docs wording**
+
+Run:
+
+```bash
+git diff -- README.md docs/product-specs/index.md
+```
+
+Expected: wording is clear, short, and consistent with the redesigned flow.
+
+**Step 3: Commit**
+
+Run:
+
+```bash
+git add README.md docs/product-specs/index.md
+git commit -m "docs: clarify first-run onboarding flow"
+```
+
+Expected: repo docs reflect the intended first-run entrypoint.
+
+---
+
+### Task 8: Full Verification Pass
+
+**Files:**
+- Modify: none expected
+
+**Step 1: Run daemon onboarding tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon onboard_cli -- --nocapture
+```
+
+Expected: PASS
+
+**Step 2: Run app chat tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app chat -- --nocapture
+```
+
+Expected: PASS
+
+**Step 3: Run full package tests if the targeted suites passed cleanly**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon
+cargo test -p loongclaw-app
+```
+
+Expected: PASS
+
+**Step 4: Smoke test the CLI manually**
+
+Run:
+
+```bash
+cargo run -p loongclaw-daemon --bin loongclawd -- onboard
+```
+
+Expected:
+
+- banner renders without wrapping in a normal terminal
+- provider selection is structured
+- model fallback path works
+- success page offers direct chat launch
+
+**Step 5: Commit the final polish if needed**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no unexpected edits remain after verification.
+
+If any verification-only tweaks were required:
+
+```bash
+git add <exact files>
+git commit -m "chore: polish onboarding rollout"
+```
+
+---
+
+## Notes for Execution
+
+- Prefer small pure helper functions to keep onboarding rendering testable.
+- Avoid introducing a full TUI crate in this plan.
+- Keep each commit tightly scoped to the task listed above.
+- Preserve user-owned config safely; never make overwrite the silent default.
+- Treat release and development build labeling as user-facing product behavior, not just debug text.
+
+---
+
+Plan complete and saved to `docs/plans/2026-03-11-loongclaw-onboarding-implementation-plan.md`. Two execution options:
+
+**1. Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration
+
+**2. Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/plans/2026-03-11-loongclaw-onboarding-implementation-plan.md
+++ b/docs/plans/2026-03-11-loongclaw-onboarding-implementation-plan.md
@@ -2,7 +2,7 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Rework `loongclawd onboard` into a guided, width-aware first-run flow that reaches a successful first chat with clearer safety, provider, credential, model, and handoff UX.
+**Goal:** Rework `loongclaw onboard` into a guided, width-aware first-run flow that reaches a successful first chat with clearer safety, provider, credential, model, and handoff UX.
 
 **Architecture:** Keep the implementation in the existing line-oriented CLI architecture instead of introducing a heavy TUI framework. Add small rendering helpers for banner selection, footer hints, stateful menus, grouped summaries, and development build labeling, then connect onboarding success directly to improved chat startup messaging.
 
@@ -461,7 +461,7 @@ Expected: onboarding success can hand off into a more informative chat surface.
 Update the quick-start sequence so first-time users are guided toward:
 
 ```text
-loongclawd onboard
+loongclaw onboard
 ```
 
 before manually running `chat`.
@@ -530,7 +530,7 @@ Expected: PASS
 Run:
 
 ```bash
-cargo run -p loongclaw-daemon --bin loongclawd -- onboard
+cargo run -p loongclaw-daemon --bin loongclaw -- onboard
 ```
 
 Expected:

--- a/docs/plans/2026-03-12-child-session-self-inspection-design.md
+++ b/docs/plans/2026-03-12-child-session-self-inspection-design.md
@@ -1,0 +1,147 @@
+# Child Session Self-Inspection Design
+
+## Context
+
+LoongClaw now supports synchronous nested delegation with lineage-based `max_depth` enforcement. Delegated child sessions can run useful work, but their current tool surface has a gap: they cannot inspect their own session state or transcript through the app-layer session tools.
+
+That makes delegated subtasks less self-aware than root sessions even though the system already records:
+
+- session state
+- session events
+- session transcript history
+
+## Problem
+
+We want delegated child sessions to be able to inspect themselves without widening cross-session visibility.
+
+The subtle constraint is that child sessions may now have descendants when `max_depth > 1`. If we simply expose `session_status` and `sessions_history` while reusing the global `tools.sessions.visibility = "children"` policy, then a child session would gain access to its own descendants. That is broader than the intended "self-inspection only" behavior.
+
+## Goals
+
+- Let delegated child sessions call `session_status` for themselves.
+- Let delegated child sessions call `sessions_history` for themselves.
+- Keep `sessions_list` hidden from delegated child sessions.
+- Prevent delegated child sessions from inspecting parent or descendant sessions.
+- Avoid introducing a new config surface unless clearly necessary.
+
+## Non-Goals
+
+- No broad session tree browsing inside child sessions.
+- No `sessions_list` in delegated child tool views.
+- No new persisted policy fields or schema changes.
+- No change to root-session visibility semantics.
+
+## Options Considered
+
+### Option 1: Expose child self-inspection tools and reuse global visibility
+
+Pros:
+
+- smallest code diff
+
+Cons:
+
+- incorrect semantics once child sessions can also delegate
+- child would inherit descendant visibility via the existing `"children"` policy
+
+Rejected.
+
+### Option 2: Expose child self-inspection tools and force a child-local self-only override
+
+Pros:
+
+- matches intended behavior exactly
+- keeps existing root semantics untouched
+- does not require new config
+
+Cons:
+
+- needs one more policy-derivation layer at app-tool dispatch time
+
+Chosen.
+
+### Option 3: Add a separate config surface for child session inspection policy
+
+Pros:
+
+- most configurable
+
+Cons:
+
+- overfits the current phase
+- adds config complexity before the simpler model is proven useful
+
+Rejected for now.
+
+## Chosen Approach
+
+Delegated child sessions will advertise:
+
+- `session_status`
+- `sessions_history`
+
+They will continue to hide:
+
+- `sessions_list`
+- all broader session-browsing behavior
+
+At execution time, app-tool dispatch will derive an effective tool policy from `SessionContext`:
+
+- root sessions use configured `tools.sessions.visibility`
+- child sessions force session-tool visibility to `self`
+
+This separation keeps the provider-visible tool surface truthful while ensuring execution policy remains narrower for delegated children.
+
+## Implementation Shape
+
+### Tool View Layer
+
+Extend delegate child tool-view construction so child sessions can see:
+
+- configured runtime child core tools
+- optional `delegate` when remaining depth allows it
+- `session_status`
+- `sessions_history`
+
+`sessions_list` remains excluded.
+
+### App Tool Policy Layer
+
+Introduce a small helper that derives an effective `ToolConfig` for the current `SessionContext`.
+
+For child sessions:
+
+- clone the current tool config
+- override `tools.sessions.visibility` to `self`
+
+This policy should be applied by the default app dispatcher before calling `execute_app_tool_with_config(...)`.
+
+### Session Tool Layer
+
+No broad semantic change is needed inside `tools/session.rs`; it already understands `SelfOnly` and `Children`. The new work is to ensure child sessions arrive with the correct effective policy.
+
+## Behavior
+
+Expected behavior after this change:
+
+- child session can call `session_status` on itself
+- child session can call `sessions_history` on itself
+- child session cannot call `sessions_list` because the tool is not visible
+- child session cannot inspect a descendant session even if it created one via nested delegation
+- child session cannot inspect its parent session
+
+## Testing Strategy
+
+Add TDD coverage for:
+
+1. child tool view includes `session_status` and `sessions_history`
+2. child tool view still excludes `sessions_list`
+3. child session can successfully read its own status
+4. child session can successfully read its own history
+5. child session gets `tool_not_visible: sessions_list`
+6. child session gets `visibility_denied` when trying to inspect a descendant session
+7. resumed child sessions get the same self-inspection tool view from the default runtime
+
+## Documentation Impact
+
+Update the product spec to clarify that delegated child sessions have self-inspection only, not session-tree browsing.

--- a/docs/plans/2026-03-12-child-session-self-inspection-implementation-plan.md
+++ b/docs/plans/2026-03-12-child-session-self-inspection-implementation-plan.md
@@ -1,0 +1,129 @@
+# Child Session Self-Inspection Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let delegated child sessions inspect their own status and history while keeping session browsing restricted to self-only semantics.
+
+**Architecture:** Extend the child tool view to expose `session_status` and `sessions_history`, then derive an effective app-tool policy from `SessionContext` so child sessions always execute session tools with `visibility = self`. This preserves root semantics and avoids a new config surface.
+
+**Tech Stack:** Rust, `loongclaw-app`, SQLite-backed session repository, app-layer tool dispatcher, existing turn-loop and session-tool tests.
+
+---
+
+### Task 1: Add Failing Tests for Child Self-Inspection Tool Views
+
+**Files:**
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- delegated child tool views include `session_status`
+- delegated child tool views include `sessions_history`
+- delegated child tool views still exclude `sessions_list`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app child_session_self_inspection -- --nocapture
+```
+
+Expected: FAIL because child tool views do not currently expose session self-inspection tools.
+
+**Step 3: Write minimal implementation**
+
+Update child tool-view builders to include the self-inspection app tools.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app child_session_self_inspection -- --nocapture
+```
+
+Expected: PASS.
+
+### Task 2: Add Failing Tests for Child Self-Only Execution Policy
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- a child session can call `session_status` for itself
+- a child session can call `sessions_history` for itself
+- a child session cannot call `sessions_list`
+- a child session cannot inspect a descendant session and receives `visibility_denied`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app child_session_self_only -- --nocapture
+```
+
+Expected: FAIL because child sessions currently inherit the broader global session visibility policy.
+
+**Step 3: Write minimal implementation**
+
+Add an effective tool-policy helper keyed by `SessionContext` and apply it in the default app dispatcher so child sessions force `tools.sessions.visibility = self`.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app child_session_self_only -- --nocapture
+```
+
+Expected: PASS.
+
+### Task 3: Update Docs and Run Final Verification
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Optionally Modify: `docs/roadmap.md`
+
+**Step 1: Write the doc updates**
+
+Document that child sessions now have self-inspection only:
+
+- `session_status`
+- `sessions_history`
+- no `sessions_list`
+- no parent/descendant session inspection
+
+**Step 2: Run focused regression**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app session_status sessions_history child_session -- --nocapture
+```
+
+Expected: PASS.
+
+**Step 3: Run full verification**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo test -p loongclaw-app -- --nocapture
+cargo fmt --all --check
+git diff --check
+```
+
+Expected: all commands pass cleanly.
+
+Plan complete and saved to `docs/plans/2026-03-12-child-session-self-inspection-implementation-plan.md`. Execution path for this session: continue locally with TDD against this plan.

--- a/docs/plans/2026-03-12-delegate-async-subprocess-design.md
+++ b/docs/plans/2026-03-12-delegate-async-subprocess-design.md
@@ -1,0 +1,230 @@
+# Delegate Async Subprocess Design
+
+## Context
+
+LoongClaw now has the following session/delegation primitives:
+
+- synchronous `delegate`
+- lineage-bounded nested delegation
+- delegated-child self-inspection
+- durable terminal outcomes
+- `session_events`
+- `session_wait`
+
+That gives the system a stable polling and observability layer, but it still lacks non-blocking delegation. Parent sessions must wait for child execution inline inside the same turn loop.
+
+## Problem
+
+We want a real `delegate_async` capability without pretending LoongClaw already has a durable worker queue or long-lived task registry.
+
+The critical architectural question is how child execution continues after the parent tool call returns.
+
+## Goals
+
+- Add a non-blocking `delegate_async` tool.
+- Reuse `child_session_id` as the wait handle.
+- Reuse existing `session_wait`, `session_status`, and `session_events` instead of inventing a second observability plane.
+- Keep nested delegation bounded by existing lineage-based `max_depth`.
+- Preserve child tool-view restrictions.
+
+## Non-Goals
+
+- No durable task queue.
+- No cancellation API in this phase.
+- No websocket/push event stream.
+- No cross-host or post-reboot recovery guarantees.
+
+## Options Considered
+
+### Option 1: In-process Tokio task spawn
+
+Pros:
+
+- smallest apparent runtime diff
+- avoids subprocess creation overhead
+
+Cons:
+
+- parent-side code only has borrowed runtime references in many paths
+- hard to detach safely across turn-loop boundaries
+- dies with the parent process
+- difficult to test without threading borrowed `ConversationRuntime` through `'static` task ownership
+
+Rejected.
+
+### Option 2: Subprocess one-shot worker
+
+Spawn the current daemon binary in a dedicated one-shot command that processes exactly one session turn and exits.
+
+Pros:
+
+- parent can return immediately after spawning
+- child work no longer depends on borrowed runtime references from the parent turn loop
+- child may outlive the parent process once the subprocess is launched
+- reuses the existing sqlite-backed session store and session id handle
+
+Cons:
+
+- needs a stable single-turn CLI entrypoint
+- requires config-path handoff into the child process
+- adds process startup overhead
+
+Chosen.
+
+### Option 3: Durable queue/worker subsystem first
+
+Pros:
+
+- strongest eventual architecture
+- best path to retries/cancel/resume
+
+Cons:
+
+- much larger than the current phase
+- drags in queue ownership, leasing, and recovery semantics
+
+Rejected for now.
+
+## Chosen Approach
+
+Add `delegate_async` as a sibling to synchronous `delegate`, backed by a subprocess worker.
+
+### Parent-side behavior
+
+When a session calls `delegate_async`:
+
+1. validate payload and lineage depth
+2. create child session row
+3. append `delegate_queued`
+4. spawn a subprocess worker
+5. return immediately with:
+   - `child_session_id`
+   - `label`
+   - `mode = "async"`
+   - `state = "queued"`
+
+### Worker-side behavior
+
+The subprocess worker executes exactly one turn for the child session:
+
+1. load config
+2. mark child session `running`
+3. append `delegate_started`
+4. run the child turn with timeout
+5. persist terminal outcome and final state
+6. append `delegate_completed` / `delegate_failed` / `delegate_timed_out`
+7. exit
+
+## CLI Foundation
+
+Add a new daemon command:
+
+- `loongclawd run-turn`
+
+Inputs:
+
+- `--config` optional
+- `--session` required
+- `--input` required
+- `--timeout-seconds` optional
+- `--delegate-child` optional flag
+
+When `--delegate-child` is set, the command wraps execution with delegate-child lifecycle state/event persistence rather than behaving like a generic one-shot turn command.
+
+## Config Handoff
+
+The subprocess worker needs the active config path.
+
+Preferred source order:
+
+1. explicit `--config`
+2. inherited `LOONGCLAW_CONFIG_PATH`
+
+Interactive and channel entrypoints should export `LOONGCLAW_CONFIG_PATH` once the resolved config file is known.
+
+## Tool Surface
+
+### Root sessions
+
+Root sessions advertise:
+
+- `delegate`
+- `delegate_async`
+- `sessions_list`
+- `sessions_history`
+- `session_status`
+- `session_events`
+- `session_wait`
+
+### Delegated child sessions
+
+When remaining depth allows further delegation, child sessions advertise:
+
+- `delegate`
+- `delegate_async`
+- `session_status`
+- `sessions_history`
+
+They still do not advertise:
+
+- `sessions_list`
+- `session_events`
+- `session_wait`
+
+## State Model
+
+### New async lifecycle events
+
+Add:
+
+- `delegate_queued`
+- `delegate_spawn_failed`
+
+Existing events remain:
+
+- `delegate_started`
+- `delegate_completed`
+- `delegate_failed`
+- `delegate_timed_out`
+
+### Session states
+
+Use existing session states only:
+
+- `ready` while queued
+- `running` once worker starts
+- `completed` / `failed` / `timed_out` on terminal exit
+
+No new state enum is needed in this phase.
+
+## App Dispatcher Design
+
+`delegate_async` should execute through `DefaultAppToolDispatcher`, not the synchronous direct tool helper.
+
+Introduce a small async delegate spawner abstraction:
+
+- production: subprocess spawner
+- tests: fake spawner
+
+This keeps app-layer tests deterministic without requiring the real daemon binary to be launched during unit tests.
+
+## Testing Strategy
+
+Add TDD coverage for:
+
+1. tool catalog/provider schema includes `delegate_async`
+2. root runtime tool view includes `delegate_async`
+3. delegated child tool view includes `delegate_async` only when remaining depth allows
+4. `delegate_async` returns immediate queued handle payload
+5. spawn failure marks child session failed and records `delegate_spawn_failed`
+6. fake async completion becomes observable via `session_wait`
+7. `run-turn --delegate-child` lifecycle helper persists terminal outcomes for success/failure/timeout
+
+## Documentation Impact
+
+Update product spec and roadmap to reflect:
+
+- async delegation is now available
+- session id is the async handle
+- waiting remains polling-based
+- no cancellation and no durable queue yet

--- a/docs/plans/2026-03-12-delegate-async-subprocess-design.md
+++ b/docs/plans/2026-03-12-delegate-async-subprocess-design.md
@@ -119,7 +119,7 @@ The subprocess worker executes exactly one turn for the child session:
 
 Add a new daemon command:
 
-- `loongclawd run-turn`
+- `loongclaw run-turn`
 
 Inputs:
 

--- a/docs/plans/2026-03-12-delegate-async-subprocess-implementation-plan.md
+++ b/docs/plans/2026-03-12-delegate-async-subprocess-implementation-plan.md
@@ -1,0 +1,220 @@
+# Delegate Async Subprocess Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add non-blocking `delegate_async` using a subprocess one-shot worker while reusing session ids plus `session_wait/session_status/session_events` as the async handle and observability surface.
+
+**Architecture:** Extend the app tool surface with `delegate_async`, add a pluggable async delegate spawner to the default app dispatcher, and add a daemon `run-turn` command for one-shot child-session execution. Parent-side async delegation queues child work and returns immediately; worker-side execution persists the normal delegate lifecycle and terminal outcomes.
+
+**Tech Stack:** Rust, Tokio, rusqlite, clap, existing LoongClaw app/daemon crates
+
+---
+
+### Task 1: Add design-level failing tests for `delegate_async` tool visibility/schema
+
+**Files:**
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/provider/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- root runtime tool view includes `delegate_async`
+- provider tool definitions include `delegate_async`
+- child tool view includes `delegate_async` only when remaining depth allows
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app delegate_async -- --nocapture`
+
+Expected: FAIL because the tool is not registered yet.
+
+**Step 3: Write minimal implementation**
+
+Register the new tool in catalog/provider views only.
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app delegate_async -- --nocapture`
+
+Expected: PASS
+
+### Task 2: Add async delegate spawner abstraction and parent-side orchestration
+
+**Files:**
+- Modify: `crates/app/src/tools/delegate.rs`
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- `delegate_async` returns queued payload immediately
+- spawn failure records child failure and `delegate_spawn_failed`
+
+Use a fake spawner in tests.
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app delegate_async_queue -- --nocapture`
+
+Expected: FAIL because no async spawner path exists.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- spawner trait + fake-test support
+- parent-side session row creation and `delegate_queued`
+- immediate queued tool outcome
+- spawn-failure cleanup/event persistence
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app delegate_async_queue -- --nocapture`
+
+Expected: PASS
+
+### Task 3: Add background child lifecycle helper
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add tests for a delegate-child lifecycle helper covering:
+
+- success
+- provider/runtime failure
+- timeout
+
+Expected observations:
+
+- session state transitions
+- lifecycle events
+- durable terminal outcomes
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app delegate_child_background_ -- --nocapture`
+
+Expected: FAIL because the lifecycle helper does not exist.
+
+**Step 3: Write minimal implementation**
+
+Factor shared delegate-child execution/finalization logic into a reusable helper that can be called by both synchronous `delegate` and async worker execution.
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app delegate_child_background_ -- --nocapture`
+
+Expected: PASS
+
+### Task 4: Add daemon `run-turn` worker command
+
+**Files:**
+- Modify: `crates/daemon/src/main.rs`
+- Test: `crates/daemon/src/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add daemon tests for:
+
+- command parsing of `run-turn`
+- `--delegate-child` path dispatch
+- config path resolution from arg/env
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-daemon run_turn -- --nocapture`
+
+Expected: FAIL because the command does not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement the CLI command and route it to the child lifecycle helper or normal one-shot turn execution.
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-daemon run_turn -- --nocapture`
+
+Expected: PASS
+
+### Task 5: Wire production subprocess spawning
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/chat.rs`
+- Modify: `crates/app/src/channel/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+
+- entrypoints export `LOONGCLAW_CONFIG_PATH`
+- production spawner command shape is stable
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app config_path -- --nocapture`
+
+Expected: FAIL because async delegate production handoff is not wired.
+
+**Step 3: Write minimal implementation**
+
+Wire:
+
+- config-path export from interactive/channel entrypoints
+- subprocess delegate spawner using current executable + `run-turn`
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app config_path -- --nocapture`
+
+Expected: PASS
+
+### Task 6: Update docs and run full verification
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Update docs**
+
+Document:
+
+- `delegate_async`
+- session id as async handle
+- subprocess worker model
+- current limits (no cancel, no durable queue)
+
+**Step 2: Run focused regression**
+
+Run:
+
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app delegate_async -- --nocapture`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_wait -- --nocapture`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-daemon run_turn -- --nocapture`
+
+Expected: PASS
+
+**Step 3: Run full verification**
+
+Run:
+
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --nocapture`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-daemon -- --nocapture`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all --check`
+- `git diff --check`
+
+Expected:
+
+- app and daemon suites green
+- formatting clean
+- no patch hygiene issues
+
+Plan complete and saved to `docs/plans/2026-03-12-delegate-async-subprocess-implementation-plan.md`. Execution path for this session: continue locally in the current worktree with TDD against this plan.

--- a/docs/plans/2026-03-12-delegate-depth-lineage-design.md
+++ b/docs/plans/2026-03-12-delegate-depth-lineage-design.md
@@ -1,0 +1,137 @@
+# Delegate Depth Lineage Design
+
+## Context
+
+LoongClaw already exposes a synchronous `delegate` app tool, session inspection tools, and config for `tools.delegate.max_depth`. The current implementation only enforces a shallow special case:
+
+- root sessions can delegate once
+- child sessions are hard-blocked when `max_depth <= 1`
+- child tool views always exclude `delegate`
+
+That means the current config surface is only partially truthful. `max_depth > 1` does not materially change runtime behavior, and nested delegate chains cannot be observed cleanly from the root session.
+
+## Problem
+
+We need to make delegate depth a real runtime policy rather than a placeholder config field, without expanding into background execution or schema migration work.
+
+The current gaps are:
+
+1. `tools.delegate.max_depth` does not permit true nested delegation.
+2. Child tool visibility is hard-coded rather than derived from remaining depth.
+3. Session visibility only covers the current session and direct children, which becomes too shallow once grandchild sessions exist.
+4. The child tool allowlist default advertises planned tools that are not actually runtime-visible today.
+
+## Goals
+
+- Make `max_depth` semantically real for synchronous nested delegation.
+- Keep the thick orchestration in the app-layer turn loop.
+- Avoid SQLite schema changes or historical backfill.
+- Let root sessions inspect the full descendant delegate chain through session tools.
+- Keep session tools hidden from delegated children for this phase.
+
+## Non-Goals
+
+- No background delegate workers.
+- No async wait handles or subscription APIs.
+- No `sessions_*` exposure inside delegated child tool views.
+- No migration that rewrites historical session rows.
+
+## Chosen Approach
+
+Use runtime lineage traversal over the existing `parent_session_id` chain.
+
+### Depth Model
+
+- Root session lineage depth is `0`.
+- A direct child created by `delegate` has depth `1`.
+- A grandchild has depth `2`, and so on.
+- A new delegate call is allowed only when `current_depth + 1 <= max_depth`.
+
+This preserves current default behavior:
+
+- `max_depth = 1`: root can create one child, that child cannot delegate again.
+- `max_depth = 2`: root can create a child, and that child can create one grandchild.
+- `max_depth = 3`: root -> child -> grandchild -> great-grandchild is allowed.
+
+### Session Visibility Model
+
+`tools.sessions.visibility = "children"` will mean "current session plus descendant delegate chain", not just one-hop children.
+
+This is necessary once nested delegation exists; otherwise the root session cannot inspect deeper delegated work it initiated indirectly.
+
+### Child Tool View Model
+
+Child tool visibility will be computed from:
+
+1. runtime-supported core tools
+2. `tools.delegate.child_tool_allowlist`
+3. `tools.delegate.allow_shell_in_child`
+4. whether another nested `delegate` step is still allowed at the child depth
+
+Session inspection tools remain excluded from delegated child views in this phase.
+
+## Implementation Shape
+
+### Repository Layer
+
+Add lineage helpers to `SessionRepository`:
+
+- compute session lineage depth from `parent_session_id`
+- determine whether a target session is a visible descendant of the current session
+- list visible descendant sessions recursively
+
+Legacy fallback stays best-effort and current-session-scoped. It remains useful for old roots and resumed sessions, but descendant visibility still depends on concrete `sessions` metadata because historical `turns` do not encode parentage.
+
+### Tool Catalog Layer
+
+Replace the hard-coded delegate child view assembly with a config-aware function that can:
+
+- include runtime-supported child core tools from allowlist
+- optionally add `shell.exec`
+- optionally add `delegate`
+
+The default child allowlist should be tightened to currently supported runtime child tools so the config no longer promises tools that do not exist.
+
+### Turn Loop Layer
+
+Before creating a child session, the delegate executor will:
+
+1. compute current lineage depth
+2. reject if the next child depth would exceed `max_depth`
+3. compute whether the child should itself see `delegate`
+4. create the child `SessionContext` with that dynamic tool view
+
+This keeps delegate orchestration in `conversation/turn_loop.rs`, where it already owns timeout, event logging, and nested turn execution.
+
+## Error Semantics
+
+Two layers remain intentional:
+
+- `tool_not_visible: delegate`
+  Returned when the provider tried to call a tool that is not in the current session's tool view.
+
+- `delegate_depth_exceeded`
+  Returned defensively when runtime lineage checks show the requested nested delegate would exceed configured depth.
+
+The first is the normal policy surface. The second protects against mismatched or stale tool-view assumptions.
+
+## Testing Strategy
+
+Use TDD and add regression coverage for:
+
+1. child tool view excludes `delegate` when no further depth remains
+2. child tool view includes `delegate` when further depth remains
+3. nested grandchild creation succeeds when `max_depth` allows it
+4. nested delegate returns `delegate_depth_exceeded` when the next level would exceed config
+5. root `sessions_list` can see descendant sessions, not only direct children
+6. root `session_status` can inspect descendant sessions
+7. legacy fallback behavior remains intact for sessions that only exist in `turns`
+
+## Documentation Impact
+
+Update product and roadmap docs to describe:
+
+- synchronous nested delegate semantics
+- descendant session visibility
+- the meaning of `max_depth`
+- the explicit non-goals that are still deferred

--- a/docs/plans/2026-03-12-delegate-depth-lineage-implementation-plan.md
+++ b/docs/plans/2026-03-12-delegate-depth-lineage-implementation-plan.md
@@ -1,0 +1,174 @@
+# Delegate Depth Lineage Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `tools.delegate.max_depth` semantically real by enabling synchronous nested delegation with lineage-based depth enforcement and descendant session visibility.
+
+**Architecture:** Keep orchestration in the app-layer turn loop and compute delegate depth from the existing `sessions.parent_session_id` lineage. Extend the session repository to understand descendants, update child tool-view derivation to reflect remaining depth, and document the resulting synchronous nested-delegate semantics.
+
+**Tech Stack:** Rust, `loongclaw-app`, SQLite via `rusqlite`, existing conversation turn-loop tests and config TOML surface.
+
+---
+
+### Task 1: Add Failing Tests for Depth-Aware Child Tool Views
+
+**Files:**
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- a delegate child view can include `delegate` when remaining depth allows nesting
+- a delegate child view excludes `delegate` when no further depth remains
+- the child allowlist defaults only include currently supported runtime child tools
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app delegate_child -- --nocapture
+```
+
+Expected: FAIL because child tool-view construction is still hard-coded.
+
+**Step 3: Write minimal implementation**
+
+Update the catalog/tool-view helpers so child tool views are derived from:
+
+- supported runtime core tools
+- child allowlist
+- shell policy
+- whether nested delegate is still allowed
+
+**Step 4: Re-run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app delegate_child -- --nocapture
+```
+
+Expected: PASS.
+
+### Task 2: Add Failing Tests for Lineage Depth Enforcement
+
+**Files:**
+- Modify: `crates/app/src/session/repository.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- repository lineage depth is computed correctly for root/child/grandchild chains
+- `max_depth = 2` allows root -> child -> grandchild
+- exceeding the next delegate level returns `delegate_depth_exceeded`
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app delegate_depth -- --nocapture
+```
+
+Expected: FAIL because lineage depth helpers do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add repository helpers for lineage depth and use them from `execute_delegate_tool(...)` before child creation.
+
+**Step 4: Re-run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app delegate_depth -- --nocapture
+```
+
+Expected: PASS.
+
+### Task 3: Add Failing Tests for Descendant Session Visibility
+
+**Files:**
+- Modify: `crates/app/src/session/repository.rs`
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- root `sessions_list` includes grandchild descendants
+- root `session_status` can inspect a grandchild descendant
+- non-ancestor sessions still cannot inspect unrelated sessions
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app descendant_session -- --nocapture
+```
+
+Expected: FAIL because visibility is still one-hop only.
+
+**Step 3: Write minimal implementation**
+
+Extend repository visibility helpers so `"children"` means descendant chain visibility.
+
+**Step 4: Re-run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app descendant_session -- --nocapture
+```
+
+Expected: PASS.
+
+### Task 4: Update Product Docs and Final Regression Coverage
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+- Modify: `crates/app/src/config/tools_memory.rs`
+- Modify: `crates/app/src/config/runtime.rs`
+
+**Step 1: Write the doc updates**
+
+Document:
+
+- synchronous nested delegate semantics
+- descendant session visibility
+- current non-goals and deferred work
+
+Also align config defaults/tests if the child allowlist is tightened to actual runtime tools.
+
+**Step 2: Run focused regression**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app tools:: conversation:: session:: config:: -- --nocapture
+```
+
+Expected: PASS.
+
+**Step 3: Run full verification**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo test -p loongclaw-app -- --nocapture
+cargo fmt --all --check
+git diff --check
+```
+
+Expected: all commands pass cleanly.
+
+Plan complete and saved to `docs/plans/2026-03-12-delegate-depth-lineage-implementation-plan.md`. Execution path for this session: continue locally with TDD against this plan.

--- a/docs/plans/2026-03-12-session-observability-design.md
+++ b/docs/plans/2026-03-12-session-observability-design.md
@@ -1,0 +1,260 @@
+# Session Observability Design
+
+## Context
+
+LoongClaw now has a working app-layer session surface:
+
+- `sessions_list`
+- `sessions_history`
+- `session_status`
+- synchronous `delegate`
+- sqlite-backed `sessions` and `session_events`
+
+That is enough to create and inspect delegate child sessions, but the observability model is still thin:
+
+- operators can only read a coarse status snapshot
+- terminal delegate results are not stored in a dedicated durable read model
+- event inspection is only available indirectly through the fixed `recent_events` block inside `session_status`
+- there is no bounded wait primitive for another session to finish
+
+## Problem
+
+We need the next thick slice to improve session observability without prematurely committing LoongClaw to a background worker architecture.
+
+If we jump straight to `delegate_async`, we immediately inherit a larger runtime problem:
+
+- which process owns the child execution after the parent returns
+- what survives process restart
+- how in-process task handles reconcile with sqlite state
+- how channels and CLI sessions discover orphaned or detached work
+
+That is solvable, but it is not the smallest causal next step.
+
+## Goals
+
+- Add a durable terminal outcome read model for delegate child sessions.
+- Add an explicit `session_events` tool for polling session event history.
+- Add an explicit `session_wait` tool for bounded waiting on visible sessions.
+- Keep root-session visibility semantics unchanged.
+- Keep delegated-child visibility semantics self-only for session tools.
+- Reuse existing sqlite session infrastructure rather than introducing a worker runtime.
+
+## Non-Goals
+
+- No background delegate workers.
+- No `delegate_async`, `session_cancel`, or push subscription transport.
+- No cross-process task registry beyond sqlite session state.
+- No historical backfill for legacy sessions that only exist in `turns`.
+
+## Options Considered
+
+### Option 1: Event log only
+
+Expose `session_events` and derive terminal result from the latest event payload.
+
+Pros:
+
+- smallest schema change
+- reuses the existing event table
+
+Cons:
+
+- terminal result remains implicit rather than a stable read model
+- callers have to infer semantics from event ordering and payload shape
+- future `session_wait` would still be coupled to event inspection heuristics
+
+Rejected.
+
+### Option 2: Durable terminal outcome + polling tools
+
+Add a `session_terminal_outcomes` table, persist delegate terminal payloads there, expose:
+
+- `session_events`
+- `session_wait`
+- `terminal_outcome` inside `session_status`
+
+Pros:
+
+- gives session tooling a real durable result model
+- keeps current synchronous `delegate` semantics unchanged
+- provides the exact primitives needed before any async delegate work
+- composes cleanly with the current sqlite session repository
+
+Cons:
+
+- adds one more read model and one async polling code path
+
+Chosen.
+
+### Option 3: Full async delegate now
+
+Introduce `delegate_async`, wait handles, and in-process task ownership immediately.
+
+Pros:
+
+- closer to the richer OpenClaw orchestration model
+- more obviously future-facing
+
+Cons:
+
+- couples this phase to worker lifecycle design
+- leaves restart/orphan semantics under-specified
+- much larger execution surface than the current runtime actually supports
+
+Rejected for now.
+
+## Chosen Approach
+
+Implement an observability-first layer on top of the existing synchronous delegate model:
+
+1. Persist terminal outcomes for delegate child sessions in a dedicated sqlite table.
+2. Expose `session_events` as a root-visible session tool for bounded event polling.
+3. Expose `session_wait` as a bounded async app tool that waits until:
+   - the target session becomes terminal, or
+   - the wait timeout expires.
+4. Extend `session_status` to surface `terminal_outcome` when present.
+
+This gives LoongClaw a stable read model for eventual async delegation without forcing async execution ownership into this slice.
+
+## Tool Surface
+
+### Root Sessions
+
+Root sessions will advertise:
+
+- `sessions_list`
+- `sessions_history`
+- `session_status`
+- `session_events`
+- `session_wait`
+- `delegate`
+
+### Delegated Child Sessions
+
+Delegated child sessions will continue to advertise:
+
+- `session_status`
+- `sessions_history`
+
+They will continue to hide:
+
+- `sessions_list`
+- `session_events`
+- `session_wait`
+
+This keeps child self-inspection narrow and avoids broadening their orchestration authority before async delegation exists.
+
+## Data Model
+
+Add a new sqlite table:
+
+- `session_terminal_outcomes`
+
+Suggested columns:
+
+- `session_id TEXT PRIMARY KEY`
+- `status TEXT NOT NULL`
+- `payload_json TEXT NOT NULL`
+- `recorded_at INTEGER NOT NULL`
+
+This table stores the terminal `ToolCoreOutcome` shape for a completed delegate child session:
+
+- success payload
+- timeout payload
+- error payload
+
+The session row remains the source of truth for lifecycle state (`ready`, `running`, `completed`, `failed`, `timed_out`).
+The terminal outcome table becomes the source of truth for terminal result payloads.
+
+## Execution Model
+
+### Delegate Completion Persistence
+
+When synchronous `delegate` exits:
+
+- success: mark child `completed`, append `delegate_completed`, persist terminal outcome
+- failure: mark child `failed`, append `delegate_failed`, persist terminal outcome
+- timeout: mark child `timed_out`, append `delegate_timed_out`, persist terminal outcome
+
+### `session_status`
+
+Keep the existing snapshot payload, but add:
+
+- `terminal_outcome`
+
+If no terminal outcome exists, return `null`.
+
+### `session_events`
+
+Add direct event inspection with:
+
+- required `session_id`
+- optional `limit`
+- optional `after_id`
+
+Semantics:
+
+- if `after_id` is present, return events with `id > after_id` in ascending order up to `limit`
+- otherwise return the most recent `limit` events in ascending order
+
+### `session_wait`
+
+`session_wait` will be async at the app-dispatch layer, not inside the synchronous sqlite helper.
+
+Inputs:
+
+- required `session_id`
+- optional `timeout_ms`
+
+Behavior:
+
+- validate visibility first
+- repeatedly read current session summary + terminal outcome
+- stop early when the target session reaches a terminal state
+- otherwise return a timeout snapshot after the deadline
+
+Return shape:
+
+- `wait_status`: `completed` or `timeout`
+- `session`
+- `terminal_outcome`
+- `recent_events`
+
+Tool outcome status remains:
+
+- `ok` when terminal state was observed before the deadline
+- `timeout` when the deadline expires first
+
+## Visibility Policy
+
+Session visibility rules stay unchanged:
+
+- root sessions use configured `tools.sessions.visibility`
+- delegated child sessions force effective visibility to `self`
+
+That means:
+
+- roots can inspect visible descendants with `session_events`, `session_wait`, and `session_status`
+- children cannot use the new tools because they are not in the child tool view
+
+## Testing Strategy
+
+Add TDD coverage for:
+
+1. repository upsert/load of terminal outcomes
+2. `session_status` includes `terminal_outcome` when present
+3. `session_events` returns ordered event payloads and respects `after_id`
+4. `session_wait` returns `ok` when a target session is already terminal
+5. `session_wait` times out cleanly for a non-terminal session
+6. synchronous `delegate` persists terminal outcome rows for success, failure, and timeout
+7. runtime root tool view includes `session_events` and `session_wait`
+8. delegated child tool view still excludes the new observability tools
+
+## Documentation Impact
+
+Update the product spec and roadmap to reflect:
+
+- durable terminal delegate outcomes
+- `session_events`
+- `session_wait`
+- continued absence of background async delegation

--- a/docs/plans/2026-03-12-session-observability-implementation-plan.md
+++ b/docs/plans/2026-03-12-session-observability-implementation-plan.md
@@ -1,0 +1,233 @@
+# Session Observability Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a thick observability layer for delegated sessions by persisting terminal outcomes and exposing `session_events` and `session_wait` without introducing async background delegation.
+
+**Architecture:** Extend the sqlite-backed session repository with a durable terminal-outcome read model, wire that data into session inspection tools, and add a bounded async `session_wait` path in the default app dispatcher. Keep delegated child tool views narrow and leave synchronous `delegate` execution semantics unchanged.
+
+**Tech Stack:** Rust, Tokio, rusqlite, serde_json, existing LoongClaw app-layer tool/session runtime
+
+---
+
+### Task 1: Add durable terminal outcome persistence
+
+**Files:**
+- Modify: `crates/app/src/memory/sqlite.rs`
+- Modify: `crates/app/src/session/repository.rs`
+- Test: `crates/app/src/session/repository.rs`
+
+**Step 1: Write the failing test**
+
+Add repository tests for:
+
+- upserting a terminal outcome for a session
+- loading it back with stable status/payload fields
+- replacing an existing terminal outcome for the same session
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_terminal_outcome -- --nocapture`
+
+Expected: FAIL because the schema and repository methods do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- `session_terminal_outcomes` table creation in sqlite schema bootstrap
+- repository record type and helpers
+- `upsert_terminal_outcome(...)`
+- `load_terminal_outcome(...)`
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_terminal_outcome -- --nocapture`
+
+Expected: PASS
+
+### Task 2: Expose terminal outcomes in session inspection tools
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+- Test: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+
+- `session_status` includes `terminal_outcome`
+- `session_status` returns `terminal_outcome = null` when no durable outcome exists
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_status_returns_state_and_last_error -- --nocapture`
+
+Expected: FAIL because `session_status` does not currently expose terminal outcomes.
+
+**Step 3: Write minimal implementation**
+
+Update the session-status payload builder to read the repository outcome row and include it in the response shape.
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_status_returns_state_and_last_error -- --nocapture`
+
+Expected: PASS
+
+### Task 3: Add `session_events`
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `crates/app/src/provider/mod.rs`
+- Test: `crates/app/src/tools/session.rs`
+- Test: `crates/app/src/tools/mod.rs`
+- Test: `crates/app/src/provider/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+
+- root runtime tool view includes `session_events`
+- delegated child tool view still excludes `session_events`
+- `session_events` returns ascending ordered events
+- `session_events` respects `after_id`
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_events -- --nocapture`
+
+Expected: FAIL because the tool is not registered or executable yet.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- catalog/definition entry for `session_events`
+- app-tool dispatch path in `tools/mod.rs`
+- repository query helper for `after_id` polling
+- tool payload/result builder in `tools/session.rs`
+- provider/tool-schema expectations
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_events -- --nocapture`
+
+Expected: PASS
+
+### Task 4: Add async `session_wait`
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `crates/app/src/provider/mod.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+- Test: `crates/app/src/tools/mod.rs`
+- Test: `crates/app/src/provider/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+
+- `session_wait` returns `ok` for an already terminal session
+- `session_wait` returns `timeout` for a non-terminal session
+- root runtime tool view includes `session_wait`
+- delegated child tool view excludes `session_wait`
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_wait -- --nocapture`
+
+Expected: FAIL because the tool is not yet advertised or executed.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- catalog/definition entry for `session_wait`
+- async handling in `DefaultAppToolDispatcher`
+- bounded polling helper with visibility enforcement
+- provider/tool-schema expectations
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_wait -- --nocapture`
+
+Expected: PASS
+
+### Task 5: Persist terminal outcomes from synchronous delegate execution
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/tools/delegate.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add delegate tests for:
+
+- successful child delegate stores terminal outcome
+- failed child delegate stores terminal outcome
+- timed-out child delegate stores terminal outcome
+
+**Step 2: Run test to verify it fails**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app delegate_terminal_outcome -- --nocapture`
+
+Expected: FAIL because delegate currently updates session state and events but does not persist a durable terminal outcome.
+
+**Step 3: Write minimal implementation**
+
+Persist the exact returned delegate tool outcome into the new repository table before returning success/error/timeout from `execute_delegate_tool(...)`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app delegate_terminal_outcome -- --nocapture`
+
+Expected: PASS
+
+### Task 6: Update docs and run full verification
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Update docs**
+
+Document:
+
+- `session_events`
+- `session_wait`
+- durable terminal delegate outcomes
+- continued synchronous-only delegate execution
+
+**Step 2: Run focused regression**
+
+Run:
+
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_events -- --nocapture`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_wait -- --nocapture`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app delegate_terminal_outcome -- --nocapture`
+
+Expected: PASS
+
+**Step 3: Run full verification**
+
+Run:
+
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --nocapture`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all --check`
+- `git diff --check`
+
+Expected:
+
+- formatting clean
+- full `loongclaw-app` suite green
+- no whitespace or merge-marker issues
+
+Plan complete and saved to `docs/plans/2026-03-12-session-observability-implementation-plan.md`. Execution path for this session: continue locally in the current worktree with TDD against this plan.

--- a/docs/plans/2026-03-12-tool-surface-session-delegate-design.md
+++ b/docs/plans/2026-03-12-tool-surface-session-delegate-design.md
@@ -1,0 +1,621 @@
+# LoongClaw Session and Delegate Tool Surface Design
+
+**Date:** 2026-03-12
+
+**Status:** Approved design for `alpha-test`
+
+**Scope:** Build the first thick app-layer session and delegation tool surface for `loongclaw-ai/loongclaw` on branch `alpha-test`, with emphasis on `delegate`, `sessions_list`, `sessions_history`, and `session_status`.
+
+---
+
+## 1. Product Goal
+
+`loongclaw` already has a working MVP loop for:
+
+- provider turns
+- tool execution through the kernel
+- SQLite-backed conversation history
+- CLI, Telegram, and Feishu channels
+
+What it does not have is a product-level session surface or a safe, inspectable delegation model. The current tool surface is too thin for multi-step agent workflows because everything is treated as a stateless core tool.
+
+This design adds a thick app-layer capability surface that lets the agent:
+
+- inspect sessions
+- inspect session history
+- inspect session status
+- delegate a focused subtask into a child session and consume the result synchronously
+
+The first milestone is intentionally narrow. It optimizes for depth, safety, and testability instead of broad tool count.
+
+---
+
+## 2. Current State
+
+### 2.1 What Exists Today
+
+The current app already has reliable primitives we can build on:
+
+- session ids are already stable across channels and CLI entrypoints
+- turns are persisted into SQLite through the conversation runtime
+- the turn loop already supports tool-result follow-up rounds
+- tool execution already routes through the kernel for policy and audit
+
+Key files:
+
+- `crates/app/src/chat.rs`
+- `crates/app/src/channel/mod.rs`
+- `crates/app/src/conversation/runtime.rs`
+- `crates/app/src/conversation/turn_loop.rs`
+- `crates/app/src/conversation/turn_engine.rs`
+- `crates/app/src/memory/sqlite.rs`
+- `crates/app/src/tools/mod.rs`
+
+### 2.2 What Is Missing
+
+The current tool architecture is insufficient for session-aware orchestration because:
+
+- only `shell.exec`, `file.read`, and `file.write` are real agent-visible tools
+- tool registration is global and static
+- provider tool schemas are global and static
+- capability snapshots are global and static
+- there is no explicit session registry beyond transcript rows
+- there is no app-layer tool dispatcher for stateful orchestration tools
+
+This means the app cannot safely expose a child session with a reduced tool view, and it cannot model delegation as a first-class workflow.
+
+---
+
+## 3. Comparison Findings
+
+The external comparison repos point in the same direction but with different levels of ambition:
+
+- `openclaw/openclaw` has the richest session routing model and background session orchestration, but it depends on a much larger session-key, delivery, and visibility system.
+- `zeroclaw-labs/zeroclaw` provides the most directly relevant reference for synchronous delegation: named sub-agents, filtered tool allowlists, and recursion guards.
+- `qwibitai/nanoclaw` shows the value of strong isolation, but its container, IPC, and scheduler architecture is substantially heavier than `loongclaw` needs for this phase.
+- `HKUDS/NanoBot` demonstrates the usefulness of `message`, `spawn`, and `cron`, but its session and subagent model is closer to bus-driven async workflows than to `loongclaw`'s current app loop.
+
+The correct conclusion for `loongclaw` is not to copy the broadest design. It is to implement the strongest design that matches current app reality:
+
+- synchronous nested delegation
+- explicit child sessions
+- dynamic per-session tool views
+- lightweight but real session registry
+
+---
+
+## 4. Goals
+
+### 4.1 In Scope
+
+- introduce app-layer tools that are not just stateless core tool adapters
+- add a session registry that can represent session metadata and parent-child relationships
+- add dynamic tool views so different sessions can see different tool sets
+- implement `sessions_list`
+- implement `sessions_history`
+- implement `session_status`
+- implement synchronous `delegate`
+- ensure child delegate sessions run with a smaller tool surface than the parent
+- add focused tests around visibility, session state, and delegate behavior
+
+### 4.2 Out of Scope
+
+- background subagents
+- `wait`, `cancel`, `resume`, or task queue management
+- cross-channel `sessions_send`
+- a general outbound `message` tool
+- kernel-native task orchestration
+- ACP-style or harness-native subagent execution
+- broad cross-agent session visibility models
+
+---
+
+## 5. Design Principles
+
+### 5.1 Thick App Layer First
+
+This phase should land in `crates/app`, not in `crates/spec` stubs and not in kernel task abstractions. The app already has working session ids, transcript persistence, and turn orchestration. That is the correct place to make the feature real.
+
+### 5.2 Dynamic Tool Exposure
+
+Tool visibility must be a runtime decision, not a global static list. Child delegate sessions must not inherit the full root tool surface.
+
+### 5.3 Transcript Cleanliness
+
+Conversation transcript rows should contain user and assistant turns that are useful to the model. Session lifecycle and delegate control events should live outside transcript history.
+
+### 5.4 Explicit Session State
+
+A session should not only exist because it has turns. It should have explicit metadata:
+
+- kind
+- parent
+- label
+- state
+- updated timestamp
+- last error
+
+### 5.5 Strong Defaults Over Broad Flexibility
+
+This milestone should default to:
+
+- one level of delegation
+- parent plus direct children visibility
+- no child `delegate`
+- no child `sessions_*`
+- no child outbound messaging
+
+---
+
+## 6. Chosen Architecture
+
+### 6.1 Split Tool Surface Into Core and App Tools
+
+Tools are split into two execution kinds:
+
+- `Core`
+  - stateless execution tools that can continue to route through the kernel core tool adapter
+  - examples: `file.read`, `file.write`, `shell.exec`
+- `App`
+  - orchestration tools that need access to config, runtime, session metadata, or nested turn execution
+  - examples: `sessions_list`, `sessions_history`, `session_status`, `delegate`
+
+This avoids forcing stateful workflows into the existing stateless `ToolCoreRequest -> ToolCoreOutcome` path.
+
+### 6.2 Add `ToolCatalog` and `ToolView`
+
+The tool system becomes runtime-aware through two new concepts:
+
+- `ToolCatalog`
+  - global registry of known tools and their execution kind
+- `ToolView`
+  - the visible subset of tools for the current session
+
+`ToolView` becomes the single source of truth for:
+
+- `is_known_tool_name` decisions in the current session
+- provider tool schema generation
+- capability snapshot generation
+- tool execution allow/deny at the turn engine boundary
+
+### 6.3 Add an App Tool Dispatcher
+
+`TurnEngine` should dispatch tools based on execution kind:
+
+- `Core` tools continue to use the current kernel execution path
+- `App` tools are executed by a new app-layer dispatcher with access to:
+  - `LoongClawConfig`
+  - conversation runtime
+  - current session context
+  - optional kernel context
+
+This dispatcher is the orchestration boundary for session and delegate tools.
+
+---
+
+## 7. Session Model
+
+### 7.1 Session Identity
+
+Existing session ids remain unchanged for compatibility:
+
+- CLI can continue using `default` or a caller-provided hint
+- Telegram remains `telegram:<chat_id>`
+- Feishu remains `feishu:<chat_id>`
+
+New delegate child sessions use:
+
+- `delegate:<uuid>`
+
+No existing session ids are rewritten.
+
+### 7.2 Session Metadata
+
+Add a session metadata model with these fields:
+
+- `session_id`
+- `kind`
+- `parent_session_id`
+- `label`
+- `state`
+- `created_at`
+- `updated_at`
+- `last_error`
+
+Recommended state values:
+
+- `ready`
+- `running`
+- `completed`
+- `failed`
+- `timed_out`
+
+### 7.3 SQLite Tables
+
+Reuse the existing SQLite file, but add two lightweight tables:
+
+`sessions`
+
+- `session_id TEXT PRIMARY KEY`
+- `kind TEXT NOT NULL`
+- `parent_session_id TEXT NULL`
+- `label TEXT NULL`
+- `state TEXT NOT NULL`
+- `created_at INTEGER NOT NULL`
+- `updated_at INTEGER NOT NULL`
+- `last_error TEXT NULL`
+
+`session_events`
+
+- `id INTEGER PRIMARY KEY AUTOINCREMENT`
+- `session_id TEXT NOT NULL`
+- `event_kind TEXT NOT NULL`
+- `actor_session_id TEXT NULL`
+- `payload_json TEXT NOT NULL`
+- `ts INTEGER NOT NULL`
+
+The existing `turns` table remains the transcript source.
+
+### 7.4 Why Separate Registry and Transcript
+
+The session registry solves problems that transcript rows should not solve:
+
+- session listing
+- status reporting
+- parent-child visibility
+- failure and timeout tracking
+- delegate lifecycle auditing
+
+This keeps provider message windows cleaner and avoids injecting control events into future prompts.
+
+---
+
+## 8. Delegate Design
+
+### 8.1 Delegate Semantics
+
+`delegate` is a synchronous nested conversation tool.
+
+The parent session:
+
+- creates a child session
+- runs a focused child turn loop
+- waits for completion
+- receives a structured result as a tool outcome
+
+The child session is not backgrounded and is not announced through channels.
+
+### 8.2 Delegate Request Shape
+
+First-phase delegate arguments:
+
+- `task: string` required
+- `label: string` optional
+- `timeout_seconds: integer` optional
+
+The tool is intentionally small. It does not accept arbitrary provider overrides, agent ids, or channel routing targets in this phase.
+
+### 8.3 Delegate Execution Flow
+
+1. Parent session invokes `delegate`
+2. App tool dispatcher creates child session metadata
+3. Session state is set to `running`
+4. `session_events` records `delegate_started`
+5. Child `ToolView` is constructed
+6. Nested `ConversationTurnLoop` runs for the child session
+7. Child session is marked `completed`, `failed`, or `timed_out`
+8. `session_events` records completion or failure
+9. Parent session receives structured tool output
+10. Existing follow-up logic turns that output into a natural-language answer
+
+### 8.4 Child Tool Surface
+
+The first-phase child tool view should default to:
+
+- `file.read`
+- `file.write`
+- `file.edit`
+- `glob_search`
+- `content_search`
+
+The child tool view should explicitly exclude:
+
+- `delegate`
+- `sessions_list`
+- `sessions_history`
+- `session_status`
+- `message`
+- `schedule`
+
+`shell.exec` should be disabled for children by default and controlled by config.
+
+### 8.5 Delegate Result Shape
+
+Delegate outcomes should be structured rather than stringly typed.
+
+Success example:
+
+```json
+{
+  "status": "ok",
+  "payload": {
+    "child_session_id": "delegate:8f3a1b2c",
+    "label": "research-subtask",
+    "final_output": "Summary text",
+    "turn_count": 4,
+    "duration_ms": 1822
+  }
+}
+```
+
+Timeout example:
+
+```json
+{
+  "status": "timeout",
+  "payload": {
+    "child_session_id": "delegate:8f3a1b2c",
+    "label": "research-subtask",
+    "duration_ms": 60000,
+    "error": "delegate_timeout"
+  }
+}
+```
+
+This gives the parent follow-up phase a stable, machine-readable contract.
+
+---
+
+## 9. Session Tool Design
+
+### 9.1 `sessions_list`
+
+Purpose:
+
+- show visible sessions for the current session tree
+
+Behavior:
+
+- default visibility is current session plus direct children
+- returns metadata rows, not full transcript history
+- merges explicit `sessions` rows with best-effort legacy rows inferred from `turns`
+
+First-phase row shape:
+
+- `session_id`
+- `kind`
+- `parent_session_id`
+- `label`
+- `state`
+- `created_at`
+- `updated_at`
+- `turn_count`
+- `last_turn_at`
+- `last_error`
+
+### 9.2 `sessions_history`
+
+Purpose:
+
+- load transcript history for one visible session
+
+Behavior:
+
+- reads from `turns`
+- returns only transcript rows, not lifecycle events
+- enforces visibility based on the current session tree
+
+### 9.3 `session_status`
+
+Purpose:
+
+- show structured status for one visible session
+
+Behavior:
+
+- reads from `sessions`
+- may include recent event summaries from `session_events`
+- should not require transcript scanning for normal cases
+
+---
+
+## 10. Visibility and Guardrails
+
+### 10.1 Visibility Default
+
+The default visibility model for this milestone is:
+
+- current session
+- direct child sessions created by the current session
+
+This is strong enough for delegate inspection and weak enough to avoid accidental cross-session sprawl.
+
+### 10.2 Delegate Guardrails
+
+The first phase should hard-code or strongly default the following:
+
+- `max_depth = 1`
+- child sessions cannot call `delegate`
+- child sessions cannot call `sessions_*`
+- child sessions cannot send outbound messages
+- child sessions time out explicitly
+- parent sessions can inspect their direct child sessions
+
+### 10.3 Failure Handling
+
+Delegate child failures should not be persisted as synthetic assistant transcript turns.
+
+Instead:
+
+- update `sessions.state`
+- write `last_error`
+- append a `session_events` row
+- return a structured tool outcome to the parent
+
+This avoids poisoning future child prompts with operator-level error text.
+
+---
+
+## 11. Configuration
+
+Extend `ToolConfig` so tool surface policy is explicit and centralized.
+
+Recommended first-phase shape:
+
+```toml
+[tools]
+shell_allowlist = ["echo", "cat", "ls", "pwd"]
+file_root = "."
+
+[tools.sessions]
+enabled = true
+visibility = "children"
+list_limit = 100
+history_limit = 200
+
+[tools.delegate]
+enabled = true
+max_depth = 1
+timeout_seconds = 60
+child_tool_allowlist = ["file.read", "file.write", "file.edit", "glob_search", "content_search"]
+allow_shell_in_child = false
+```
+
+The first phase should keep visibility values intentionally narrow:
+
+- `self`
+- `children`
+
+No broader session-visibility matrix is needed yet.
+
+---
+
+## 12. Migration Strategy
+
+### 12.1 No Destructive Migration
+
+Do not rewrite or rename existing session ids.
+
+Do not rewrite transcript history.
+
+Do not require a separate migration command.
+
+### 12.2 Incremental Schema Upgrade
+
+On SQLite initialization:
+
+- keep creating the existing `turns` table if missing
+- add `sessions` if missing
+- add `session_events` if missing
+
+### 12.3 Legacy Session Fallback
+
+For users with historical transcripts but no `sessions` rows:
+
+- infer legacy session rows from `turns`
+- derive `kind` from known prefixes when possible
+- expose them through `sessions_list`
+
+This preserves continuity after upgrade without rewriting history.
+
+---
+
+## 13. Testing Strategy
+
+### 13.1 Tool Catalog and Tool View
+
+Add tests that verify:
+
+- root sessions see the full intended tool view
+- delegate children do not see `delegate`
+- delegate children do not see `sessions_*`
+- provider tool schemas change with `ToolView`
+- capability snapshots change with `ToolView`
+
+### 13.2 Session Repository
+
+Add tests that verify:
+
+- session rows are created and updated correctly
+- parent-child relationships are persisted
+- state transitions are persisted
+- events are stored outside transcript history
+
+### 13.3 Delegate Integration
+
+Add tests that verify:
+
+- a parent tool call creates a child session
+- child tool results return to the parent follow-up flow
+- timeout produces a structured timeout result
+- failed child execution updates session state and error metadata
+
+### 13.4 Negative Controls
+
+Add tests that verify:
+
+- visibility restrictions block unrelated session inspection
+- delegate depth limits are enforced
+- child sessions cannot invoke forbidden tools
+- transcript history excludes session control events
+
+---
+
+## 14. File Ownership
+
+Primary files to modify:
+
+- `crates/app/src/tools/mod.rs`
+- `crates/app/src/conversation/turn_engine.rs`
+- `crates/app/src/conversation/turn_loop.rs`
+- `crates/app/src/conversation/runtime.rs`
+- `crates/app/src/provider/mod.rs`
+- `crates/app/src/config/tools_memory.rs`
+- `crates/app/src/memory/sqlite.rs`
+
+Recommended new files:
+
+- `crates/app/src/tools/catalog.rs`
+- `crates/app/src/tools/session.rs`
+- `crates/app/src/tools/delegate.rs`
+- `crates/app/src/session/repository.rs`
+
+`session/repository.rs` is preferred over continuing to accumulate unrelated responsibilities in `memory/sqlite.rs`.
+
+---
+
+## 15. Rejected Alternatives
+
+### 15.1 Background Spawn First
+
+Rejected for this phase because it requires:
+
+- task ownership
+- wait/cancel/resume semantics
+- announce delivery semantics
+- persistent async orchestration
+
+`loongclaw` does not yet have that product surface.
+
+### 15.2 Kernel Task Supervisor First
+
+Rejected for this phase because the kernel task and harness abstractions are still low-level infrastructure, not an app-facing subagent UX.
+
+### 15.3 Global Static Tool Registry
+
+Rejected because it cannot support child-session tool reduction and will expose tools to the model that the child should never see.
+
+---
+
+## 16. Delivery Sequence
+
+Implementation should proceed in this order:
+
+1. dynamic tool catalog and tool view
+2. app tool dispatcher
+3. session repository and schema
+4. `sessions_list`, `sessions_history`, `session_status`
+5. synchronous `delegate`
+6. docs and config template updates
+
+This ordering minimizes rework and keeps the new abstractions honest.

--- a/docs/plans/2026-03-12-tool-surface-session-delegate-implementation-plan.md
+++ b/docs/plans/2026-03-12-tool-surface-session-delegate-implementation-plan.md
@@ -1,0 +1,652 @@
+# LoongClaw Session and Delegate Tool Surface Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a thick app-layer session and delegation tool surface to `loongclaw` by introducing dynamic tool views, a session registry, session inspection tools, and synchronous nested delegation.
+
+**Architecture:** Keep kernel core tools for stateless execution, but add an app-layer dispatcher for orchestration tools. Back session metadata with lightweight SQLite tables in the existing memory database, then build `sessions_list`, `sessions_history`, `session_status`, and `delegate` on top of that session repository and a per-session `ToolView`.
+
+**Tech Stack:** Rust, existing `loongclaw-app` conversation runtime and provider stack, SQLite via `rusqlite`, existing turn-loop integration tests, app config TOML, kernel-backed core tool execution.
+
+---
+
+### Task 1: Add Tool Catalog and Tool View Primitives
+
+**Files:**
+- Create: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Test: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- the catalog distinguishes core tools from app tools
+- a root tool view includes the expected first-phase tools
+- a child delegate tool view excludes `delegate` and `sessions_*`
+- `provider_tool_definitions` can be derived from a restricted tool view
+
+Suggested test names:
+
+```rust
+#[test]
+fn tool_catalog_marks_core_and_app_tools() {}
+
+#[test]
+fn child_tool_view_excludes_delegate_and_session_tools() {}
+
+#[test]
+fn provider_tool_definitions_follow_tool_view() {}
+```
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app tools:: -- --nocapture
+```
+
+Expected: FAIL because the catalog and view types do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- `ToolExecutionKind`
+- `ToolDescriptor`
+- `ToolCatalog`
+- `ToolView`
+
+Update `tools/mod.rs` so catalog lookups replace hard-coded name checks for new code paths.
+
+**Step 4: Re-run the tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app tools:: -- --nocapture
+```
+
+Expected: PASS for the new catalog and view tests.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/app/src/tools/catalog.rs crates/app/src/tools/mod.rs
+git commit -m "feat: add tool catalog and tool view primitives"
+```
+
+---
+
+### Task 2: Make Provider Tool Schema and Capability Snapshot Dynamic
+
+**Files:**
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/provider/mod.rs`
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Test: `crates/app/src/provider/mod.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- capability snapshot output changes when tool view changes
+- provider turn requests include only visible tools
+- child sessions do not advertise forbidden tools in request bodies
+
+Suggested test names:
+
+```rust
+#[test]
+fn capability_snapshot_respects_tool_view() {}
+
+#[test]
+fn build_turn_request_body_respects_restricted_tool_view() {}
+```
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app provider:: conversation:: -- --nocapture
+```
+
+Expected: FAIL because provider schema generation is currently global.
+
+**Step 3: Write minimal implementation**
+
+Thread `ToolView` into:
+
+- capability snapshot generation
+- provider tool definition generation
+- runtime message building for system prompt disclosure
+- turn-request construction for tool schema
+
+Avoid changing unrelated provider behavior.
+
+**Step 4: Re-run the tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app provider:: conversation:: -- --nocapture
+```
+
+Expected: PASS for the new dynamic-schema tests.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/app/src/tools/mod.rs crates/app/src/provider/mod.rs crates/app/src/conversation/runtime.rs crates/app/src/conversation/tests.rs
+git commit -m "feat: derive provider tool schema from per-session tool views"
+```
+
+---
+
+### Task 3: Introduce Session Repository and SQLite Metadata Tables
+
+**Files:**
+- Create: `crates/app/src/session/repository.rs`
+- Modify: `crates/app/src/memory/sqlite.rs`
+- Modify: `crates/app/src/memory/mod.rs`
+- Test: `crates/app/src/session/repository.rs`
+- Test: `crates/app/src/memory/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- session metadata can be inserted and loaded
+- state transitions persist
+- parent-child relationships persist
+- session events do not appear in transcript window queries
+
+Suggested test names:
+
+```rust
+#[test]
+fn session_repository_creates_and_loads_session_rows() {}
+
+#[test]
+fn session_repository_updates_state_and_last_error() {}
+
+#[test]
+fn transcript_window_excludes_session_events() {}
+```
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app session:: memory:: -- --nocapture
+```
+
+Expected: FAIL because the session repository and new tables do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- session row model
+- session event model
+- schema creation for `sessions` and `session_events`
+- repository helpers for create, update, list, and event append
+
+Keep transcript history in `turns` unchanged.
+
+**Step 4: Re-run the tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app session:: memory:: -- --nocapture
+```
+
+Expected: PASS for the new repository tests.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/app/src/session/repository.rs crates/app/src/memory/sqlite.rs crates/app/src/memory/mod.rs
+git commit -m "feat: add session repository and metadata tables"
+```
+
+---
+
+### Task 4: Add Session Context and App Tool Dispatcher
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/chat.rs`
+- Modify: `crates/app/src/channel/mod.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+- Test: `crates/app/src/conversation/integration_tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- turn execution can route app tools without sending them through the kernel core tool adapter
+- current session context is available during tool execution
+- root sessions and child sessions receive different tool views
+
+Suggested test names:
+
+```rust
+#[tokio::test]
+async fn turn_engine_routes_app_tools_through_dispatcher() {}
+
+#[tokio::test]
+async fn conversation_turn_uses_tool_view_from_session_context() {}
+```
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app conversation:: -- --nocapture
+```
+
+Expected: FAIL because the dispatcher and session context do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Introduce:
+
+- session context model
+- app tool dispatcher trait or module
+- turn-engine branching by `ToolExecutionKind`
+- root session context construction in CLI and channel entrypoints
+
+Keep core-tool execution behavior unchanged for `file.read`, `file.write`, and `shell.exec`.
+
+**Step 4: Re-run the tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app conversation:: -- --nocapture
+```
+
+Expected: PASS for dispatcher routing tests and no regression in existing core-tool tests.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/app/src/conversation/turn_engine.rs crates/app/src/conversation/turn_loop.rs crates/app/src/conversation/runtime.rs crates/app/src/chat.rs crates/app/src/channel/mod.rs crates/app/src/conversation/tests.rs crates/app/src/conversation/integration_tests.rs
+git commit -m "feat: add session context and app tool dispatch"
+```
+
+---
+
+### Task 5: Implement `sessions_list`, `sessions_history`, and `session_status`
+
+**Files:**
+- Create: `crates/app/src/tools/session.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/session/repository.rs`
+- Test: `crates/app/src/tools/session.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- `sessions_list` returns current session and visible children
+- `sessions_history` returns transcript rows only
+- `session_status` returns state and last error
+- unrelated sessions are hidden by visibility rules
+
+Suggested test names:
+
+```rust
+#[tokio::test]
+async fn sessions_list_returns_current_session_and_children() {}
+
+#[tokio::test]
+async fn sessions_history_returns_transcript_without_control_events() {}
+
+#[tokio::test]
+async fn session_status_returns_state_and_last_error() {}
+
+#[tokio::test]
+async fn session_tools_reject_invisible_sessions() {}
+```
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app session_status -- --nocapture
+```
+
+Expected: FAIL because the session tools do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement first-phase app tools:
+
+- `sessions_list`
+- `sessions_history`
+- `session_status`
+
+Wire them into the catalog and app dispatcher.
+
+**Step 4: Re-run the tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app session -- --nocapture
+```
+
+Expected: PASS for new session tool behavior and visibility tests.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/app/src/tools/session.rs crates/app/src/tools/mod.rs crates/app/src/session/repository.rs crates/app/src/conversation/tests.rs
+git commit -m "feat: add session inspection tools"
+```
+
+---
+
+### Task 6: Implement Synchronous `delegate`
+
+**Files:**
+- Create: `crates/app/src/tools/delegate.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/session/repository.rs`
+- Test: `crates/app/src/tools/delegate.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+- Test: `crates/app/src/conversation/integration_tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- `delegate` creates a child session
+- child sessions run with a restricted tool view
+- child completion returns structured output to the parent
+- timeout sets session state to `timed_out`
+- child cannot call `delegate`
+
+Suggested test names:
+
+```rust
+#[tokio::test]
+async fn delegate_creates_child_session_and_returns_structured_result() {}
+
+#[tokio::test]
+async fn delegate_child_uses_restricted_tool_view() {}
+
+#[tokio::test]
+async fn delegate_timeout_sets_child_session_to_timed_out() {}
+
+#[tokio::test]
+async fn delegate_child_cannot_reenter_delegate() {}
+```
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app delegate -- --nocapture
+```
+
+Expected: FAIL because the delegate tool does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- child session creation
+- state transition to `running`
+- child event logging
+- nested `ConversationTurnLoop` execution
+- structured delegate result
+- timeout and failure mapping
+
+Do not add background execution, wait handles, or channel announcements.
+
+**Step 4: Re-run the tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app delegate -- --nocapture
+```
+
+Expected: PASS for delegate happy path, timeout path, and tool-visibility restrictions.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/app/src/tools/delegate.rs crates/app/src/tools/mod.rs crates/app/src/conversation/turn_loop.rs crates/app/src/session/repository.rs crates/app/src/conversation/tests.rs crates/app/src/conversation/integration_tests.rs
+git commit -m "feat: add synchronous delegate sessions"
+```
+
+---
+
+### Task 7: Add Config Surface for Session and Delegate Policy
+
+**Files:**
+- Modify: `crates/app/src/config/tools_memory.rs`
+- Modify: `crates/app/src/config/runtime.rs`
+- Test: `crates/app/src/config/runtime.rs`
+- Test: `crates/app/src/config/tools_memory.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- default config enables session and delegate tools with safe defaults
+- `visibility = "children"` is parsed correctly
+- child shell execution defaults to disabled
+- config round-trips through TOML
+
+Suggested test names:
+
+```rust
+#[test]
+fn tool_config_defaults_enable_safe_session_and_delegate_policy() {}
+
+#[test]
+fn tool_config_parses_children_visibility() {}
+
+#[test]
+fn tool_config_round_trips_session_and_delegate_settings() {}
+```
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app config:: -- --nocapture
+```
+
+Expected: FAIL because the new config sections do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Extend `ToolConfig` with nested config types for:
+
+- session tool visibility and limits
+- delegate enablement, timeout, depth, and child allowlist
+
+Keep the config shape intentionally small.
+
+**Step 4: Re-run the tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app config:: -- --nocapture
+```
+
+Expected: PASS for defaults and TOML round-trip behavior.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/app/src/config/tools_memory.rs crates/app/src/config/runtime.rs
+git commit -m "feat: add config for session and delegate policy"
+```
+
+---
+
+### Task 8: Cover Legacy Session Fallback and Final Regression Cases
+
+**Files:**
+- Modify: `crates/app/src/session/repository.rs`
+- Modify: `crates/app/src/memory/sqlite.rs`
+- Test: `crates/app/src/session/repository.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- `sessions_list` can surface a legacy session inferred from `turns`
+- legacy rows do not require backfill
+- inferred legacy kind uses known prefixes when possible
+
+Suggested test names:
+
+```rust
+#[test]
+fn sessions_list_infers_legacy_rows_from_turn_history() {}
+
+#[test]
+fn inferred_legacy_session_kind_uses_known_prefixes() {}
+```
+
+**Step 2: Run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app legacy_session -- --nocapture
+```
+
+Expected: FAIL because legacy fallback is not implemented yet.
+
+**Step 3: Write minimal implementation**
+
+Add best-effort legacy-row inference by scanning `turns` for sessions missing from the `sessions` table.
+
+Do not rewrite historical rows.
+
+**Step 4: Re-run the tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app legacy_session -- --nocapture
+```
+
+Expected: PASS for inferred legacy session coverage.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add crates/app/src/session/repository.rs crates/app/src/memory/sqlite.rs
+git commit -m "feat: preserve legacy sessions in session listing"
+```
+
+---
+
+### Task 9: Update Docs and Validate the Final Slice
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+- Optionally Modify: `docs/releases/TEMPLATE.md`
+- Test: existing app tests
+
+**Step 1: Write the doc changes**
+
+Document:
+
+- new session tools
+- delegate semantics
+- current limitations of the synchronous child-session model
+- future work explicitly deferred
+
+**Step 2: Run the focused regression suite**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app tools:: conversation:: session:: config:: -- --nocapture
+```
+
+Expected: PASS for the new surface and existing core behavior.
+
+**Step 3: Run the broader app test suite**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app -- --nocapture
+```
+
+Expected: PASS, or else stop and fix regressions before claiming completion.
+
+**Step 4: Review git scope**
+
+Run:
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```
+
+Expected: only session/delegate tool-surface work is staged.
+
+**Step 5: Commit**
+
+Run:
+
+```bash
+git add docs/product-specs/index.md docs/roadmap.md docs/releases/TEMPLATE.md
+git commit -m "docs: describe session and delegate tool surface"
+```
+
+---
+
+Plan complete and saved to `docs/plans/2026-03-12-tool-surface-session-delegate-implementation-plan.md`. Two execution options:
+
+**1. Subagent-Driven (this session)** - I dispatch a fresh subagent per task, review between tasks, and iterate quickly.
+
+**2. Parallel Session (separate)** - Open a new session in this worktree and execute the plan task-by-task with checkpoints.
+
+Recommended: **Subagent-Driven (this session)**, because the work splits cleanly between tool catalog, session repository, and delegate integration, but still benefits from stepwise review between commits.

--- a/docs/plans/2026-03-13-memory-search-design.md
+++ b/docs/plans/2026-03-13-memory-search-design.md
@@ -1,0 +1,375 @@
+# Memory Search Design
+
+## Context
+
+LoongClaw's current thick app-layer tool surface is centered on session inspection and delegation:
+
+- `sessions_list`
+- `sessions_history`
+- `session_status`
+- `session_events`
+- `session_archive`
+- `session_unarchive`
+- `session_cancel`
+- `session_recover`
+- `session_wait`
+- `sessions_send`
+- `delegate`
+- `delegate_async`
+
+That surface is now substantially stronger, but it still lacks a truthful memory retrieval primitive.
+The app already persists transcript turns into SQLite and already has session visibility rules, yet
+the only memory-facing behavior exposed to the model is indirect session history inspection.
+
+External comparison points in the same direction, but also clarifies what *not* to do:
+
+- OpenClaw's `memory_search` rides on a much heavier substrate with indexed Markdown memories,
+  FTS, embeddings, and hybrid retrieval.
+- ZeroClaw's memory recall similarly depends on FTS, vector search, hybrid merge, and pluggable
+  memory backends.
+- NanoBot and NanoClaw both reinforce that memory and scheduling are useful, but their broader
+  runtime architecture is substantially heavier than LoongClaw's current app substrate.
+
+The correct next step for LoongClaw is not "semantic memory." It is a truthful transcript-backed
+search primitive over the durable data the app already owns.
+
+## Problem
+
+Operators and models can inspect a known session's history, but they cannot ask the system to find
+where a fact, phrase, or prior instruction appeared within the caller's visible transcript scope.
+
+Today that means:
+
+- history can only be inspected session-by-session
+- agents must already know which session to inspect
+- archived but still relevant sessions are harder to rediscover
+- transcript persistence exists, but there is no direct search affordance over it
+
+This is a real product gap and a better target than broadening into scheduler, browser, or fake
+semantic-memory claims.
+
+## Goals
+
+- Add a truthful `memory_search` app tool for transcript retrieval.
+- Search only over persisted transcript turns in SQLite `turns`.
+- Reuse existing session visibility rules instead of broadening authority.
+- Support single-target, batch-target, and default visible-scope searches.
+- Return enough structure for agents to identify where a hit came from without dumping full
+  transcript bodies.
+- Keep the tool contract honest about match semantics in this phase.
+
+## Non-Goals
+
+- No embeddings, vector search, BM25, hybrid recall, or semantic ranking.
+- No search over `session_events` or other control-plane records.
+- No new long-term memory store distinct from transcript persistence.
+- No full-content export behavior; complete transcript reading remains `sessions_history`.
+- No pagination or streaming in the first slice.
+- No scheduler, cron, browser, or web retrieval work in this phase.
+
+## Chosen Primitive
+
+Add `memory_search`.
+
+`memory_search` searches durable transcript turns that are visible from the calling session and
+returns structured matches. It is intentionally transcript search, not knowledge-base search and
+not semantic recall.
+
+The tool should be described truthfully:
+
+- source: transcript turns already written to SQLite
+- match type: exact text / substring-style search
+- authority: existing visible session scope only
+- output: match records with snippets and identifiers, not synthesized answers
+
+## Scope Rules
+
+### Visible scope
+
+When the request does not specify a target session, `memory_search` searches the caller's current
+visible scope:
+
+- the current root session plus visible descendant delegate sessions
+- or only `self` when session visibility is configured that way
+
+### Single-target scope
+
+When the request specifies `session_id`, the tool searches only that target session.
+
+Rules:
+
+- target must be visible under the existing visibility model
+- target may be archived; archive affects inventory visibility, not transcript existence
+- legacy current-session transcript rows remain eligible through the same best-effort fallback used
+  elsewhere in session inspection
+
+### Batch scope
+
+When the request specifies `session_ids`, the tool searches the visible subset of those targets.
+
+Rules:
+
+- visible targets are searched
+- hidden or missing targets are reported in structured skipped metadata
+- one bad target must not fail the entire batch request
+
+## Request Contract
+
+`memory_search` accepts these fields:
+
+- `query` (required)
+- `session_id` (optional, mutually exclusive with `session_ids`)
+- `session_ids` (optional, mutually exclusive with `session_id`)
+- `limit` (optional, default `20`, max `100`)
+- `excerpt_chars` (optional, default `120`, clamped to a safe range)
+
+Request rules:
+
+- `query` must be a non-empty string after trimming
+- `session_id` and `session_ids` cannot both be present
+- no explicit target means "search visible scope"
+- single-target invisible requests fail like existing direct inspection tools
+- batch requests use best-effort result accounting instead of failing on partial invisibility
+
+Representative requests:
+
+```json
+{
+  "query": "timeout budget"
+}
+```
+
+```json
+{
+  "query": "handoff note",
+  "session_id": "delegate:child-123",
+  "limit": 10,
+  "excerpt_chars": 160
+}
+```
+
+```json
+{
+  "query": "memory adapter",
+  "session_ids": ["root-a", "delegate:child-1", "hidden-root"],
+  "limit": 25
+}
+```
+
+## Response Contract
+
+The top-level response should stay simple and explicit:
+
+- `query`
+- `scope`
+- `matches`
+- `returned_count`
+- `limit`
+- `truncated`
+
+### Scope payload
+
+`scope` should include:
+
+- `mode`: `visible`, `single`, or `batch`
+- `current_session_id`
+- `searched_session_ids`
+- `searched_session_count`
+- `skipped_targets` for batch requests
+
+`skipped_targets` should classify each skipped target, for example:
+
+- `skipped_not_visible`
+- `skipped_not_found`
+
+### Match payload
+
+Each match should include:
+
+- `session_id`
+- `turn_id`
+- `role`
+- `ts`
+- `content_snippet`
+- `match`
+
+`match` should include:
+
+- `query`
+- `match_kind` with phase-one value `substring`
+- `excerpt_chars`
+
+Representative match shape:
+
+```json
+{
+  "session_id": "delegate:child-123",
+  "turn_id": 91,
+  "role": "assistant",
+  "ts": 1763020000,
+  "content_snippet": "...timeout budget was reduced after the second retry spike...",
+  "match": {
+    "query": "timeout budget",
+    "match_kind": "substring",
+    "excerpt_chars": 120
+  }
+}
+```
+
+## Query Semantics
+
+Phase one should deliberately use the simplest honest query semantics:
+
+- search only `turns.content`
+- perform substring-style text matching
+- order hits by most recent first: `ts DESC`, then `id DESC`
+
+This is intentionally not positioned as "best" or "most relevant" retrieval. It is recent-first
+transcript search over exact stored text.
+
+## Why Not FTS Or Semantic Memory Yet
+
+LoongClaw does not yet have the supporting substrate required to make stronger claims:
+
+- no memory-specific chunking pipeline
+- no embedding lifecycle
+- no vector index maintenance
+- no hybrid merge semantics
+- no durable semantic-retrieval contract already exposed elsewhere in the app
+
+Adding a tool named `memory_search` that clearly performs transcript text search is still honest.
+Adding a tool that implies semantic recall without those supporting layers would not be.
+
+This design leaves a clean future path:
+
+- phase 1: `LIKE` / substring transcript search
+- future phase: SQLite FTS5 keyword search
+- later phase: hybrid or semantic retrieval only once indexing and consistency semantics are real
+
+## Internal Design
+
+### Storage and query layer
+
+Add a transcript search helper on top of the existing SQLite memory store.
+
+The query should:
+
+- read from `turns`
+- restrict to resolved target session ids
+- match on `content`
+- return `id`, `session_id`, `role`, `content`, and `ts`
+
+The helper should not search `session_events`, because control-plane events are intentionally kept
+out of transcript history and should stay out of transcript search results too.
+
+### Visibility layer
+
+Reuse the existing session repository and visibility semantics:
+
+- `list_visible_sessions`
+- `is_session_visible`
+- legacy current-session fallback where already supported
+
+This ensures `memory_search` behaves like the session tool family rather than introducing a second
+visibility model.
+
+### Tool layer
+
+Expose `memory_search` as a real app tool:
+
+- add it to the tool catalog and provider definitions
+- gate it under session-tool enablement for this phase
+- implement it in a dedicated tool module rather than expanding `session.rs` further
+
+This keeps the new tool aligned with the thick app-layer direction while containing code growth.
+
+## Error Model
+
+Representative direct errors:
+
+- `memory_search_invalid_request: ...`
+- `visibility_denied: ...`
+- `session_not_found: ...`
+
+Batch requests should not fail for hidden or missing targets. Those targets should instead appear
+under `scope.skipped_targets`.
+
+No matches is not an error. It should return:
+
+- `matches: []`
+- `returned_count: 0`
+- `truncated: false`
+
+## Testing Plan
+
+Minimum required coverage:
+
+- single-session search returns structured hits with `turn_id`, `role`, `ts`, and snippet
+- default visible-scope search includes current root plus visible descendant delegate sessions
+- delegated child search cannot reach hidden or sibling sessions outside visibility rules
+- archived visible sessions still contribute searchable transcript hits
+- legacy current-session transcript rows can be searched without backfilling `sessions`
+- single-target hidden session returns `visibility_denied`
+- batch search returns mixed searched and skipped target accounting
+- search results never include control-plane session events
+- `limit` and `excerpt_chars` clamping works as documented
+- no-hit queries return an empty result set rather than an error
+
+## Alternatives Considered
+
+### 1. Expose only `memory_window` or `memory_get`
+
+Pros:
+
+- smaller implementation
+- almost no new query semantics
+
+Cons:
+
+- does not solve rediscovery
+- overlaps heavily with `sessions_history`
+- weaker user value than true transcript search
+
+Rejected because the next thick tool should increase retrieval power, not just add another way to
+read already-known history.
+
+### 2. Build scheduler or cron tools first
+
+Pros:
+
+- externally comparable repos often expose scheduling primitives
+
+Cons:
+
+- LoongClaw does not yet have a truthful durable scheduler substrate
+- delivery semantics, retries, ownership, and restart behavior are still undefined
+
+Rejected because it would force a wider and less honest control surface than the app currently
+supports.
+
+### 3. Jump directly to semantic memory
+
+Pros:
+
+- richer retrieval story
+
+Cons:
+
+- requires a much heavier substrate than LoongClaw currently has
+- would encourage product claims the runtime cannot yet back up
+
+Rejected because the product direction is "few but thick and truthful," not "broad but suggestive."
+
+## Why This Design
+
+`memory_search` is the strongest next tool LoongClaw can add without pretending to have a larger
+memory system than it does.
+
+It deepens real substrate that already exists:
+
+- durable transcript persistence
+- session visibility rules
+- session archive lifecycle
+- app-layer orchestration tools
+
+And it does so without widening into adjacent surfaces that still lack honest runtime backing.

--- a/docs/plans/2026-03-13-memory-search-implementation-plan.md
+++ b/docs/plans/2026-03-13-memory-search-implementation-plan.md
@@ -1,0 +1,335 @@
+# Memory Search Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a truthful `memory_search` app tool that searches visible transcript turns and returns structured snippet matches without claiming semantic memory.
+
+**Architecture:** Implement transcript search on top of the existing SQLite `turns` store, reuse session visibility and legacy fallback rules from the session repository, and expose `memory_search` as a new app-layer tool with a narrow provider schema. Land the feature through TDD in small slices: repository-free query helper first, then app-tool surface and scope resolution, then product docs and full verification.
+
+**Tech Stack:** Rust, `rusqlite`, existing LoongClaw app tool catalog and dispatcher, SQLite-backed session repository, Cargo tests.
+
+---
+
+### Task 1: Add the failing transcript-search memory tests
+
+**Files:**
+- Modify: `crates/app/src/memory/mod.rs`
+- Modify: `crates/app/src/memory/sqlite.rs`
+
+**Step 1: Write the failing tests**
+
+Add focused unit tests in `crates/app/src/memory/mod.rs` or `crates/app/src/memory/sqlite.rs` for:
+
+- `search_transcript_direct_returns_recent_matching_turns`
+- `search_transcript_direct_excludes_non_matching_turns`
+- `search_transcript_direct_clamps_limit_and_excerpt`
+
+The tests should:
+
+- create an isolated SQLite path with `MemoryRuntimeConfig`
+- append several turns across one or more sessions
+- search for a phrase that appears in multiple rows
+- assert that results include `turn_id`, `session_id`, `role`, `ts`, and a clipped snippet
+- assert newest-first ordering
+- assert a no-match query returns an empty list
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app search_transcript_direct -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- compile or test failure because transcript-search helpers and result structs do not exist yet
+
+**Step 3: Write minimal implementation**
+
+Implement the minimum SQLite search support in `crates/app/src/memory/sqlite.rs`:
+
+- add a search result struct that includes `turn_id`, `session_id`, `role`, `content`, and `ts`
+- add a helper that executes a substring-style query against `turns.content`
+- add safe clamping for limit and excerpt sizes
+- add a direct helper callable from tests
+
+Keep the implementation narrow:
+
+- search only `turns`
+- use recent-first ordering
+- do not add FTS, extra indexes, or semantic-ranking behavior
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app search_transcript_direct -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- the new transcript-search tests pass
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/memory/mod.rs crates/app/src/memory/sqlite.rs
+git commit -m "feat(app): add transcript memory search helpers"
+```
+
+### Task 2: Add the failing app-tool behavior tests for `memory_search`
+
+**Files:**
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/catalog.rs`
+- Create: `crates/app/src/tools/memory.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing tests**
+
+Add focused app-tool tests alongside the existing session-tool coverage, preferably in
+`crates/app/src/tools/memory.rs` if that module owns its own tests.
+
+Add tests for:
+
+- `memory_search_searches_visible_scope_by_default`
+- `memory_search_rejects_invisible_single_target`
+- `memory_search_batch_reports_skipped_targets`
+- `memory_search_includes_archived_visible_sessions`
+- `memory_search_supports_legacy_current_session_transcript`
+- `memory_search_does_not_return_session_events`
+
+Test fixtures should:
+
+- build isolated `MemoryRuntimeConfig`
+- create root and delegate-child sessions with `SessionRepository`
+- archive one finished visible session to prove archived transcripts still search
+- append transcript turns and control-plane events separately
+- execute the tool through `execute_app_tool_with_config`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app memory_search_ -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- compile or test failure because the tool is not cataloged or implemented yet
+
+**Step 3: Write minimal implementation**
+
+Implement the app-layer tool:
+
+- add `memory_search` to `crates/app/src/tools/catalog.rs`
+- expose a provider schema with `query`, `session_id`, `session_ids`, `limit`, and `excerpt_chars`
+- route `memory_search` from `crates/app/src/tools/mod.rs`
+- create `crates/app/src/tools/memory.rs` to own:
+  - request parsing
+  - visible-scope target resolution
+  - single-target visibility checks
+  - batch skipped-target accounting
+  - snippet shaping and top-level response payload
+
+Reuse existing session visibility and legacy-fallback behavior rather than re-inventing it.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app memory_search_ -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- the new `memory_search` app-tool tests pass
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/mod.rs crates/app/src/tools/catalog.rs crates/app/src/tools/memory.rs crates/app/src/tools/session.rs
+git commit -m "feat(app): add memory search tool surface"
+```
+
+### Task 3: Add provider-view and runtime registration coverage
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add or extend tests to prove:
+
+- `memory_search` appears in the runtime tool registry when session tools are enabled
+- provider tool definitions include the new function schema
+- canonical tool-name resolution works for `memory_search`
+
+If existing tests already cover adjacent registry behavior, extend them with `memory_search`
+assertions instead of creating redundant new fixtures.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app tool_registry -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- failure because the registry/provider surface does not yet advertise `memory_search` completely
+
+**Step 3: Write minimal implementation**
+
+Adjust the tool view and registration paths so `memory_search` is treated as a truthful runtime app
+tool in the same enablement family as other session-scoped app tools.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app tool_registry -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- the registry/provider assertions pass
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/catalog.rs crates/app/src/tools/mod.rs
+git commit -m "feat(app): advertise memory search runtime tool"
+```
+
+### Task 4: Update product docs and acceptance criteria
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Write the doc changes**
+
+Update product-facing docs to reflect the new tool:
+
+- add `memory_search` to the accepted root tool surface
+- document the truthful phase-one scope: transcript search over visible sessions
+- note that semantic memory, FTS, and vector retrieval remain out of scope
+
+Keep the wording aligned with the design doc rather than promising future capabilities as if they
+already ship.
+
+**Step 2: Review the doc diff**
+
+Run:
+
+```bash
+git diff -- docs/product-specs/index.md docs/roadmap.md
+```
+
+Expected:
+
+- only the documented `memory_search` surface and roadmap wording changed
+
+**Step 3: Commit**
+
+```bash
+git add docs/product-specs/index.md docs/roadmap.md
+git commit -m "docs: describe memory search tool surface"
+```
+
+### Task 5: Full verification and cleanup
+
+**Files:**
+- Modify if needed: any files touched above
+
+**Step 1: Run focused package tests**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app memory_search_ search_transcript_direct tool_registry -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- focused new coverage passes
+
+**Step 2: Run the full app package tests**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- all `loongclaw-app` tests pass
+
+**Step 3: Run formatting**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all
+```
+
+Expected:
+
+- no formatting errors
+
+**Step 4: Re-run the full app package tests after formatting**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --nocapture --test-threads=1
+```
+
+Expected:
+
+- all `loongclaw-app` tests still pass after formatting
+
+**Step 5: Compile daemon tests without running**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-daemon --no-run
+```
+
+Expected:
+
+- daemon targets compile successfully, proving the app-tool surface change does not break daemon integration
+
+**Step 6: Inspect the final branch state**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -6
+```
+
+Expected:
+
+- clean worktree
+- small, isolated commits for helpers, tool surface, docs, and formatting if needed
+
+**Step 7: Commit any final formatting-only adjustments**
+
+```bash
+git add -A
+git commit -m "style(rust): format memory search changes"
+```
+
+Only do this step if formatting changed tracked files and those changes are not already included in
+an earlier commit.

--- a/docs/plans/2026-03-13-session-archive-design.md
+++ b/docs/plans/2026-03-13-session-archive-design.md
@@ -1,0 +1,177 @@
+# Session Archive Design
+
+## Context
+
+LoongClaw's current session surface is strong on truthful execution control for delegate children:
+
+- inspect: `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_wait`
+- mutate: `session_cancel`, `session_recover`
+- outbound operator messaging: `sessions_send`
+
+The remaining gap is not a fake `close` primitive. External comparison showed that OpenClaw's `close` is tied to real ACP runtime shutdown and route unbinding. LoongClaw does not yet have equivalent live runtime bindings, root-session reopening semantics, or a session epoch model for channel-backed roots. Adding a `session_close` name right now would either:
+
+1. lie by only adding a label without changing routing, or
+2. break inbound channel routing for fixed ids like `telegram:<chat_id>` / `feishu:<chat_id>`.
+
+What LoongClaw can truthfully support today is archive semantics for already-terminal visible sessions.
+
+## Problem
+
+Root sessions can accumulate many completed, failed, or timed-out delegate children. `sessions_list` currently keeps returning those terminal children forever unless the caller manually filters by state every time. That creates inventory noise without providing an explicit operator action to retire finished work.
+
+## Goals
+
+- Add a truthful operator primitive to retire finished visible sessions from default inventory.
+- Keep direct inspection possible after archival.
+- Preserve transcript rows and terminal outcomes exactly as they are.
+- Reuse the existing single-target and batch mutation patterns (`session_cancel` / `session_recover`).
+- Avoid introducing fake runtime-close behavior.
+
+## Non-Goals
+
+- No root-session routing shutdown or channel unbinding.
+- No hard session deletion.
+- No transcript truncation or memory clearing.
+- No hiding of running or ready sessions.
+- No automatic reopen / successor-session model.
+- No unarchive tool in this phase.
+
+## Chosen Primitive
+
+Add `session_archive`.
+
+`session_archive` archives a visible terminal session so it no longer appears in `sessions_list` by default. The archival is durable and auditable, but does not remove any historical data.
+
+This is intentionally narrower than `close`:
+
+- `session_cancel` changes an in-flight delegate lifecycle.
+- `session_recover` marks an overdue async delegate as failed.
+- `session_archive` changes only session inventory visibility for already-terminal sessions.
+
+## Scope Rules
+
+`session_archive` is allowed only when all of the following are true:
+
+- target session is visible from the caller under existing visibility rules
+- target session is already terminal: `completed`, `failed`, or `timed_out`
+- target session is not already archived
+
+Practical effect in today's architecture:
+
+- terminal delegate children are archivable
+- non-terminal root sessions are rejected because they are not terminal
+
+This keeps the primitive truthful and avoids pretending to close active channel-backed roots.
+
+## State Model
+
+Archive is not a new execution state. Session execution state remains:
+
+- `ready`
+- `running`
+- `completed`
+- `failed`
+- `timed_out`
+
+Archive is a separate inventory overlay represented as archive metadata on session summaries:
+
+- `archived: boolean`
+- `archived_at: integer|null`
+
+This avoids conflating execution lifecycle with operator inventory hygiene.
+
+## Persistence Model
+
+Archive state is persisted via control-plane metadata rather than transcript mutation:
+
+- append a durable `session_archived` session event
+- derive `archived_at` from archive metadata when loading session summaries
+
+Consequences:
+
+- transcript rows stay unchanged
+- terminal outcome rows stay unchanged
+- `session_events` naturally exposes the archive action
+- `session_status` can report that a session is archived
+
+## Tool Semantics
+
+### Single-target mode
+
+Request:
+
+```json
+{
+  "session_id": "delegate:child-123"
+}
+```
+
+Response shape follows the existing single-target mutation pattern:
+
+- returns normal inspection payload
+- adds `archive_action`
+
+### Batch mode
+
+Request:
+
+```json
+{
+  "session_ids": ["delegate:child-1", "delegate:child-2"],
+  "dry_run": true
+}
+```
+
+Batch result classifications:
+
+- `would_apply`
+- `applied`
+- `skipped_not_visible`
+- `skipped_not_archivable`
+- `skipped_already_archived`
+- `skipped_state_changed`
+
+## Listing Semantics
+
+`sessions_list` changes in one important way:
+
+- default behavior excludes archived visible sessions
+- `include_archived=true` returns both archived and non-archived visible sessions
+
+Returned session summaries include:
+
+- `archived`
+- `archived_at`
+
+This makes archive state explicit instead of silently hiding data.
+
+## Inspection Semantics
+
+`session_status` remains available for archived visible sessions and includes archive metadata.
+
+`sessions_history` remains available for archived visible sessions.
+
+`session_events` remains available for archived visible sessions and includes the `session_archived` event.
+
+`session_wait` is unchanged. Waiting on a terminal archived session still returns completed state immediately because archive does not alter terminality.
+
+## Error Model
+
+Representative rejections:
+
+- `session_archive_not_archivable: session \`...\` is not terminal`
+- `session_archive_not_archivable: session \`...\` is already archived`
+- `visibility_denied: ...`
+- `session_archive_state_changed: session \`...\` is no longer archivable`
+
+The `state_changed` branch covers races where another actor archives or mutates the target after inspection.
+
+## Why This Design
+
+This is the smallest truthful primitive that closes the current operator gap:
+
+- it solves real inventory clutter for child-session orchestration
+- it preserves LoongClaw's auditable session model
+- it does not claim capabilities the runtime does not yet possess
+
+If LoongClaw later grows real route-bound root sessions with explicit reopen / successor semantics, a future `session_close` can be added honestly on top of that stronger substrate.

--- a/docs/plans/2026-03-13-session-archive-implementation-plan.md
+++ b/docs/plans/2026-03-13-session-archive-implementation-plan.md
@@ -1,0 +1,205 @@
+# Session Archive Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a truthful `session_archive` operator primitive that retires visible terminal sessions from default `sessions_list` inventory while preserving direct inspection and history.
+
+**Architecture:** Archive is a separate inventory overlay, not a new execution state. The implementation adds durable archive metadata to session summaries, exposes a new `session_archive` tool with single-target and batch behavior, and teaches `sessions_list` to exclude archived sessions by default while surfacing archive metadata when requested.
+
+**Tech Stack:** Rust, rusqlite, serde_json, sqlite-backed session repository, cargo test
+
+---
+
+### Task 1: Add the first failing session-tool test
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing test**
+
+Add a test proving that:
+
+- a terminal visible child can be archived
+- the returned payload includes `archive_action`
+- `session_status` still reports the target and marks it archived
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_archive_archives_terminal_visible_session -- --nocapture --test-threads=1
+```
+
+Expected: FAIL because `session_archive` is not implemented.
+
+**Step 3: Write minimal implementation**
+
+Implement the smallest code path needed for single-target archive behavior.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and confirm PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/session.rs crates/app/src/session/repository.rs crates/app/src/tools/catalog.rs crates/app/src/tools/mod.rs crates/app/src/provider/mod.rs
+git commit -m "feat(app): add single-session archive flow"
+```
+
+### Task 2: Add list filtering and archive metadata coverage
+
+**Files:**
+- Modify: `crates/app/src/session/repository.rs`
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/provider/mod.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests proving that:
+
+- `sessions_list` excludes archived sessions by default
+- `sessions_list` returns archived sessions when `include_archived=true`
+- returned summaries expose `archived` and `archived_at`
+- provider/tool-catalog output now includes `session_archive`
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_archive -- --nocapture --test-threads=1
+```
+
+Expected: FAIL on the new list/catalog assertions.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- archive metadata loading in repository summaries
+- `include_archived` parsing and filtering
+- tool catalog / provider schema exposure for `session_archive`
+
+**Step 4: Run tests to verify they pass**
+
+Run the same command and confirm PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/session/repository.rs crates/app/src/tools/session.rs crates/app/src/tools/catalog.rs crates/app/src/tools/mod.rs crates/app/src/provider/mod.rs
+git commit -m "feat(app): hide archived sessions from default listings"
+```
+
+### Task 3: Add batch archive and rejection-path coverage
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests proving that:
+
+- batch `session_archive` supports `session_ids`
+- `dry_run=true` previews mixed outcomes without mutation
+- already archived sessions are classified separately
+- non-terminal or hidden sessions are rejected/classified correctly
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_archive_batch -- --nocapture --test-threads=1
+```
+
+Expected: FAIL on missing batch behavior.
+
+**Step 3: Write minimal implementation**
+
+Extend the mutation helper pattern used by `session_cancel` / `session_recover` to archive batching.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same command and confirm PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/session.rs
+git commit -m "feat(app): add batch session archive support"
+```
+
+### Task 4: Update product docs
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Write the doc updates**
+
+Document:
+
+- `session_archive` in the accepted root tool surface
+- default `sessions_list` archive exclusion
+- archive limitations and non-goals
+
+**Step 2: Verify docs are accurate**
+
+Re-read the design doc and match wording against actual implementation behavior.
+
+**Step 3: Commit**
+
+```bash
+git add docs/product-specs/index.md docs/roadmap.md
+git commit -m "docs: describe session archive behavior"
+```
+
+### Task 5: Run full verification
+
+**Files:**
+- No code changes expected
+
+**Step 1: Run focused tests**
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_archive -- --nocapture --test-threads=1
+```
+
+Expected: PASS
+
+**Step 2: Run package test suite**
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --nocapture --test-threads=1
+```
+
+Expected: PASS
+
+**Step 3: Run daemon compile verification**
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-daemon --no-run
+```
+
+Expected: PASS
+
+**Step 4: Run formatting**
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all
+```
+
+Expected: no diff
+
+**Step 5: Inspect and commit any final cleanups**
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```

--- a/docs/plans/2026-03-13-session-batch-remediation-design.md
+++ b/docs/plans/2026-03-13-session-batch-remediation-design.md
@@ -1,0 +1,219 @@
+# Session Batch Remediation Design
+
+## Context
+
+LoongClaw's current session operator surface is materially stronger than it was at the start of
+this track:
+
+- `sessions_list` can now discover visible delegate children with machine-readable filters
+- `session_status` / `session_wait` expose stable delegate lifecycle metadata
+- `session_cancel` handles queued cancellation and cooperative running cancellation
+- `session_recover` handles overdue queued and overdue running async delegate children
+
+That leaves one practical operator gap: once discovery returns several visible stale delegate
+children, the operator still has to remediate them one-by-one. The underlying state transitions are
+already race-safe, but the tool surface still forces repetitive single-target calls.
+
+## Problem
+
+We need a thicker operator remediation slice without adding new top-level tools or weakening the
+existing visibility and state guards.
+
+The design question is how to let operators preview and apply remediation across several visible
+delegate children while preserving:
+
+- backward compatibility for existing single-session callers
+- race-safe conditional state transitions
+- per-target evidence about why a requested action did or did not apply
+
+## Goals
+
+- Extend `session_recover` and `session_cancel` to support batch targeting.
+- Add `dry_run` preview semantics for safe operator planning.
+- Keep single-session existing calls backward compatible.
+- Return machine-readable per-target outcomes instead of failing the whole batch on the first
+  inapplicable target.
+- Preserve visibility boundaries and repository-backed conditional state transitions.
+
+## Non-Goals
+
+- No new top-level tools such as `session_recover_many` or `session_cancel_many`.
+- No hard kill, PID targeting, restart recovery, or worker lease management.
+- No all-or-nothing multi-session transaction semantics.
+- No pagination or saved query model for remediation batches.
+- No broadening of delegated child authority.
+
+## Options Considered
+
+### Option 1: Add dedicated batch tools
+
+Examples:
+
+- `session_recover_many`
+- `session_cancel_many`
+
+Pros:
+
+- explicit names
+- leaves current tools untouched
+
+Cons:
+
+- expands tool count for behavior already owned by existing remediation tools
+- duplicates schema and documentation surface
+- encourages thin wrappers instead of strengthening the current operator path
+
+Rejected.
+
+### Option 2: Extend existing tools with `session_ids` and `dry_run`
+
+Keep `session_recover` and `session_cancel` as the only remediation tools, but allow:
+
+- `session_id` for the current single-target path
+- `session_ids` for batch targeting
+- `dry_run` for non-mutating preview
+
+Pros:
+
+- preserves a compact tool surface
+- layers naturally on top of `sessions_list`
+- reuses the current race-safe repository writes
+- lets operators preview mixed applicability before mutating state
+
+Cons:
+
+- response shape needs a new aggregated form for batch and preview flows
+- tools must normalize visibility, planning, and state-changed outcomes per target
+
+Chosen.
+
+### Option 3: Keep tools single-target and rely on caller loops
+
+Pros:
+
+- zero schema change
+- smallest implementation diff
+
+Cons:
+
+- no shared `dry_run` preview
+- no structured mixed-result summary
+- pushes repetitive control logic and error handling into every caller
+
+Rejected.
+
+## Chosen Approach
+
+Extend the existing remediation tools instead of adding new ones.
+
+### Request model
+
+`session_recover` and `session_cancel` accept:
+
+- `session_id: string` for backward-compatible single-target calls
+- `session_ids: string[]` for batch calls
+- `dry_run: boolean` for preview mode
+
+Exactly one of `session_id` or `session_ids` must be present.
+
+### Backward compatibility
+
+Preserve the current response shape when all of the following are true:
+
+- request uses `session_id`
+- `dry_run` is absent or `false`
+
+In that legacy path, successful single-target execution keeps returning the existing inspection
+payload plus `recovery_action` / `cancel_action`.
+
+Use the new aggregated response shape when:
+
+- `session_ids` is present, or
+- `dry_run = true`
+
+This keeps existing callers stable while allowing richer operator flows for new callers.
+
+### Aggregated response shape
+
+Batch and preview flows return:
+
+- `tool`
+- `current_session_id`
+- `dry_run`
+- `requested_count`
+- `result_counts`
+- `results`
+
+Each `results[]` item includes:
+
+- `session_id`
+- `result`
+- `message`
+- `action` when the target is applicable
+- fresh inspection payload fields when the target is visible and inspectable
+
+The main result buckets are:
+
+- `would_apply`
+- `applied`
+- `skipped_not_visible`
+- `skipped_not_recoverable`
+- `skipped_not_cancellable`
+- `skipped_state_changed`
+
+The first two distinguish preview from actual mutation. The skipped buckets retain the causal class
+without forcing the caller to parse free-form error strings.
+
+### Visibility and race semantics
+
+Per target:
+
+1. normalize the requested session id
+2. enforce visibility from the current session
+3. inspect the session and build a recover/cancel plan
+4. if `dry_run = true`, report `would_apply` without mutating state
+5. otherwise apply the existing conditional finalize/transition write
+
+If the conditional write loses a race, the result becomes `skipped_state_changed` for that target.
+The batch continues; it does not abort on the first race.
+
+### Error handling philosophy
+
+Batch mode should only hard-fail on malformed input, not on mixed applicability.
+
+Examples of batch hard failures:
+
+- both `session_id` and `session_ids` are supplied
+- neither target field is supplied
+- `session_ids` contains no non-empty strings
+
+Examples of per-target skipped outcomes:
+
+- target is not visible
+- target is already terminal
+- target is not an async delegate child
+- target is fresh rather than overdue
+- target state changes before the conditional write commits
+
+## Data Model
+
+No schema change is required.
+
+The slice continues to use:
+
+- `sessions`
+- `session_events`
+- `session_terminal_outcomes`
+
+The implementation is an app-layer orchestration enhancement over the existing repository APIs.
+
+## Testing
+
+Add focused coverage for:
+
+- provider schema updates exposing `session_ids` and `dry_run`
+- `session_recover` dry-run preview with mixed visible recoverable and non-recoverable targets
+- `session_recover` batch apply with partial success and per-target result classification
+- `session_cancel` dry-run preview with queued/running/applicability mixing
+- `session_cancel` batch apply with queued terminalization and running cancel-request writes
+- preservation of legacy single-target response behavior

--- a/docs/plans/2026-03-13-session-batch-remediation-implementation-plan.md
+++ b/docs/plans/2026-03-13-session-batch-remediation-implementation-plan.md
@@ -1,0 +1,176 @@
+# Session Batch Remediation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend `session_recover` and `session_cancel` with safe batch targeting and `dry_run`
+preview while preserving existing single-session behavior.
+
+**Architecture:** Keep repository state transitions unchanged and add a thin tool-layer
+normalization/aggregation path. Single-target non-preview calls continue down the legacy path;
+batch or preview calls use a shared aggregated result model with per-target classifications.
+
+**Tech Stack:** Rust, serde_json, sqlite-backed session repository, cargo test
+
+---
+
+### Task 1: Document the chosen operator model
+
+**Files:**
+- Create: `docs/plans/2026-03-13-session-batch-remediation-design.md`
+- Create: `docs/plans/2026-03-13-session-batch-remediation-implementation-plan.md`
+
+**Step 1: Write the design doc**
+
+Capture goals, non-goals, options, chosen request/response shape, compatibility rules, and testing
+scope.
+
+**Step 2: Save the implementation plan**
+
+Record exact implementation tasks, TDD flow, and verification commands.
+
+### Task 2: Add provider-schema red tests
+
+**Files:**
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/catalog.rs`
+
+**Step 1: Write the failing test**
+
+Extend `provider_tool_definitions_are_stable_and_complete` so `session_recover` and
+`session_cancel` must expose:
+
+- `session_id`
+- `session_ids`
+- `dry_run`
+
+and a schema rule requiring exactly one target field.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app provider_tool_definitions_are_stable_and_complete -- --nocapture --test-threads=1`
+
+Expected: FAIL because the current schema only exposes `session_id`.
+
+**Step 3: Write minimal implementation**
+
+Update the provider definitions in `crates/app/src/tools/catalog.rs`.
+
+**Step 4: Run test to verify it passes**
+
+Run the same focused test and confirm PASS.
+
+### Task 3: Add `session_recover` batch red tests
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing tests**
+
+Add focused tests for:
+
+- batch `session_recover` dry-run returning `would_apply` and skipped classifications
+- batch `session_recover` apply returning `applied` and skipped classifications while mutating only
+  applicable targets
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+`cargo test -p loongclaw-app session_recover_batch_ -- --nocapture --test-threads=1`
+
+Expected: FAIL because the tool currently requires a single `session_id` and has no aggregated
+result path.
+
+**Step 3: Write minimal implementation**
+
+Add request parsing helpers and a shared aggregated execution path for batch or preview recover
+calls.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same focused recover batch tests and confirm PASS.
+
+### Task 4: Add `session_cancel` batch red tests
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing tests**
+
+Add focused tests for:
+
+- batch `session_cancel` dry-run returning queued/running `would_apply` results
+- batch `session_cancel` apply returning `applied` for queued and running targets while preserving
+  per-target state semantics
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+`cargo test -p loongclaw-app session_cancel_batch_ -- --nocapture --test-threads=1`
+
+Expected: FAIL because the tool currently only accepts a single `session_id`.
+
+**Step 3: Write minimal implementation**
+
+Extend the shared request/result helpers and apply existing cancel logic per target.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same focused cancel batch tests and confirm PASS.
+
+### Task 5: Update product docs
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Update acceptance criteria / roadmap bullets**
+
+Document batch targeting and `dry_run` preview on the existing remediation tools.
+
+**Step 2: Verify wording matches shipped behavior**
+
+Confirm docs describe no new top-level tool and preserve current limits.
+
+### Task 6: Run completion verification
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Run focused verification**
+
+Run the focused schema and batch tests:
+
+- `cargo test -p loongclaw-app provider_tool_definitions_are_stable_and_complete -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app session_recover_batch_ -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app session_cancel_batch_ -- --nocapture --test-threads=1`
+
+**Step 2: Run broader session-tool verification**
+
+Run:
+
+- `cargo test -p loongclaw-app session_recover_ -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app session_cancel_ -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app session_ -- --nocapture --test-threads=1`
+
+**Step 3: Run full repository verification**
+
+Run:
+
+- `cargo fmt --all`
+- `cargo test --workspace --all-features -- --test-threads=1`
+- `cargo fmt --all --check`
+- `git diff --check`
+
+**Step 4: Inspect final git state**
+
+Run:
+
+- `git status --short`
+- `git diff --cached --name-only`
+- `git diff --cached`

--- a/docs/plans/2026-03-13-session-cancel-design.md
+++ b/docs/plans/2026-03-13-session-cancel-design.md
@@ -1,0 +1,242 @@
+# Session Cancel Design
+
+## Context
+
+LoongClaw now exposes a usable session control surface for async delegation:
+
+- `delegate_async`
+- `session_status`
+- `session_events`
+- `session_wait`
+- `session_recover` for overdue queued async children
+
+That gives operators observability plus one narrow recovery action, but it still leaves a control gap: once an async delegate child is visible and running, there is no first-class way to ask that child to stop.
+
+## Problem
+
+We want the next thick control slice without pretending LoongClaw already has a durable worker pool, cross-host task registry, or safe OS-level process identity model.
+
+The key design question is what “cancel” should mean for a subprocess-backed async delegate child:
+
+- do we kill the worker process immediately
+- do we record intent and let the worker stop itself at a safe checkpoint
+- or do we keep cancellation out of scope until a stronger worker runtime exists
+
+## Goals
+
+- Add a root-visible `session_cancel` tool for visible async delegate child sessions.
+- Support immediate cancellation of queued async delegate children.
+- Support safe best-effort cancellation of running async delegate children.
+- Preserve child-session authority boundaries.
+- Keep terminal state transitions race-safe and auditable.
+
+## Non-Goals
+
+- No durable queue or leased worker subsystem.
+- No cross-host worker discovery or cancellation.
+- No OS-level hard kill as the primary cancellation path in this phase.
+- No new `cancelled` session state enum in this slice.
+- No retries, restarts, or post-reboot worker recovery.
+
+## Options Considered
+
+### Option 1: Hard kill running subprocesses by PID
+
+Pros:
+
+- most immediate operator effect
+- matches a stronger “stop now” intuition
+
+Cons:
+
+- current async spawn path does not persist a process handle or PID
+- safe later kill requires more identity data than a bare PID to avoid reuse hazards
+- pushes this phase into platform-specific process-control work before the repository has a durable worker model
+
+Rejected for now.
+
+### Option 2: Cooperative cancellation via session events
+
+Record a structured cancel request in sqlite, let queued children fail immediately, and let running children observe cancellation at turn-loop checkpoints and then finalize themselves into a durable cancelled outcome.
+
+Pros:
+
+- reuses the existing sqlite-backed session/event model
+- preserves race safety because terminal finalize still happens through the worker
+- keeps cancellation explicit and auditable
+- avoids unsafe or weakly identified process-kill semantics
+
+Cons:
+
+- cancellation is best-effort, not immediate preemption
+- a child blocked inside a provider call or long tool step will only stop at the next checkpoint
+
+Chosen.
+
+### Option 3: No cancel until a durable worker runtime exists
+
+Pros:
+
+- smallest implementation risk
+- avoids operator expectations that cannot be met yet
+
+Cons:
+
+- leaves the current session control surface materially incomplete
+- forces operators to wait for timeout/recovery even when they know a child should stop
+
+Rejected.
+
+## Chosen Approach
+
+Add a new root-visible session tool:
+
+- `session_cancel`
+
+Use two distinct execution paths:
+
+### Queued async child
+
+If the visible target session is:
+
+- `kind = delegate_child`
+- `state = ready`
+- async
+- queued
+- not terminal
+
+then `session_cancel` immediately finalizes it to terminal `failed` with:
+
+- terminal event `delegate_cancelled`
+- terminal outcome status `error`
+- structured terminal payload carrying `cancel_reason = operator_requested`
+- `cancel_action.kind = "queued_async_cancelled"`
+
+This path is analogous to `session_recover`, except it is operator-driven rather than timeout-driven.
+
+### Running async child
+
+If the visible target session is:
+
+- `kind = delegate_child`
+- `state = running`
+- async
+- running
+- not terminal
+
+then `session_cancel` appends a structured `delegate_cancel_requested` event while keeping the session in `running`.
+
+The delegated worker checks for that request at safe turn-loop checkpoints. Once observed, it exits its turn loop with a typed cancel error and finalizes the child to terminal `failed` with:
+
+- terminal event `delegate_cancelled`
+- terminal outcome status `error`
+- `last_error = "delegate_cancelled: operator_requested"`
+
+This is a cooperative, best-effort stop, not a hard process preemption.
+
+## Tool Surface
+
+### Root sessions
+
+When enabled, root sessions will expose:
+
+- `sessions_list`
+- `sessions_history`
+- `session_status`
+- `session_events`
+- `session_recover`
+- `session_cancel`
+- `session_wait`
+- `delegate`
+- `delegate_async`
+
+### Delegated child sessions
+
+Delegated child sessions will continue to hide:
+
+- `session_cancel`
+- `session_recover`
+- `sessions_list`
+- `session_events`
+- `session_wait`
+
+They keep only the current self-inspection surface.
+
+## Data Model
+
+No new sqlite table is required in this phase.
+
+Cancellation state is represented through existing session/event storage:
+
+- `delegate_cancel_requested`
+- `delegate_cancelled`
+
+Structured event payloads carry:
+
+- `kind`
+- `reference`
+- `cancel_reason`
+- optional operator session id in `actor_session_id`
+
+## Execution Model
+
+### `session_cancel`
+
+`session_cancel` should:
+
+1. validate target visibility
+2. inspect delegate lifecycle
+3. reject non-async or non-delegate-child targets
+4. for queued child: conditionally finalize `ready -> failed`
+5. for running child: atomically append `delegate_cancel_requested` while staying `running`
+6. return a fresh session inspection payload plus a machine-readable `cancel_action`
+
+### Delegate child worker checkpoint
+
+At the start of each turn-loop round for a delegated child session:
+
+1. inspect recent child-session events
+2. detect whether a newer `delegate_cancel_requested` exists for the active running lifecycle
+3. if cancellation is requested, stop before the next provider turn
+
+This makes cancellation effective between provider/tool rounds while avoiding partially executed app-tool actions inside the same checkpoint boundary.
+
+### Session inspection payload
+
+Extend `delegate_lifecycle` for running children with optional cancellation metadata:
+
+- `cancellation.state = "requested"`
+- `cancellation.reference = "running"`
+- `cancellation.requested_at`
+- `cancellation.reason = "operator_requested"`
+
+Queued cancelled children become terminal and therefore surface through existing terminal outcome plus recent events.
+
+## Race Semantics
+
+- If a queued child starts running before `session_cancel` finalizes it, the queued cancellation path must fail with a state-changed error.
+- If a running child reaches terminal completion before it sees the cancel request, terminal completion wins.
+- If a running child sees the cancel request before the next provider round, cancellation wins and finalizes the child as failed/cancelled.
+
+This preserves “first durable terminal write wins” semantics without introducing destructive overrides.
+
+## Testing Strategy
+
+Add TDD coverage for:
+
+1. root tool view/provider schema includes `session_cancel`
+2. delegated child view still excludes `session_cancel`
+3. `session_cancel` immediately finalizes a queued async child to failed with `delegate_cancelled`
+4. `session_cancel` rejects unsupported targets such as synchronous/running non-async or non-delegate-child sessions
+5. `session_cancel` records `delegate_cancel_requested` for a running async child
+6. delegated child execution stops on the next checkpoint after a cancel request
+7. `session_status` / `session_wait` surface cancellation metadata for running children with a pending cancel request
+
+## Documentation Impact
+
+Update product spec and roadmap to reflect:
+
+- explicit `session_cancel`
+- queued immediate cancel
+- running cooperative cancel
+- continued absence of hard kill, retry, and restart recovery semantics

--- a/docs/plans/2026-03-13-session-cancel-implementation-plan.md
+++ b/docs/plans/2026-03-13-session-cancel-implementation-plan.md
@@ -1,0 +1,180 @@
+# Session Cancel Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a first cancellation control surface for async delegate child sessions, with immediate queued cancellation and cooperative running cancellation at safe turn-loop checkpoints.
+
+**Architecture:** Reuse the sqlite session/event model instead of introducing worker registry or hard process control. Add a root-visible `session_cancel` tool, represent cancellation through `delegate_cancel_requested` and `delegate_cancelled` events, and teach delegated child execution to stop at round boundaries when a cancel request is present.
+
+**Tech Stack:** Rust, Tokio, rusqlite, serde_json, existing LoongClaw session repository / conversation turn-loop / app-tool runtime
+
+---
+
+### Task 1: Register the new tool surface
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/provider/mod.rs`
+- Test: `crates/app/src/tools/mod.rs`
+- Test: `crates/app/src/provider/mod.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that:
+
+- root runtime tool view includes `session_cancel`
+- delegated child runtime tool view excludes `session_cancel`
+- default dispatcher rejects hidden `session_cancel` from a child session
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app session_cancel -- --nocapture --test-threads=1`
+
+Expected: FAIL because the tool is not registered or dispatched yet.
+
+**Step 3: Write minimal implementation**
+
+Add catalog/provider/dispatcher registration for `session_cancel` as a root-visible session tool.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app session_cancel -- --nocapture --test-threads=1`
+
+Expected: PASS for tool registration / visibility cases.
+
+### Task 2: Implement queued and running cancel requests
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `crates/app/src/session/repository.rs`
+- Test: `crates/app/src/tools/session.rs`
+- Test: `crates/app/src/session/repository.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that:
+
+- `session_cancel` immediately terminalizes a queued async child as failed with `delegate_cancelled`
+- `session_cancel` records a running-child `delegate_cancel_requested` event without terminalizing immediately
+- unsupported targets are rejected cleanly
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app session_cancel -- --nocapture --test-threads=1`
+
+Expected: FAIL because the tool behavior does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- `execute_session_cancel(...)`
+- lifecycle validation helper
+- conditional queued finalize path
+- running request path using an atomic state-preserving event write
+- response payload with `cancel_action`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app session_cancel -- --nocapture --test-threads=1`
+
+Expected: PASS
+
+### Task 3: Teach delegated child execution to stop cooperatively
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/tools/session.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that:
+
+- a delegated child with a pending cancel request stops before the next provider round
+- terminal state becomes failed with `delegate_cancelled`
+- terminal outcome carries `delegate_cancelled: operator_requested`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app delegate_child_background_cancel -- --nocapture --test-threads=1`
+
+Expected: FAIL because delegated child execution currently ignores cancel request events.
+
+**Step 3: Write minimal implementation**
+
+Implement a delegated-child cancellation checkpoint before each turn-loop round and finalize cancellation through the existing terminal persistence path.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app delegate_child_background_cancel -- --nocapture --test-threads=1`
+
+Expected: PASS
+
+### Task 4: Surface cancellation in session inspection
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+- Test: `crates/app/src/tools/session.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that:
+
+- `session_status` surfaces pending cancellation metadata for a running child
+- `session_wait` returns that same metadata before terminal completion when cancellation is pending
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app session_cancel_requested -- --nocapture --test-threads=1`
+
+Expected: FAIL because `delegate_lifecycle` does not currently encode cancellation state.
+
+**Step 3: Write minimal implementation**
+
+Extend delegate lifecycle inspection with optional cancellation metadata derived from the latest relevant cancel-request event.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app session_cancel_requested -- --nocapture --test-threads=1`
+
+Expected: PASS
+
+### Task 5: Update docs and run full verification
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Update docs**
+
+Document:
+
+- `session_cancel`
+- queued immediate cancellation
+- running cooperative cancellation
+- continued absence of hard process kill / retry / restart recovery
+
+**Step 2: Run focused regression**
+
+Run:
+
+- `cargo test -p loongclaw-app session_cancel -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app delegate_child_background_cancel -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app session_ -- --nocapture --test-threads=1`
+
+Expected: PASS
+
+**Step 3: Run full verification**
+
+Run:
+
+- `cargo fmt --all`
+- `cargo test --workspace --all-features -- --test-threads=1`
+- `cargo fmt --all --check`
+- `git diff --check`
+
+Expected: PASS

--- a/docs/plans/2026-03-13-session-recover-running-design.md
+++ b/docs/plans/2026-03-13-session-recover-running-design.md
@@ -1,0 +1,179 @@
+# Session Recover Running Delegate Design
+
+## Context
+
+LoongClaw already gives operators two narrow controls over async delegate children:
+
+- `session_cancel` for queued cancellation and cooperative running cancellation
+- `session_recover` for overdue queued async children still stuck in `ready`
+
+That still leaves one operational hole: a visible async delegate child can remain in `running`
+past its timeout and still be unrecoverable if the worker is wedged, lost, or never comes back
+to observe a cooperative cancel request.
+
+## Problem
+
+We need one more thick control slice that helps operators resolve stale `running` async delegate
+children without pretending LoongClaw already has durable worker identity, safe process kill, or a
+restart-aware worker registry.
+
+The key design question is what `session_recover` should do when an async delegate child is:
+
+- visible
+- still `running`
+- clearly overdue from its lifecycle metadata
+- not terminal yet
+
+## Goals
+
+- Extend `session_recover` to handle overdue `running` async delegate children.
+- Keep recovery auditable and race-safe through existing sqlite session state.
+- Preserve child authority boundaries.
+- Distinguish queued-overdue and running-overdue recovery in machine-readable metadata.
+- Preserve fallback recovery inference when structured recovery event persistence fails.
+
+## Non-Goals
+
+- No hard process kill or PID-based worker targeting.
+- No automatic restart recovery daemon or lease manager.
+- No new session state enum for "cancelled" or "recovered".
+- No broad retry queue, requeue, or worker resurrection semantics.
+- No change to child-visible tool authority.
+
+## Options Considered
+
+### Option 1: Keep `session_recover` queued-only
+
+Pros:
+
+- zero new semantics
+- smallest implementation delta
+
+Cons:
+
+- operators cannot clear a visibly stale `running` child when cooperative cancel cannot progress
+- keeps the session control surface incomplete in real failure cases
+
+Rejected.
+
+### Option 2: Extend `session_recover` to finalize overdue running async children as failed
+
+Use the same race-safe conditional terminal finalize pattern already used for queued recovery, but
+allow `expected_state = running` when lifecycle metadata says the async child is overdue in its
+running phase.
+
+Pros:
+
+- reuses the current sqlite session/event model
+- fits the existing operator-driven remediation tool surface
+- avoids unsafe process-level control
+- gives a deterministic remediation path for wedged or orphaned workers
+
+Cons:
+
+- if the worker is still alive, the operator can mark the session failed before the worker notices
+- recovery remains an operator decision, not an automatic policy
+
+Chosen.
+
+### Option 3: Add process-aware hard recovery
+
+Pros:
+
+- more direct operator semantics
+
+Cons:
+
+- requires stronger worker identity and ownership semantics than the current subprocess model has
+- expands this slice into platform/process management rather than session correctness
+
+Rejected for now.
+
+## Chosen Approach
+
+Extend `session_recover` so it accepts two recoverable delegate lifecycle shapes:
+
+### Queued async overdue child
+
+Existing behavior remains unchanged:
+
+- `state = ready`
+- lifecycle `mode = async`
+- lifecycle `phase = queued`
+- lifecycle `staleness.state = overdue`
+
+Recovery finalizes `ready -> failed` with recovery kind
+`queued_async_overdue_marked_failed`.
+
+### Running async overdue child
+
+New behavior:
+
+- `state = running`
+- lifecycle `mode = async`
+- lifecycle `phase = running`
+- lifecycle `staleness.state = overdue`
+
+Recovery finalizes `running -> failed` with recovery kind
+`running_async_overdue_marked_failed`.
+
+The recovery event stays `delegate_recovery_applied`, but the structured payload and `last_error`
+prefix distinguish queued vs running remediation.
+
+## Data Model
+
+No schema change is required.
+
+We continue using:
+
+- `sessions.state`
+- `sessions.last_error`
+- `session_events`
+- `session_terminal_outcomes`
+
+Add one new recovery classification:
+
+- `running_async_overdue_marked_failed`
+
+Add one new `last_error` prefix for fallback inference:
+
+- `delegate_async_running_overdue_marked_failed:`
+
+## Payload Shape
+
+`session_recover` continues returning a fresh inspection payload plus `recovery_action`.
+
+For running overdue recovery:
+
+- `recovery_action.kind = "running_async_overdue_marked_failed"`
+- `recovery_action.previous_state = "running"`
+- `recovery_action.next_state = "failed"`
+- `recovery_action.reference = "started"` when a `delegate_started` timestamp exists
+- the timeout / elapsed / deadline fields mirror lifecycle staleness
+
+Queued recovery keeps its existing payload shape.
+
+## Race Semantics
+
+- If the target session becomes terminal before recovery finalizes it, terminal state wins and
+  `session_recover` returns a state-changed error.
+- If a `running` child transitions away from `running` before the operator recovery writes, the
+  conditional finalize is a no-op and the caller gets a state-changed error.
+- If a stale worker later tries to finalize after operator recovery already marked the session
+  failed, repository guards must continue preventing double terminalization.
+
+## Inspection Semantics
+
+`session_status` and `session_wait` already prefer structured recovery events and fall back to
+`last_error` prefixes when the recovery event is missing. This slice extends that fallback parser so
+running-overdue recovery remains attributable even if event persistence fails.
+
+## Testing
+
+Add focused tests for:
+
+- `session_recover` marking an overdue running async child failed
+- `session_recover` still rejecting fresh running children
+- recovery kind fallback inference from the new running-overdue `last_error` prefix
+- optional session inspection coverage to ensure recovered-running sessions surface the new recovery
+  kind through existing inspection payloads

--- a/docs/plans/2026-03-13-session-recover-running-implementation-plan.md
+++ b/docs/plans/2026-03-13-session-recover-running-implementation-plan.md
@@ -1,0 +1,110 @@
+# Session Recover Running Delegate Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend `session_recover` so operators can mark an overdue `running` async delegate child
+as failed using the same audited sqlite session surface already used for queued recovery.
+
+**Architecture:** Reuse `session_delegate_lifecycle_at(...)` and the repository's
+`finalize_session_terminal_if_current(...)` guard. Generalize the recovery plan to describe the
+expected source state and reference timestamp, add a distinct running-overdue recovery kind and
+fallback error prefix, and keep the response payload machine-readable.
+
+**Tech Stack:** Rust, rusqlite, serde_json, existing LoongClaw session repository and session tool
+runtime
+
+---
+
+### Task 1: Pin the new recoverable shape with tests
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `crates/app/src/session/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that:
+
+- `session_recover` marks an overdue running async child failed
+- `session_recover` rejects a fresh running child
+- missing recovery events still infer `running_async_overdue_marked_failed` from `last_error`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+- `cargo test -p loongclaw-app session_recover_marks_overdue_running_async_child_failed -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app observe_missing_recovery_infers_running_async_overdue_from_last_error -- --nocapture --test-threads=1`
+
+Expected: FAIL because running-overdue recovery is not implemented yet.
+
+**Step 3: Write minimal implementation**
+
+Implement only the code required to make those tests pass.
+
+**Step 4: Run test to verify it passes**
+
+Run the same focused commands and confirm both pass.
+
+### Task 2: Generalize recovery planning and execution
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `crates/app/src/session/recovery.rs`
+
+**Step 1: Refactor the recovery plan**
+
+Make `SessionRecoverPlan` encode:
+
+- expected current state (`ready` or `running`)
+- recovery kind
+- reference (`queued` or `started`)
+- reference timestamp and timeout metadata
+
+**Step 2: Extend execution**
+
+Update `execute_session_recover(...)` to:
+
+- build the correct recovery error string per recovery kind
+- conditionally finalize from the plan's expected state
+- emit the matching structured recovery payload and `recovery_action`
+
+**Step 3: Verify focused tests**
+
+Run:
+
+- `cargo test -p loongclaw-app session_recover_ -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app observe_missing_recovery_ -- --nocapture --test-threads=1`
+
+Expected: PASS
+
+### Task 3: Update product docs and run full verification
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Update docs**
+
+Document that:
+
+- `session_recover` now covers overdue queued and overdue running async delegate children
+- hard kill / retries / automatic post-restart recovery remain out of scope
+
+**Step 2: Run focused regression**
+
+Run:
+
+- `cargo test -p loongclaw-app session_recover_ -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app session_wait_reports_missing_terminal_outcome_for_recovered_failed_session -- --nocapture --test-threads=1`
+
+**Step 3: Run full verification**
+
+Run:
+
+- `cargo fmt --all`
+- `cargo test --workspace --all-features -- --test-threads=1`
+- `cargo fmt --all --check`
+- `git diff --check`
+
+Expected: PASS

--- a/docs/plans/2026-03-13-session-status-batch-inspection-design.md
+++ b/docs/plans/2026-03-13-session-status-batch-inspection-design.md
@@ -1,0 +1,184 @@
+# Session Status Batch Inspection Design
+
+## Context
+
+LoongClaw's operator surface now supports:
+
+- filtered `sessions_list` discovery
+- single-session `session_status`
+- batch `session_cancel` / `session_recover` with `session_ids`
+
+That still leaves one practical inspection gap. After discovery returns several relevant sessions,
+operators still need to call `session_status` one target at a time to get the richer inspection
+payload that includes terminal outcome state, delegate lifecycle, recovery metadata, and recent
+events.
+
+## Problem
+
+We need a thicker inspection slice without adding a new top-level tool and without widening session
+authority.
+
+The design question is how to let operators inspect multiple visible sessions through the existing
+`session_status` surface while preserving:
+
+- backward compatibility for current single-session callers
+- visibility boundaries per target
+- clear per-target results when some requested sessions are not visible
+
+## Goals
+
+- Extend `session_status` to support batch targeting via `session_ids`.
+- Preserve the legacy single-session response shape for `session_id`.
+- Return machine-readable per-target inspection results in batch mode.
+- Keep visibility checks per target and avoid leaking hidden-session details.
+- Reuse the existing `session_inspection_payload` rather than inventing another inspection schema.
+
+## Non-Goals
+
+- No new top-level tool such as `session_status_many`.
+- No mutation behavior, `dry_run`, or operator remediation in this slice.
+- No event streaming or wait semantics for multiple sessions.
+- No pagination, saved queries, or push updates.
+- No broadening of delegated child authority.
+
+## Options Considered
+
+### Option 1: Keep `session_status` single-target and rely on caller loops
+
+Pros:
+
+- zero schema change
+- no implementation risk
+
+Cons:
+
+- pushes repetitive inspection orchestration onto every caller
+- makes the control surface uneven after batch remediation already exists
+- discourages richer inspection after `sessions_list`
+
+Rejected.
+
+### Option 2: Extend `session_status` with `session_ids`
+
+Accept either:
+
+- `session_id`
+- `session_ids`
+
+Preserve the old single-target response shape and use an aggregated response only for batch calls.
+
+Pros:
+
+- keeps the tool surface compact
+- composes naturally with `sessions_list`
+- reuses the existing inspection payload
+- mirrors the compatibility pattern already used by batch remediation
+
+Cons:
+
+- introduces a second response shape
+- requires per-target visibility normalization and result classification
+
+Chosen.
+
+### Option 3: Add a new batch inspection tool
+
+Examples:
+
+- `session_status_many`
+- `sessions_inspect`
+
+Pros:
+
+- explicit name
+- no dual response shape on `session_status`
+
+Cons:
+
+- expands the top-level tool surface
+- overlaps heavily with an existing tool whose meaning already matches the need
+
+Rejected.
+
+## Chosen Approach
+
+Extend `session_status` rather than adding a new tool.
+
+### Request model
+
+`session_status` accepts exactly one of:
+
+- `session_id: string`
+- `session_ids: string[]`
+
+### Backward compatibility
+
+When the request uses `session_id`, behavior stays unchanged:
+
+- status remains `ok`
+- payload remains the existing `session_inspection_payload`
+
+When the request uses `session_ids`, the response becomes aggregated.
+
+### Batch response shape
+
+Batch inspection returns:
+
+- `tool`
+- `current_session_id`
+- `requested_count`
+- `result_counts`
+- `results`
+
+Each `results[]` item includes:
+
+- `session_id`
+- `result`
+- `message`
+- `inspection`
+
+Result values are intentionally narrow:
+
+- `ok`
+- `skipped_not_visible`
+
+Visible targets get the full `session_inspection_payload`. Hidden or non-resolvable targets return
+`inspection = null` plus a visibility-denied message.
+
+### Visibility semantics
+
+Visibility remains enforced per target using the same repository-backed checks as the current
+single-target path.
+
+Batch inspection must not hard-fail the whole request just because one requested target is hidden.
+Instead:
+
+- visible targets are inspected normally
+- hidden targets become `skipped_not_visible`
+
+Malformed input still hard-fails the request.
+
+### Ordering semantics
+
+Return `results[]` in the same order as the requested `session_ids`.
+
+This keeps the response easy for callers to correlate with the input set and avoids adding extra
+sorting semantics.
+
+## Data Model
+
+No schema change is required.
+
+The slice reuses:
+
+- `sessions`
+- `session_events`
+- `session_terminal_outcomes`
+
+## Testing
+
+Add focused coverage for:
+
+- provider schema updates exposing `session_ids` on `session_status`
+- batch `session_status` with mixed visible and hidden targets
+- preservation of the legacy single-target `session_status` response shape

--- a/docs/plans/2026-03-13-session-status-batch-inspection-implementation-plan.md
+++ b/docs/plans/2026-03-13-session-status-batch-inspection-implementation-plan.md
@@ -1,0 +1,133 @@
+# Session Status Batch Inspection Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend `session_status` with `session_ids` batch inspection while preserving the legacy
+single-session response shape.
+
+**Architecture:** Keep the existing single-target path unchanged and add a batch aggregation path
+that loops over visible-session inspection using the current `session_inspection_payload`. Hidden
+targets become per-item skipped results instead of failing the whole request.
+
+**Tech Stack:** Rust, serde_json, sqlite-backed session repository, cargo test
+
+---
+
+### Task 1: Document the slice
+
+**Files:**
+- Create: `docs/plans/2026-03-13-session-status-batch-inspection-design.md`
+- Create: `docs/plans/2026-03-13-session-status-batch-inspection-implementation-plan.md`
+
+**Step 1: Write the design doc**
+
+Capture request/response shape, compatibility rules, visibility semantics, and test scope.
+
+**Step 2: Save the implementation plan**
+
+Record the concrete TDD sequence and verification commands.
+
+### Task 2: Add provider-schema red tests
+
+**Files:**
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/catalog.rs`
+
+**Step 1: Write the failing test**
+
+Extend `provider_tool_definitions_are_stable_and_complete` so `session_status` must expose:
+
+- `session_id`
+- `session_ids`
+
+with `oneOf` enforcing exactly one target field.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+`cargo test -p loongclaw-app provider_tool_definitions_are_stable_and_complete -- --nocapture --test-threads=1`
+
+Expected: FAIL because the current schema only exposes `session_id`.
+
+**Step 3: Write minimal implementation**
+
+Update the provider definition in `crates/app/src/tools/catalog.rs`.
+
+**Step 4: Run test to verify it passes**
+
+Re-run the same focused schema test and confirm PASS.
+
+### Task 3: Add `session_status` batch red tests
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing tests**
+
+Add focused coverage for:
+
+- batch `session_status` returning full inspection payloads for visible targets
+- hidden targets returning `skipped_not_visible`
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+`cargo test -p loongclaw-app session_status_batch_ -- --nocapture --test-threads=1`
+
+Expected: FAIL because the tool currently requires a single `session_id`.
+
+**Step 3: Write minimal implementation**
+
+Add request parsing and aggregated batch response handling in `crates/app/src/tools/session.rs`.
+
+**Step 4: Run tests to verify they pass**
+
+Re-run the focused batch status tests and confirm PASS.
+
+### Task 4: Update product docs
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Update acceptance criteria / roadmap**
+
+Document batch inspection support on `session_status`.
+
+**Step 2: Confirm wording preserves boundaries**
+
+Verify docs still say no new top-level tool and no authority expansion.
+
+### Task 5: Run completion verification
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Run focused verification**
+
+- `cargo test -p loongclaw-app provider_tool_definitions_are_stable_and_complete -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app session_status_batch_ -- --nocapture --test-threads=1`
+
+**Step 2: Run broader session inspection verification**
+
+- `cargo test -p loongclaw-app session_status_ -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app session_ -- --nocapture --test-threads=1`
+
+**Step 3: Run full repository verification**
+
+- `cargo fmt --all`
+- `cargo test --workspace --all-features -- --test-threads=1`
+- `cargo fmt --all --check`
+- `git diff --check`
+
+**Step 4: Inspect final git state**
+
+- `git status --short`
+- `git diff --cached --name-only`
+- `git diff --cached`

--- a/docs/plans/2026-03-13-session-unarchive-design.md
+++ b/docs/plans/2026-03-13-session-unarchive-design.md
@@ -1,0 +1,236 @@
+# Session Unarchive Design
+
+## Context
+
+LoongClaw now has a truthful `session_archive` primitive for inventory cleanup of visible
+terminal sessions. That solved the first half of the operator lifecycle: a finished session can be
+retired from default `sessions_list` inventory without deleting history or pretending to close a
+live route.
+
+The next honest gap is reversibility. Once a session is archived, an operator can still inspect it
+directly, but there is no durable tool to restore it back into default inventory. That creates an
+asymmetry:
+
+- `session_archive` is explicit and auditable
+- rediscovery is possible through direct inspection or `include_archived=true`
+- restoration back into the default list is not yet explicit or auditable
+
+This is a better target than a fake `session_close`. External comparison showed that OpenClaw does
+not provide a meaningful reopen path after close/delete, and LoongClaw still lacks truthful
+route-unbinding or root-session successor semantics for fixed ids like `telegram:<chat_id>` and
+`feishu:<chat_id>`.
+
+## Problem
+
+Operators can archive visible terminal sessions, but cannot later restore them into default
+inventory without manual rediscovery workarounds. The current archive-state derivation also only
+looks for `session_archived`, which is sufficient for archive-only behavior but becomes incorrect as
+soon as a reversible lifecycle exists.
+
+## Goals
+
+- Add a truthful `session_unarchive` operator primitive for visible archived terminal sessions.
+- Preserve the event-sourced audit trail instead of replacing archive state with mutable flags.
+- Make archive state derivation correct under both archive and unarchive actions.
+- Reuse the existing single-target and batch mutation patterns already used by
+  `session_archive`, `session_cancel`, and `session_recover`.
+- Keep archived sessions directly inspectable before and after restoration.
+
+## Non-Goals
+
+- No fake `session_close`, route shutdown, or inbound channel unbinding.
+- No reopen / successor-session model for fixed channel-backed root ids.
+- No transcript deletion, rewriting, or terminal outcome mutation.
+- No mutation of non-terminal sessions.
+- No hidden side effects beyond inventory visibility.
+
+## Chosen Primitive
+
+Add `session_unarchive`.
+
+`session_unarchive` restores a visible archived terminal session back into the default
+`sessions_list` inventory. It does not change execution state, transcript rows, or terminal
+outcomes.
+
+This keeps the tool truthful:
+
+- `session_archive` hides a finished session from default inventory
+- `session_unarchive` restores that finished session to default inventory
+- neither tool claims to shut down runtime routing or reopen live execution
+
+## Scope Rules
+
+`session_unarchive` is allowed only when all of the following are true:
+
+- target session is visible from the caller under existing visibility rules
+- target session is currently archived
+- target session is terminal: `completed`, `failed`, or `timed_out`
+
+The terminal-state requirement keeps archive and unarchive as pure inventory hygiene over finished
+work, rather than broad session-lifecycle control.
+
+## State Model
+
+Archive is still not a new execution state. Session execution state remains:
+
+- `ready`
+- `running`
+- `completed`
+- `failed`
+- `timed_out`
+
+Archive is an inventory overlay represented on summaries as:
+
+- `archived: boolean`
+- `archived_at: integer|null`
+
+The key refinement is how that overlay is derived.
+
+## Persistence Model
+
+Archive lifecycle remains event-sourced:
+
+- `session_archive` appends `session_archived`
+- `session_unarchive` appends `session_unarchived`
+
+The repository must no longer ask only "has this session ever been archived?" Instead it must look
+at the most recent archive control event for the session and derive state from that event:
+
+- latest control event = `session_archived` => session is archived, `archived_at = event.ts`
+- latest control event = `session_unarchived` => session is not archived, `archived_at = null`
+- no archive control event => session is not archived, `archived_at = null`
+
+To avoid incorrect ties from second-granularity timestamps, "latest" should be resolved primarily by
+session-event row `id`, not only by `ts`.
+
+## Repository Semantics
+
+Both visible-session listing and single-session summary loading must use the same archive-state
+derivation so the tool layer does not drift from inventory behavior.
+
+Recommended query shape:
+
+- restrict to archive-control events: `session_archived`, `session_unarchived`
+- pick the latest control event per session using descending event `id`
+- project:
+  - archived flag from latest event kind
+  - `archived_at` only when latest event kind is `session_archived`
+
+This avoids introducing a mutable `sessions.archived_at` column and preserves the full audit trail.
+
+## Tool Semantics
+
+### Single-target mode
+
+Request:
+
+```json
+{
+  "session_id": "delegate:child-123"
+}
+```
+
+Response shape follows the existing single-target mutation pattern:
+
+- returns the normal inspection payload
+- adds `unarchive_action`
+
+Representative action payload:
+
+```json
+{
+  "kind": "session_unarchived",
+  "previous_state": "completed",
+  "next_state": "completed",
+  "restores_to_sessions_list": true
+}
+```
+
+### Batch mode
+
+Request:
+
+```json
+{
+  "session_ids": ["delegate:child-1", "delegate:child-2"],
+  "dry_run": true
+}
+```
+
+Batch result classifications:
+
+- `would_apply`
+- `applied`
+- `skipped_not_visible`
+- `skipped_not_archived`
+- `skipped_not_archivable`
+- `skipped_state_changed`
+
+`skipped_not_archived` is separate from `skipped_not_archivable` so operators can distinguish "not
+currently archived" from "wrong lifecycle state".
+
+## Inspection And Listing Semantics
+
+`session_status`, `session_events`, and `sessions_history` remain available for archived sessions and
+for later-unarchived sessions. `session_events` naturally exposes both `session_archived` and
+`session_unarchived`.
+
+`sessions_list` behavior becomes:
+
+- archived sessions are still excluded by default
+- `include_archived=true` returns both archived and non-archived visible sessions
+- after `session_unarchive`, the target reappears in default `sessions_list`
+
+`session_wait` remains unchanged because archive lifecycle does not alter terminality.
+
+## Error Model
+
+Representative rejections:
+
+- `session_unarchive_not_archivable: session \`...\` is not terminal`
+- `session_unarchive_not_unarchivable: session \`...\` is not archived`
+- `visibility_denied: ...`
+- `session_unarchive_state_changed: session \`...\` is no longer unarchivable from state \`...\``
+
+The `state_changed` branch covers races where another actor archives, unarchives, or otherwise
+mutates the target after inspection.
+
+## Alternatives Considered
+
+### 1. Mutable `sessions.archived_at` field
+
+Pros:
+
+- simpler query path
+
+Cons:
+
+- weaker audit trail
+- duplicates information already present in durable events
+- makes archive lifecycle less transparent in `session_events`
+
+Rejected because LoongClaw's session surface is explicitly trying to stay auditable and truthful.
+
+### 2. List-layer filtering without durable unarchive state
+
+Pros:
+
+- smaller change set
+
+Cons:
+
+- inventory behavior can drift from inspection behavior
+- no durable record of restoration
+- weak operator evidence for who restored a session and when
+
+Rejected because it is not robust enough for a control-plane primitive.
+
+## Why This Design
+
+This is the smallest reversible lifecycle that stays honest:
+
+- it deepens the existing archive primitive instead of widening the surface with a fake close
+- it keeps state event-sourced and auditable
+- it fixes the underlying repository model rather than papering over it in the tool layer
+- it gives operators a complete archive / restore inventory workflow without claiming runtime
+  semantics LoongClaw does not yet have

--- a/docs/plans/2026-03-13-session-unarchive-implementation-plan.md
+++ b/docs/plans/2026-03-13-session-unarchive-implementation-plan.md
@@ -1,0 +1,251 @@
+# Session Unarchive Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a truthful `session_unarchive` primitive that restores visible archived terminal
+sessions to default `sessions_list` inventory and updates archive-state derivation to use the latest
+archive control event.
+
+**Architecture:** Keep archive lifecycle event-sourced. Introduce `session_unarchived` as a durable
+control event, teach repository summary queries to derive archive state from the latest archive
+control event (`session_archived` or `session_unarchived`), and expose `session_unarchive` with the
+same single-target / batch / `dry_run` mutation pattern used elsewhere in the session tool surface.
+
+**Tech Stack:** Rust, rusqlite, serde_json, sqlite-backed session repository, cargo test
+
+---
+
+### Task 1: Document the reversible archive design
+
+**Files:**
+- Create: `docs/plans/2026-03-13-session-unarchive-design.md`
+- Create: `docs/plans/2026-03-13-session-unarchive-implementation-plan.md`
+
+**Step 1: Write the design doc**
+
+Capture:
+
+- why `session_unarchive` is the next truthful primitive
+- why `session_close` is still rejected
+- why latest archive control event must win
+- why repository derivation should prefer event `id` over `ts`
+
+**Step 2: Write the implementation plan**
+
+Break implementation into TDD-sized tasks with exact files and commands.
+
+**Step 3: Commit**
+
+```bash
+git add docs/plans/2026-03-13-session-unarchive-design.md docs/plans/2026-03-13-session-unarchive-implementation-plan.md
+git commit -m "docs(plans): design session unarchive tool"
+```
+
+### Task 2: Add the first failing `session_unarchive` test
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing test**
+
+Add a test proving that:
+
+- a visible archived terminal child can be unarchived
+- the returned payload includes `unarchive_action`
+- the target becomes non-archived in the returned inspection payload
+- `session_status` still reports the target and now marks it unarchived
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_unarchive_restores_archived_terminal_visible_session -- --nocapture --test-threads=1
+```
+
+Expected: FAIL because `session_unarchive` is not implemented.
+
+**Step 3: Write minimal implementation**
+
+Implement the smallest code path needed for single-target unarchive behavior in the session tool
+layer.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and confirm PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/session.rs
+git commit -m "feat(app): add single-session unarchive flow"
+```
+
+### Task 3: Add the failing repository regression for archive-state derivation
+
+**Files:**
+- Modify: `crates/app/src/session/repository.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests proving that:
+
+- a session archived and then unarchived reports `archived_at = null`
+- `sessions_list` default output includes that session again
+- `include_archived=true` still shows genuinely archived sessions
+- the latest archive control event wins even when both archive and unarchive events exist
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_unarchive -- --nocapture --test-threads=1
+```
+
+Expected: FAIL because repository summary queries still only read `session_archived`.
+
+**Step 3: Write minimal implementation**
+
+Update repository summary loading to derive archive state from the latest archive control event,
+preferring event `id` ordering.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same command and confirm PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/session/repository.rs crates/app/src/tools/session.rs
+git commit -m "feat(app): derive archive state from latest control event"
+```
+
+### Task 4: Add batch and `dry_run` unarchive coverage
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests proving that:
+
+- batch `session_unarchive` supports `session_ids`
+- `dry_run=true` previews mixed results without mutation
+- already-visible non-archived sessions are classified as `skipped_not_archived`
+- non-terminal or hidden sessions classify correctly
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_unarchive_batch -- --nocapture --test-threads=1
+```
+
+Expected: FAIL on missing batch behavior.
+
+**Step 3: Write minimal implementation**
+
+Extend the existing mutation helper pattern used by `session_archive` to implement batch
+`session_unarchive`.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same command and confirm PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/session.rs
+git commit -m "feat(app): add batch session unarchive support"
+```
+
+### Task 5: Update the tool surface and product docs
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/provider/mod.rs`
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Write the failing tests**
+
+Add or update tests proving that:
+
+- `session_unarchive` appears in the root tool surface
+- delegated child views still do not gain it
+- provider request bodies expose its schema
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_unarchive -- --nocapture --test-threads=1
+```
+
+Expected: FAIL on catalog / provider assertions.
+
+**Step 3: Write minimal implementation**
+
+Add tool catalog entries, schema definition, visibility wiring, and product-doc updates that match
+the implemented behavior.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same command and confirm PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/catalog.rs crates/app/src/tools/mod.rs crates/app/src/provider/mod.rs docs/product-specs/index.md docs/roadmap.md
+git commit -m "feat(app): expose session unarchive tool surface"
+```
+
+### Task 6: Run full verification
+
+**Files:**
+- No code changes expected
+
+**Step 1: Run focused tests**
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_unarchive -- --nocapture --test-threads=1
+```
+
+Expected: PASS
+
+**Step 2: Run package test suite**
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app -- --nocapture --test-threads=1
+```
+
+Expected: PASS
+
+**Step 3: Run daemon compile verification**
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-daemon --no-run
+```
+
+Expected: PASS
+
+**Step 4: Run formatting**
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all
+```
+
+Expected: no diff
+
+**Step 5: Inspect and commit any final cleanups**
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```

--- a/docs/plans/2026-03-13-session-wait-batch-design.md
+++ b/docs/plans/2026-03-13-session-wait-batch-design.md
@@ -1,0 +1,205 @@
+# Session Wait Batch Design
+
+## Context
+
+LoongClaw's session tool surface already supports:
+
+- filtered `sessions_list` discovery
+- batch `session_status`
+- batch `session_cancel` / `session_recover`
+- single-target `session_wait` with bounded polling and optional `after_id`
+
+That leaves one operator gap: after discovering or remediating several candidate sessions, the
+caller still has to wait on each child one by one. That makes the thick session surface uneven and
+pushes orchestration loops back into the provider.
+
+External repo review points in the same direction:
+
+- OpenClaw emphasizes a compact operator control surface with primitives such as list, status, log,
+  send, steer, cancel, and spawn rather than proliferating top-level tools.
+- NanoBot similarly concentrates lifecycle actions into thicker tools and command families instead
+  of many narrow single-purpose commands.
+
+## Problem
+
+We need to deepen `session_wait` without adding a new top-level tool and without widening
+visibility or child authority.
+
+The design question is how to let operators wait on multiple visible sessions while preserving:
+
+- backward compatibility for existing single-session callers
+- shared bounded wait behavior
+- per-target visibility boundaries
+- per-target terminal or timeout classification
+- optional incremental event-tail continuation via the existing `after_id` contract
+
+## Goals
+
+- Extend `session_wait` to accept either `session_id` or `session_ids`.
+- Preserve the legacy single-target response shape and status codes.
+- Support shared `timeout_ms` and shared `after_id` semantics in batch mode.
+- Return per-target results in request order with machine-readable outcome classification.
+- Reuse the existing inspection and wait payload shapes rather than inventing a second wait schema.
+
+## Non-Goals
+
+- No new top-level tool such as `session_wait_many`.
+- No push streaming or subscription transport.
+- No hard-kill or preemptive cancellation semantics.
+- No widening of delegated child visibility.
+- No full async dispatcher signature refactor in this slice.
+
+## Options Considered
+
+### Option 1: Keep `session_wait` single-target and rely on caller loops
+
+Pros:
+
+- zero request-schema change
+- no implementation risk
+
+Cons:
+
+- leaves the session surface inconsistent after batch status and remediation
+- forces providers to reimplement bounded wait fan-out
+- makes multi-session orchestration less auditable
+
+Rejected.
+
+### Option 2: Extend `session_wait` with `session_ids`
+
+Accept either:
+
+- `session_id`
+- `session_ids`
+
+Keep the old single-target shape for `session_id`. In batch mode, use a shared timeout window and
+return structured per-target results.
+
+Pros:
+
+- keeps the tool surface compact
+- composes directly with `sessions_list`, `session_status`, `session_cancel`, and `session_recover`
+- preserves the strong existing single-target wait payload
+- keeps visibility enforcement per target
+
+Cons:
+
+- introduces a second response shape for batch calls
+- requires explicit classification for mixed completed, timeout, and hidden targets
+
+Chosen.
+
+### Option 3: Add a new batch wait tool
+
+Examples:
+
+- `session_wait_many`
+- `sessions_wait`
+
+Pros:
+
+- explicit name
+- no dual response shape on `session_wait`
+
+Cons:
+
+- expands the top-level operator surface
+- overlaps almost entirely with an existing wait primitive
+
+Rejected.
+
+## Chosen Approach
+
+Extend `session_wait` instead of adding a new tool.
+
+### Request model
+
+`session_wait` accepts exactly one of:
+
+- `session_id: string`
+- `session_ids: string[]`
+
+It continues to accept:
+
+- `timeout_ms?: integer`
+- `after_id?: integer`
+
+For batch mode, `timeout_ms` and `after_id` apply to the whole request.
+
+### Backward compatibility
+
+When the request uses `session_id`, behavior remains unchanged:
+
+- top-level status stays `ok` or `timeout`
+- payload stays the existing wait payload shape
+
+### Batch response shape
+
+Batch mode returns:
+
+- `tool`
+- `current_session_id`
+- `requested_count`
+- `timeout_ms`
+- `after_id`
+- `result_counts`
+- `results[]`
+
+Each result entry returns:
+
+- `session_id`
+- `result`
+- `message`
+- `inspection`
+
+Result values:
+
+- `ok`
+- `timeout`
+- `skipped_not_visible`
+
+For `ok` and `timeout`, `inspection` reuses the existing single-target wait payload including:
+
+- `wait_status`
+- `timeout_ms`
+- `after_id`
+- `next_after_id`
+- `events`
+- the normal inspection fields
+
+For hidden or not-visible targets:
+
+- `inspection = null`
+- `message` contains the visibility failure reason
+
+### Execution semantics
+
+- Visibility is checked per target.
+- Hidden targets are classified immediately as `skipped_not_visible`.
+- Visible targets share one bounded timeout window.
+- The wait loop polls only the remaining non-terminal visible targets.
+- Terminal targets finalize early with `result = ok`.
+- Targets still non-terminal at deadline finalize with `result = timeout`.
+- Request order is preserved in the final `results[]`.
+
+### Routing choice
+
+`session_wait` still needs async polling, so this slice does not change the dispatcher signature.
+Instead, it moves the core wait logic into `tools/session.rs` so the routing split becomes thinner:
+
+- `tools/mod.rs` remains the async app-tool entrypoint
+- `tools/session.rs` owns the actual wait semantics and shared payload construction
+
+That keeps this slice focused on user-facing depth without turning it into a cross-cutting async
+refactor.
+
+## Testing
+
+Required coverage:
+
+1. provider schema exposes `session_ids` for `session_wait`
+2. single-target `session_wait` remains behaviorally unchanged
+3. batch wait returns mixed `ok`, `timeout`, and `skipped_not_visible` results in request order
+4. existing `after_id` event-tail tests remain green for single-target calls
+

--- a/docs/plans/2026-03-13-session-wait-batch-implementation-plan.md
+++ b/docs/plans/2026-03-13-session-wait-batch-implementation-plan.md
@@ -1,0 +1,87 @@
+# Session Wait Batch Implementation Plan
+
+**Goal:** deepen the existing `session_wait` tool so operators can wait on multiple visible
+sessions through one request, without adding a new top-level tool and without regressing the
+single-target contract.
+
+**Architecture:** keep `tools/mod.rs` as the async app-tool wrapper for `session_wait`, but move
+the actual wait orchestration into `tools/session.rs` beside the rest of the session tool logic.
+Batch mode reuses the existing inspection and wait payloads per target and wraps them in the same
+batch-result envelope pattern already used by `session_status`, `session_cancel`, and
+`session_recover`.
+
+## Task 1: Extend the provider schema
+
+Update the `session_wait` catalog definition so it accepts:
+
+- `session_id`
+- `session_ids`
+
+Keep `after_id` and `timeout_ms` unchanged.
+
+Acceptance criteria:
+
+- provider schema exposes `session_ids`
+- schema uses `oneOf` to require exactly one of `session_id` or `session_ids`
+
+## Task 2: Add failing behavior coverage first
+
+Add tests for:
+
+- provider schema stability for batch `session_wait`
+- mixed batch outcomes:
+  - one visible terminal session
+  - one visible non-terminal session that times out
+  - one hidden session
+
+Acceptance criteria:
+
+- tests fail before implementation for the expected reasons:
+  - schema missing `session_ids`
+  - runtime rejects `payload.session_ids`
+
+## Task 3: Move wait semantics into `tools/session.rs`
+
+Implement:
+
+- shared request parsing for single or batch targets
+- preserved single-target loop semantics
+- batch wait loop with:
+  - shared timeout window
+  - per-target visibility checks
+  - early completion for terminal sessions
+  - timeout finalization for remaining sessions
+  - request-order-preserving results
+
+Acceptance criteria:
+
+- single-target callers still get the legacy wait payload and top-level status
+- batch callers get a structured batch response with `ok`, `timeout`, and `skipped_not_visible`
+- `after_id` continues to populate per-target `events` and `next_after_id`
+
+## Task 4: Document the surface
+
+Update:
+
+- `docs/product-specs/index.md`
+- `docs/roadmap.md`
+- this design and implementation plan pair
+
+Acceptance criteria:
+
+- product spec captures batch wait as part of the session operator surface
+- roadmap notes that wait joins the existing batch status/remediation family
+
+## Verification
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_tool_definitions_are_stable_and_complete -- --nocapture --test-threads=1
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app session_wait_ -- --nocapture --test-threads=1
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test --workspace --all-features -- --test-threads=1
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all --check
+git diff --check
+```
+

--- a/docs/plans/2026-03-13-sessions-list-discovery-design.md
+++ b/docs/plans/2026-03-13-sessions-list-discovery-design.md
@@ -1,0 +1,209 @@
+# Sessions List Discovery Design
+
+## Context
+
+LoongClaw's session control surface is now materially stronger:
+
+- `session_status` and `session_wait` expose normalized delegate lifecycle metadata
+- `session_cancel` handles queued cancellation and cooperative running cancellation
+- `session_recover` handles overdue queued and overdue running async delegate children
+
+That still leaves a practical operator gap: the control tools are usable only after the caller
+already knows which `session_id` needs attention.
+
+At the same time, the current lifecycle implementation still leans on recent event windows. That is
+acceptable for thin inspection, but it becomes a problem if we want discovery features to identify
+stale delegate children reliably after a session has accumulated unrelated events.
+
+## Problem
+
+We need the next thick slice to improve operator discovery without adding new tool sprawl.
+
+Two issues need to be solved together:
+
+1. `sessions_list` is too coarse. It returns visible sessions, but offers no targeted filtering for
+   root operators looking for stale delegate work.
+2. `delegate_lifecycle` currently depends on a bounded recent-event window. A long-running child can
+   push `delegate_queued` / `delegate_started` out of that window, which makes lifecycle-based
+   discovery unreliable.
+
+## Goals
+
+- Extend `sessions_list` so root operators can find visible sessions by machine-readable filters.
+- Allow `sessions_list` to identify overdue async delegate children directly.
+- Make delegate lifecycle inspection use stable lifecycle anchor events rather than arbitrary recent
+  event windows.
+- Reuse the improved lifecycle path in `session_status` and `session_wait`.
+- Preserve the existing root/child visibility boundaries and tool surface.
+
+## Non-Goals
+
+- No new discovery tool such as `session_search`.
+- No batch mutation tool such as `session_recover_many` or `session_cancel_many`.
+- No schema migration or new sqlite table.
+- No broad session-tree browsing for delegated child sessions.
+- No hard kill / worker registry / push subscriptions.
+
+## Options Considered
+
+### Option 1: Add app-layer filters to `sessions_list` and reuse recent events
+
+Pros:
+
+- smallest implementation diff
+- no repository changes
+
+Cons:
+
+- overdue detection remains fragile once lifecycle anchor events are pushed out of the recent-event
+  window
+- discovery results can silently regress on noisier sessions
+
+Rejected.
+
+### Option 2: Strengthen lifecycle reads and extend `sessions_list`
+
+Keep the existing `sessions_list` tool, but:
+
+- add filter parameters for stateful discovery
+- introduce a stable repository read for lifecycle anchor events
+- reuse the stronger lifecycle path across `sessions_list`, `session_status`, and `session_wait`
+
+Pros:
+
+- fixes the causal weakness rather than just layering a filter on top
+- keeps the tool surface compact
+- improves both discovery and inspection correctness
+
+Cons:
+
+- larger code change than an app-only filter
+- adds one more repository read path
+
+Chosen.
+
+### Option 3: Add a dedicated discovery tool
+
+Examples:
+
+- `session_search`
+- `delegate_overdue_list`
+
+Pros:
+
+- highly explicit semantics
+- leaves `sessions_list` unchanged
+
+Cons:
+
+- expands tool count for a problem the existing session list already owns
+- splits discovery semantics across overlapping tools
+
+Rejected.
+
+## Chosen Approach
+
+Enhance `sessions_list` instead of adding a new tool.
+
+### Request filters
+
+Add narrow, operator-meaningful filters:
+
+- `limit`
+- `state`
+- `kind`
+- `parent_session_id`
+- `overdue_only`
+- `include_delegate_lifecycle`
+
+This keeps the tool simple while covering the real stale-delegate discovery flow.
+
+### Stable lifecycle anchors
+
+Introduce a repository helper that reads only lifecycle-relevant session events:
+
+- `delegate_queued`
+- `delegate_started`
+- `delegate_cancel_requested`
+
+This avoids relying on a fixed `recent_events` window when reconstructing delegate lifecycle.
+
+### Shared lifecycle path
+
+Use the lifecycle-anchor events for:
+
+- `sessions_list` discovery and optional lifecycle payloads
+- `session_status`
+- `session_wait`
+- internal recovery/cancel plan building
+
+Recent event windows still matter for:
+
+- user-facing `recent_events`
+- recovery fallback inference when terminal outcome persistence is missing
+
+## Tool Behavior
+
+### `sessions_list`
+
+Without filters, behavior stays compatible:
+
+- returns visible sessions
+- respects `tools.sessions.visibility`
+- truncates to configured/default limit
+
+With filters:
+
+- `state` filters by session state
+- `kind` filters by session kind
+- `parent_session_id` filters by direct parent
+- `overdue_only` keeps only sessions whose delegate lifecycle is async and overdue
+- `include_delegate_lifecycle` adds normalized lifecycle payloads to returned sessions
+
+When `overdue_only = true`, lifecycle payloads are included automatically because the caller
+selected a lifecycle-derived filter and needs the evidence.
+
+### Response shape
+
+Add lightweight result metadata:
+
+- `filters`
+- `matched_count`
+- `returned_count`
+
+Each returned session keeps the existing summary fields. When lifecycle output is enabled, the item
+also includes:
+
+- `delegate_lifecycle`
+
+## Data Model
+
+No schema change is required.
+
+We continue using:
+
+- `sessions`
+- `session_events`
+- `session_terminal_outcomes`
+
+The new repository helper is just a narrower read model over existing `session_events`.
+
+## Race and Consistency Semantics
+
+- `sessions_list` is still a point-in-time sqlite read; it is not a live stream.
+- If a session transitions during list generation, callers may observe slightly stale data. That is
+  acceptable because control tools (`session_cancel`, `session_recover`) already enforce
+  conditional state transitions.
+- Lifecycle reconstruction must not depend on whether unrelated progress or telemetry events were
+  recently appended.
+
+## Testing
+
+Add focused tests for:
+
+- `sessions_list` filtering by `state`, `kind`, and `parent_session_id`
+- `sessions_list` returning overdue delegate children when `overdue_only = true`
+- `sessions_list` surfacing `delegate_lifecycle` when requested
+- lifecycle reconstruction still working when recent events are noisy and no longer contain
+  `delegate_queued` / `delegate_started`
+- `session_status` continuing to show lifecycle data with the same noisy-event condition

--- a/docs/plans/2026-03-13-sessions-list-discovery-implementation-plan.md
+++ b/docs/plans/2026-03-13-sessions-list-discovery-implementation-plan.md
@@ -1,0 +1,124 @@
+# Sessions List Discovery Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `sessions_list` a real operator discovery surface by adding machine-readable filters
+and reliable overdue delegate detection without adding new tools.
+
+**Architecture:** Keep the existing `sessions_list` tool, but add request filters and response
+metadata at the app layer. Strengthen delegate lifecycle reconstruction with a repository helper
+that reads lifecycle anchor events directly, then reuse that path in `sessions_list`,
+`session_status`, and internal cancel/recover planning so lifecycle-derived discovery remains
+correct even when recent event windows are noisy.
+
+**Tech Stack:** Rust, rusqlite, serde_json, existing LoongClaw app-layer session tools and sqlite
+session repository
+
+---
+
+### Task 1: Write failing tests for discovery filters and stable lifecycle anchors
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that:
+
+- `sessions_list` filters visible sessions by `state`, `kind`, and `parent_session_id`
+- `sessions_list` returns overdue delegate children when `overdue_only = true`
+- `session_status` still reconstructs delegate lifecycle when recent events are noisy
+- provider schema for `sessions_list` advertises the new filter parameters
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+- `cargo test -p loongclaw-app sessions_list_filters_visible_sessions_by_state_kind_and_parent -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app sessions_list_overdue_only_uses_lifecycle_anchor_events -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app session_status_uses_delegate_lifecycle_anchor_events_when_recent_window_is_noisy -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app provider_tool_definitions_are_stable_and_complete -- --nocapture --test-threads=1`
+
+Expected: FAIL because `sessions_list` has no filters and lifecycle still depends on recent events.
+
+**Step 3: Write minimal implementation**
+
+Implement only the code needed to satisfy the tests.
+
+**Step 4: Run test to verify it passes**
+
+Run the same commands and confirm they pass.
+
+### Task 2: Add repository lifecycle-anchor reads and wire shared lifecycle usage
+
+**Files:**
+- Modify: `crates/app/src/session/repository.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Add lifecycle-anchor repository helper**
+
+Introduce a helper that returns lifecycle-relevant events in ascending order for one session:
+
+- `delegate_queued`
+- `delegate_started`
+- `delegate_cancel_requested`
+
+**Step 2: Reuse the helper in session inspection**
+
+Update session inspection snapshots and lifecycle planning so:
+
+- `session_status`
+- `session_wait`
+- `session_cancel`
+- `session_recover`
+
+all reconstruct delegate lifecycle from the stable lifecycle-anchor events instead of arbitrary
+recent-event windows.
+
+**Step 3: Extend `sessions_list`**
+
+Add request parsing, filter application, response metadata, and optional `delegate_lifecycle`
+payloads.
+
+**Step 4: Verify focused tests**
+
+Run:
+
+- `cargo test -p loongclaw-app sessions_list_ -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app session_status_uses_delegate_lifecycle_anchor_events_when_recent_window_is_noisy -- --nocapture --test-threads=1`
+
+Expected: PASS
+
+### Task 3: Update docs and run full verification
+
+**Files:**
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Update docs**
+
+Document that:
+
+- `sessions_list` supports filtered discovery of visible sessions
+- overdue delegate discovery is available through the existing tool surface
+- lifecycle-derived discovery uses the stable lifecycle read path rather than recent-event windows
+
+**Step 2: Run focused regression**
+
+Run:
+
+- `cargo test -p loongclaw-app sessions_list_ -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app session_status_ -- --nocapture --test-threads=1`
+- `cargo test -p loongclaw-app session_recover_ -- --nocapture --test-threads=1`
+
+**Step 3: Run full verification**
+
+Run:
+
+- `cargo fmt --all`
+- `cargo test --workspace --all-features -- --test-threads=1`
+- `cargo fmt --all --check`
+- `git diff --check`
+
+Expected: PASS

--- a/docs/plans/2026-03-13-sessions-send-design.md
+++ b/docs/plans/2026-03-13-sessions-send-design.md
@@ -1,0 +1,173 @@
+# Sessions Send Design
+
+## Context
+
+LoongClaw now has a fairly thick session and delegate control surface for:
+
+- discovery via `sessions_list`
+- transcript and event inspection via `sessions_history` and `session_events`
+- status and bounded waiting via `session_status` and `session_wait`
+- remediation via `session_cancel` and `session_recover`
+- child creation via `delegate` and `delegate_async`
+
+That still leaves one major operator gap compared with the external references:
+
+- OpenClaw's minimum thick control surface includes `send` or `steer`
+- NanoBot emphasizes `message`
+- the original LoongClaw phase-1 design explicitly deferred cross-channel `sessions_send`
+
+## Problem
+
+We need to add one real outbound control primitive without pretending the current runtime already
+has capabilities it does not have.
+
+The critical architectural constraint is that LoongClaw does **not** currently have:
+
+- a live inbox for running delegate children
+- safe real-time steering of in-flight child turns
+- safe restart or resume semantics for terminal sessions
+
+That means a direct `session_send` or `session_steer` tool for running delegate children would be
+misleading. It would expose a name without a truthful execution model.
+
+## Goals
+
+- Add a real outbound operator tool that can send a text message to a known external session.
+- Keep the capability anchored to stable session ids instead of raw provider-specific target ids.
+- Avoid mutating transcript history or pretending to execute a new turn in the target session.
+- Keep child delegate sessions unable to send outbound messages.
+- Require explicit opt-in through config.
+
+## Non-Goals
+
+- No live steering of running delegate children.
+- No generic outbound messaging to arbitrary destinations.
+- No implicit transcript append to the target session.
+- No broadening of session visibility for delegate children.
+- No background queue or inbox for later target-session execution.
+
+## Options Considered
+
+### Option 1: Direct `session_send` into visible delegate children
+
+Pros:
+
+- closest to OpenClaw's `send` or `steer`
+- keeps everything inside the session/delegate model
+
+Cons:
+
+- current runtime has no truthful live inbox for running children
+- queued async children already have their task bound at spawn time
+- terminal children have no safe restart semantics
+
+Rejected.
+
+### Option 2: Generic `message_send(channel, target, text)`
+
+Pros:
+
+- straightforward adapter-level implementation
+- does not depend on the session registry
+
+Cons:
+
+- bypasses the session model entirely
+- weakens audit readability by using raw channel-specific target ids
+- broadens authority to arbitrary configured destinations
+
+Rejected for this slice.
+
+### Option 3: Constrained `sessions_send(session_id, text)` for known channel-backed root sessions
+
+Pros:
+
+- uses the stable session id model already visible to operators
+- does not fake subagent steering semantics
+- can be restricted to previously seen root sessions only
+- composes naturally with the existing session registry and audit surface
+
+Cons:
+
+- does not solve delegate-child steering yet
+- requires async app-tool dispatch with channel config access
+
+Chosen.
+
+## Chosen Approach
+
+Add a new app tool: `sessions_send`.
+
+### Request model
+
+`sessions_send` accepts:
+
+- `session_id: string`
+- `text: string`
+
+The target `session_id` must resolve to a known root session backed by a currently supported
+outbound channel:
+
+- `telegram:<chat_id>`
+- `feishu:<chat_id>`
+
+### Safety boundary
+
+The tool only works when all of the following are true:
+
+- `tools.messages.enabled = true`
+- the target session already exists in session metadata or legacy transcript fallback
+- the target session is a root session, not a delegate child
+- the target session uses a supported channel-backed session id prefix
+- the corresponding channel is enabled in config
+- the target id is still present in the configured channel allowlist
+
+If any of those fail, the tool returns a hard error rather than silently broadening authority.
+
+### Visibility model
+
+`sessions_send` is exposed only to root sessions.
+
+Delegate child tool views continue to exclude outbound messaging. This preserves the earlier
+guardrail that child sessions cannot send external messages.
+
+### Delivery semantics
+
+`sessions_send` sends a text message through the relevant channel adapter:
+
+- Telegram: bot sendMessage path
+- Feishu: text message path through the existing adapter and tenant-token refresh flow
+
+It does **not**:
+
+- append a user turn to the target transcript
+- execute a provider turn for the target session
+- change target session state
+
+### Evidence and observability
+
+On success, `sessions_send`:
+
+- returns a structured delivery receipt payload
+- appends a non-transcript control event to the target session
+
+The event should record only operational metadata such as:
+
+- channel kind
+- target id
+- actor session id
+- text length
+
+It should not persist the full outbound message text in session events.
+
+## Testing
+
+Required coverage:
+
+1. config defaults keep outbound messaging disabled
+2. config TOML round-trips the new `tools.messages.enabled` switch
+3. provider schema exposes `sessions_send` only when enabled
+4. root sessions can send to a known Telegram or Feishu session through an injected fake sender
+5. unknown sessions, delegate-child targets, and child callers are rejected
+6. successful send appends a control event but does not append transcript rows
+

--- a/docs/plans/2026-03-13-sessions-send-implementation-plan.md
+++ b/docs/plans/2026-03-13-sessions-send-implementation-plan.md
@@ -1,0 +1,80 @@
+# Sessions Send Implementation Plan
+
+**Goal:** add a truthful outbound control primitive by introducing `sessions_send` for known
+channel-backed root sessions, without pretending LoongClaw already supports live subagent steering
+or target-session inbox execution.
+
+**Architecture:** keep the channel-specific delivery logic in `crates/app/src/channel`, but add a
+new async app tool path in the dispatcher. The tool validates the target through the session
+registry, resolves the channel-backed session id, uses an injected sender for delivery, and records
+an operational session event without modifying transcript history.
+
+## Task 1: Extend config and tool catalog
+
+Add:
+
+- `tools.messages.enabled`
+- `sessions_send` tool descriptor and provider schema
+- runtime-tool-view gating so the tool is hidden unless explicitly enabled
+
+Acceptance criteria:
+
+- messaging is disabled by default
+- enabling `tools.messages.enabled` exposes `sessions_send` in root tool views only
+
+## Task 2: Add failing tests first
+
+Add tests for:
+
+- config default and TOML round-trip
+- provider schema visibility for `sessions_send`
+- root send success with fake delivery transport
+- rejection of delegate-child callers or unsupported targets
+
+Acceptance criteria:
+
+- tests fail before implementation for the expected reasons:
+  - config field missing
+  - tool schema missing
+  - runtime path not wired
+
+## Task 3: Implement async dispatcher path
+
+Add:
+
+- constrained `sessions_send` request parsing and target validation
+- dispatcher support for async outbound delivery
+- injected sender abstraction for tests
+- control-event persistence on successful send
+
+Acceptance criteria:
+
+- `sessions_send` never appends transcript rows
+- `sessions_send` only targets known root sessions with supported channel prefixes
+- delivery uses existing channel adapters rather than reimplementing per-channel HTTP logic
+
+## Task 4: Document the surface
+
+Update:
+
+- `docs/product-specs/index.md`
+- `docs/roadmap.md`
+- this design and implementation-plan pair
+
+Acceptance criteria:
+
+- product spec explicitly captures the constrained outbound message scope
+- roadmap notes that LoongClaw now has a real outbound operator primitive without live child steer
+
+## Verification
+
+Run:
+
+```bash
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app tools:: conversation:: config::runtime:: -- --nocapture --test-threads=1
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test --workspace --all-features -- --test-threads=1
+/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all --check
+git diff --check
+```
+

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -28,13 +28,13 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_status` and `session_wait` expose a normalized `delegate_lifecycle` summary for real delegate children, including queued vs running phase, inline vs async mode, and timeout-based staleness hints when the child is still non-terminal.
 - [x] `session_status` and `session_wait` surface pending cancellation metadata for running async delegate children after an operator requests cancellation.
 - [x] `session_cancel` can immediately cancel a visible queued async delegate child and can request cooperative cancellation for a visible running async delegate child without broadening child-session authority.
-- [x] `session_recover` can mark a visible overdue queued async delegate child as failed and persist both a terminal outcome and structured recovery event without broadening child-session authority.
+- [x] `session_recover` can mark a visible overdue queued or overdue running async delegate child as failed and persist both a terminal outcome and structured recovery event without broadening child-session authority.
 
 ## Current Limits
 - `delegate_async` uses a subprocess one-shot worker (`loongclawd run-turn`) rather than a durable queue or resident worker pool.
 - Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
 - `session_cancel` cancels queued async children immediately, but running cancellation is cooperative at turn-loop checkpoints rather than hard process preemption.
-- `session_recover` only handles queued async delegate children that are overdue while still in `ready`; it does not cancel a running child.
+- `session_recover` only handles overdue async delegate children in `ready` or `running`; it is an operator-driven recovery path, not hard kill, retry, or automatic restart recovery.
 - `session_wait` is bounded polling over sqlite-backed session state, not a push stream.
 - Async delegation has no hard kill, retry queue, or post-restart recovery semantics in this phase.
 - Legacy fallback is best-effort for the current session only. Historical rows without `sessions` metadata cannot recover descendant lineage because `turns` do not encode parentage.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -28,6 +28,7 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_status` and `session_wait` expose a normalized `delegate_lifecycle` summary for real delegate children, including queued vs running phase, inline vs async mode, and timeout-based staleness hints when the child is still non-terminal.
 - [x] `sessions_list` supports machine-readable filtering for visible-session discovery and can surface `delegate_lifecycle` metadata when requested or when filtering overdue delegate children.
 - [x] `session_status` accepts either `session_id` or `session_ids` and returns per-target inspection results for batch flows while preserving the legacy single-target response shape.
+- [x] `session_wait` accepts either `session_id` or `session_ids`, preserves the legacy single-target response shape, and returns per-target wait results for batch flows with shared `timeout_ms` / `after_id` request context.
 - [x] `session_status` and `session_wait` surface pending cancellation metadata for running async delegate children after an operator requests cancellation.
 - [x] `session_cancel` can immediately cancel a visible queued async delegate child and can request cooperative cancellation for a visible running async delegate child without broadening child-session authority.
 - [x] `session_recover` can mark a visible overdue queued or overdue running async delegate child as failed and persist both a terminal outcome and structured recovery event without broadening child-session authority.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -14,7 +14,7 @@ Product specs describe **what** the product does from the user's perspective, no
 As an operator using LoongClaw's tool-calling runtime, I want to inspect active sessions and delegate focused subtasks into child sessions so that I can keep orchestration explicit, auditable, and bounded.
 
 ## Acceptance Criteria
-- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
+- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
 - [x] Delegated child sessions run with a restricted tool surface derived from config rather than inheriting the full root tool set.
 - [x] Delegated child sessions can use `session_status` and `sessions_history` for self-inspection only, and never gain `sessions_list`.
 - [x] Nested delegation is bounded by `tools.delegate.max_depth` and enforced from session lineage, not by ad-hoc one-off checks.
@@ -33,8 +33,10 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_cancel` can immediately cancel a visible queued async delegate child and can request cooperative cancellation for a visible running async delegate child without broadening child-session authority.
 - [x] `session_recover` can mark a visible overdue queued or overdue running async delegate child as failed and persist both a terminal outcome and structured recovery event without broadening child-session authority.
 - [x] `session_archive` can mark a visible terminal session as archived, preserve direct inspection and event history, and hide archived sessions from default `sessions_list` results while allowing explicit rediscovery via `include_archived=true`.
+- [x] `session_unarchive` can restore a visible archived terminal session back into default `sessions_list` inventory, preserve direct inspection and event history, and record a durable `session_unarchived` control event.
 - [x] `session_cancel` and `session_recover` accept either `session_id` or `session_ids`, support `dry_run` preview, and return per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
 - [x] `session_archive` accepts either `session_id` or `session_ids`, supports `dry_run` preview, and returns per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
+- [x] `session_unarchive` accepts either `session_id` or `session_ids`, supports `dry_run` preview, and returns per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
 - [x] `sessions_send` can send plain outbound text to a known channel-backed root session (`telegram:<chat_id>` or `feishu:<chat_id>`), recording a non-transcript control event without executing a target-side provider turn or mutating transcript rows.
 
 ## Current Limits
@@ -42,6 +44,7 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
 - `sessions_send` is intentionally narrow: only known root sessions backed by currently supported Telegram or Feishu targets are eligible.
 - `session_archive` only applies to already-terminal visible sessions; it is inventory cleanup, not route shutdown, transcript deletion, or true session close.
+- `session_unarchive` only applies to already-archived terminal visible sessions; it restores default listing visibility, not execution, routing, or a new live session epoch.
 - `session_cancel` cancels queued async children immediately, but running cancellation is cooperative at turn-loop checkpoints rather than hard process preemption.
 - `session_recover` only handles overdue async delegate children in `ready` or `running`; it is an operator-driven recovery path, not hard kill, retry, or automatic restart recovery.
 - Batch remediation is best-effort per target. Mixed applicability returns structured per-target results rather than an atomic all-or-nothing transaction.
@@ -50,7 +53,6 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - Async delegation has no hard kill, retry queue, or post-restart recovery semantics in this phase.
 - Legacy fallback is best-effort for the current session only. Historical rows without `sessions` metadata cannot recover descendant lineage because `turns` do not encode parentage.
 - Child tool allowlists only activate runtime-supported tools. Unknown or planned tool names are ignored.
-- There is no `session_unarchive` tool in this phase. Archive is durable until explicitly rediscovered through inspection.
 
 ## Out of Scope
 - Durable delegate queues or leased worker pools

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -14,7 +14,7 @@ Product specs describe **what** the product does from the user's perspective, no
 As an operator using LoongClaw's tool-calling runtime, I want to inspect active sessions and delegate focused subtasks into child sessions so that I can keep orchestration explicit, auditable, and bounded.
 
 ## Acceptance Criteria
-- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
+- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
 - [x] Delegated child sessions run with a restricted tool surface derived from config rather than inheriting the full root tool set.
 - [x] Delegated child sessions can use `session_status` and `sessions_history` for self-inspection only, and never gain `sessions_list`.
 - [x] Nested delegation is bounded by `tools.delegate.max_depth` and enforced from session lineage, not by ad-hoc one-off checks.
@@ -32,21 +32,25 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_status` and `session_wait` surface pending cancellation metadata for running async delegate children after an operator requests cancellation.
 - [x] `session_cancel` can immediately cancel a visible queued async delegate child and can request cooperative cancellation for a visible running async delegate child without broadening child-session authority.
 - [x] `session_recover` can mark a visible overdue queued or overdue running async delegate child as failed and persist both a terminal outcome and structured recovery event without broadening child-session authority.
+- [x] `session_archive` can mark a visible terminal session as archived, preserve direct inspection and event history, and hide archived sessions from default `sessions_list` results while allowing explicit rediscovery via `include_archived=true`.
 - [x] `session_cancel` and `session_recover` accept either `session_id` or `session_ids`, support `dry_run` preview, and return per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
+- [x] `session_archive` accepts either `session_id` or `session_ids`, supports `dry_run` preview, and returns per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
 - [x] `sessions_send` can send plain outbound text to a known channel-backed root session (`telegram:<chat_id>` or `feishu:<chat_id>`), recording a non-transcript control event without executing a target-side provider turn or mutating transcript rows.
 
 ## Current Limits
 - `delegate_async` uses a subprocess one-shot worker (`loongclawd run-turn`) rather than a durable queue or resident worker pool.
 - Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
 - `sessions_send` is intentionally narrow: only known root sessions backed by currently supported Telegram or Feishu targets are eligible.
+- `session_archive` only applies to already-terminal visible sessions; it is inventory cleanup, not route shutdown, transcript deletion, or true session close.
 - `session_cancel` cancels queued async children immediately, but running cancellation is cooperative at turn-loop checkpoints rather than hard process preemption.
 - `session_recover` only handles overdue async delegate children in `ready` or `running`; it is an operator-driven recovery path, not hard kill, retry, or automatic restart recovery.
 - Batch remediation is best-effort per target. Mixed applicability returns structured per-target results rather than an atomic all-or-nothing transaction.
 - `session_wait` is bounded polling over sqlite-backed session state, not a push stream.
-- `sessions_list` is a bounded filtered snapshot, not a paginated or push-based session inventory stream.
+- `sessions_list` is a bounded filtered snapshot, not a paginated or push-based session inventory stream; archived sessions are excluded by default and must be requested with `include_archived=true`.
 - Async delegation has no hard kill, retry queue, or post-restart recovery semantics in this phase.
 - Legacy fallback is best-effort for the current session only. Historical rows without `sessions` metadata cannot recover descendant lineage because `turns` do not encode parentage.
 - Child tool allowlists only activate runtime-supported tools. Unknown or planned tool names are ignored.
+- There is no `session_unarchive` tool in this phase. Archive is durable until explicitly rediscovered through inspection.
 
 ## Out of Scope
 - Durable delegate queues or leased worker pools

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -14,7 +14,7 @@ Product specs describe **what** the product does from the user's perspective, no
 As an operator using LoongClaw's tool-calling runtime, I want to inspect active sessions and delegate focused subtasks into child sessions so that I can keep orchestration explicit, auditable, and bounded.
 
 ## Acceptance Criteria
-- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_wait`, `delegate`, and `delegate_async` when enabled in config.
+- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_recover`, `session_wait`, `delegate`, and `delegate_async` when enabled in config.
 - [x] Delegated child sessions run with a restricted tool surface derived from config rather than inheriting the full root tool set.
 - [x] Delegated child sessions can use `session_status` and `sessions_history` for self-inspection only, and never gain `sessions_list`.
 - [x] Nested delegation is bounded by `tools.delegate.max_depth` and enforced from session lineage, not by ad-hoc one-off checks.
@@ -26,10 +26,12 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_wait` can optionally continue an event cursor via `after_id` and return the full unseen incremental tail plus `next_after_id` together with the wait snapshot, including the terminal event when the session completes during the wait.
 - [x] `session_status` and `session_wait` expose machine-readable terminal outcome record state plus normalized recovery metadata, preferring structured recovery events and falling back to synthesized `last_error` metadata when recovery event persistence also fails.
 - [x] `session_status` and `session_wait` expose a normalized `delegate_lifecycle` summary for real delegate children, including queued vs running phase, inline vs async mode, and timeout-based staleness hints when the child is still non-terminal.
+- [x] `session_recover` can mark a visible overdue queued async delegate child as failed and persist both a terminal outcome and structured recovery event without broadening child-session authority.
 
 ## Current Limits
 - `delegate_async` uses a subprocess one-shot worker (`loongclawd run-turn`) rather than a durable queue or resident worker pool.
 - Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
+- `session_recover` only handles queued async delegate children that are overdue while still in `ready`; it does not cancel a running child.
 - `session_wait` is bounded polling over sqlite-backed session state, not a push stream.
 - Async delegation has no cancellation, retry queue, or post-restart recovery semantics in this phase.
 - Legacy fallback is best-effort for the current session only. Historical rows without `sessions` metadata cannot recover descendant lineage because `turns` do not encode parentage.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -14,7 +14,7 @@ Product specs describe **what** the product does from the user's perspective, no
 As an operator using LoongClaw's tool-calling runtime, I want to inspect active sessions and delegate focused subtasks into child sessions so that I can keep orchestration explicit, auditable, and bounded.
 
 ## Acceptance Criteria
-- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_cancel`, `session_recover`, `session_wait`, `delegate`, and `delegate_async` when enabled in config.
+- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
 - [x] Delegated child sessions run with a restricted tool surface derived from config rather than inheriting the full root tool set.
 - [x] Delegated child sessions can use `session_status` and `sessions_history` for self-inspection only, and never gain `sessions_list`.
 - [x] Nested delegation is bounded by `tools.delegate.max_depth` and enforced from session lineage, not by ad-hoc one-off checks.
@@ -33,10 +33,12 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_cancel` can immediately cancel a visible queued async delegate child and can request cooperative cancellation for a visible running async delegate child without broadening child-session authority.
 - [x] `session_recover` can mark a visible overdue queued or overdue running async delegate child as failed and persist both a terminal outcome and structured recovery event without broadening child-session authority.
 - [x] `session_cancel` and `session_recover` accept either `session_id` or `session_ids`, support `dry_run` preview, and return per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
+- [x] `sessions_send` can send plain outbound text to a known channel-backed root session (`telegram:<chat_id>` or `feishu:<chat_id>`), recording a non-transcript control event without executing a target-side provider turn or mutating transcript rows.
 
 ## Current Limits
 - `delegate_async` uses a subprocess one-shot worker (`loongclawd run-turn`) rather than a durable queue or resident worker pool.
 - Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
+- `sessions_send` is intentionally narrow: only known root sessions backed by currently supported Telegram or Feishu targets are eligible.
 - `session_cancel` cancels queued async children immediately, but running cancellation is cooperative at turn-loop checkpoints rather than hard process preemption.
 - `session_recover` only handles overdue async delegate children in `ready` or `running`; it is an operator-driven recovery path, not hard kill, retry, or automatic restart recovery.
 - Batch remediation is best-effort per target. Mixed applicability returns structured per-target results rather than an atomic all-or-nothing transaction.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -14,7 +14,7 @@ Product specs describe **what** the product does from the user's perspective, no
 As an operator using LoongClaw's tool-calling runtime, I want to inspect active sessions and delegate focused subtasks into child sessions so that I can keep orchestration explicit, auditable, and bounded.
 
 ## Acceptance Criteria
-- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_recover`, `session_wait`, `delegate`, and `delegate_async` when enabled in config.
+- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_cancel`, `session_recover`, `session_wait`, `delegate`, and `delegate_async` when enabled in config.
 - [x] Delegated child sessions run with a restricted tool surface derived from config rather than inheriting the full root tool set.
 - [x] Delegated child sessions can use `session_status` and `sessions_history` for self-inspection only, and never gain `sessions_list`.
 - [x] Nested delegation is bounded by `tools.delegate.max_depth` and enforced from session lineage, not by ad-hoc one-off checks.
@@ -26,19 +26,22 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_wait` can optionally continue an event cursor via `after_id` and return the full unseen incremental tail plus `next_after_id` together with the wait snapshot, including the terminal event when the session completes during the wait.
 - [x] `session_status` and `session_wait` expose machine-readable terminal outcome record state plus normalized recovery metadata, preferring structured recovery events and falling back to synthesized `last_error` metadata when recovery event persistence also fails.
 - [x] `session_status` and `session_wait` expose a normalized `delegate_lifecycle` summary for real delegate children, including queued vs running phase, inline vs async mode, and timeout-based staleness hints when the child is still non-terminal.
+- [x] `session_status` and `session_wait` surface pending cancellation metadata for running async delegate children after an operator requests cancellation.
+- [x] `session_cancel` can immediately cancel a visible queued async delegate child and can request cooperative cancellation for a visible running async delegate child without broadening child-session authority.
 - [x] `session_recover` can mark a visible overdue queued async delegate child as failed and persist both a terminal outcome and structured recovery event without broadening child-session authority.
 
 ## Current Limits
 - `delegate_async` uses a subprocess one-shot worker (`loongclawd run-turn`) rather than a durable queue or resident worker pool.
 - Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
+- `session_cancel` cancels queued async children immediately, but running cancellation is cooperative at turn-loop checkpoints rather than hard process preemption.
 - `session_recover` only handles queued async delegate children that are overdue while still in `ready`; it does not cancel a running child.
 - `session_wait` is bounded polling over sqlite-backed session state, not a push stream.
-- Async delegation has no cancellation, retry queue, or post-restart recovery semantics in this phase.
+- Async delegation has no hard kill, retry queue, or post-restart recovery semantics in this phase.
 - Legacy fallback is best-effort for the current session only. Historical rows without `sessions` metadata cannot recover descendant lineage because `turns` do not encode parentage.
 - Child tool allowlists only activate runtime-supported tools. Unknown or planned tool names are ignored.
 
 ## Out of Scope
 - Durable delegate queues or leased worker pools
-- Cancellation, retries, or push subscriptions for child sessions
+- Hard process kill, retries, or push subscriptions for child sessions
 - Historical backfill or schema migration for old session lineage
 - Exposing session-tree browsing tools such as `sessions_list` to delegated child sessions

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -26,6 +26,7 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_wait` can optionally continue an event cursor via `after_id` and return the full unseen incremental tail plus `next_after_id` together with the wait snapshot, including the terminal event when the session completes during the wait.
 - [x] `session_status` and `session_wait` expose machine-readable terminal outcome record state plus normalized recovery metadata, preferring structured recovery events and falling back to synthesized `last_error` metadata when recovery event persistence also fails.
 - [x] `session_status` and `session_wait` expose a normalized `delegate_lifecycle` summary for real delegate children, including queued vs running phase, inline vs async mode, and timeout-based staleness hints when the child is still non-terminal.
+- [x] `sessions_list` supports machine-readable filtering for visible-session discovery and can surface `delegate_lifecycle` metadata when requested or when filtering overdue delegate children.
 - [x] `session_status` and `session_wait` surface pending cancellation metadata for running async delegate children after an operator requests cancellation.
 - [x] `session_cancel` can immediately cancel a visible queued async delegate child and can request cooperative cancellation for a visible running async delegate child without broadening child-session authority.
 - [x] `session_recover` can mark a visible overdue queued or overdue running async delegate child as failed and persist both a terminal outcome and structured recovery event without broadening child-session authority.
@@ -36,6 +37,7 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - `session_cancel` cancels queued async children immediately, but running cancellation is cooperative at turn-loop checkpoints rather than hard process preemption.
 - `session_recover` only handles overdue async delegate children in `ready` or `running`; it is an operator-driven recovery path, not hard kill, retry, or automatic restart recovery.
 - `session_wait` is bounded polling over sqlite-backed session state, not a push stream.
+- `sessions_list` is a bounded filtered snapshot, not a paginated or push-based session inventory stream.
 - Async delegation has no hard kill, retry queue, or post-restart recovery semantics in this phase.
 - Legacy fallback is best-effort for the current session only. Historical rows without `sessions` metadata cannot recover descendant lineage because `turns` do not encode parentage.
 - Child tool allowlists only activate runtime-supported tools. Unknown or planned tool names are ignored.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -30,12 +30,14 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_status` and `session_wait` surface pending cancellation metadata for running async delegate children after an operator requests cancellation.
 - [x] `session_cancel` can immediately cancel a visible queued async delegate child and can request cooperative cancellation for a visible running async delegate child without broadening child-session authority.
 - [x] `session_recover` can mark a visible overdue queued or overdue running async delegate child as failed and persist both a terminal outcome and structured recovery event without broadening child-session authority.
+- [x] `session_cancel` and `session_recover` accept either `session_id` or `session_ids`, support `dry_run` preview, and return per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
 
 ## Current Limits
 - `delegate_async` uses a subprocess one-shot worker (`loongclawd run-turn`) rather than a durable queue or resident worker pool.
 - Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
 - `session_cancel` cancels queued async children immediately, but running cancellation is cooperative at turn-loop checkpoints rather than hard process preemption.
 - `session_recover` only handles overdue async delegate children in `ready` or `running`; it is an operator-driven recovery path, not hard kill, retry, or automatic restart recovery.
+- Batch remediation is best-effort per target. Mixed applicability returns structured per-target results rather than an atomic all-or-nothing transaction.
 - `session_wait` is bounded polling over sqlite-backed session state, not a push stream.
 - `sessions_list` is a bounded filtered snapshot, not a paginated or push-based session inventory stream.
 - Async delegation has no hard kill, retry queue, or post-restart recovery semantics in this phase.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -41,7 +41,7 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `memory_search` can search persisted transcript turns across the caller's visible session scope, or within explicitly targeted visible sessions, and return structured recent-first match snippets without searching control-plane `session_events`.
 
 ## Current Limits
-- `delegate_async` uses a subprocess one-shot worker (`loongclawd run-turn`) rather than a durable queue or resident worker pool.
+- `delegate_async` uses a subprocess one-shot worker (`loongclaw run-turn`) rather than a durable queue or resident worker pool.
 - Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
 - `sessions_send` is intentionally narrow: only known root sessions backed by currently supported Telegram or Feishu targets are eligible.
 - `memory_search` is transcript text search only. It does not claim embedding-based, vector, BM25, hybrid, or semantic memory recall in this phase.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -27,6 +27,7 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_status` and `session_wait` expose machine-readable terminal outcome record state plus normalized recovery metadata, preferring structured recovery events and falling back to synthesized `last_error` metadata when recovery event persistence also fails.
 - [x] `session_status` and `session_wait` expose a normalized `delegate_lifecycle` summary for real delegate children, including queued vs running phase, inline vs async mode, and timeout-based staleness hints when the child is still non-terminal.
 - [x] `sessions_list` supports machine-readable filtering for visible-session discovery and can surface `delegate_lifecycle` metadata when requested or when filtering overdue delegate children.
+- [x] `session_status` accepts either `session_id` or `session_ids` and returns per-target inspection results for batch flows while preserving the legacy single-target response shape.
 - [x] `session_status` and `session_wait` surface pending cancellation metadata for running async delegate children after an operator requests cancellation.
 - [x] `session_cancel` can immediately cancel a visible queued async delegate child and can request cooperative cancellation for a visible running async delegate child without broadening child-session authority.
 - [x] `session_recover` can mark a visible overdue queued or overdue running async delegate child as failed and persist both a terminal outcome and structured recovery event without broadening child-session authority.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -8,20 +8,35 @@ Product specs describe **what** the product does from the user's perspective, no
 
 ## Specs
 
-No product specs yet. Add them here as LoongClaw's user-facing surface grows.
-
-Template for new specs:
-
-```markdown
-# [Feature Name]
+# Session And Delegate Tool Surface
 
 ## User Story
-As a [role], I want [capability] so that [benefit].
+As an operator using LoongClaw's tool-calling runtime, I want to inspect active sessions and delegate focused subtasks into child sessions so that I can keep orchestration explicit, auditable, and bounded.
 
 ## Acceptance Criteria
-- [ ] Criterion 1
-- [ ] Criterion 2
+- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_wait`, `delegate`, and `delegate_async` when enabled in config.
+- [x] Delegated child sessions run with a restricted tool surface derived from config rather than inheriting the full root tool set.
+- [x] Delegated child sessions can use `session_status` and `sessions_history` for self-inspection only, and never gain `sessions_list`.
+- [x] Nested delegation is bounded by `tools.delegate.max_depth` and enforced from session lineage, not by ad-hoc one-off checks.
+- [x] When nested delegation is allowed, child sessions only see `delegate` and `delegate_async` while they still have remaining depth budget.
+- [x] Session visibility for `tools.sessions.visibility = "children"` includes the current session plus descendant delegate sessions.
+- [x] Delegate child terminal outcomes are durably persisted and available through session inspection tools.
+- [x] Legacy sessions that only exist in `turns` can still surface their own session summary without rewriting old rows.
+- [x] `delegate_async` returns a child session id handle immediately, without waiting for worker launch completion, and child execution becomes observable through `session_status`, `session_events`, and `session_wait`.
+- [x] `session_wait` can optionally continue an event cursor via `after_id` and return the full unseen incremental tail plus `next_after_id` together with the wait snapshot, including the terminal event when the session completes during the wait.
+- [x] `session_status` and `session_wait` expose machine-readable terminal outcome record state plus normalized recovery metadata, preferring structured recovery events and falling back to synthesized `last_error` metadata when recovery event persistence also fails.
+- [x] `session_status` and `session_wait` expose a normalized `delegate_lifecycle` summary for real delegate children, including queued vs running phase, inline vs async mode, and timeout-based staleness hints when the child is still non-terminal.
+
+## Current Limits
+- `delegate_async` uses a subprocess one-shot worker (`loongclawd run-turn`) rather than a durable queue or resident worker pool.
+- Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
+- `session_wait` is bounded polling over sqlite-backed session state, not a push stream.
+- Async delegation has no cancellation, retry queue, or post-restart recovery semantics in this phase.
+- Legacy fallback is best-effort for the current session only. Historical rows without `sessions` metadata cannot recover descendant lineage because `turns` do not encode parentage.
+- Child tool allowlists only activate runtime-supported tools. Unknown or planned tool names are ignored.
 
 ## Out of Scope
-- Item 1
-```
+- Durable delegate queues or leased worker pools
+- Cancellation, retries, or push subscriptions for child sessions
+- Historical backfill or schema migration for old session lineage
+- Exposing session-tree browsing tools such as `sessions_list` to delegated child sessions

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -14,7 +14,7 @@ Product specs describe **what** the product does from the user's perspective, no
 As an operator using LoongClaw's tool-calling runtime, I want to inspect active sessions and delegate focused subtasks into child sessions so that I can keep orchestration explicit, auditable, and bounded.
 
 ## Acceptance Criteria
-- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
+- [x] Root sessions expose `sessions_list`, `sessions_history`, `session_status`, `session_events`, `memory_search`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, `sessions_send`, `delegate`, and `delegate_async` when enabled in config.
 - [x] Delegated child sessions run with a restricted tool surface derived from config rather than inheriting the full root tool set.
 - [x] Delegated child sessions can use `session_status` and `sessions_history` for self-inspection only, and never gain `sessions_list`.
 - [x] Nested delegation is bounded by `tools.delegate.max_depth` and enforced from session lineage, not by ad-hoc one-off checks.
@@ -38,13 +38,16 @@ As an operator using LoongClaw's tool-calling runtime, I want to inspect active 
 - [x] `session_archive` accepts either `session_id` or `session_ids`, supports `dry_run` preview, and returns per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
 - [x] `session_unarchive` accepts either `session_id` or `session_ids`, supports `dry_run` preview, and returns per-target classifications for batch or preview flows while preserving the legacy single-target response shape.
 - [x] `sessions_send` can send plain outbound text to a known channel-backed root session (`telegram:<chat_id>` or `feishu:<chat_id>`), recording a non-transcript control event without executing a target-side provider turn or mutating transcript rows.
+- [x] `memory_search` can search persisted transcript turns across the caller's visible session scope, or within explicitly targeted visible sessions, and return structured recent-first match snippets without searching control-plane `session_events`.
 
 ## Current Limits
 - `delegate_async` uses a subprocess one-shot worker (`loongclawd run-turn`) rather than a durable queue or resident worker pool.
 - Child session inspection is self-only. A delegated child cannot browse descendants or list the session tree even when nested delegation is enabled.
 - `sessions_send` is intentionally narrow: only known root sessions backed by currently supported Telegram or Feishu targets are eligible.
+- `memory_search` is transcript text search only. It does not claim embedding-based, vector, BM25, hybrid, or semantic memory recall in this phase.
 - `session_archive` only applies to already-terminal visible sessions; it is inventory cleanup, not route shutdown, transcript deletion, or true session close.
 - `session_unarchive` only applies to already-archived terminal visible sessions; it restores default listing visibility, not execution, routing, or a new live session epoch.
+- `memory_search` only searches persisted transcript rows in `turns`; it does not search `session_events`, external knowledge stores, or detached long-term memory documents.
 - `session_cancel` cancels queued async children immediately, but running cancellation is cooperative at turn-loop checkpoints rather than hard process preemption.
 - `session_recover` only handles overdue async delegate children in `ready` or `running`; it is an operator-driven recovery path, not hard kill, retry, or automatic restart recovery.
 - Batch remediation is best-effort per target. Mixed applicability returns structured per-target results rather than an atomic all-or-nothing transaction.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,13 +200,14 @@ Delivered in current baseline:
   - per-session runtime tool views derived from config
   - sqlite-backed session registry and session event history
   - durable terminal outcomes for delegated child sessions
-  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
+  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
     with optional incremental event-tail return via `after_id`, draining unseen events through the
     current cursor and terminal completion
   - filtered `sessions_list` discovery for visible stale delegates, with optional lifecycle payloads
     and stable lifecycle-anchor reads that do not depend on recent-event windows
-  - durable session archival for visible terminal sessions, including default list exclusion,
-    `include_archived` rediscovery, and batch / `dry_run` operator flows
+  - durable session archive / unarchive lifecycle for visible terminal sessions, including default
+    list exclusion, `include_archived` rediscovery, latest-control-event archive derivation, and
+    batch / `dry_run` operator flows
   - batch `session_status` inspection targeting with `session_ids`, reusing the existing
     inspection payload while preserving legacy single-target response shape
   - batch `session_wait` targeting with `session_ids`, shared bounded wait context, and per-target

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -196,11 +196,11 @@ Delivered in current baseline:
 - active `http_json` runtime execution lane (no longer plan-only):
   - timeout-controlled request execution
   - structured runtime evidence (`status_code`, `response_json`)
-- app-layer session and delegation tool surface:
+  - app-layer session and delegation tool surface:
   - per-session runtime tool views derived from config
   - sqlite-backed session registry and session event history
   - durable terminal outcomes for delegated child sessions
-  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_cancel`, `session_recover`, and `session_wait`
+  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
     with optional incremental event-tail return via `after_id`, draining unseen events through the
     current cursor and terminal completion
   - filtered `sessions_list` discovery for visible stale delegates, with optional lifecycle payloads
@@ -210,6 +210,8 @@ Delivered in current baseline:
   - batch `session_wait` targeting with `session_ids`, shared bounded wait context, and per-target
     `ok` / `timeout` / `skipped_not_visible` classification while preserving legacy single-target
     response shape
+  - constrained outbound `sessions_send` delivery for known channel-backed root sessions, with
+    allowlist enforcement, legacy-session fallback materialization, and non-transcript control events
   - cooperative cancellation requests for running async delegate children, surfaced through
     session lifecycle metadata and finalized as durable cancelled failures at the next safe
     turn-loop checkpoint

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,11 +200,13 @@ Delivered in current baseline:
   - per-session runtime tool views derived from config
   - sqlite-backed session registry and session event history
   - durable terminal outcomes for delegated child sessions
-  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
+  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
     with optional incremental event-tail return via `after_id`, draining unseen events through the
     current cursor and terminal completion
   - filtered `sessions_list` discovery for visible stale delegates, with optional lifecycle payloads
     and stable lifecycle-anchor reads that do not depend on recent-event windows
+  - durable session archival for visible terminal sessions, including default list exclusion,
+    `include_archived` rediscovery, and batch / `dry_run` operator flows
   - batch `session_status` inspection targeting with `session_ids`, reusing the existing
     inspection payload while preserving legacy single-target response shape
   - batch `session_wait` targeting with `session_ids`, shared bounded wait context, and per-target

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,9 +200,10 @@ Delivered in current baseline:
   - per-session runtime tool views derived from config
   - sqlite-backed session registry and session event history
   - durable terminal outcomes for delegated child sessions
-  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, and `session_wait`
+  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_recover`, and `session_wait`
     with optional incremental event-tail return via `after_id`, draining unseen events through the
     current cursor and terminal completion
+  - explicit recovery of overdue queued async delegate children into durable failed terminal state
   - synchronous `delegate` orchestration with timeout/error mapping
   - asynchronous `delegate_async` queueing with immediate child session id return as the durable handle
   - daemon `run-turn` one-shot worker for delegated child execution

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # LoongClaw Roadmap
 
-Last updated: 2026-03-12
+Last updated: 2026-03-13
 
 This roadmap is execution-focused. Every stage has:
 
@@ -206,7 +206,7 @@ Delivered in current baseline:
   - cooperative cancellation requests for running async delegate children, surfaced through
     session lifecycle metadata and finalized as durable cancelled failures at the next safe
     turn-loop checkpoint
-  - explicit recovery of overdue queued async delegate children into durable failed terminal state
+  - explicit recovery of overdue queued or running async delegate children into durable failed terminal state
   - synchronous `delegate` orchestration with timeout/error mapping
   - asynchronous `delegate_async` queueing with immediate child session id return as the durable handle
   - daemon `run-turn` one-shot worker for delegated child execution

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -207,6 +207,9 @@ Delivered in current baseline:
     and stable lifecycle-anchor reads that do not depend on recent-event windows
   - batch `session_status` inspection targeting with `session_ids`, reusing the existing
     inspection payload while preserving legacy single-target response shape
+  - batch `session_wait` targeting with `session_ids`, shared bounded wait context, and per-target
+    `ok` / `timeout` / `skipped_not_visible` classification while preserving legacy single-target
+    response shape
   - cooperative cancellation requests for running async delegate children, surfaced through
     session lifecycle metadata and finalized as durable cancelled failures at the next safe
     turn-loop checkpoint

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -203,6 +203,8 @@ Delivered in current baseline:
   - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_cancel`, `session_recover`, and `session_wait`
     with optional incremental event-tail return via `after_id`, draining unseen events through the
     current cursor and terminal completion
+  - filtered `sessions_list` discovery for visible stale delegates, with optional lifecycle payloads
+    and stable lifecycle-anchor reads that do not depend on recent-event windows
   - cooperative cancellation requests for running async delegate children, surfaced through
     session lifecycle metadata and finalized as durable cancelled failures at the next safe
     turn-loop checkpoint

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,9 +200,12 @@ Delivered in current baseline:
   - per-session runtime tool views derived from config
   - sqlite-backed session registry and session event history
   - durable terminal outcomes for delegated child sessions
-  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_recover`, and `session_wait`
+  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_cancel`, `session_recover`, and `session_wait`
     with optional incremental event-tail return via `after_id`, draining unseen events through the
     current cursor and terminal completion
+  - cooperative cancellation requests for running async delegate children, surfaced through
+    session lifecycle metadata and finalized as durable cancelled failures at the next safe
+    turn-loop checkpoint
   - explicit recovery of overdue queued async delegate children into durable failed terminal state
   - synchronous `delegate` orchestration with timeout/error mapping
   - asynchronous `delegate_async` queueing with immediate child session id return as the durable handle

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -209,6 +209,8 @@ Delivered in current baseline:
     session lifecycle metadata and finalized as durable cancelled failures at the next safe
     turn-loop checkpoint
   - explicit recovery of overdue queued or running async delegate children into durable failed terminal state
+  - batch `session_cancel` / `session_recover` targeting with `session_ids`, `dry_run` preview,
+    and per-target result classification while preserving legacy single-target response shape
   - synchronous `delegate` orchestration with timeout/error mapping
   - asynchronous `delegate_async` queueing with immediate child session id return as the durable handle
   - daemon `run-turn` one-shot worker for delegated child execution

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,9 +200,11 @@ Delivered in current baseline:
   - per-session runtime tool views derived from config
   - sqlite-backed session registry and session event history
   - durable terminal outcomes for delegated child sessions
-  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
+  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, `memory_search`, `session_archive`, `session_unarchive`, `session_cancel`, `session_recover`, `session_wait`, and `sessions_send`
     with optional incremental event-tail return via `after_id`, draining unseen events through the
     current cursor and terminal completion
+  - transcript-backed `memory_search` over visible session scope or explicit visible targets, with
+    structured recent-first snippet matches and no control-plane event search
   - filtered `sessions_list` discovery for visible stale delegates, with optional lifecycle payloads
     and stable lifecycle-anchor reads that do not depend on recent-event windows
   - durable session archive / unarchive lifecycle for visible terminal sessions, including default

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # LoongClaw Roadmap
 
-Last updated: 2026-03-08
+Last updated: 2026-03-12
 
 This roadmap is execution-focused. Every stage has:
 
@@ -196,6 +196,20 @@ Delivered in current baseline:
 - active `http_json` runtime execution lane (no longer plan-only):
   - timeout-controlled request execution
   - structured runtime evidence (`status_code`, `response_json`)
+- app-layer session and delegation tool surface:
+  - per-session runtime tool views derived from config
+  - sqlite-backed session registry and session event history
+  - durable terminal outcomes for delegated child sessions
+  - `sessions_list`, `sessions_history`, `session_status`, `session_events`, and `session_wait`
+    with optional incremental event-tail return via `after_id`, draining unseen events through the
+    current cursor and terminal completion
+  - synchronous `delegate` orchestration with timeout/error mapping
+  - asynchronous `delegate_async` queueing with immediate child session id return as the durable handle
+  - daemon `run-turn` one-shot worker for delegated child execution
+  - lineage-based nested delegation bounded by `tools.delegate.max_depth`
+  - descendant session visibility for delegate chains
+  - delegated-child self-inspection via `session_status` and `sessions_history` without `sessions_list`
+  - legacy current-session fallback from `turns` without historical backfill
 
 Planned deliverables:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -205,6 +205,8 @@ Delivered in current baseline:
     current cursor and terminal completion
   - filtered `sessions_list` discovery for visible stale delegates, with optional lifecycle payloads
     and stable lifecycle-anchor reads that do not depend on recent-event windows
+  - batch `session_status` inspection targeting with `session_ids`, reusing the existing
+    inspection payload while preserving legacy single-target response shape
   - cooperative cancellation requests for running async delegate children, surfaced through
     session lifecycle metadata and finalized as durable cancelled failures at the next safe
     turn-loop checkpoint

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -10,8 +10,8 @@ function Write-Usage {
 Usage: pwsh ./scripts/install.ps1 [-Prefix <dir>] [-Setup]
 
 Options:
-  -Prefix <dir>   Install directory for loongclawd (default: $HOME/.local/bin)
-  -Setup          Run 'loongclawd setup --force' after install
+  -Prefix <dir>   Install directory for loongclaw (default: $HOME/.local/bin)
+  -Setup          Run 'loongclaw setup --force' after install
 "@
 }
 
@@ -27,23 +27,23 @@ if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Resolve-Path (Join-Path $scriptDir "..")
 
-Write-Host "==> Building loongclawd (release)"
+Write-Host "==> Building loongclaw (release)"
 Push-Location $repoRoot
 try {
-    cargo build -p loongclaw-daemon --bin loongclawd --release | Out-Host
+    cargo build -p loongclaw-daemon --bin loongclaw --release | Out-Host
 } finally {
     Pop-Location
 }
 
 New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
-$sourceBinary = Join-Path $repoRoot "target/release/loongclawd"
+$sourceBinary = Join-Path $repoRoot "target/release/loongclaw"
 if (-not (Test-Path $sourceBinary)) {
-    $sourceBinary = Join-Path $repoRoot "target/release/loongclawd.exe"
+    $sourceBinary = Join-Path $repoRoot "target/release/loongclaw.exe"
 }
 $destBinary = Join-Path $Prefix (Split-Path -Leaf $sourceBinary)
 Copy-Item -Force $sourceBinary $destBinary
 
-Write-Host "==> Installed loongclawd to $destBinary"
+Write-Host "==> Installed loongclaw to $destBinary"
 
 if ($Setup) {
     Write-Host "==> Running initial setup"
@@ -59,4 +59,4 @@ if (-not ($pathItems -contains $Prefix)) {
 
 Write-Host ""
 Write-Host "Done. Try:"
-Write-Host "  loongclawd --help"
+Write-Host "  loongclaw --help"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,8 +6,8 @@ usage() {
 Usage: ./scripts/install.sh [--prefix <dir>] [--setup]
 
 Options:
-  --prefix <dir>   Install directory for loongclawd (default: $HOME/.local/bin)
-  --setup          Run `loongclawd setup --force` after install
+  --prefix <dir>   Install directory for loongclaw (default: $HOME/.local/bin)
+  --setup          Run `loongclaw setup --force` after install
   -h, --help       Show this help
 USAGE
 }
@@ -49,20 +49,20 @@ fi
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/.." && pwd)"
 
-printf '==> Building loongclawd (release)\n'
+printf '==> Building loongclaw (release)\n'
 (
   cd "${repo_root}"
-  cargo build -p loongclaw-daemon --bin loongclawd --release
+  cargo build -p loongclaw-daemon --bin loongclaw --release
 )
 
 mkdir -p "${prefix}"
-install -m 755 "${repo_root}/target/release/loongclawd" "${prefix}/loongclawd"
+install -m 755 "${repo_root}/target/release/loongclaw" "${prefix}/loongclaw"
 
-printf '==> Installed loongclawd to %s\n' "${prefix}/loongclawd"
+printf '==> Installed loongclaw to %s\n' "${prefix}/loongclaw"
 
 if [[ "${run_setup}" -eq 1 ]]; then
   printf '==> Running initial setup\n'
-  "${prefix}/loongclawd" setup --force
+  "${prefix}/loongclaw" setup --force
 fi
 
 case ":${PATH}:" in
@@ -73,4 +73,4 @@ case ":${PATH}:" in
     ;;
 esac
 
-printf '\nDone. Try:\n  loongclawd --help\n'
+printf '\nDone. Try:\n  loongclaw --help\n'


### PR DESCRIPTION
## Summary

- expose the hidden `feat/session-archive-base-20260313` foundation branch as a first-class PR to `alpha-test`
- restore strict CI parity on the session runtime base by removing production `clippy` violations and tightening non-panicking batch/session handling
- scope test-only lint allowances to daemon test targets that intentionally serialize process-global environment state across async boundaries
- this change is needed because stacked PRs `#88`, `#92`, and `#95` depend on this base branch, and `#129` indirectly depends on the same runtime foundation

## Scope

- [ ] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

Scope note: this is broad by file count because it exposes the previously hidden session-runtime base branch, but the diff is intentionally limited to that foundation and its supporting docs.

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

Risk note: this base branch touches session runtime, tool surfaces, daemon wiring, and supporting docs across 61 files, so review should treat it as the stack foundation rather than a narrow leaf PR.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional checks executed:

- [x] `cargo test --workspace -- --test-threads=1`
- [x] `cargo test --workspace --all-features --locked -- --test-threads=1`
- [x] `cargo doc --workspace --no-deps`

Process-global env note: lint allowances remain scoped to daemon test targets that intentionally serialize those tests across async boundaries.

## Stack Context

- base branch for stacked PRs `#88`, `#92`, and `#95`
- indirectly unblocks `#129`

## Linked Issues

Closes #132