### PR TITLE
fix(approval): preserve approval-required tool failures

### DIFF
--- a/crates/app/src/conversation/integration_tests.rs
+++ b/crates/app/src/conversation/integration_tests.rs
@@ -84,6 +84,23 @@ impl TurnTestHarness {
     }
 
     pub fn with_capabilities(capabilities: BTreeSet<Capability>) -> Self {
+        Self::with_capabilities_and_shell_allowlist(
+            capabilities,
+            BTreeSet::from(["echo".to_owned(), "cat".to_owned(), "ls".to_owned()]),
+        )
+    }
+
+    pub fn with_shell_allowlist(shell_allowlist: BTreeSet<String>) -> Self {
+        Self::with_capabilities_and_shell_allowlist(
+            BTreeSet::from([Capability::InvokeTool]),
+            shell_allowlist,
+        )
+    }
+
+    pub fn with_capabilities_and_shell_allowlist(
+        capabilities: BTreeSet<Capability>,
+        shell_allowlist: BTreeSet<String>,
+    ) -> Self {
         let id = HARNESS_COUNTER.fetch_add(1, Ordering::SeqCst);
         let temp_dir =
             std::env::temp_dir().join(format!("loongclaw-integ-{}-{id}", std::process::id()));
@@ -91,7 +108,7 @@ impl TurnTestHarness {
 
         // Inject config so tests don't race on the global OnceLock
         let tool_config = ToolRuntimeConfig {
-            shell_allowlist: BTreeSet::from(["echo".to_owned(), "cat".to_owned(), "ls".to_owned()]),
+            shell_allowlist,
             file_root: Some(temp_dir.clone()),
             external_skills: Default::default(),
         };
@@ -330,6 +347,30 @@ mod tests {
                 );
             }
             other => panic!("expected ToolDenied with policy reason, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn integ_shell_exec_allowlisted_curl_still_requires_approval() {
+        let harness = TurnTestHarness::with_shell_allowlist(BTreeSet::from(["curl".to_owned()]));
+
+        let turn = FakeProviderBuilder::new()
+            .with_tool_call(
+                "shell.exec",
+                json!({"command": "curl", "args": ["http://127.0.0.1:8080/search?q=arch"]}),
+            )
+            .build();
+        let result = harness.execute(&turn).await;
+
+        #[allow(clippy::wildcard_enum_match_arm)]
+        match result {
+            TurnResult::NeedsApproval(err) => {
+                assert!(
+                    err.contains("requires approval by default shell policy"),
+                    "expected approval-required reason, got: {err}"
+                );
+            }
+            other => panic!("expected NeedsApproval for allowlisted curl, got: {other:?}"),
         }
     }
 

--- a/crates/app/src/conversation/plan_executor.rs
+++ b/crates/app/src/conversation/plan_executor.rs
@@ -35,6 +35,7 @@ pub enum PlanRunFailure {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PlanNodeErrorKind {
     Retryable,
+    ApprovalRequired,
     PolicyDenied,
     NonRetryable,
 }
@@ -56,6 +57,13 @@ impl PlanNodeError {
     pub fn policy_denied(message: impl Into<String>) -> Self {
         Self {
             kind: PlanNodeErrorKind::PolicyDenied,
+            message: message.into(),
+        }
+    }
+
+    pub fn approval_required(message: impl Into<String>) -> Self {
+        Self {
+            kind: PlanNodeErrorKind::ApprovalRequired,
             message: message.into(),
         }
     }

--- a/crates/app/src/conversation/plan_executor.rs
+++ b/crates/app/src/conversation/plan_executor.rs
@@ -244,7 +244,11 @@ impl PlanExecutor {
                                 error_kind: Some(normalized.kind),
                                 error: Some(normalized.message.clone()),
                             });
-                            if attempt == node.max_attempts {
+                            // Approval-required failures are terminal until the caller changes
+                            // execution context, so retrying the same node cannot make progress.
+                            if normalized.kind == PlanNodeErrorKind::ApprovalRequired
+                                || attempt == node.max_attempts
+                            {
                                 let elapsed_ms = started_at.elapsed().as_millis();
                                 return PlanRunReport {
                                     status: PlanRunStatus::Failed(PlanRunFailure::NodeFailed {
@@ -472,6 +476,39 @@ mod tests {
         }
     }
 
+    struct ApprovalRequiredExecutor {
+        approval_node: String,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl ApprovalRequiredExecutor {
+        fn new(node_id: &str) -> Self {
+            Self {
+                approval_node: node_id.to_owned(),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PlanNodeExecutor for ApprovalRequiredExecutor {
+        async fn execute(&self, node: &PlanNode, attempt: u8) -> Result<(), PlanNodeError> {
+            self.calls
+                .lock()
+                .expect("calls lock")
+                .push(format!("{}#{attempt}", node.id));
+
+            if node.id == self.approval_node {
+                return Err(PlanNodeError::approval_required(format!(
+                    "approval required for {}",
+                    node.id
+                )));
+            }
+
+            Ok(())
+        }
+    }
+
     #[async_trait]
     impl PlanNodeExecutor for RecordingExecutor {
         async fn execute(&self, node: &PlanNode, attempt: u8) -> Result<(), PlanNodeError> {
@@ -620,6 +657,36 @@ mod tests {
             }
             other => panic!("expected timeout node failure, got: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn executor_stops_retrying_after_approval_required_failure() {
+        let graph = sample_graph();
+        let executor = ApprovalRequiredExecutor::new("n2");
+        let report = PlanExecutor::execute(&graph, &executor).await;
+
+        #[allow(clippy::wildcard_enum_match_arm)]
+        match report.status {
+            PlanRunStatus::Failed(PlanRunFailure::NodeFailed {
+                node_id,
+                attempts_used,
+                last_error_kind,
+                ref last_error,
+            }) => {
+                assert_eq!(node_id, "n2");
+                assert_eq!(attempts_used, 1);
+                assert_eq!(last_error_kind, PlanNodeErrorKind::ApprovalRequired);
+                assert!(
+                    last_error.contains("approval required"),
+                    "expected approval-required reason, got: {last_error}"
+                );
+            }
+            other => panic!("expected approval-required node failure, got: {other:?}"),
+        }
+
+        let calls = executor.calls.lock().expect("calls lock").clone();
+        assert_eq!(calls, vec!["n1#1".to_owned(), "n2#1".to_owned()]);
+        assert_eq!(report.attempts_used, 2);
     }
 
     #[tokio::test]

--- a/crates/app/src/conversation/safe_lane_failure.rs
+++ b/crates/app/src/conversation/safe_lane_failure.rs
@@ -99,6 +99,7 @@ pub enum SafeLaneFailureCode {
     PlanTopologyResolutionFailed,
     PlanBudgetExceeded,
     PlanWallTimeExceeded,
+    PlanNodeApprovalRequired,
     PlanNodePolicyDenied,
     PlanNodeRetryableError,
     PlanNodeNonRetryableError,
@@ -117,6 +118,7 @@ impl SafeLaneFailureCode {
             Self::PlanTopologyResolutionFailed => "safe_lane_plan_topology_resolution_failed",
             Self::PlanBudgetExceeded => "safe_lane_plan_budget_exceeded",
             Self::PlanWallTimeExceeded => "safe_lane_plan_wall_time_exceeded",
+            Self::PlanNodeApprovalRequired => "safe_lane_plan_node_approval_required",
             Self::PlanNodePolicyDenied => "safe_lane_plan_node_policy_denied",
             Self::PlanNodeRetryableError => "safe_lane_plan_node_retryable_error",
             Self::PlanNodeNonRetryableError => "safe_lane_plan_node_non_retryable_error",
@@ -137,6 +139,7 @@ impl SafeLaneFailureCode {
             "safe_lane_plan_topology_resolution_failed" => Some(Self::PlanTopologyResolutionFailed),
             "safe_lane_plan_budget_exceeded" => Some(Self::PlanBudgetExceeded),
             "safe_lane_plan_wall_time_exceeded" => Some(Self::PlanWallTimeExceeded),
+            "safe_lane_plan_node_approval_required" => Some(Self::PlanNodeApprovalRequired),
             "safe_lane_plan_node_policy_denied" => Some(Self::PlanNodePolicyDenied),
             "safe_lane_plan_node_retryable_error" => Some(Self::PlanNodeRetryableError),
             "safe_lane_plan_node_non_retryable_error" => Some(Self::PlanNodeNonRetryableError),
@@ -215,6 +218,10 @@ pub fn classify_safe_lane_plan_failure(
         PlanRunFailure::NodeFailed {
             last_error_kind, ..
         } => match last_error_kind {
+            PlanNodeErrorKind::ApprovalRequired => (
+                SafeLaneFailureCode::PlanNodeApprovalRequired,
+                TurnFailureKind::ApprovalRequired,
+            ),
             PlanNodeErrorKind::PolicyDenied => (
                 SafeLaneFailureCode::PlanNodePolicyDenied,
                 TurnFailureKind::PolicyDenied,

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -4888,6 +4888,66 @@ async fn handle_turn_with_runtime_tool_failure_completion_error_uses_raw_reason_
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_approval_required_skips_completion_rewrite() {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::with_shell_allowlist(BTreeSet::from(["curl".to_owned()]));
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Trying the local search endpoint.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "shell.exec".to_owned(),
+                args_json: json!({
+                    "command": "curl",
+                    "args": ["http://127.0.0.1:8080/search?q=arch"]
+                }),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-approval-required".to_owned(),
+                turn_id: "turn-approval-required".to_owned(),
+                tool_call_id: "call-approval-required".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("MODEL_SHOULD_NOT_RUN".to_owned()),
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-approval-required",
+            "search Arch Linux news with my local searxng instance",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("approval-required tool failure should finalize directly");
+
+    assert!(
+        reply.contains("Trying the local search endpoint."),
+        "expected assistant preface, got: {reply}"
+    );
+    assert!(
+        reply.contains("[tool_approval_required]"),
+        "expected approval-required marker, got: {reply}"
+    );
+    assert!(
+        reply.contains("requires approval by default shell policy"),
+        "expected truthful approval-required reason, got: {reply}"
+    );
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0,
+        "approval-required replies should not run a completion rewrite"
+    );
+}
+
 #[test]
 fn format_provider_error_reply_is_stable() {
     let output = format_provider_error_reply("timeout");
@@ -5209,6 +5269,15 @@ fn kernel_error_classification_table_is_stable() {
     assert_eq!(
         classify_kernel_error(&policy_error),
         KernelFailureClass::PolicyDenied
+    );
+
+    let approval_required_error = KernelError::Policy(PolicyError::ToolCallApprovalRequired {
+        tool_name: "shell.exec".to_owned(),
+        prompt: "command `curl` requires approval".to_owned(),
+    });
+    assert_eq!(
+        classify_kernel_error(&approval_required_error),
+        KernelFailureClass::ApprovalRequired
     );
 
     let boundary_error = KernelError::PackCapabilityBoundary {

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -4948,6 +4948,82 @@ async fn handle_turn_with_runtime_approval_required_skips_completion_rewrite() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_safe_lane_approval_required_is_not_retried() {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::with_shell_allowlist(BTreeSet::from(["curl".to_owned()]));
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Trying the local search endpoint.".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "shell.exec".to_owned(),
+                args_json: json!({
+                    "command": "curl",
+                    "args": ["http://127.0.0.1:8080/search?q=arch"]
+                }),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-safe-approval-required".to_owned(),
+                turn_id: "turn-safe-approval-required".to_owned(),
+                tool_call_id: "call-safe-approval-required".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        }),
+        Ok("MODEL_SHOULD_NOT_RUN".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = true;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-approval-required",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("safe-lane approval-required tool failure should finalize directly");
+
+    assert!(
+        reply.contains("[tool_approval_required]"),
+        "expected approval-required marker, got: {reply}"
+    );
+    assert!(
+        reply.contains("requires approval by default shell policy"),
+        "expected truthful approval-required reason, got: {reply}"
+    );
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0,
+        "safe-lane approval-required replies should not run a completion rewrite"
+    );
+
+    let approval_denials = harness
+        .audit
+        .snapshot()
+        .iter()
+        .filter(|event| {
+            matches!(
+                &event.kind,
+                loongclaw_kernel::AuditEventKind::AuthorizationDenied { reason, .. }
+                    if reason.contains("requires approval by default shell policy")
+            )
+        })
+        .count();
+    assert_eq!(
+        approval_denials, 1,
+        "safe-lane approval-required tool calls should be audited once"
+    );
+}
+
 #[test]
 fn format_provider_error_reply_is_stable() {
     let output = format_provider_error_reply("timeout");

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3779,6 +3779,9 @@ impl SafeLaneFailureRoute {
 
         if let Some(code) = SafeLaneFailureCode::parse(failure.code.as_str()) {
             match code {
+                SafeLaneFailureCode::PlanNodeApprovalRequired => {
+                    return Self::terminal(SafeLaneFailureRouteReason::ApprovalRequired);
+                }
                 SafeLaneFailureCode::PlanNodePolicyDenied => {
                     return Self::terminal(SafeLaneFailureRouteReason::PolicyDenied);
                 }
@@ -4233,10 +4236,13 @@ fn terminal_turn_failure_from_verify_failure(
 
 fn turn_result_from_plan_failure(failure: PlanRunFailure) -> TurnResult {
     let failure_meta = turn_failure_from_plan_failure(&failure);
-    if matches!(failure_meta.kind, TurnFailureKind::PolicyDenied) {
-        TurnResult::ToolDenied(failure_meta)
-    } else {
-        TurnResult::ToolError(failure_meta)
+    match failure_meta.kind {
+        TurnFailureKind::ApprovalRequired => TurnResult::NeedsApproval(failure_meta),
+        TurnFailureKind::PolicyDenied => TurnResult::ToolDenied(failure_meta),
+        TurnFailureKind::Retryable | TurnFailureKind::NonRetryable => {
+            TurnResult::ToolError(failure_meta)
+        }
+        TurnFailureKind::Provider => TurnResult::ProviderError(failure_meta),
     }
 }
 
@@ -4380,6 +4386,7 @@ async fn execute_single_tool_intent(
         .await
         .map_err(|error| {
             let kind = match classify_kernel_error(&error) {
+                KernelFailureClass::ApprovalRequired => PlanNodeErrorKind::ApprovalRequired,
                 KernelFailureClass::PolicyDenied => PlanNodeErrorKind::PolicyDenied,
                 KernelFailureClass::RetryableExecution => PlanNodeErrorKind::Retryable,
                 KernelFailureClass::NonRetryable => PlanNodeErrorKind::NonRetryable,
@@ -5303,6 +5310,19 @@ mod tests {
     }
 
     #[test]
+    fn safe_lane_route_approval_required_failure_is_terminal() {
+        let failure = TurnFailure::approval_required(
+            "safe_lane_plan_node_approval_required",
+            "approval required",
+        );
+        let route = SafeLaneFailureRoute::from_failure(&failure, SafeLaneReplanBudget::new(3));
+
+        assert_eq!(route.decision, SafeLaneFailureRouteDecision::Terminal);
+        assert_eq!(route.reason, SafeLaneFailureRouteReason::ApprovalRequired);
+        assert_eq!(route.source, SafeLaneFailureRouteSource::BaseRouting);
+    }
+
+    #[test]
     fn safe_lane_route_non_retryable_failure_is_terminal() {
         let failure = TurnFailure::non_retryable("safe_lane_plan_node_non_retryable_error", "bad");
         let route = SafeLaneFailureRoute::from_failure(&failure, SafeLaneReplanBudget::new(3));
@@ -5318,6 +5338,12 @@ mod tests {
     #[test]
     fn turn_failure_from_plan_failure_node_error_mapping_is_stable() {
         let cases = [
+            (
+                PlanNodeErrorKind::ApprovalRequired,
+                TurnFailureKind::ApprovalRequired,
+                "safe_lane_plan_node_approval_required",
+                false,
+            ),
             (
                 PlanNodeErrorKind::PolicyDenied,
                 TurnFailureKind::PolicyDenied,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -184,6 +184,7 @@ impl TurnResult {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum KernelFailureClass {
+    ApprovalRequired,
     PolicyDenied,
     RetryableExecution,
     NonRetryable,
@@ -192,6 +193,9 @@ pub(crate) enum KernelFailureClass {
 pub(crate) fn classify_kernel_error(error: &KernelError) -> KernelFailureClass {
     #[allow(clippy::wildcard_enum_match_arm)]
     match error {
+        KernelError::Policy(loongclaw_contracts::PolicyError::ToolCallApprovalRequired {
+            ..
+        }) => KernelFailureClass::ApprovalRequired,
         KernelError::Policy(_)
         | KernelError::PackCapabilityBoundary { .. }
         | KernelError::ConnectorNotAllowed { .. } => KernelFailureClass::PolicyDenied,
@@ -332,7 +336,7 @@ impl TurnEngine {
     /// 2. Too many intents → `ToolDenied("max_tool_steps_exceeded")`
     /// 3. Unknown tool → `ToolDenied("tool_not_found: ...")`
     /// 4. No kernel context → `ToolDenied("no_kernel_context")`
-    /// 5. Policy/capability check via kernel → `ToolDenied` with reason if denied
+    /// 5. Policy/capability check via kernel → `NeedsApproval` or `ToolDenied`
     /// 6. Execute tool → map result to `TurnResult`
     pub async fn execute_turn(
         &self,
@@ -386,6 +390,9 @@ impl TurnEngine {
                 Err(e) => {
                     let reason = format!("{e}");
                     return match classify_kernel_error(&e) {
+                        KernelFailureClass::ApprovalRequired => {
+                            TurnResult::needs_approval("kernel_approval_required", reason)
+                        }
                         KernelFailureClass::PolicyDenied => {
                             TurnResult::policy_denied("kernel_policy_denied", reason)
                         }


### PR DESCRIPTION
## Summary

- What changed? Preserved kernel `ToolCallApprovalRequired` outcomes as `ApprovalRequired` instead of collapsing them into generic policy denial; `shell.exec` approval-required failures now return `TurnResult::NeedsApproval(...)` and bypass the completion-pass rewrite path; safe-lane plan-node mapping preserves the same semantics and regression tests cover allowlisted `curl` still requiring approval.
- Why this change is needed? `alpha-test` was rewriting approval-required shell failures into misleading assistant narration, especially in allowlisted `curl` local-search workflows, even though `tools.shell_allowlist` and kernel approval policy are separate gates.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

No docs update was needed for this internal behavior fix.

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

- This changes policy-impacting failure classification and reply surfacing, but does not relax any shell execution guardrails.
- Actual kernel enforcement is unchanged; only approval-required outcomes now keep their semantics through fast-lane and safe-lane execution paths.
- Adjacent policy-denied and tool-error paths retain existing completion-pass behavior and are covered by regression checks.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional scenario checks covered the allowlisted `curl` approval-required regression, direct approval-required reply finalization, and nearby denial/error control paths.

Not applicable for the config/env fallback item: this change does not alter config/env fallback behavior, limits, or defaults.

Not applicable for the process-global env item: the added tests do not mutate process-global environment state.

## Linked Issues

Closes #135