### PR TITLE
feat(onboard): surface channel follow-up guidance

### DIFF
--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -222,7 +222,44 @@ pub(crate) async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult
     #[cfg(feature = "memory-sqlite")]
     println!("- sqlite memory: {}", memory_path.display());
     println!("next step: loongclaw chat --config {}", path.display());
+    for line in build_channel_onboarding_follow_up_lines(&config) {
+        println!("{line}");
+    }
     Ok(())
+}
+
+pub(crate) fn build_channel_onboarding_follow_up_lines(
+    config: &mvp::config::LoongClawConfig,
+) -> Vec<String> {
+    let inventory = mvp::channel::channel_inventory(config);
+    let mut lines = Vec::with_capacity(inventory.channel_surfaces.len() + 1);
+    lines.push("channel next steps:".to_owned());
+
+    for surface in inventory.channel_surfaces {
+        let aliases = if surface.catalog.aliases.is_empty() {
+            "-".to_owned()
+        } else {
+            surface.catalog.aliases.join(",")
+        };
+        let repair_command = surface
+            .catalog
+            .onboarding
+            .repair_command
+            .map(|command| format!("\"{command}\""))
+            .unwrap_or_else(|| "-".to_owned());
+        lines.push(format!(
+            "- {} [{}] strategy={} aliases={} status_command=\"{}\" repair_command={} setup_hint=\"{}\"",
+            surface.catalog.label,
+            surface.catalog.id,
+            surface.catalog.onboarding.strategy.as_str(),
+            aliases,
+            surface.catalog.onboarding.status_command,
+            repair_command,
+            surface.catalog.onboarding.setup_hint,
+        ));
+    }
+
+    lines
 }
 
 fn resolve_provider_selection(

--- a/crates/daemon/src/tests/onboard_cli.rs
+++ b/crates/daemon/src/tests/onboard_cli.rs
@@ -273,3 +273,32 @@ async fn non_interactive_onboard_preserves_inline_api_key_literals() {
     fs::remove_file(&config_path).ok();
     fs::remove_dir_all(&temp_dir).ok();
 }
+
+#[test]
+fn build_channel_onboarding_follow_up_lines_reports_manual_and_planned_channels() {
+    let lines = crate::onboard_cli::build_channel_onboarding_follow_up_lines(
+        &mvp::config::LoongClawConfig::default(),
+    );
+
+    assert_eq!(
+        lines.first().map(String::as_str),
+        Some("channel next steps:")
+    );
+    assert!(lines.iter().any(|line| {
+        line.contains("Telegram [telegram]")
+            && line.contains("strategy=manual_config")
+            && line.contains("status_command=\"loongclaw doctor\"")
+            && line.contains("repair_command=\"loongclaw doctor --fix\"")
+    }));
+    assert!(lines.iter().any(|line| {
+        line.contains("Feishu/Lark [feishu]")
+            && line.contains("strategy=manual_config")
+            && line.contains("aliases=lark")
+    }));
+    assert!(lines.iter().any(|line| {
+        line.contains("Discord [discord]")
+            && line.contains("strategy=planned")
+            && line.contains("repair_command=-")
+            && line.contains("status_command=\"loongclaw channels --json\"")
+    }));
+}


### PR DESCRIPTION
## Summary
- teach `loongclaw onboard` to render channel follow-up guidance from channel catalog onboarding descriptors
- include strategy, aliases, status command, repair command, and setup hint for each channel surface
- add daemon coverage proving manual-config and planned channels are both surfaced from registry metadata

## Validation
- `cargo test -p loongclaw-daemon --locked --target-dir target/final-verify-channel-onboard-flow`
- `cargo test -p loongclaw-app channel::registry::tests --locked --target-dir target/final-verify-channel-onboard-flow`
- `cargo clippy --workspace --all-targets --all-features --target-dir target/final-verify-channel-onboard-flow -- -D warnings`

## Refs
- refs #130
- refs #120