### PR TITLE
feat: adopt discovery-first provider tool routing

### DIFF
--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -1099,6 +1099,22 @@ mod tests {
                             Json(json!({
                                 "choices": [{
                                     "message": {
+                                        "content": "looking up the right callback card tool",
+                                        "tool_calls": [{
+                                            "id": "call_tool_search_1",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "tool_search",
+                                                "arguments": "{\"query\":\"feishu card update callback token markdown\",\"limit\":1}"
+                                            }
+                                        }]
+                                    }
+                                }]
+                            }))
+                        } else if *turn_index == 2 {
+                            Json(json!({
+                                "choices": [{
+                                    "message": {
                                         "content": "updating card",
                                         "tool_calls": [{
                                             "id": "call_feishu_card_update_1",

--- a/crates/app/src/config/conversation.rs
+++ b/crates/app/src/config/conversation.rs
@@ -200,6 +200,8 @@ pub struct ConversationTurnLoopConfig {
     pub max_followup_tool_payload_chars: usize,
     #[serde(default = "default_turn_loop_max_followup_tool_payload_chars_total")]
     pub max_followup_tool_payload_chars_total: usize,
+    #[serde(default = "default_turn_loop_max_discovery_followup_rounds")]
+    pub max_discovery_followup_rounds: usize,
 }
 
 impl Default for ConversationTurnLoopConfig {
@@ -213,6 +215,7 @@ impl Default for ConversationTurnLoopConfig {
             max_followup_tool_payload_chars: default_turn_loop_max_followup_tool_payload_chars(),
             max_followup_tool_payload_chars_total:
                 default_turn_loop_max_followup_tool_payload_chars_total(),
+            max_discovery_followup_rounds: default_turn_loop_max_discovery_followup_rounds(),
         }
     }
 }
@@ -436,6 +439,10 @@ const fn default_turn_loop_max_followup_tool_payload_chars() -> usize {
 
 const fn default_turn_loop_max_followup_tool_payload_chars_total() -> usize {
     20_000
+}
+
+const fn default_turn_loop_max_discovery_followup_rounds() -> usize {
+    2
 }
 
 const fn default_fast_lane_max_tool_steps_per_turn() -> usize {

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -2187,7 +2187,7 @@ api_key = "${DEEPSEEK_API_KEY}"
         assert!(raw.contains("[external_skills]"));
         assert!(raw.contains("enabled = false"));
         assert!(raw.contains("require_download_approval = true"));
-        assert!(raw.contains("auto_expose_installed = true"));
+        assert!(raw.contains("auto_expose_installed = false"));
 
         let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
         assert!(!loaded.external_skills.enabled);
@@ -2195,7 +2195,7 @@ api_key = "${DEEPSEEK_API_KEY}"
         assert!(loaded.external_skills.allowed_domains.is_empty());
         assert!(loaded.external_skills.blocked_domains.is_empty());
         assert!(loaded.external_skills.install_root.is_none());
-        assert!(loaded.external_skills.auto_expose_installed);
+        assert!(!loaded.external_skills.auto_expose_installed);
 
         let _ = fs::remove_file(path);
     }

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -511,7 +511,7 @@ const fn default_true() -> bool {
 }
 
 const fn default_auto_expose_installed() -> bool {
-    true
+    false
 }
 
 fn normalize_domain_entries(entries: &[String]) -> Vec<String> {
@@ -706,7 +706,7 @@ child_tool_allowlist = ["file.read", "shell.exec"]
         assert!(config.allowed_domains.is_empty());
         assert!(config.blocked_domains.is_empty());
         assert!(config.install_root.is_none());
-        assert!(config.auto_expose_installed);
+        assert!(!config.auto_expose_installed);
     }
 
     #[test]

--- a/crates/app/src/conversation/analytics.rs
+++ b/crates/app/src/conversation/analytics.rs
@@ -392,6 +392,25 @@ pub struct ConversationEventRecord {
     pub payload: Value,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscoveryFirstEventSummary {
+    pub search_round_events: u32,
+    pub followup_requested_events: u32,
+    pub followup_result_events: u32,
+    pub raw_output_followup_events: u32,
+    pub search_to_invoke_hits: u32,
+    pub aggregate_added_estimated_tokens: u64,
+    pub added_estimated_token_samples: u32,
+    pub average_added_estimated_tokens: Option<u32>,
+    pub latest_followup_outcome: Option<String>,
+    pub latest_followup_tool_name: Option<String>,
+    pub latest_followup_target_tool_id: Option<String>,
+    pub latest_initial_estimated_tokens: Option<u32>,
+    pub latest_followup_estimated_tokens: Option<u32>,
+    pub latest_added_estimated_tokens: Option<u32>,
+    pub outcome_counts: BTreeMap<String, u32>,
+}
+
 pub fn parse_conversation_event(content: &str) -> Option<ConversationEventRecord> {
     let parsed = serde_json::from_str::<Value>(content).ok()?;
     if parsed.get("type")?.as_str()? != "conversation_event" {
@@ -428,6 +447,22 @@ where
     I: IntoIterator<Item = &'a str>,
 {
     summarize_safe_lane_history(contents).summary
+}
+
+pub fn summarize_discovery_first_events<'a, I>(contents: I) -> DiscoveryFirstEventSummary
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut summary = DiscoveryFirstEventSummary::default();
+
+    for content in contents {
+        let Some(record) = parse_conversation_event(content) else {
+            continue;
+        };
+        fold_discovery_first_event_record(&record, &mut summary);
+    }
+
+    summary
 }
 
 fn fold_safe_lane_event_record(
@@ -609,6 +644,104 @@ fn fold_safe_lane_event_record(
     }
 
     final_status_sample
+}
+
+fn fold_discovery_first_event_record(
+    record: &ConversationEventRecord,
+    summary: &mut DiscoveryFirstEventSummary,
+) {
+    if !is_discovery_first_event_name(record.event.as_str()) {
+        return;
+    }
+
+    match record.event.as_str() {
+        "discovery_first_search_round" => {
+            summary.search_round_events = summary.search_round_events.saturating_add(1);
+            if let Some(initial_estimated_tokens) = record
+                .payload
+                .get("initial_estimated_tokens")
+                .and_then(Value::as_u64)
+                .map(|value| value.min(u32::MAX as u64) as u32)
+            {
+                summary.latest_initial_estimated_tokens = Some(initial_estimated_tokens);
+            }
+        }
+        "discovery_first_followup_requested" => {
+            summary.followup_requested_events = summary.followup_requested_events.saturating_add(1);
+            if let Some(initial_estimated_tokens) = record
+                .payload
+                .get("initial_estimated_tokens")
+                .and_then(Value::as_u64)
+                .map(|value| value.min(u32::MAX as u64) as u32)
+            {
+                summary.latest_initial_estimated_tokens = Some(initial_estimated_tokens);
+            }
+            if let Some(followup_estimated_tokens) = record
+                .payload
+                .get("followup_estimated_tokens")
+                .and_then(Value::as_u64)
+                .map(|value| value.min(u32::MAX as u64) as u32)
+            {
+                summary.latest_followup_estimated_tokens = Some(followup_estimated_tokens);
+            }
+            if let Some(added_estimated_tokens) = record
+                .payload
+                .get("followup_added_estimated_tokens")
+                .and_then(Value::as_u64)
+                .map(|value| value.min(u32::MAX as u64) as u32)
+            {
+                summary.latest_added_estimated_tokens = Some(added_estimated_tokens);
+                summary.aggregate_added_estimated_tokens = summary
+                    .aggregate_added_estimated_tokens
+                    .saturating_add(u64::from(added_estimated_tokens));
+                summary.added_estimated_token_samples =
+                    summary.added_estimated_token_samples.saturating_add(1);
+                summary.average_added_estimated_tokens = Some(
+                    summary
+                        .aggregate_added_estimated_tokens
+                        .saturating_div(u64::from(summary.added_estimated_token_samples))
+                        .min(u32::MAX as u64) as u32,
+                );
+            }
+        }
+        "discovery_first_followup_result" => {
+            summary.followup_result_events = summary.followup_result_events.saturating_add(1);
+
+            if record
+                .payload
+                .get("raw_tool_output_requested")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                summary.raw_output_followup_events =
+                    summary.raw_output_followup_events.saturating_add(1);
+            }
+            if record
+                .payload
+                .get("resolved_to_tool_invoke")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                summary.search_to_invoke_hits = summary.search_to_invoke_hits.saturating_add(1);
+            }
+
+            if let Some(outcome) = record.payload.get("outcome").and_then(Value::as_str) {
+                summary.latest_followup_outcome = Some(outcome.to_owned());
+                bump_count(&mut summary.outcome_counts, outcome);
+            }
+            summary.latest_followup_tool_name = record
+                .payload
+                .get("followup_tool_name")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            summary.latest_followup_target_tool_id = record
+                .payload
+                .get("followup_target_tool_id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+        }
+        _ => {}
+    }
 }
 
 pub(crate) fn summarize_turn_checkpoint_history<'a, I>(
@@ -1064,6 +1197,15 @@ fn is_safe_lane_event_name(event_name: &str) -> bool {
             | "verify_policy_adjusted"
             | "replan_triggered"
             | "final_status"
+    )
+}
+
+fn is_discovery_first_event_name(event_name: &str) -> bool {
+    matches!(
+        event_name,
+        "discovery_first_search_round"
+            | "discovery_first_followup_requested"
+            | "discovery_first_followup_result"
     )
 }
 
@@ -2279,5 +2421,103 @@ mod tests {
             summary.latest_safe_lane_route_labels_or_default(),
             ("terminal", "session_governor_no_replan", "session_governor")
         );
+    }
+
+    #[test]
+    fn summarize_discovery_first_events_counts_followup_and_tokens() {
+        let payloads = [
+            json!({
+                "type": "conversation_event",
+                "event": "discovery_first_search_round",
+                "payload": {
+                    "provider_round": 0,
+                    "search_tool_calls": 1,
+                    "raw_tool_output_requested": false,
+                    "initial_estimated_tokens": 12
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "discovery_first_followup_requested",
+                "payload": {
+                    "provider_round": 1,
+                    "raw_tool_output_requested": true,
+                    "initial_estimated_tokens": 12,
+                    "followup_estimated_tokens": 21,
+                    "followup_added_estimated_tokens": 9
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "discovery_first_followup_result",
+                "payload": {
+                    "provider_round": 1,
+                    "outcome": "tool.invoke",
+                    "followup_tool_name": "tool.invoke",
+                    "followup_target_tool_id": "file.read",
+                    "resolved_to_tool_invoke": true,
+                    "raw_tool_output_requested": true
+                }
+            })
+            .to_string(),
+        ];
+
+        let summary = summarize_discovery_first_events(payloads.iter().map(String::as_str));
+        assert_eq!(summary.search_round_events, 1);
+        assert_eq!(summary.followup_requested_events, 1);
+        assert_eq!(summary.followup_result_events, 1);
+        assert_eq!(summary.raw_output_followup_events, 1);
+        assert_eq!(summary.search_to_invoke_hits, 1);
+        assert_eq!(summary.aggregate_added_estimated_tokens, 9);
+        assert_eq!(summary.average_added_estimated_tokens, Some(9));
+        assert_eq!(
+            summary.latest_followup_outcome.as_deref(),
+            Some("tool.invoke")
+        );
+        assert_eq!(
+            summary.latest_followup_tool_name.as_deref(),
+            Some("tool.invoke")
+        );
+        assert_eq!(
+            summary.latest_followup_target_tool_id.as_deref(),
+            Some("file.read")
+        );
+        assert_eq!(summary.latest_initial_estimated_tokens, Some(12));
+        assert_eq!(summary.latest_followup_estimated_tokens, Some(21));
+        assert_eq!(summary.latest_added_estimated_tokens, Some(9));
+        assert_eq!(summary.outcome_counts.get("tool.invoke").copied(), Some(1));
+    }
+
+    #[test]
+    fn summarize_discovery_first_events_ignores_lookalikes_and_tracks_latest_request_snapshot() {
+        let payloads = [
+            r#"{"type":"conversation_event","event":"discovery_first_search_round","payload":{"provider_round":0}}"#,
+            r#"{"type":"conversation_event","event":"discovery_first_followup_requested","payload":{"provider_round":1,"initial_estimated_tokens":20,"followup_estimated_tokens":32,"followup_added_estimated_tokens":12}}"#,
+            r#"{"type":"conversation_event","event":"discovery_first_followup_result","payload":{"provider_round":1,"outcome":"final_reply","resolved_to_tool_invoke":false}}"#,
+            r#"{"type":"conversation_event","event":"discovery_first_followup_noise","payload":{"outcome":"tool.invoke","resolved_to_tool_invoke":true,"followup_added_estimated_tokens":999}}"#,
+            r#"{"type":"tool_outcome","event":"discovery_first_followup_result","payload":{"outcome":"tool.invoke"}}"#,
+        ];
+
+        let summary = summarize_discovery_first_events(payloads.iter().copied());
+        assert_eq!(summary.search_round_events, 1);
+        assert_eq!(summary.followup_requested_events, 1);
+        assert_eq!(summary.followup_result_events, 1);
+        assert_eq!(summary.raw_output_followup_events, 0);
+        assert_eq!(summary.search_to_invoke_hits, 0);
+        assert_eq!(summary.aggregate_added_estimated_tokens, 12);
+        assert_eq!(summary.average_added_estimated_tokens, Some(12));
+        assert_eq!(
+            summary.latest_followup_outcome.as_deref(),
+            Some("final_reply")
+        );
+        assert_eq!(summary.latest_followup_tool_name, None);
+        assert_eq!(summary.latest_followup_target_tool_id, None);
+        assert_eq!(summary.latest_initial_estimated_tokens, Some(20));
+        assert_eq!(summary.latest_followup_estimated_tokens, Some(32));
+        assert_eq!(summary.latest_added_estimated_tokens, Some(12));
+        assert_eq!(summary.outcome_counts.get("final_reply").copied(), Some(1));
+        assert_eq!(summary.outcome_counts.get("tool.invoke").copied(), None);
     }
 }

--- a/crates/app/src/conversation/integration_tests.rs
+++ b/crates/app/src/conversation/integration_tests.rs
@@ -41,17 +41,28 @@ impl FakeProviderBuilder {
     }
 
     pub fn build(self) -> ProviderTurn {
+        let session_id = "test-session";
+        let turn_id = "test-turn";
         let tool_intents = self
             .tool_calls
             .into_iter()
             .enumerate()
-            .map(|(i, (name, args))| ToolIntent {
-                tool_name: name,
-                args_json: args,
-                source: "fake_provider".to_owned(),
-                session_id: "test-session".to_owned(),
-                turn_id: "test-turn".to_owned(),
-                tool_call_id: format!("call-{i}"),
+            .map(|(i, (name, args))| {
+                let (tool_name, args_json) =
+                    crate::tools::synthesize_test_provider_tool_call_with_scope(
+                        &name,
+                        args,
+                        Some(session_id),
+                        Some(turn_id),
+                    );
+                ToolIntent {
+                    tool_name,
+                    args_json,
+                    source: "fake_provider".to_owned(),
+                    session_id: session_id.to_owned(),
+                    turn_id: turn_id.to_owned(),
+                    tool_call_id: format!("call-{i}"),
+                }
             })
             .collect();
 
@@ -80,36 +91,25 @@ pub(crate) struct TurnTestHarness {
 
 impl TurnTestHarness {
     pub fn new() -> Self {
-        Self::with_capabilities(BTreeSet::from([
-            Capability::InvokeTool,
-            Capability::FilesystemRead,
-            Capability::FilesystemWrite,
-        ]))
+        Self::with_capabilities(default_tool_capabilities())
     }
 
     pub fn with_capabilities(capabilities: BTreeSet<Capability>) -> Self {
-        Self::with_tool_config(capabilities, ToolRuntimeConfig::default())
+        let temp_dir = next_temp_dir();
+
+        Self::with_capabilities_and_tool_config(
+            capabilities,
+            temp_dir.clone(),
+            default_tool_runtime_config(temp_dir),
+        )
     }
 
-    /// Construct a harness with a caller-supplied `ToolRuntimeConfig`.
-    /// Use this when a test needs specific allow/deny/approval lists rather
-    /// than the generic defaults.
-    pub fn with_tool_config(
+    pub fn with_capabilities_and_tool_config(
         capabilities: BTreeSet<Capability>,
-        tool_config_override: ToolRuntimeConfig,
+        temp_dir: PathBuf,
+        tool_config: ToolRuntimeConfig,
     ) -> Self {
-        let id = HARNESS_COUNTER.fetch_add(1, Ordering::SeqCst);
-        let temp_dir =
-            std::env::temp_dir().join(format!("loongclaw-integ-{}-{id}", std::process::id()));
         std::fs::create_dir_all(&temp_dir).expect("create temp dir");
-
-        // Merge the caller's overrides with the unique temp dir as file_root.
-        let tool_config = ToolRuntimeConfig {
-            file_root: Some(temp_dir.clone()),
-            config_path: Some(temp_dir.join("loongclaw.toml")),
-            ..tool_config_override
-        };
-
         let audit = Arc::new(InMemoryAuditSink::default());
         let clock = Arc::new(FixedClock::new(1_700_000_000));
         let mut kernel =
@@ -180,6 +180,48 @@ impl TurnTestHarness {
     pub async fn execute(&self, turn: &ProviderTurn) -> TurnResult {
         self.engine.execute_turn(turn, &self.kernel_ctx).await
     }
+
+    /// Construct a harness with a caller-supplied `ToolRuntimeConfig`.
+    /// Use this when a test needs specific allow/deny settings rather than the
+    /// generic defaults.
+    pub fn with_tool_config(
+        capabilities: BTreeSet<Capability>,
+        tool_config_override: ToolRuntimeConfig,
+    ) -> Self {
+        let temp_dir = next_temp_dir();
+        let tool_config = ToolRuntimeConfig {
+            file_root: Some(temp_dir.clone()),
+            ..tool_config_override
+        };
+        Self::with_capabilities_and_tool_config(capabilities, temp_dir, tool_config)
+    }
+}
+
+fn default_tool_capabilities() -> BTreeSet<Capability> {
+    BTreeSet::from([
+        Capability::InvokeTool,
+        Capability::FilesystemRead,
+        Capability::FilesystemWrite,
+    ])
+}
+
+fn next_temp_dir() -> PathBuf {
+    let id = HARNESS_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let temp_dir =
+        std::env::temp_dir().join(format!("loongclaw-integ-{}-{id}", std::process::id()));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    temp_dir
+}
+
+fn default_tool_runtime_config(temp_dir: PathBuf) -> ToolRuntimeConfig {
+    ToolRuntimeConfig {
+        shell_allow: BTreeSet::from(["echo".to_owned(), "cat".to_owned(), "ls".to_owned()]),
+        shell_deny: BTreeSet::new(),
+        shell_default_mode: crate::tools::shell_policy_ext::ShellPolicyDefault::Deny,
+        file_root: Some(temp_dir),
+        config_path: None,
+        external_skills: Default::default(),
+    }
 }
 
 impl Drop for TurnTestHarness {
@@ -209,8 +251,17 @@ mod tests {
             .build();
         assert_eq!(turn.assistant_text, "checking file");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "file.read");
-        assert_eq!(turn.tool_intents[0].args_json, json!({"path": "test.txt"}));
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
+        assert_eq!(
+            turn.tool_intents[0].args_json["arguments"],
+            json!({"path": "test.txt"})
+        );
+        assert!(
+            turn.tool_intents[0].args_json["lease"]
+                .as_str()
+                .is_some_and(|lease| !lease.is_empty())
+        );
         assert!(!turn.tool_intents[0].tool_call_id.is_empty());
     }
 
@@ -221,6 +272,8 @@ mod tests {
             .with_tool_call("file.read", json!({"path": "b.txt"}))
             .build();
         assert_eq!(turn.tool_intents.len(), 2);
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[1].tool_name, "tool.invoke");
         assert_ne!(
             turn.tool_intents[0].tool_call_id,
             turn.tool_intents[1].tool_call_id
@@ -236,6 +289,20 @@ mod tests {
                 .token
                 .allowed_capabilities
                 .contains(&Capability::InvokeTool)
+        );
+        assert!(
+            harness
+                .kernel_ctx
+                .token
+                .allowed_capabilities
+                .contains(&Capability::FilesystemRead)
+        );
+        assert!(
+            harness
+                .kernel_ctx
+                .token
+                .allowed_capabilities
+                .contains(&Capability::FilesystemWrite)
         );
         assert!(harness.temp_dir.exists());
     }
@@ -417,6 +484,171 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn integ_missing_filesystem_read_capability_denies_file_read() {
+        let harness = TurnTestHarness::with_capabilities(BTreeSet::from([Capability::InvokeTool]));
+
+        let turn = FakeProviderBuilder::new()
+            .with_tool_call("file.read", json!({"path": "anything.txt"}))
+            .build();
+        let result = harness.execute(&turn).await;
+
+        #[allow(clippy::wildcard_enum_match_arm)]
+        match result {
+            TurnResult::ToolDenied(reason) => {
+                assert!(
+                    reason.contains("FilesystemRead"),
+                    "expected FilesystemRead denial, got: {reason}"
+                );
+            }
+            other => panic!("expected ToolDenied, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn integ_missing_filesystem_write_capability_denies_file_write() {
+        let harness = TurnTestHarness::with_capabilities(BTreeSet::from([
+            Capability::InvokeTool,
+            Capability::FilesystemRead,
+        ]));
+
+        let turn = FakeProviderBuilder::new()
+            .with_tool_call(
+                "file.write",
+                json!({"path": "note.txt", "content": "hello"}),
+            )
+            .build();
+        let result = harness.execute(&turn).await;
+
+        #[allow(clippy::wildcard_enum_match_arm)]
+        match result {
+            TurnResult::ToolDenied(reason) => {
+                assert!(
+                    reason.contains("FilesystemWrite"),
+                    "expected FilesystemWrite denial, got: {reason}"
+                );
+            }
+            other => panic!("expected ToolDenied, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn integ_missing_filesystem_write_capability_denies_writeful_claw_import() {
+        let harness = TurnTestHarness::with_capabilities(BTreeSet::from([
+            Capability::InvokeTool,
+            Capability::FilesystemRead,
+        ]));
+
+        let turn = FakeProviderBuilder::new()
+            .with_tool_call(
+                "claw.import",
+                json!({
+                    "mode": "apply",
+                    "input_path": "imports/nanobot",
+                    "output_path": "loongclaw.toml"
+                }),
+            )
+            .build();
+        let result = harness.execute(&turn).await;
+
+        #[allow(clippy::wildcard_enum_match_arm)]
+        match result {
+            TurnResult::ToolDenied(reason) => {
+                assert!(
+                    reason.contains("FilesystemWrite"),
+                    "expected FilesystemWrite denial, got: {reason}"
+                );
+            }
+            other => panic!("expected ToolDenied, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn integ_tool_search_filters_results_to_current_capabilities() {
+        let harness = TurnTestHarness::with_capabilities(BTreeSet::from([Capability::InvokeTool]));
+
+        let turn = FakeProviderBuilder::new()
+            .with_tool_call("tool.search", json!({"query": "read file import config"}))
+            .build();
+        let result = harness.execute(&turn).await;
+
+        #[allow(clippy::wildcard_enum_match_arm)]
+        match result {
+            TurnResult::FinalText(text) => {
+                assert!(
+                    !text.contains("\"tool_id\":\"file.read\""),
+                    "file.read should be hidden without FilesystemRead: {text}"
+                );
+                assert!(
+                    !text.contains("\"tool_id\":\"file.write\""),
+                    "file.write should be hidden without FilesystemWrite: {text}"
+                );
+                assert!(
+                    !text.contains("\"tool_id\":\"claw.import\""),
+                    "claw.import should be hidden without filesystem access: {text}"
+                );
+            }
+            other => panic!("expected FinalText, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn integ_shell_exec_wrapped_policy_respects_default_deny() {
+        let harness = TurnTestHarness::new();
+
+        let turn = FakeProviderBuilder::new()
+            .with_tool_call("shell.exec", json!({"command": "pwd"}))
+            .build();
+        let result = harness.execute(&turn).await;
+
+        #[allow(clippy::wildcard_enum_match_arm)]
+        match result {
+            TurnResult::ToolDenied(reason) => {
+                assert!(
+                    reason.contains("not in the allow list"),
+                    "expected default-deny reason, got: {reason}"
+                );
+            }
+            other => panic!("expected ToolDenied, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn integ_shell_exec_wrapped_policy_denies_hard_blocked_commands_even_if_allowlisted() {
+        let temp_dir = next_temp_dir();
+        let harness = TurnTestHarness::with_capabilities_and_tool_config(
+            default_tool_capabilities(),
+            temp_dir.clone(),
+            ToolRuntimeConfig {
+                shell_allow: BTreeSet::from(["rm".to_owned()]),
+                shell_deny: BTreeSet::from(["rm".to_owned()]),
+                shell_default_mode: crate::tools::shell_policy_ext::ShellPolicyDefault::Deny,
+                file_root: Some(temp_dir),
+                config_path: None,
+                external_skills: Default::default(),
+            },
+        );
+
+        let turn = FakeProviderBuilder::new()
+            .with_tool_call(
+                "shell.exec",
+                json!({"command": "rm", "args": ["-rf", "/tmp/nope"]}),
+            )
+            .build();
+        let result = harness.execute(&turn).await;
+
+        #[allow(clippy::wildcard_enum_match_arm)]
+        match result {
+            TurnResult::ToolDenied(reason) => {
+                assert!(
+                    reason.contains("blocked by shell policy"),
+                    "expected shell policy hard deny, got: {reason}"
+                );
+            }
+            other => panic!("expected ToolDenied, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn integ_audit_captures_tool_plane_invocation() {
         let harness = TurnTestHarness::with_tool_config(
             BTreeSet::from([
@@ -472,12 +704,12 @@ mod tests {
         match result {
             TurnResult::ToolError(err) => {
                 assert!(
-                    err.contains("payload must be an object"),
-                    "expected 'payload must be an object' in error, got: {err}"
+                    err.contains("must be an object"),
+                    "expected object-shape error in response, got: {err}"
                 );
             }
             other => {
-                panic!("expected ToolError with 'payload must be an object', got: {other:?}");
+                panic!("expected ToolError with object-shape reason, got: {other:?}");
             }
         }
     }

--- a/crates/app/src/conversation/integration_tests.rs
+++ b/crates/app/src/conversation/integration_tests.rs
@@ -221,6 +221,8 @@ fn default_tool_runtime_config(temp_dir: PathBuf) -> ToolRuntimeConfig {
         file_root: Some(temp_dir),
         config_path: None,
         external_skills: Default::default(),
+        #[cfg(feature = "feishu-integration")]
+        feishu: None,
     }
 }
 
@@ -625,6 +627,8 @@ mod tests {
                 file_root: Some(temp_dir),
                 config_path: None,
                 external_skills: Default::default(),
+                #[cfg(feature = "feishu-integration")]
+                feishu: None,
             },
         );
 

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -18,13 +18,13 @@ mod turn_loop;
 mod turn_shared;
 
 pub use analytics::{
-    ConversationEventRecord, SafeLaneEventSummary, SafeLaneFinalStatus,
+    ConversationEventRecord, DiscoveryFirstEventSummary, SafeLaneEventSummary, SafeLaneFinalStatus,
     SafeLaneHealthSignalSnapshot, SafeLaneMetricsSnapshot, SafeLaneToolOutputSnapshot,
     TurnCheckpointEventSummary, TurnCheckpointFailureStep, TurnCheckpointProgressStatus,
     TurnCheckpointRecoveryAction, TurnCheckpointRepairManualReason, TurnCheckpointRepairPlan,
     TurnCheckpointSessionState, TurnCheckpointStage, build_turn_checkpoint_repair_plan,
-    parse_conversation_event, plan_turn_checkpoint_recovery, summarize_safe_lane_events,
-    summarize_turn_checkpoint_events,
+    parse_conversation_event, plan_turn_checkpoint_recovery, summarize_discovery_first_events,
+    summarize_safe_lane_events, summarize_turn_checkpoint_events,
 };
 pub use context_engine::{
     AssembledConversationContext, CONTEXT_ENGINE_API_VERSION, ContextEngineBootstrapResult,
@@ -56,6 +56,7 @@ pub use safe_lane_failure::{
     is_safe_lane_terminal_instability_failure_code,
 };
 pub use session_address::ConversationSessionAddress;
+pub use session_history::load_discovery_first_event_summary;
 pub use session_history::{load_safe_lane_event_summary, load_turn_checkpoint_event_summary};
 pub use turn_budget::SafeLaneFailureRouteReason;
 pub use turn_coordinator::ConversationTurnCoordinator;

--- a/crates/app/src/conversation/plan_executor.rs
+++ b/crates/app/src/conversation/plan_executor.rs
@@ -34,6 +34,7 @@ pub enum PlanRunFailure {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PlanNodeErrorKind {
+    ApprovalRequired,
     Retryable,
     PolicyDenied,
     NonRetryable,
@@ -46,6 +47,13 @@ pub struct PlanNodeError {
 }
 
 impl PlanNodeError {
+    pub fn approval_required(message: impl Into<String>) -> Self {
+        Self {
+            kind: PlanNodeErrorKind::ApprovalRequired,
+            message: message.into(),
+        }
+    }
+
     pub fn retryable(message: impl Into<String>) -> Self {
         Self {
             kind: PlanNodeErrorKind::Retryable,
@@ -238,8 +246,11 @@ impl PlanExecutor {
                             });
                             // Approval-required failures are terminal until the caller changes
                             // execution context, so retrying the same node cannot make progress.
-                            if normalized.kind == PlanNodeErrorKind::PolicyDenied
-                                || attempt == node.max_attempts
+                            if matches!(
+                                normalized.kind,
+                                PlanNodeErrorKind::PolicyDenied
+                                    | PlanNodeErrorKind::ApprovalRequired
+                            ) || attempt == node.max_attempts
                             {
                                 let elapsed_ms = started_at.elapsed().as_millis();
                                 return PlanRunReport {
@@ -482,6 +493,39 @@ mod tests {
         }
     }
 
+    struct ApprovalRequiredExecutor {
+        approval_node: String,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl ApprovalRequiredExecutor {
+        fn new(node_id: &str) -> Self {
+            Self {
+                approval_node: node_id.to_owned(),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PlanNodeExecutor for ApprovalRequiredExecutor {
+        async fn execute(&self, node: &PlanNode, attempt: u8) -> Result<(), PlanNodeError> {
+            self.calls
+                .lock()
+                .expect("calls lock")
+                .push(format!("{}#{attempt}", node.id));
+
+            if node.id == self.approval_node {
+                return Err(PlanNodeError::approval_required(format!(
+                    "approval required for {}",
+                    node.id
+                )));
+            }
+
+            Ok(())
+        }
+    }
+
     #[async_trait]
     impl PlanNodeExecutor for PolicyDeniedExecutor {
         async fn execute(&self, node: &PlanNode, attempt: u8) -> Result<(), PlanNodeError> {
@@ -674,6 +718,36 @@ mod tests {
                 );
             }
             other => panic!("expected policy-denied node failure, got: {other:?}"),
+        }
+
+        let calls = executor.calls.lock().expect("calls lock").clone();
+        assert_eq!(calls, vec!["n1#1".to_owned(), "n2#1".to_owned()]);
+        assert_eq!(report.attempts_used, 2);
+    }
+
+    #[tokio::test]
+    async fn executor_stops_retrying_after_approval_required_failure() {
+        let graph = sample_graph();
+        let executor = ApprovalRequiredExecutor::new("n2");
+        let report = PlanExecutor::execute(&graph, &executor).await;
+
+        #[allow(clippy::wildcard_enum_match_arm)]
+        match report.status {
+            PlanRunStatus::Failed(PlanRunFailure::NodeFailed {
+                node_id,
+                attempts_used,
+                last_error_kind,
+                ref last_error,
+            }) => {
+                assert_eq!(node_id, "n2");
+                assert_eq!(attempts_used, 1);
+                assert_eq!(last_error_kind, PlanNodeErrorKind::ApprovalRequired);
+                assert!(
+                    last_error.contains("approval required"),
+                    "expected approval-required reason, got: {last_error}"
+                );
+            }
+            other => panic!("expected approval-required node failure, got: {other:?}"),
         }
 
         let calls = executor.calls.lock().expect("calls lock").clone();

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -358,6 +358,8 @@ pub trait ConversationRuntime: Send + Sync {
     async fn request_turn(
         &self,
         config: &LoongClawConfig,
+        session_id: &str,
+        turn_id: &str,
         messages: &[Value],
         tool_view: &ToolView,
         kernel_ctx: Option<&KernelContext>,
@@ -591,11 +593,14 @@ where
     async fn request_turn(
         &self,
         config: &LoongClawConfig,
+        session_id: &str,
+        turn_id: &str,
         messages: &[Value],
         tool_view: &ToolView,
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<ProviderTurn> {
-        provider::request_turn_in_view(config, messages, tool_view, kernel_ctx).await
+        provider::request_turn_in_view(config, session_id, turn_id, messages, tool_view, kernel_ctx)
+            .await
     }
 
     async fn persist_turn(

--- a/crates/app/src/conversation/safe_lane_failure.rs
+++ b/crates/app/src/conversation/safe_lane_failure.rs
@@ -212,6 +212,10 @@ pub fn classify_safe_lane_plan_failure(
         PlanRunFailure::NodeFailed {
             last_error_kind, ..
         } => match last_error_kind {
+            PlanNodeErrorKind::ApprovalRequired => (
+                SafeLaneFailureCode::PlanNodePolicyDenied,
+                TurnFailureKind::PolicyDenied,
+            ),
             PlanNodeErrorKind::PolicyDenied => (
                 SafeLaneFailureCode::PlanNodePolicyDenied,
                 TurnFailureKind::PolicyDenied,
@@ -385,6 +389,20 @@ mod tests {
 
     #[test]
     fn classify_safe_lane_plan_failure_maps_node_and_static_failures() {
+        let approval_node = PlanRunFailure::NodeFailed {
+            node_id: "tool-approval".to_owned(),
+            attempts_used: 1,
+            last_error_kind: PlanNodeErrorKind::ApprovalRequired,
+            last_error: "approval required".to_owned(),
+        };
+        assert_eq!(
+            classify_safe_lane_plan_failure(&approval_node),
+            (
+                SafeLaneFailureCode::PlanNodePolicyDenied,
+                TurnFailureKind::PolicyDenied
+            )
+        );
+
         let retryable_node = PlanRunFailure::NodeFailed {
             node_id: "tool-1".to_owned(),
             attempts_used: 1,

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -14,7 +14,8 @@ use crate::memory;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 
 use super::analytics::{
-    SafeLaneEventSummary, TurnCheckpointEventSummary, summarize_safe_lane_events,
+    DiscoveryFirstEventSummary, SafeLaneEventSummary, TurnCheckpointEventSummary,
+    summarize_discovery_first_events, summarize_safe_lane_events,
     summarize_turn_checkpoint_history,
 };
 
@@ -106,6 +107,33 @@ pub async fn load_safe_lane_event_summary(
     {
         let _ = (session_id, limit, kernel_ctx);
         Err("safe-lane summary unavailable: memory-sqlite feature disabled".to_owned())
+    }
+}
+
+pub async fn load_discovery_first_event_summary(
+    session_id: &str,
+    limit: usize,
+    kernel_ctx: Option<&KernelContext>,
+    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+) -> CliResult<DiscoveryFirstEventSummary> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let assistant_contents = load_assistant_contents_from_session_window(
+            session_id,
+            limit,
+            kernel_ctx,
+            memory_config,
+        )
+        .await?;
+        Ok(summarize_discovery_first_events(
+            assistant_contents.iter().map(String::as_str),
+        ))
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (session_id, limit, kernel_ctx);
+        Err("discovery-first summary unavailable: memory-sqlite feature disabled".to_owned())
     }
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -3899,11 +3899,11 @@ async fn handle_turn_with_runtime_tool_search_raw_request_still_uses_followup_pr
             Some(&harness.kernel_ctx),
         )
         .await
-        .expect("raw tool-search turn should succeed");
+        .expect("tool search raw-output turn should succeed");
 
     assert!(
         reply.contains("[ok]"),
-        "raw-request mode should keep tool marker after followup, got: {reply}"
+        "raw-request mode should return the invoked tool output, got: {reply}"
     );
     assert!(
         reply.contains("hello from coordinator raw search followup test"),
@@ -12374,6 +12374,130 @@ async fn durable_turn_checkpoint_repair_persists_finalized_checkpoint_and_repeat
         Some(TurnCheckpointStage::Finalized)
     );
     assert!(!summary_after_second.requires_recovery);
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn repair_turn_checkpoint_tail_with_runtime_recovers_discovery_followup_checkpoint() {
+    use super::integration_tests::TurnTestHarness;
+
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "discovery-followup-repair")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 16;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+    config.conversation.compact_fail_open = false;
+
+    let session_id = "session-turn-checkpoint-discovery-followup-repair";
+    let user_input = "search for the right tool, then read and summarize note.md";
+    let final_reply = "Summary: the note says hello from discovery followup repair.";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    let harness = TurnTestHarness::new();
+    std::fs::write(
+        harness.temp_dir.join("note.md"),
+        "hello from discovery followup repair",
+    )
+    .expect("seed discovery followup repair note");
+
+    let failing_runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Let me search first.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({"query": "read note.md", "limit": 3}),
+                    session_id,
+                    "turn-discovery-followup-repair",
+                    "call-search-repair",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Now I'll read the file.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "file.read",
+                    json!({"path": "note.md"}),
+                    session_id,
+                    "turn-discovery-followup-repair",
+                    "call-invoke-repair",
+                )],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![Ok(final_reply.to_owned())],
+    )
+    .with_durable_memory_config(mem_config.clone())
+    .with_compact_result(Err("discovery followup compaction failed".to_owned()));
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let error = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            session_id,
+            user_input,
+            ProviderErrorMode::Propagate,
+            &failing_runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect_err("initial run should persist a failed checkpoint when compaction fails");
+    assert!(error.contains("discovery followup compaction failed"));
+
+    let summary_after_failure =
+        load_turn_checkpoint_event_summary(session_id, 32, None, &mem_config)
+            .await
+            .expect("load summary after failed discovery followup run");
+    assert!(summary_after_failure.requires_recovery);
+    assert_eq!(
+        plan_turn_checkpoint_recovery(&summary_after_failure),
+        TurnCheckpointRecoveryAction::RunCompaction
+    );
+
+    let retry_runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "user", "content": user_input}),
+            json!({"role": "assistant", "content": final_reply}),
+        ],
+        vec![],
+        vec![],
+    )
+    .with_durable_memory_config(mem_config.clone());
+
+    let repair = coordinator
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &retry_runtime, None)
+        .await
+        .expect("discovery followup checkpoint should remain repairable");
+    assert_eq!(repair.status().as_str(), "repaired");
+    assert_eq!(repair.action().as_str(), "run_compaction");
+    assert_eq!(repair.reason(), TurnCheckpointTailRepairReason::Repaired);
+    assert_eq!(
+        retry_runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .len(),
+        0,
+        "compaction-only retry should not rerun after_turn"
+    );
+    assert_eq!(
+        retry_runtime
+            .compact_calls
+            .lock()
+            .expect("compact lock")
+            .len(),
+        1
+    );
 
     let _ = std::fs::remove_file(&db_path);
 }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -38,7 +38,7 @@ struct FakeRuntime {
     assembled_context_without_system_prompt: Option<AssembledConversationContext>,
     tool_view_override: Option<crate::tools::ToolView>,
     completion_responses: Mutex<VecDeque<Result<String, String>>>,
-    turn_responses: Mutex<VecDeque<Result<ProviderTurn, String>>>,
+    turn_responses: Mutex<VecDeque<Result<FakeTurnResponse, String>>>,
     after_turn_result: Result<(), String>,
     compact_result: Result<(), String>,
     #[cfg(feature = "memory-sqlite")]
@@ -60,6 +60,11 @@ struct FakeRuntime {
     turn_calls: Mutex<usize>,
     after_turn_calls: Mutex<Vec<(String, String, String, usize)>>,
     compact_calls: Mutex<Vec<(String, usize)>>,
+}
+
+enum FakeTurnResponse {
+    Parsed(ProviderTurn),
+    RawBody(Value),
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -466,13 +471,37 @@ impl FakeRuntime {
         turns: Vec<Result<ProviderTurn, String>>,
         completions: Vec<Result<String, String>>,
     ) -> Self {
+        let turn_responses = turns
+            .into_iter()
+            .map(|turn| turn.map(FakeTurnResponse::Parsed))
+            .collect::<Vec<_>>();
+        Self::with_fake_turn_responses(seed_messages, turn_responses, completions)
+    }
+
+    fn with_turn_bodies_and_completions(
+        seed_messages: Vec<Value>,
+        bodies: Vec<Result<Value, String>>,
+        completions: Vec<Result<String, String>>,
+    ) -> Self {
+        let turn_responses = bodies
+            .into_iter()
+            .map(|body| body.map(FakeTurnResponse::RawBody))
+            .collect::<Vec<_>>();
+        Self::with_fake_turn_responses(seed_messages, turn_responses, completions)
+    }
+
+    fn with_fake_turn_responses(
+        seed_messages: Vec<Value>,
+        turn_responses: Vec<Result<FakeTurnResponse, String>>,
+        completions: Vec<Result<String, String>>,
+    ) -> Self {
         Self {
             seed_messages,
             assembled_context_with_system_prompt: None,
             assembled_context_without_system_prompt: None,
             tool_view_override: None,
             completion_responses: Mutex::new(VecDeque::from(completions)),
-            turn_responses: Mutex::new(VecDeque::from(turns)),
+            turn_responses: Mutex::new(VecDeque::from(turn_responses)),
             after_turn_result: Ok(()),
             compact_result: Ok(()),
             #[cfg(feature = "memory-sqlite")]
@@ -655,11 +684,6 @@ fn persisted_conversation_event_payloads_by_name(
         .collect()
 }
 
-fn provider_turn_from_body(body: Value, session_id: &str, turn_id: &str) -> ProviderTurn {
-    crate::provider::extract_provider_turn_with_scope(&body, Some(session_id), Some(turn_id))
-        .expect("provider body should parse into a turn")
-}
-
 fn assert_discovery_first_followup_summary(
     persisted: &[(String, String, String)],
     raw_tool_output_requested: bool,
@@ -709,20 +733,9 @@ async fn run_provider_shape_tool_search_followup(
     let harness = TurnTestHarness::new();
     std::fs::write(harness.temp_dir.join("note.md"), note_contents).expect("seed test note");
 
-    let runtime = FakeRuntime::with_turns_and_completions(
+    let runtime = FakeRuntime::with_turn_bodies_and_completions(
         vec![],
-        vec![
-            Ok(provider_turn_from_body(
-                first_body,
-                session_id,
-                &format!("{session_id}-provider-turn-0"),
-            )),
-            Ok(provider_turn_from_body(
-                second_body,
-                session_id,
-                &format!("{session_id}-provider-turn-1"),
-            )),
-        ],
+        vec![Ok(first_body), Ok(second_body)],
         vec![completion],
     );
 
@@ -1002,8 +1015,8 @@ impl ConversationRuntime for FakeRuntime {
     async fn request_turn(
         &self,
         config: &LoongClawConfig,
-        _session_id: &str,
-        _turn_id: &str,
+        session_id: &str,
+        turn_id: &str,
         messages: &[Value],
         tool_view: &crate::tools::ToolView,
         _kernel_ctx: Option<&KernelContext>,
@@ -1024,11 +1037,25 @@ impl ConversationRuntime for FakeRuntime {
             .expect("turn provider ids lock")
             .push(config.active_provider_id().unwrap_or_default().to_owned());
         drop(calls);
-        self.turn_responses
+        match self
+            .turn_responses
             .lock()
             .expect("turn response lock")
             .pop_front()
             .unwrap_or_else(|| Err("unexpected_turn_call".to_owned()))
+        {
+            Ok(FakeTurnResponse::Parsed(turn)) => Ok(turn),
+            Ok(FakeTurnResponse::RawBody(body)) => {
+                crate::provider::extract_provider_turn_with_scope_and_messages(
+                    &body,
+                    Some(session_id),
+                    Some(turn_id),
+                    messages,
+                )
+                .ok_or_else(|| "fake_runtime_failed_to_parse_provider_body".to_owned())
+            }
+            Err(error) => Err(error),
+        }
     }
 
     async fn persist_turn(
@@ -6638,8 +6665,8 @@ fn turn_engine_no_tool_intents_returns_final_text() {
 }
 
 #[test]
-fn provider_tool_aliases_flow_through_parse_and_turn_validation() {
-    use crate::conversation::turn_engine::{TurnEngine, TurnValidation};
+fn provider_direct_discoverable_alias_without_search_is_rejected() {
+    use crate::conversation::turn_engine::{TurnEngine, TurnFailureKind};
     use crate::provider::extract_provider_turn;
 
     let response_body = serde_json::json!({
@@ -6660,18 +6687,66 @@ fn provider_tool_aliases_flow_through_parse_and_turn_validation() {
 
     let turn = extract_provider_turn(&response_body).expect("provider turn");
     assert_eq!(turn.tool_intents.len(), 1);
-    assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
-    assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
-    assert_eq!(
-        turn.tool_intents[0].args_json["arguments"],
-        serde_json::json!({"path":"README.md"})
-    );
+    assert_eq!(turn.tool_intents[0].tool_name, "file.read");
 
     let engine = TurnEngine::new(1);
     let result = engine.validate_turn(&turn);
     match result {
-        Ok(TurnValidation::ToolExecutionRequired) => {}
-        other => panic!("expected ToolExecutionRequired, got {:?}", other),
+        Err(failure) => {
+            assert_eq!(failure.kind, TurnFailureKind::PolicyDenied);
+            assert_eq!(failure.code, "tool_not_found");
+            assert!(
+                !failure.reason.contains("file.read"),
+                "provider denial should not confirm guessed discoverable tool names: {failure:?}"
+            );
+        }
+        other => panic!("expected provider denial, got {:?}", other),
+    }
+}
+
+#[test]
+fn provider_hidden_tool_denial_does_not_leak_name() {
+    use crate::conversation::turn_engine::{
+        ProviderTurn, ToolIntent, TurnEngine, TurnFailureKind, TurnResult,
+    };
+
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "tool.invoke".to_owned(),
+            args_json: serde_json::json!({
+                "tool_id": "sessions_send",
+                "lease": "guessed.invalid",
+                "arguments": {"session_id": "child", "text": "hi"}
+            }),
+            source: "provider_tool_call".to_owned(),
+            session_id: "child-session".to_owned(),
+            turn_id: "turn-hidden".to_owned(),
+            tool_call_id: "call-hidden".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+
+    let engine = TurnEngine::new(1);
+    let result = engine.evaluate_turn_in_view(
+        &turn,
+        &crate::tools::ToolView::from_tool_names(["tool.search", "tool.invoke", "file.read"]),
+    );
+
+    match result {
+        TurnResult::ToolDenied(failure) => {
+            assert_eq!(failure.kind, TurnFailureKind::PolicyDenied);
+            assert_eq!(failure.code, "tool_not_found");
+            assert!(
+                !failure.reason.contains("sessions_send"),
+                "provider denial should not leak hidden tool ids: {failure:?}"
+            );
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected ToolDenied, got {:?}", other)
+        }
     }
 }
 
@@ -6800,10 +6875,14 @@ fn turn_engine_denies_known_tool_outside_restricted_view() {
     match result {
         TurnResult::ToolDenied(failure) => {
             assert_eq!(failure.kind, TurnFailureKind::PolicyDenied);
-            assert_eq!(failure.code, "tool_not_visible");
+            assert_eq!(failure.code, "tool_not_found");
             assert!(
-                failure.reason.contains("tool_not_visible"),
+                failure.reason.contains("tool_not_found"),
                 "failure={failure:?}"
+            );
+            assert!(
+                !failure.reason.contains("shell.exec"),
+                "provider denial should not leak hidden tool names: {failure:?}"
             );
         }
         other @ TurnResult::FinalText(_)
@@ -11460,8 +11539,12 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_by_defa
         .expect("nested delegate denial reply");
 
     assert!(
-        reply.contains("tool_not_visible: delegate"),
-        "reply should surface nested delegate denial, got: {reply}"
+        reply.contains("tool_not_found: requested tool is not available"),
+        "reply should surface generic nested delegate denial, got: {reply}"
+    );
+    assert!(
+        !reply.contains("tool_not_visible: delegate"),
+        "reply should not leak the nested delegate tool id in the denial reason, got: {reply}"
     );
 }
 
@@ -11587,12 +11670,16 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_b
     assert_eq!(waited.payload["wait_status"], "completed");
     assert_eq!(waited.payload["session"]["state"], "completed");
     assert_eq!(waited.payload["terminal_outcome"]["status"], "ok");
+    let final_output = waited.payload["terminal_outcome"]["payload"]["final_output"]
+        .as_str()
+        .expect("delegate child final output");
     assert!(
-        waited.payload["terminal_outcome"]["payload"]["final_output"]
-            .as_str()
-            .expect("delegate child final output")
-            .contains("tool_not_visible: delegate_async"),
-        "child terminal output should surface nested delegate_async denial, got: {waited:?}"
+        final_output.contains("tool_not_found: requested tool is not available"),
+        "child terminal output should surface generic nested delegate_async denial, got: {waited:?}"
+    );
+    assert!(
+        !final_output.contains("delegate_async"),
+        "child terminal output should not leak hidden delegate_async by name, got: {waited:?}"
     );
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use async_trait::async_trait;
-use loongclaw_contracts::{Capability, ExecutionRoute, HarnessKind, MemoryPlaneError};
+use loongclaw_contracts::{
+    Capability, ExecutionRoute, HarnessKind, MemoryPlaneError, ToolCoreRequest,
+};
 use loongclaw_kernel::{
     CoreMemoryAdapter, FixedClock, InMemoryAuditSink, LoongClawKernel, MemoryCoreOutcome,
     MemoryCoreRequest, StaticPolicyEngine, VerticalPackManifest,
@@ -1047,6 +1049,44 @@ fn test_kernel_context_with_memory(
     }
 }
 
+fn provider_tool_intent(
+    tool_name: &str,
+    args_json: Value,
+    session_id: &str,
+    turn_id: &str,
+    tool_call_id: &str,
+) -> ToolIntent {
+    let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call_with_scope(
+        tool_name,
+        args_json,
+        Some(session_id),
+        Some(turn_id),
+    );
+    ToolIntent {
+        tool_name,
+        args_json,
+        source: "provider_tool_call".to_owned(),
+        session_id: session_id.to_owned(),
+        turn_id: turn_id.to_owned(),
+        tool_call_id: tool_call_id.to_owned(),
+    }
+}
+
+fn effective_tool_request(request: &ToolCoreRequest) -> (String, &Value) {
+    let tool_name = crate::tools::canonical_tool_name(request.tool_name.as_str());
+    if tool_name != "tool.invoke" {
+        return (tool_name.to_owned(), &request.payload);
+    }
+    let invoked_tool = request
+        .payload
+        .get("tool_id")
+        .and_then(Value::as_str)
+        .map(crate::tools::canonical_tool_name)
+        .unwrap_or(tool_name)
+        .to_owned();
+    let arguments = request.payload.get("arguments").unwrap_or(&request.payload);
+    (invoked_tool, arguments)
+}
 #[tokio::test]
 async fn default_runtime_supports_injected_context_engine() {
     let runtime = DefaultConversationRuntime::with_context_engine(StubContextEngine);
@@ -3673,14 +3713,13 @@ async fn handle_turn_with_runtime_tool_turn_uses_natural_language_completion_by_
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Reading the file now.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-tool".to_owned(),
-                turn_id: "turn-tool".to_owned(),
-                tool_call_id: "call-tool".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-tool",
+                "turn-tool",
+                "call-tool",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("Summary: the note says hello from coordinator test.".to_owned()),
@@ -3736,14 +3775,13 @@ async fn handle_turn_with_runtime_tool_turn_raw_request_skips_second_pass_comple
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Reading the file now.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-tool-raw".to_owned(),
-                turn_id: "turn-tool-raw".to_owned(),
-                tool_call_id: "call-tool-raw".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-tool-raw",
+                "turn-tool-raw",
+                "call-tool-raw",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("this must not be used".to_owned()),
@@ -3881,14 +3919,13 @@ async fn handle_turn_with_runtime_honors_configured_tool_result_summary_limit_on
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Reading large note.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "large-note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-fast-limit".to_owned(),
-                turn_id: "turn-fast-limit".to_owned(),
-                tool_call_id: "call-fast-limit".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "large-note.md"}),
+                "session-fast-limit",
+                "turn-fast-limit",
+                "call-fast-limit",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -3953,14 +3990,13 @@ async fn handle_turn_with_runtime_honors_configured_tool_result_summary_limit_on
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Running deployment read checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "large-note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-limit".to_owned(),
-                turn_id: "turn-safe-limit".to_owned(),
-                tool_call_id: "call-safe-limit".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "large-note.md"}),
+                "session-safe-limit",
+                "turn-safe-limit",
+                "call-safe-limit",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -4021,22 +4057,20 @@ async fn handle_turn_with_runtime_safe_lane_honors_configured_tool_step_budget()
         Ok(ProviderTurn {
             assistant_text: "Executing deployment checks.".to_owned(),
             tool_intents: vec![
-                ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-safe-budget".to_owned(),
-                    turn_id: "turn-safe-budget".to_owned(),
-                    tool_call_id: "call-safe-budget-1".to_owned(),
-                },
-                ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "checklist.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-safe-budget".to_owned(),
-                    turn_id: "turn-safe-budget".to_owned(),
-                    tool_call_id: "call-safe-budget-2".to_owned(),
-                },
+                provider_tool_intent(
+                    "file.read",
+                    json!({"path": "note.md"}),
+                    "session-safe-budget",
+                    "turn-safe-budget",
+                    "call-safe-budget-1",
+                ),
+                provider_tool_intent(
+                    "file.read",
+                    json!({"path": "checklist.md"}),
+                    "session-safe-budget",
+                    "turn-safe-budget",
+                    "call-safe-budget-2",
+                ),
             ],
             raw_meta: Value::Null,
         }),
@@ -4076,22 +4110,20 @@ async fn handle_turn_with_runtime_safe_lane_plan_path_bypasses_turn_step_limit()
         Ok(ProviderTurn {
             assistant_text: "Executing deployment checks.".to_owned(),
             tool_intents: vec![
-                ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-safe-plan".to_owned(),
-                    turn_id: "turn-safe-plan".to_owned(),
-                    tool_call_id: "call-safe-plan-1".to_owned(),
-                },
-                ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "checklist.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-safe-plan".to_owned(),
-                    turn_id: "turn-safe-plan".to_owned(),
-                    tool_call_id: "call-safe-plan-2".to_owned(),
-                },
+                provider_tool_intent(
+                    "file.read",
+                    json!({"path": "note.md"}),
+                    "session-safe-plan",
+                    "turn-safe-plan",
+                    "call-safe-plan-1",
+                ),
+                provider_tool_intent(
+                    "file.read",
+                    json!({"path": "checklist.md"}),
+                    "session-safe-plan",
+                    "turn-safe-plan",
+                    "call-safe-plan-2",
+                ),
             ],
             raw_meta: Value::Null,
         }),
@@ -4131,14 +4163,13 @@ async fn handle_turn_with_runtime_safe_lane_plan_persists_runtime_events_when_en
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Executing deployment checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-events".to_owned(),
-                turn_id: "turn-safe-events".to_owned(),
-                tool_call_id: "call-safe-events-1".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-safe-events",
+                "turn-safe-events",
+                "call-safe-events-1",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -4257,14 +4288,13 @@ async fn handle_turn_with_runtime_safe_lane_plan_skips_runtime_events_when_disab
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Executing deployment checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-events-off".to_owned(),
-                turn_id: "turn-safe-events-off".to_owned(),
-                tool_call_id: "call-safe-events-off-1".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-safe-events-off",
+                "turn-safe-events-off",
+                "call-safe-events-off-1",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -4316,14 +4346,13 @@ async fn handle_turn_with_runtime_safe_lane_plan_emits_kernel_runtime_audit_even
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Executing deployment checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-audit-on".to_owned(),
-                turn_id: "turn-safe-audit-on".to_owned(),
-                tool_call_id: "call-safe-audit-on-1".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-safe-audit-on",
+                "turn-safe-audit-on",
+                "call-safe-audit-on-1",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -4407,14 +4436,13 @@ async fn handle_turn_with_runtime_safe_lane_plan_does_not_emit_kernel_runtime_au
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Executing deployment checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-audit-off".to_owned(),
-                turn_id: "turn-safe-audit-off".to_owned(),
-                tool_call_id: "call-safe-audit-off-1".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-safe-audit-off",
+                "turn-safe-audit-off",
+                "call-safe-audit-off-1",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -4474,6 +4502,7 @@ async fn handle_turn_with_runtime_safe_lane_plan_replans_after_transient_tool_fa
             &self,
             request: ToolCoreRequest,
         ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            let (tool_name, _arguments) = effective_tool_request(&request);
             let current_call = {
                 let mut calls = self.calls.lock().expect("flaky calls lock");
                 *calls = calls.saturating_add(1);
@@ -4487,7 +4516,7 @@ async fn handle_turn_with_runtime_safe_lane_plan_replans_after_transient_tool_fa
             Ok(ToolCoreOutcome {
                 status: "ok".to_owned(),
                 payload: json!({
-                    "tool": request.tool_name,
+                    "tool": tool_name,
                     "attempt": current_call
                 }),
             })
@@ -4508,7 +4537,7 @@ async fn handle_turn_with_runtime_safe_lane_plan_replans_after_transient_tool_fa
             adapter: None,
         },
         allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead]),
         metadata: BTreeMap::new(),
     };
     kernel.register_pack(pack).expect("register pack");
@@ -4531,14 +4560,13 @@ async fn handle_turn_with_runtime_safe_lane_plan_replans_after_transient_tool_fa
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Running checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-replan".to_owned(),
-                turn_id: "turn-safe-replan".to_owned(),
-                tool_call_id: "call-safe-replan-1".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-safe-replan",
+                "turn-safe-replan",
+                "call-safe-replan-1",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -4721,7 +4749,7 @@ async fn handle_turn_with_runtime_safe_lane_backpressure_guard_blocks_retry_stor
             adapter: None,
         },
         allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead]),
         metadata: BTreeMap::new(),
     };
     kernel.register_pack(pack).expect("register pack");
@@ -4744,14 +4772,13 @@ async fn handle_turn_with_runtime_safe_lane_backpressure_guard_blocks_retry_stor
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Running checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-backpressure".to_owned(),
-                turn_id: "turn-safe-backpressure".to_owned(),
-                tool_call_id: "call-safe-backpressure-1".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-safe-backpressure",
+                "turn-safe-backpressure",
+                "call-safe-backpressure-1",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -4863,7 +4890,7 @@ async fn handle_turn_with_runtime_safe_lane_verify_non_retryable_failure_skips_r
             adapter: None,
         },
         allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead]),
         metadata: BTreeMap::new(),
     };
     kernel.register_pack(pack).expect("register pack");
@@ -4886,14 +4913,13 @@ async fn handle_turn_with_runtime_safe_lane_verify_non_retryable_failure_skips_r
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Running checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-verify-nonretryable".to_owned(),
-                turn_id: "turn-safe-verify-nonretryable".to_owned(),
-                tool_call_id: "call-safe-verify-nonretryable-1".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-safe-verify-nonretryable",
+                "turn-safe-verify-nonretryable",
+                "call-safe-verify-nonretryable-1",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -5081,7 +5107,11 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_forces_no_replan() 
             adapter: None,
         },
         allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::MemoryRead]),
+        granted_capabilities: BTreeSet::from([
+            Capability::InvokeTool,
+            Capability::MemoryRead,
+            Capability::FilesystemRead,
+        ]),
         metadata: BTreeMap::new(),
     };
     kernel.register_pack(pack).expect("register pack");
@@ -5108,14 +5138,13 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_forces_no_replan() 
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Running checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-governor".to_owned(),
-                turn_id: "turn-safe-governor".to_owned(),
-                tool_call_id: "call-safe-governor-1".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-safe-governor",
+                "turn-safe-governor",
+                "call-safe-governor-1",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -5354,14 +5383,13 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_requests_extended_h
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Running checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-governor-window".to_owned(),
-                turn_id: "turn-safe-governor-window".to_owned(),
-                tool_call_id: "call-safe-governor-window-1".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-safe-governor-window",
+                "turn-safe-governor-window",
+                "call-safe-governor-window-1",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -5479,7 +5507,11 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_falls_back_to_confi
             adapter: None,
         },
         allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::MemoryRead]),
+        granted_capabilities: BTreeSet::from([
+            Capability::InvokeTool,
+            Capability::MemoryRead,
+            Capability::FilesystemRead,
+        ]),
         metadata: BTreeMap::new(),
     };
     kernel.register_pack(pack).expect("register pack");
@@ -5535,14 +5567,13 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_falls_back_to_confi
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Running checks.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-safe-governor-fallback".to_owned(),
-                turn_id: "turn-safe-governor-fallback".to_owned(),
-                tool_call_id: "call-safe-governor-fallback-1".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-safe-governor-fallback",
+                "turn-safe-governor-fallback",
+                "call-safe-governor-fallback-1",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -5619,8 +5650,8 @@ async fn handle_turn_with_runtime_safe_lane_replans_failed_subgraph_only() {
             &self,
             request: ToolCoreRequest,
         ) -> Result<ToolCoreOutcome, ToolPlaneError> {
-            let path = request
-                .payload
+            let (_tool_name, arguments) = effective_tool_request(&request);
+            let path = arguments
                 .get("path")
                 .and_then(Value::as_str)
                 .unwrap_or_default()
@@ -5666,7 +5697,7 @@ async fn handle_turn_with_runtime_safe_lane_replans_failed_subgraph_only() {
             adapter: None,
         },
         allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead]),
         metadata: BTreeMap::new(),
     };
     kernel.register_pack(pack).expect("register pack");
@@ -5690,22 +5721,20 @@ async fn handle_turn_with_runtime_safe_lane_replans_failed_subgraph_only() {
         Ok(ProviderTurn {
             assistant_text: "Running checks.".to_owned(),
             tool_intents: vec![
-                ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "note.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-safe-subgraph".to_owned(),
-                    turn_id: "turn-safe-subgraph".to_owned(),
-                    tool_call_id: "call-safe-subgraph-1".to_owned(),
-                },
-                ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "checklist.md"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-safe-subgraph".to_owned(),
-                    turn_id: "turn-safe-subgraph".to_owned(),
-                    tool_call_id: "call-safe-subgraph-2".to_owned(),
-                },
+                provider_tool_intent(
+                    "file.read",
+                    json!({"path": "note.md"}),
+                    "session-safe-subgraph",
+                    "turn-safe-subgraph",
+                    "call-safe-subgraph-1",
+                ),
+                provider_tool_intent(
+                    "file.read",
+                    json!({"path": "checklist.md"}),
+                    "session-safe-subgraph",
+                    "turn-safe-subgraph",
+                    "call-safe-subgraph-2",
+                ),
             ],
             raw_meta: Value::Null,
         }),
@@ -5754,14 +5783,13 @@ async fn handle_turn_with_runtime_tool_denial_returns_inline_reply_even_in_propa
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Reading the file now.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-denied".to_owned(),
-                turn_id: "turn-denied".to_owned(),
-                tool_call_id: "call-denied".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-denied",
+                "turn-denied",
+                "call-denied",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("MODEL_DENIED_REPLY".to_owned()),
@@ -5813,14 +5841,13 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Reading the file now.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!("not an object"),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-tool-error".to_owned(),
-                turn_id: "turn-tool-error".to_owned(),
-                tool_call_id: "call-tool-error".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!("not an object"),
+                "session-tool-error",
+                "turn-tool-error",
+                "call-tool-error",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("MODEL_ERROR_REPLY".to_owned()),
@@ -5870,14 +5897,13 @@ async fn handle_turn_with_runtime_tool_failure_completion_error_uses_raw_reason_
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Reading the file now.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "file.read".to_owned(),
-                args_json: json!({"path": "note.md"}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-denied-fallback".to_owned(),
-                turn_id: "turn-denied-fallback".to_owned(),
-                tool_call_id: "call-denied-fallback".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-denied-fallback",
+                "turn-denied-fallback",
+                "call-denied-fallback",
+            )],
             raw_meta: Value::Null,
         }),
         Err("completion_unavailable".to_owned()),
@@ -5962,7 +5988,7 @@ fn turn_engine_no_tool_intents_returns_final_text() {
 
 #[test]
 fn provider_tool_aliases_flow_through_parse_and_turn_validation() {
-    use crate::conversation::turn_engine::{TurnEngine, TurnValidation};
+    use crate::conversation::turn_engine::TurnEngine;
     use crate::provider::extract_provider_turn;
 
     let response_body = serde_json::json!({
@@ -5988,7 +6014,12 @@ fn provider_tool_aliases_flow_through_parse_and_turn_validation() {
     let engine = TurnEngine::new(1);
     let result = engine.validate_turn(&turn);
     match result {
-        Ok(TurnValidation::ToolExecutionRequired) => {}
+        Err(reason) => {
+            assert!(
+                reason.contains("tool_not_provider_exposed"),
+                "reason: {reason}"
+            );
+        }
         other => panic!("expected ToolDenied, got {:?}", other),
     }
 }
@@ -6050,16 +6081,9 @@ fn turn_engine_unknown_tool_exposes_structured_policy_denial() {
 
 #[test]
 fn turn_engine_exceeding_max_steps_returns_denied() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine};
+    use crate::conversation::turn_engine::{ProviderTurn, TurnEngine};
     let engine = TurnEngine::new(1);
-    let intent = ToolIntent {
-        tool_name: "file.read".to_owned(),
-        args_json: serde_json::json!({}),
-        source: "provider_tool_call".to_owned(),
-        session_id: "s1".to_owned(),
-        turn_id: "t1".to_owned(),
-        tool_call_id: "c1".to_owned(),
-    };
+    let intent = provider_tool_intent("file.read", serde_json::json!({}), "s1", "t1", "c1");
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
         tool_intents: vec![intent.clone(), intent],
@@ -6077,18 +6101,17 @@ fn turn_engine_exceeding_max_steps_returns_denied() {
 
 #[test]
 fn turn_engine_known_tool_validates_to_execution_required() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnValidation};
+    use crate::conversation::turn_engine::{ProviderTurn, TurnEngine, TurnValidation};
     let engine = TurnEngine::new(1);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
-        tool_intents: vec![ToolIntent {
-            tool_name: "file.read".to_owned(),
-            args_json: serde_json::json!({"path": "test.txt"}),
-            source: "provider_tool_call".to_owned(),
-            session_id: "s1".to_owned(),
-            turn_id: "t1".to_owned(),
-            tool_call_id: "c1".to_owned(),
-        }],
+        tool_intents: vec![provider_tool_intent(
+            "file.read",
+            serde_json::json!({"path": "test.txt"}),
+            "s1",
+            "t1",
+            "c1",
+        )],
         raw_meta: serde_json::Value::Null,
     };
     let result = engine.validate_turn(&turn);
@@ -6177,14 +6200,13 @@ async fn turn_engine_routes_app_tools_through_dispatcher() {
     let engine = TurnEngine::new(1);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
-        tool_intents: vec![ToolIntent {
-            tool_name: "sessions_list".to_owned(),
-            args_json: json!({}),
-            source: "provider_tool_call".to_owned(),
-            session_id: "root-session".to_owned(),
-            turn_id: "turn-app-1".to_owned(),
-            tool_call_id: "call-app-1".to_owned(),
-        }],
+        tool_intents: vec![provider_tool_intent(
+            "sessions_list",
+            json!({}),
+            "root-session",
+            "turn-app-1",
+            "call-app-1",
+        )],
         raw_meta: Value::Null,
     };
     let session_context = crate::conversation::SessionContext::root_with_tool_view(
@@ -6526,9 +6548,7 @@ async fn sessions_send_rejects_delegate_child_target() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn turn_engine_tool_execution_error_is_marked_retryable() {
-    use crate::conversation::turn_engine::{
-        ProviderTurn, ToolIntent, TurnEngine, TurnFailureKind, TurnResult,
-    };
+    use crate::conversation::turn_engine::{ProviderTurn, TurnEngine, TurnFailureKind, TurnResult};
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
     use loongclaw_kernel::CoreToolAdapter;
 
@@ -6561,7 +6581,7 @@ async fn turn_engine_tool_execution_error_is_marked_retryable() {
             adapter: None,
         },
         allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead]),
         metadata: BTreeMap::new(),
     };
     kernel.register_pack(pack).expect("register pack");
@@ -6582,14 +6602,13 @@ async fn turn_engine_tool_execution_error_is_marked_retryable() {
     let engine = TurnEngine::new(1);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
-        tool_intents: vec![ToolIntent {
-            tool_name: "file.read".to_owned(),
-            args_json: json!({"path": "test.txt"}),
-            source: "provider_tool_call".to_owned(),
-            session_id: "s1".to_owned(),
-            turn_id: "t1".to_owned(),
-            tool_call_id: "c1".to_owned(),
-        }],
+        tool_intents: vec![provider_tool_intent(
+            "file.read",
+            json!({"path": "test.txt"}),
+            "s1",
+            "t1",
+            "c1",
+        )],
         raw_meta: serde_json::Value::Null,
     };
 
@@ -6648,6 +6667,14 @@ fn kernel_error_classification_table_is_stable() {
         KernelFailureClass::RetryableExecution
     );
 
+    let policy_wrapped_tool_error = KernelError::ToolPlane(ToolPlaneError::Execution(
+        "policy_denied: blocked".to_owned(),
+    ));
+    assert_eq!(
+        classify_kernel_error(&policy_wrapped_tool_error),
+        KernelFailureClass::PolicyDenied
+    );
+
     let non_retryable_tool_error = KernelError::ToolPlane(ToolPlaneError::NoDefaultCoreAdapter);
     assert_eq!(
         classify_kernel_error(&non_retryable_tool_error),
@@ -6664,7 +6691,7 @@ fn kernel_error_classification_table_is_stable() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn turn_engine_executes_known_tool_with_kernel() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+    use crate::conversation::turn_engine::{ProviderTurn, TurnEngine, TurnResult};
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
     use loongclaw_kernel::CoreToolAdapter;
 
@@ -6680,10 +6707,11 @@ async fn turn_engine_executes_known_tool_with_kernel() {
             &self,
             request: ToolCoreRequest,
         ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            let (tool_name, arguments) = effective_tool_request(&request);
             // Echo back the tool name and payload
             Ok(ToolCoreOutcome {
                 status: "ok".to_owned(),
-                payload: json!({"tool": request.tool_name, "input": request.payload}),
+                payload: json!({"tool": tool_name, "input": arguments}),
             })
         }
     }
@@ -6701,7 +6729,7 @@ async fn turn_engine_executes_known_tool_with_kernel() {
             adapter: None,
         },
         allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead]),
         metadata: BTreeMap::new(),
     };
     kernel.register_pack(pack).expect("register pack");
@@ -6722,14 +6750,13 @@ async fn turn_engine_executes_known_tool_with_kernel() {
     let engine = TurnEngine::new(5);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
-        tool_intents: vec![ToolIntent {
-            tool_name: "file.read".to_owned(),
-            args_json: json!({"path": "test.txt"}),
-            source: "provider_tool_call".to_owned(),
-            session_id: "s1".to_owned(),
-            turn_id: "t1".to_owned(),
-            tool_call_id: "c1".to_owned(),
-        }],
+        tool_intents: vec![provider_tool_intent(
+            "file.read",
+            json!({"path": "test.txt"}),
+            "s1",
+            "t1",
+            "c1",
+        )],
         raw_meta: serde_json::Value::Null,
     };
 
@@ -6783,7 +6810,7 @@ async fn turn_engine_executes_known_tool_with_kernel() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn turn_engine_truncates_oversized_tool_payload_summary() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+    use crate::conversation::turn_engine::{ProviderTurn, TurnEngine, TurnResult};
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
     use loongclaw_kernel::CoreToolAdapter;
 
@@ -6799,10 +6826,11 @@ async fn turn_engine_truncates_oversized_tool_payload_summary() {
             &self,
             request: ToolCoreRequest,
         ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            let (tool_name, _arguments) = effective_tool_request(&request);
             Ok(ToolCoreOutcome {
                 status: "ok".to_owned(),
                 payload: json!({
-                    "tool": request.tool_name,
+                    "tool": tool_name,
                     "blob": "x".repeat(10_000)
                 }),
             })
@@ -6822,7 +6850,7 @@ async fn turn_engine_truncates_oversized_tool_payload_summary() {
             adapter: None,
         },
         allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead]),
         metadata: BTreeMap::new(),
     };
     kernel.register_pack(pack).expect("register pack");
@@ -6843,14 +6871,13 @@ async fn turn_engine_truncates_oversized_tool_payload_summary() {
     let engine = TurnEngine::new(5);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
-        tool_intents: vec![ToolIntent {
-            tool_name: "file.read".to_owned(),
-            args_json: json!({"path": "test.txt"}),
-            source: "provider_tool_call".to_owned(),
-            session_id: "s1".to_owned(),
-            turn_id: "t1".to_owned(),
-            tool_call_id: "c-large".to_owned(),
-        }],
+        tool_intents: vec![provider_tool_intent(
+            "file.read",
+            json!({"path": "test.txt"}),
+            "s1",
+            "t1",
+            "c-large",
+        )],
         raw_meta: serde_json::Value::Null,
     };
 
@@ -6893,7 +6920,7 @@ async fn turn_engine_truncates_oversized_tool_payload_summary() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+    use crate::conversation::turn_engine::{ProviderTurn, TurnEngine, TurnResult};
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
     use loongclaw_kernel::CoreToolAdapter;
 
@@ -6909,10 +6936,11 @@ async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
             &self,
             request: ToolCoreRequest,
         ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            let (tool_name, _arguments) = effective_tool_request(&request);
             Ok(ToolCoreOutcome {
                 status: "ok".to_owned(),
                 payload: json!({
-                    "tool": request.tool_name,
+                    "tool": tool_name,
                     "instructions": "Follow the managed skill instruction. ".repeat(200),
                     "invocation_summary": "Loaded managed external skill instructions."
                 }),
@@ -6933,7 +6961,7 @@ async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
             adapter: None,
         },
         allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead]),
         metadata: BTreeMap::new(),
     };
     kernel.register_pack(pack).expect("register pack");
@@ -6954,14 +6982,13 @@ async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
     let engine = TurnEngine::new(5);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
-        tool_intents: vec![ToolIntent {
-            tool_name: "external_skills.invoke".to_owned(),
-            args_json: json!({"skill_id": "demo-skill"}),
-            source: "provider_tool_call".to_owned(),
-            session_id: "s1".to_owned(),
-            turn_id: "t1".to_owned(),
-            tool_call_id: "c-skill".to_owned(),
-        }],
+        tool_intents: vec![provider_tool_intent(
+            "external_skills.invoke",
+            json!({"skill_id": "demo-skill"}),
+            "s1",
+            "t1",
+            "c-skill",
+        )],
         raw_meta: serde_json::Value::Null,
     };
 
@@ -6993,7 +7020,7 @@ async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn turn_engine_execute_turn_denied_without_capability() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+    use crate::conversation::turn_engine::{ProviderTurn, TurnEngine, TurnResult};
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
     use loongclaw_kernel::CoreToolAdapter;
 
@@ -7051,14 +7078,13 @@ async fn turn_engine_execute_turn_denied_without_capability() {
     let engine = TurnEngine::new(5);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
-        tool_intents: vec![ToolIntent {
-            tool_name: "file.read".to_owned(),
-            args_json: json!({"path": "test.txt"}),
-            source: "provider_tool_call".to_owned(),
-            session_id: "s1".to_owned(),
-            turn_id: "t1".to_owned(),
-            tool_call_id: "c1".to_owned(),
-        }],
+        tool_intents: vec![provider_tool_intent(
+            "file.read",
+            json!({"path": "test.txt"}),
+            "s1",
+            "t1",
+            "c1",
+        )],
         raw_meta: serde_json::Value::Null,
     };
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -915,6 +915,8 @@ impl ConversationRuntime for FakeRuntime {
     async fn request_turn(
         &self,
         config: &LoongClawConfig,
+        _session_id: &str,
+        _turn_id: &str,
         messages: &[Value],
         tool_view: &crate::tools::ToolView,
         _kernel_ctx: Option<&KernelContext>,
@@ -3761,6 +3763,180 @@ async fn handle_turn_with_runtime_tool_turn_uses_natural_language_completion_by_
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_tool_search_requests_a_followup_provider_turn() {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    std::fs::write(
+        harness.temp_dir.join("note.md"),
+        "hello from coordinator search followup test",
+    )
+    .expect("seed test note");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Let me search for the right tool first.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({"query": "read note.md", "limit": 3}),
+                    "session-tool-search",
+                    "turn-tool-search",
+                    "call-tool-search",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Now I'll read the file.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "file.read",
+                    json!({"path": "note.md"}),
+                    "session-tool-search",
+                    "turn-tool-search",
+                    "call-tool-invoke",
+                )],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![Ok(
+            "Summary: the note says hello from coordinator search followup test.".to_owned(),
+        )],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-tool-search",
+            "search for the right tool, then read and summarize note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("tool search turn should succeed");
+
+    assert_eq!(
+        reply,
+        "Summary: the note says hello from coordinator search followup test."
+    );
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        1
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 2);
+    assert!(
+        requested_turn_messages[1].iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| content.starts_with("[tool_result]\n"))
+        }),
+        "second provider turn should receive tool-search followup context: {requested_turn_messages:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_tool_search_raw_request_still_uses_followup_provider_turn() {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    std::fs::write(
+        harness.temp_dir.join("note.md"),
+        "hello from coordinator raw search followup test",
+    )
+    .expect("seed test note");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Let me search for the right tool first.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({"query": "read note.md", "limit": 3}),
+                    "session-tool-search-raw",
+                    "turn-tool-search-raw",
+                    "call-tool-search-raw",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Now I'll read the file.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "file.read",
+                    json!({"path": "note.md"}),
+                    "session-tool-search-raw",
+                    "turn-tool-search-raw",
+                    "call-tool-invoke-raw",
+                )],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![Ok("this must not be used".to_owned())],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-tool-search-raw",
+            "search for the right tool, then read note.md and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("raw tool-search turn should succeed");
+
+    assert!(
+        reply.contains("[ok]"),
+        "raw-request mode should keep tool marker after followup, got: {reply}"
+    );
+    assert!(
+        reply.contains("hello from coordinator raw search followup test"),
+        "expected the second-round tool output, got: {reply}"
+    );
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 2);
+    assert!(
+        requested_turn_messages[1].iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| content.starts_with("[tool_result]\n"))
+        }),
+        "second provider turn should still receive tool-search followup context in raw mode: {requested_turn_messages:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn handle_turn_with_runtime_tool_turn_raw_request_skips_second_pass_completion() {
     use super::integration_tests::TurnTestHarness;
 
@@ -3812,6 +3988,89 @@ async fn handle_turn_with_runtime_tool_turn_raw_request_skips_second_pass_comple
         0
     );
     assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_tool_search_followup_checkpoint_uses_visible_context() {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    std::fs::write(
+        harness.temp_dir.join("note.md"),
+        "hello from coordinator search checkpoint test",
+    )
+    .expect("seed test note");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Let me search for the right tool first.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({"query": "read note.md", "limit": 3}),
+                    "session-tool-search-checkpoint",
+                    "turn-tool-search-checkpoint",
+                    "call-tool-search-checkpoint",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Now I'll read the file.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "file.read",
+                    json!({"path": "note.md"}),
+                    "session-tool-search-checkpoint",
+                    "turn-tool-search-checkpoint",
+                    "call-tool-invoke-checkpoint",
+                )],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![Ok(
+            "Summary: the note says hello from coordinator search checkpoint test.".to_owned(),
+        )],
+    );
+    let mut config = test_config();
+    config.conversation.compact_enabled = false;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-tool-search-checkpoint",
+            "search for the right tool, then read and summarize note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("tool-search checkpoint turn should succeed");
+
+    assert_eq!(
+        reply,
+        "Summary: the note says hello from coordinator search checkpoint test."
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(
+        payloads.len(),
+        2,
+        "expected post-persist and finalization-success events"
+    );
+    assert_eq!(payloads[0]["stage"], "post_persist");
+    assert_eq!(
+        payloads[0]["checkpoint"]["preparation"]["context_message_count"],
+        1
+    );
+    assert_eq!(
+        payloads[0]["checkpoint"]["preparation"]["context_fingerprint_sha256"],
+        test_turn_preparation_context_fingerprint(&[json!({
+            "role": "user",
+            "content": "search for the right tool, then read and summarize note.md"
+        })])
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -6009,14 +6268,19 @@ fn provider_tool_aliases_flow_through_parse_and_turn_validation() {
 
     let turn = extract_provider_turn(&response_body).expect("provider turn");
     assert_eq!(turn.tool_intents.len(), 1);
-    assert_eq!(turn.tool_intents[0].tool_name, "file.read");
+    assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+    assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
+    assert_eq!(
+        turn.tool_intents[0].args_json["arguments"],
+        serde_json::json!({"path":"README.md"})
+    );
 
     let engine = TurnEngine::new(1);
     let result = engine.validate_turn(&turn);
     match result {
         Err(reason) => {
             assert!(
-                reason.contains("tool_not_provider_exposed"),
+                reason.contains("kernel_context_required"),
                 "reason: {reason}"
             );
         }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -6743,6 +6743,7 @@ fn provider_hidden_tool_denial_does_not_leak_name() {
             );
         }
         other @ TurnResult::FinalText(_)
+        | other @ TurnResult::NeedsApproval(_)
         | other @ TurnResult::ToolError(_)
         | other @ TurnResult::ProviderError(_) => {
             panic!("expected ToolDenied, got {:?}", other)

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10157,17 +10157,16 @@ async fn handle_turn_with_runtime_requires_approval_before_delegate_execution() 
         vec![
             Ok(ProviderTurn {
                 assistant_text: "Delegating.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "delegate".to_owned(),
-                    args_json: json!({
+                tool_intents: vec![provider_tool_intent(
+                    "delegate",
+                    json!({
                         "task": "child task",
                         "label": "research-subtask"
                     }),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "root-session".to_owned(),
-                    turn_id: "turn-delegate-parent".to_owned(),
-                    tool_call_id: "call-delegate-parent".to_owned(),
-                }],
+                    "root-session",
+                    "turn-delegate-parent",
+                    "call-delegate-parent",
+                )],
                 raw_meta: Value::Null,
             }),
             Ok(ProviderTurn {
@@ -10419,17 +10418,16 @@ async fn handle_turn_with_runtime_approval_request_resolve_replays_delegate_for_
         vec![
             Ok(ProviderTurn {
                 assistant_text: "resolving approval".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "approval_request_resolve".to_owned(),
-                    args_json: json!({
+                tool_intents: vec![provider_tool_intent(
+                    "approval_request_resolve",
+                    json!({
                         "approval_request_id": "apr-delegate-1",
                         "decision": "approve_once"
                     }),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "root-session".to_owned(),
-                    turn_id: "turn-approval-resolve".to_owned(),
-                    tool_call_id: "call-approval-resolve".to_owned(),
-                }],
+                    "root-session",
+                    "turn-approval-resolve",
+                    "call-approval-resolve",
+                )],
                 raw_meta: Value::Null,
             }),
             Ok(ProviderTurn {
@@ -10562,17 +10560,16 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses
         vec![
             Ok(ProviderTurn {
                 assistant_text: "resolving approval".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "approval_request_resolve".to_owned(),
-                    args_json: json!({
+                tool_intents: vec![provider_tool_intent(
+                    "approval_request_resolve",
+                    json!({
                         "approval_request_id": "apr-delegate-always",
                         "decision": "approve_always"
                     }),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "root-session".to_owned(),
-                    turn_id: "turn-approval-resolve".to_owned(),
-                    tool_call_id: "call-approval-resolve".to_owned(),
-                }],
+                    "root-session",
+                    "turn-approval-resolve",
+                    "call-approval-resolve",
+                )],
                 raw_meta: Value::Null,
             }),
             Ok(ProviderTurn {
@@ -10626,17 +10623,16 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses
         vec![
             Ok(ProviderTurn {
                 assistant_text: "delegating with grant".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "delegate".to_owned(),
-                    args_json: json!({
+                tool_intents: vec![provider_tool_intent(
+                    "delegate",
+                    json!({
                         "task": "second child task",
                         "label": "granted-subtask"
                     }),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "root-session".to_owned(),
-                    turn_id: "turn-after-grant".to_owned(),
-                    tool_call_id: "call-after-grant".to_owned(),
-                }],
+                    "root-session",
+                    "turn-after-grant",
+                    "call-after-grant",
+                )],
                 raw_meta: Value::Null,
             }),
             Ok(ProviderTurn {
@@ -10737,17 +10733,16 @@ async fn handle_turn_with_runtime_approval_request_resolve_deny_does_not_replay_
         vec![
             Ok(ProviderTurn {
                 assistant_text: "denying approval".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "approval_request_resolve".to_owned(),
-                    args_json: json!({
+                tool_intents: vec![provider_tool_intent(
+                    "approval_request_resolve",
+                    json!({
                         "approval_request_id": "apr-delegate-deny",
                         "decision": "deny"
                     }),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "root-session".to_owned(),
-                    turn_id: "turn-approval-deny".to_owned(),
-                    tool_call_id: "call-approval-deny".to_owned(),
-                }],
+                    "root-session",
+                    "turn-approval-deny",
+                    "call-approval-deny",
+                )],
                 raw_meta: Value::Null,
             }),
             Ok(ProviderTurn {

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1167,7 +1167,10 @@ async fn default_runtime_build_messages_respects_restricted_tool_view() {
 
     assert!(!messages.is_empty());
     let system_content = messages[0]["content"].as_str().expect("system content");
-    assert!(system_content.contains("- file.read:"));
+    assert!(system_content.contains("- tool.search: Discover non-core tools"));
+    assert!(system_content.contains("- tool.invoke: Invoke a discovered non-core tool"));
+    assert!(system_content.contains("Non-core tools are intentionally hidden"));
+    assert!(!system_content.contains("- file.read:"));
     assert!(!system_content.contains("- file.write:"));
     assert!(!system_content.contains("- shell.exec:"));
 }
@@ -4114,17 +4117,16 @@ async fn handle_turn_with_runtime_provider_switch_tool_updates_provider_for_foll
         vec![],
         vec![Ok(ProviderTurn {
             assistant_text: "Switching provider.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "provider_switch".to_owned(),
-                args_json: json!({
+            tool_intents: vec![provider_tool_intent(
+                "provider.switch",
+                json!({
                     "selector": "deepseek",
                     "config_path": canonical_config_path.display().to_string()
                 }),
-                source: "provider_tool_call".to_owned(),
-                session_id: "session-provider-switch".to_owned(),
-                turn_id: "turn-provider-switch-1".to_owned(),
-                tool_call_id: "call-provider-switch".to_owned(),
-            }],
+                "session-provider-switch",
+                "turn-provider-switch-1",
+                "call-provider-switch",
+            )],
             raw_meta: Value::Null,
         })],
         vec![Ok("DeepSeek is now active.".to_owned())],
@@ -9587,14 +9589,13 @@ async fn handle_turn_with_runtime_executes_session_tools_via_default_dispatcher(
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Listing sessions.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "sessions_list".to_owned(),
-                args_json: json!({}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "root-session".to_owned(),
-                turn_id: "turn-session-tools".to_owned(),
-                tool_call_id: "call-session-tools".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "sessions_list",
+                json!({}),
+                "root-session",
+                "turn-session-tools",
+                "call-session-tools",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -9670,17 +9671,16 @@ async fn handle_turn_with_runtime_executes_sessions_send_via_default_dispatcher(
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Sending to known session.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "sessions_send".to_owned(),
-                args_json: json!({
+            tool_intents: vec![provider_tool_intent(
+                "sessions_send",
+                json!({
                     "session_id": "telegram:123",
                     "text": "hello root channel"
                 }),
-                source: "provider_tool_call".to_owned(),
-                session_id: "controller-root".to_owned(),
-                turn_id: "turn-sessions-send".to_owned(),
-                tool_call_id: "call-sessions-send".to_owned(),
-            }],
+                "controller-root",
+                "turn-sessions-send",
+                "call-sessions-send",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -9871,17 +9871,16 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
         vec![
             Ok(ProviderTurn {
                 assistant_text: "Delegating.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "delegate".to_owned(),
-                    args_json: json!({
+                tool_intents: vec![provider_tool_intent(
+                    "delegate",
+                    json!({
                         "task": "child task",
                         "label": "research-subtask"
                     }),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "root-session".to_owned(),
-                    turn_id: "turn-delegate-parent".to_owned(),
-                    tool_call_id: "call-delegate-parent".to_owned(),
-                }],
+                    "root-session",
+                    "turn-delegate-parent",
+                    "call-delegate-parent",
+                )],
                 raw_meta: Value::Null,
             }),
             Ok(ProviderTurn {
@@ -10466,17 +10465,16 @@ async fn handle_turn_with_runtime_delegate_async_queue_failure_rolls_back_child_
         vec![],
         vec![Ok(ProviderTurn {
             assistant_text: "Delegating async.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "delegate_async".to_owned(),
-                args_json: json!({
+            tool_intents: vec![provider_tool_intent(
+                "delegate_async",
+                json!({
                     "task": "child async task",
                     "label": "async-child"
                 }),
-                source: "provider_tool_call".to_owned(),
-                session_id: "root-session".to_owned(),
-                turn_id: "turn-delegate-async-parent".to_owned(),
-                tool_call_id: "call-delegate-async-parent".to_owned(),
-            }],
+                "root-session",
+                "turn-delegate-async-parent",
+                "call-delegate-async-parent",
+            )],
             raw_meta: Value::Null,
         })],
         vec![],
@@ -10545,18 +10543,17 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
         vec![],
         vec![Ok(ProviderTurn {
             assistant_text: "Delegating async.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "delegate_async".to_owned(),
-                args_json: json!({
+            tool_intents: vec![provider_tool_intent(
+                "delegate_async",
+                json!({
                     "task": "child async task",
                     "label": "async-child",
                     "timeout_seconds": 9
                 }),
-                source: "provider_tool_call".to_owned(),
-                session_id: "root-session".to_owned(),
-                turn_id: "turn-delegate-async-parent".to_owned(),
-                tool_call_id: "call-delegate-async-parent".to_owned(),
-            }],
+                "root-session",
+                "turn-delegate-async-parent",
+                "call-delegate-async-parent",
+            )],
             raw_meta: Value::Null,
         })],
         vec![],
@@ -10678,17 +10675,16 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_is_observable_aft
         vec![],
         vec![Ok(ProviderTurn {
             assistant_text: "Delegating async.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "delegate_async".to_owned(),
-                args_json: json!({
+            tool_intents: vec![provider_tool_intent(
+                "delegate_async",
+                json!({
                     "task": "child async task",
                     "label": "async-child"
                 }),
-                source: "provider_tool_call".to_owned(),
-                session_id: "root-session".to_owned(),
-                turn_id: "turn-delegate-async-parent".to_owned(),
-                tool_call_id: "call-delegate-async-parent".to_owned(),
-            }],
+                "root-session",
+                "turn-delegate-async-parent",
+                "call-delegate-async-parent",
+            )],
             raw_meta: Value::Null,
         })],
         vec![],
@@ -10794,17 +10790,16 @@ async fn handle_turn_with_runtime_delegate_async_spawn_panic_is_observable_after
         vec![],
         vec![Ok(ProviderTurn {
             assistant_text: "Delegating async.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "delegate_async".to_owned(),
-                args_json: json!({
+            tool_intents: vec![provider_tool_intent(
+                "delegate_async",
+                json!({
                     "task": "child async task",
                     "label": "async-child"
                 }),
-                source: "provider_tool_call".to_owned(),
-                session_id: "root-session".to_owned(),
-                turn_id: "turn-delegate-async-parent".to_owned(),
-                tool_call_id: "call-delegate-async-parent".to_owned(),
-            }],
+                "root-session",
+                "turn-delegate-async-parent",
+                "call-delegate-async-parent",
+            )],
             raw_meta: Value::Null,
         })],
         vec![],
@@ -10918,17 +10913,16 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_persistence_recov
         vec![],
         vec![Ok(ProviderTurn {
             assistant_text: "Delegating async.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "delegate_async".to_owned(),
-                args_json: json!({
+            tool_intents: vec![provider_tool_intent(
+                "delegate_async",
+                json!({
                     "task": "child async task",
                     "label": "async-child"
                 }),
-                source: "provider_tool_call".to_owned(),
-                session_id: "root-session".to_owned(),
-                turn_id: "turn-delegate-async-parent".to_owned(),
-                tool_call_id: "call-delegate-async-parent".to_owned(),
-            }],
+                "root-session",
+                "turn-delegate-async-parent",
+                "call-delegate-async-parent",
+            )],
             raw_meta: Value::Null,
         })],
         vec![],
@@ -11042,31 +11036,29 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_by_defa
         vec![
             Ok(ProviderTurn {
                 assistant_text: "Delegating.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "delegate".to_owned(),
-                    args_json: json!({
+                tool_intents: vec![provider_tool_intent(
+                    "delegate",
+                    json!({
                         "task": "show raw json tool output",
                         "label": "nested-child"
                     }),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "root-session".to_owned(),
-                    turn_id: "turn-delegate-parent".to_owned(),
-                    tool_call_id: "call-delegate-parent".to_owned(),
-                }],
+                    "root-session",
+                    "turn-delegate-parent",
+                    "call-delegate-parent",
+                )],
                 raw_meta: Value::Null,
             }),
             Ok(ProviderTurn {
                 assistant_text: "Trying nested delegate.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "delegate".to_owned(),
-                    args_json: json!({
+                tool_intents: vec![provider_tool_intent(
+                    "delegate",
+                    json!({
                         "task": "nested"
                     }),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "delegate:child".to_owned(),
-                    turn_id: "turn-delegate-child".to_owned(),
-                    tool_call_id: "call-delegate-child".to_owned(),
-                }],
+                    "delegate:child",
+                    "turn-delegate-child",
+                    "call-delegate-child",
+                )],
                 raw_meta: Value::Null,
             }),
         ],
@@ -11127,31 +11119,29 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_b
             vec![
                 Ok(ProviderTurn {
                     assistant_text: "Delegating async.".to_owned(),
-                    tool_intents: vec![ToolIntent {
-                        tool_name: "delegate_async".to_owned(),
-                        args_json: json!({
+                    tool_intents: vec![provider_tool_intent(
+                        "delegate_async",
+                        json!({
                             "task": "show raw json tool output",
                             "label": "nested-child"
                         }),
-                        source: "provider_tool_call".to_owned(),
-                        session_id: "root-session".to_owned(),
-                        turn_id: "turn-delegate-async-parent".to_owned(),
-                        tool_call_id: "call-delegate-async-parent".to_owned(),
-                    }],
+                        "root-session",
+                        "turn-delegate-async-parent",
+                        "call-delegate-async-parent",
+                    )],
                     raw_meta: Value::Null,
                 }),
                 Ok(ProviderTurn {
                     assistant_text: "Trying nested async delegate.".to_owned(),
-                    tool_intents: vec![ToolIntent {
-                        tool_name: "delegate_async".to_owned(),
-                        args_json: json!({
+                    tool_intents: vec![provider_tool_intent(
+                        "delegate_async",
+                        json!({
                             "task": "nested"
                         }),
-                        source: "provider_tool_call".to_owned(),
-                        session_id: "delegate:child".to_owned(),
-                        turn_id: "turn-delegate-async-child".to_owned(),
-                        tool_call_id: "call-delegate-async-child".to_owned(),
-                    }],
+                        "delegate:child",
+                        "turn-delegate-async-child",
+                        "call-delegate-async-child",
+                    )],
                     raw_meta: Value::Null,
                 }),
             ],
@@ -11255,32 +11245,30 @@ async fn handle_turn_with_runtime_delegate_child_can_reenter_when_max_depth_allo
         vec![
             Ok(ProviderTurn {
                 assistant_text: "Delegating from root.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "delegate".to_owned(),
-                    args_json: json!({
+                tool_intents: vec![provider_tool_intent(
+                    "delegate",
+                    json!({
                         "task": "show raw json tool output",
                         "label": "child"
                     }),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "root-session".to_owned(),
-                    turn_id: "turn-root".to_owned(),
-                    tool_call_id: "call-root".to_owned(),
-                }],
+                    "root-session",
+                    "turn-root",
+                    "call-root",
+                )],
                 raw_meta: Value::Null,
             }),
             Ok(ProviderTurn {
                 assistant_text: "Delegating from child.".to_owned(),
-                tool_intents: vec![ToolIntent {
-                    tool_name: "delegate".to_owned(),
-                    args_json: json!({
+                tool_intents: vec![provider_tool_intent(
+                    "delegate",
+                    json!({
                         "task": "final grandchild task",
                         "label": "grandchild"
                     }),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "delegate:child-runtime".to_owned(),
-                    turn_id: "turn-child".to_owned(),
-                    tool_call_id: "call-child".to_owned(),
-                }],
+                    "delegate:child-runtime",
+                    "turn-child",
+                    "call-child",
+                )],
                 raw_meta: Value::Null,
             }),
             Ok(ProviderTurn {
@@ -11381,17 +11369,16 @@ async fn handle_turn_with_runtime_executes_session_wait_via_default_dispatcher()
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Waiting for session completion.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "session_wait".to_owned(),
-                args_json: json!({
+            tool_intents: vec![provider_tool_intent(
+                "session_wait",
+                json!({
                     "session_id": "child-session",
                     "timeout_ms": 50
                 }),
-                source: "provider_tool_call".to_owned(),
-                session_id: "root-session".to_owned(),
-                turn_id: "turn-session-wait".to_owned(),
-                tool_call_id: "call-session-wait".to_owned(),
-            }],
+                "root-session",
+                "turn-session-wait",
+                "call-session-wait",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -11460,14 +11447,13 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_d
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Listing sessions safely.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "sessions_list".to_owned(),
-                args_json: json!({}),
-                source: "provider_tool_call".to_owned(),
-                session_id: "root-session".to_owned(),
-                turn_id: "turn-safe-session-tools".to_owned(),
-                tool_call_id: "call-safe-session-tools".to_owned(),
-            }],
+            tool_intents: vec![provider_tool_intent(
+                "sessions_list",
+                json!({}),
+                "root-session",
+                "turn-safe-session-tools",
+                "call-safe-session-tools",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -11540,17 +11526,16 @@ async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_d
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Sending to known session safely.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "sessions_send".to_owned(),
-                args_json: json!({
+            tool_intents: vec![provider_tool_intent(
+                "sessions_send",
+                json!({
                     "session_id": "telegram:123",
                     "text": "hello safe lane"
                 }),
-                source: "provider_tool_call".to_owned(),
-                session_id: "controller-root".to_owned(),
-                turn_id: "turn-safe-sessions-send".to_owned(),
-                tool_call_id: "call-safe-sessions-send".to_owned(),
-            }],
+                "controller-root",
+                "turn-safe-sessions-send",
+                "call-safe-sessions-send",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),
@@ -11640,17 +11625,16 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_wait_via_default_di
         vec![],
         Ok(ProviderTurn {
             assistant_text: "Waiting for session completion safely.".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name: "session_wait".to_owned(),
-                args_json: json!({
+            tool_intents: vec![provider_tool_intent(
+                "session_wait",
+                json!({
                     "session_id": "child-session",
                     "timeout_ms": 50
                 }),
-                source: "provider_tool_call".to_owned(),
-                session_id: "root-session".to_owned(),
-                turn_id: "turn-safe-session-wait".to_owned(),
-                tool_call_id: "call-safe-session-wait".to_owned(),
-            }],
+                "root-session",
+                "turn-safe-session-wait",
+                "call-safe-session-wait",
+            )],
             raw_meta: Value::Null,
         }),
         Ok("unused".to_owned()),

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -6249,7 +6249,7 @@ fn turn_engine_no_tool_intents_returns_final_text() {
 
 #[test]
 fn provider_tool_aliases_flow_through_parse_and_turn_validation() {
-    use crate::conversation::turn_engine::TurnEngine;
+    use crate::conversation::turn_engine::{TurnEngine, TurnValidation};
     use crate::provider::extract_provider_turn;
 
     let response_body = serde_json::json!({
@@ -6280,13 +6280,8 @@ fn provider_tool_aliases_flow_through_parse_and_turn_validation() {
     let engine = TurnEngine::new(1);
     let result = engine.validate_turn(&turn);
     match result {
-        Err(reason) => {
-            assert!(
-                reason.contains("kernel_context_required"),
-                "reason: {reason}"
-            );
-        }
-        other => panic!("expected ToolDenied, got {:?}", other),
+        Ok(TurnValidation::ToolExecutionRequired) => {}
+        other => panic!("expected ToolExecutionRequired, got {:?}", other),
     }
 }
 
@@ -12457,9 +12452,18 @@ async fn repair_turn_checkpoint_tail_with_runtime_recovers_discovery_followup_ch
         vec![],
     )
     .with_durable_memory_config(mem_config.clone());
+    let kernel_ctx = test_kernel_context_with_memory(
+        "test-turn-checkpoint-discovery-followup-repair",
+        &mem_config,
+    );
 
     let repair = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &retry_runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &retry_runtime,
+            Some(&kernel_ctx),
+        )
         .await
         .expect("discovery followup checkpoint should remain repairable");
     assert_eq!(repair.status().as_str(), "repaired");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -655,6 +655,93 @@ fn persisted_conversation_event_payloads_by_name(
         .collect()
 }
 
+fn provider_turn_from_body(body: Value, session_id: &str, turn_id: &str) -> ProviderTurn {
+    crate::provider::extract_provider_turn_with_scope(&body, Some(session_id), Some(turn_id))
+        .expect("provider body should parse into a turn")
+}
+
+fn assert_discovery_first_followup_summary(
+    persisted: &[(String, String, String)],
+    raw_tool_output_requested: bool,
+    expected_target_tool_id: &str,
+) {
+    let summary = super::analytics::summarize_discovery_first_events(
+        persisted
+            .iter()
+            .filter_map(|(_, role, content)| (role == "assistant").then_some(content.as_str())),
+    );
+    assert_eq!(summary.search_round_events, 1);
+    assert_eq!(summary.followup_requested_events, 1);
+    assert_eq!(summary.followup_result_events, 1);
+    assert_eq!(
+        summary.raw_output_followup_events,
+        u32::from(raw_tool_output_requested)
+    );
+    assert_eq!(summary.search_to_invoke_hits, 1);
+    assert_eq!(
+        summary.latest_followup_outcome.as_deref(),
+        Some("tool.invoke")
+    );
+    assert_eq!(
+        summary.latest_followup_tool_name.as_deref(),
+        Some("tool.invoke")
+    );
+    assert_eq!(
+        summary.latest_followup_target_tool_id.as_deref(),
+        Some(expected_target_tool_id)
+    );
+    assert!(
+        summary.aggregate_added_estimated_tokens > 0,
+        "follow-up telemetry should record a positive added token estimate: {summary:?}"
+    );
+}
+
+async fn run_provider_shape_tool_search_followup(
+    session_id: &str,
+    user_input: &str,
+    note_contents: &str,
+    first_body: Value,
+    second_body: Value,
+    completion: Result<String, String>,
+) -> (String, FakeRuntime) {
+    use super::integration_tests::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    std::fs::write(harness.temp_dir.join("note.md"), note_contents).expect("seed test note");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(provider_turn_from_body(
+                first_body,
+                session_id,
+                &format!("{session_id}-provider-turn-0"),
+            )),
+            Ok(provider_turn_from_body(
+                second_body,
+                session_id,
+                &format!("{session_id}-provider-turn-1"),
+            )),
+        ],
+        vec![completion],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            session_id,
+            user_input,
+            ProviderErrorMode::Propagate,
+            &runtime,
+            Some(&harness.kernel_ctx),
+        )
+        .await
+        .expect("provider-shape discovery-first followup should succeed");
+
+    (reply, runtime)
+}
+
 fn is_internal_assistant_record(content: &str) -> bool {
     serde_json::from_str::<Value>(content)
         .ok()
@@ -3937,6 +4024,309 @@ async fn handle_turn_with_runtime_tool_search_raw_request_still_uses_followup_pr
         }),
         "second provider turn should still receive tool-search followup context in raw mode: {requested_turn_messages:?}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_provider_shape_tool_search_followup_openai_chat_completions() {
+    let (reply, runtime) = run_provider_shape_tool_search_followup(
+        "session-provider-shape-openai",
+        "search for the right tool, then read and summarize note.md",
+        "hello from openai provider-shape discovery followup test",
+        json!({
+            "choices": [{
+                "message": {
+                    "content": "Let me search for the right tool first.",
+                    "tool_calls": [{
+                        "id": "call-openai-search",
+                        "type": "function",
+                        "function": {
+                            "name": "tool_search",
+                            "arguments": "{\"query\":\"read note.md\",\"limit\":3}"
+                        }
+                    }]
+                }
+            }]
+        }),
+        json!({
+            "choices": [{
+                "message": {
+                    "content": "Now I'll read the file.",
+                    "tool_calls": [{
+                        "id": "call-openai-read",
+                        "type": "function",
+                        "function": {
+                            "name": "file_read",
+                            "arguments": "{\"path\":\"note.md\"}"
+                        }
+                    }]
+                }
+            }]
+        }),
+        Ok(
+            "Summary: the note says hello from openai provider-shape discovery followup test."
+                .to_owned(),
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        reply,
+        "Summary: the note says hello from openai provider-shape discovery followup test."
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        1
+    );
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 2);
+    assert!(
+        requested_turn_messages[1].iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| content.starts_with("[tool_result]\n"))
+        }),
+        "second provider turn should receive tool-search followup context: {requested_turn_messages:?}"
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    assert_discovery_first_followup_summary(&persisted, false, "file.read");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_provider_shape_tool_search_followup_responses() {
+    let (reply, runtime) = run_provider_shape_tool_search_followup(
+        "session-provider-shape-responses",
+        "search for the right tool, then read and summarize note.md",
+        "hello from responses provider-shape discovery followup test",
+        json!({
+            "output": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Let me search for the right tool first."}
+                    ]
+                },
+                {
+                    "type": "function_call",
+                    "name": "tool_search",
+                    "arguments": "{\"query\":\"read note.md\",\"limit\":3}",
+                    "call_id": "call-responses-search"
+                }
+            ]
+        }),
+        json!({
+            "output": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Now I'll read the file."}
+                    ]
+                },
+                {
+                    "type": "function_call",
+                    "name": "file_read",
+                    "arguments": "{\"path\":\"note.md\"}",
+                    "call_id": "call-responses-read"
+                }
+            ]
+        }),
+        Ok(
+            "Summary: the note says hello from responses provider-shape discovery followup test."
+                .to_owned(),
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        reply,
+        "Summary: the note says hello from responses provider-shape discovery followup test."
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    assert_discovery_first_followup_summary(&persisted, false, "file.read");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_provider_shape_tool_search_followup_anthropic() {
+    let (reply, runtime) = run_provider_shape_tool_search_followup(
+        "session-provider-shape-anthropic",
+        "search for the right tool, then read and summarize note.md",
+        "hello from anthropic provider-shape discovery followup test",
+        json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Let me search for the right tool first."
+                },
+                {
+                    "type": "tool_use",
+                    "id": "toolu-search",
+                    "name": "tool_search",
+                    "input": {
+                        "query": "read note.md",
+                        "limit": 3
+                    }
+                }
+            ]
+        }),
+        json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Now I'll read the file."
+                },
+                {
+                    "type": "tool_use",
+                    "id": "toolu-read",
+                    "name": "file_read",
+                    "input": {
+                        "path": "note.md"
+                    }
+                }
+            ]
+        }),
+        Ok(
+            "Summary: the note says hello from anthropic provider-shape discovery followup test."
+                .to_owned(),
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        reply,
+        "Summary: the note says hello from anthropic provider-shape discovery followup test."
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    assert_discovery_first_followup_summary(&persisted, false, "file.read");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_provider_shape_tool_search_followup_bedrock() {
+    let (reply, runtime) = run_provider_shape_tool_search_followup(
+        "session-provider-shape-bedrock",
+        "search for the right tool, then read and summarize note.md",
+        "hello from bedrock provider-shape discovery followup test",
+        json!({
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "text": "Let me search for the right tool first."
+                        },
+                        {
+                            "toolUse": {
+                                "toolUseId": "toolu-search",
+                                "name": "tool_search",
+                                "input": {
+                                    "query": "read note.md",
+                                    "limit": 3
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "stopReason": "tool_use"
+        }),
+        json!({
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "text": "Now I'll read the file."
+                        },
+                        {
+                            "toolUse": {
+                                "toolUseId": "toolu-read",
+                                "name": "file_read",
+                                "input": {
+                                    "path": "note.md"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "stopReason": "tool_use"
+        }),
+        Ok(
+            "Summary: the note says hello from bedrock provider-shape discovery followup test."
+                .to_owned(),
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        reply,
+        "Summary: the note says hello from bedrock provider-shape discovery followup test."
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    assert_discovery_first_followup_summary(&persisted, false, "file.read");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_provider_shape_tool_search_followup_inline_raw_output() {
+    let (reply, runtime) = run_provider_shape_tool_search_followup(
+        "session-provider-shape-inline",
+        "search for the right tool, then read note.md and show raw json tool output",
+        "hello from inline provider-shape discovery followup raw test",
+        json!({
+            "choices": [{
+                "message": {
+                    "content": "Let me search for the right tool first.\n<function=tool_search><parameter=query>read note.md</parameter><parameter=limit>3</parameter></function>"
+                }
+            }]
+        }),
+        json!({
+            "choices": [{
+                "message": {
+                    "content": "Now I'll read the file.\n<function=file_read><parameter=path>note.md</parameter></function>"
+                }
+            }]
+        }),
+        Ok("unused completion".to_owned()),
+    )
+    .await;
+
+    assert!(
+        reply.contains("[ok]"),
+        "raw-request mode should return the invoked tool output, got: {reply}"
+    );
+    assert!(
+        reply.contains("hello from inline provider-shape discovery followup raw test"),
+        "expected second-round invoked tool output, got: {reply}"
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    assert_discovery_first_followup_summary(&persisted, true, "file.read");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -747,6 +747,7 @@ struct ProviderTurnPreparation {
     session: ProviderTurnSessionState,
     lane_plan: ProviderTurnLanePlan,
     raw_tool_output_requested: bool,
+    turn_id: String,
 }
 
 impl ProviderTurnPreparation {
@@ -756,6 +757,7 @@ impl ProviderTurnPreparation {
         user_input: &str,
         ingress: Option<&ConversationIngressContext>,
     ) -> Self {
+        let turn_id = build_provider_turn_scope_id(&assembled_context.messages, user_input);
         Self {
             session: ProviderTurnSessionState::from_assembled_context(
                 assembled_context,
@@ -764,6 +766,7 @@ impl ProviderTurnPreparation {
             ),
             lane_plan: ProviderTurnLanePlan::from_user_input(config, user_input),
             raw_tool_output_requested: user_requested_raw_tool_output(user_input),
+            turn_id,
         }
     }
 
@@ -779,6 +782,18 @@ impl ProviderTurnPreparation {
             estimated_tokens: self.session.estimated_tokens,
         }
     }
+}
+
+fn build_provider_turn_scope_id(messages: &[Value], user_input: &str) -> String {
+    let mut visible_context = messages.to_vec();
+    visible_context.push(json!({
+        "role": "user",
+        "content": user_input,
+    }));
+    format!(
+        "turn:{}",
+        checkpoint_context_fingerprint_sha256(&visible_context)
+    )
 }
 
 #[derive(Debug, Clone)]
@@ -1958,9 +1973,27 @@ impl ConversationTurnCoordinator {
         turn: &ProviderTurn,
     ) -> LoongClawConfig {
         let config_path_from_tool = turn.tool_intents.iter().rev().find_map(|intent| {
-            (crate::tools::canonical_tool_name(intent.tool_name.as_str()) == "provider.switch")
-                .then_some(intent.args_json.as_object())
-                .flatten()
+            let canonical_tool_name = crate::tools::canonical_tool_name(intent.tool_name.as_str());
+            let payload = if canonical_tool_name == "provider.switch" {
+                intent.args_json.as_object()
+            } else if canonical_tool_name == "tool.invoke" {
+                intent
+                    .args_json
+                    .as_object()
+                    .filter(|payload| {
+                        payload
+                            .get("tool_id")
+                            .and_then(Value::as_str)
+                            .map(crate::tools::canonical_tool_name)
+                            == Some("provider.switch")
+                    })
+                    .and_then(|payload| payload.get("arguments"))
+                    .and_then(Value::as_object)
+            } else {
+                None
+            };
+
+            payload
                 .and_then(|payload| payload.get("config_path"))
                 .and_then(Value::as_str)
                 .map(str::trim)
@@ -2175,6 +2208,8 @@ async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
 ) -> ResolvedProviderTurn {
     match decide_provider_turn_request_action(result, error_mode) {
         ProviderTurnRequestAction::Continue { turn } => {
+            let turn =
+                scope_provider_turn_tool_intents(turn, session_id, preparation.turn_id.as_str());
             let continue_phase = prepare_provider_turn_continue_phase(
                 config,
                 runtime,
@@ -2199,6 +2234,22 @@ async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
             ProviderTurnRequestTerminalPhase::return_error(error).resolve(preparation, user_input)
         }
     }
+}
+
+fn scope_provider_turn_tool_intents(
+    mut turn: ProviderTurn,
+    session_id: &str,
+    turn_id: &str,
+) -> ProviderTurn {
+    for intent in &mut turn.tool_intents {
+        if intent.session_id.trim().is_empty() {
+            intent.session_id = session_id.to_owned();
+        }
+        if intent.turn_id.trim().is_empty() {
+            intent.turn_id = turn_id.to_owned();
+        }
+    }
+    turn
 }
 
 async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
@@ -5493,12 +5544,12 @@ fn terminal_turn_failure_from_verify_failure(
 
 fn turn_result_from_plan_failure(failure: PlanRunFailure) -> TurnResult {
     let failure_meta = turn_failure_from_plan_failure(&failure);
-    match failure_meta.kind {
-        TurnFailureKind::PolicyDenied => TurnResult::ToolDenied(failure_meta),
-        TurnFailureKind::Retryable | TurnFailureKind::NonRetryable => {
-            TurnResult::ToolError(failure_meta)
-        }
-        TurnFailureKind::Provider => TurnResult::ProviderError(failure_meta),
+    if matches!(failure_meta.kind, TurnFailureKind::PolicyDenied) {
+        TurnResult::ToolDenied(failure_meta)
+    } else if matches!(failure_meta.kind, TurnFailureKind::Provider) {
+        TurnResult::ProviderError(failure_meta)
+    } else {
+        TurnResult::ToolError(failure_meta)
     }
 }
 
@@ -6284,6 +6335,99 @@ mod tests {
     }
 
     #[test]
+    fn scope_provider_turn_tool_intents_populates_missing_ids_and_preserves_existing_ids() {
+        let turn = ProviderTurn {
+            assistant_text: String::new(),
+            tool_intents: vec![
+                ToolIntent {
+                    tool_name: "tool.search".to_owned(),
+                    args_json: json!({"query": "read file"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: String::new(),
+                    turn_id: String::new(),
+                    tool_call_id: "call-1".to_owned(),
+                },
+                ToolIntent {
+                    tool_name: "tool.invoke".to_owned(),
+                    args_json: json!({"tool_id": "file.read", "lease": "stub", "arguments": {"path": "README.md"}}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "already-session".to_owned(),
+                    turn_id: "already-turn".to_owned(),
+                    tool_call_id: "call-2".to_owned(),
+                },
+            ],
+            raw_meta: Value::Null,
+        };
+
+        let scoped = scope_provider_turn_tool_intents(turn, "session-a", "turn-a");
+
+        assert_eq!(scoped.tool_intents[0].session_id, "session-a");
+        assert_eq!(scoped.tool_intents[0].turn_id, "turn-a");
+        assert_eq!(scoped.tool_intents[1].session_id, "already-session");
+        assert_eq!(scoped.tool_intents[1].turn_id, "already-turn");
+    }
+
+    #[test]
+    fn reload_followup_provider_config_reads_provider_switch_wrapped_by_tool_invoke() {
+        use std::fs;
+
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-provider-switch-followup-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).expect("create fixture root");
+        let config_path = root.join("loongclaw.toml");
+
+        let mut expected = LoongClawConfig::default();
+        let mut openai =
+            crate::config::ProviderConfig::fresh_for_kind(crate::config::ProviderKind::Openai);
+        openai.model = "gpt-5".to_owned();
+        expected.set_active_provider_profile(
+            "openai-gpt-5",
+            crate::config::ProviderProfileConfig {
+                default_for_kind: true,
+                provider: openai.clone(),
+            },
+        );
+        expected.provider = openai;
+        expected.active_provider = Some("openai-gpt-5".to_owned());
+        fs::write(
+            &config_path,
+            crate::config::render(&expected).expect("render config"),
+        )
+        .expect("write config");
+
+        let turn = ProviderTurn {
+            assistant_text: String::new(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "tool.invoke".to_owned(),
+                args_json: json!({
+                    "tool_id": "provider.switch",
+                    "lease": "ignored",
+                    "arguments": {
+                        "selector": "openai",
+                        "config_path": config_path.to_string_lossy()
+                    }
+                }),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-a".to_owned(),
+                turn_id: "turn-a".to_owned(),
+                tool_call_id: "call-1".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        };
+
+        let reloaded = ConversationTurnCoordinator::reload_followup_provider_config_after_tool_turn(
+            &LoongClawConfig::default(),
+            &turn,
+        );
+
+        assert_eq!(reloaded.active_provider_id(), Some("openai-gpt-5"));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
     fn provider_turn_continue_phase_checkpoint_keeps_direct_reply_without_followup() {
         let preparation = ProviderTurnPreparation::from_assembled_context(
             &LoongClawConfig::default(),
@@ -6860,6 +7004,12 @@ mod tests {
     #[test]
     fn turn_failure_from_plan_failure_node_error_mapping_is_stable() {
         let cases = [
+            (
+                PlanNodeErrorKind::ApprovalRequired,
+                TurnFailureKind::PolicyDenied,
+                "safe_lane_plan_node_policy_denied",
+                false,
+            ),
             (
                 PlanNodeErrorKind::PolicyDenied,
                 TurnFailureKind::PolicyDenied,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -921,6 +921,14 @@ impl ProviderTurnContinuePhase {
         )
     }
 
+    fn tool_intent_count(&self) -> usize {
+        match self.request {
+            TurnCheckpointRequest::Continue { tool_intents } => tool_intents,
+            TurnCheckpointRequest::FinalizeInlineProviderError
+            | TurnCheckpointRequest::ReturnError => 0,
+        }
+    }
+
     async fn resolve<R: ConversationRuntime + ?Sized>(
         &self,
         runtime: &R,
@@ -2330,8 +2338,33 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     let mut current_preparation = preparation.clone();
     let mut current_continue_phase = continue_phase.clone();
     let mut remaining_provider_rounds = remaining_provider_rounds.max(1);
+    let mut provider_round_index = 0usize;
 
     loop {
+        if current_continue_phase
+            .lane_execution
+            .requires_provider_turn_followup
+        {
+            emit_discovery_first_event(
+                runtime,
+                session_id,
+                "discovery_first_search_round",
+                json!({
+                    "provider_round": provider_round_index,
+                    "search_tool_calls": current_continue_phase.tool_intent_count(),
+                    "raw_tool_output_requested": current_continue_phase
+                        .lane_execution
+                        .raw_tool_output_requested,
+                    "initial_estimated_tokens": estimate_tokens_for_messages(
+                        current_preparation.session.estimated_tokens,
+                        &current_preparation.session.messages,
+                    ),
+                }),
+                kernel_ctx,
+            )
+            .await;
+        }
+
         let reply_decision = match current_continue_phase.reply_phase.decision() {
             ToolDrivenReplyBaseDecision::FinalizeDirect { reply } => {
                 if current_continue_phase
@@ -2386,6 +2419,14 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                     && remaining_provider_rounds > 1
                 {
                     remaining_provider_rounds -= 1;
+                    let initial_estimated_tokens = estimate_tokens_for_messages(
+                        current_preparation.session.estimated_tokens,
+                        &current_preparation.session.messages,
+                    );
+                    let followup_estimated_tokens = estimate_tokens(&follow_up_messages);
+                    let followup_added_estimated_tokens = initial_estimated_tokens
+                        .zip(followup_estimated_tokens)
+                        .map(|(initial, followup)| followup.saturating_sub(initial));
                     let followup_preparation =
                         current_preparation.for_followup_messages(follow_up_messages);
                     let followup_tool_view = match runtime.tool_view(
@@ -2403,6 +2444,22 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                             return ResolvedProviderTurn::persist_reply(raw_reply, checkpoint);
                         }
                     };
+                    emit_discovery_first_event(
+                        runtime,
+                        session_id,
+                        "discovery_first_followup_requested",
+                        json!({
+                            "provider_round": provider_round_index.saturating_add(1),
+                            "raw_tool_output_requested": current_continue_phase
+                                .lane_execution
+                                .raw_tool_output_requested,
+                            "initial_estimated_tokens": initial_estimated_tokens,
+                            "followup_estimated_tokens": followup_estimated_tokens,
+                            "followup_added_estimated_tokens": followup_added_estimated_tokens,
+                        }),
+                        kernel_ctx,
+                    )
+                    .await;
                     match decide_provider_turn_request_action(
                         runtime
                             .request_turn(
@@ -2422,6 +2479,25 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                                 session_id,
                                 followup_preparation.turn_id.as_str(),
                             );
+                            let followup_result = summarize_discovery_first_followup_turn(&turn);
+                            emit_discovery_first_event(
+                                runtime,
+                                session_id,
+                                "discovery_first_followup_result",
+                                json!({
+                                    "provider_round": provider_round_index.saturating_add(1),
+                                    "outcome": followup_result.outcome,
+                                    "followup_tool_name": followup_result.followup_tool_name,
+                                    "followup_target_tool_id": followup_result.followup_target_tool_id,
+                                    "resolved_to_tool_invoke": followup_result
+                                        .resolved_to_tool_invoke,
+                                    "raw_tool_output_requested": current_continue_phase
+                                        .lane_execution
+                                        .raw_tool_output_requested,
+                                }),
+                                kernel_ctx,
+                            )
+                            .await;
                             current_continue_phase = prepare_provider_turn_continue_phase(
                                 &current_continue_phase.followup_config,
                                 runtime,
@@ -2432,10 +2508,28 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                             )
                             .await;
                             current_preparation = followup_preparation;
+                            provider_round_index = provider_round_index.saturating_add(1);
                             continue;
                         }
                         ProviderTurnRequestAction::FinalizeInlineProviderError { .. }
                         | ProviderTurnRequestAction::ReturnError { .. } => {
+                            emit_discovery_first_event(
+                                runtime,
+                                session_id,
+                                "discovery_first_followup_result",
+                                json!({
+                                    "provider_round": provider_round_index.saturating_add(1),
+                                    "outcome": "provider_error",
+                                    "followup_tool_name": Value::Null,
+                                    "followup_target_tool_id": Value::Null,
+                                    "resolved_to_tool_invoke": false,
+                                    "raw_tool_output_requested": current_continue_phase
+                                        .lane_execution
+                                        .raw_tool_output_requested,
+                                }),
+                                kernel_ctx,
+                            )
+                            .await;
                             let checkpoint = current_continue_phase.checkpoint(
                                 preparation,
                                 user_input,
@@ -2514,6 +2608,78 @@ fn build_turn_reply_followup_messages(
         |_, text| text.to_owned(),
     ));
     messages
+}
+
+#[derive(Debug)]
+struct DiscoveryFirstFollowupTurnSummary {
+    outcome: String,
+    followup_tool_name: Option<String>,
+    followup_target_tool_id: Option<String>,
+    resolved_to_tool_invoke: bool,
+}
+
+fn summarize_discovery_first_followup_turn(
+    turn: &ProviderTurn,
+) -> DiscoveryFirstFollowupTurnSummary {
+    let Some(intent) = turn.tool_intents.first() else {
+        return DiscoveryFirstFollowupTurnSummary {
+            outcome: "final_reply".to_owned(),
+            followup_tool_name: None,
+            followup_target_tool_id: None,
+            resolved_to_tool_invoke: false,
+        };
+    };
+
+    let canonical_tool_name =
+        crate::tools::canonical_tool_name(intent.tool_name.as_str()).to_owned();
+    let resolved_to_tool_invoke = canonical_tool_name == "tool.invoke";
+    let followup_target_tool_id = resolved_to_tool_invoke
+        .then(|| {
+            intent
+                .args_json
+                .get("tool_id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .flatten();
+
+    DiscoveryFirstFollowupTurnSummary {
+        outcome: canonical_tool_name.clone(),
+        followup_tool_name: Some(canonical_tool_name),
+        followup_target_tool_id,
+        resolved_to_tool_invoke,
+    }
+}
+
+fn estimate_tokens_for_messages(
+    estimated_tokens: Option<usize>,
+    messages: &[Value],
+) -> Option<usize> {
+    estimated_tokens.or_else(|| estimate_tokens(messages))
+}
+
+async fn emit_discovery_first_event<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    event_name: &str,
+    payload: Value,
+    kernel_ctx: Option<&KernelContext>,
+) {
+    let _ = persist_conversation_event(runtime, session_id, event_name, payload, kernel_ctx).await;
+    if let Some(ctx) = kernel_ctx {
+        let _ = ctx.kernel.record_audit_event(
+            Some(ctx.agent_id()),
+            AuditEventKind::PlaneInvoked {
+                pack_id: ctx.pack_id().to_owned(),
+                plane: ExecutionPlane::Runtime,
+                tier: PlaneTier::Core,
+                primary_adapter: "conversation.discovery_first".to_owned(),
+                delegated_core_adapter: None,
+                operation: format!("conversation.discovery_first.{event_name}"),
+                required_capabilities: Vec::new(),
+            },
+        );
+    }
 }
 
 async fn persist_turn_checkpoint_event<R: ConversationRuntime + ?Sized>(

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -887,6 +887,7 @@ struct ProviderTurnContinuePhase {
     lane_execution: ProviderTurnLaneExecution,
     reply_phase: ToolDrivenReplyPhase,
     followup_config: LoongClawConfig,
+    ingress: Option<ConversationIngressContext>,
 }
 
 impl ProviderTurnContinuePhase {
@@ -894,6 +895,7 @@ impl ProviderTurnContinuePhase {
         tool_intents: usize,
         lane_execution: ProviderTurnLaneExecution,
         followup_config: LoongClawConfig,
+        ingress: Option<&ConversationIngressContext>,
     ) -> Self {
         let reply_phase = lane_execution.reply_phase();
         Self {
@@ -901,6 +903,7 @@ impl ProviderTurnContinuePhase {
             lane_execution,
             reply_phase,
             followup_config,
+            ingress: ingress.cloned(),
         }
     }
 
@@ -947,6 +950,7 @@ impl ProviderTurnContinuePhase {
             user_input,
             remaining_provider_rounds,
             kernel_ctx,
+            self.ingress.as_ref(),
         )
         .await
     }
@@ -2313,7 +2317,7 @@ async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
     .await;
     let followup_config =
         ConversationTurnCoordinator::reload_followup_provider_config_after_tool_turn(config, &turn);
-    ProviderTurnContinuePhase::new(tool_intents, lane_execution, followup_config)
+    ProviderTurnContinuePhase::new(tool_intents, lane_execution, followup_config, ingress)
 }
 
 async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
@@ -2325,6 +2329,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     user_input: &str,
     remaining_provider_rounds: usize,
     kernel_ctx: Option<&KernelContext>,
+    ingress: Option<&ConversationIngressContext>,
 ) -> ResolvedProviderTurn {
     enum ReplyLoopDecision {
         FinalizeDirect(String),
@@ -2505,6 +2510,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                                 &followup_preparation,
                                 turn,
                                 kernel_ctx,
+                                ingress,
                             )
                             .await;
                             current_preparation = followup_preparation;
@@ -6604,6 +6610,7 @@ mod tests {
                 }),
             },
             config,
+            None,
         );
 
         let checkpoint =
@@ -6779,6 +6786,7 @@ mod tests {
                 safe_lane_terminal_route: None,
             },
             LoongClawConfig::default(),
+            None,
         );
 
         let checkpoint = phase.checkpoint(&preparation, "say hello", "hello there");

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -44,8 +44,8 @@ use super::persistence::{
     persist_reply_turns_raw_with_mode, persist_reply_turns_with_mode,
 };
 use super::plan_executor::{
-    PlanExecutor, PlanNodeAttemptEvent, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor,
-    PlanRunFailure, PlanRunReport, PlanRunStatus,
+    PlanExecutor, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor, PlanRunFailure,
+    PlanRunReport, PlanRunStatus,
 };
 use super::plan_ir::{
     PLAN_GRAPH_VERSION, PlanBudget, PlanEdge, PlanGraph, PlanNode, PlanNodeKind, RiskTier,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2264,7 +2264,11 @@ async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
                     session_id,
                     preparation,
                     user_input,
-                    config.conversation.turn_loop.max_rounds.max(1),
+                    config
+                        .conversation
+                        .turn_loop
+                        .max_discovery_followup_rounds
+                        .max(1),
                     kernel_ctx,
                 )
                 .await

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -44,8 +44,8 @@ use super::persistence::{
     persist_reply_turns_raw_with_mode, persist_reply_turns_with_mode,
 };
 use super::plan_executor::{
-    PlanExecutor, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor, PlanRunFailure,
-    PlanRunReport, PlanRunStatus,
+    PlanExecutor, PlanNodeAttemptEvent, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor,
+    PlanRunFailure, PlanRunReport, PlanRunStatus,
 };
 use super::plan_ir::{
     PLAN_GRAPH_VERSION, PlanBudget, PlanEdge, PlanGraph, PlanNode, PlanNodeKind, RiskTier,
@@ -79,7 +79,8 @@ use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ReplyResolutionMode, ToolDrivenFollowupKind,
     ToolDrivenFollowupPayload, ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase,
     build_tool_driven_followup_tail, decide_provider_turn_request_action,
-    format_approval_required_reply, request_completion_with_raw_fallback,
+    format_approval_required_reply, next_conversation_turn_id,
+    request_completion_with_raw_fallback, tool_driven_followup_payload,
     tool_result_contains_truncation_signal, user_requested_raw_tool_output,
 };
 #[cfg(feature = "memory-sqlite")]
@@ -751,13 +752,30 @@ struct ProviderTurnPreparation {
 }
 
 impl ProviderTurnPreparation {
+    #[cfg(test)]
     fn from_assembled_context(
         config: &LoongClawConfig,
         assembled_context: AssembledConversationContext,
         user_input: &str,
         ingress: Option<&ConversationIngressContext>,
     ) -> Self {
-        let turn_id = build_provider_turn_scope_id(&assembled_context.messages, user_input);
+        let turn_id = next_conversation_turn_id();
+        Self::from_assembled_context_with_turn_id(
+            config,
+            assembled_context,
+            user_input,
+            turn_id.as_str(),
+            ingress,
+        )
+    }
+
+    fn from_assembled_context_with_turn_id(
+        config: &LoongClawConfig,
+        assembled_context: AssembledConversationContext,
+        user_input: &str,
+        turn_id: &str,
+        ingress: Option<&ConversationIngressContext>,
+    ) -> Self {
         Self {
             session: ProviderTurnSessionState::from_assembled_context(
                 assembled_context,
@@ -766,7 +784,19 @@ impl ProviderTurnPreparation {
             ),
             lane_plan: ProviderTurnLanePlan::from_user_input(config, user_input),
             raw_tool_output_requested: user_requested_raw_tool_output(user_input),
-            turn_id,
+            turn_id: turn_id.to_owned(),
+        }
+    }
+
+    fn for_followup_messages(&self, messages: Vec<Value>) -> Self {
+        Self {
+            session: ProviderTurnSessionState {
+                messages,
+                estimated_tokens: None,
+            },
+            lane_plan: self.lane_plan.clone(),
+            raw_tool_output_requested: self.raw_tool_output_requested,
+            turn_id: self.turn_id.clone(),
         }
     }
 
@@ -782,18 +812,6 @@ impl ProviderTurnPreparation {
             estimated_tokens: self.session.estimated_tokens,
         }
     }
-}
-
-fn build_provider_turn_scope_id(messages: &[Value], user_input: &str) -> String {
-    let mut visible_context = messages.to_vec();
-    visible_context.push(json!({
-        "role": "user",
-        "content": user_input,
-    }));
-    format!(
-        "turn:{}",
-        checkpoint_context_fingerprint_sha256(&visible_context)
-    )
 }
 
 #[derive(Debug, Clone)]
@@ -836,6 +854,7 @@ struct ProviderTurnLaneExecution {
     lane: ExecutionLane,
     assistant_preface: String,
     had_tool_intents: bool,
+    requires_provider_turn_followup: bool,
     raw_tool_output_requested: bool,
     turn_result: TurnResult,
     safe_lane_terminal_route: Option<SafeLaneFailureRoute>,
@@ -902,20 +921,23 @@ impl ProviderTurnContinuePhase {
         )
     }
 
-    async fn resolve_reply<R: ConversationRuntime + ?Sized>(
+    async fn resolve<R: ConversationRuntime + ?Sized>(
         &self,
         runtime: &R,
+        session_id: &str,
         preparation: &ProviderTurnPreparation,
         user_input: &str,
+        remaining_provider_rounds: usize,
         kernel_ctx: Option<&KernelContext>,
-    ) -> String {
+    ) -> ResolvedProviderTurn {
         resolve_provider_turn_reply(
             runtime,
             &self.followup_config,
+            session_id,
             preparation,
-            &self.lane_execution,
-            &self.reply_phase,
+            self,
             user_input,
+            remaining_provider_rounds,
             kernel_ctx,
         )
         .await
@@ -1928,12 +1950,14 @@ impl ConversationTurnCoordinator {
         let tool_view = session_context.tool_view.clone();
         let visible_ingress = ingress.filter(|value| value.has_contextual_hints());
         emit_turn_ingress_event(runtime, session_id, visible_ingress, kernel_ctx).await;
-        let preparation = ProviderTurnPreparation::from_assembled_context(
+        let turn_id = next_conversation_turn_id();
+        let preparation = ProviderTurnPreparation::from_assembled_context_with_turn_id(
             config,
             runtime
                 .build_context(config, session_id, true, kernel_ctx)
                 .await?,
             user_input,
+            turn_id.as_str(),
             visible_ingress,
         );
         let resolved_turn = resolve_provider_turn(
@@ -1945,6 +1969,8 @@ impl ConversationTurnCoordinator {
             runtime
                 .request_turn(
                     config,
+                    session_id,
+                    preparation.turn_id.as_str(),
                     &preparation.session.messages,
                     &tool_view,
                     kernel_ctx,
@@ -2220,11 +2246,16 @@ async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
                 ingress,
             )
             .await;
-            let reply = continue_phase
-                .resolve_reply(runtime, preparation, user_input, kernel_ctx)
-                .await;
-            let checkpoint = continue_phase.checkpoint(preparation, user_input, reply.as_str());
-            ResolvedProviderTurn::persist_reply(reply, checkpoint)
+            continue_phase
+                .resolve(
+                    runtime,
+                    session_id,
+                    preparation,
+                    user_input,
+                    config.conversation.turn_loop.max_rounds.max(1),
+                    kernel_ctx,
+                )
+                .await
         }
         ProviderTurnRequestAction::FinalizeInlineProviderError { reply } => {
             ProviderTurnRequestTerminalPhase::persist_inline_provider_error(reply)
@@ -2279,33 +2310,159 @@ async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
 
 async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     runtime: &R,
-    config: &LoongClawConfig,
+    _config: &LoongClawConfig,
+    session_id: &str,
     preparation: &ProviderTurnPreparation,
-    lane_execution: &ProviderTurnLaneExecution,
-    phase: &ToolDrivenReplyPhase,
+    continue_phase: &ProviderTurnContinuePhase,
     user_input: &str,
+    remaining_provider_rounds: usize,
     kernel_ctx: Option<&KernelContext>,
-) -> String {
-    match phase.decision() {
-        ToolDrivenReplyBaseDecision::FinalizeDirect { reply } => reply.clone(),
-        ToolDrivenReplyBaseDecision::RequireFollowup {
-            raw_reply,
-            payload: followup,
-        } => {
-            let follow_up_messages = build_turn_reply_followup_messages(
-                &preparation.session.messages,
-                lane_execution.assistant_preface.as_str(),
-                followup.clone(),
-                user_input,
-            );
-            request_completion_with_raw_fallback(
-                runtime,
-                config,
-                &follow_up_messages,
-                kernel_ctx,
-                raw_reply.as_str(),
-            )
-            .await
+) -> ResolvedProviderTurn {
+    enum ReplyLoopDecision {
+        FinalizeDirect(String),
+        Followup {
+            raw_reply: String,
+            payload: ToolDrivenFollowupPayload,
+            requires_completion_pass: bool,
+        },
+    }
+
+    let mut current_preparation = preparation.clone();
+    let mut current_continue_phase = continue_phase.clone();
+    let mut remaining_provider_rounds = remaining_provider_rounds.max(1);
+
+    loop {
+        let reply_decision = match current_continue_phase.reply_phase.decision() {
+            ToolDrivenReplyBaseDecision::FinalizeDirect { reply } => {
+                if current_continue_phase
+                    .lane_execution
+                    .requires_provider_turn_followup
+                    && let Some(payload) = tool_driven_followup_payload(
+                        current_continue_phase.lane_execution.had_tool_intents,
+                        &current_continue_phase.lane_execution.turn_result,
+                    )
+                {
+                    ReplyLoopDecision::Followup {
+                        raw_reply: reply.clone(),
+                        payload,
+                        requires_completion_pass: false,
+                    }
+                } else {
+                    ReplyLoopDecision::FinalizeDirect(reply.clone())
+                }
+            }
+            ToolDrivenReplyBaseDecision::RequireFollowup {
+                raw_reply,
+                payload: followup,
+            } => ReplyLoopDecision::Followup {
+                raw_reply: raw_reply.clone(),
+                payload: followup.clone(),
+                requires_completion_pass: true,
+            },
+        };
+
+        match reply_decision {
+            ReplyLoopDecision::FinalizeDirect(reply) => {
+                let checkpoint = current_continue_phase.checkpoint(preparation, user_input, &reply);
+                return ResolvedProviderTurn::persist_reply(reply, checkpoint);
+            }
+            ReplyLoopDecision::Followup {
+                raw_reply,
+                payload: followup,
+                requires_completion_pass,
+            } => {
+                let follow_up_messages = build_turn_reply_followup_messages(
+                    &current_preparation.session.messages,
+                    current_continue_phase
+                        .lane_execution
+                        .assistant_preface
+                        .as_str(),
+                    followup.clone(),
+                    user_input,
+                );
+                if current_continue_phase
+                    .lane_execution
+                    .requires_provider_turn_followup
+                    && remaining_provider_rounds > 1
+                {
+                    remaining_provider_rounds -= 1;
+                    let followup_preparation =
+                        current_preparation.for_followup_messages(follow_up_messages);
+                    let followup_tool_view = match runtime.tool_view(
+                        &current_continue_phase.followup_config,
+                        session_id,
+                        kernel_ctx,
+                    ) {
+                        Ok(tool_view) => tool_view,
+                        Err(_error) => {
+                            let checkpoint = current_continue_phase.checkpoint(
+                                preparation,
+                                user_input,
+                                raw_reply.as_str(),
+                            );
+                            return ResolvedProviderTurn::persist_reply(raw_reply, checkpoint);
+                        }
+                    };
+                    match decide_provider_turn_request_action(
+                        runtime
+                            .request_turn(
+                                &current_continue_phase.followup_config,
+                                session_id,
+                                followup_preparation.turn_id.as_str(),
+                                &followup_preparation.session.messages,
+                                &followup_tool_view,
+                                kernel_ctx,
+                            )
+                            .await,
+                        ProviderErrorMode::Propagate,
+                    ) {
+                        ProviderTurnRequestAction::Continue { turn } => {
+                            let turn = scope_provider_turn_tool_intents(
+                                turn,
+                                session_id,
+                                followup_preparation.turn_id.as_str(),
+                            );
+                            current_continue_phase = prepare_provider_turn_continue_phase(
+                                &current_continue_phase.followup_config,
+                                runtime,
+                                session_id,
+                                &followup_preparation,
+                                turn,
+                                kernel_ctx,
+                            )
+                            .await;
+                            current_preparation = followup_preparation;
+                            continue;
+                        }
+                        ProviderTurnRequestAction::FinalizeInlineProviderError { .. }
+                        | ProviderTurnRequestAction::ReturnError { .. } => {
+                            let checkpoint = current_continue_phase.checkpoint(
+                                preparation,
+                                user_input,
+                                raw_reply.as_str(),
+                            );
+                            return ResolvedProviderTurn::persist_reply(raw_reply, checkpoint);
+                        }
+                    }
+                }
+                if requires_completion_pass {
+                    let reply = request_completion_with_raw_fallback(
+                        runtime,
+                        &current_continue_phase.followup_config,
+                        &follow_up_messages,
+                        kernel_ctx,
+                        raw_reply.as_str(),
+                    )
+                    .await;
+                    let checkpoint =
+                        current_continue_phase.checkpoint(preparation, user_input, reply.as_str());
+                    return ResolvedProviderTurn::persist_reply(reply, checkpoint);
+                }
+
+                let checkpoint =
+                    current_continue_phase.checkpoint(preparation, user_input, raw_reply.as_str());
+                return ResolvedProviderTurn::persist_reply(raw_reply, checkpoint);
+            }
         }
     }
 }
@@ -3943,6 +4100,9 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
     ingress: Option<&ConversationIngressContext>,
 ) -> ProviderTurnLaneExecution {
     let had_tool_intents = !turn.tool_intents.is_empty();
+    let requires_provider_turn_followup = turn.tool_intents.iter().any(|intent| {
+        crate::tools::canonical_tool_name(intent.tool_name.as_str()) == "tool.search"
+    });
     let assistant_preface = turn.assistant_text.clone();
     let lane = preparation.lane_plan.decision.lane;
     let session_context = match runtime.session_context(config, session_id, kernel_ctx) {
@@ -3952,6 +4112,7 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
                 lane,
                 assistant_preface,
                 had_tool_intents,
+                requires_provider_turn_followup,
                 raw_tool_output_requested: preparation.raw_tool_output_requested,
                 turn_result: TurnResult::non_retryable_tool_error("session_context_failed", error),
                 safe_lane_terminal_route: None,
@@ -4019,6 +4180,7 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         lane,
         assistant_preface,
         had_tool_intents,
+        requires_provider_turn_followup,
         raw_tool_output_requested: preparation.raw_tool_output_requested,
         turn_result,
         safe_lane_terminal_route,
@@ -6263,6 +6425,7 @@ mod tests {
                 lane: ExecutionLane::Safe,
                 assistant_preface: "preface".to_owned(),
                 had_tool_intents: true,
+                requires_provider_turn_followup: false,
                 raw_tool_output_requested: false,
                 turn_result: TurnResult::ToolError(TurnFailure::retryable(
                     "safe_lane_plan_node_retryable_error",
@@ -6444,6 +6607,7 @@ mod tests {
                 lane: ExecutionLane::Fast,
                 assistant_preface: "preface".to_owned(),
                 had_tool_intents: false,
+                requires_provider_turn_followup: false,
                 raw_tool_output_requested: false,
                 turn_result: TurnResult::FinalText("hello there".to_owned()),
                 safe_lane_terminal_route: None,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use loongclaw_contracts::Capability;
 use loongclaw_contracts::{KernelError, ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -238,8 +239,8 @@ pub(crate) fn classify_kernel_error(error: &KernelError) -> KernelFailureClass {
         KernelError::Policy(_)
         | KernelError::PackCapabilityBoundary { .. }
         | KernelError::ConnectorNotAllowed { .. } => KernelFailureClass::PolicyDenied,
-        KernelError::ToolPlane(ToolPlaneError::Execution(_)) => {
-            KernelFailureClass::RetryableExecution
+        KernelError::ToolPlane(ToolPlaneError::Execution(reason)) => {
+            classify_tool_execution_reason(reason)
         }
         _ => KernelFailureClass::NonRetryable,
     }
@@ -594,36 +595,22 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
     }
 }
 
-pub(crate) async fn execute_tool_intent_via_kernel(
-    request: ToolCoreRequest,
-    kernel_ctx: &KernelContext,
-    trusted_internal_context: bool,
-) -> Result<ToolCoreOutcome, TurnFailure> {
-    crate::tools::execute_kernel_tool_request(kernel_ctx, request, trusted_internal_context)
-        .await
-        .map_err(|error| {
-            let reason = format!("{error}");
-            match classify_kernel_error(&error) {
-                KernelFailureClass::PolicyDenied => {
-                    TurnFailure::policy_denied("kernel_policy_denied", reason)
-                }
-                KernelFailureClass::RetryableExecution => {
-                    TurnFailure::retryable("tool_execution_failed", reason)
-                }
-                KernelFailureClass::NonRetryable => {
-                    TurnFailure::non_retryable("kernel_execution_failed", reason)
-                }
-            }
-        })
+fn classify_tool_execution_reason(reason: &str) -> KernelFailureClass {
+    if reason.starts_with("policy_denied: ") {
+        KernelFailureClass::PolicyDenied
+    } else {
+        KernelFailureClass::RetryableExecution
+    }
 }
 
-fn turn_result_from_tool_execution_failure(failure: TurnFailure) -> TurnResult {
-    match failure.kind {
-        TurnFailureKind::PolicyDenied => TurnResult::ToolDenied(failure),
-        TurnFailureKind::Retryable | TurnFailureKind::NonRetryable => {
-            TurnResult::ToolError(failure)
-        }
-        TurnFailureKind::Provider => TurnResult::ProviderError(failure),
+pub(crate) fn render_kernel_error_reason(error: &KernelError) -> String {
+    #[allow(clippy::wildcard_enum_match_arm)]
+    match error {
+        KernelError::ToolPlane(ToolPlaneError::Execution(reason)) => format!(
+            "tool execution failed: {}",
+            reason.strip_prefix("policy_denied: ").unwrap_or(reason)
+        ),
+        _ => format!("{error}"),
     }
 }
 
@@ -638,11 +625,12 @@ pub(crate) fn format_tool_result_line_with_limit(
     payload_summary_limit_chars: usize,
 ) -> String {
     let envelope = build_tool_result_envelope(intent, outcome, payload_summary_limit_chars);
+    let effective_tool_name = effective_result_tool_name(intent);
     let encoded = serde_json::to_string(&envelope).unwrap_or_else(|_| {
         format!(
             "{{\"status\":\"{}\",\"tool\":\"{}\",\"tool_call_id\":\"{}\",\"payload_summary\":\"[tool_payload_unserializable]\",\"payload_chars\":0,\"payload_truncated\":false}}",
             outcome.status,
-            crate::tools::canonical_tool_name(intent.tool_name.as_str()),
+            effective_tool_name,
             intent.tool_call_id
         )
     });
@@ -654,6 +642,7 @@ fn build_tool_result_envelope(
     outcome: &ToolCoreOutcome,
     payload_summary_limit_chars: usize,
 ) -> ToolResultEnvelope {
+    let effective_tool_name = effective_result_tool_name(intent);
     let normalized_limit = effective_payload_summary_limit(intent, payload_summary_limit_chars)
         .clamp(
             MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
@@ -666,7 +655,7 @@ fn build_tool_result_envelope(
 
     ToolResultEnvelope {
         status: outcome.status.clone(),
-        tool: crate::tools::canonical_tool_name(intent.tool_name.as_str()).to_owned(),
+        tool: effective_tool_name,
         tool_call_id: intent.tool_call_id.clone(),
         payload_summary,
         payload_chars,
@@ -675,10 +664,28 @@ fn build_tool_result_envelope(
 }
 
 fn effective_payload_summary_limit(intent: &ToolIntent, default_limit: usize) -> usize {
-    if crate::tools::canonical_tool_name(intent.tool_name.as_str()) == "external_skills.invoke" {
+    if effective_result_tool_name(intent) == "external_skills.invoke" {
         return MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS;
     }
     default_limit
+}
+
+fn effective_result_tool_name(intent: &ToolIntent) -> String {
+    let canonical_tool_name = crate::tools::canonical_tool_name(intent.tool_name.as_str());
+    if canonical_tool_name != "tool.invoke" {
+        return canonical_tool_name.to_owned();
+    }
+    intent
+        .args_json
+        .get("tool_id")
+        .and_then(serde_json::Value::as_str)
+        .map(crate::tools::canonical_tool_name)
+        .filter(|tool_name| {
+            crate::tools::is_known_tool_name(tool_name)
+                && !crate::tools::is_provider_exposed_tool_name(tool_name)
+        })
+        .unwrap_or(canonical_tool_name)
+        .to_owned()
 }
 
 fn truncate_by_chars(value: &str, limit: usize) -> (String, usize, bool) {
@@ -693,6 +700,192 @@ fn truncate_by_chars(value: &str, limit: usize) -> (String, usize, bool) {
     let omitted = total_chars.saturating_sub(limit);
     truncated.push_str(&format!("...(truncated {omitted} chars)"));
     (truncated, total_chars, true)
+}
+
+fn effective_visible_tool_name(
+    intent: &ToolIntent,
+    descriptor: &crate::tools::ToolDescriptor,
+) -> String {
+    if descriptor.name != "tool.invoke" {
+        return descriptor.name.to_owned();
+    }
+
+    intent
+        .args_json
+        .get("tool_id")
+        .and_then(serde_json::Value::as_str)
+        .map(crate::tools::canonical_tool_name)
+        .and_then(|tool_name| {
+            tool_catalog()
+                .descriptor(tool_name)
+                .filter(|target| !target.is_provider_core())
+                .map(|target| target.name.to_owned())
+        })
+        .unwrap_or_else(|| descriptor.name.to_owned())
+}
+
+fn tool_intent_is_visible(
+    session_context: &SessionContext,
+    intent: &ToolIntent,
+    descriptor: &crate::tools::ToolDescriptor,
+) -> bool {
+    if descriptor.is_provider_core() {
+        if descriptor.name != "tool.invoke" {
+            return true;
+        }
+        let effective_name = effective_visible_tool_name(intent, descriptor);
+        return effective_name == descriptor.name
+            || session_context.tool_view.contains(effective_name.as_str());
+    }
+
+    session_context.tool_view.contains(descriptor.name)
+}
+
+fn map_app_tool_error(reason: String) -> TurnResult {
+    if reason.starts_with("tool_not_visible:") {
+        TurnResult::policy_denied("tool_not_visible", reason)
+    } else if reason.starts_with("tool_not_found:") || reason.starts_with("app_tool_not_found:") {
+        TurnResult::policy_denied("tool_not_found", reason)
+    } else if reason.starts_with("app_tool_disabled:") {
+        TurnResult::policy_denied("app_tool_disabled", reason)
+    } else {
+        TurnResult::non_retryable_tool_error("app_tool_execution_failed", reason)
+    }
+}
+
+async fn preflight_app_tool_request<D: AppToolDispatcher + ?Sized>(
+    app_dispatcher: &D,
+    session_context: &SessionContext,
+    intent: &ToolIntent,
+    descriptor: &crate::tools::ToolDescriptor,
+    request: &ToolCoreRequest,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<(), TurnResult> {
+    let approval_intent = ToolIntent {
+        tool_name: request.tool_name.clone(),
+        args_json: request.payload.clone(),
+        source: intent.source.clone(),
+        session_id: intent.session_id.clone(),
+        turn_id: intent.turn_id.clone(),
+        tool_call_id: intent.tool_call_id.clone(),
+    };
+
+    match app_dispatcher
+        .maybe_require_approval(session_context, &approval_intent, descriptor, kernel_ctx)
+        .await
+    {
+        Ok(Some(requirement)) => Err(TurnResult::NeedsApproval(requirement)),
+        Ok(None) => Ok(()),
+        Err(reason) if reason.starts_with("app_tool_denied:") => {
+            Err(TurnResult::policy_denied("app_tool_denied", reason))
+        }
+        Err(reason) => Err(TurnResult::non_retryable_tool_error(
+            "app_tool_preflight_failed",
+            reason,
+        )),
+    }
+}
+
+async fn execute_app_tool_request<D: AppToolDispatcher + ?Sized>(
+    app_dispatcher: &D,
+    session_context: &SessionContext,
+    request: ToolCoreRequest,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<ToolCoreOutcome, TurnResult> {
+    app_dispatcher
+        .execute_app_tool(session_context, request, kernel_ctx)
+        .await
+        .map_err(map_app_tool_error)
+}
+
+async fn execute_tool_intent_via_kernel<D: AppToolDispatcher + ?Sized>(
+    intent: &ToolIntent,
+    descriptor: &crate::tools::ToolDescriptor,
+    session_context: &SessionContext,
+    app_dispatcher: &D,
+    kernel_ctx: Option<&KernelContext>,
+) -> Result<ToolCoreOutcome, TurnResult> {
+    let prepared_request = match kernel_ctx {
+        Some(ctx) => crate::tools::prepare_kernel_tool_request(
+            ToolCoreRequest {
+                tool_name: descriptor.name.to_owned(),
+                payload: intent.args_json.clone(),
+            },
+            &ctx.token.allowed_capabilities,
+            Some(ctx.token.token_id.as_str()),
+            Some(intent.session_id.as_str()),
+            Some(intent.turn_id.as_str()),
+        ),
+        None => crate::tools::prepare_kernel_tool_request(
+            ToolCoreRequest {
+                tool_name: descriptor.name.to_owned(),
+                payload: intent.args_json.clone(),
+            },
+            &BTreeSet::from([Capability::InvokeTool]),
+            None,
+            Some(intent.session_id.as_str()),
+            Some(intent.turn_id.as_str()),
+        ),
+    };
+
+    if descriptor.name == "tool.invoke"
+        && let Ok((effective_descriptor, effective_request)) =
+            crate::tools::resolve_tool_invoke_request(&prepared_request)
+        && effective_descriptor.execution_kind == ToolExecutionKind::App
+    {
+        let effective_descriptor = tool_catalog()
+            .descriptor(effective_descriptor.canonical_name)
+            .copied()
+            .expect("resolved tool.invoke target should exist in catalog");
+        preflight_app_tool_request(
+            app_dispatcher,
+            session_context,
+            intent,
+            &effective_descriptor,
+            &effective_request,
+            kernel_ctx,
+        )
+        .await?;
+        return execute_app_tool_request(
+            app_dispatcher,
+            session_context,
+            effective_request,
+            kernel_ctx,
+        )
+        .await;
+    }
+
+    let Some(kernel_ctx) = kernel_ctx else {
+        return Err(TurnResult::policy_denied(
+            "no_kernel_context",
+            "no_kernel_context",
+        ));
+    };
+    let caps = crate::tools::required_capabilities_for_request(&prepared_request);
+    kernel_ctx
+        .kernel
+        .execute_tool_core(
+            kernel_ctx.pack_id(),
+            &kernel_ctx.token,
+            &caps,
+            None,
+            prepared_request,
+        )
+        .await
+        .map_err(|error| {
+            let reason = render_kernel_error_reason(&error);
+            match classify_kernel_error(&error) {
+                KernelFailureClass::PolicyDenied => {
+                    TurnResult::policy_denied("kernel_policy_denied", reason)
+                }
+                KernelFailureClass::RetryableExecution => {
+                    TurnResult::retryable_tool_error("tool_execution_failed", reason)
+                }
+                KernelFailureClass::NonRetryable => {
+                    TurnResult::non_retryable_tool_error("kernel_execution_failed", reason)
+                }
+            }
+        })
 }
 
 /// Single orchestration boundary for tool-call evaluation and execution.
@@ -781,18 +974,36 @@ impl TurnEngine {
             ));
         }
 
+        let catalog = tool_catalog();
         for intent in &turn.tool_intents {
             let Some(resolved_tool) = crate::tools::resolve_tool_execution(&intent.tool_name)
             else {
                 let reason = format!("tool_not_found: {}", intent.tool_name);
                 return Err(TurnFailure::policy_denied("tool_not_found", reason));
             };
-            if !session_context
+            if let Some(descriptor) = catalog.resolve(&intent.tool_name) {
+                if !tool_intent_is_visible(session_context, intent, descriptor) {
+                    let reason = format!(
+                        "tool_not_visible: {}",
+                        effective_visible_tool_name(intent, descriptor)
+                    );
+                    return Err(TurnFailure::policy_denied("tool_not_visible", reason));
+                }
+            } else if !session_context
                 .tool_view
                 .contains(resolved_tool.canonical_name)
             {
                 let reason = format!("tool_not_visible: {}", intent.tool_name);
                 return Err(TurnFailure::policy_denied("tool_not_visible", reason));
+            }
+            if intent.source.starts_with("provider_")
+                && !crate::tools::is_provider_exposed_tool_name(&intent.tool_name)
+            {
+                let reason = format!("tool_not_provider_exposed: {}", intent.tool_name);
+                return Err(TurnFailure::policy_denied(
+                    "tool_not_provider_exposed",
+                    reason,
+                ));
             }
         }
 
@@ -862,6 +1073,7 @@ impl TurnEngine {
             Ok(TurnValidation::ToolExecutionRequired) => {}
         }
 
+        let catalog = tool_catalog();
         let mut outputs = Vec::new();
         for intent in &turn.tool_intents {
             let Some(resolved_tool) = crate::tools::resolve_tool_execution(&intent.tool_name)
@@ -869,84 +1081,89 @@ impl TurnEngine {
                 let reason = format!("tool_not_found: {}", intent.tool_name);
                 return TurnResult::policy_denied("tool_not_found", reason);
             };
-            let injected = inject_internal_tool_ingress(
-                resolved_tool.canonical_name,
-                intent.args_json.clone(),
-                ingress,
-            );
-            let request = ToolCoreRequest {
-                tool_name: resolved_tool.canonical_name.to_owned(),
-                payload: injected.payload,
-            };
-            let outcome = match resolved_tool.execution_kind {
-                ToolExecutionKind::Core => {
-                    let Some(kernel_ctx) = kernel_ctx else {
-                        return TurnResult::policy_denied("no_kernel_context", "no_kernel_context");
-                    };
-                    match execute_tool_intent_via_kernel(
-                        request,
-                        kernel_ctx,
-                        injected.trusted_internal_context,
-                    )
-                    .await
-                    {
-                        Ok(outcome) => outcome,
-                        Err(failure) => return turn_result_from_tool_execution_failure(failure),
+            let outcome = if let Some(descriptor) = catalog.resolve(&intent.tool_name) {
+                match descriptor.execution_kind {
+                    ToolExecutionKind::Core => {
+                        match execute_tool_intent_via_kernel(
+                            intent,
+                            descriptor,
+                            session_context,
+                            app_dispatcher,
+                            kernel_ctx,
+                        )
+                        .await
+                        {
+                            Ok(outcome) => outcome,
+                            Err(result) => return result,
+                        }
+                    }
+                    ToolExecutionKind::App => {
+                        let request = ToolCoreRequest {
+                            tool_name: descriptor.name.to_owned(),
+                            payload: intent.args_json.clone(),
+                        };
+                        if let Err(result) = preflight_app_tool_request(
+                            app_dispatcher,
+                            session_context,
+                            intent,
+                            descriptor,
+                            &request,
+                            kernel_ctx,
+                        )
+                        .await
+                        {
+                            return result;
+                        }
+                        match execute_app_tool_request(
+                            app_dispatcher,
+                            session_context,
+                            request,
+                            kernel_ctx,
+                        )
+                        .await
+                        {
+                            Ok(outcome) => outcome,
+                            Err(result) => return result,
+                        }
                     }
                 }
-                ToolExecutionKind::App => {
-                    let catalog = crate::tools::tool_catalog();
-                    let Some(descriptor) = catalog.resolve(resolved_tool.canonical_name) else {
-                        let reason =
-                            format!("tool_descriptor_missing: {}", resolved_tool.canonical_name);
-                        return TurnResult::non_retryable_tool_error(
-                            "tool_descriptor_missing",
-                            reason,
-                        );
-                    };
-                    match app_dispatcher
-                        .maybe_require_approval(session_context, intent, descriptor, kernel_ctx)
-                        .await
-                    {
-                        Ok(Some(requirement)) => return TurnResult::NeedsApproval(requirement),
-                        Ok(None) => {}
-                        Err(reason) if reason.starts_with("app_tool_denied:") => {
-                            return TurnResult::policy_denied("app_tool_denied", reason);
-                        }
-                        Err(reason) => {
-                            return TurnResult::non_retryable_tool_error(
-                                "app_tool_preflight_failed",
-                                reason,
-                            );
-                        }
-                    }
-
-                    match app_dispatcher
-                        .execute_app_tool(session_context, request, kernel_ctx)
-                        .await
-                    {
-                        Ok(outcome) => outcome,
-                        Err(reason) if reason.starts_with("tool_not_visible:") => {
-                            return TurnResult::policy_denied("tool_not_visible", reason);
-                        }
-                        Err(reason)
-                            if reason.starts_with("tool_not_found:")
-                                || reason.starts_with("app_tool_not_found:") =>
-                        {
-                            return TurnResult::policy_denied("tool_not_found", reason);
-                        }
-                        Err(reason) if reason.starts_with("app_tool_disabled:") => {
-                            return TurnResult::policy_denied("app_tool_disabled", reason);
-                        }
-                        Err(reason) if reason.starts_with("app_tool_denied:") => {
-                            return TurnResult::policy_denied("app_tool_denied", reason);
-                        }
-                        Err(reason) => {
-                            return TurnResult::non_retryable_tool_error(
-                                "app_tool_execution_failed",
-                                reason,
-                            );
-                        }
+            } else {
+                let injected = inject_internal_tool_ingress(
+                    resolved_tool.canonical_name,
+                    intent.args_json.clone(),
+                    ingress,
+                );
+                let request = ToolCoreRequest {
+                    tool_name: resolved_tool.canonical_name.to_owned(),
+                    payload: injected.payload,
+                };
+                let Some(kernel_ctx) = kernel_ctx else {
+                    return TurnResult::policy_denied("no_kernel_context", "no_kernel_context");
+                };
+                match crate::tools::execute_kernel_tool_request(
+                    kernel_ctx,
+                    request,
+                    injected.trusted_internal_context,
+                )
+                .await
+                {
+                    Ok(outcome) => outcome,
+                    Err(error) => {
+                        let reason = render_kernel_error_reason(&error);
+                        return match classify_kernel_error(&error) {
+                            KernelFailureClass::PolicyDenied => {
+                                TurnResult::policy_denied("kernel_policy_denied", reason)
+                            }
+                            KernelFailureClass::RetryableExecution => {
+                                TurnResult::retryable_tool_error("tool_execution_failed", reason)
+                            }
+                            KernelFailureClass::NonRetryable => {
+                                TurnResult::non_retryable_tool_error(
+                                    "kernel_execution_failed",
+                                    reason,
+                                )
+                            }
+                        };
                     }
                 }
             };
@@ -1005,6 +1222,33 @@ mod tests {
                 args_json: json!({
                     "task": "inspect the child task"
                 }),
+                source: "assistant".to_owned(),
+                session_id: session_id.to_owned(),
+                turn_id: turn_id.to_owned(),
+                tool_call_id: tool_call_id.to_owned(),
+            }],
+            raw_meta: json!({}),
+        }
+    }
+
+    fn discovered_delegate_async_turn(
+        session_id: &str,
+        turn_id: &str,
+        tool_call_id: &str,
+    ) -> ProviderTurn {
+        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call_with_scope(
+            "delegate_async",
+            json!({
+                "task": "inspect the child task"
+            }),
+            Some(session_id),
+            Some(turn_id),
+        );
+        ProviderTurn {
+            assistant_text: "queueing discovered child delegate".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name,
+                args_json,
                 source: "assistant".to_owned(),
                 session_id: session_id.to_owned(),
                 turn_id: turn_id.to_owned(),
@@ -1075,6 +1319,75 @@ mod tests {
         assert_eq!(stored.tool_call_id, "call-1");
         assert_eq!(stored.turn_id, "turn-1");
         assert_eq!(stored.approval_key, "tool:delegate_async");
+    }
+
+    #[tokio::test]
+    async fn governed_tool_approval_request_is_persisted_for_discovered_delegate_async() {
+        let memory_config = isolated_memory_config("persist-discovered");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let mut tool_config = ToolConfig::default();
+        tool_config.approval.mode = GovernedToolApprovalMode::Strict;
+        let tool_view = runtime_tool_view_for_config(&tool_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &discovered_delegate_async_turn(
+                    "root-session",
+                    "turn-discovered",
+                    "call-discovered",
+                ),
+                &session_context,
+                &dispatcher,
+                None,
+            )
+            .await;
+
+        let approval_request_id = match result {
+            TurnResult::NeedsApproval(requirement) => {
+                assert_eq!(requirement.tool_name.as_deref(), Some("delegate_async"));
+                assert_eq!(
+                    requirement.approval_key.as_deref(),
+                    Some("tool:delegate_async")
+                );
+                requirement
+                    .approval_request_id
+                    .expect("approval request id should be present")
+            }
+            other @ TurnResult::FinalText(_)
+            | other @ TurnResult::ToolDenied(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_) => {
+                panic!("expected NeedsApproval, got {other:?}")
+            }
+        };
+
+        let stored = repo
+            .load_approval_request(&approval_request_id)
+            .expect("load approval request")
+            .expect("approval request row");
+        assert_eq!(stored.status, ApprovalRequestStatus::Pending);
+        assert_eq!(stored.tool_name, "delegate_async");
+        assert_eq!(stored.turn_id, "turn-discovered");
+        assert_eq!(stored.tool_call_id, "call-discovered");
+        assert_eq!(stored.approval_key, "tool:delegate_async");
+        assert_eq!(stored.request_payload_json["tool_name"], "delegate_async");
+        assert_eq!(
+            stored.request_payload_json["args_json"],
+            json!({
+                "task": "inspect the child task"
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -724,6 +724,29 @@ fn effective_visible_tool_name(
         .unwrap_or_else(|| descriptor.name.to_owned())
 }
 
+fn provider_tool_denial_should_conceal_name(
+    intent: &ToolIntent,
+    descriptor: &crate::tools::ToolDescriptor,
+) -> bool {
+    if !intent.source.starts_with("provider_") {
+        return false;
+    }
+
+    if !descriptor.is_provider_core() {
+        return true;
+    }
+
+    descriptor.name == "tool.invoke"
+        && effective_visible_tool_name(intent, descriptor) != descriptor.name
+}
+
+fn concealed_provider_tool_denial() -> TurnFailure {
+    TurnFailure::policy_denied(
+        "tool_not_found",
+        "tool_not_found: requested tool is not available",
+    )
+}
+
 fn tool_intent_is_visible(
     session_context: &SessionContext,
     intent: &ToolIntent,
@@ -991,27 +1014,36 @@ impl TurnEngine {
             };
             if let Some(descriptor) = catalog.resolve(&intent.tool_name) {
                 if !tool_intent_is_visible(session_context, intent, descriptor) {
+                    if provider_tool_denial_should_conceal_name(intent, descriptor) {
+                        return Err(concealed_provider_tool_denial());
+                    }
                     let reason = format!(
                         "tool_not_visible: {}",
                         effective_visible_tool_name(intent, descriptor)
                     );
                     return Err(TurnFailure::policy_denied("tool_not_visible", reason));
                 }
-            } else if !session_context
-                .tool_view
-                .contains(resolved_tool.canonical_name)
-            {
-                let reason = format!("tool_not_visible: {}", intent.tool_name);
-                return Err(TurnFailure::policy_denied("tool_not_visible", reason));
-            }
-            if intent.source.starts_with("provider_")
-                && !crate::tools::is_provider_exposed_tool_name(&intent.tool_name)
-            {
-                let reason = format!("tool_not_provider_exposed: {}", intent.tool_name);
-                return Err(TurnFailure::policy_denied(
-                    "tool_not_provider_exposed",
-                    reason,
-                ));
+                if provider_tool_denial_should_conceal_name(intent, descriptor) {
+                    return Err(concealed_provider_tool_denial());
+                }
+                if !crate::tools::is_provider_exposed_tool_name(&intent.tool_name) {
+                    let reason = format!("tool_not_provider_exposed: {}", intent.tool_name);
+                    return Err(TurnFailure::policy_denied(
+                        "tool_not_provider_exposed",
+                        reason,
+                    ));
+                }
+            } else {
+                if !session_context
+                    .tool_view
+                    .contains(resolved_tool.canonical_name)
+                {
+                    let reason = format!("tool_not_visible: {}", intent.tool_name);
+                    return Err(TurnFailure::policy_denied("tool_not_visible", reason));
+                }
+                if intent.source.starts_with("provider_") {
+                    return Err(concealed_provider_tool_denial());
+                }
             }
         }
 

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1215,13 +1215,19 @@ mod tests {
     }
 
     fn delegate_async_turn(session_id: &str, turn_id: &str, tool_call_id: &str) -> ProviderTurn {
+        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call_with_scope(
+            "delegate_async",
+            json!({
+                "task": "inspect the child task"
+            }),
+            Some(session_id),
+            Some(turn_id),
+        );
         ProviderTurn {
             assistant_text: "queueing child delegate".to_owned(),
             tool_intents: vec![ToolIntent {
-                tool_name: "delegate_async".to_owned(),
-                args_json: json!({
-                    "task": "inspect the child task"
-                }),
+                tool_name,
+                args_json,
                 source: "assistant".to_owned(),
                 session_id: session_id.to_owned(),
                 turn_id: turn_id.to_owned(),
@@ -1236,26 +1242,7 @@ mod tests {
         turn_id: &str,
         tool_call_id: &str,
     ) -> ProviderTurn {
-        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call_with_scope(
-            "delegate_async",
-            json!({
-                "task": "inspect the child task"
-            }),
-            Some(session_id),
-            Some(turn_id),
-        );
-        ProviderTurn {
-            assistant_text: "queueing discovered child delegate".to_owned(),
-            tool_intents: vec![ToolIntent {
-                tool_name,
-                args_json,
-                source: "assistant".to_owned(),
-                session_id: session_id.to_owned(),
-                turn_id: turn_id.to_owned(),
-                tool_call_id: tool_call_id.to_owned(),
-            }],
-            raw_meta: json!({}),
-        }
+        delegate_async_turn(session_id, turn_id, tool_call_id)
     }
 
     #[tokio::test]

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -833,10 +833,18 @@ async fn execute_tool_intent_via_kernel<D: AppToolDispatcher + ?Sized>(
             crate::tools::resolve_tool_invoke_request(&prepared_request)
         && effective_descriptor.execution_kind == ToolExecutionKind::App
     {
-        let effective_descriptor = tool_catalog()
+        let Some(effective_descriptor) = tool_catalog()
             .descriptor(effective_descriptor.canonical_name)
             .copied()
-            .expect("resolved tool.invoke target should exist in catalog");
+        else {
+            return Err(TurnResult::non_retryable_tool_error(
+                "tool_catalog_drift",
+                format!(
+                    "tool_catalog_drift: missing descriptor for resolved tool.invoke target `{}`",
+                    effective_descriptor.canonical_name
+                ),
+            ));
+        };
         preflight_app_tool_request(
             app_dispatcher,
             session_context,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -680,10 +680,10 @@ fn effective_result_tool_name(intent: &ToolIntent) -> String {
         .get("tool_id")
         .and_then(serde_json::Value::as_str)
         .map(crate::tools::canonical_tool_name)
-        .filter(|tool_name| {
-            crate::tools::is_known_tool_name(tool_name)
-                && !crate::tools::is_provider_exposed_tool_name(tool_name)
+        .and_then(|tool_name| {
+            crate::tools::resolve_tool_execution(tool_name).map(|resolved| resolved.canonical_name)
         })
+        .filter(|tool_name| !crate::tools::is_provider_exposed_tool_name(tool_name))
         .unwrap_or(canonical_tool_name)
         .to_owned()
 }
@@ -727,6 +727,7 @@ fn effective_visible_tool_name(
 fn provider_tool_denial_should_conceal_name(
     intent: &ToolIntent,
     descriptor: &crate::tools::ToolDescriptor,
+    tool_is_visible: bool,
 ) -> bool {
     if !intent.source.starts_with("provider_") {
         return false;
@@ -736,7 +737,8 @@ fn provider_tool_denial_should_conceal_name(
         return true;
     }
 
-    descriptor.name == "tool.invoke"
+    !tool_is_visible
+        && descriptor.name == "tool.invoke"
         && effective_visible_tool_name(intent, descriptor) != descriptor.name
 }
 
@@ -827,6 +829,7 @@ async fn execute_tool_intent_via_kernel<D: AppToolDispatcher + ?Sized>(
     session_context: &SessionContext,
     app_dispatcher: &D,
     kernel_ctx: Option<&KernelContext>,
+    ingress: Option<&ConversationIngressContext>,
 ) -> Result<ToolCoreOutcome, TurnResult> {
     let prepared_request = match kernel_ctx {
         Some(ctx) => crate::tools::prepare_kernel_tool_request(
@@ -851,39 +854,54 @@ async fn execute_tool_intent_via_kernel<D: AppToolDispatcher + ?Sized>(
         ),
     };
 
+    let mut kernel_request = prepared_request;
+    let mut trusted_internal_payload = false;
+
     if descriptor.name == "tool.invoke"
         && let Ok((effective_descriptor, effective_request)) =
-            crate::tools::resolve_tool_invoke_request(&prepared_request)
-        && effective_descriptor.execution_kind == ToolExecutionKind::App
+            crate::tools::resolve_tool_invoke_request(&kernel_request)
     {
-        let Some(effective_descriptor) = tool_catalog()
-            .descriptor(effective_descriptor.canonical_name)
-            .copied()
-        else {
-            return Err(TurnResult::non_retryable_tool_error(
-                "tool_catalog_drift",
-                format!(
-                    "tool_catalog_drift: missing descriptor for resolved tool.invoke target `{}`",
-                    effective_descriptor.canonical_name
-                ),
-            ));
+        if effective_descriptor.execution_kind == ToolExecutionKind::App {
+            let Some(effective_descriptor) = tool_catalog()
+                .descriptor(effective_descriptor.canonical_name)
+                .copied()
+            else {
+                return Err(TurnResult::non_retryable_tool_error(
+                    "tool_catalog_drift",
+                    format!(
+                        "tool_catalog_drift: missing descriptor for resolved tool.invoke target `{}`",
+                        effective_descriptor.canonical_name
+                    ),
+                ));
+            };
+            preflight_app_tool_request(
+                app_dispatcher,
+                session_context,
+                intent,
+                &effective_descriptor,
+                &effective_request,
+                kernel_ctx,
+            )
+            .await?;
+            return execute_app_tool_request(
+                app_dispatcher,
+                session_context,
+                effective_request,
+                kernel_ctx,
+            )
+            .await;
+        }
+
+        let injected = inject_internal_tool_ingress(
+            effective_descriptor.canonical_name,
+            effective_request.payload,
+            ingress,
+        );
+        trusted_internal_payload |= injected.trusted_internal_context;
+        kernel_request = ToolCoreRequest {
+            tool_name: effective_request.tool_name,
+            payload: injected.payload,
         };
-        preflight_app_tool_request(
-            app_dispatcher,
-            session_context,
-            intent,
-            &effective_descriptor,
-            &effective_request,
-            kernel_ctx,
-        )
-        .await?;
-        return execute_app_tool_request(
-            app_dispatcher,
-            session_context,
-            effective_request,
-            kernel_ctx,
-        )
-        .await;
     }
 
     let Some(kernel_ctx) = kernel_ctx else {
@@ -892,31 +910,36 @@ async fn execute_tool_intent_via_kernel<D: AppToolDispatcher + ?Sized>(
             "no_kernel_context",
         ));
     };
-    let caps = crate::tools::required_capabilities_for_request(&prepared_request);
-    kernel_ctx
-        .kernel
-        .execute_tool_core(
-            kernel_ctx.pack_id(),
-            &kernel_ctx.token,
-            &caps,
-            None,
-            prepared_request,
-        )
-        .await
-        .map_err(|error| {
-            let reason = render_kernel_error_reason(&error);
-            match classify_kernel_error(&error) {
-                KernelFailureClass::PolicyDenied => {
-                    TurnResult::policy_denied("kernel_policy_denied", reason)
-                }
-                KernelFailureClass::RetryableExecution => {
-                    TurnResult::retryable_tool_error("tool_execution_failed", reason)
-                }
-                KernelFailureClass::NonRetryable => {
-                    TurnResult::non_retryable_tool_error("kernel_execution_failed", reason)
-                }
+    let injected = crate::tools::inject_internal_tool_search_context(
+        kernel_request.tool_name.as_str(),
+        kernel_request.payload,
+        Some(&session_context.tool_view),
+    );
+    trusted_internal_payload |= injected.trusted_internal_context;
+    let prepared_request = ToolCoreRequest {
+        tool_name: kernel_request.tool_name,
+        payload: injected.payload,
+    };
+    crate::tools::execute_kernel_tool_request(
+        kernel_ctx,
+        prepared_request,
+        trusted_internal_payload,
+    )
+    .await
+    .map_err(|error| {
+        let reason = render_kernel_error_reason(&error);
+        match classify_kernel_error(&error) {
+            KernelFailureClass::PolicyDenied => {
+                TurnResult::policy_denied("kernel_policy_denied", reason)
             }
-        })
+            KernelFailureClass::RetryableExecution => {
+                TurnResult::retryable_tool_error("tool_execution_failed", reason)
+            }
+            KernelFailureClass::NonRetryable => {
+                TurnResult::non_retryable_tool_error("kernel_execution_failed", reason)
+            }
+        }
+    })
 }
 
 /// Single orchestration boundary for tool-call evaluation and execution.
@@ -1013,8 +1036,9 @@ impl TurnEngine {
                 return Err(TurnFailure::policy_denied("tool_not_found", reason));
             };
             if let Some(descriptor) = catalog.resolve(&intent.tool_name) {
-                if !tool_intent_is_visible(session_context, intent, descriptor) {
-                    if provider_tool_denial_should_conceal_name(intent, descriptor) {
+                let tool_is_visible = tool_intent_is_visible(session_context, intent, descriptor);
+                if !tool_is_visible {
+                    if provider_tool_denial_should_conceal_name(intent, descriptor, false) {
                         return Err(concealed_provider_tool_denial());
                     }
                     let reason = format!(
@@ -1023,7 +1047,7 @@ impl TurnEngine {
                     );
                     return Err(TurnFailure::policy_denied("tool_not_visible", reason));
                 }
-                if provider_tool_denial_should_conceal_name(intent, descriptor) {
+                if provider_tool_denial_should_conceal_name(intent, descriptor, true) {
                     return Err(concealed_provider_tool_denial());
                 }
                 if !crate::tools::is_provider_exposed_tool_name(&intent.tool_name) {
@@ -1130,6 +1154,7 @@ impl TurnEngine {
                             session_context,
                             app_dispatcher,
                             kernel_ctx,
+                            ingress,
                         )
                         .await
                         {
@@ -1376,6 +1401,7 @@ mod tests {
                 ),
                 &session_context,
                 &dispatcher,
+                None,
                 None,
             )
             .await;

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1050,7 +1050,22 @@ impl TurnEngine {
                 if provider_tool_denial_should_conceal_name(intent, descriptor, true) {
                     return Err(concealed_provider_tool_denial());
                 }
-                if !crate::tools::is_provider_exposed_tool_name(&intent.tool_name) {
+                // For tool.invoke, validate that the inner tool_id is also visible.
+                // For all other provider-sourced intents, verify they are provider-exposed
+                // (this gate catches non-bridge paths where a discoverable tool name
+                // arrives without being rewritten to tool.invoke).
+                if descriptor.name == "tool.invoke" {
+                    let inner_name = effective_visible_tool_name(intent, descriptor);
+                    if inner_name != descriptor.name
+                        && !session_context.tool_view.contains(inner_name.as_str())
+                    {
+                        if intent.source.starts_with("provider_") {
+                            return Err(concealed_provider_tool_denial());
+                        }
+                        let reason = format!("tool_not_visible: {inner_name}");
+                        return Err(TurnFailure::policy_denied("tool_not_visible", reason));
+                    }
+                } else if !crate::tools::is_provider_exposed_tool_name(&intent.tool_name) {
                     let reason = format!("tool_not_provider_exposed: {}", intent.tool_name);
                     return Err(TurnFailure::policy_denied(
                         "tool_not_provider_exposed",

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -115,6 +115,7 @@ impl ConversationTurnLoop {
             MemoryRuntimeConfig::from_memory_config(&config.memory),
             config.clone(),
         );
+        let turn_id = super::turn_shared::next_conversation_turn_id();
         let mut session = initialize_turn_loop_session(
             runtime
                 .build_messages(config, session_id, true, &tool_view, kernel_ctx)
@@ -126,7 +127,14 @@ impl ConversationTurnLoop {
         for round_index in 0..policy.max_rounds {
             let turn = match decide_provider_turn_request_action(
                 runtime
-                    .request_turn(config, &session.messages, &tool_view, kernel_ctx)
+                    .request_turn(
+                        config,
+                        session_id,
+                        turn_id.as_str(),
+                        &session.messages,
+                        &tool_view,
+                        kernel_ctx,
+                    )
                     .await,
                 error_mode,
             ) {

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -5,6 +5,8 @@ use super::runtime::ConversationRuntime;
 use super::turn_engine::{ApprovalRequirement, ApprovalRequirementKind, ProviderTurn, TurnResult};
 use serde::Serialize;
 use serde_json::Value;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::CliResult;
 use crate::KernelContext;
@@ -13,6 +15,16 @@ pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the 
 pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
 pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "A managed external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
 pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
+
+pub fn next_conversation_turn_id() -> String {
+    static NEXT_CONVERSATION_TURN_SEQ: AtomicU64 = AtomicU64::new(1);
+    let seq = NEXT_CONVERSATION_TURN_SEQ.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("turn-{nanos:x}-{seq:x}")
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolDrivenFollowupPayload {
@@ -40,6 +52,27 @@ impl ToolDrivenFollowupPayload {
             Self::ToolResult { text } => ("tool_result", text.as_str()),
             Self::ToolFailure { reason } => ("tool_failure", reason.as_str()),
         }
+    }
+}
+
+pub fn tool_driven_followup_payload(
+    had_tool_intents: bool,
+    turn_result: &TurnResult,
+) -> Option<ToolDrivenFollowupPayload> {
+    if !had_tool_intents {
+        return None;
+    }
+
+    match turn_result {
+        TurnResult::FinalText(text) => {
+            Some(ToolDrivenFollowupPayload::ToolResult { text: text.clone() })
+        }
+        TurnResult::ToolDenied(failure) | TurnResult::ToolError(failure) => {
+            Some(ToolDrivenFollowupPayload::ToolFailure {
+                reason: failure.reason.clone(),
+            })
+        }
+        TurnResult::ProviderError(_) => None,
     }
 }
 
@@ -208,21 +241,7 @@ impl<'a> ToolDrivenReplyKernel<'a> {
     }
 
     pub fn followup_payload(&self) -> Option<ToolDrivenFollowupPayload> {
-        if !self.had_tool_intents {
-            return None;
-        }
-        match self.turn_result {
-            TurnResult::FinalText(text) => {
-                Some(ToolDrivenFollowupPayload::ToolResult { text: text.clone() })
-            }
-            TurnResult::NeedsApproval(_) => None,
-            TurnResult::ToolDenied(failure) | TurnResult::ToolError(failure) => {
-                Some(ToolDrivenFollowupPayload::ToolFailure {
-                    reason: failure.reason.clone(),
-                })
-            }
-            TurnResult::ProviderError(_) => None,
-        }
+        tool_driven_followup_payload(self.had_tool_intents, self.turn_result)
     }
 
     pub fn base_decision(&self, raw_tool_output_requested: bool) -> ToolDrivenReplyBaseDecision {

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -67,6 +67,7 @@ pub fn tool_driven_followup_payload(
         TurnResult::FinalText(text) => {
             Some(ToolDrivenFollowupPayload::ToolResult { text: text.clone() })
         }
+        TurnResult::NeedsApproval(_) => None,
         TurnResult::ToolDenied(failure) | TurnResult::ToolError(failure) => {
             Some(ToolDrivenFollowupPayload::ToolFailure {
                 reason: failure.reason.clone(),

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -41,7 +41,10 @@ mod request_session_runtime;
 mod shape;
 mod transport;
 
-pub use shape::{extract_provider_turn, extract_provider_turn_with_scope};
+pub use shape::{
+    extract_provider_turn, extract_provider_turn_with_scope,
+    extract_provider_turn_with_scope_and_messages,
+};
 
 #[cfg(test)]
 use auth_profile_runtime::{ProviderAuthProfile, resolve_provider_auth_profiles};

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -41,7 +41,7 @@ mod request_session_runtime;
 mod shape;
 mod transport;
 
-pub use shape::extract_provider_turn;
+pub use shape::{extract_provider_turn, extract_provider_turn_with_scope};
 
 #[cfg(test)]
 use auth_profile_runtime::{ProviderAuthProfile, resolve_provider_auth_profiles};

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -194,11 +194,15 @@ pub async fn request_completion(
 
 pub async fn request_turn(
     config: &LoongClawConfig,
+    session_id: &str,
+    turn_id: &str,
     messages: &[Value],
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<crate::conversation::turn_engine::ProviderTurn> {
     request_turn_in_view(
         config,
+        session_id,
+        turn_id,
         messages,
         &crate::tools::runtime_tool_view(),
         kernel_ctx,
@@ -208,6 +212,8 @@ pub async fn request_turn(
 
 pub async fn request_turn_in_view(
     config: &LoongClawConfig,
+    session_id: &str,
+    turn_id: &str,
     messages: &[Value],
     tool_view: &crate::tools::ToolView,
     kernel_ctx: Option<&KernelContext>,
@@ -233,6 +239,8 @@ pub async fn request_turn_in_view(
         |model, auto_model_mode, auth_profile| {
             request_turn_with_model(
                 config,
+                session_id,
+                turn_id,
                 messages,
                 model,
                 auto_model_mode,

--- a/crates/app/src/provider/request_dispatch_runtime.rs
+++ b/crates/app/src/provider/request_dispatch_runtime.rs
@@ -207,7 +207,14 @@ async fn request_turn_with_provider(
                     tool_definitions,
                 )
             },
-            |body| shape::extract_provider_turn_with_scope(body, Some(session_id), Some(turn_id)),
+            |body| {
+                shape::extract_provider_turn_with_scope_and_messages(
+                    body,
+                    Some(session_id),
+                    Some(turn_id),
+                    messages,
+                )
+            },
             "choices[0].message",
             |api_error| {
                 if include_tool_schema.load(Ordering::Relaxed)

--- a/crates/app/src/provider/request_dispatch_runtime.rs
+++ b/crates/app/src/provider/request_dispatch_runtime.rs
@@ -49,6 +49,8 @@ pub(super) async fn request_completion_with_model(
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn request_turn_with_model(
     config: &LoongClawConfig,
+    session_id: &str,
+    turn_id: &str,
     messages: &[Value],
     model: String,
     auto_model_mode: bool,
@@ -63,6 +65,8 @@ pub(super) async fn request_turn_with_model(
     request_turn_with_provider(
         config,
         &config.provider,
+        session_id,
+        turn_id,
         messages,
         model.as_str(),
         auto_model_mode,
@@ -151,6 +155,8 @@ async fn request_completion_with_provider(
 async fn request_turn_with_provider(
     base_config: &LoongClawConfig,
     request_provider: &ProviderConfig,
+    session_id: &str,
+    turn_id: &str,
     messages: &[Value],
     model: &str,
     auto_model_mode: bool,
@@ -201,7 +207,7 @@ async fn request_turn_with_provider(
                     tool_definitions,
                 )
             },
-            shape::extract_provider_turn,
+            |body| shape::extract_provider_turn_with_scope(body, Some(session_id), Some(turn_id)),
             "choices[0].message",
             |api_error| {
                 if include_tool_schema.load(Ordering::Relaxed)

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -188,7 +188,7 @@ mod tests {
         let system = build_system_message(&config, true).expect("system message");
         let content = system["content"].as_str().expect("system content");
         assert!(content.starts_with("Stay concise and technical."));
-        assert!(content.contains("[available_tools]"));
+        assert!(content.contains("[tool_discovery_runtime]"));
     }
 
     #[test]
@@ -241,7 +241,7 @@ mod tests {
         let system_content = messages[0]["content"].as_str().expect("system content");
 
         assert!(system_content.contains("## Personality Overlay: Friendly Collaboration"));
-        assert!(system_content.contains("[available_tools]"));
+        assert!(system_content.contains("[tool_discovery_runtime]"));
 
         let _ = std::fs::remove_file(config.memory.sqlite_path.as_str());
     }

--- a/crates/app/src/provider/shape.rs
+++ b/crates/app/src/provider/shape.rs
@@ -17,17 +17,35 @@ pub fn extract_provider_turn_with_scope(
     session_id: Option<&str>,
     turn_id: Option<&str>,
 ) -> Option<ProviderTurn> {
-    if let Some(turn) = extract_responses_provider_turn(body, session_id, turn_id) {
+    extract_provider_turn_with_scope_and_messages(body, session_id, turn_id, &[])
+}
+
+pub fn extract_provider_turn_with_scope_and_messages(
+    body: &Value,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+    messages: &[Value],
+) -> Option<ProviderTurn> {
+    let bridge_context = provider_tool_bridge_context_from_messages(messages);
+
+    if let Some(turn) = extract_responses_provider_turn(body, session_id, turn_id, &bridge_context)
+    {
         return Some(turn);
     }
 
     if let Some(message) = openai_message(body) {
         let mut assistant_text = message_content(message).unwrap_or_default();
         let mut raw_meta = message.clone();
-        let mut tool_intents = extract_openai_tool_intents(message, session_id, turn_id);
+        let mut tool_intents =
+            extract_openai_tool_intents(message, session_id, turn_id, &bridge_context);
 
         if tool_intents.is_empty() {
-            match extract_inline_function_call_turn(assistant_text.as_str(), session_id, turn_id) {
+            match extract_inline_function_call_turn(
+                assistant_text.as_str(),
+                session_id,
+                turn_id,
+                &bridge_context,
+            ) {
                 InlineFunctionParseResult::Parsed {
                     cleaned_text,
                     tool_intents: inline_tool_intents,
@@ -54,13 +72,18 @@ pub fn extract_provider_turn_with_scope(
     if let Some(message) = bedrock_message(body) {
         return Some(ProviderTurn {
             assistant_text: message_content(message).unwrap_or_default(),
-            tool_intents: extract_bedrock_tool_intents(message, session_id, turn_id),
+            tool_intents: extract_bedrock_tool_intents(
+                message,
+                session_id,
+                turn_id,
+                &bridge_context,
+            ),
             raw_meta: normalize_bedrock_message(message),
         });
     }
 
     let assistant_text = extract_body_content_text(body).unwrap_or_default();
-    let tool_intents = extract_anthropic_tool_intents(body, session_id, turn_id);
+    let tool_intents = extract_anthropic_tool_intents(body, session_id, turn_id, &bridge_context);
     if assistant_text.is_empty() && tool_intents.is_empty() {
         return None;
     }
@@ -69,6 +92,88 @@ pub fn extract_provider_turn_with_scope(
         assistant_text,
         tool_intents,
         raw_meta: body.clone(),
+    })
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ProviderToolBridgeContext {
+    discoverable_leases: BTreeMap<String, String>,
+}
+
+fn provider_tool_bridge_context_from_messages(messages: &[Value]) -> ProviderToolBridgeContext {
+    messages
+        .iter()
+        .rev()
+        .filter(|message| message.get("role").and_then(Value::as_str) == Some("assistant"))
+        .filter_map(|message| {
+            message
+                .get("content")
+                .and_then(Value::as_str)
+                .and_then(parse_discovery_followup_leases_from_message_content)
+        })
+        .find(|context| !context.discoverable_leases.is_empty())
+        .unwrap_or_default()
+}
+
+fn parse_discovery_followup_leases_from_message_content(
+    content: &str,
+) -> Option<ProviderToolBridgeContext> {
+    let tool_result_text = content.trim().strip_prefix("[tool_result]\n")?;
+    let mut discoverable_leases = BTreeMap::new();
+    let catalog = tools::tool_catalog();
+
+    for line in tool_result_text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some(payload) = trimmed.strip_prefix("[ok] ") else {
+            continue;
+        };
+        let Ok(envelope) = serde_json::from_str::<Value>(payload) else {
+            continue;
+        };
+        if envelope.get("tool").and_then(Value::as_str) != Some("tool.search") {
+            continue;
+        }
+        if envelope
+            .get("payload_truncated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        let Some(payload_summary) = envelope.get("payload_summary").and_then(Value::as_str) else {
+            continue;
+        };
+        let Ok(payload_json) = serde_json::from_str::<Value>(payload_summary) else {
+            continue;
+        };
+        let Some(results) = payload_json.get("results").and_then(Value::as_array) else {
+            continue;
+        };
+        for result in results {
+            let Some(tool_id) = result.get("tool_id").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(lease) = result.get("lease").and_then(Value::as_str) else {
+                continue;
+            };
+            let canonical_tool_name = tools::canonical_tool_name(tool_id);
+            let Some(descriptor) = catalog.descriptor(canonical_tool_name) else {
+                continue;
+            };
+            if !descriptor.is_discoverable() {
+                continue;
+            }
+            discoverable_leases
+                .entry(descriptor.name.to_owned())
+                .or_insert_with(|| lease.to_owned());
+        }
+    }
+
+    (!discoverable_leases.is_empty()).then_some(ProviderToolBridgeContext {
+        discoverable_leases,
     })
 }
 
@@ -118,9 +223,28 @@ fn build_provider_tool_intent(
     session_id: Option<&str>,
     turn_id: Option<&str>,
     tool_call_id: String,
+    bridge_context: &ProviderToolBridgeContext,
 ) -> ToolIntent {
+    let canonical_tool_name = tools::canonical_tool_name(raw_tool_name).to_owned();
     let (tool_name, args_json) =
-        tools::bridge_provider_tool_call_with_scope(raw_tool_name, args_json, session_id, turn_id);
+        match tools::tool_catalog().descriptor(canonical_tool_name.as_str()) {
+            Some(descriptor) if descriptor.is_discoverable() => bridge_context
+                .discoverable_leases
+                .get(descriptor.name)
+                .cloned()
+                .map(|lease| {
+                    (
+                        "tool.invoke".to_owned(),
+                        json!({
+                            "tool_id": descriptor.name,
+                            "lease": lease,
+                            "arguments": args_json,
+                        }),
+                    )
+                })
+                .unwrap_or_else(|| (canonical_tool_name, args_json)),
+            _ => (canonical_tool_name, args_json),
+        };
     ToolIntent {
         tool_name,
         args_json,
@@ -135,6 +259,7 @@ fn extract_openai_tool_intents(
     message: &Value,
     session_id: Option<&str>,
     turn_id: Option<&str>,
+    bridge_context: &ProviderToolBridgeContext,
 ) -> Vec<ToolIntent> {
     message
         .get("tool_calls")
@@ -168,6 +293,7 @@ fn extract_openai_tool_intents(
                         session_id,
                         turn_id,
                         tool_call_id,
+                        bridge_context,
                     ))
                 })
                 .collect()
@@ -179,6 +305,7 @@ fn extract_anthropic_tool_intents(
     body: &Value,
     session_id: Option<&str>,
     turn_id: Option<&str>,
+    bridge_context: &ProviderToolBridgeContext,
 ) -> Vec<ToolIntent> {
     body.get("content")
         .and_then(Value::as_array)
@@ -201,6 +328,7 @@ fn extract_anthropic_tool_intents(
                             .and_then(Value::as_str)
                             .unwrap_or("")
                             .to_owned(),
+                        bridge_context,
                     ))
                 })
                 .collect()
@@ -212,6 +340,7 @@ fn extract_bedrock_tool_intents(
     message: &Value,
     session_id: Option<&str>,
     turn_id: Option<&str>,
+    bridge_context: &ProviderToolBridgeContext,
 ) -> Vec<ToolIntent> {
     message
         .get("content")
@@ -233,6 +362,7 @@ fn extract_bedrock_tool_intents(
                             .and_then(Value::as_str)
                             .unwrap_or("")
                             .to_owned(),
+                        bridge_context,
                     ))
                 })
                 .collect()
@@ -288,12 +418,15 @@ fn extract_responses_provider_turn(
     body: &Value,
     session_id: Option<&str>,
     turn_id: Option<&str>,
+    bridge_context: &ProviderToolBridgeContext,
 ) -> Option<ProviderTurn> {
     let output = response_output_items(body)?;
     let assistant_text = extract_responses_message_content(body).unwrap_or_default();
     let tool_intents = output
         .iter()
-        .filter_map(|item| response_tool_intent_from_item(item, session_id, turn_id))
+        .filter_map(|item| {
+            response_tool_intent_from_item(item, session_id, turn_id, bridge_context)
+        })
         .collect::<Vec<_>>();
 
     if assistant_text.is_empty() && tool_intents.is_empty() {
@@ -342,6 +475,7 @@ fn response_tool_intent_from_item(
     item: &Value,
     session_id: Option<&str>,
     turn_id: Option<&str>,
+    bridge_context: &ProviderToolBridgeContext,
 ) -> Option<ToolIntent> {
     let item_type = item.get("type").and_then(Value::as_str).unwrap_or_default();
     if item_type != "function_call" && item_type != "tool_call" {
@@ -383,6 +517,7 @@ fn response_tool_intent_from_item(
         session_id,
         turn_id,
         tool_call_id,
+        bridge_context,
     ))
 }
 
@@ -548,6 +683,7 @@ fn extract_inline_function_call_turn(
     text: &str,
     session_id: Option<&str>,
     turn_id: Option<&str>,
+    bridge_context: &ProviderToolBridgeContext,
 ) -> InlineFunctionParseResult {
     const FUNCTION_OPEN: &str = "<function=";
     const FUNCTION_CLOSE: &str = "</function>";
@@ -631,6 +767,7 @@ fn extract_inline_function_call_turn(
             session_id,
             turn_id,
             tool_call_id,
+            bridge_context,
         ));
 
         cursor = function_end;
@@ -1128,6 +1265,31 @@ mod tests {
 
     use super::*;
 
+    fn discovery_followup_messages(tool_id: &str, lease: &str) -> Vec<Value> {
+        let payload_summary = serde_json::to_string(&json!({
+            "results": [
+                {
+                    "tool_id": tool_id,
+                    "lease": lease,
+                }
+            ]
+        }))
+        .expect("encode search payload summary");
+        let envelope = serde_json::to_string(&json!({
+            "status": "ok",
+            "tool": "tool.search",
+            "tool_call_id": "call-search",
+            "payload_summary": payload_summary,
+            "payload_chars": payload_summary.chars().count(),
+            "payload_truncated": false,
+        }))
+        .expect("encode search envelope");
+        vec![json!({
+            "role": "assistant",
+            "content": format!("[tool_result]\n[ok] {envelope}"),
+        })]
+    }
+
     #[test]
     fn extract_provider_turn_parses_tool_calls() {
         let body = serde_json::json!({
@@ -1148,12 +1310,8 @@ mod tests {
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.assistant_text, "checking");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
-        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
-        assert_eq!(
-            turn.tool_intents[0].args_json["arguments"],
-            json!({"path":"README.md"})
-        );
+        assert_eq!(turn.tool_intents[0].tool_name, "file.read");
+        assert_eq!(turn.tool_intents[0].args_json, json!({"path":"README.md"}));
         assert_eq!(turn.tool_intents[0].tool_call_id, "call_1");
     }
 
@@ -1178,13 +1336,11 @@ mod tests {
         assert_eq!(turn.tool_intents.len(), 1);
         let args = &turn.tool_intents[0].args_json;
         assert!(
-            args["arguments"].get("_parse_error").is_some(),
+            args.get("_parse_error").is_some(),
             "malformed args should surface parse error, got: {args}"
         );
         assert_eq!(
-            args["arguments"]
-                .get("_raw_arguments")
-                .and_then(|v| v.as_str()),
+            args.get("_raw_arguments").and_then(|v| v.as_str()),
             Some("{{not valid json")
         );
     }
@@ -1208,12 +1364,12 @@ mod tests {
         });
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
-        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
+        assert_eq!(turn.tool_intents[0].tool_name, "file.read");
+        assert_eq!(turn.tool_intents[0].args_json, json!({"path":"README.md"}));
     }
 
     #[test]
-    fn extract_provider_turn_with_scope_rewrites_discoverable_tools_to_tool_invoke() {
+    fn extract_provider_turn_with_scope_rewrites_discoverable_tools_to_tool_invoke_after_search() {
         let body = serde_json::json!({
             "choices": [{
                 "message": {
@@ -1229,10 +1385,15 @@ mod tests {
                 }
             }]
         });
+        let messages = discovery_followup_messages("file.read", "lease-openai");
 
-        let turn =
-            extract_provider_turn_with_scope(&body, Some("session-shape"), Some("turn-shape"))
-                .expect("turn");
+        let turn = extract_provider_turn_with_scope_and_messages(
+            &body,
+            Some("session-shape"),
+            Some("turn-shape"),
+            &messages,
+        )
+        .expect("turn");
         assert_eq!(turn.assistant_text, "checking");
         assert_eq!(turn.tool_intents.len(), 1);
         assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
@@ -1244,11 +1405,7 @@ mod tests {
             turn.tool_intents[0].args_json["arguments"],
             json!({"path":"README.md"})
         );
-        assert!(
-            turn.tool_intents[0].args_json["lease"]
-                .as_str()
-                .is_some_and(|lease: &str| !lease.is_empty())
-        );
+        assert_eq!(turn.tool_intents[0].args_json["lease"], "lease-openai");
     }
 
     #[test]
@@ -1284,28 +1441,36 @@ mod tests {
                 }
             ]
         });
+        let messages = discovery_followup_messages("file.read", "lease-responses");
         let turn = extract_provider_turn_with_scope(
             &body,
             Some("session-responses"),
             Some("turn-responses"),
         )
-        .expect("responses turn");
+        .expect("responses turn without search context should stay direct");
         assert_eq!(turn.assistant_text, "Reading the file.");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[0].tool_name, "file.read");
         assert_eq!(turn.tool_intents[0].session_id, "session-responses");
         assert_eq!(turn.tool_intents[0].turn_id, "turn-responses");
+        assert_eq!(turn.tool_intents[0].args_json, json!({"path": "README.md"}));
+        assert_eq!(turn.tool_intents[0].tool_call_id, "call_resp_1");
+
+        let turn = extract_provider_turn_with_scope_and_messages(
+            &body,
+            Some("session-responses"),
+            Some("turn-responses"),
+            &messages,
+        )
+        .expect("responses turn with search context");
+        assert_eq!(turn.tool_intents.len(), 1);
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
         assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
         assert_eq!(
             turn.tool_intents[0].args_json["arguments"],
             json!({"path": "README.md"})
         );
-        assert!(
-            turn.tool_intents[0].args_json["lease"]
-                .as_str()
-                .is_some_and(|lease| !lease.is_empty())
-        );
-        assert_eq!(turn.tool_intents[0].tool_call_id, "call_resp_1");
+        assert_eq!(turn.tool_intents[0].args_json["lease"], "lease-responses");
     }
 
     #[test]
@@ -1317,8 +1482,10 @@ mod tests {
                 }
             }]
         });
+        let messages = discovery_followup_messages("shell.exec", "lease-shell-inline");
 
-        let turn = extract_provider_turn(&body).expect("turn");
+        let turn = extract_provider_turn_with_scope_and_messages(&body, None, None, &messages)
+            .expect("turn");
         assert_eq!(
             turn.assistant_text,
             "sorry, that command failed. let me retry with a simpler approach:"
@@ -1329,6 +1496,10 @@ mod tests {
         assert_eq!(
             turn.tool_intents[0].args_json["arguments"],
             json!({"command":"ls /root"})
+        );
+        assert_eq!(
+            turn.tool_intents[0].args_json["lease"],
+            "lease-shell-inline"
         );
         assert_eq!(
             turn.raw_meta["loongclaw_provider_parse"]["inline_function"]["status"],
@@ -1349,8 +1520,11 @@ mod tests {
                 }
             }]
         });
+        let messages =
+            discovery_followup_messages("external_skills.invoke", "lease-external-skill-inline");
 
-        let turn = extract_provider_turn(&body).expect("turn");
+        let turn = extract_provider_turn_with_scope_and_messages(&body, None, None, &messages)
+            .expect("turn");
         assert_eq!(
             turn.assistant_text,
             "i can see the Home Assistant skill is installed. let me call it to fetch all entity states."
@@ -1364,6 +1538,10 @@ mod tests {
         assert_eq!(
             turn.tool_intents[0].args_json["arguments"],
             json!({"skill_id":"home-assistant-1-0-0","action":"get_states"})
+        );
+        assert_eq!(
+            turn.tool_intents[0].args_json["lease"],
+            "lease-external-skill-inline"
         );
     }
 
@@ -1470,12 +1648,8 @@ mod tests {
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.assistant_text, "let me retry:");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
-        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "shell.exec");
-        assert_eq!(
-            turn.tool_intents[0].args_json["arguments"],
-            json!({"command": "ls"})
-        );
+        assert_eq!(turn.tool_intents[0].tool_name, "shell.exec");
+        assert_eq!(turn.tool_intents[0].args_json, json!({"command": "ls"}));
     }
 
     #[test]
@@ -1491,12 +1665,8 @@ mod tests {
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.assistant_text, "let me retry:");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
-        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "shell.exec");
-        assert_eq!(
-            turn.tool_intents[0].args_json["arguments"],
-            json!({"command": "ls"})
-        );
+        assert_eq!(turn.tool_intents[0].tool_name, "shell.exec");
+        assert_eq!(turn.tool_intents[0].args_json, json!({"command": "ls"}));
     }
 
     #[test]
@@ -1512,7 +1682,7 @@ mod tests {
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.tool_intents.len(), 1);
         assert_eq!(
-            turn.tool_intents[0].args_json["arguments"],
+            turn.tool_intents[0].args_json,
             json!({
                 "command": "echo",
                 "args": ["hello", "world"],
@@ -1535,7 +1705,7 @@ mod tests {
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.tool_intents.len(), 1);
         assert_eq!(
-            turn.tool_intents[0].args_json["arguments"],
+            turn.tool_intents[0].args_json,
             json!({
                 "command": "true",
                 "args": ["hello"]
@@ -1619,7 +1789,9 @@ mod tests {
                 }
             ]
         });
-        let turn = extract_provider_turn(&body).expect("turn");
+        let messages = discovery_followup_messages("file.read", "lease-anthropic");
+        let turn = extract_provider_turn_with_scope_and_messages(&body, None, None, &messages)
+            .expect("turn");
         assert_eq!(turn.assistant_text, "checking");
         assert_eq!(turn.tool_intents.len(), 1);
         assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
@@ -1629,6 +1801,7 @@ mod tests {
             turn.tool_intents[0].args_json["arguments"]["path"],
             "README.md"
         );
+        assert_eq!(turn.tool_intents[0].args_json["lease"], "lease-anthropic");
     }
 
     #[test]
@@ -1655,7 +1828,9 @@ mod tests {
             },
             "stopReason": "tool_use"
         });
-        let turn = extract_provider_turn(&body).expect("turn");
+        let messages = discovery_followup_messages("file.read", "lease-bedrock");
+        let turn = extract_provider_turn_with_scope_and_messages(&body, None, None, &messages)
+            .expect("turn");
         assert_eq!(turn.assistant_text, "checking");
         assert_eq!(turn.tool_intents.len(), 1);
         assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
@@ -1665,6 +1840,7 @@ mod tests {
             turn.tool_intents[0].args_json["arguments"]["path"],
             "README.md"
         );
+        assert_eq!(turn.tool_intents[0].args_json["lease"], "lease-bedrock");
         assert_eq!(turn.raw_meta["content"][1]["type"], "tool_use");
         assert_eq!(turn.raw_meta["content"][1]["id"], "toolu_1");
     }

--- a/crates/app/src/provider/shape.rs
+++ b/crates/app/src/provider/shape.rs
@@ -700,32 +700,13 @@ fn inline_parameter_schema_types()
     SCHEMA_TYPES.get_or_init(|| {
         let mut tools_by_name =
             BTreeMap::<String, BTreeMap<String, InlineParameterSchemaType>>::new();
-        for tool in tools::provider_tool_definitions() {
-            let Some(function) = tool.get("function") else {
-                continue;
-            };
-            let Some(raw_tool_name) = function.get("name").and_then(Value::as_str) else {
-                continue;
-            };
-            let Some(properties) = function
-                .get("parameters")
-                .and_then(|value| value.get("properties"))
-                .and_then(Value::as_object)
-            else {
-                continue;
-            };
-
-            let tool_name = tools::canonical_tool_name(raw_tool_name).to_owned();
+        for (tool_name, properties) in tools::tool_parameter_schema_types() {
             let entry = tools_by_name.entry(tool_name).or_default();
-            for (parameter_name, schema) in properties {
-                let Some(parameter_type) = schema
-                    .get("type")
-                    .and_then(Value::as_str)
-                    .and_then(InlineParameterSchemaType::parse)
-                else {
+            for (parameter_name, schema_type) in properties {
+                let Some(parameter_type) = InlineParameterSchemaType::parse(schema_type) else {
                     continue;
                 };
-                entry.insert(parameter_name.clone(), parameter_type);
+                entry.insert(parameter_name, parameter_type);
             }
         }
         tools_by_name

--- a/crates/app/src/provider/shape.rs
+++ b/crates/app/src/provider/shape.rs
@@ -120,7 +120,6 @@ fn parse_discovery_followup_leases_from_message_content(
 ) -> Option<ProviderToolBridgeContext> {
     let tool_result_text = content.trim().strip_prefix("[tool_result]\n")?;
     let mut discoverable_leases = BTreeMap::new();
-    let catalog = tools::tool_catalog();
 
     for line in tool_result_text.lines() {
         let trimmed = line.trim();
@@ -159,15 +158,11 @@ fn parse_discovery_followup_leases_from_message_content(
             let Some(lease) = result.get("lease").and_then(Value::as_str) else {
                 continue;
             };
-            let canonical_tool_name = tools::canonical_tool_name(tool_id);
-            let Some(descriptor) = catalog.descriptor(canonical_tool_name) else {
+            let Some(discoverable_tool_name) = discoverable_tool_name(tool_id) else {
                 continue;
             };
-            if !descriptor.is_discoverable() {
-                continue;
-            }
             discoverable_leases
-                .entry(descriptor.name.to_owned())
+                .entry(discoverable_tool_name.to_owned())
                 .or_insert_with(|| lease.to_owned());
         }
     }
@@ -226,25 +221,24 @@ fn build_provider_tool_intent(
     bridge_context: &ProviderToolBridgeContext,
 ) -> ToolIntent {
     let canonical_tool_name = tools::canonical_tool_name(raw_tool_name).to_owned();
-    let (tool_name, args_json) =
-        match tools::tool_catalog().descriptor(canonical_tool_name.as_str()) {
-            Some(descriptor) if descriptor.is_discoverable() => bridge_context
+    let (tool_name, args_json) = discoverable_tool_name(canonical_tool_name.as_str())
+        .and_then(|discoverable_tool_name| {
+            bridge_context
                 .discoverable_leases
-                .get(descriptor.name)
+                .get(discoverable_tool_name)
                 .cloned()
                 .map(|lease| {
                     (
                         "tool.invoke".to_owned(),
                         json!({
-                            "tool_id": descriptor.name,
+                            "tool_id": discoverable_tool_name,
                             "lease": lease,
                             "arguments": args_json,
                         }),
                     )
                 })
-                .unwrap_or_else(|| (canonical_tool_name, args_json)),
-            _ => (canonical_tool_name, args_json),
-        };
+        })
+        .unwrap_or((canonical_tool_name, args_json));
     ToolIntent {
         tool_name,
         args_json,
@@ -253,6 +247,12 @@ fn build_provider_tool_intent(
         turn_id: turn_id.unwrap_or_default().to_owned(),
         tool_call_id,
     }
+}
+
+fn discoverable_tool_name(raw_tool_name: &str) -> Option<&'static str> {
+    let resolved = tools::resolve_tool_execution(raw_tool_name)?;
+    (!tools::is_provider_exposed_tool_name(resolved.canonical_name))
+        .then_some(resolved.canonical_name)
 }
 
 fn extract_openai_tool_intents(
@@ -1406,6 +1406,54 @@ mod tests {
             json!({"path":"README.md"})
         );
         assert_eq!(turn.tool_intents[0].args_json["lease"], "lease-openai");
+    }
+
+    #[cfg(feature = "feishu-integration")]
+    #[test]
+    fn extract_provider_turn_with_scope_rewrites_runtime_discovered_feishu_tools_to_tool_invoke_after_search()
+     {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "updating card",
+                    "tool_calls": [{
+                        "id": "call_feishu_card_update_1",
+                        "type": "function",
+                        "function": {
+                            "name": "feishu_card_update",
+                            "arguments": "{\"markdown\":\"callback updated\"}"
+                        }
+                    }]
+                }
+            }]
+        });
+        let messages = discovery_followup_messages("feishu.card.update", "lease-feishu");
+
+        let turn = extract_provider_turn_with_scope_and_messages(
+            &body,
+            Some("session-feishu"),
+            Some("turn-feishu"),
+            &messages,
+        )
+        .expect("turn");
+        assert_eq!(turn.assistant_text, "updating card");
+        assert_eq!(turn.tool_intents.len(), 1);
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[0].session_id, "session-feishu");
+        assert_eq!(turn.tool_intents[0].turn_id, "turn-feishu");
+        assert_eq!(
+            turn.tool_intents[0].tool_call_id,
+            "call_feishu_card_update_1"
+        );
+        assert_eq!(
+            turn.tool_intents[0].args_json["tool_id"],
+            "feishu.card.update"
+        );
+        assert_eq!(
+            turn.tool_intents[0].args_json["arguments"],
+            json!({"markdown":"callback updated"})
+        );
+        assert_eq!(turn.tool_intents[0].args_json["lease"], "lease-feishu");
     }
 
     #[test]

--- a/crates/app/src/provider/shape.rs
+++ b/crates/app/src/provider/shape.rs
@@ -9,17 +9,25 @@ use crate::conversation::turn_engine::{ProviderTurn, ToolIntent};
 use crate::tools;
 
 pub fn extract_provider_turn(body: &Value) -> Option<ProviderTurn> {
-    if let Some(turn) = extract_responses_provider_turn(body) {
+    extract_provider_turn_with_scope(body, None, None)
+}
+
+pub fn extract_provider_turn_with_scope(
+    body: &Value,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> Option<ProviderTurn> {
+    if let Some(turn) = extract_responses_provider_turn(body, session_id, turn_id) {
         return Some(turn);
     }
 
     if let Some(message) = openai_message(body) {
         let mut assistant_text = message_content(message).unwrap_or_default();
         let mut raw_meta = message.clone();
-        let mut tool_intents = extract_openai_tool_intents(message);
+        let mut tool_intents = extract_openai_tool_intents(message, session_id, turn_id);
 
         if tool_intents.is_empty() {
-            match extract_inline_function_call_turn(assistant_text.as_str()) {
+            match extract_inline_function_call_turn(assistant_text.as_str(), session_id, turn_id) {
                 InlineFunctionParseResult::Parsed {
                     cleaned_text,
                     tool_intents: inline_tool_intents,
@@ -46,13 +54,13 @@ pub fn extract_provider_turn(body: &Value) -> Option<ProviderTurn> {
     if let Some(message) = bedrock_message(body) {
         return Some(ProviderTurn {
             assistant_text: message_content(message).unwrap_or_default(),
-            tool_intents: extract_bedrock_tool_intents(message),
+            tool_intents: extract_bedrock_tool_intents(message, session_id, turn_id),
             raw_meta: normalize_bedrock_message(message),
         });
     }
 
     let assistant_text = extract_body_content_text(body).unwrap_or_default();
-    let tool_intents = extract_anthropic_tool_intents(body);
+    let tool_intents = extract_anthropic_tool_intents(body, session_id, turn_id);
     if assistant_text.is_empty() && tool_intents.is_empty() {
         return None;
     }
@@ -103,7 +111,31 @@ fn extract_body_content_text(body: &Value) -> Option<String> {
     body_content_value(body).and_then(extract_content_text)
 }
 
-fn extract_openai_tool_intents(message: &Value) -> Vec<ToolIntent> {
+fn build_provider_tool_intent(
+    raw_tool_name: &str,
+    args_json: Value,
+    source: &str,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+    tool_call_id: String,
+) -> ToolIntent {
+    let (tool_name, args_json) =
+        tools::bridge_provider_tool_call_with_scope(raw_tool_name, args_json, session_id, turn_id);
+    ToolIntent {
+        tool_name,
+        args_json,
+        source: source.to_owned(),
+        session_id: session_id.unwrap_or_default().to_owned(),
+        turn_id: turn_id.unwrap_or_default().to_owned(),
+        tool_call_id,
+    }
+}
+
+fn extract_openai_tool_intents(
+    message: &Value,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> Vec<ToolIntent> {
     message
         .get("tool_calls")
         .and_then(Value::as_array)
@@ -113,7 +145,6 @@ fn extract_openai_tool_intents(message: &Value) -> Vec<ToolIntent> {
                 .filter_map(|call| {
                     let function = call.get("function")?;
                     let raw_tool_name = function.get("name").and_then(Value::as_str)?;
-                    let tool_name = tools::canonical_tool_name(raw_tool_name).to_owned();
                     let args_str = function
                         .get("arguments")
                         .and_then(Value::as_str)
@@ -130,21 +161,25 @@ fn extract_openai_tool_intents(message: &Value) -> Vec<ToolIntent> {
                         .and_then(Value::as_str)
                         .unwrap_or("")
                         .to_owned();
-                    Some(ToolIntent {
-                        tool_name,
+                    Some(build_provider_tool_intent(
+                        raw_tool_name,
                         args_json,
-                        source: "provider_tool_call".to_owned(),
-                        session_id: String::new(),
-                        turn_id: String::new(),
+                        "provider_tool_call",
+                        session_id,
+                        turn_id,
                         tool_call_id,
-                    })
+                    ))
                 })
                 .collect()
         })
         .unwrap_or_default()
 }
 
-fn extract_anthropic_tool_intents(body: &Value) -> Vec<ToolIntent> {
+fn extract_anthropic_tool_intents(
+    body: &Value,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> Vec<ToolIntent> {
     body.get("content")
         .and_then(Value::as_array)
         .map(|blocks| {
@@ -155,25 +190,29 @@ fn extract_anthropic_tool_intents(body: &Value) -> Vec<ToolIntent> {
                         return None;
                     }
                     let raw_tool_name = block.get("name").and_then(Value::as_str)?;
-                    Some(ToolIntent {
-                        tool_name: tools::canonical_tool_name(raw_tool_name).to_owned(),
-                        args_json: block.get("input").cloned().unwrap_or_else(|| json!({})),
-                        source: "provider_tool_call".to_owned(),
-                        session_id: String::new(),
-                        turn_id: String::new(),
-                        tool_call_id: block
+                    Some(build_provider_tool_intent(
+                        raw_tool_name,
+                        block.get("input").cloned().unwrap_or_else(|| json!({})),
+                        "provider_tool_call",
+                        session_id,
+                        turn_id,
+                        block
                             .get("id")
                             .and_then(Value::as_str)
                             .unwrap_or("")
                             .to_owned(),
-                    })
+                    ))
                 })
                 .collect()
         })
         .unwrap_or_default()
 }
 
-fn extract_bedrock_tool_intents(message: &Value) -> Vec<ToolIntent> {
+fn extract_bedrock_tool_intents(
+    message: &Value,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> Vec<ToolIntent> {
     message
         .get("content")
         .and_then(Value::as_array)
@@ -183,18 +222,18 @@ fn extract_bedrock_tool_intents(message: &Value) -> Vec<ToolIntent> {
                 .filter_map(|block| {
                     let tool_use = block.get("toolUse")?;
                     let raw_tool_name = tool_use.get("name").and_then(Value::as_str)?;
-                    Some(ToolIntent {
-                        tool_name: tools::canonical_tool_name(raw_tool_name).to_owned(),
-                        args_json: tool_use.get("input").cloned().unwrap_or_else(|| json!({})),
-                        source: "provider_tool_call".to_owned(),
-                        session_id: String::new(),
-                        turn_id: String::new(),
-                        tool_call_id: tool_use
+                    Some(build_provider_tool_intent(
+                        raw_tool_name,
+                        tool_use.get("input").cloned().unwrap_or_else(|| json!({})),
+                        "provider_tool_call",
+                        session_id,
+                        turn_id,
+                        tool_use
                             .get("toolUseId")
                             .and_then(Value::as_str)
                             .unwrap_or("")
                             .to_owned(),
-                    })
+                    ))
                 })
                 .collect()
         })
@@ -245,12 +284,16 @@ fn normalize_bedrock_content_block(block: &Value) -> Option<Value> {
     }))
 }
 
-fn extract_responses_provider_turn(body: &Value) -> Option<ProviderTurn> {
+fn extract_responses_provider_turn(
+    body: &Value,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> Option<ProviderTurn> {
     let output = response_output_items(body)?;
     let assistant_text = extract_responses_message_content(body).unwrap_or_default();
     let tool_intents = output
         .iter()
-        .filter_map(response_tool_intent_from_item)
+        .filter_map(|item| response_tool_intent_from_item(item, session_id, turn_id))
         .collect::<Vec<_>>();
 
     if assistant_text.is_empty() && tool_intents.is_empty() {
@@ -295,7 +338,11 @@ fn response_output_items(body: &Value) -> Option<&[Value]> {
         .map(Vec::as_slice)
 }
 
-fn response_tool_intent_from_item(item: &Value) -> Option<ToolIntent> {
+fn response_tool_intent_from_item(
+    item: &Value,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> Option<ToolIntent> {
     let item_type = item.get("type").and_then(Value::as_str).unwrap_or_default();
     if item_type != "function_call" && item_type != "tool_call" {
         return None;
@@ -329,14 +376,14 @@ fn response_tool_intent_from_item(item: &Value) -> Option<ToolIntent> {
         .unwrap_or("")
         .to_owned();
 
-    Some(ToolIntent {
-        tool_name: tools::canonical_tool_name(raw_tool_name).to_owned(),
+    Some(build_provider_tool_intent(
+        raw_tool_name,
         args_json,
-        source: "provider_tool_call".to_owned(),
-        session_id: String::new(),
-        turn_id: String::new(),
+        "provider_tool_call",
+        session_id,
+        turn_id,
         tool_call_id,
-    })
+    ))
 }
 
 fn extract_content_text(content: &Value) -> Option<String> {
@@ -497,7 +544,11 @@ fn attach_inline_function_parse_telemetry(
     );
 }
 
-fn extract_inline_function_call_turn(text: &str) -> InlineFunctionParseResult {
+fn extract_inline_function_call_turn(
+    text: &str,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> InlineFunctionParseResult {
     const FUNCTION_OPEN: &str = "<function=";
     const FUNCTION_CLOSE: &str = "</function>";
 
@@ -572,14 +623,15 @@ fn extract_inline_function_call_turn(text: &str) -> InlineFunctionParseResult {
 
         found_inline_function = true;
         cleaned.push_str(&text[cursor..start]);
-        tool_intents.push(ToolIntent {
-            tool_name: canonical_tool_name,
+        let tool_call_id = format!("inline-call-{}", tool_intents.len());
+        tool_intents.push(build_provider_tool_intent(
+            canonical_tool_name.as_str(),
             args_json,
-            source: "provider_inline_function_call".to_owned(),
-            session_id: String::new(),
-            turn_id: String::new(),
-            tool_call_id: format!("inline-call-{}", tool_intents.len()),
-        });
+            "provider_inline_function_call",
+            session_id,
+            turn_id,
+            tool_call_id,
+        ));
 
         cursor = function_end;
     }
@@ -1096,7 +1148,12 @@ mod tests {
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.assistant_text, "checking");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "file.read");
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
+        assert_eq!(
+            turn.tool_intents[0].args_json["arguments"],
+            json!({"path":"README.md"})
+        );
         assert_eq!(turn.tool_intents[0].tool_call_id, "call_1");
     }
 
@@ -1121,11 +1178,13 @@ mod tests {
         assert_eq!(turn.tool_intents.len(), 1);
         let args = &turn.tool_intents[0].args_json;
         assert!(
-            args.get("_parse_error").is_some(),
+            args["arguments"].get("_parse_error").is_some(),
             "malformed args should surface parse error, got: {args}"
         );
         assert_eq!(
-            args.get("_raw_arguments").and_then(|v| v.as_str()),
+            args["arguments"]
+                .get("_raw_arguments")
+                .and_then(|v| v.as_str()),
             Some("{{not valid json")
         );
     }
@@ -1149,7 +1208,47 @@ mod tests {
         });
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "file.read");
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
+    }
+
+    #[test]
+    fn extract_provider_turn_with_scope_rewrites_discoverable_tools_to_tool_invoke() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "checking",
+                    "tool_calls": [{
+                        "id": "call_compat",
+                        "type": "function",
+                        "function": {
+                            "name": "file.read",
+                            "arguments": "{\"path\":\"README.md\"}"
+                        }
+                    }]
+                }
+            }]
+        });
+
+        let turn =
+            extract_provider_turn_with_scope(&body, Some("session-shape"), Some("turn-shape"))
+                .expect("turn");
+        assert_eq!(turn.assistant_text, "checking");
+        assert_eq!(turn.tool_intents.len(), 1);
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[0].session_id, "session-shape");
+        assert_eq!(turn.tool_intents[0].turn_id, "turn-shape");
+        assert_eq!(turn.tool_intents[0].tool_call_id, "call_compat");
+        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
+        assert_eq!(
+            turn.tool_intents[0].args_json["arguments"],
+            json!({"path":"README.md"})
+        );
+        assert!(
+            turn.tool_intents[0].args_json["lease"]
+                .as_str()
+                .is_some_and(|lease: &str| !lease.is_empty())
+        );
     }
 
     #[test]
@@ -1185,11 +1284,27 @@ mod tests {
                 }
             ]
         });
-        let turn = extract_provider_turn(&body).expect("responses turn");
+        let turn = extract_provider_turn_with_scope(
+            &body,
+            Some("session-responses"),
+            Some("turn-responses"),
+        )
+        .expect("responses turn");
         assert_eq!(turn.assistant_text, "Reading the file.");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "file.read");
-        assert_eq!(turn.tool_intents[0].args_json, json!({"path": "README.md"}));
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[0].session_id, "session-responses");
+        assert_eq!(turn.tool_intents[0].turn_id, "turn-responses");
+        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
+        assert_eq!(
+            turn.tool_intents[0].args_json["arguments"],
+            json!({"path": "README.md"})
+        );
+        assert!(
+            turn.tool_intents[0].args_json["lease"]
+                .as_str()
+                .is_some_and(|lease| !lease.is_empty())
+        );
         assert_eq!(turn.tool_intents[0].tool_call_id, "call_resp_1");
     }
 
@@ -1209,9 +1324,10 @@ mod tests {
             "sorry, that command failed. let me retry with a simpler approach:"
         );
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "shell.exec");
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "shell.exec");
         assert_eq!(
-            turn.tool_intents[0].args_json,
+            turn.tool_intents[0].args_json["arguments"],
             json!({"command":"ls /root"})
         );
         assert_eq!(
@@ -1240,9 +1356,13 @@ mod tests {
             "i can see the Home Assistant skill is installed. let me call it to fetch all entity states."
         );
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "external_skills.invoke");
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
         assert_eq!(
-            turn.tool_intents[0].args_json,
+            turn.tool_intents[0].args_json["tool_id"],
+            "external_skills.invoke"
+        );
+        assert_eq!(
+            turn.tool_intents[0].args_json["arguments"],
             json!({"skill_id":"home-assistant-1-0-0","action":"get_states"})
         );
     }
@@ -1350,8 +1470,12 @@ mod tests {
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.assistant_text, "let me retry:");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "shell.exec");
-        assert_eq!(turn.tool_intents[0].args_json, json!({"command": "ls"}));
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "shell.exec");
+        assert_eq!(
+            turn.tool_intents[0].args_json["arguments"],
+            json!({"command": "ls"})
+        );
     }
 
     #[test]
@@ -1367,8 +1491,12 @@ mod tests {
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.assistant_text, "let me retry:");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "shell.exec");
-        assert_eq!(turn.tool_intents[0].args_json, json!({"command": "ls"}));
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "shell.exec");
+        assert_eq!(
+            turn.tool_intents[0].args_json["arguments"],
+            json!({"command": "ls"})
+        );
     }
 
     #[test]
@@ -1384,7 +1512,7 @@ mod tests {
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.tool_intents.len(), 1);
         assert_eq!(
-            turn.tool_intents[0].args_json,
+            turn.tool_intents[0].args_json["arguments"],
             json!({
                 "command": "echo",
                 "args": ["hello", "world"],
@@ -1407,7 +1535,7 @@ mod tests {
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.tool_intents.len(), 1);
         assert_eq!(
-            turn.tool_intents[0].args_json,
+            turn.tool_intents[0].args_json["arguments"],
             json!({
                 "command": "true",
                 "args": ["hello"]
@@ -1494,9 +1622,13 @@ mod tests {
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.assistant_text, "checking");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "file.read");
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
         assert_eq!(turn.tool_intents[0].tool_call_id, "toolu_1");
-        assert_eq!(turn.tool_intents[0].args_json["path"], "README.md");
+        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
+        assert_eq!(
+            turn.tool_intents[0].args_json["arguments"]["path"],
+            "README.md"
+        );
     }
 
     #[test]
@@ -1526,9 +1658,13 @@ mod tests {
         let turn = extract_provider_turn(&body).expect("turn");
         assert_eq!(turn.assistant_text, "checking");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "file.read");
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
         assert_eq!(turn.tool_intents[0].tool_call_id, "toolu_1");
-        assert_eq!(turn.tool_intents[0].args_json["path"], "README.md");
+        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
+        assert_eq!(
+            turn.tool_intents[0].args_json["arguments"]["path"],
+            "README.md"
+        );
         assert_eq!(turn.raw_meta["content"][1]["type"], "tool_use");
         assert_eq!(turn.raw_meta["content"][1]["id"], "toolu_1");
     }

--- a/crates/app/src/provider/shape.rs
+++ b/crates/app/src/provider/shape.rs
@@ -1457,6 +1457,59 @@ mod tests {
     }
 
     #[test]
+    fn bridge_context_skips_truncated_search_results() {
+        let payload_summary = serde_json::to_string(&json!({
+            "results": [
+                {
+                    "tool_id": "file.read",
+                    "lease": "lease-truncated",
+                }
+            ]
+        }))
+        .expect("encode");
+        let envelope = serde_json::to_string(&json!({
+            "status": "ok",
+            "tool": "tool.search",
+            "tool_call_id": "call-search",
+            "payload_summary": payload_summary,
+            "payload_chars": payload_summary.chars().count(),
+            "payload_truncated": true,
+        }))
+        .expect("encode envelope");
+        let messages = vec![json!({
+            "role": "assistant",
+            "content": format!("[tool_result]\n[ok] {envelope}"),
+        })];
+
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "reading",
+                    "tool_calls": [{
+                        "id": "call_trunc",
+                        "type": "function",
+                        "function": {
+                            "name": "file_read",
+                            "arguments": "{\"path\":\"README.md\"}"
+                        }
+                    }]
+                }
+            }]
+        });
+        let turn = extract_provider_turn_with_scope_and_messages(
+            &body,
+            Some("session-trunc"),
+            Some("turn-trunc"),
+            &messages,
+        )
+        .expect("turn");
+        // When payload is truncated, bridge context should be empty,
+        // so the tool call should NOT be rewritten to tool.invoke.
+        assert_eq!(turn.tool_intents[0].tool_name, "file.read");
+        assert_eq!(turn.tool_intents[0].args_json, json!({"path": "README.md"}));
+    }
+
+    #[test]
     fn extract_provider_turn_handles_text_only() {
         let body = serde_json::json!({
             "choices": [{

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -636,21 +636,17 @@ fn build_messages_includes_capability_snapshot_block() {
     assert!(!messages.is_empty());
     let system_content = messages[0]["content"].as_str().expect("system content");
     assert!(
-        system_content.contains("[available_tools]"),
+        system_content.contains("[tool_discovery_runtime]"),
         "system prompt should contain capability snapshot marker, got: {system_content}"
     );
     assert!(
-        system_content.contains("- shell.exec: Execute shell commands"),
-        "system prompt should list shell.exec tool"
+        system_content.contains("- tool.search: Discover non-core tools"),
+        "system prompt should describe tool.search"
     );
-    assert!(
-        system_content.contains("- file.read: Read file contents"),
-        "system prompt should list file.read tool"
-    );
-    assert!(
-        system_content.contains("- file.write: Write file contents"),
-        "system prompt should list file.write tool"
-    );
+    assert!(system_content.contains("- tool.invoke: Invoke a discovered non-core tool"));
+    assert!(!system_content.contains("shell.exec"));
+    assert!(!system_content.contains("file.read"));
+    assert!(!system_content.contains("file.write"));
 }
 
 #[test]
@@ -934,16 +930,7 @@ fn turn_body_includes_tool_schema_and_auto_choice() {
         .filter_map(Value::as_str)
         .collect();
 
-    let mut expected = Vec::new();
-    #[cfg(feature = "tool-file")]
-    {
-        expected.push("file_read");
-        expected.push("file_write");
-    }
-    #[cfg(feature = "tool-shell")]
-    {
-        expected.push("shell_exec");
-    }
+    let expected = vec!["tool_invoke", "tool_search"];
 
     for expected_name in expected {
         assert!(

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -1926,6 +1926,8 @@ async fn responses_turn_falls_back_to_chat_completions_for_compatible_endpoints(
 
     let turn = request_turn(
         &config,
+        "session-provider-test",
+        "turn-provider-test",
         &[json!({
             "role": "user",
             "content": "turn ping"

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1,22 +1,23 @@
 use std::collections::BTreeSet;
 
+use serde::Serialize;
 use serde_json::{Value, json};
 
 use crate::config::ToolConfig;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ToolExecutionKind {
     Core,
     App,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ToolAvailability {
     Runtime,
     Planned,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ToolGovernanceScope {
     Routine,
     TopologyMutation,
@@ -31,7 +32,7 @@ impl ToolGovernanceScope {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ToolRiskClass {
     Low,
     Elevated,
@@ -48,7 +49,7 @@ impl ToolRiskClass {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ToolApprovalMode {
     Never,
     PolicyDriven,
@@ -63,7 +64,7 @@ impl ToolApprovalMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct ToolGovernanceProfile {
     pub scope: ToolGovernanceScope,
     pub risk_class: ToolRiskClass,
@@ -96,6 +97,12 @@ pub fn governance_profile_for_descriptor(descriptor: &ToolDescriptor) -> ToolGov
     governance_profile_for_tool_name(descriptor.name)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum ToolExposureClass {
+    ProviderCore,
+    Discoverable,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ToolDescriptor {
     pub name: &'static str,
@@ -104,6 +111,7 @@ pub struct ToolDescriptor {
     pub description: &'static str,
     pub execution_kind: ToolExecutionKind,
     pub availability: ToolAvailability,
+    pub exposure: ToolExposureClass,
     provider_definition_builder: fn(&ToolDescriptor) -> Value,
 }
 
@@ -114,6 +122,54 @@ impl ToolDescriptor {
 
     pub fn provider_definition(&self) -> Value {
         (self.provider_definition_builder)(self)
+    }
+
+    pub fn argument_hint(&self) -> &'static str {
+        tool_argument_hint(self.name)
+    }
+
+    pub fn parameter_types(&self) -> &'static [(&'static str, &'static str)] {
+        tool_parameter_types(self.name)
+    }
+
+    pub fn required_fields(&self) -> &'static [&'static str] {
+        tool_required_fields(self.name)
+    }
+
+    pub fn tags(&self) -> &'static [&'static str] {
+        tool_tags(self.name)
+    }
+
+    pub fn is_provider_core(&self) -> bool {
+        self.exposure == ToolExposureClass::ProviderCore
+    }
+
+    pub fn is_discoverable(&self) -> bool {
+        self.exposure == ToolExposureClass::Discoverable
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct ToolCatalogEntry {
+    pub canonical_name: &'static str,
+    pub provider_function_name: &'static str,
+    pub summary: &'static str,
+    pub argument_hint: &'static str,
+    pub parameter_types: &'static [(&'static str, &'static str)],
+    pub required_fields: &'static [&'static str],
+    pub tags: &'static [&'static str],
+    pub exposure: ToolExposureClass,
+    pub execution_kind: ToolExecutionKind,
+    pub availability: ToolAvailability,
+}
+
+impl ToolCatalogEntry {
+    pub fn is_provider_core(&self) -> bool {
+        self.exposure == ToolExposureClass::ProviderCore
+    }
+
+    pub fn is_discoverable(&self) -> bool {
+        self.exposure == ToolExposureClass::Discoverable
     }
 }
 
@@ -203,12 +259,33 @@ impl ToolCatalog {
 pub fn tool_catalog() -> ToolCatalog {
     let mut descriptors = vec![
         ToolDescriptor {
+            name: "tool.search",
+            provider_name: "tool_search",
+            aliases: &[],
+            description: "Discover non-core tools",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::ProviderCore,
+            provider_definition_builder: tool_search_definition,
+        },
+        ToolDescriptor {
+            name: "tool.invoke",
+            provider_name: "tool_invoke",
+            aliases: &[],
+            description: "Invoke a discovered non-core tool",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::ProviderCore,
+            provider_definition_builder: tool_invoke_definition,
+        },
+        ToolDescriptor {
             name: "claw.import",
             provider_name: "claw_import",
             aliases: &["import_claw"],
             description: "Import legacy Claw configs into native LoongClaw settings",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: claw_import_definition,
         },
         ToolDescriptor {
@@ -218,6 +295,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Download external skills artifacts with domain policy and approval guards",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: external_skills_fetch_definition,
         },
         ToolDescriptor {
@@ -227,6 +305,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Read metadata for an installed external skill",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: external_skills_inspect_definition,
         },
         ToolDescriptor {
@@ -236,6 +315,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Install a managed external skill from a local directory or archive",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: external_skills_install_definition,
         },
         ToolDescriptor {
@@ -245,6 +325,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Load an installed external skill into the conversation loop",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: external_skills_invoke_definition,
         },
         ToolDescriptor {
@@ -254,6 +335,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "List managed external skills available for invocation",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: external_skills_list_definition,
         },
         ToolDescriptor {
@@ -263,6 +345,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Read/update external skills domain allow/block policy at runtime",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: external_skills_policy_definition,
         },
         ToolDescriptor {
@@ -272,6 +355,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Remove an installed external skill from the managed runtime",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: external_skills_remove_definition,
         },
         ToolDescriptor {
@@ -281,6 +365,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Inspect current provider state or switch the default provider profile for subsequent turns",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: provider_switch_definition,
         },
         ToolDescriptor {
@@ -290,6 +375,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Resolve one visible governed tool approval request",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: approval_request_resolve_definition,
         },
         ToolDescriptor {
@@ -299,6 +385,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Inspect full detail for a visible governed tool approval request",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: approval_request_status_definition,
         },
         ToolDescriptor {
@@ -308,6 +395,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "List visible governed tool approval requests across the current session scope",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: approval_requests_list_definition,
         },
         ToolDescriptor {
@@ -317,6 +405,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Delegate a focused subtask into a child session",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: delegate_definition,
         },
         ToolDescriptor {
@@ -326,6 +415,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Delegate a focused subtask into a background child session",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: delegate_async_definition,
         },
         ToolDescriptor {
@@ -335,6 +425,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Archive a visible terminal session from default session listings",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: session_archive_definition,
         },
         ToolDescriptor {
@@ -344,6 +435,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Cancel a visible async delegate child session",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: session_cancel_definition,
         },
         ToolDescriptor {
@@ -353,6 +445,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Fetch session events for a visible session",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: session_events_definition,
         },
         ToolDescriptor {
@@ -362,6 +455,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Recover an overdue queued async delegate child session by marking it failed",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: session_recover_definition,
         },
         ToolDescriptor {
@@ -371,6 +465,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Inspect the current status of a visible session",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: session_status_definition,
         },
         ToolDescriptor {
@@ -380,6 +475,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Wait for a visible session to reach a terminal state",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: session_wait_definition,
         },
         ToolDescriptor {
@@ -389,6 +485,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Fetch transcript history for a visible session",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: sessions_history_definition,
         },
         ToolDescriptor {
@@ -398,6 +495,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "List visible sessions and their high-level state",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: sessions_list_definition,
         },
         ToolDescriptor {
@@ -407,6 +505,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Send an outbound text message to a known channel-backed root session",
             execution_kind: ToolExecutionKind::App,
             availability: runtime_messaging_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: sessions_send_definition,
         },
     ];
@@ -420,6 +519,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Read file contents",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: file_read_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -429,6 +529,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Write file contents",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: file_write_definition,
         });
     }
@@ -442,6 +543,7 @@ pub fn tool_catalog() -> ToolCatalog {
             description: "Execute shell commands",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
             provider_definition_builder: shell_exec_definition,
         });
     }
@@ -535,6 +637,51 @@ pub fn delegate_child_tool_view_for_config_with_delegate(
     ToolView::from_tool_names(names)
 }
 
+pub fn provider_core_tool_catalog() -> Vec<ToolCatalogEntry> {
+    tool_catalog()
+        .descriptors()
+        .iter()
+        .filter(|descriptor| descriptor.is_provider_core())
+        .map(descriptor_to_entry)
+        .collect()
+}
+
+pub fn discoverable_tool_catalog() -> Vec<ToolCatalogEntry> {
+    tool_catalog()
+        .descriptors()
+        .iter()
+        .filter(|descriptor| descriptor.is_discoverable())
+        .map(descriptor_to_entry)
+        .collect()
+}
+
+pub fn all_tool_catalog() -> Vec<ToolCatalogEntry> {
+    tool_catalog()
+        .descriptors()
+        .iter()
+        .map(descriptor_to_entry)
+        .collect()
+}
+
+pub fn find_tool_catalog_entry(name: &str) -> Option<ToolCatalogEntry> {
+    tool_catalog().resolve(name).map(descriptor_to_entry)
+}
+
+fn descriptor_to_entry(descriptor: &ToolDescriptor) -> ToolCatalogEntry {
+    ToolCatalogEntry {
+        canonical_name: descriptor.name,
+        provider_function_name: descriptor.provider_name,
+        summary: descriptor.description,
+        argument_hint: descriptor.argument_hint(),
+        parameter_types: descriptor.parameter_types(),
+        required_fields: descriptor.required_fields(),
+        tags: descriptor.tags(),
+        exposure: descriptor.exposure,
+        execution_kind: descriptor.execution_kind,
+        availability: descriptor.availability,
+    }
+}
+
 fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> bool {
     match tool_name {
         "approval_request_resolve"
@@ -552,6 +699,60 @@ fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> boo
         "delegate" | "delegate_async" => config.delegate.enabled,
         _ => true,
     }
+}
+
+fn tool_search_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": "Discover non-core tools relevant to the current task.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Natural-language description of the tool capability you need."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Optional maximum number of search results to return."
+                    }
+                },
+                "required": ["query"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn tool_invoke_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": "Invoke a discovered non-core tool using a valid lease from tool_search.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "tool_id": {
+                        "type": "string",
+                        "description": "Canonical id of the discovered tool."
+                    },
+                    "lease": {
+                        "type": "string",
+                        "description": "Short-lived lease returned by tool_search."
+                    },
+                    "arguments": {
+                        "type": "object",
+                        "description": "Arguments for the discovered tool payload."
+                    }
+                },
+                "required": ["tool_id", "lease", "arguments"],
+                "additionalProperties": false
+            }
+        }
+    })
 }
 
 fn claw_import_definition(descriptor: &ToolDescriptor) -> Value {
@@ -1375,4 +1576,130 @@ fn delegate_async_definition(descriptor: &ToolDescriptor) -> Value {
             }
         }
     })
+}
+
+fn tool_argument_hint(name: &str) -> &'static str {
+    match name {
+        "tool.search" => "query:string,limit?:integer",
+        "tool.invoke" => "tool_id:string,lease:string,arguments:object",
+        "claw.import" => "input_path?:string,mode?:string,source?:string",
+        "external_skills.fetch" => {
+            "url:string,approval_granted?:boolean,save_as?:string,max_bytes?:integer"
+        }
+        "external_skills.inspect" => "skill_id:string",
+        "external_skills.install" => "path:string",
+        "external_skills.invoke" => "skill_id:string",
+        "external_skills.list" => "active_only?:boolean",
+        "external_skills.policy" => {
+            "action?:string,enabled?:boolean,allowed_domains?:string[],blocked_domains?:string[]"
+        }
+        "external_skills.remove" => "skill_id:string",
+        "file.read" => "path:string,max_bytes?:integer",
+        "file.write" => "path:string,content:string,create_dirs?:boolean",
+        "shell.exec" => "command:string,args?:string[]",
+        "provider.switch" => "selector?:string",
+        "delegate" | "delegate_async" => "task:string,label?:string,timeout_seconds?:integer",
+        "session_archive" | "session_cancel" | "session_events" | "session_recover"
+        | "session_status" | "session_wait" | "sessions_history" => "session_id:string",
+        "sessions_list" => "limit?:integer,status?:string",
+        "sessions_send" => "session_id:string,text:string",
+        _ => "",
+    }
+}
+
+fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
+    match name {
+        "tool.search" => &[("query", "string"), ("limit", "integer")],
+        "tool.invoke" => &[
+            ("tool_id", "string"),
+            ("lease", "string"),
+            ("arguments", "object"),
+        ],
+        "claw.import" => &[
+            ("input_path", "string"),
+            ("mode", "string"),
+            ("source", "string"),
+        ],
+        "external_skills.fetch" => &[
+            ("url", "string"),
+            ("approval_granted", "boolean"),
+            ("save_as", "string"),
+            ("max_bytes", "integer"),
+        ],
+        "external_skills.inspect" | "external_skills.invoke" | "external_skills.remove" => {
+            &[("skill_id", "string")]
+        }
+        "external_skills.install" => &[("path", "string")],
+        "external_skills.list" => &[("active_only", "boolean")],
+        "external_skills.policy" => &[
+            ("action", "string"),
+            ("enabled", "boolean"),
+            ("allowed_domains", "array"),
+            ("blocked_domains", "array"),
+        ],
+        "file.read" => &[("path", "string"), ("max_bytes", "integer")],
+        "file.write" => &[
+            ("path", "string"),
+            ("content", "string"),
+            ("create_dirs", "boolean"),
+        ],
+        "shell.exec" => &[("command", "string"), ("args", "array")],
+        "provider.switch" => &[("selector", "string")],
+        "delegate" | "delegate_async" => &[
+            ("task", "string"),
+            ("label", "string"),
+            ("timeout_seconds", "integer"),
+        ],
+        "session_archive" | "session_cancel" | "session_events" | "session_recover"
+        | "session_status" | "session_wait" | "sessions_history" => &[("session_id", "string")],
+        "sessions_list" => &[("limit", "integer"), ("status", "string")],
+        "sessions_send" => &[("session_id", "string"), ("text", "string")],
+        _ => &[],
+    }
+}
+
+fn tool_required_fields(name: &str) -> &'static [&'static str] {
+    match name {
+        "tool.search" => &["query"],
+        "tool.invoke" => &["tool_id", "lease", "arguments"],
+        "external_skills.fetch" => &["url"],
+        "external_skills.inspect" | "external_skills.invoke" | "external_skills.remove" => {
+            &["skill_id"]
+        }
+        "external_skills.install" => &["path"],
+        "file.read" => &["path"],
+        "file.write" => &["path", "content"],
+        "shell.exec" => &["command"],
+        "delegate" | "delegate_async" => &["task"],
+        "session_archive" | "session_cancel" | "session_events" | "session_recover"
+        | "session_status" | "session_wait" | "sessions_history" => &["session_id"],
+        "sessions_send" => &["session_id", "text"],
+        _ => &[],
+    }
+}
+
+fn tool_tags(name: &str) -> &'static [&'static str] {
+    match name {
+        "tool.search" => &["core", "discover", "search"],
+        "tool.invoke" => &["core", "dispatch", "invoke"],
+        "claw.import" => &["migration", "import", "config", "legacy"],
+        "external_skills.fetch" => &["skills", "download", "external", "fetch"],
+        "external_skills.inspect" => &["skills", "inspect", "metadata"],
+        "external_skills.install" => &["skills", "install", "package"],
+        "external_skills.invoke" => &["skills", "invoke", "instructions"],
+        "external_skills.list" => &["skills", "list", "discover"],
+        "external_skills.policy" => &["skills", "policy", "security"],
+        "external_skills.remove" => &["skills", "remove", "uninstall"],
+        "file.read" => &["file", "read", "filesystem", "repo"],
+        "file.write" => &["file", "write", "filesystem"],
+        "shell.exec" => &["shell", "command", "process", "exec"],
+        "provider.switch" => &["provider", "switch", "model", "runtime"],
+        "delegate" | "delegate_async" => &["session", "delegate", "child"],
+        "session_archive" | "session_cancel" | "session_events" | "session_recover"
+        | "session_status" | "session_wait" | "sessions_history" | "sessions_list" => {
+            &["session", "history", "runtime"]
+        }
+        "sessions_send" => &["session", "message", "channel"],
+        _ => &[],
+    }
 }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -196,6 +196,10 @@ impl ToolView {
         self.allowed_names.contains(tool_name)
     }
 
+    pub fn tool_names(&self) -> impl Iterator<Item = &str> {
+        self.allowed_names.iter().map(String::as_str)
+    }
+
     pub fn iter<'a>(
         &'a self,
         catalog: &'a ToolCatalog,

--- a/crates/app/src/tools/claw_import.rs
+++ b/crates/app/src/tools/claw_import.rs
@@ -550,7 +550,7 @@ fn ensure_path_within_root(root: &Path, path: &Path) -> Result<(), String> {
         return Ok(());
     }
     Err(format!(
-        "migration path {} escapes configured file root {}",
+        "policy_denied: migration path {} escapes configured file root {}",
         path.display(),
         root.display()
     ))
@@ -580,5 +580,43 @@ fn split_existing_ancestor(path: &Path) -> Result<(PathBuf, Vec<OsString>), Stri
             ));
         };
         cursor = parent.to_path_buf();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+    use crate::tools::runtime_config::ToolRuntimeConfig;
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    #[test]
+    fn resolve_safe_path_rejects_root_escape_with_policy_prefix() {
+        let base = unique_temp_dir("loongclaw-claw-import");
+        let root = base.join("root");
+        fs::create_dir_all(&root).expect("create root");
+
+        let config = ToolRuntimeConfig {
+            shell_allow: Default::default(),
+            shell_deny: Default::default(),
+            shell_default_mode: crate::tools::shell_policy_ext::ShellPolicyDefault::Deny,
+            file_root: Some(root),
+            config_path: None,
+            external_skills: Default::default(),
+        };
+        let error = resolve_safe_path_with_config("../outside.toml", &config)
+            .expect_err("escape should be denied");
+
+        assert!(error.starts_with("policy_denied: "));
+        assert!(error.contains("escapes configured file root"));
+        let _ = fs::remove_dir_all(base);
     }
 }

--- a/crates/app/src/tools/claw_import.rs
+++ b/crates/app/src/tools/claw_import.rs
@@ -611,6 +611,8 @@ mod tests {
             file_root: Some(root),
             config_path: None,
             external_skills: Default::default(),
+            #[cfg(feature = "feishu-integration")]
+            feishu: None,
         };
         let error = resolve_safe_path_with_config("../outside.toml", &config)
             .expect_err("escape should be denied");

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -20,6 +20,7 @@ const DEFAULT_SKILL_FILENAME: &str = "SKILL.md";
 const DEFAULT_INDEX_FILENAME: &str = "index.json";
 const DEFAULT_MAX_DOWNLOAD_BYTES: usize = 5 * 1024 * 1024;
 const HARD_MAX_DOWNLOAD_BYTES: usize = 20 * 1024 * 1024;
+#[cfg(test)]
 const INSTALLED_SKILL_SNAPSHOT_HINT: &str = "installed managed external skill; use external_skills.inspect or external_skills.invoke for details";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1368,6 +1369,7 @@ fn installed_skill_by_id(
         .ok_or_else(|| format!("external skill `{skill_id}` is not installed"))
 }
 
+#[cfg(test)]
 pub(super) fn installed_skill_snapshot_lines_with_config(
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<Vec<String>, String> {

--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -180,7 +180,7 @@ fn ensure_path_within_root(root: &Path, path: &Path) -> Result<(), String> {
         return Ok(());
     }
     Err(format!(
-        "file path {} escapes configured file root {}",
+        "policy_denied: file path {} escapes configured file root {}",
         path.display(),
         root.display()
     ))
@@ -279,6 +279,7 @@ mod tests {
         let error =
             resolve_safe_file_path_with_config("secret-link", &config).expect_err("escape denied");
 
+        assert!(error.starts_with("policy_denied: "));
         assert!(error.contains("escapes configured file root"));
         let _ = fs::remove_dir_all(base);
     }
@@ -310,6 +311,7 @@ mod tests {
         let error =
             execute_file_write_tool_with_config(request, &config).expect_err("escape denied");
 
+        assert!(error.starts_with("policy_denied: "));
         assert!(error.contains("escapes configured file root"));
         let _ = fs::remove_dir_all(base);
     }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -5,10 +5,15 @@ use std::{
     ffi::OsString,
     future::Future,
     path::{Path, PathBuf},
+    sync::OnceLock,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use loongclaw_contracts::{Capability, ToolCoreOutcome, ToolCoreRequest};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 
 use crate::KernelContext;
 use crate::config::ToolConfig;
@@ -105,12 +110,21 @@ fn payload_uses_reserved_internal_tool_context(payload: &Value) -> bool {
 /// policy enforcement and audit recording.
 ///
 /// All requests are dispatched via `kernel.execute_tool_core` which
-/// enforces `InvokeTool` capability, runs policy extensions, and records
-/// audit events.  Callers must always supply a `KernelContext`.
+/// enforces the derived capability set for the effective tool request, runs
+/// policy extensions, and records audit events.
+/// `kernel.execute_tool_core` which enforces the derived capability set
+/// for the effective tool request and records audit events.
 pub async fn execute_tool(
     request: ToolCoreRequest,
     kernel_ctx: &KernelContext,
 ) -> Result<ToolCoreOutcome, String> {
+    let request = prepare_kernel_tool_request(
+        request,
+        &kernel_ctx.token.allowed_capabilities,
+        Some(kernel_ctx.token.token_id.as_str()),
+        None,
+        None,
+    );
     execute_kernel_tool_request(kernel_ctx, request, false)
         .await
         .map_err(|e| format!("{e}"))
@@ -121,7 +135,7 @@ pub(crate) async fn execute_kernel_tool_request(
     request: ToolCoreRequest,
     trusted_internal_payload: bool,
 ) -> Result<ToolCoreOutcome, loongclaw_kernel::KernelError> {
-    let caps = BTreeSet::from([Capability::InvokeTool]);
+    let caps = required_capabilities_for_request(&request);
     if trusted_internal_payload {
         return with_trusted_internal_tool_payload_async(async move {
             ctx.kernel
@@ -263,6 +277,62 @@ pub(super) fn normalize_without_fs(path: &Path) -> PathBuf {
     }
 }
 
+const TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD: &str = "_granted_capabilities";
+const TOOL_LEASE_TOKEN_ID_FIELD: &str = "_lease_token_id";
+const TOOL_LEASE_SESSION_ID_FIELD: &str = "_lease_session_id";
+const TOOL_LEASE_TURN_ID_FIELD: &str = "_lease_turn_id";
+
+pub(crate) fn prepare_kernel_tool_request(
+    mut request: ToolCoreRequest,
+    granted_capabilities: &BTreeSet<Capability>,
+    token_id: Option<&str>,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> ToolCoreRequest {
+    let canonical_tool_name = canonical_tool_name(request.tool_name.as_str());
+    if !matches!(canonical_tool_name, "tool.search" | "tool.invoke") {
+        return request;
+    }
+
+    if let Value::Object(payload) = &mut request.payload {
+        if canonical_tool_name == "tool.search" {
+            let granted =
+                serde_json::to_value(granted_capabilities.iter().copied().collect::<Vec<_>>())
+                    .unwrap_or_else(|_| Value::Array(Vec::new()));
+            payload.insert(TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD.to_owned(), granted);
+        }
+        inject_tool_lease_binding(payload, token_id, session_id, turn_id);
+    }
+
+    request
+}
+
+fn inject_tool_lease_binding(
+    payload: &mut serde_json::Map<String, Value>,
+    token_id: Option<&str>,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) {
+    if let Some(token_id) = token_id {
+        payload.insert(
+            TOOL_LEASE_TOKEN_ID_FIELD.to_owned(),
+            Value::String(token_id.to_owned()),
+        );
+    }
+    if let Some(session_id) = session_id {
+        payload.insert(
+            TOOL_LEASE_SESSION_ID_FIELD.to_owned(),
+            Value::String(session_id.to_owned()),
+        );
+    }
+    if let Some(turn_id) = turn_id {
+        payload.insert(
+            TOOL_LEASE_TURN_ID_FIELD.to_owned(),
+            Value::String(turn_id.to_owned()),
+        );
+    }
+}
+
 pub fn canonical_tool_name(raw: &str) -> &str {
     let catalog = tool_catalog();
     if let Some(descriptor) = catalog.resolve(raw) {
@@ -273,6 +343,74 @@ pub fn canonical_tool_name(raw: &str) -> &str {
         return canonical;
     }
     raw
+}
+
+pub(crate) fn required_capabilities_for_request(request: &ToolCoreRequest) -> BTreeSet<Capability> {
+    required_capabilities_for_tool_name_and_payload(
+        canonical_tool_name(request.tool_name.as_str()),
+        &request.payload,
+    )
+}
+
+fn required_capabilities_for_tool_name_and_payload(
+    tool_name: &str,
+    payload: &Value,
+) -> BTreeSet<Capability> {
+    let mut caps = BTreeSet::from([Capability::InvokeTool]);
+    match tool_name {
+        "tool.invoke" => {
+            let Some((invoked_tool_name, invoked_payload)) =
+                invoked_discoverable_tool_request(payload)
+            else {
+                return caps;
+            };
+            return required_capabilities_for_tool_name_and_payload(
+                invoked_tool_name,
+                invoked_payload,
+            );
+        }
+        "file.read" => {
+            caps.insert(Capability::FilesystemRead);
+        }
+        "file.write" => {
+            caps.insert(Capability::FilesystemWrite);
+        }
+        "claw.import" => {
+            caps.insert(Capability::FilesystemRead);
+            if claw_import_mode_requires_write(payload) {
+                caps.insert(Capability::FilesystemWrite);
+            }
+        }
+        _ => {}
+    }
+    caps
+}
+
+fn invoked_discoverable_tool_request(payload: &Value) -> Option<(&str, &Value)> {
+    let tool_id = payload
+        .get("tool_id")
+        .and_then(Value::as_str)
+        .map(canonical_tool_name)?;
+    if matches!(tool_id, "tool.search" | "tool.invoke") {
+        return None;
+    }
+    let entry = catalog::find_tool_catalog_entry(tool_id)?;
+    if !entry.is_discoverable() {
+        return None;
+    }
+    Some((tool_id, payload.get("arguments").unwrap_or(payload)))
+}
+
+fn claw_import_mode_requires_write(payload: &Value) -> bool {
+    matches!(
+        payload
+            .get("mode")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("plan"),
+        "apply" | "apply_selected" | "rollback_last_apply"
+    )
 }
 
 pub fn is_known_tool_name(raw: &str) -> bool {
@@ -290,7 +428,13 @@ pub fn is_known_tool_name(raw: &str) -> bool {
 }
 
 pub fn is_known_tool_name_in_view(raw: &str, view: &ToolView) -> bool {
-    view.contains(canonical_tool_name(raw))
+    let canonical_name = canonical_tool_name(raw);
+    is_provider_exposed_tool_name(canonical_name) || view.contains(canonical_name)
+}
+
+pub fn is_provider_exposed_tool_name(raw: &str) -> bool {
+    catalog::find_tool_catalog_entry(canonical_tool_name(raw))
+        .is_some_and(|entry| entry.is_provider_core())
 }
 
 pub(crate) fn runtime_tool_view_from_loongclaw_config(
@@ -361,6 +505,17 @@ pub fn execute_tool_core_with_config(
         payload: request.payload,
     };
     match canonical_name {
+        "tool.search" => execute_tool_search_tool_with_config(request, config),
+        "tool.invoke" => execute_tool_invoke_tool_with_config(request, config),
+        _ => execute_discoverable_tool_core_with_config(request, config),
+    }
+}
+
+fn execute_discoverable_tool_core_with_config(
+    request: ToolCoreRequest,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    match request.tool_name.as_str() {
         "claw.import" => claw_import::execute_claw_import_tool_with_config(request, config),
         "external_skills.inspect" => {
             external_skills::execute_external_skills_inspect_tool_with_config(request, config)
@@ -413,21 +568,16 @@ pub fn tool_registry() -> Vec<ToolRegistryEntry> {
 }
 
 pub(crate) fn tool_registry_with_config(
-    config: Option<&runtime_config::ToolRuntimeConfig>,
+    _config: Option<&runtime_config::ToolRuntimeConfig>,
 ) -> Vec<ToolRegistryEntry> {
-    let catalog = tool_catalog();
-    let mut entries = runtime_tool_view()
-        .iter(&catalog)
-        .map(|descriptor| ToolRegistryEntry {
-            name: descriptor.name,
-            description: descriptor.description,
+    let mut entries: Vec<ToolRegistryEntry> = catalog::discoverable_tool_catalog()
+        .into_iter()
+        .map(|entry| ToolRegistryEntry {
+            name: entry.canonical_name,
+            description: entry.summary,
         })
-        .collect::<Vec<_>>();
-    #[cfg(feature = "feishu-integration")]
-    if feishu_runtime_enabled(config) {
-        entries.extend(feishu::feishu_tool_registry_entries());
-        entries.sort_by_key(|entry| entry.name);
-    }
+        .collect();
+    entries.sort_by_key(|entry| entry.name);
     entries
 }
 
@@ -446,33 +596,16 @@ pub fn capability_snapshot_for_view(view: &ToolView) -> String {
 }
 
 pub(crate) fn capability_snapshot_for_view_with_config(
-    view: &ToolView,
-    config: &runtime_config::ToolRuntimeConfig,
+    _view: &ToolView,
+    _config: &runtime_config::ToolRuntimeConfig,
 ) -> String {
-    let root_view = runtime_tool_view();
-    let mut lines = vec!["[available_tools]".to_owned()];
-    if view == &root_view {
-        for entry in tool_registry_with_config(Some(config)) {
-            lines.push(format!("- {}: {}", entry.name, entry.description));
-        }
-    } else {
-        let catalog = tool_catalog();
-        for descriptor in view.iter(&catalog) {
-            lines.push(format!("- {}: {}", descriptor.name, descriptor.description));
-        }
+    let mut lines = vec!["[tool_discovery_runtime]".to_owned()];
+    for entry in catalog::provider_core_tool_catalog() {
+        lines.push(format!("- {}: {}", entry.canonical_name, entry.summary));
     }
-    let catalog = tool_catalog();
-    let includes_external_skills = view
-        .iter(&catalog)
-        .any(|descriptor| descriptor.name.starts_with("external_skills."));
-    if includes_external_skills
-        && let Ok(skill_lines) = external_skills::installed_skill_snapshot_lines_with_config(config)
-        && !skill_lines.is_empty()
-    {
-        lines.push(String::new());
-        lines.push("[available_external_skills]".to_owned());
-        lines.extend(skill_lines);
-    }
+    lines.push(
+        "Non-core tools are intentionally hidden until discovered with tool.search.".to_owned(),
+    );
     lines.join("\n")
 }
 
@@ -485,45 +618,432 @@ pub fn provider_tool_definitions() -> Vec<Value> {
 }
 
 pub(crate) fn provider_tool_definitions_with_config(
-    config: Option<&runtime_config::ToolRuntimeConfig>,
+    _config: Option<&runtime_config::ToolRuntimeConfig>,
 ) -> Vec<Value> {
+    provider_tool_definitions_for_view(&runtime_tool_view())
+}
+
+pub fn try_provider_tool_definitions_for_view(_view: &ToolView) -> Result<Vec<Value>, String> {
+    Ok(provider_tool_definitions_for_view(_view))
+}
+
+fn provider_tool_definitions_for_view(_view: &ToolView) -> Vec<Value> {
     let catalog = tool_catalog();
-    let mut tools = runtime_tool_view()
-        .iter(&catalog)
-        .map(|descriptor| {
-            debug_assert_eq!(descriptor.availability, ToolAvailability::Runtime);
-            descriptor.provider_definition()
+    let mut tools = catalog
+        .descriptors()
+        .iter()
+        .filter(|descriptor| {
+            descriptor.is_provider_core() && descriptor.availability == ToolAvailability::Runtime
         })
+        .map(ToolDescriptor::provider_definition)
         .collect::<Vec<_>>();
-    #[cfg(feature = "feishu-integration")]
-    if feishu_runtime_enabled(config) {
-        tools.extend(feishu::feishu_provider_tool_definitions());
-        tools.sort_by(|left, right| tool_function_name(left).cmp(tool_function_name(right)));
-    }
+    tools.sort_by(|left, right| tool_function_name(left).cmp(tool_function_name(right)));
     tools
 }
 
-pub fn try_provider_tool_definitions_for_view(view: &ToolView) -> Result<Vec<Value>, String> {
-    let catalog = tool_catalog();
-    let mut tools = Vec::new();
-    for descriptor in view.iter(&catalog) {
-        if descriptor.availability != ToolAvailability::Runtime {
-            return Err(format!(
-                "tool_not_advertisable: `{}` is still planned and cannot be exposed yet",
-                descriptor.name
-            ));
+pub fn tool_parameter_schema_types() -> BTreeMap<String, BTreeMap<String, &'static str>> {
+    let mut tools_by_name = BTreeMap::<String, BTreeMap<String, &'static str>>::new();
+    for entry in catalog::all_tool_catalog() {
+        let parameters = entry
+            .parameter_types
+            .iter()
+            .map(|(parameter_name, parameter_type)| ((*parameter_name).to_owned(), *parameter_type))
+            .collect::<BTreeMap<_, _>>();
+        if !parameters.is_empty() {
+            tools_by_name.insert(entry.canonical_name.to_owned(), parameters);
         }
-        tools.push(descriptor.provider_definition());
     }
-    Ok(tools)
+    tools_by_name
 }
 
-#[cfg(feature = "feishu-integration")]
-fn feishu_runtime_enabled(config: Option<&runtime_config::ToolRuntimeConfig>) -> bool {
-    match config {
-        Some(config) => config.feishu.is_some(),
-        None => runtime_config::get_tool_runtime_config().feishu.is_some(),
+const TOOL_LEASE_TTL_SECONDS: u64 = 300;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ToolLeaseClaims {
+    tool_id: String,
+    catalog_digest: String,
+    expires_at_unix: u64,
+    token_id: Option<String>,
+    session_id: Option<String>,
+    turn_id: Option<String>,
+}
+fn execute_tool_search_tool_with_config(
+    request: ToolCoreRequest,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "tool.search payload must be an object".to_owned())?;
+    let query = payload
+        .get("query")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "tool.search requires payload.query".to_owned())?;
+    let limit = payload
+        .get("limit")
+        .and_then(Value::as_u64)
+        .map(|value| value.clamp(1, 8) as usize)
+        .unwrap_or(5);
+    let granted_capabilities = payload
+        .get(TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD)
+        .cloned()
+        .and_then(|value| serde_json::from_value::<BTreeSet<Capability>>(value).ok());
+
+    let query_normalized = query.to_ascii_lowercase();
+    let tokens = tokenize_search_query(query_normalized.as_str());
+    let mut ranked: Vec<(u32, Vec<String>, catalog::ToolCatalogEntry)> =
+        catalog::discoverable_tool_catalog()
+            .into_iter()
+            .filter(|entry| tool_search_entry_is_runtime_usable(*entry, config))
+            .filter(|entry| {
+                tool_search_entry_is_capability_usable(*entry, granted_capabilities.as_ref())
+            })
+            .filter_map(|entry| {
+                let (score, why) = search_score(entry, query_normalized.as_str(), &tokens);
+                if score == 0 {
+                    None
+                } else {
+                    Some((score, why, entry))
+                }
+            })
+            .collect();
+    ranked.sort_by(|(left_score, _, left), (right_score, _, right)| {
+        right_score
+            .cmp(left_score)
+            .then_with(|| left.canonical_name.cmp(right.canonical_name))
+    });
+
+    let results: Vec<Value> = ranked
+        .into_iter()
+        .take(limit)
+        .map(|(_score, why, entry)| {
+            json!({
+                "tool_id": entry.canonical_name,
+                "summary": entry.summary,
+                "argument_hint": entry.argument_hint,
+                "required_fields": entry.required_fields,
+                "tags": entry.tags,
+                "why": why,
+                "lease": issue_tool_lease(entry.canonical_name, payload),
+            })
+        })
+        .collect();
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": request.tool_name,
+            "query": query,
+            "returned": results.len(),
+            "results": results,
+        }),
+    })
+}
+
+fn tool_search_entry_is_runtime_usable(
+    entry: catalog::ToolCatalogEntry,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> bool {
+    match entry.canonical_name {
+        "shell.exec" => {
+            !config.shell_allow.is_empty()
+                || matches!(
+                    config.shell_default_mode,
+                    crate::tools::shell_policy_ext::ShellPolicyDefault::Allow
+                )
+        }
+        "external_skills.fetch"
+        | "external_skills.install"
+        | "external_skills.inspect"
+        | "external_skills.invoke"
+        | "external_skills.list"
+        | "external_skills.remove" => config.external_skills.enabled,
+        _ => true,
     }
+}
+
+fn tool_search_entry_is_capability_usable(
+    entry: catalog::ToolCatalogEntry,
+    granted_capabilities: Option<&BTreeSet<Capability>>,
+) -> bool {
+    let Some(granted_capabilities) = granted_capabilities else {
+        return true;
+    };
+    let required =
+        required_capabilities_for_tool_name_and_payload(entry.canonical_name, &json!({}));
+    required
+        .iter()
+        .all(|capability| granted_capabilities.contains(capability))
+}
+
+pub(crate) fn resolve_tool_invoke_request(
+    request: &ToolCoreRequest,
+) -> Result<(catalog::ToolCatalogEntry, ToolCoreRequest), String> {
+    if canonical_tool_name(request.tool_name.as_str()) != "tool.invoke" {
+        return Err(format!(
+            "tool_invoke_required: expected `tool.invoke`, got `{}`",
+            request.tool_name
+        ));
+    }
+
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "tool.invoke payload must be an object".to_owned())?;
+    let tool_id = payload
+        .get("tool_id")
+        .and_then(Value::as_str)
+        .map(canonical_tool_name)
+        .ok_or_else(|| "tool.invoke requires payload.tool_id".to_owned())?;
+    let lease = payload
+        .get("lease")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "tool.invoke requires payload.lease".to_owned())?;
+    let arguments = payload
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    if !arguments.is_object() {
+        return Err("tool.invoke payload.arguments must be an object".to_owned());
+    }
+
+    let entry = catalog::find_tool_catalog_entry(tool_id)
+        .ok_or_else(|| format!("tool_not_found: unknown tool `{tool_id}`"))?;
+    if !entry.is_discoverable() {
+        return Err(format!(
+            "tool_not_provider_exposed: {tool_id} must be called directly as a core tool"
+        ));
+    }
+    validate_tool_lease(tool_id, lease, payload)?;
+
+    Ok((
+        entry,
+        ToolCoreRequest {
+            tool_name: tool_id.to_owned(),
+            payload: arguments,
+        },
+    ))
+}
+
+fn execute_tool_invoke_tool_with_config(
+    request: ToolCoreRequest,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let (entry, effective_request) = resolve_tool_invoke_request(&request)?;
+    match entry.execution_kind {
+        ToolExecutionKind::Core => {
+            execute_discoverable_tool_core_with_config(effective_request, config)
+        }
+        ToolExecutionKind::App => Err(format!(
+            "tool_requires_app_dispatcher: {}",
+            entry.canonical_name
+        )),
+    }
+}
+
+fn tokenize_search_query(query: &str) -> Vec<String> {
+    query
+        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '-')
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn search_score(
+    entry: catalog::ToolCatalogEntry,
+    query: &str,
+    tokens: &[String],
+) -> (u32, Vec<String>) {
+    let name = entry.canonical_name.to_ascii_lowercase();
+    let summary = entry.summary.to_ascii_lowercase();
+    let argument_hint = entry.argument_hint.to_ascii_lowercase();
+    let tags = entry.tags.join(" ").to_ascii_lowercase();
+
+    let mut score = 0u32;
+    let mut why = Vec::new();
+
+    if name.contains(query) {
+        score += 50;
+        why.push("name_match".to_owned());
+    }
+    if summary.contains(query) {
+        score += 30;
+        why.push("summary_match".to_owned());
+    }
+    if argument_hint.contains(query) {
+        score += 20;
+        why.push("argument_match".to_owned());
+    }
+
+    for token in tokens {
+        if name.contains(token) {
+            score += 16;
+            why.push(format!("name:{token}"));
+        }
+        if summary.contains(token) {
+            score += 10;
+            why.push(format!("summary:{token}"));
+        }
+        if argument_hint.contains(token) {
+            score += 8;
+            why.push(format!("argument:{token}"));
+        }
+        if tags.contains(token) {
+            score += 12;
+            why.push(format!("tag:{token}"));
+        }
+    }
+
+    (score, why)
+}
+
+fn issue_tool_lease(tool_id: &str, payload: &serde_json::Map<String, Value>) -> String {
+    let binding = extract_tool_lease_binding(payload);
+    let claims = ToolLeaseClaims {
+        tool_id: tool_id.to_owned(),
+        catalog_digest: tool_catalog_digest(),
+        expires_at_unix: now_unix_seconds().saturating_add(TOOL_LEASE_TTL_SECONDS),
+        token_id: binding.token_id,
+        session_id: binding.session_id,
+        turn_id: binding.turn_id,
+    };
+    let claims_bytes = serde_json::to_vec(&claims).unwrap_or_default();
+    let encoded_claims = URL_SAFE_NO_PAD.encode(claims_bytes);
+    let signature = sign_tool_lease(encoded_claims.as_str());
+    format!("{encoded_claims}.{signature}")
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn synthesize_test_provider_tool_call(
+    tool_name: &str,
+    args_json: Value,
+) -> (String, Value) {
+    synthesize_test_provider_tool_call_with_scope(tool_name, args_json, None, None)
+}
+
+#[cfg(test)]
+pub(crate) fn synthesize_test_provider_tool_call_with_scope(
+    tool_name: &str,
+    args_json: Value,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> (String, Value) {
+    let canonical_name = canonical_tool_name(tool_name).to_owned();
+    let Some(entry) = catalog::find_tool_catalog_entry(canonical_name.as_str()) else {
+        return (canonical_name, args_json);
+    };
+    if !entry.is_discoverable() {
+        return (canonical_name, args_json);
+    }
+    let mut lease_payload = serde_json::Map::new();
+    inject_tool_lease_binding(&mut lease_payload, None, session_id, turn_id);
+    (
+        "tool.invoke".to_owned(),
+        json!({
+            "tool_id": entry.canonical_name,
+            "lease": issue_tool_lease(entry.canonical_name, &lease_payload),
+            "arguments": args_json,
+        }),
+    )
+}
+
+fn validate_tool_lease(
+    expected_tool_id: &str,
+    lease: &str,
+    payload: &serde_json::Map<String, Value>,
+) -> Result<(), String> {
+    let Some((encoded_claims, signature)) = lease.split_once('.') else {
+        return Err("invalid_tool_lease: malformed lease".to_owned());
+    };
+    let expected_signature = sign_tool_lease(encoded_claims);
+    if expected_signature != signature {
+        return Err("invalid_tool_lease: signature mismatch".to_owned());
+    }
+    let claims_bytes = URL_SAFE_NO_PAD
+        .decode(encoded_claims)
+        .map_err(|error| format!("invalid_tool_lease: claims decode failed: {error}"))?;
+    let claims: ToolLeaseClaims = serde_json::from_slice(&claims_bytes)
+        .map_err(|error| format!("invalid_tool_lease: claims parse failed: {error}"))?;
+    if claims.tool_id != expected_tool_id {
+        return Err("invalid_tool_lease: tool mismatch".to_owned());
+    }
+    if claims.catalog_digest != tool_catalog_digest() {
+        return Err("invalid_tool_lease: catalog mismatch".to_owned());
+    }
+    if claims.expires_at_unix <= now_unix_seconds() {
+        return Err("invalid_tool_lease: expired lease".to_owned());
+    }
+    let binding = extract_tool_lease_binding(payload);
+    if claims.token_id.is_some() && claims.token_id != binding.token_id {
+        return Err("invalid_tool_lease: token mismatch".to_owned());
+    }
+    if claims.session_id.is_some() && claims.session_id != binding.session_id {
+        return Err("invalid_tool_lease: session mismatch".to_owned());
+    }
+    if claims.turn_id.is_some() && claims.turn_id != binding.turn_id {
+        return Err("invalid_tool_lease: turn mismatch".to_owned());
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Default)]
+struct ToolLeaseBinding {
+    token_id: Option<String>,
+    session_id: Option<String>,
+    turn_id: Option<String>,
+}
+
+fn extract_tool_lease_binding(payload: &serde_json::Map<String, Value>) -> ToolLeaseBinding {
+    ToolLeaseBinding {
+        token_id: payload
+            .get(TOOL_LEASE_TOKEN_ID_FIELD)
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        session_id: payload
+            .get(TOOL_LEASE_SESSION_ID_FIELD)
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        turn_id: payload
+            .get(TOOL_LEASE_TURN_ID_FIELD)
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+    }
+}
+
+fn sign_tool_lease(encoded_claims: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(tool_lease_secret().as_bytes());
+    hasher.update(b":");
+    hasher.update(encoded_claims.as_bytes());
+    let digest = hasher.finalize();
+    format!("{digest:x}")
+}
+
+fn tool_catalog_digest() -> String {
+    let payload = serde_json::to_vec(&catalog::all_tool_catalog()).unwrap_or_default();
+    let digest = Sha256::digest(payload);
+    format!("{digest:x}")
+}
+
+fn tool_lease_secret() -> &'static str {
+    static SECRET: OnceLock<String> = OnceLock::new();
+    SECRET.get_or_init(|| {
+        let seed = format!("tool-lease:{}:{}", std::process::id(), now_unix_seconds());
+        let digest = Sha256::digest(seed.as_bytes());
+        format!("{digest:x}")
+    })
+}
+
+fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 fn tool_function_name(tool: &Value) -> &str {
@@ -595,6 +1115,25 @@ fn _shape_examples() -> BTreeMap<&'static str, Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+
+    fn test_tool_runtime_config(root: PathBuf) -> runtime_config::ToolRuntimeConfig {
+        runtime_config::ToolRuntimeConfig {
+            shell_allow: BTreeSet::from(["echo".to_owned(), "cat".to_owned(), "ls".to_owned()]),
+            shell_deny: BTreeSet::new(),
+            shell_default_mode: crate::tools::shell_policy_ext::ShellPolicyDefault::Deny,
+            file_root: Some(root),
+            config_path: None,
+            external_skills: runtime_config::ExternalSkillsRuntimePolicy {
+                enabled: true,
+                require_download_approval: true,
+                allowed_domains: BTreeSet::new(),
+                blocked_domains: BTreeSet::new(),
+                install_root: None,
+                auto_expose_installed: false,
+            },
+        }
+    }
 
     fn execute_tool_core_with_test_context(
         request: ToolCoreRequest,
@@ -611,9 +1150,12 @@ mod tests {
 
     #[test]
     fn capability_snapshot_is_deterministic() {
-        let snapshot =
-            capability_snapshot_with_config(&runtime_config::ToolRuntimeConfig::default());
-        assert!(snapshot.starts_with("[available_tools]"));
+        let snapshot = capability_snapshot();
+        assert!(snapshot.starts_with("[tool_discovery_runtime]"));
+        assert!(snapshot.contains("- tool.search: Discover non-core tools"));
+        assert!(snapshot.contains("- tool.invoke: Invoke a discovered non-core tool"));
+        assert!(!snapshot.contains("shell.exec"));
+        assert!(!snapshot.contains("file.read"));
 
         let snapshot2 =
             capability_snapshot_with_config(&runtime_config::ToolRuntimeConfig::default());
@@ -621,7 +1163,7 @@ mod tests {
     }
 
     #[test]
-    fn capability_snapshot_can_include_installed_external_skills() {
+    fn capability_snapshot_stays_compact_when_external_skills_are_installed() {
         use std::{
             fs,
             path::{Path, PathBuf},
@@ -652,19 +1194,7 @@ mod tests {
             "# Demo Skill\n\nUse this skill for explicit verification.\n",
         );
 
-        let config = runtime_config::ToolRuntimeConfig {
-            file_root: Some(root.clone()),
-            config_path: None,
-            external_skills: runtime_config::ExternalSkillsRuntimePolicy {
-                enabled: true,
-                require_download_approval: true,
-                allowed_domains: BTreeSet::new(),
-                blocked_domains: BTreeSet::new(),
-                install_root: None,
-                auto_expose_installed: true,
-            },
-            ..runtime_config::ToolRuntimeConfig::default()
-        };
+        let config = test_tool_runtime_config(root.clone());
         execute_tool_core_with_config(
             ToolCoreRequest {
                 tool_name: "external_skills.install".to_owned(),
@@ -677,10 +1207,10 @@ mod tests {
         .expect("install should succeed");
 
         let snapshot = capability_snapshot_with_config(&config);
-        assert!(snapshot.contains("[available_external_skills]"));
-        assert!(snapshot.contains(
-            "- demo-skill: installed managed external skill; use external_skills.inspect or external_skills.invoke for details"
-        ));
+        assert!(snapshot.starts_with("[tool_discovery_runtime]"));
+        assert!(!snapshot.contains("[available_external_skills]"));
+        assert!(!snapshot.contains("demo-skill"));
+        assert!(!snapshot.contains("external_skills.invoke"));
 
         fs::remove_dir_all(&root).ok();
     }
@@ -691,110 +1221,20 @@ mod tests {
         feature = "memory-sqlite"
     ))]
     #[test]
-    fn capability_snapshot_lists_all_tools_when_all_features_enabled() {
-        let snapshot =
-            capability_snapshot_with_config(&runtime_config::ToolRuntimeConfig::default());
-        assert!(snapshot.contains(
-            "- approval_request_resolve: Resolve one visible governed tool approval request"
-        ));
-        assert!(snapshot.contains(
-            "- approval_request_status: Inspect full detail for a visible governed tool approval request"
-        ));
-        assert!(snapshot.contains(
-            "- approval_requests_list: List visible governed tool approval requests across the current session scope"
-        ));
-        assert!(
-            snapshot.contains(
-                "- claw.import: Import legacy Claw configs into native LoongClaw settings"
-            )
-        );
-        assert!(snapshot.contains("- delegate: Delegate a focused subtask into a child session"));
-        assert!(snapshot.contains(
-            "- delegate_async: Delegate a focused subtask into a background child session"
-        ));
-        assert!(snapshot.contains("- external_skills.fetch: Download external skills artifacts with domain policy and approval guards"));
-        assert!(snapshot.contains("- external_skills.install: Install a managed external skill from a local directory or archive"));
-        assert!(
-            snapshot.contains(
-                "- external_skills.inspect: Read metadata for an installed external skill"
-            )
-        );
-        assert!(snapshot.contains(
-            "- external_skills.invoke: Load an installed external skill into the conversation loop"
-        ));
-        assert!(snapshot.contains(
-            "- external_skills.list: List managed external skills available for invocation"
-        ));
-        assert!(snapshot.contains("- external_skills.policy: Read/update external skills domain allow/block policy at runtime"));
-        assert!(snapshot.contains(
-            "- external_skills.remove: Remove an installed external skill from the managed runtime"
-        ));
-        assert!(snapshot.contains("- file.read: Read file contents"));
-        assert!(snapshot.contains("- file.write: Write file contents"));
-        assert!(snapshot.contains(
-            "- provider.switch: Inspect current provider state or switch the default provider profile for subsequent turns"
-        ));
-        assert!(snapshot.contains(
-            "- session_archive: Archive a visible terminal session from default session listings"
-        ));
-        assert!(
-            snapshot.contains("- session_cancel: Cancel a visible async delegate child session")
-        );
-        assert!(snapshot.contains("- session_events: Fetch session events for a visible session"));
-        assert!(snapshot.contains(
-            "- session_recover: Recover an overdue queued async delegate child session by marking it failed"
-        ));
-        assert!(
-            snapshot.contains("- session_status: Inspect the current status of a visible session")
-        );
-        assert!(
-            snapshot
-                .contains("- session_wait: Wait for a visible session to reach a terminal state")
-        );
-        assert!(
-            snapshot.contains("- sessions_history: Fetch transcript history for a visible session")
-        );
-        assert!(
-            snapshot.contains("- sessions_list: List visible sessions and their high-level state")
-        );
-        assert!(snapshot.contains("- shell.exec: Execute shell commands"));
+    fn capability_snapshot_only_lists_core_discovery_tools() {
+        let snapshot = capability_snapshot();
+        assert!(snapshot.contains("- tool.search: Discover non-core tools"));
+        assert!(snapshot.contains("- tool.invoke: Invoke a discovered non-core tool"));
+        assert!(snapshot.contains("Non-core tools are intentionally hidden"));
+        assert!(!snapshot.contains("claw.import"));
+        assert!(!snapshot.contains("external_skills.fetch"));
+        assert!(!snapshot.contains("file.read"));
+        assert!(!snapshot.contains("shell.exec"));
 
-        // Verify sorted order matches the catalog snapshot emitted to providers.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        let ordered_prefixes = vec![
-            "- approval_request_resolve",
-            "- approval_request_status",
-            "- approval_requests_list",
-            "- claw.import",
-            "- delegate",
-            "- delegate_async",
-            "- external_skills.fetch",
-            "- external_skills.inspect",
-            "- external_skills.install",
-            "- external_skills.invoke",
-            "- external_skills.list",
-            "- external_skills.policy",
-            "- external_skills.remove",
-            "- file.read",
-            "- file.write",
-            "- provider.switch",
-            "- session_archive",
-            "- session_cancel",
-            "- session_events",
-            "- session_recover",
-            "- session_status",
-            "- session_wait",
-            "- sessions_history",
-            "- sessions_list",
-            "- shell.exec",
-        ];
-        assert_eq!(lines.len(), ordered_prefixes.len());
-        for (line, prefix) in lines.iter().zip(ordered_prefixes) {
-            assert!(
-                line.starts_with(prefix),
-                "expected `{prefix}`, got `{line}`"
-            );
-        }
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].starts_with("- tool.invoke"));
+        assert!(lines[1].starts_with("- tool.search"));
     }
 
     #[cfg(all(
@@ -836,22 +1276,22 @@ mod tests {
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
-    fn capability_snapshot_for_view_only_lists_selected_tools() {
+    fn capability_snapshot_for_view_stays_core_only_under_restricted_view() {
         let view = ToolView::from_tool_names(["claw.import", "shell.exec"]);
         let snapshot = capability_snapshot_for_view(&view);
 
-        assert!(snapshot.contains("- claw.import:"));
-        assert!(snapshot.contains("- shell.exec:"));
-        assert!(!snapshot.contains("- file.read:"));
-        assert!(!snapshot.contains("- external_skills.list:"));
+        assert!(snapshot.contains("- tool.search: Discover non-core tools"));
+        assert!(snapshot.contains("- tool.invoke: Invoke a discovered non-core tool"));
+        assert!(!snapshot.contains("- claw.import:"));
+        assert!(!snapshot.contains("- shell.exec:"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
-    fn try_provider_tool_definitions_for_view_returns_sorted_subset() {
+    fn try_provider_tool_definitions_for_view_returns_core_only_subset() {
         let view = ToolView::from_tool_names(["shell.exec", "claw.import"]);
         let defs = try_provider_tool_definitions_for_view(&view)
-            .expect("restricted runtime view should be advertisable");
+            .expect("restricted runtime view should still expose provider-core schemas");
         let names: Vec<&str> = defs
             .iter()
             .filter_map(|item| item.get("function"))
@@ -859,16 +1299,7 @@ mod tests {
             .filter_map(Value::as_str)
             .collect();
 
-        assert_eq!(names, vec!["claw_import", "shell_exec"]);
-    }
-
-    #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
-    #[test]
-    fn planned_root_tool_view_is_advertisable_when_all_tools_are_runtime_ready() {
-        let defs = try_provider_tool_definitions_for_view(&planned_root_tool_view())
-            .expect("all tools should now be advertisable");
-
-        assert_eq!(defs.len(), 26);
+        assert_eq!(names, vec!["tool_invoke", "tool_search"]);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -965,9 +1396,9 @@ mod tests {
         feature = "memory-sqlite"
     ))]
     #[test]
-    fn provider_tool_definitions_are_stable_and_complete() {
+    fn provider_tool_definitions_are_stable_and_core_only() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 25);
+        assert_eq!(defs.len(), 2);
 
         let names: Vec<&str> = defs
             .iter()
@@ -975,153 +1406,42 @@ mod tests {
             .filter_map(|function| function.get("name"))
             .filter_map(Value::as_str)
             .collect();
-        assert_eq!(
-            names,
-            vec![
-                "approval_request_resolve",
-                "approval_request_status",
-                "approval_requests_list",
-                "claw_import",
-                "delegate",
-                "delegate_async",
-                "external_skills_fetch",
-                "external_skills_inspect",
-                "external_skills_install",
-                "external_skills_invoke",
-                "external_skills_list",
-                "external_skills_policy",
-                "external_skills_remove",
-                "file_read",
-                "file_write",
-                "provider_switch",
-                "session_archive",
-                "session_cancel",
-                "session_events",
-                "session_recover",
-                "session_status",
-                "session_wait",
-                "sessions_history",
-                "sessions_list",
-                "shell_exec"
-            ]
-        );
+        assert_eq!(names, vec!["tool_invoke", "tool_search"]);
 
         for item in &defs {
             assert_eq!(item["type"], "function");
             assert_eq!(item["function"]["parameters"]["type"], "object");
         }
 
-        let claw_import = defs
+        let tool_search = defs
             .iter()
             .find(|item| {
                 item.get("function")
                     .and_then(|function| function.get("name"))
                     .and_then(Value::as_str)
-                    == Some("claw_import")
+                    == Some("tool_search")
             })
-            .expect("claw_import definition should exist");
-        let mode_enum: Vec<&str> =
-            claw_import["function"]["parameters"]["properties"]["mode"]["enum"]
-                .as_array()
-                .expect("mode enum should be an array")
-                .iter()
-                .filter_map(Value::as_str)
-                .collect();
-        assert_eq!(
-            mode_enum,
-            vec![
-                "plan",
-                "apply",
-                "discover",
-                "plan_many",
-                "recommend_primary",
-                "merge_profiles",
-                "map_external_skills",
-                "apply_selected",
-                "rollback_last_apply"
-            ]
-        );
+            .expect("tool_search definition should exist");
         assert!(
-            claw_import["function"]["parameters"]["required"]
+            tool_search["function"]["parameters"]["required"]
                 .as_array()
                 .expect("required should be an array")
-                .is_empty()
+                .contains(&Value::String("query".to_owned()))
         );
     }
 
     #[test]
-    fn provider_tool_definitions_include_delegate_when_enabled() {
-        let defs = try_provider_tool_definitions_for_view(&runtime_tool_view_for_config(
-            &crate::config::ToolConfig::default(),
-        ))
-        .expect("runtime-visible tool schemas");
-        let delegate = defs
-            .iter()
-            .find(|item| item["function"]["name"] == "delegate")
-            .expect("delegate definition");
-        let properties = delegate["function"]["parameters"]["properties"]
-            .as_object()
-            .expect("delegate properties");
-        assert!(properties.contains_key("task"));
-        assert!(properties.contains_key("label"));
-        assert!(properties.contains_key("timeout_seconds"));
-    }
-
-    #[test]
-    fn provider_tool_definitions_include_delegate_async_when_enabled() {
-        let defs = try_provider_tool_definitions_for_view(&runtime_tool_view_for_config(
-            &crate::config::ToolConfig::default(),
-        ))
-        .expect("runtime-visible tool schemas");
-        let delegate_async = defs
-            .iter()
-            .find(|item| item["function"]["name"] == "delegate_async")
-            .expect("delegate_async definition");
-        let properties = delegate_async["function"]["parameters"]["properties"]
-            .as_object()
-            .expect("delegate_async properties");
-        assert!(properties.contains_key("task"));
-        assert!(properties.contains_key("label"));
-        assert!(properties.contains_key("timeout_seconds"));
-    }
-
-    #[test]
-    fn provider_tool_definitions_include_approval_request_resolve_when_enabled() {
-        let defs = try_provider_tool_definitions_for_view(&runtime_tool_view_for_config(
-            &crate::config::ToolConfig::default(),
-        ))
-        .expect("runtime-visible tool schemas");
-        let approval_request_resolve = defs
-            .iter()
-            .find(|item| item["function"]["name"] == "approval_request_resolve")
-            .expect("approval_request_resolve definition");
-        let properties = approval_request_resolve["function"]["parameters"]["properties"]
-            .as_object()
-            .expect("approval_request_resolve properties");
-        assert!(properties.contains_key("approval_request_id"));
-        assert!(properties.contains_key("decision"));
-    }
-
-    #[test]
-    fn provider_tool_definitions_include_sessions_send_when_enabled() {
-        let mut config = crate::config::ToolConfig::default();
-        config.messages.enabled = true;
-
-        let defs = try_provider_tool_definitions_for_view(&runtime_tool_view_for_config(&config))
-            .expect("runtime-visible tool schemas");
-        let sessions_send = defs
-            .iter()
-            .find(|item| item["function"]["name"] == "sessions_send")
-            .expect("sessions_send definition");
-        let properties = sessions_send["function"]["parameters"]["properties"]
-            .as_object()
-            .expect("sessions_send properties");
-        assert!(properties.contains_key("session_id"));
-        assert!(properties.contains_key("text"));
+    fn provider_exposed_tool_gate_is_core_only() {
+        assert!(is_provider_exposed_tool_name("tool.search"));
+        assert!(is_provider_exposed_tool_name("tool.invoke"));
+        assert!(!is_provider_exposed_tool_name("file.read"));
+        assert!(!is_provider_exposed_tool_name("shell.exec"));
     }
 
     #[test]
     fn canonical_tool_name_maps_known_aliases() {
+        assert_eq!(canonical_tool_name("tool_search"), "tool.search");
+        assert_eq!(canonical_tool_name("tool_invoke"), "tool.invoke");
         assert_eq!(canonical_tool_name("claw_import"), "claw.import");
         assert_eq!(
             canonical_tool_name("external_skills_policy"),
@@ -1179,6 +1499,360 @@ mod tests {
             "feishu.calendar.freebusy"
         );
         assert_eq!(canonical_tool_name("file.read"), "file.read");
+    }
+
+    #[test]
+    fn required_capabilities_follow_effective_tool_request() {
+        let direct_file_read = ToolCoreRequest {
+            tool_name: "file.read".to_owned(),
+            payload: json!({"path": "README.md"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_file_read),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
+        let direct_file_write = ToolCoreRequest {
+            tool_name: "file.write".to_owned(),
+            payload: json!({"path": "notes.txt", "content": "hello"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_file_write),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemWrite])
+        );
+
+        let invoked_file_read = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "file.read",
+                "lease": "unused",
+                "arguments": {"path": "README.md"}
+            }),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&invoked_file_read),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
+        let invoked_claw_plan = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "claw.import",
+                "lease": "unused",
+                "arguments": {"mode": "plan", "input_path": "imports/nanobot"}
+            }),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&invoked_claw_plan),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
+        let invoked_claw_apply = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "claw.import",
+                "lease": "unused",
+                "arguments": {
+                    "mode": "apply",
+                    "input_path": "imports/nanobot",
+                    "output_path": "loongclaw.toml"
+                }
+            }),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&invoked_claw_apply),
+            BTreeSet::from([
+                Capability::InvokeTool,
+                Capability::FilesystemRead,
+                Capability::FilesystemWrite,
+            ])
+        );
+
+        let malformed_invoke = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({"lease": "unused"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&malformed_invoke),
+            BTreeSet::from([Capability::InvokeTool])
+        );
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
+    #[test]
+    fn tool_search_returns_discoverable_tools_with_leases() {
+        use std::fs;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("loongclaw-tool-search-{nanos}"));
+        fs::create_dir_all(&root).expect("create fixture root");
+        fs::write(root.join("README.md"), "hello tool search").expect("write fixture");
+
+        let config = test_tool_runtime_config(root.clone());
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({
+                    "query": "read repo file",
+                    "limit": 3
+                }),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert!(!results.is_empty());
+        assert!(
+            results
+                .iter()
+                .all(|entry| entry["tool_id"] != "tool.search")
+        );
+        assert!(
+            results
+                .iter()
+                .any(|entry| entry["tool_id"] == "file.read" && entry["lease"].as_str().is_some())
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
+    #[test]
+    fn tool_search_hides_filesystem_tools_without_filesystem_capabilities() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-tool-search-cap-filter-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let config = test_tool_runtime_config(root.clone());
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({
+                    "query": "read file import config",
+                    TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD: serde_json::to_value(BTreeSet::from([Capability::InvokeTool]))
+                        .expect("serialize capabilities")
+                }),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert!(results.iter().all(|entry| entry["tool_id"] != "file.read"));
+        assert!(results.iter().all(|entry| entry["tool_id"] != "file.write"));
+        assert!(
+            results
+                .iter()
+                .all(|entry| entry["tool_id"] != "claw.import")
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-shell")]
+    #[test]
+    fn tool_search_hides_shell_exec_when_runtime_allowlist_is_empty() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-tool-search-shell-filter-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let config = runtime_config::ToolRuntimeConfig {
+            shell_allow: BTreeSet::new(),
+            shell_deny: BTreeSet::new(),
+            shell_default_mode: crate::tools::shell_policy_ext::ShellPolicyDefault::Deny,
+            file_root: Some(root.clone()),
+            config_path: None,
+            external_skills: runtime_config::ExternalSkillsRuntimePolicy::default(),
+        };
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({"query": "shell command"}),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert!(results.iter().all(|entry| entry["tool_id"] != "shell.exec"));
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
+    #[test]
+    fn tool_search_result_includes_compact_argument_hints() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-tool-search-hints-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let config = test_tool_runtime_config(root.clone());
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({"query": "shell command"}),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert!(results.iter().any(|entry| {
+            entry["tool_id"] == "shell.exec"
+                && entry["argument_hint"].as_str() == Some("command:string,args?:string[]")
+        }));
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn tool_invoke_dispatches_a_discovered_tool_with_a_valid_lease() {
+        use std::fs;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("loongclaw-tool-invoke-{nanos}"));
+        fs::create_dir_all(&root).expect("create fixture root");
+        fs::write(root.join("README.md"), "tool invoke fixture").expect("write fixture");
+
+        let config = test_tool_runtime_config(root.clone());
+        let search = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({"query": "read file"}),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let result = search.payload["results"]
+            .as_array()
+            .expect("results")
+            .iter()
+            .find(|entry| entry["tool_id"] == "file.read")
+            .expect("file.read search result");
+
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.invoke".to_owned(),
+                payload: json!({
+                    "tool_id": "file.read",
+                    "lease": result["lease"].clone(),
+                    "arguments": {
+                        "path": "README.md",
+                        "max_bytes": 64
+                    }
+                }),
+            },
+            &config,
+        )
+        .expect("tool invoke should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert!(
+            outcome.payload["path"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("README.md"))
+        );
+        assert_eq!(outcome.payload["content"], "tool invoke fixture");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn tool_invoke_rejects_tampered_or_missing_leases() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-tool-invoke-invalid-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let config = test_tool_runtime_config(root.clone());
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.invoke".to_owned(),
+                payload: json!({
+                    "tool_id": "file.read",
+                    "lease": "tampered",
+                    "arguments": {
+                        "path": "README.md"
+                    }
+                }),
+            },
+            &config,
+        )
+        .expect_err("tampered lease should fail");
+
+        assert!(error.contains("invalid_tool_lease"), "error: {error}");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn tool_invoke_rejects_leases_replayed_in_another_turn() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-tool-invoke-replay-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let config = test_tool_runtime_config(root.clone());
+        let search = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({
+                    "query": "read file",
+                    TOOL_LEASE_SESSION_ID_FIELD: "session-a",
+                    TOOL_LEASE_TURN_ID_FIELD: "turn-a"
+                }),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let result = search.payload["results"]
+            .as_array()
+            .expect("results")
+            .iter()
+            .find(|entry| entry["tool_id"] == "file.read")
+            .expect("file.read search result");
+
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.invoke".to_owned(),
+                payload: json!({
+                    "tool_id": "file.read",
+                    "lease": result["lease"].clone(),
+                    "arguments": {
+                        "path": "README.md"
+                    },
+                    TOOL_LEASE_SESSION_ID_FIELD: "session-a",
+                    TOOL_LEASE_TURN_ID_FIELD: "turn-b"
+                }),
+            },
+            &config,
+        )
+        .expect_err("replayed turn lease should fail");
+
+        assert!(error.contains("turn mismatch"), "error: {error}");
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -49,6 +49,8 @@ pub(crate) use feishu::{DeferredFeishuCardUpdate, drain_deferred_feishu_card_upd
 pub use kernel_adapter::MvpToolAdapter;
 
 pub(crate) const LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY: &str = "_loongclaw";
+const LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY: &str = "tool_search";
+const LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY: &str = "visible_tool_ids";
 
 tokio::task_local! {
     static TRUSTED_INTERNAL_TOOL_PAYLOAD_TASK: bool;
@@ -104,6 +106,51 @@ fn payload_uses_reserved_internal_tool_context(payload: &Value) -> bool {
     payload
         .as_object()
         .is_some_and(|body| body.contains_key(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY))
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct InjectedToolPayload {
+    pub payload: Value,
+    pub trusted_internal_context: bool,
+}
+
+pub(crate) fn inject_internal_tool_search_context(
+    tool_name: &str,
+    payload: Value,
+    visible_tool_view: Option<&ToolView>,
+) -> InjectedToolPayload {
+    let Some(visible_tool_view) = visible_tool_view else {
+        return InjectedToolPayload {
+            payload,
+            trusted_internal_context: false,
+        };
+    };
+    if canonical_tool_name(tool_name) != "tool.search" {
+        return InjectedToolPayload {
+            payload,
+            trusted_internal_context: false,
+        };
+    }
+
+    let Value::Object(mut body) = payload else {
+        return InjectedToolPayload {
+            payload,
+            trusted_internal_context: false,
+        };
+    };
+
+    body.insert(
+        LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
+        json!({
+            LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY: {
+                LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY: visible_tool_view.tool_names().collect::<Vec<_>>(),
+            }
+        }),
+    );
+    InjectedToolPayload {
+        payload: Value::Object(body),
+        trusted_internal_context: true,
+    }
 }
 
 /// Execute a tool request, routing through the kernel for
@@ -394,11 +441,14 @@ fn invoked_discoverable_tool_request(payload: &Value) -> Option<(&str, &Value)> 
     if matches!(tool_id, "tool.search" | "tool.invoke") {
         return None;
     }
-    let entry = catalog::find_tool_catalog_entry(tool_id)?;
-    if !entry.is_discoverable() {
+    let resolved = resolve_tool_execution(tool_id)?;
+    if is_provider_exposed_tool_name(resolved.canonical_name) {
         return None;
     }
-    Some((tool_id, payload.get("arguments").unwrap_or(payload)))
+    Some((
+        resolved.canonical_name,
+        payload.get("arguments").unwrap_or(payload),
+    ))
 }
 
 fn claw_import_mode_requires_write(payload: &Value) -> bool {
@@ -464,6 +514,7 @@ pub(crate) fn runtime_tool_view_with_runtime_config(
     ToolView::from_tool_names(names)
 }
 
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct ResolvedToolExecution {
     pub canonical_name: &'static str,
     pub execution_kind: ToolExecutionKind,
@@ -562,21 +613,50 @@ pub struct ToolRegistryEntry {
     pub description: &'static str,
 }
 
+#[derive(Debug, Clone)]
+struct SearchableToolEntry {
+    canonical_name: String,
+    summary: String,
+    argument_hint: String,
+    required_fields: Vec<String>,
+    tags: Vec<String>,
+}
+
 /// Returns a sorted list of all registered tools, gated by feature flags.
 pub fn tool_registry() -> Vec<ToolRegistryEntry> {
     tool_registry_with_config(Some(runtime_config::get_tool_runtime_config()))
 }
 
 pub(crate) fn tool_registry_with_config(
-    _config: Option<&runtime_config::ToolRuntimeConfig>,
+    config: Option<&runtime_config::ToolRuntimeConfig>,
 ) -> Vec<ToolRegistryEntry> {
+    let default_runtime_config;
+    let config = match config {
+        Some(config) => config,
+        None => {
+            default_runtime_config = runtime_config::ToolRuntimeConfig::default();
+            &default_runtime_config
+        }
+    };
+    let default_visible_tool_view =
+        runtime_tool_view_with_runtime_config(&ToolConfig::default(), config);
     let mut entries: Vec<ToolRegistryEntry> = catalog::discoverable_tool_catalog()
         .into_iter()
+        .filter(|entry| default_visible_tool_view.contains(entry.canonical_name))
+        .filter(|entry| tool_search_entry_is_runtime_usable(*entry, config))
         .map(|entry| ToolRegistryEntry {
             name: entry.canonical_name,
             description: entry.summary,
         })
         .collect();
+    #[cfg(feature = "feishu-integration")]
+    if config.feishu.is_some() {
+        entries.extend(
+            feishu::feishu_tool_registry_entries()
+                .into_iter()
+                .filter(|entry| default_visible_tool_view.contains(entry.name)),
+        );
+    }
     entries.sort_by_key(|entry| entry.name);
     entries
 }
@@ -641,6 +721,139 @@ fn provider_tool_definitions_for_view(_view: &ToolView) -> Vec<Value> {
     tools
 }
 
+fn search_argument_hint_from_provider_definition(parameters: &Value) -> String {
+    let Some(properties) = parameters.get("properties").and_then(Value::as_object) else {
+        return String::new();
+    };
+    let required = parameters
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect::<BTreeSet<_>>();
+    let mut fields = properties
+        .iter()
+        .map(|(name, schema)| {
+            let schema_type = schema
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("value");
+            let suffix = if required.contains(name.as_str()) {
+                ""
+            } else {
+                "?"
+            };
+            format!("{name}{suffix}:{schema_type}")
+        })
+        .collect::<Vec<_>>();
+    fields.sort();
+    fields.join(",")
+}
+
+fn searchable_entry_from_catalog(entry: catalog::ToolCatalogEntry) -> SearchableToolEntry {
+    SearchableToolEntry {
+        canonical_name: entry.canonical_name.to_owned(),
+        summary: entry.summary.to_owned(),
+        argument_hint: entry.argument_hint.to_owned(),
+        required_fields: entry
+            .required_fields
+            .iter()
+            .map(|field| (*field).to_owned())
+            .collect(),
+        tags: entry.tags.iter().map(|tag| (*tag).to_owned()).collect(),
+    }
+}
+
+#[cfg(feature = "feishu-integration")]
+fn feishu_searchable_entries() -> Vec<SearchableToolEntry> {
+    feishu::feishu_provider_tool_definitions()
+        .into_iter()
+        .filter_map(|tool| {
+            let function = tool.get("function")?;
+            let provider_name = function.get("name")?.as_str()?;
+            let parameters = function
+                .get("parameters")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            Some(SearchableToolEntry {
+                canonical_name: canonical_tool_name(provider_name).to_owned(),
+                summary: function
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned(),
+                argument_hint: search_argument_hint_from_provider_definition(&parameters),
+                required_fields: parameters
+                    .get("required")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(Value::as_str)
+                    .map(str::to_owned)
+                    .collect(),
+                tags: vec!["feishu".to_owned()],
+            })
+        })
+        .collect()
+}
+
+fn search_tool_view_from_payload(
+    payload: &serde_json::Map<String, Value>,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> ToolView {
+    let visible_tool_names = if trusted_internal_tool_payload_enabled() {
+        payload
+            .get(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
+            .and_then(|body| body.get(LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY))
+            .and_then(|body| body.get(LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY))
+            .and_then(Value::as_array)
+            .map(|tool_names| {
+                tool_names
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(canonical_tool_name)
+                    .collect::<Vec<_>>()
+            })
+    } else {
+        None
+    };
+    match visible_tool_names {
+        Some(visible_tool_names) => ToolView::from_tool_names(visible_tool_names),
+        None => runtime_tool_view_with_runtime_config(&ToolConfig::default(), config),
+    }
+}
+
+fn runtime_discoverable_tool_entries(
+    config: &runtime_config::ToolRuntimeConfig,
+    visible_tool_view: Option<&ToolView>,
+) -> Vec<SearchableToolEntry> {
+    let default_visible_tool_view;
+    let visible_tool_view = match visible_tool_view {
+        Some(view) => view,
+        None => {
+            default_visible_tool_view =
+                runtime_tool_view_with_runtime_config(&ToolConfig::default(), config);
+            &default_visible_tool_view
+        }
+    };
+    let mut entries = catalog::discoverable_tool_catalog()
+        .into_iter()
+        .filter(|entry| visible_tool_view.contains(entry.canonical_name))
+        .filter(|entry| tool_search_entry_is_runtime_usable(*entry, config))
+        .map(searchable_entry_from_catalog)
+        .collect::<Vec<_>>();
+    #[cfg(feature = "feishu-integration")]
+    if config.feishu.is_some() {
+        entries.extend(
+            feishu_searchable_entries()
+                .into_iter()
+                .filter(|entry| visible_tool_view.contains(entry.canonical_name.as_str())),
+        );
+    }
+    entries
+}
+
 pub fn tool_parameter_schema_types() -> BTreeMap<String, BTreeMap<String, &'static str>> {
     let mut tools_by_name = BTreeMap::<String, BTreeMap<String, &'static str>>::new();
     for entry in catalog::all_tool_catalog() {
@@ -690,18 +903,21 @@ fn execute_tool_search_tool_with_config(
         .get(TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD)
         .cloned()
         .and_then(|value| serde_json::from_value::<BTreeSet<Capability>>(value).ok());
+    let visible_tool_view = search_tool_view_from_payload(payload, config);
 
     let query_normalized = query.to_ascii_lowercase();
     let tokens = tokenize_search_query(query_normalized.as_str());
-    let mut ranked: Vec<(u32, Vec<String>, catalog::ToolCatalogEntry)> =
-        catalog::discoverable_tool_catalog()
+    let mut ranked: Vec<(u32, Vec<String>, SearchableToolEntry)> =
+        runtime_discoverable_tool_entries(config, Some(&visible_tool_view))
             .into_iter()
-            .filter(|entry| tool_search_entry_is_runtime_usable(*entry, config))
             .filter(|entry| {
-                tool_search_entry_is_capability_usable(*entry, granted_capabilities.as_ref())
+                tool_search_entry_is_capability_usable(
+                    entry.canonical_name.as_str(),
+                    granted_capabilities.as_ref(),
+                )
             })
             .filter_map(|entry| {
-                let (score, why) = search_score(entry, query_normalized.as_str(), &tokens);
+                let (score, why) = search_score(&entry, query_normalized.as_str(), &tokens);
                 if score == 0 {
                     None
                 } else {
@@ -712,7 +928,7 @@ fn execute_tool_search_tool_with_config(
     ranked.sort_by(|(left_score, _, left), (right_score, _, right)| {
         right_score
             .cmp(left_score)
-            .then_with(|| left.canonical_name.cmp(right.canonical_name))
+            .then_with(|| left.canonical_name.cmp(&right.canonical_name))
     });
 
     let results: Vec<Value> = ranked
@@ -726,7 +942,7 @@ fn execute_tool_search_tool_with_config(
                 "required_fields": entry.required_fields,
                 "tags": entry.tags,
                 "why": why,
-                "lease": issue_tool_lease(entry.canonical_name, payload),
+                "lease": issue_tool_lease(entry.canonical_name.as_str(), payload),
             })
         })
         .collect();
@@ -766,14 +982,13 @@ fn tool_search_entry_is_runtime_usable(
 }
 
 fn tool_search_entry_is_capability_usable(
-    entry: catalog::ToolCatalogEntry,
+    tool_name: &str,
     granted_capabilities: Option<&BTreeSet<Capability>>,
 ) -> bool {
     let Some(granted_capabilities) = granted_capabilities else {
         return true;
     };
-    let required =
-        required_capabilities_for_tool_name_and_payload(entry.canonical_name, &json!({}));
+    let required = required_capabilities_for_tool_name_and_payload(tool_name, &json!({}));
     required
         .iter()
         .all(|capability| granted_capabilities.contains(capability))
@@ -781,7 +996,7 @@ fn tool_search_entry_is_capability_usable(
 
 pub(crate) fn resolve_tool_invoke_request(
     request: &ToolCoreRequest,
-) -> Result<(catalog::ToolCatalogEntry, ToolCoreRequest), String> {
+) -> Result<(ResolvedToolExecution, ToolCoreRequest), String> {
     if canonical_tool_name(request.tool_name.as_str()) != "tool.invoke" {
         return Err(format!(
             "tool_invoke_required: expected `tool.invoke`, got `{}`",
@@ -810,19 +1025,21 @@ pub(crate) fn resolve_tool_invoke_request(
         return Err("tool.invoke payload.arguments must be an object".to_owned());
     }
 
-    let entry = catalog::find_tool_catalog_entry(tool_id)
+    let resolved = resolve_tool_execution(tool_id)
         .ok_or_else(|| format!("tool_not_found: unknown tool `{tool_id}`"))?;
-    if !entry.is_discoverable() {
+    let resolved_tool_name = resolved.canonical_name;
+    if is_provider_exposed_tool_name(resolved_tool_name) {
         return Err(format!(
-            "tool_not_provider_exposed: {tool_id} must be called directly as a core tool"
+            "tool_not_provider_exposed: {} must be called directly as a core tool",
+            resolved_tool_name
         ));
     }
-    validate_tool_lease(tool_id, lease, payload)?;
+    validate_tool_lease(resolved_tool_name, lease, payload)?;
 
     Ok((
-        entry,
+        resolved,
         ToolCoreRequest {
-            tool_name: tool_id.to_owned(),
+            tool_name: resolved_tool_name.to_owned(),
             payload: arguments,
         },
     ))
@@ -853,11 +1070,7 @@ fn tokenize_search_query(query: &str) -> Vec<String> {
         .collect()
 }
 
-fn search_score(
-    entry: catalog::ToolCatalogEntry,
-    query: &str,
-    tokens: &[String],
-) -> (u32, Vec<String>) {
+fn search_score(entry: &SearchableToolEntry, query: &str, tokens: &[String]) -> (u32, Vec<String>) {
     let name = entry.canonical_name.to_ascii_lowercase();
     let summary = entry.summary.to_ascii_lowercase();
     let argument_hint = entry.argument_hint.to_ascii_lowercase();
@@ -1142,6 +1355,8 @@ mod tests {
                 install_root: None,
                 auto_expose_installed: false,
             },
+            #[cfg(feature = "feishu-integration")]
+            feishu: None,
         }
     }
 
@@ -1253,9 +1468,9 @@ mod tests {
         feature = "memory-sqlite"
     ))]
     #[test]
-    fn tool_registry_returns_all_known_tools() {
+    fn tool_registry_returns_runtime_discoverable_tools_for_default_config() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 26);
+        assert_eq!(entries.len(), 18);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"approval_request_resolve"));
         assert!(names.contains(&"approval_request_status"));
@@ -1263,14 +1478,6 @@ mod tests {
         assert!(names.contains(&"claw.import"));
         assert!(names.contains(&"delegate"));
         assert!(names.contains(&"delegate_async"));
-        assert!(names.contains(&"external_skills.fetch"));
-        assert!(names.contains(&"external_skills.install"));
-        assert!(names.contains(&"external_skills.inspect"));
-        assert!(names.contains(&"external_skills.invoke"));
-        assert!(names.contains(&"external_skills.list"));
-        assert!(names.contains(&"external_skills.policy"));
-        assert!(names.contains(&"external_skills.remove"));
-        assert!(names.contains(&"shell.exec"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
         assert!(names.contains(&"provider.switch"));
@@ -1282,7 +1489,15 @@ mod tests {
         assert!(names.contains(&"session_wait"));
         assert!(names.contains(&"sessions_history"));
         assert!(names.contains(&"sessions_list"));
-        assert!(names.contains(&"sessions_send"));
+        assert!(!names.contains(&"external_skills.fetch"));
+        assert!(!names.contains(&"external_skills.install"));
+        assert!(!names.contains(&"external_skills.inspect"));
+        assert!(!names.contains(&"external_skills.invoke"));
+        assert!(!names.contains(&"external_skills.list"));
+        assert!(names.contains(&"external_skills.policy"));
+        assert!(!names.contains(&"external_skills.remove"));
+        assert!(!names.contains(&"shell.exec"));
+        assert!(!names.contains(&"sessions_send"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
@@ -1684,6 +1899,8 @@ mod tests {
             file_root: Some(root.clone()),
             config_path: None,
             external_skills: runtime_config::ExternalSkillsRuntimePolicy::default(),
+            #[cfg(feature = "feishu-integration")]
+            feishu: None,
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -1726,6 +1943,170 @@ mod tests {
         }));
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn tool_search_respects_visible_tool_ids_from_runtime_context() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-tool-search-visible-filter-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let config = test_tool_runtime_config(root.clone());
+        let outcome = execute_tool_core_with_test_context(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({
+                    "query": "session history status",
+                    "_loongclaw": {
+                        "tool_search": {
+                            "visible_tool_ids": ["tool.search", "tool.invoke", "file.read"],
+                        }
+                    }
+                }),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert!(
+            results.iter().all(|entry| !entry["tool_id"]
+                .as_str()
+                .is_some_and(|tool_id| tool_id.starts_with("session"))),
+            "search should honor the injected visible tool surface: {results:?}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn tool_search_rejects_forged_visible_tool_ids_from_untrusted_payload() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-tool-search-visible-forged-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let config = test_tool_runtime_config(root.clone());
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({
+                    "query": "session history status",
+                    "_loongclaw": {
+                        "tool_search": {
+                            "visible_tool_ids": ["tool.search", "tool.invoke", "file.read"],
+                        }
+                    }
+                }),
+            },
+            &config,
+        )
+        .expect_err("untrusted tool search should reject reserved internal visibility context");
+
+        assert!(
+            error.contains("payload._loongclaw is reserved for trusted internal tool context"),
+            "error={error}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "feishu-integration")]
+    #[test]
+    fn tool_search_includes_feishu_tools_when_runtime_configured() {
+        let mut config = runtime_config::ToolRuntimeConfig::default();
+        config.feishu = Some(runtime_config::FeishuToolRuntimeConfig {
+            channel: crate::config::FeishuChannelConfig {
+                enabled: true,
+                app_id: Some("cli_a1b2c3".to_owned()),
+                app_secret: Some("app-secret".to_owned()),
+                ..crate::config::FeishuChannelConfig::default()
+            },
+            integration: crate::config::FeishuIntegrationConfig::default(),
+        });
+
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({"query": "feishu message search", "limit": 8}),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert!(
+            results
+                .iter()
+                .any(|entry| entry["tool_id"] == "feishu.messages.search"),
+            "feishu runtime tools should be discoverable through tool.search: {results:?}"
+        );
+        assert!(
+            results
+                .iter()
+                .any(|entry| entry["tool_id"] == "feishu.messages.send"),
+            "feishu send should be discoverable through tool.search: {results:?}"
+        );
+    }
+
+    #[cfg(all(feature = "feishu-integration", feature = "channel-feishu"))]
+    #[test]
+    fn tool_invoke_dispatches_feishu_discovered_tool_with_a_valid_lease() {
+        use std::fs;
+
+        let temp_dir = unique_feishu_tool_temp_dir("tool-invoke-feishu-send");
+        fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let sqlite_path = temp_dir.join("feishu.sqlite3");
+        let _store = seed_feishu_tool_grant(
+            &sqlite_path,
+            "u-token-tool-invoke-feishu-send",
+            &["offline_access"],
+        );
+        let config =
+            build_feishu_tool_runtime_config("http://127.0.0.1:9".to_owned(), &sqlite_path);
+
+        let search = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({"query": "send feishu message", "limit": 8}),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let result = search.payload["results"]
+            .as_array()
+            .expect("results")
+            .iter()
+            .find(|entry| entry["tool_id"] == "feishu.messages.send")
+            .expect("feishu.messages.send search result");
+
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.invoke".to_owned(),
+                payload: json!({
+                    "tool_id": "feishu.messages.send",
+                    "lease": result["lease"].clone(),
+                    "arguments": {
+                        "text": "ship by invoke"
+                    }
+                }),
+            },
+            &config,
+        )
+        .expect_err("missing receive_id should fail after discovery-first invoke routing");
+
+        assert!(
+            error.contains("feishu.messages.send requires payload.receive_id"),
+            "error={error}"
+        );
+
+        fs::remove_dir_all(&temp_dir).ok();
     }
 
     #[cfg(feature = "tool-file")]
@@ -1946,7 +2327,7 @@ mod tests {
 
     #[cfg(feature = "feishu-integration")]
     #[test]
-    fn provider_tool_definitions_with_config_includes_feishu_functions_when_runtime_configured() {
+    fn provider_tool_definitions_with_config_remains_core_only_when_feishu_runtime_is_configured() {
         let mut config = runtime_config::ToolRuntimeConfig::default();
         config.feishu = Some(runtime_config::FeishuToolRuntimeConfig {
             channel: crate::config::FeishuChannelConfig {
@@ -1966,19 +2347,7 @@ mod tests {
             .filter_map(Value::as_str)
             .collect::<Vec<_>>();
 
-        assert!(names.contains(&"feishu_whoami"));
-        assert!(names.contains(&"feishu_doc_create"));
-        assert!(names.contains(&"feishu_doc_append"));
-        assert!(names.contains(&"feishu_doc_read"));
-        assert!(names.contains(&"feishu_messages_history"));
-        assert!(names.contains(&"feishu_messages_get"));
-        assert!(names.contains(&"feishu_messages_resource_get"));
-        assert!(names.contains(&"feishu_messages_search"));
-        assert!(names.contains(&"feishu_messages_send"));
-        assert!(names.contains(&"feishu_messages_reply"));
-        assert!(names.contains(&"feishu_card_update"));
-        assert!(names.contains(&"feishu_calendar_list"));
-        assert!(names.contains(&"feishu_calendar_freebusy"));
+        assert_eq!(names, vec!["tool_invoke", "tool_search"]);
     }
 
     #[cfg(feature = "feishu-integration")]
@@ -2039,18 +2408,7 @@ mod tests {
     #[cfg(feature = "feishu-integration")]
     #[test]
     fn provider_tool_definitions_with_config_advertises_feishu_message_write_uuid() {
-        let mut config = runtime_config::ToolRuntimeConfig::default();
-        config.feishu = Some(runtime_config::FeishuToolRuntimeConfig {
-            channel: crate::config::FeishuChannelConfig {
-                enabled: true,
-                app_id: Some("cli_a1b2c3".to_owned()),
-                app_secret: Some("app-secret".to_owned()),
-                ..crate::config::FeishuChannelConfig::default()
-            },
-            integration: crate::config::FeishuIntegrationConfig::default(),
-        });
-
-        let defs = provider_tool_definitions_with_config(Some(&config));
+        let defs = feishu::feishu_provider_tool_definitions();
         let send = defs
             .iter()
             .find(|item| item["function"]["name"] == "feishu_messages_send")
@@ -2073,18 +2431,7 @@ mod tests {
     #[cfg(feature = "feishu-integration")]
     #[test]
     fn provider_tool_definitions_with_config_advertises_feishu_message_post_and_media_payloads() {
-        let mut config = runtime_config::ToolRuntimeConfig::default();
-        config.feishu = Some(runtime_config::FeishuToolRuntimeConfig {
-            channel: crate::config::FeishuChannelConfig {
-                enabled: true,
-                app_id: Some("cli_a1b2c3".to_owned()),
-                app_secret: Some("app-secret".to_owned()),
-                ..crate::config::FeishuChannelConfig::default()
-            },
-            integration: crate::config::FeishuIntegrationConfig::default(),
-        });
-
-        let defs = provider_tool_definitions_with_config(Some(&config));
+        let defs = feishu::feishu_provider_tool_definitions();
         let send = defs
             .iter()
             .find(|item| item["function"]["name"] == "feishu_messages_send")
@@ -2179,18 +2526,7 @@ mod tests {
     #[cfg(feature = "feishu-integration")]
     #[test]
     fn provider_tool_definitions_with_config_advertises_feishu_ingress_defaults() {
-        let mut config = runtime_config::ToolRuntimeConfig::default();
-        config.feishu = Some(runtime_config::FeishuToolRuntimeConfig {
-            channel: crate::config::FeishuChannelConfig {
-                enabled: true,
-                app_id: Some("cli_a1b2c3".to_owned()),
-                app_secret: Some("app-secret".to_owned()),
-                ..crate::config::FeishuChannelConfig::default()
-            },
-            integration: crate::config::FeishuIntegrationConfig::default(),
-        });
-
-        let defs = provider_tool_definitions_with_config(Some(&config));
+        let defs = feishu::feishu_provider_tool_definitions();
         let send = defs
             .iter()
             .find(|item| item["function"]["name"] == "feishu_messages_send")
@@ -2388,18 +2724,7 @@ mod tests {
     #[cfg(feature = "feishu-integration")]
     #[test]
     fn provider_tool_definitions_with_config_advertises_feishu_card_update_shared_semantics() {
-        let mut config = runtime_config::ToolRuntimeConfig::default();
-        config.feishu = Some(runtime_config::FeishuToolRuntimeConfig {
-            channel: crate::config::FeishuChannelConfig {
-                enabled: true,
-                app_id: Some("cli_a1b2c3".to_owned()),
-                app_secret: Some("app-secret".to_owned()),
-                ..crate::config::FeishuChannelConfig::default()
-            },
-            integration: crate::config::FeishuIntegrationConfig::default(),
-        });
-
-        let defs = provider_tool_definitions_with_config(Some(&config));
+        let defs = feishu::feishu_provider_tool_definitions();
         let card_update = defs
             .iter()
             .find(|item| item["function"]["name"] == "feishu_card_update")
@@ -2433,18 +2758,7 @@ mod tests {
     #[cfg(feature = "feishu-integration")]
     #[test]
     fn provider_tool_definitions_with_config_advertises_feishu_card_update_markdown_shortcut() {
-        let mut config = runtime_config::ToolRuntimeConfig::default();
-        config.feishu = Some(runtime_config::FeishuToolRuntimeConfig {
-            channel: crate::config::FeishuChannelConfig {
-                enabled: true,
-                app_id: Some("cli_a1b2c3".to_owned()),
-                app_secret: Some("app-secret".to_owned()),
-                ..crate::config::FeishuChannelConfig::default()
-            },
-            integration: crate::config::FeishuIntegrationConfig::default(),
-        });
-
-        let defs = provider_tool_definitions_with_config(Some(&config));
+        let defs = feishu::feishu_provider_tool_definitions();
         let card_update = defs
             .iter()
             .find(|item| item["function"]["name"] == "feishu_card_update")
@@ -2468,18 +2782,7 @@ mod tests {
     #[cfg(feature = "feishu-integration")]
     #[test]
     fn provider_tool_definitions_with_config_advertises_feishu_card_update_token_budget() {
-        let mut config = runtime_config::ToolRuntimeConfig::default();
-        config.feishu = Some(runtime_config::FeishuToolRuntimeConfig {
-            channel: crate::config::FeishuChannelConfig {
-                enabled: true,
-                app_id: Some("cli_a1b2c3".to_owned()),
-                app_secret: Some("app-secret".to_owned()),
-                ..crate::config::FeishuChannelConfig::default()
-            },
-            integration: crate::config::FeishuIntegrationConfig::default(),
-        });
-
-        let defs = provider_tool_definitions_with_config(Some(&config));
+        let defs = feishu::feishu_provider_tool_definitions();
         let card_update = defs
             .iter()
             .find(|item| item["function"]["name"] == "feishu_card_update")
@@ -2496,18 +2799,7 @@ mod tests {
     #[cfg(feature = "feishu-integration")]
     #[test]
     fn provider_tool_definitions_with_config_advertises_feishu_search_ingress_scope() {
-        let mut config = runtime_config::ToolRuntimeConfig::default();
-        config.feishu = Some(runtime_config::FeishuToolRuntimeConfig {
-            channel: crate::config::FeishuChannelConfig {
-                enabled: true,
-                app_id: Some("cli_a1b2c3".to_owned()),
-                app_secret: Some("app-secret".to_owned()),
-                ..crate::config::FeishuChannelConfig::default()
-            },
-            integration: crate::config::FeishuIntegrationConfig::default(),
-        });
-
-        let defs = provider_tool_definitions_with_config(Some(&config));
+        let defs = feishu::feishu_provider_tool_definitions();
         let search = defs
             .iter()
             .find(|item| item["function"]["name"] == "feishu_messages_search")

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1256,7 +1256,19 @@ fn tool_catalog_digest() -> String {
 fn tool_lease_secret() -> &'static str {
     static SECRET: OnceLock<String> = OnceLock::new();
     SECRET.get_or_init(|| {
-        let seed = format!("tool-lease:{}:{}", std::process::id(), now_unix_seconds());
+        // Use RandomState for OS-level entropy rather than deterministic PID+timestamp.
+        // RandomState is seeded from the OS CSPRNG on most platforms.
+        use std::collections::hash_map::RandomState;
+        use std::hash::{BuildHasher, Hasher};
+        let random_state = RandomState::new();
+        let mut hasher = random_state.build_hasher();
+        hasher.write_u64(std::process::id() as u64);
+        hasher.write_u64(now_unix_seconds());
+        let entropy = hasher.finish();
+        let seed = format!(
+            "tool-lease:{entropy:x}:{:x}",
+            random_state.build_hasher().finish()
+        );
         let digest = Sha256::digest(seed.as_bytes());
         format!("{digest:x}")
     })
@@ -2244,6 +2256,42 @@ mod tests {
         .expect_err("replayed turn lease should fail");
 
         assert!(error.contains("turn mismatch"), "error: {error}");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn tool_search_hides_tools_exceeding_granted_capabilities() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-tool-search-cap-filter-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let config = test_tool_runtime_config(root.clone());
+        let result = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({
+                    "query": "read",
+                    TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD: [
+                        "InvokeTool"
+                    ]
+                }),
+            },
+            &config,
+        )
+        .expect("search should succeed");
+
+        let results = result.payload["results"].as_array().expect("results array");
+        let tool_ids: Vec<&str> = results
+            .iter()
+            .filter_map(|entry| entry["tool_id"].as_str())
+            .collect();
+        assert!(
+            !tool_ids.contains(&"file.read"),
+            "file.read requires FilesystemRead, should be hidden when only InvokeTool is granted; got: {tool_ids:?}"
+        );
+
         std::fs::remove_dir_all(&root).ok();
     }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -917,17 +917,8 @@ fn issue_tool_lease(tool_id: &str, payload: &serde_json::Map<String, Value>) -> 
     format!("{encoded_claims}.{signature}")
 }
 
-#[cfg(test)]
 #[allow(dead_code)]
-pub(crate) fn synthesize_test_provider_tool_call(
-    tool_name: &str,
-    args_json: Value,
-) -> (String, Value) {
-    synthesize_test_provider_tool_call_with_scope(tool_name, args_json, None, None)
-}
-
-#[cfg(test)]
-pub(crate) fn synthesize_test_provider_tool_call_with_scope(
+pub(crate) fn bridge_provider_tool_call_with_scope(
     tool_name: &str,
     args_json: Value,
     session_id: Option<&str>,
@@ -950,6 +941,25 @@ pub(crate) fn synthesize_test_provider_tool_call_with_scope(
             "arguments": args_json,
         }),
     )
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn synthesize_test_provider_tool_call(
+    tool_name: &str,
+    args_json: Value,
+) -> (String, Value) {
+    bridge_provider_tool_call_with_scope(tool_name, args_json, None, None)
+}
+
+#[cfg(test)]
+pub(crate) fn synthesize_test_provider_tool_call_with_scope(
+    tool_name: &str,
+    args_json: Value,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> (String, Value) {
+    bridge_provider_tool_call_with_scope(tool_name, args_json, session_id, turn_id)
 }
 
 fn validate_tool_lease(

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1255,7 +1255,7 @@ mod tests {
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 25);
+        assert_eq!(entries.len(), 26);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"approval_request_resolve"));
         assert!(names.contains(&"approval_request_status"));

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1282,6 +1282,7 @@ mod tests {
         assert!(names.contains(&"session_wait"));
         assert!(names.contains(&"sessions_history"));
         assert!(names.contains(&"sessions_list"));
+        assert!(names.contains(&"sessions_send"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -26,7 +26,7 @@ impl Default for ExternalSkillsRuntimePolicy {
             allowed_domains: BTreeSet::new(),
             blocked_domains: BTreeSet::new(),
             install_root: None,
-            auto_expose_installed: true,
+            auto_expose_installed: false,
         }
     }
 }
@@ -149,7 +149,7 @@ impl ToolRuntimeConfig {
             .ok()
             .map(PathBuf::from);
         let auto_expose_installed =
-            parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED").unwrap_or(true);
+            parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED").unwrap_or(false);
 
         Self {
             file_root,
@@ -295,7 +295,7 @@ mod tests {
         assert!(config.external_skills.allowed_domains.is_empty());
         assert!(config.external_skills.blocked_domains.is_empty());
         assert!(config.external_skills.install_root.is_none());
-        assert!(config.external_skills.auto_expose_installed);
+        assert!(!config.external_skills.auto_expose_installed);
     }
 
     /// Deny starts empty so users are not forced to carry
@@ -349,6 +349,12 @@ mod tests {
             ..ToolRuntimeConfig::default()
         };
         assert_eq!(config.file_root, Some(PathBuf::from("/tmp/test-root")));
+    }
+
+    #[test]
+    fn from_env_defaults_to_empty_allowlist() {
+        let config = ToolRuntimeConfig::from_env();
+        assert!(config.shell_allow.is_empty());
     }
 
     #[cfg(feature = "tool-shell")]

--- a/crates/app/src/tools/shell.rs
+++ b/crates/app/src/tools/shell.rs
@@ -7,11 +7,11 @@ use serde_json::{Value, json};
 
 pub(super) fn execute_shell_tool_with_config(
     request: ToolCoreRequest,
-    _config: &super::runtime_config::ToolRuntimeConfig,
+    config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
     #[cfg(not(feature = "tool-shell"))]
     {
-        let _ = (request, _config);
+        let _ = (request, config);
         return Err(
             "shell tool is disabled in this build (enable feature `tool-shell`)".to_owned(),
         );
@@ -44,6 +44,30 @@ pub(super) fn execute_shell_tool_with_config(
             .and_then(Value::as_str)
             .map(PathBuf::from)
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+
+        let normalized_command = command.to_ascii_lowercase();
+        let basename = normalized_command
+            .rsplit('/')
+            .find(|segment| !segment.is_empty())
+            .and_then(|segment| segment.rsplit('\\').find(|segment| !segment.is_empty()))
+            .unwrap_or(&normalized_command);
+
+        if config.shell_deny.contains(basename) {
+            return Err(format!(
+                "policy_denied: shell command `{basename}` is blocked by shell policy"
+            ));
+        }
+
+        let explicitly_allowed = config.shell_allow.contains(basename);
+        let default_allows = matches!(
+            config.shell_default_mode,
+            crate::tools::shell_policy_ext::ShellPolicyDefault::Allow
+        );
+        if !explicitly_allowed && !default_allows {
+            return Err(format!(
+                "policy_denied: shell command `{basename}` is not in the allow list (default-deny policy)"
+            ));
+        }
 
         let output = Command::new(command)
             .args(&args)

--- a/crates/app/src/tools/shell_policy_ext.rs
+++ b/crates/app/src/tools/shell_policy_ext.rs
@@ -58,20 +58,13 @@ impl PolicyExtension for ToolPolicyExtension {
             return Ok(());
         };
 
-        let raw_tool_name = params
-            .get("tool_name")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-
-        let tool_name = super::canonical_tool_name(raw_tool_name);
-
+        let (tool_name, payload) = effective_shell_request(params);
         if tool_name != "shell.exec" {
             return Ok(());
         }
 
-        let command = params
-            .get("payload")
-            .and_then(|p| p.get("command"))
+        let command = payload
+            .and_then(|payload| payload.get("command"))
             .and_then(|v| v.as_str())
             .map(str::trim)
             .filter(|s| !s.is_empty())
@@ -112,6 +105,26 @@ impl PolicyExtension for ToolPolicyExtension {
             }),
         }
     }
+}
+
+fn effective_shell_request(params: &serde_json::Value) -> (&str, Option<&serde_json::Value>) {
+    let raw_tool_name = params
+        .get("tool_name")
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+    let tool_name = super::canonical_tool_name(raw_tool_name);
+    if tool_name != "tool.invoke" {
+        return (tool_name, params.get("payload"));
+    }
+
+    let payload = params.get("payload");
+    let invoked_tool_name = payload
+        .and_then(|payload| payload.get("tool_id"))
+        .and_then(|value| value.as_str())
+        .map(super::canonical_tool_name)
+        .unwrap_or(tool_name);
+    let invoked_payload = payload.and_then(|payload| payload.get("arguments"));
+    (invoked_tool_name, invoked_payload)
 }
 
 #[cfg(test)]
@@ -216,6 +229,41 @@ mod tests {
             result.unwrap_err(),
             PolicyError::ToolCallDenied { .. }
         ));
+    }
+
+    #[test]
+    fn unwraps_tool_invoke_shell_payloads() {
+        let ext = ToolPolicyExtension::new(
+            BTreeSet::from(["rm".to_owned()]),
+            BTreeSet::from(["ls".to_owned()]),
+            ShellPolicyDefault::Deny,
+        );
+        let pack = test_pack();
+        let token = test_token();
+        let caps = BTreeSet::from([Capability::InvokeTool]);
+
+        let denied = json!({
+            "tool_name": "tool.invoke",
+            "payload": {
+                "tool_id": "shell.exec",
+                "arguments": {"command": "rm"}
+            }
+        });
+        let denied_ctx = make_context(&pack, &token, &caps, Some(&denied));
+        assert!(matches!(
+            ext.authorize_extension(&denied_ctx).unwrap_err(),
+            PolicyError::ToolCallDenied { .. }
+        ));
+
+        let allowed = json!({
+            "tool_name": "tool.invoke",
+            "payload": {
+                "tool_id": "shell_exec",
+                "arguments": {"command": "ls"}
+            }
+        });
+        let allowed_ctx = make_context(&pack, &token, &caps, Some(&allowed));
+        assert!(ext.authorize_extension(&allowed_ctx).is_ok());
     }
 
     #[test]

--- a/crates/daemon/src/tests/import_cli.rs
+++ b/crates/daemon/src/tests/import_cli.rs
@@ -1606,6 +1606,8 @@ requires_openai_auth = true
         .expect("load imported config");
     let turn = mvp::provider::request_turn(
         &imported,
+        "import-codex-session",
+        "import-codex-turn",
         &[json!({
             "role": "user",
             "content": "ping"

--- a/docs/design-docs/discovery-first-tool-runtime-contract.md
+++ b/docs/design-docs/discovery-first-tool-runtime-contract.md
@@ -1,0 +1,154 @@
+# Discovery-First Tool Runtime Contract
+
+## Purpose
+
+This document defines the durable runtime contract for discovery-first provider
+tool routing in LoongClaw.
+
+The goal is to keep the provider-visible tool surface minimal, make non-core
+tool access explicit and auditable, and prevent future refactors from drifting
+back toward broad static tool exposure.
+
+## Core Contract
+
+### Provider-core tools
+
+Only these tools are provider-callable by schema:
+
+- `tool.search`
+- `tool.invoke`
+
+No other built-in tool or external skill should be directly exposed to the
+provider as a first-round function schema without an explicit architecture
+change.
+
+### Discoverable tools
+
+All other runtime tools are discoverable, not directly provider-callable.
+
+This includes built-in non-core tools such as:
+
+- `file.read`
+- `file.write`
+- `shell.exec`
+- `claw.import`
+- managed external-skill lifecycle and invoke tools
+
+Discoverable tools may execute only through `tool.invoke` after discovery.
+
+## Parser Contract
+
+Provider parsers may receive legacy or provider-specific tool names such as:
+
+- `file_read`
+- `file.read`
+- `shell_exec`
+- `shell.exec`
+
+If a provider response names a discoverable tool directly, the parser/runtime
+ bridge must rewrite that intent into:
+
+- `tool.invoke`
+- with the discoverable target carried in `args_json.tool_id`
+- with a valid short-lived lease carried in `args_json.lease`
+
+This rewrite is compatibility behavior, not broad direct-tool permission.
+Provider output is still expected to converge onto the discovery-first runtime
+surface.
+
+If provider payloads omit `session_id` or `turn_id`, the runtime must scope
+them to the active session/turn before execution so lease validation remains
+bound to the real conversation context.
+
+## Lease Contract
+
+`tool.search` returns compact result cards, not full provider schemas.
+
+Each result card may include:
+
+- canonical `tool_id`
+- short summary
+- compact argument hint
+- required fields
+- tags / match rationale
+- a short-lived invoke lease
+
+The lease must be validated by `tool.invoke` before dispatch. At minimum the
+lease is expected to bind to:
+
+- discovered tool id
+- issuing session
+- issuing turn
+- short expiry / TTL
+
+Execution must fail closed if the lease is invalid, expired, mismatched, or
+missing.
+
+## Follow-up Provider Turn Contract
+
+If a provider turn executes `tool.search`, the coordinator must treat that turn
+as discovery-only and request a follow-up provider turn before finalizing,
+provided turn-round budget still permits it.
+
+The follow-up turn receives:
+
+- the original visible conversation context
+- the assistant preface from the search turn
+- a `[tool_result]` follow-up payload containing the search results
+
+This contract exists so the model can select one concrete discovered tool after
+search instead of terminating on the search payload itself.
+
+### Raw-output mode
+
+Raw-output requests do not bypass the discovery-first follow-up contract.
+
+If the first turn is `tool.search` and the user requested raw tool output, the
+runtime must still request the follow-up provider turn. Raw mode only changes
+how the final invoked tool output is returned after the second round.
+
+## Telemetry Contract
+
+Discovery-first runtime telemetry is emitted through conversation events rather
+than a separate DB or a second heavyweight persistence path.
+
+The canonical event family is:
+
+- `discovery_first_search_round`
+- `discovery_first_followup_requested`
+- `discovery_first_followup_result`
+
+These events are intentionally compact and are used to quantify:
+
+- how many search rounds occurred
+- how many extra provider follow-up turns were requested
+- how many follow-up rounds resolved to `tool.invoke`
+- how often raw-output mode preserved the follow-up path
+- best-effort estimated token growth caused by the follow-up context
+
+Session-history loaders and analytics projections should read these persisted
+conversation events instead of re-deriving the behavior from ad-hoc text logs.
+
+## Security And Governance Boundaries
+
+- Provider schema size is a security boundary as well as a token-cost boundary.
+- Provider visibility must not silently widen when optional tools or external
+  skills are installed.
+- Non-core tool execution remains governed by the existing kernel/tool plane.
+- Discovery compatibility rewrites are allowed only to funnel provider behavior
+  back into `tool.invoke`, not to re-authorize direct discoverable tool calls.
+- Missing scope metadata must be repaired before lease validation and execution.
+
+## Unsupported Patterns
+
+The current contract intentionally does not support:
+
+- per-turn dynamic reinjection of discovered full tool schemas into provider
+  requests
+- direct provider access to discoverable tools as first-class schema entries
+- database-backed tool discovery as a requirement for correctness
+- search-time widening of provider-visible tools beyond the core
+  `tool.search` / `tool.invoke` pair
+
+These may be reconsidered later, but only as explicit architecture changes that
+preserve the discovery-first default and its governance guarantees.

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -7,6 +7,7 @@ Catalog of design documents and architectural decisions.
 | Document | Scope | Status |
 |----------|-------|--------|
 | [Core Beliefs](core-beliefs.md) | Engineering principles and taste enforcement | Living |
+| [Discovery-First Tool Runtime Contract](discovery-first-tool-runtime-contract.md) | Provider-core tools, leases, parser rewrites, and follow-up turn contract | Active |
 | [Layered Kernel Design](layered-kernel-design.md) | L0-L9 kernel layer specification and boundary rules | Living |
 | [Provider Runtime Roadmap](provider-runtime-roadmap.md) | Provider/runtime evolution strategy | Active |
 | [ACP/ACPX Pre-Embed](acp-acpx-preembed.md) | Advanced cryptographic primitives | Active |

--- a/docs/design-docs/provider-runtime-roadmap.md
+++ b/docs/design-docs/provider-runtime-roadmap.md
@@ -8,6 +8,14 @@
 
 This document captures architecture comparison, implemented hardening, and a durable roadmap for provider runtime evolution.
 
+## Related Runtime Contracts
+
+- Discovery-first tool routing contract:
+  [`discovery-first-tool-runtime-contract.md`](discovery-first-tool-runtime-contract.md)
+  fixes the provider-core tool surface, lease expectations, compatibility
+  rewrites, and follow-up provider-turn behavior for the discovery-first tool
+  path.
+
 ## Comparative Architecture Snapshot
 
 | Dimension | OpenClaw (`main`) | LoongClaw (`alpha-test`) | Current branch (`feat/provider-runtime-abstraction`) |

--- a/docs/plans/2026-03-15-discovery-first-hardening-design.md
+++ b/docs/plans/2026-03-15-discovery-first-hardening-design.md
@@ -1,0 +1,263 @@
+# Discovery-First Hardening Design
+
+Date: 2026-03-15
+Branch: `feat/tool-discovery-architecture`
+Scope: post-architecture hardening for discovery-first provider tool routing
+Status: Approved for implementation
+
+## Summary
+
+The discovery-first runtime now exists, but the branch still needs a stronger
+contract around three operational seams:
+
+- real provider-shape end-to-end coverage across the full
+  `tool.search -> follow-up provider turn -> tool.invoke` path
+- lightweight telemetry that quantifies the cost and effectiveness of the
+  extra provider follow-up turn
+- a concise architecture note that fixes the runtime contract in one durable
+  place so future refactors do not drift back toward broad static tool
+  exposure
+
+This hardening slice should stay lightweight. It should not add a database, a
+new distributed state layer, or per-turn dynamic provider schema expansion.
+The existing discovery-first runtime already has the correct primary shape:
+
+- provider-visible core tools: `tool.search`, `tool.invoke`
+- discoverable non-core tools behind a short-lived lease
+- provider parser rewriting discoverable legacy tool names into `tool.invoke`
+- coordinator follow-up loop that can request a second provider turn after
+  `tool.search`
+
+The remaining work is to prove that contract across real provider response
+shapes, make its runtime cost visible, and document the invariants clearly.
+
+## Goals
+
+- Prove the discovery-first contract across real provider body shapes instead
+  of only synthetic `ProviderTurn` fixtures.
+- Quantify discovery-first behavior with minimal runtime overhead.
+- Keep telemetry local and low-risk by reusing existing conversation-event
+  infrastructure.
+- Write one durable architecture note that describes the supported contract,
+  the security boundaries, and the expected failure behavior.
+- Keep implementation additive on top of PR #149 without widening the provider
+  surface or introducing stateful infrastructure.
+
+## Non-Goals
+
+- No external DB or vector store.
+- No per-tool dynamic provider schema injection after `tool.search`.
+- No new cross-crate audit event type unless a real observability gap remains.
+- No rewrite of the existing provider request adapters.
+- No expansion of the core provider-visible tool set beyond
+  `tool.search` and `tool.invoke`.
+
+## Current Gaps
+
+### 1. Provider-shape coverage stops at parser-only normalization
+
+`crates/app/src/provider/shape.rs` already proves that OpenAI chat-completions,
+Responses, Anthropic native content blocks, Bedrock Converse blocks, and inline
+function blocks normalize discoverable tools into `tool.invoke`. That is
+useful, but it still stops before the real coordinator loop.
+
+`crates/app/src/conversation/tests.rs` does cover the follow-up provider-turn
+loop, but it uses manually constructed `ProviderTurn` values rather than real
+provider body shapes. That leaves a contract gap between parser correctness and
+coordinator correctness.
+
+### 2. Discovery-first runtime cost is not summarized anywhere
+
+The coordinator already knows when a tool turn contains `tool.search`, when it
+requests an extra provider follow-up turn, and whether the follow-up resolves
+into a second tool call or a direct final reply. It also already carries
+message-level token estimates in `ProviderTurnPreparation`.
+
+Today none of those discovery-first signals are summarized in a single runtime
+projection, so it is hard to answer:
+
+- how often a discovery-first turn requires an extra provider round
+- how many extra estimated tokens the follow-up context adds
+- how often `tool.search` leads to `tool.invoke` versus a dead-end reply
+- whether raw-output mode still preserves the second round
+
+### 3. The long-lived runtime contract is not fixed in design docs
+
+The implementation plan and design plan for 2026-03-15 explain the discovery
+architecture, but they are branch-local plan artifacts, not the durable design
+docs index used to document living runtime contracts.
+
+Without a concise long-lived note, later changes can drift on:
+
+- what counts as a provider-core tool
+- whether provider parsers may emit discoverable direct tool names
+- whether missing `session_id` / `turn_id` scope should be rewritten
+- whether raw-output mode is allowed to bypass the follow-up provider turn
+- what guarantees a lease is expected to bind
+
+## Approaches Considered
+
+### Approach 1: add a separate runtime telemetry module
+
+Pros:
+
+- can expose process-local counters similar to provider failover telemetry
+- avoids extending conversation analytics parsing
+
+Cons:
+
+- duplicates data that already exists in persisted conversation events
+- adds a second observability path for one coordinator behavior
+- makes post-turn debugging harder because the metrics and the event stream
+  diverge
+
+### Approach 2: extend the existing conversation-event path
+
+Pros:
+
+- reuses an existing persistence and analytics mechanism
+- keeps telemetry local to the coordinator behavior being measured
+- produces debuggable per-turn evidence and rollup-friendly summaries
+- avoids cross-crate audit surface churn
+
+Cons:
+
+- requires adding a new event family and analytics summarizer
+- slightly increases event volume when enabled
+
+### Approach 3: do only tests + docs, skip telemetry for now
+
+Pros:
+
+- smallest code change
+- no runtime overhead
+
+Cons:
+
+- leaves token and efficiency claims unmeasured
+- makes future regressions in follow-up cost harder to catch
+
+## Decision
+
+Adopt Approach 2.
+
+The hardening slice should:
+
+1. Add end-to-end tests that begin with real provider response bodies,
+   normalize through `extract_provider_turn_with_scope(...)`, and then run the
+   real coordinator follow-up loop.
+2. Emit a dedicated discovery-first conversation event family from the
+   coordinator follow-up path and add an analytics summary for it.
+3. Write a design-doc note that defines the discovery-first runtime contract
+   and links it from the design-doc index.
+
+## Architecture
+
+### Provider-shape end-to-end matrix
+
+Add coordinator tests that exercise these source shapes:
+
+- OpenAI chat-completions `message.tool_calls`
+- Responses `output.function_call`
+- Anthropic `content[].tool_use`
+- Bedrock `output.message.content[].toolUse`
+- inline `<function=...>` blocks inside plain assistant text
+
+Each test should:
+
+- start from a real provider response JSON body
+- parse it with `extract_provider_turn_with_scope(...)`
+- feed the resulting `ProviderTurn` into `ConversationTurnCoordinator`
+- execute a real `tool.search` result against the real harness/runtime
+- verify the second provider turn receives the `[tool_result]` follow-up
+  context
+- verify the second round can issue a discoverable tool name that rewrites to
+  `tool.invoke`
+- verify the final reply or raw-output result comes from the invoked tool, not
+  the first-round search payload
+
+This keeps parser correctness and coordinator correctness under one contract
+without duplicating parser-only tests.
+
+### Discovery-first telemetry
+
+Use persisted conversation events rather than a new DB or a separate exported
+metrics sink.
+
+Add a dedicated event family, for example:
+
+- `discovery_first_search_round`
+- `discovery_first_followup_requested`
+- `discovery_first_followup_result`
+
+Each payload should stay compact and structured, carrying only the fields
+needed to answer efficiency and correctness questions:
+
+- `round`
+- `search_tool_calls`
+- `followup_requested`
+- `raw_tool_output_requested`
+- `followup_outcome`
+- `followup_tool_name`
+- `followup_resolved_to_tool_invoke`
+- `initial_estimated_tokens`
+- `followup_estimated_tokens`
+- `followup_added_estimated_tokens`
+
+The coordinator already has enough state to populate those fields from the
+existing preparation and follow-up messages. Estimated tokens should remain
+best-effort and use the same message estimator already used by the turn
+coordinator.
+
+Analytics should summarize:
+
+- total search rounds seen
+- total follow-up rounds requested
+- total follow-up result events observed
+- total raw-output follow-up rounds preserved
+- total search-to-invoke hits
+- average / aggregate added estimated tokens
+- latest snapshot for debugging
+
+### Durable contract note
+
+Add `docs/design-docs/discovery-first-tool-runtime-contract.md` and link it
+from `docs/design-docs/index.md`.
+
+The note should define:
+
+- the only provider-core tools
+- the discoverable-tool boundary
+- parser rewrite rules for legacy discoverable tool names
+- lease scope and turn/session binding expectations
+- when the coordinator must request a follow-up provider turn
+- raw-output behavior
+- intentionally unsupported patterns, such as dynamic per-tool schema
+  reinjection and direct provider access to discoverable tools
+
+## Testing Strategy
+
+- Add failing coordinator tests first for provider-shape e2e coverage.
+- Add failing analytics tests for discovery-first event summarization.
+- Implement minimal coordinator and analytics changes to pass those tests.
+- Keep existing parser-only tests unchanged except where helper reuse is
+  helpful.
+- Run targeted `cargo test -p loongclaw-app ...` during red-green cycles, then
+  a broader verification pass before commit / push.
+
+## Risks And Mitigations
+
+### Event volume growth
+
+Mitigation: emit discovery-first events only when the turn actually contains
+`tool.search`, and keep payloads small.
+
+### Test brittleness from provider-shape fixtures
+
+Mitigation: use one concise fixture per provider family and assert only the
+contractual outcomes, not incidental formatting.
+
+### Analytics drift
+
+Mitigation: keep the event family narrowly scoped and add direct unit tests for
+the summary projection.

--- a/docs/plans/2026-03-15-discovery-first-hardening.md
+++ b/docs/plans/2026-03-15-discovery-first-hardening.md
@@ -1,0 +1,231 @@
+# Discovery-First Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Harden the discovery-first provider runtime by proving real provider-shape follow-up behavior, summarizing discovery-first runtime telemetry, and fixing the contract in durable architecture docs.
+
+**Architecture:** Extend the existing discovery-first coordinator path rather than adding new infrastructure. Use real provider response shapes in coordinator tests, emit compact discovery-first conversation events only on `tool.search` turns, summarize them in analytics, and document the contract in a living design note.
+
+**Tech Stack:** Rust, `loongclaw-app` conversation/provider/tools modules, `serde_json`, cargo test, cargo fmt, GitHub PR workflow.
+
+---
+
+### Task 1: Add failing discovery-first analytics summary tests
+
+**Files:**
+- Modify: `crates/app/src/conversation/analytics.rs`
+
+**Step 1: Write the failing tests**
+
+Add unit tests for a new discovery-first event summary function. Cover:
+
+- counts for search rounds, follow-up requested/completed, raw-output preserved
+- aggregation of `followup_added_estimated_tokens`
+- search-to-invoke hit counting based on structured event payloads
+- ignoring lookalike events or malformed payloads
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app summarize_discovery_first_events -- --nocapture`
+Expected: FAIL because the new summary type and parser do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add a discovery-first summary type and parser in `analytics.rs` that reads only
+the new event family and produces the small rollup needed by the coordinator
+tests.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app summarize_discovery_first_events -- --nocapture`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/analytics.rs
+git commit -m "feat: summarize discovery-first telemetry"
+```
+
+### Task 2: Add failing provider-shape end-to-end follow-up tests
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add coordinator tests that:
+
+- build the first-round `ProviderTurn` via `extract_provider_turn_with_scope(...)`
+- use real JSON bodies for:
+  - OpenAI chat-completions tool calls
+  - Responses function calls
+  - Anthropic `tool_use`
+  - Bedrock `toolUse`
+  - inline function blocks
+- queue a second provider turn that requests a discoverable tool by its native
+  name
+- assert:
+  - two provider turn requests occurred
+  - the second request received `[tool_result]` follow-up context
+  - the second-turn native tool name rewrites to `tool.invoke`
+  - final reply or raw output comes from the invoked tool, not the search card
+- add at least one assertion that the persisted discovery-first events summarize
+  the follow-up behavior correctly
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app provider_shape_tool_search -- --nocapture`
+Expected: FAIL because the helper coverage and telemetry assertions do not exist
+yet.
+
+**Step 3: Write minimal implementation**
+
+Add compact fixture helpers if needed, but keep the real coordinator path
+unchanged until the telemetry seam is wired.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app provider_shape_tool_search -- --nocapture`
+Expected: PASS with the real follow-up loop exercised.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/tests.rs
+git commit -m "test: cover provider-shape discovery followups"
+```
+
+### Task 3: Implement discovery-first coordinator telemetry
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/mod.rs`
+- Modify: `crates/app/src/conversation/analytics.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Reuse the new analytics and coordinator tests so they fail on missing telemetry
+events / summaries.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app summarize_discovery_first_events provider_shape_tool_search -- --nocapture`
+Expected: FAIL because no discovery-first events are emitted or summarized.
+
+**Step 3: Write minimal implementation**
+
+Emit compact discovery-first conversation events from the provider follow-up
+path when a turn contains `tool.search`. Include:
+
+- whether follow-up was requested
+- the follow-up result outcome
+- whether raw-output mode preserved the follow-up
+- the follow-up tool name
+- whether it resolved to `tool.invoke`
+- initial / follow-up / added estimated tokens
+
+Add analytics parsing and re-exports as needed.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app summarize_discovery_first_events provider_shape_tool_search -- --nocapture`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/turn_coordinator.rs crates/app/src/conversation/mod.rs crates/app/src/conversation/analytics.rs crates/app/src/conversation/tests.rs
+git commit -m "feat: emit discovery-first followup telemetry"
+```
+
+### Task 4: Add the long-lived architecture note
+
+**Files:**
+- Create: `docs/design-docs/discovery-first-tool-runtime-contract.md`
+- Modify: `docs/design-docs/index.md`
+- Modify: `docs/design-docs/provider-runtime-roadmap.md`
+
+**Step 1: Write the failing test**
+
+No automated test. Use doc review against the approved design.
+
+**Step 2: Review expected contract coverage**
+
+Confirm the note covers:
+
+- provider-core tools
+- discoverable tools and parser rewrite rules
+- lease/session/turn scope
+- follow-up provider turn requirement
+- raw-output behavior
+- unsupported patterns
+
+**Step 3: Write minimal implementation**
+
+Add the new note, link it from the design-doc index, and add a short pointer
+from the provider runtime roadmap.
+
+**Step 4: Review docs**
+
+Read the changed docs for accuracy and consistency with the implementation.
+
+**Step 5: Commit**
+
+```bash
+git add docs/design-docs/discovery-first-tool-runtime-contract.md docs/design-docs/index.md docs/design-docs/provider-runtime-roadmap.md
+git commit -m "docs: add discovery-first runtime contract note"
+```
+
+### Task 5: Verification and GitHub packaging
+
+**Files:**
+- Modify: GitHub artifacts only if needed
+
+**Step 1: Run targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app summarize_discovery_first_events -- --nocapture
+cargo test -p loongclaw-app provider_shape_tool_search -- --nocapture
+```
+
+Expected: PASS.
+
+**Step 2: Run broader verification**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo test -p loongclaw-app -- --test-threads=1
+```
+
+Expected: PASS.
+
+**Step 3: Inspect isolation**
+
+Run:
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```
+
+Expected: only hardening-scope files are present.
+
+**Step 4: Push and update PR**
+
+Push the branch and update existing issue / PR copy in English, explicitly
+describing:
+
+- provider-shape discovery-first e2e coverage
+- discovery-first telemetry summary
+- durable runtime contract note
+
+**Step 5: Clean branch-local build artifacts**
+
+Remove any branch-local `target/` output before reporting completion.

--- a/docs/plans/2026-03-15-discovery-first-hardening.md
+++ b/docs/plans/2026-03-15-discovery-first-hardening.md
@@ -1,7 +1,5 @@
 # Discovery-First Hardening Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Harden the discovery-first provider runtime by proving real provider-shape follow-up behavior, summarizing discovery-first runtime telemetry, and fixing the contract in durable architecture docs.
 
 **Architecture:** Extend the existing discovery-first coordinator path rather than adding new infrastructure. Use real provider response shapes in coordinator tests, emit compact discovery-first conversation events only on `tool.search` turns, summarize them in analytics, and document the contract in a living design note.

--- a/docs/plans/2026-03-15-tool-discovery-architecture-design.md
+++ b/docs/plans/2026-03-15-tool-discovery-architecture-design.md
@@ -1,0 +1,425 @@
+# Tool Discovery Architecture Design
+
+Date: 2026-03-15
+Branch: `feat/tool-discovery-architecture`
+Scope: discovery-first provider tool surface for `alpha-test`
+Status: Approved for implementation
+
+## Summary
+
+`alpha-test` still exposes the model to a broad static provider tool surface.
+The current provider hot path:
+
+- builds a full static function schema in `crates/app/src/tools/mod.rs`
+- appends a full capability snapshot to the system prompt in
+  `crates/app/src/provider/request_message_runtime.rs`
+- accepts direct provider calls to any statically known tool in both fast-lane
+  and safe-lane execution
+
+That shape conflicts with the target product model:
+
+- the model should begin with only a minimal core tool surface
+- `tool_search` should be the path to discover non-core tools
+- real execution of non-core tools should flow through one audited dispatcher
+- installed external skills should not silently enlarge the provider-visible
+  surface
+
+The recommended architecture for this branch is a discovery-first hybrid:
+
+1. Expose only `tool_search` and `tool_invoke` to provider function calling.
+2. Keep all non-core tools in a runtime catalog that is searchable but not
+   directly provider-callable.
+3. Make `tool_search` return short tool cards plus a short-lived invoke lease,
+   not full per-tool provider schemas.
+4. Make `tool_invoke` validate the lease and dispatch the real tool call
+   through the existing kernel-governed tool plane.
+5. Shrink the system prompt capability snapshot so it only describes the
+   discovery-first runtime contract.
+
+This keeps the model-facing surface small, preserves kernel-first execution,
+and creates a clean seam for later progressive exposure modes without forcing a
+database or a full dynamic provider schema system into v1.
+
+## Product Goals
+
+- Make provider-visible tools discovery-first by default.
+- Prevent direct model access to non-core tools unless they were explicitly
+  discovered for the current turn.
+- Reduce prompt and schema token cost for normal turns.
+- Keep all real tool execution on the existing kernel-governed path.
+- Preserve deterministic behavior and low operational weight.
+- Keep the implementation additive and compatible with current app/kernel
+  contracts.
+- Leave room for future progressive exposure modes without redesigning the
+  whole tool stack again.
+
+## Non-Goals For This Slice
+
+- No external database.
+- No external vector database.
+- No model-generated per-tool provider schema expansion in the first shipped
+  implementation.
+- No attempt to turn installed external skills into first-class provider tools.
+- No new remote execution bridge or plugin sandbox in this slice.
+- No removal of the existing static core tool executors themselves; only their
+  provider exposure and routing model changes.
+
+## Current State
+
+### Provider surface is still static and broad
+
+The provider-visible function schema is hardcoded in
+`crates/app/src/tools/mod.rs` via `provider_tool_definitions()`. The request
+path in `crates/app/src/provider/request_dispatch_runtime.rs` always loads that
+full definition set and `crates/app/src/provider/request_payload_runtime.rs`
+always emits it with `tool_choice = "auto"` when tool schema is enabled.
+
+### The system prompt still leaks the full runtime tool surface
+
+`crates/app/src/provider/request_message_runtime.rs` appends
+`capability_snapshot_with_config(...)` into the system message. That snapshot
+currently enumerates all built-in tools and can also auto-expose installed
+external skills. This means the model still sees a wide tool inventory even if
+the JSON function schema were narrowed later.
+
+### Provider turns can directly request any statically known tool
+
+`crates/app/src/conversation/turn_engine.rs` and the provider safe-lane tool
+path in `crates/app/src/conversation/turn_coordinator.rs` both rely on
+`is_known_tool_name()` for direct provider-emitted tool validation. Today that
+means a model that already knows or guesses `file.read` or `shell.exec` can try
+to call it directly.
+
+### `tool_search` exists in `crates/spec`, not on the app/provider hot path
+
+There is already a `tool_search` operation in `crates/spec`, but it does not
+participate in the current conversation/provider runtime path. The provider hot
+path lives in `crates/app`, so a discovery-first provider architecture must add
+an app-native search tool rather than assuming the existing spec operation is
+already in play.
+
+### There is still a kernel-governance bypass helper
+
+`crates/app/src/tools/mod.rs::execute_tool(...)` still falls through to direct
+core execution when `kernel_ctx` is `None`. The primary provider turn path
+already uses the kernel adapter directly, but keeping this helper permissive
+works against the codebase's kernel-first architecture rule.
+
+### Installed external skills are still auto-exposed by default
+
+`ExternalSkillsRuntimePolicy::default()` currently sets
+`auto_expose_installed = true`. That default conflicts with a discovery-first
+contract where non-core tools and managed skills should become visible only via
+explicit search or inspection flows.
+
+## Approaches Considered
+
+### Approach 1: Keep the current static provider tool surface
+
+Pros:
+
+- smallest code change
+- no new routing concepts
+
+Cons:
+
+- large token overhead on every function-calling turn
+- weak separation between core runtime tools and optional tools
+- models can directly guess and call non-core tools
+- installed-skill auto-exposure keeps widening the prompt surface
+
+### Approach 2: Search first, then dynamically inject full schemas per turn
+
+Pros:
+
+- gives the model direct function calling for discovered tools
+- good ergonomics when the provider strongly prefers explicit per-tool schemas
+
+Cons:
+
+- higher control-plane complexity
+- requires per-turn exposure bookkeeping on request build and parser paths
+- inline function parsing currently assumes a static provider schema source
+- increases risk of schema drift between search results, parser expectations,
+  and execution-time routing
+
+### Approach 3: Discovery-first hybrid dispatcher
+
+Expose only a core search/invoke pair to the provider, keep a runtime catalog
+for discoverable tools, and require a short-lived lease from search before
+invoke dispatches the real tool.
+
+Pros:
+
+- smallest provider-visible surface
+- strongest default enforcement of search-first behavior
+- execution still goes through one governed path
+- easy to keep lightweight because catalog data can stay in memory or be
+  derived from existing runtime state
+- future dynamic exposure modes can still be layered on top later
+
+Cons:
+
+- the model calls a generic dispatcher instead of a discovered tool's native
+  function name
+- search results must carry enough argument hints to keep invocation usable
+  without shipping full schemas
+
+## Decision
+
+Adopt Approach 3 as the default runtime contract for this slice.
+
+The shipped v1 behavior should be:
+
+- provider-visible tool schema contains only `tool_search` and `tool_invoke`
+- system prompt describes only the discovery-first contract, not the full tool
+  inventory
+- direct provider calls to non-core tools are rejected
+- `tool_search` returns short cards, not full schemas
+- `tool_invoke` validates a lease and dispatches the underlying tool through
+  the existing kernel-governed adapter
+- installed external skills stop auto-expanding provider visibility by default
+
+## Architecture Overview
+
+### 1. Tool classes
+
+The runtime tool catalog is split into two classes:
+
+- core provider tools
+  - `tool.search`
+  - `tool.invoke`
+- discoverable tools
+  - existing built-in tools such as `claw.import`, `file.read`, `file.write`,
+    `shell.exec`, and the managed external-skill lifecycle tools
+
+Only core provider tools are directly valid provider-emitted tool intents.
+Discoverable tools remain executable, but only behind `tool.invoke`.
+
+### 2. Runtime catalog
+
+Add an app-native tool catalog abstraction in `crates/app/src/tools/` that
+describes:
+
+- canonical tool id
+- provider-facing function name when applicable
+- exposure class
+- short summary
+- compact argument hint string
+- required field names
+- search tags
+
+This catalog becomes the single source of truth for:
+
+- provider core tool schema generation
+- compact capability snapshot generation
+- discovery search space
+- direct provider-call allowlisting
+- dispatcher routing to the real executor
+
+The existing static match-based executor remains the real implementation
+surface. The new catalog is a routing and disclosure layer, not a second tool
+runtime.
+
+### 3. `tool_search`
+
+`tool_search` is promoted into the app/provider runtime as a first-class core
+tool. It should:
+
+- accept a natural-language `query`
+- return only discoverable tools
+- rank results deterministically using local metadata
+- return compact cards with:
+  - `tool_id`
+  - `summary`
+  - `argument_hint`
+  - `required_fields`
+  - `tags`
+  - `why`
+  - `lease`
+
+The lease is an invoke-scoped token bound to:
+
+- target tool id
+- expiration time
+- current catalog/schema digest
+- process-local secret
+
+The token is short-lived and self-validating so v1 does not require a database.
+
+### 4. `tool_invoke`
+
+`tool_invoke` is the only provider-visible path to non-core tool execution.
+It should:
+
+- accept `tool_id`, `lease`, and `arguments`
+- validate the lease and tool id match
+- reject expired or tampered leases
+- dispatch only to discoverable tools
+- never dispatch back into the provider-visible core pair
+
+The dispatch itself still uses the current app executor and kernel adapter
+stack. The model-facing function name changes, but the underlying governance
+path does not.
+
+### 5. Provider exposure modes
+
+This slice ships only the dispatcher-only mode, but the architecture should
+leave space for two future modes:
+
+- `dispatcher_only`
+  - current slice
+- `ephemeral_stub`
+  - search returns a temporary handle and a narrow callable stub may be exposed
+    on the next round
+- `ephemeral_full`
+  - search results can escalate to full per-tool provider schemas for a later
+    round when justified
+
+Those later modes should reuse the same catalog and lease model. The source of
+truth remains the catalog plus the dispatcher, not ad hoc schema generation.
+
+### 6. Prompt surface minimization
+
+The system prompt should stop enumerating the full tool surface. Instead it
+should describe the contract:
+
+- `tool_search` discovers task-relevant tools
+- `tool_invoke` executes a previously discovered tool with a valid lease
+- non-core tools are intentionally hidden until discovered
+
+This cuts prompt tokens and prevents prompt-level leakage from bypassing the
+discovery-first model.
+
+### 7. External skills behavior
+
+Installed external skills should no longer auto-appear in the provider prompt
+surface by default. Their runtime tools remain discoverable through
+`tool_search`, and explicit managed-skill inspection/invocation continues to
+work through the dispatcher path.
+
+## User-Facing Runtime Model
+
+### Normal turn
+
+The model sees only:
+
+- `tool_search`
+- `tool_invoke`
+
+The system prompt tells the model to search before invoking non-core tools.
+
+### Discovery turn
+
+The model calls `tool_search("read a file from the repo")`.
+
+The runtime returns a short card such as:
+
+- `tool_id = "file.read"`
+- `summary = "Read file contents"`
+- `argument_hint = "path:string,max_bytes?:integer"`
+- `required_fields = ["path"]`
+- `lease = "..."`
+
+### Execution turn
+
+The model calls `tool_invoke` with:
+
+- the returned `tool_id`
+- the returned `lease`
+- an `arguments` object for the real tool payload
+
+`tool_invoke` validates the lease and dispatches the underlying tool through
+the existing governed executor.
+
+### Failure behavior
+
+If the model tries to call `file.read` directly as a provider tool:
+
+- provider parsing may still recover the intent
+- execution rejects it as not provider-exposed
+- the runtime can steer the model back toward `tool_search`
+
+If the model reuses an expired or tampered lease:
+
+- `tool_invoke` fails closed
+- the reply explains the model must re-run `tool_search`
+
+## Security, Stability, and Lightweight Constraints
+
+### Security
+
+- direct provider calls are limited to the core pair
+- all real tool execution still goes through the kernel-governed tool path
+- `tool.invoke` derives required kernel capabilities from the effective target
+  tool request instead of stopping at `InvokeTool`
+  - `file.read` requires `InvokeTool + FilesystemRead`
+  - `file.write` requires `InvokeTool + FilesystemWrite`
+  - writeful `claw.import` modes require `FilesystemWrite` in addition to read
+- leases are scoped to one tool id and expire quickly
+- file-root and migration-root escapes surface as explicit `policy_denied:`
+  tool-plane failures so retry logic stays fail-closed
+- shell execution keeps a default-deny posture unless an explicit allowlist is
+  configured
+- installed-skill auto-exposure defaults off
+- the permissive `execute_tool(..., None)` helper should be closed in this
+  slice so kernel-first is true in code, not only in docs
+
+### Stability
+
+- catalog metadata is static/derived from existing runtime configuration
+- provider schema shape becomes much smaller and more stable
+- inline function parser no longer needs to track the full tool universe for
+  the provider surface
+- no new durable state is required for v1
+
+### Lightweight operation
+
+Do not add a database in v1.
+
+The right lightweight default is:
+
+- static or derived metadata catalog
+- in-memory ranking
+- stateless signed lease tokens
+- existing on-disk managed-skill index reused as an input when needed
+
+If future scale or ranking quality requires acceleration, the next step should
+be a local derived cache such as SQLite/FTS. It should remain an optimization
+layer, not the source of truth.
+
+## Validation Strategy
+
+### New behavior tests
+
+- provider tool definitions expose only `tool_search` and `tool_invoke`
+- compact capability snapshot no longer leaks discoverable tools
+- `tool_search` returns only discoverable tools and returns leases
+- `tool_invoke` dispatches a discovered tool successfully
+- `tool_invoke` rejects tampered or expired leases
+- `tool.invoke` enforces the effective tool capability boundary for file and
+  import tools
+- file-root escape paths classify as policy denial instead of retryable tool
+  execution errors
+- shell runtime defaults remain default-deny when no allowlist is configured
+- direct provider validation rejects non-core tools
+- installed external skills are not auto-exposed by default
+- `execute_tool(..., None)` fails closed instead of bypassing the kernel
+
+### Existing regression coverage
+
+- direct tool execution through the kernel adapter still works
+- safe-lane and fast-lane both execute `tool_invoke`
+- provider request fallback for tool-schema-unsupported models still behaves
+  correctly
+
+## Follow-On Work
+
+After this slice is stable, the next architectural options are:
+
+1. add optional progressive exposure modes (`ephemeral_stub`,
+   `ephemeral_full`)
+2. improve search ranking with derived local indexing
+3. add richer tool-card hints for complex tools without shipping full schemas
+4. add explicit runtime metrics around search-hit rate, lease failures, and
+   dispatcher-only success rate

--- a/docs/plans/2026-03-15-tool-discovery-architecture.md
+++ b/docs/plans/2026-03-15-tool-discovery-architecture.md
@@ -1,0 +1,546 @@
+# Tool Discovery Architecture Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the current static provider-wide tool exposure with a discovery-first runtime where only `tool_search` and `tool_invoke` are provider-callable, while non-core tools remain executable behind a lease-validated dispatcher.
+
+**Architecture:** Introduce an app-native tool catalog that separates provider-core tools from discoverable tools. Generate the provider schema and capability snapshot from that catalog, add first-class `tool_search` and `tool_invoke` executors, reject direct provider calls to discoverable tools, and keep real execution routed through the existing kernel-governed tool plane.
+
+**Tech Stack:** Rust, existing `loongclaw-app` tool/runtime/provider/conversation modules, `serde`, `serde_json`, `sha2`, `base64`, cargo test, cargo fmt, cargo clippy.
+
+---
+
+### Task 1: Add the discovery-first tool catalog primitives
+
+**Files:**
+- Create: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Test: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn provider_tool_definitions_only_expose_core_discovery_tools() {
+    let defs = provider_tool_definitions();
+    let names: Vec<&str> = defs
+        .iter()
+        .filter_map(|item| item.get("function"))
+        .filter_map(|function| function.get("name"))
+        .filter_map(Value::as_str)
+        .collect();
+    assert_eq!(names, vec!["tool_invoke", "tool_search"]);
+}
+
+#[test]
+fn provider_exposed_tool_gate_rejects_discoverable_tools() {
+    assert!(is_provider_exposed_tool_name("tool.search"));
+    assert!(!is_provider_exposed_tool_name("file.read"));
+    assert!(!is_provider_exposed_tool_name("shell.exec"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app provider_tool_definitions_only_expose_core_discovery_tools provider_exposed_tool_gate_rejects_discoverable_tools -- --nocapture`
+Expected: FAIL because the provider tool schema is still the old full static surface and there is no provider-core exposure gate yet.
+
+**Step 3: Write minimal implementation**
+
+Create a catalog module with deterministic metadata for:
+
+- provider-core tools
+  - `tool.search`
+  - `tool.invoke`
+- discoverable tools
+  - `claw.import`
+  - `external_skills.fetch`
+  - `external_skills.inspect`
+  - `external_skills.install`
+  - `external_skills.invoke`
+  - `external_skills.list`
+  - `external_skills.policy`
+  - `external_skills.remove`
+  - feature-gated `file.read`
+  - feature-gated `file.write`
+  - feature-gated `shell.exec`
+
+Expose helpers such as:
+
+```rust
+pub enum ToolExposureClass {
+    ProviderCore,
+    Discoverable,
+}
+
+pub struct ToolCatalogEntry {
+    pub canonical_name: &'static str,
+    pub provider_function_name: &'static str,
+    pub summary: &'static str,
+    pub argument_hint: &'static str,
+    pub required_fields: &'static [&'static str],
+    pub tags: &'static [&'static str],
+    pub exposure: ToolExposureClass,
+}
+```
+
+Refactor `provider_tool_definitions()` to emit only the provider-core pair.
+Add `is_provider_exposed_tool_name(...)` and keep `is_known_tool_name(...)`
+for internal dispatch use.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app provider_tool_definitions_only_expose_core_discovery_tools provider_exposed_tool_gate_rejects_discoverable_tools -- --nocapture`
+Expected: PASS with only the two core tool functions exposed.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/catalog.rs crates/app/src/tools/mod.rs
+git commit -m "feat: add discovery-first tool catalog"
+```
+
+### Task 2: Add `tool_search` with compact cards and leases
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Test: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn tool_search_returns_discoverable_tools_with_leases() {
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.search".to_owned(),
+            payload: json!({"query": "read repo file", "limit": 3}),
+        },
+        &test_config(),
+    )
+    .expect("tool search should succeed");
+
+    assert_eq!(outcome.status, "ok");
+    let results = outcome.payload["results"].as_array().expect("results");
+    assert!(!results.is_empty());
+    assert!(results.iter().all(|entry| entry["tool_id"] != "tool.search"));
+    assert!(results[0]["lease"].as_str().is_some());
+}
+
+#[test]
+fn tool_search_result_includes_compact_argument_hints() {
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.search".to_owned(),
+            payload: json!({"query": "shell command"}),
+        },
+        &test_config(),
+    )
+    .expect("tool search should succeed");
+
+    let results = outcome.payload["results"].as_array().expect("results");
+    assert!(results.iter().any(|entry| {
+        entry["tool_id"] == "shell.exec"
+            && entry["argument_hint"].as_str() == Some("command:string,args?:string[]")
+    }));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app tool_search_returns_discoverable_tools_with_leases tool_search_result_includes_compact_argument_hints -- --nocapture`
+Expected: FAIL because `tool.search` does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add a new app-native `tool.search` executor that:
+
+- accepts `query` and optional `limit`
+- searches only discoverable catalog entries
+- uses deterministic local ranking from:
+  - exact name match
+  - query token match in summary
+  - query token match in tags
+  - argument-hint match
+- returns:
+
+```rust
+json!({
+    "query": query,
+    "returned": results.len(),
+    "results": [{
+        "tool_id": entry.canonical_name,
+        "summary": entry.summary,
+        "argument_hint": entry.argument_hint,
+        "required_fields": entry.required_fields,
+        "tags": entry.tags,
+        "why": why,
+        "lease": lease_token,
+    }]
+})
+```
+
+Implement a short-lived signed lease token using:
+
+- JSON claims
+- URL-safe base64 encoding
+- SHA-256 over `secret || encoded_claims`
+
+Bind the lease to:
+
+- tool id
+- expiry
+- catalog digest
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app tool_search_returns_discoverable_tools_with_leases tool_search_result_includes_compact_argument_hints -- --nocapture`
+Expected: PASS with stable search results and non-empty leases.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/catalog.rs crates/app/src/tools/mod.rs
+git commit -m "feat: add app-native tool search and leases"
+```
+
+### Task 3: Add `tool_invoke` and fail closed on invalid leases
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Test: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn tool_invoke_dispatches_a_discovered_tool_with_a_valid_lease() {
+    let search = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.search".to_owned(),
+            payload: json!({"query": "read file"}),
+        },
+        &test_config(),
+    )
+    .expect("tool search should succeed");
+
+    let result = search.payload["results"]
+        .as_array()
+        .expect("results")
+        .iter()
+        .find(|entry| entry["tool_id"] == "file.read")
+        .expect("file.read result");
+
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "file.read",
+                "lease": result["lease"].clone(),
+                "arguments": { "path": "README.md", "max_bytes": 64 }
+            }),
+        },
+        &test_config(),
+    )
+    .expect("tool invoke should succeed");
+
+    assert_eq!(outcome.status, "ok");
+}
+
+#[test]
+fn tool_invoke_rejects_tampered_or_missing_leases() {
+    let error = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "file.read",
+                "lease": "tampered",
+                "arguments": { "path": "README.md" }
+            }),
+        },
+        &test_config(),
+    )
+    .expect_err("tampered lease should fail");
+
+    assert!(error.contains("invalid_tool_lease"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app tool_invoke_dispatches_a_discovered_tool_with_a_valid_lease tool_invoke_rejects_tampered_or_missing_leases -- --nocapture`
+Expected: FAIL because `tool.invoke` does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add a `tool.invoke` executor that:
+
+- accepts:
+  - `tool_id`
+  - `lease`
+  - `arguments`
+- validates the lease
+- rejects:
+  - expired lease
+  - tampered lease
+  - lease/tool mismatch
+  - attempts to invoke provider-core tools
+- dispatches the underlying discoverable tool by calling a narrow internal
+  helper, for example:
+
+```rust
+fn execute_discoverable_tool_core_with_config(
+    request: ToolCoreRequest,
+    config: &ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String>
+```
+
+Do not recurse through `tool.invoke` again. The dispatcher must call only the
+real discoverable tool executors.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app tool_invoke_dispatches_a_discovered_tool_with_a_valid_lease tool_invoke_rejects_tampered_or_missing_leases -- --nocapture`
+Expected: PASS with successful dispatch for a valid lease and fail-closed
+behavior for invalid leases.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/catalog.rs crates/app/src/tools/mod.rs
+git commit -m "feat: add discovery dispatcher for non-core tools"
+```
+
+### Task 4: Enforce core-only provider calls in fast-lane and safe-lane
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+```rust
+#[tokio::test]
+async fn turn_engine_rejects_direct_discoverable_tool_calls() {
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "file.read".to_owned(),
+            args_json: json!({"path": "README.md"}),
+            source: "provider_tool_call".to_owned(),
+            session_id: String::new(),
+            turn_id: String::new(),
+            tool_call_id: "call-1".to_owned(),
+        }],
+        raw_meta: json!({}),
+    };
+
+    let result = TurnEngine::new(1).execute_turn(&turn, None).await;
+    let failure = result.failure().expect("direct discoverable tool should fail");
+    assert_eq!(failure.code, "tool_not_provider_exposed");
+}
+```
+
+Add an equivalent safe-lane regression that ensures the coordinator's
+single-tool execution path also rejects direct discoverable tool names.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app turn_engine_rejects_direct_discoverable_tool_calls -- --nocapture`
+Expected: FAIL because provider turns still accept any statically known tool.
+
+**Step 3: Write minimal implementation**
+
+Replace direct provider validation from `is_known_tool_name(...)` to
+`is_provider_exposed_tool_name(...)` in:
+
+- `TurnEngine::evaluate_turn(...)`
+- `TurnEngine::execute_turn(...)`
+- the provider safe-lane single-tool path in `turn_coordinator.rs`
+
+Return a distinct error such as:
+
+```rust
+TurnResult::policy_denied(
+    "tool_not_provider_exposed",
+    format!("tool_not_provider_exposed: {}", intent.tool_name),
+)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app turn_engine_rejects_direct_discoverable_tool_calls -- --nocapture`
+Expected: PASS with direct non-core provider calls rejected.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/turn_engine.rs crates/app/src/conversation/turn_coordinator.rs crates/app/src/conversation/tests.rs
+git commit -m "feat: enforce core-only provider tool calls"
+```
+
+### Task 5: Shrink prompt exposure and close the permissive fallback
+
+**Files:**
+- Modify: `crates/app/src/tools/runtime_config.rs`
+- Modify: `crates/app/src/tools/external_skills.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/provider/request_message_runtime.rs`
+- Test: `crates/app/src/tools/mod.rs`
+- Test: `crates/app/src/provider/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn capability_snapshot_only_describes_discovery_runtime_contract() {
+    let snapshot = capability_snapshot();
+    assert!(snapshot.contains("tool.search"));
+    assert!(snapshot.contains("tool.invoke"));
+    assert!(!snapshot.contains("file.read"));
+    assert!(!snapshot.contains("shell.exec"));
+}
+
+#[test]
+fn external_skills_auto_expose_default_is_disabled() {
+    let config = ToolRuntimeConfig::default();
+    assert!(!config.external_skills.auto_expose_installed);
+}
+
+#[test]
+fn required_capabilities_follow_effective_tool_request() {
+    // `tool.invoke(file.read)` must require FilesystemRead.
+    // Writeful `claw.import` must also require FilesystemWrite.
+}
+
+#[tokio::test]
+async fn integ_file_read_sandbox_rejects_path_escape_as_policy_denial() {
+    // File root escapes must not be treated as retryable execution errors.
+}
+
+#[test]
+fn from_env_defaults_to_empty_allowlist() {
+    crate::process_env::remove_var("LOONGCLAW_SHELL_ALLOWLIST");
+    let config = ToolRuntimeConfig::from_env();
+    assert!(config.shell_allowlist.is_empty());
+}
+
+#[tokio::test]
+async fn execute_tool_requires_kernel_context() {
+    let error = execute_tool(
+        ToolCoreRequest {
+            tool_name: "tool.search".to_owned(),
+            payload: json!({"query": "file"}),
+        },
+        None,
+    )
+    .await
+    .expect_err("missing kernel context should fail");
+
+    assert!(error.contains("kernel_context_required"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app capability_snapshot_only_describes_discovery_runtime_contract external_skills_auto_expose_default_is_disabled execute_tool_requires_kernel_context -- --nocapture`
+Expected: FAIL because the prompt snapshot still leaks the full tool surface,
+installed skills auto-expose by default, and `execute_tool(..., None)` still
+falls through.
+
+**Step 3: Write minimal implementation**
+
+- Replace the full capability snapshot with a compact discovery contract block.
+- Update `request_message_runtime.rs` to use the compact snapshot.
+- Change `ExternalSkillsRuntimePolicy::default()` and env fallback behavior so
+  auto-exposure defaults to `false`.
+- Restore default-deny shell behavior when no explicit allowlist is configured.
+- Derive required kernel capabilities from the effective `tool.invoke` target.
+- Prefix file-root and migration-root escapes with `policy_denied:` so tool
+  retries stay fail-closed.
+- Change `execute_tool(...)` to fail closed when `kernel_ctx` is `None`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app capability_snapshot_only_describes_discovery_runtime_contract external_skills_auto_expose_default_is_disabled required_capabilities_follow_effective_tool_request integ_file_read_sandbox_rejects_path_escape_as_policy_denial from_env_defaults_to_empty_allowlist execute_tool_requires_kernel_context -- --nocapture`
+Expected: PASS with the new compact runtime contract, restored capability
+boundaries, fail-closed path denial, default-deny shell behavior, and closed
+fallback.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/runtime_config.rs crates/app/src/tools/external_skills.rs crates/app/src/tools/mod.rs crates/app/src/provider/request_message_runtime.rs crates/app/src/provider/tests.rs
+git commit -m "feat: shrink provider prompt exposure and close tool bypass"
+```
+
+### Task 6: Run CI-parity verification and prepare GitHub delivery
+
+**Files:**
+- Modify: `docs/plans/2026-03-15-tool-discovery-architecture-design.md`
+- Modify: `docs/plans/2026-03-15-tool-discovery-architecture.md`
+- Optional: issue/PR metadata only, no code changes unless verification reveals problems
+
+**Step 1: Run focused regression checks**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app tool_search_returns_discoverable_tools_with_leases tool_invoke_dispatches_a_discovered_tool_with_a_valid_lease turn_engine_rejects_direct_discoverable_tool_calls -- --nocapture
+```
+
+Expected: PASS.
+
+**Step 2: Run formatting**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: exit 0.
+
+**Step 3: Run lints**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: exit 0.
+
+**Step 4: Run workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace --all-features
+```
+
+Expected: exit 0.
+
+**Step 5: Update docs or tests if verification reveals gaps**
+
+Keep changes focused. Do not add unrelated refactors.
+
+**Step 6: Commit final verification fixes**
+
+```bash
+git add docs/plans/2026-03-15-tool-discovery-architecture-design.md docs/plans/2026-03-15-tool-discovery-architecture.md
+git commit -m "docs: record tool discovery architecture plan"
+```

--- a/docs/plans/2026-03-15-tool-discovery-architecture.md
+++ b/docs/plans/2026-03-15-tool-discovery-architecture.md
@@ -1,7 +1,5 @@
 # Tool Discovery Architecture Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Replace the current static provider-wide tool exposure with a discovery-first runtime where only `tool_search` and `tool_invoke` are provider-callable, while non-core tools remain executable behind a lease-validated dispatcher.
 
 **Architecture:** Introduce an app-native tool catalog that separates provider-core tools from discoverable tools. Generate the provider schema and capability snapshot from that catalog, add first-class `tool_search` and `tool_invoke` executors, reject direct provider calls to discoverable tools, and keep real execution routed through the existing kernel-governed tool plane.

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-15T11:46:15Z
+- Generated at: 2026-03-15T11:59:42Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -13,7 +13,7 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3020 | 3600 | 580 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1478 | 3700 | 2222 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
-| provider_mod | `crates/app/src/provider/mod.rs` | 281 | 1000 | 719 | 7 | 20 | 13 | n/a | n/a | N/A | n/a |
+| provider_mod | `crates/app/src/provider/mod.rs` | 284 | 1000 | 716 | 7 | 20 | 13 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 312 | 650 | 338 | 15 | 16 | 1 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
@@ -40,7 +40,7 @@
 
 <!-- arch-hotspot key=spec_runtime lines=3020 functions=47 -->
 <!-- arch-hotspot key=spec_execution lines=1478 functions=23 -->
-<!-- arch-hotspot key=provider_mod lines=281 functions=7 -->
+<!-- arch-hotspot key=provider_mod lines=284 functions=7 -->
 <!-- arch-hotspot key=memory_mod lines=312 functions=15 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-15T15:25:33Z
+- Generated at: 2026-03-16T03:46:17Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -13,7 +13,7 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3020 | 3600 | 580 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1478 | 3700 | 2222 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
-| provider_mod | `crates/app/src/provider/mod.rs` | 284 | 1000 | 716 | 7 | 20 | 13 | n/a | n/a | N/A | n/a |
+| provider_mod | `crates/app/src/provider/mod.rs` | 294 | 1000 | 706 | 7 | 20 | 13 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 312 | 650 | 338 | 15 | 16 | 1 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
@@ -40,7 +40,7 @@
 
 <!-- arch-hotspot key=spec_runtime lines=3020 functions=47 -->
 <!-- arch-hotspot key=spec_execution lines=1478 functions=23 -->
-<!-- arch-hotspot key=provider_mod lines=284 functions=7 -->
+<!-- arch-hotspot key=provider_mod lines=294 functions=7 -->
 <!-- arch-hotspot key=memory_mod lines=312 functions=15 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- What changed?
  - limit the provider-visible tool schema to `tool_search` and `tool_invoke`, backed by a runtime tool catalog and short-lived discovery leases for non-core tools
  - route wrapped tool invocations through effective capability derivation and effective shell-policy enforcement, and bind leases to token/session/turn scope when runtime context is available
  - default installed external skills to no auto-exposure, shrink the prompt capability snapshot to the discovery contract, and add design docs plus regression coverage for the new routing path
  - add provider-shape end-to-end follow-up coverage across OpenAI chat-completions, Responses, Anthropic native content blocks, Bedrock Converse blocks, and inline-function parsing for the real `tool.search -> tool.invoke` coordinator path
  - emit and summarize discovery-first runtime telemetry for search rounds, follow-up provider turns, raw-output preservation, token delta estimates, and search-to-invoke hit rate, and expose that summary through session-history helpers
  - add a durable discovery-first runtime contract note under `docs/design-docs/` so provider-core tool exposure, lease expectations, compatibility rewrites, and follow-up turn requirements stop drifting
- Why this change is needed?
  - reduce per-turn schema/prompt token overhead
  - force discovery-first access to non-core tools without opening a second ungoverned execution path
  - harden the new routing path with real provider-shape coverage and lightweight observability before merge

## Scope

- [ ] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

- This changes provider disclosure, tool routing, and default governance behavior. The main guardrails are lease validation, direct-call rejection for discoverable tools, wrapped capability/shell-policy enforcement, and regression coverage across fast-lane and safe-lane execution.
- Before: the provider schema and prompt-level capability snapshot exposed the broad static tool surface, installed external skills auto-exposed by default, and wrapped `tool.invoke(shell.exec)` payloads could miss effective shell-policy evaluation.
- After: the provider sees only the discovery contract, installed external skills stay hidden unless explicitly surfaced, wrapped shell calls are evaluated under the same allow/deny/default policy as direct shell execution, and the real follow-up path is exercised across provider response families with telemetry on extra provider-round cost.

## Validation

- [x] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [ ] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional verification:

- `cargo test -p loongclaw-app summarize_discovery_first_events -- --nocapture`
- `cargo test -p loongclaw-app provider_shape_tool_search -- --nocapture`
- `cargo test -p loongclaw-app handle_turn_with_runtime_tool_search_ -- --nocapture`
- `cargo test -p loongclaw-app -- --test-threads=1`
- regression coverage for wrapped `tool.invoke` capability derivation, wrapped shell policy enforcement, lease replay rejection across turn/session scope, discovery-first provider-shape follow-up execution, raw-output preservation, and checkpoint-visible follow-up context
- process-global env mutation remains serialized and restored via `ScopedEnv` in [`crates/app/src/test_support.rs`](./crates/app/src/test_support.rs)

## Linked Issues

Closes #148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented discovery-first tool runtime with searchable tool catalog and lease-based invocation.
  * Added tool categorization distinguishing provider-core tools from discoverable tools.
  * Enhanced follow-up handling for multi-round provider interactions.
  * Added discovery-first event tracking and analytics summaries.

* **Chores**
  * Changed default for external skills auto-exposure from enabled to disabled.
  * Updated tool governance and visibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->