### PR TITLE
refactor: kernelize conversation runtime execution paths

### DIFF
--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -106,7 +106,7 @@ pub trait ConversationContextEngine: Send + Sync {
         &self,
         _config: &LoongClawConfig,
         _session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineBootstrapResult> {
         Ok(ContextEngineBootstrapResult::default())
     }
@@ -115,7 +115,7 @@ pub trait ConversationContextEngine: Send + Sync {
         &self,
         _session_id: &str,
         _message: &Value,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineIngestResult> {
         Ok(ContextEngineIngestResult::default())
     }
@@ -126,7 +126,7 @@ pub trait ConversationContextEngine: Send + Sync {
         _user_input: &str,
         _assistant_reply: &str,
         _messages: &[Value],
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         Ok(())
     }
@@ -136,7 +136,7 @@ pub trait ConversationContextEngine: Send + Sync {
         _config: &LoongClawConfig,
         _session_id: &str,
         _messages: &[Value],
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         Ok(())
     }
@@ -145,7 +145,7 @@ pub trait ConversationContextEngine: Send + Sync {
         &self,
         _parent_session_id: &str,
         _subagent_session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         Ok(())
     }
@@ -154,7 +154,7 @@ pub trait ConversationContextEngine: Send + Sync {
         &self,
         _parent_session_id: &str,
         _subagent_session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         Ok(())
     }
@@ -197,7 +197,7 @@ where
         &self,
         config: &LoongClawConfig,
         session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineBootstrapResult> {
         self.as_ref()
             .bootstrap(config, session_id, kernel_ctx)
@@ -208,7 +208,7 @@ where
         &self,
         session_id: &str,
         message: &Value,
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineIngestResult> {
         self.as_ref().ingest(session_id, message, kernel_ctx).await
     }
@@ -219,7 +219,7 @@ where
         user_input: &str,
         assistant_reply: &str,
         messages: &[Value],
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         self.as_ref()
             .after_turn(
@@ -237,7 +237,7 @@ where
         config: &LoongClawConfig,
         session_id: &str,
         messages: &[Value],
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         self.as_ref()
             .compact_context(config, session_id, messages, kernel_ctx)
@@ -248,7 +248,7 @@ where
         &self,
         parent_session_id: &str,
         subagent_session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         self.as_ref()
             .prepare_subagent_spawn(parent_session_id, subagent_session_id, kernel_ctx)
@@ -259,7 +259,7 @@ where
         &self,
         parent_session_id: &str,
         subagent_session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         self.as_ref()
             .on_subagent_ended(parent_session_id, subagent_session_id, kernel_ctx)

--- a/crates/app/src/conversation/integration_tests.rs
+++ b/crates/app/src/conversation/integration_tests.rs
@@ -178,7 +178,7 @@ impl TurnTestHarness {
     /// Execute a provider turn through the full TurnEngine path.
     #[allow(dead_code)]
     pub async fn execute(&self, turn: &ProviderTurn) -> TurnResult {
-        self.engine.execute_turn(turn, Some(&self.kernel_ctx)).await
+        self.engine.execute_turn(turn, &self.kernel_ctx).await
     }
 }
 

--- a/crates/app/src/conversation/persistence.rs
+++ b/crates/app/src/conversation/persistence.rs
@@ -186,16 +186,18 @@ async fn persist_and_ingest_turn<R: ConversationRuntime + ?Sized>(
     runtime
         .persist_turn(session_id, role, content, kernel_ctx)
         .await?;
-    runtime
-        .ingest(
-            session_id,
-            &json!({
-                "role": role,
-                "content": content,
-            }),
-            kernel_ctx,
-        )
-        .await?;
+    if let Some(kernel_ctx) = kernel_ctx {
+        runtime
+            .ingest(
+                session_id,
+                &json!({
+                    "role": role,
+                    "content": content,
+                }),
+                kernel_ctx,
+            )
+            .await?;
+    }
     Ok(())
 }
 

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -305,7 +305,7 @@ pub trait ConversationRuntime: Send + Sync {
         &self,
         _config: &LoongClawConfig,
         _session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineBootstrapResult> {
         Ok(ContextEngineBootstrapResult::default())
     }
@@ -314,7 +314,7 @@ pub trait ConversationRuntime: Send + Sync {
         &self,
         _session_id: &str,
         _message: &Value,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineIngestResult> {
         Ok(ContextEngineIngestResult::default())
     }
@@ -375,7 +375,7 @@ pub trait ConversationRuntime: Send + Sync {
         _user_input: &str,
         _assistant_reply: &str,
         _messages: &[Value],
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         Ok(())
     }
@@ -385,7 +385,7 @@ pub trait ConversationRuntime: Send + Sync {
         _config: &LoongClawConfig,
         _session_id: &str,
         _messages: &[Value],
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         Ok(())
     }
@@ -394,7 +394,7 @@ pub trait ConversationRuntime: Send + Sync {
         &self,
         _parent_session_id: &str,
         _subagent_session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         Ok(())
     }
@@ -403,7 +403,7 @@ pub trait ConversationRuntime: Send + Sync {
         &self,
         _parent_session_id: &str,
         _subagent_session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         Ok(())
     }
@@ -511,7 +511,7 @@ where
         &self,
         config: &LoongClawConfig,
         session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineBootstrapResult> {
         self.context_engine
             .bootstrap(config, session_id, kernel_ctx)
@@ -522,7 +522,7 @@ where
         &self,
         session_id: &str,
         message: &Value,
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineIngestResult> {
         self.context_engine
             .ingest(session_id, message, kernel_ctx)
@@ -636,7 +636,7 @@ where
         user_input: &str,
         assistant_reply: &str,
         messages: &[Value],
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         self.context_engine
             .after_turn(
@@ -654,7 +654,7 @@ where
         config: &LoongClawConfig,
         session_id: &str,
         messages: &[Value],
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         self.context_engine
             .compact_context(config, session_id, messages, kernel_ctx)
@@ -665,7 +665,7 @@ where
         &self,
         parent_session_id: &str,
         subagent_session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         self.context_engine
             .prepare_subagent_spawn(parent_session_id, subagent_session_id, kernel_ctx)
@@ -676,7 +676,7 @@ where
         &self,
         parent_session_id: &str,
         subagent_session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         self.context_engine
             .on_subagent_ended(parent_session_id, subagent_session_id, kernel_ctx)

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -337,7 +337,7 @@ impl ConversationContextEngine for RecordingLifecycleContextEngine {
         &self,
         _config: &LoongClawConfig,
         session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineBootstrapResult> {
         self.calls
             .lock()
@@ -354,7 +354,7 @@ impl ConversationContextEngine for RecordingLifecycleContextEngine {
         &self,
         session_id: &str,
         message: &Value,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineIngestResult> {
         let role = message
             .get("role")
@@ -371,7 +371,7 @@ impl ConversationContextEngine for RecordingLifecycleContextEngine {
         &self,
         parent_session_id: &str,
         subagent_session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         self.calls
             .lock()
@@ -386,7 +386,7 @@ impl ConversationContextEngine for RecordingLifecycleContextEngine {
         &self,
         parent_session_id: &str,
         subagent_session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         self.calls
             .lock()
@@ -817,7 +817,7 @@ impl ConversationRuntime for FakeRuntime {
         &self,
         _config: &LoongClawConfig,
         session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineBootstrapResult> {
         self.bootstrap_calls
             .lock()
@@ -834,7 +834,7 @@ impl ConversationRuntime for FakeRuntime {
         &self,
         session_id: &str,
         message: &Value,
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineIngestResult> {
         self.ingested_messages
             .lock()
@@ -966,7 +966,7 @@ impl ConversationRuntime for FakeRuntime {
         user_input: &str,
         assistant_reply: &str,
         messages: &[Value],
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         self.after_turn_calls
             .lock()
@@ -985,7 +985,7 @@ impl ConversationRuntime for FakeRuntime {
         _config: &LoongClawConfig,
         session_id: &str,
         messages: &[Value],
-        _kernel_ctx: Option<&KernelContext>,
+        _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
         self.compact_calls
             .lock()
@@ -999,6 +999,51 @@ fn test_config() -> LoongClawConfig {
     LoongClawConfig {
         provider: ProviderConfig::default(),
         ..LoongClawConfig::default()
+    }
+}
+
+fn test_kernel_context(agent_id: &str) -> KernelContext {
+    crate::context::bootstrap_kernel_context(agent_id, 60).expect("bootstrap test kernel context")
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn test_kernel_context_with_memory(
+    agent_id: &str,
+    memory_config: &MemoryRuntimeConfig,
+) -> KernelContext {
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack-memory".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::MemoryRead, Capability::MemoryWrite]),
+        metadata: BTreeMap::new(),
+    };
+    kernel
+        .register_pack(pack)
+        .expect("register memory test pack");
+    kernel.register_core_memory_adapter(crate::memory::MvpMemoryAdapter::with_config(
+        memory_config.clone(),
+    ));
+    kernel
+        .set_default_core_memory_adapter("mvp-memory")
+        .expect("set memory test adapter");
+
+    let token = kernel
+        .issue_token("test-pack-memory", agent_id, 60)
+        .expect("issue memory test token");
+
+    KernelContext {
+        kernel: Arc::new(kernel),
+        token,
     }
 }
 
@@ -1207,15 +1252,17 @@ fn default_runtime_session_context_uses_persisted_parent_session_id() {
 }
 
 #[tokio::test]
-async fn default_runtime_delegates_bootstrap_and_ingest_to_context_engine() {
+async fn default_runtime_delegates_bootstrap_and_ingest_to_context_engine_with_kernel() {
     let calls = Arc::new(Mutex::new(Vec::new()));
     let runtime =
         DefaultConversationRuntime::with_context_engine(RecordingLifecycleContextEngine {
             calls: calls.clone(),
         });
+    let kernel_ctx = crate::context::bootstrap_kernel_context("test-runtime-lifecycle", 60)
+        .expect("bootstrap kernel context");
 
     let bootstrap = runtime
-        .bootstrap(&test_config(), "session-lifecycle", None)
+        .bootstrap(&test_config(), "session-lifecycle", &kernel_ctx)
         .await
         .expect("bootstrap should delegate to context engine");
     let ingest = runtime
@@ -1225,7 +1272,7 @@ async fn default_runtime_delegates_bootstrap_and_ingest_to_context_engine() {
                 "role": "user",
                 "content": "hello",
             }),
-            None,
+            &kernel_ctx,
         )
         .await
         .expect("ingest should delegate to context engine");
@@ -1242,19 +1289,21 @@ async fn default_runtime_delegates_bootstrap_and_ingest_to_context_engine() {
 }
 
 #[tokio::test]
-async fn default_runtime_delegates_subagent_lifecycle_to_context_engine() {
+async fn default_runtime_delegates_subagent_lifecycle_to_context_engine_with_kernel() {
     let calls = Arc::new(Mutex::new(Vec::new()));
     let runtime =
         DefaultConversationRuntime::with_context_engine(RecordingLifecycleContextEngine {
             calls: calls.clone(),
         });
+    let kernel_ctx = crate::context::bootstrap_kernel_context("test-runtime-subagent", 60)
+        .expect("bootstrap kernel context");
 
     runtime
-        .prepare_subagent_spawn("session-parent", "session-child", None)
+        .prepare_subagent_spawn("session-parent", "session-child", &kernel_ctx)
         .await
         .expect("prepare_subagent_spawn should delegate to context engine");
     runtime
-        .on_subagent_ended("session-parent", "session-child", None)
+        .on_subagent_ended("session-parent", "session-child", &kernel_ctx)
         .await
         .expect("on_subagent_ended should delegate to context engine");
 
@@ -1525,12 +1574,14 @@ async fn default_runtime_prefers_env_context_engine_over_config() {
 }
 
 #[tokio::test]
-async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
+async fn handle_turn_with_runtime_success_with_kernel_runs_lifecycle_hooks() {
     let runtime = FakeRuntime::new(
         vec![json!({"role": "system", "content": "sys"})],
         Ok("assistant-reply".to_owned()),
     );
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = crate::context::bootstrap_kernel_context("test-handle-turn-success", 60)
+        .expect("bootstrap kernel context");
     let reply = coordinator
         .handle_turn_with_runtime(
             &test_config(),
@@ -1538,7 +1589,7 @@ async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            Some(&kernel_ctx),
         )
         .await
         .expect("handle turn success");
@@ -1606,6 +1657,76 @@ async fn handle_turn_with_runtime_success_persists_user_and_assistant_turns() {
     assert_eq!(compact.len(), 1);
     assert_eq!(compact[0].0, "session-1");
     assert_eq!(compact[0].1, 3);
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_success_without_kernel_skips_lifecycle_hooks() {
+    let runtime = FakeRuntime::new(
+        vec![json!({"role": "system", "content": "sys"})],
+        Ok("assistant-reply".to_owned()),
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-1-no-kernel",
+            "hello",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("handle turn success without kernel");
+
+    assert_eq!(reply, "assistant-reply");
+    assert!(
+        runtime
+            .bootstrap_calls
+            .lock()
+            .expect("bootstrap lock")
+            .is_empty()
+    );
+    assert!(
+        runtime
+            .ingested_messages
+            .lock()
+            .expect("ingest lock")
+            .is_empty()
+    );
+    assert!(
+        runtime
+            .after_turn_calls
+            .lock()
+            .expect("after-turn lock")
+            .is_empty()
+    );
+    assert!(
+        runtime
+            .compact_calls
+            .lock()
+            .expect("compact lock")
+            .is_empty()
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let visible_turns = persisted_visible_turns(&persisted);
+    assert_eq!(visible_turns.len(), 2);
+    assert_eq!(
+        visible_turns[0],
+        (
+            "session-1-no-kernel".to_owned(),
+            "user".to_owned(),
+            "hello".to_owned()
+        )
+    );
+    assert_eq!(
+        visible_turns[1],
+        (
+            "session-1-no-kernel".to_owned(),
+            "assistant".to_owned(),
+            "assistant-reply".to_owned(),
+        )
+    );
 }
 
 #[tokio::test]
@@ -2151,13 +2272,12 @@ async fn handle_turn_with_runtime_uses_provider_path_when_acp_dispatch_is_disabl
         "ACP backend should not receive turns when dispatch is disabled"
     );
     assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
-    assert_eq!(
+    assert!(
         runtime
             .bootstrap_calls
             .lock()
             .expect("bootstrap lock")
-            .as_slice(),
-        ["telegram:424242"]
+            .is_empty()
     );
 }
 
@@ -3128,6 +3248,7 @@ async fn handle_turn_with_runtime_compacts_when_token_threshold_reached() {
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("test-compaction-token-threshold");
     let reply = coordinator
         .handle_turn_with_runtime(
             &config,
@@ -3135,7 +3256,7 @@ async fn handle_turn_with_runtime_compacts_when_token_threshold_reached() {
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            Some(&kernel_ctx),
         )
         .await
         .expect("handle turn success");
@@ -3157,6 +3278,7 @@ async fn handle_turn_with_runtime_compaction_error_is_ignored_when_fail_open() {
     config.conversation.compact_fail_open = true;
 
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("test-compaction-fail-open");
     let reply = coordinator
         .handle_turn_with_runtime(
             &config,
@@ -3164,7 +3286,7 @@ async fn handle_turn_with_runtime_compaction_error_is_ignored_when_fail_open() {
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            Some(&kernel_ctx),
         )
         .await
         .expect("fail-open mode should keep turn successful");
@@ -3185,6 +3307,7 @@ async fn handle_turn_with_runtime_compaction_error_propagates_when_fail_closed()
     config.conversation.compact_fail_open = false;
 
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("test-compaction-fail-closed");
     let error = coordinator
         .handle_turn_with_runtime(
             &config,
@@ -3192,7 +3315,7 @@ async fn handle_turn_with_runtime_compaction_error_propagates_when_fail_closed()
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            Some(&kernel_ctx),
         )
         .await
         .expect_err("fail-closed mode should propagate compaction error");
@@ -3213,6 +3336,7 @@ async fn handle_turn_with_runtime_persists_turn_checkpoint_events_for_successful
     config.conversation.compact_enabled = false;
 
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("test-turn-checkpoint-success");
     let reply = coordinator
         .handle_turn_with_runtime(
             &config,
@@ -3220,7 +3344,7 @@ async fn handle_turn_with_runtime_persists_turn_checkpoint_events_for_successful
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            Some(&kernel_ctx),
         )
         .await
         .expect("success path should persist checkpoint events");
@@ -3282,6 +3406,7 @@ async fn handle_turn_with_runtime_persists_turn_checkpoint_events_for_inline_pro
     config.conversation.compact_enabled = false;
 
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("test-turn-checkpoint-inline-error");
     let reply = coordinator
         .handle_turn_with_runtime(
             &config,
@@ -3289,7 +3414,7 @@ async fn handle_turn_with_runtime_persists_turn_checkpoint_events_for_inline_pro
             "hello",
             ProviderErrorMode::InlineMessage,
             &runtime,
-            None,
+            Some(&kernel_ctx),
         )
         .await
         .expect("inline provider error should persist checkpoint events");
@@ -3382,6 +3507,7 @@ async fn handle_turn_with_runtime_persists_failed_turn_checkpoint_when_compactio
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("test-turn-checkpoint-compaction-failure");
     let error = coordinator
         .handle_turn_with_runtime(
             &config,
@@ -3389,7 +3515,7 @@ async fn handle_turn_with_runtime_persists_failed_turn_checkpoint_when_compactio
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            Some(&kernel_ctx),
         )
         .await
         .expect_err("compaction failure should still persist failed checkpoint event");
@@ -3434,13 +3560,12 @@ async fn handle_turn_with_runtime_propagates_error_without_persisting_reply_turn
         .expect_err("propagate mode should return error");
 
     assert!(error.contains("timeout"));
-    assert_eq!(
+    assert!(
         runtime
             .bootstrap_calls
             .lock()
             .expect("bootstrap lock")
-            .as_slice(),
-        ["session-2"]
+            .is_empty()
     );
     let persisted = runtime.persisted.lock().expect("persisted lock").clone();
     let payloads = persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
@@ -3487,13 +3612,12 @@ async fn handle_turn_with_runtime_inline_mode_returns_synthetic_reply_and_persis
         .expect("inline mode should return synthetic reply");
 
     assert_eq!(output, "[provider_error] timeout");
-    assert_eq!(
+    assert!(
         runtime
             .bootstrap_calls
             .lock()
             .expect("bootstrap lock")
-            .as_slice(),
-        ["session-3"]
+            .is_empty()
     );
 
     let persisted = runtime.persisted.lock().expect("persisted lock").clone();
@@ -3521,27 +3645,17 @@ async fn handle_turn_with_runtime_inline_mode_returns_synthetic_reply_and_persis
         .lock()
         .expect("ingest lock")
         .clone();
-    assert_eq!(ingested.len(), 2);
-    assert_eq!(ingested[0].1["role"], "user");
-    assert_eq!(ingested[0].1["content"], "hello");
-    assert_eq!(ingested[1].1["role"], "assistant");
-    assert_eq!(ingested[1].1["content"], "[provider_error] timeout");
+    assert!(ingested.is_empty());
 
     let after_turn = runtime
         .after_turn_calls
         .lock()
         .expect("after-turn lock")
         .clone();
-    assert_eq!(after_turn.len(), 1);
-    assert_eq!(after_turn[0].0, "session-3");
-    assert_eq!(after_turn[0].1, "hello");
-    assert_eq!(after_turn[0].2, "[provider_error] timeout");
-    assert_eq!(after_turn[0].3, 2);
+    assert!(after_turn.is_empty());
 
     let compact = runtime.compact_calls.lock().expect("compact lock").clone();
-    assert_eq!(compact.len(), 1);
-    assert_eq!(compact[0].0, "session-3");
-    assert_eq!(compact[0].1, 2);
+    assert!(compact.is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -7706,9 +7820,11 @@ async fn repair_turn_checkpoint_tail_with_runtime_finalizes_pending_checkpoint()
         vec![],
     );
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx =
+        test_kernel_context_with_memory("test-turn-checkpoint-repair-pending", &mem_config);
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
         .await
         .expect("repair pending checkpoint");
 
@@ -8112,9 +8228,11 @@ async fn repair_turn_checkpoint_tail_with_runtime_retries_failed_compaction_only
         vec![],
     );
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx =
+        test_kernel_context_with_memory("test-turn-checkpoint-repair-compaction", &mem_config);
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
         .await
         .expect("repair failed compaction checkpoint");
 
@@ -8226,9 +8344,13 @@ async fn repair_turn_checkpoint_tail_rebuilds_original_finalization_context_for_
             },
         );
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context_with_memory(
+        "test-turn-checkpoint-repair-compaction-context",
+        &mem_config,
+    );
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
         .await
         .expect("repair should replay compaction against original finalization context");
 
@@ -8329,9 +8451,13 @@ async fn repair_turn_checkpoint_tail_prefers_checkpoint_estimate_for_compaction_
             system_prompt_addition: None,
         });
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context_with_memory(
+        "test-turn-checkpoint-repair-compaction-estimate",
+        &mem_config,
+    );
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
         .await
         .expect("repair should reuse checkpoint estimate for compaction retry");
 
@@ -11109,9 +11235,13 @@ async fn repair_turn_checkpoint_tail_with_runtime_persists_failed_after_turn_rep
     )
     .with_after_turn_result(Err("repair after_turn failed".to_owned()));
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context_with_memory(
+        "test-turn-checkpoint-repair-after-turn-failure",
+        &mem_config,
+    );
 
     let error = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
         .await
         .expect_err("after_turn repair should fail closed");
     assert!(error.contains("repair after_turn failed"));
@@ -11215,9 +11345,13 @@ async fn repair_turn_checkpoint_tail_with_runtime_persists_failed_compaction_rep
     )
     .with_compact_result(Err("repair compaction failed".to_owned()));
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context_with_memory(
+        "test-turn-checkpoint-repair-compaction-failure",
+        &mem_config,
+    );
 
     let error = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
         .await
         .expect_err("compaction repair should fail closed");
     assert!(error.contains("repair compaction failed"));
@@ -11319,9 +11453,13 @@ async fn durable_turn_checkpoint_repair_persists_finalized_checkpoint_and_repeat
     )
     .with_durable_memory_config(mem_config.clone());
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context_with_memory(
+        "test-turn-checkpoint-durable-repair-idempotent",
+        &mem_config,
+    );
 
     let first = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
         .await
         .expect("first durable repair should succeed");
     assert_eq!(first.status().as_str(), "repaired");
@@ -11357,7 +11495,7 @@ async fn durable_turn_checkpoint_repair_persists_finalized_checkpoint_and_repeat
     assert!(!summary_after_first.requires_recovery);
 
     let second = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
         .await
         .expect("second durable repair should be a noop");
     assert_eq!(second.status().as_str(), "not_needed");
@@ -11462,9 +11600,16 @@ async fn durable_turn_checkpoint_repair_persists_failed_terminal_checkpoint_then
     .with_durable_memory_config(mem_config.clone())
     .with_compact_result(Err("durable repair compaction failed".to_owned()));
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx =
+        test_kernel_context_with_memory("test-turn-checkpoint-durable-repair-retry", &mem_config);
 
     let error = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &failing_runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &failing_runtime,
+            Some(&kernel_ctx),
+        )
         .await
         .expect_err("first durable repair should persist failure and return error");
     assert!(error.contains("durable repair compaction failed"));
@@ -11521,7 +11666,12 @@ async fn durable_turn_checkpoint_repair_persists_failed_terminal_checkpoint_then
     .with_durable_memory_config(mem_config.clone());
 
     let retry = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &retry_runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &retry_runtime,
+            Some(&kernel_ctx),
+        )
         .await
         .expect("second durable repair should recover");
     assert_eq!(retry.status().as_str(), "repaired");
@@ -11565,7 +11715,12 @@ async fn durable_turn_checkpoint_repair_persists_failed_terminal_checkpoint_then
     assert!(!summary_after_retry.requires_recovery);
 
     let third = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &retry_runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &retry_runtime,
+            Some(&kernel_ctx),
+        )
         .await
         .expect("finalized durable repair should stay noop");
     assert_eq!(third.status().as_str(), "not_needed");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -5832,24 +5832,23 @@ fn turn_contracts_have_stable_defaults() {
 
 #[test]
 fn turn_engine_no_tool_intents_returns_final_text() {
-    use crate::conversation::turn_engine::{ProviderTurn, TurnEngine, TurnResult};
+    use crate::conversation::turn_engine::{ProviderTurn, TurnEngine, TurnValidation};
     let engine = TurnEngine::new(1); // max_tool_steps = 1
     let turn = ProviderTurn {
         assistant_text: "Hello!".to_owned(),
         tool_intents: vec![],
         raw_meta: serde_json::Value::Null,
     };
-    let result = engine.evaluate_turn(&turn);
-    #[allow(clippy::wildcard_enum_match_arm)]
+    let result = engine.validate_turn(&turn);
     match result {
-        TurnResult::FinalText(text) => assert_eq!(text, "Hello!"),
+        Ok(TurnValidation::FinalText(text)) => assert_eq!(text, "Hello!"),
         other => panic!("expected FinalText, got {:?}", other),
     }
 }
 
 #[test]
 fn provider_tool_aliases_flow_through_parse_and_turn_validation() {
-    use crate::conversation::turn_engine::{TurnEngine, TurnResult};
+    use crate::conversation::turn_engine::{TurnEngine, TurnValidation};
     use crate::provider::extract_provider_turn;
 
     let response_body = serde_json::json!({
@@ -5873,22 +5872,16 @@ fn provider_tool_aliases_flow_through_parse_and_turn_validation() {
     assert_eq!(turn.tool_intents[0].tool_name, "file.read");
 
     let engine = TurnEngine::new(1);
-    let result = engine.evaluate_turn(&turn);
-    #[allow(clippy::wildcard_enum_match_arm)]
+    let result = engine.validate_turn(&turn);
     match result {
-        TurnResult::ToolDenied(reason) => {
-            assert!(
-                reason.contains("kernel_context_required"),
-                "reason: {reason}"
-            );
-        }
+        Ok(TurnValidation::ToolExecutionRequired) => {}
         other => panic!("expected ToolDenied, got {:?}", other),
     }
 }
 
 #[test]
 fn turn_engine_unknown_tool_returns_tool_denied() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine};
     let engine = TurnEngine::new(1);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
@@ -5902,21 +5895,16 @@ fn turn_engine_unknown_tool_returns_tool_denied() {
         }],
         raw_meta: serde_json::Value::Null,
     };
-    let result = engine.evaluate_turn(&turn);
-    #[allow(clippy::wildcard_enum_match_arm)]
+    let result = engine.validate_turn(&turn);
     match result {
-        TurnResult::ToolDenied(reason) => {
-            assert!(reason.contains("tool_not_found"), "reason: {reason}")
-        }
+        Err(reason) => assert!(reason.contains("tool_not_found"), "reason: {reason}"),
         other => panic!("expected ToolDenied, got {:?}", other),
     }
 }
 
 #[test]
 fn turn_engine_unknown_tool_exposes_structured_policy_denial() {
-    use crate::conversation::turn_engine::{
-        ProviderTurn, ToolIntent, TurnEngine, TurnFailureKind, TurnResult,
-    };
+    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnFailureKind};
     let engine = TurnEngine::new(1);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
@@ -5931,10 +5919,9 @@ fn turn_engine_unknown_tool_exposes_structured_policy_denial() {
         raw_meta: serde_json::Value::Null,
     };
 
-    let result = engine.evaluate_turn(&turn);
-    #[allow(clippy::wildcard_enum_match_arm)]
+    let result = engine.validate_turn(&turn);
     match result {
-        TurnResult::ToolDenied(failure) => {
+        Err(failure) => {
             assert_eq!(failure.kind, TurnFailureKind::PolicyDenied);
             assert_eq!(failure.code, "tool_not_found");
             assert!(!failure.retryable);
@@ -5949,7 +5936,7 @@ fn turn_engine_unknown_tool_exposes_structured_policy_denial() {
 
 #[test]
 fn turn_engine_exceeding_max_steps_returns_denied() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine};
     let engine = TurnEngine::new(1);
     let intent = ToolIntent {
         tool_name: "file.read".to_owned(),
@@ -5964,10 +5951,9 @@ fn turn_engine_exceeding_max_steps_returns_denied() {
         tool_intents: vec![intent.clone(), intent],
         raw_meta: serde_json::Value::Null,
     };
-    let result = engine.evaluate_turn(&turn);
-    #[allow(clippy::wildcard_enum_match_arm)]
+    let result = engine.validate_turn(&turn);
     match result {
-        TurnResult::ToolDenied(reason) => assert!(
+        Err(reason) => assert!(
             reason.contains("max_tool_steps_exceeded"),
             "reason: {reason}"
         ),
@@ -5976,8 +5962,8 @@ fn turn_engine_exceeding_max_steps_returns_denied() {
 }
 
 #[test]
-fn turn_engine_known_tool_with_no_kernel_returns_tool_denied() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
+fn turn_engine_known_tool_validates_to_execution_required() {
+    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnValidation};
     let engine = TurnEngine::new(1);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
@@ -5991,43 +5977,10 @@ fn turn_engine_known_tool_with_no_kernel_returns_tool_denied() {
         }],
         raw_meta: serde_json::Value::Null,
     };
-    // Without kernel context, known tools should be validated but flagged as needing execution
-    let result = engine.evaluate_turn(&turn);
-    #[allow(clippy::wildcard_enum_match_arm)]
+    let result = engine.validate_turn(&turn);
     match result {
-        TurnResult::ToolDenied(reason) => {
-            assert!(
-                reason.contains("kernel_context_required"),
-                "reason: {reason}"
-            );
-        }
-        other => panic!("expected ToolDenied, got {:?}", other),
-    }
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn turn_engine_execute_turn_no_kernel_returns_denied() {
-    use crate::conversation::turn_engine::{ProviderTurn, ToolIntent, TurnEngine, TurnResult};
-    let engine = TurnEngine::new(1);
-    let turn = ProviderTurn {
-        assistant_text: "".to_owned(),
-        tool_intents: vec![ToolIntent {
-            tool_name: "file.read".to_owned(),
-            args_json: serde_json::json!({"path": "test.txt"}),
-            source: "provider_tool_call".to_owned(),
-            session_id: "s1".to_owned(),
-            turn_id: "t1".to_owned(),
-            tool_call_id: "c1".to_owned(),
-        }],
-        raw_meta: serde_json::Value::Null,
-    };
-    let result = engine.execute_turn(&turn, None).await;
-    #[allow(clippy::wildcard_enum_match_arm)]
-    match result {
-        TurnResult::ToolDenied(reason) => {
-            assert!(reason.contains("no_kernel_context"), "reason: {reason}");
-        }
-        other => panic!("expected ToolDenied, got {:?}", other),
+        Ok(TurnValidation::ToolExecutionRequired) => {}
+        other => panic!("expected ToolExecutionRequired, got {:?}", other),
     }
 }
 
@@ -6123,9 +6076,10 @@ async fn turn_engine_routes_app_tools_through_dispatcher() {
         "root-session",
         crate::tools::planned_root_tool_view(),
     );
+    let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
 
     let result = engine
-        .execute_turn_in_context(&turn, &session_context, &dispatcher, None)
+        .execute_turn_in_context(&turn, &session_context, &dispatcher, &kernel_ctx)
         .await;
 
     match result {
@@ -6517,7 +6471,7 @@ async fn turn_engine_tool_execution_error_is_marked_retryable() {
         raw_meta: serde_json::Value::Null,
     };
 
-    let result = engine.execute_turn(&turn, Some(&ctx)).await;
+    let result = engine.execute_turn(&turn, &ctx).await;
     #[allow(clippy::wildcard_enum_match_arm)]
     match result {
         TurnResult::ToolError(failure) => {
@@ -6657,7 +6611,7 @@ async fn turn_engine_executes_known_tool_with_kernel() {
         raw_meta: serde_json::Value::Null,
     };
 
-    let result = engine.execute_turn(&turn, Some(&ctx)).await;
+    let result = engine.execute_turn(&turn, &ctx).await;
     #[allow(clippy::wildcard_enum_match_arm)]
     match result {
         TurnResult::FinalText(text) => {
@@ -6778,7 +6732,7 @@ async fn turn_engine_truncates_oversized_tool_payload_summary() {
         raw_meta: serde_json::Value::Null,
     };
 
-    let result = engine.execute_turn(&turn, Some(&ctx)).await;
+    let result = engine.execute_turn(&turn, &ctx).await;
     #[allow(clippy::wildcard_enum_match_arm)]
     match result {
         TurnResult::FinalText(text) => {
@@ -6889,7 +6843,7 @@ async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
         raw_meta: serde_json::Value::Null,
     };
 
-    let result = engine.execute_turn(&turn, Some(&ctx)).await;
+    let result = engine.execute_turn(&turn, &ctx).await;
     match result {
         TurnResult::FinalText(text) => {
             let line = text.lines().next().expect("tool result line should exist");
@@ -6985,7 +6939,7 @@ async fn turn_engine_execute_turn_denied_without_capability() {
         raw_meta: serde_json::Value::Null,
     };
 
-    let result = engine.execute_turn(&turn, Some(&ctx)).await;
+    let result = engine.execute_turn(&turn, &ctx).await;
     #[allow(clippy::wildcard_enum_match_arm)]
     match result {
         TurnResult::ToolDenied(reason) => {

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -6193,7 +6193,7 @@ async fn turn_engine_routes_app_tools_through_dispatcher() {
     let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
 
     let result = engine
-        .execute_turn_in_context(&turn, &session_context, &dispatcher, &kernel_ctx)
+        .execute_turn_in_context(&turn, &session_context, &dispatcher, Some(&kernel_ctx))
         .await;
 
     match result {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3422,18 +3422,12 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
             .await;
             (outcome.result, outcome.terminal_route)
         }
-        Ok(TurnValidation::ToolExecutionRequired) => match kernel_ctx {
-            Some(kernel_ctx) => (
-                engine
-                    .execute_turn_in_context(turn, &session_context, &app_dispatcher, kernel_ctx)
-                    .await,
-                None,
-            ),
-            None => (
-                TurnResult::policy_denied("no_kernel_context", "no_kernel_context"),
-                None,
-            ),
-        },
+        Ok(TurnValidation::ToolExecutionRequired) => (
+            engine
+                .execute_turn_in_context(turn, &session_context, &app_dispatcher, kernel_ctx)
+                .await,
+            None,
+        ),
     };
 
     ProviderTurnLaneExecution {
@@ -5130,7 +5124,7 @@ async fn execute_single_tool_intent(
     };
 
     match engine
-        .execute_turn_in_context(&turn, session_context, app_dispatcher, kernel_ctx)
+        .execute_turn_in_context(&turn, session_context, app_dispatcher, Some(kernel_ctx))
         .await
     {
         TurnResult::FinalText(output) => Ok(output),

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -41,8 +41,8 @@ use super::persistence::{
     persist_reply_turns_raw_with_mode, persist_reply_turns_with_mode,
 };
 use super::plan_executor::{
-    PlanExecutor, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor, PlanRunFailure,
-    PlanRunReport, PlanRunStatus,
+    PlanExecutor, PlanNodeAttemptEvent, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor,
+    PlanRunFailure, PlanRunReport, PlanRunStatus,
 };
 use super::plan_ir::{
     PLAN_GRAPH_VERSION, PlanBudget, PlanEdge, PlanGraph, PlanNode, PlanNodeKind, RiskTier,
@@ -70,7 +70,7 @@ use super::turn_budget::{
 };
 use super::turn_engine::{
     AppToolDispatcher, DefaultAppToolDispatcher, ProviderTurn, ToolIntent, TurnEngine, TurnFailure,
-    TurnFailureKind, TurnResult,
+    TurnFailureKind, TurnResult, TurnValidation,
 };
 use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ReplyResolutionMode, ToolDrivenFollowupKind,
@@ -3355,34 +3355,51 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         runtime,
         fallback: &base_app_dispatcher,
     };
-    let (turn_result, safe_lane_terminal_route) = if preparation
+    let payload_summary_limit_chars = config
+        .conversation
+        .tool_result_payload_summary_limit_chars();
+    let use_safe_lane_plan_path = preparation
         .lane_plan
-        .should_use_safe_lane_plan_path(config, turn)
-    {
-        let outcome = execute_turn_with_safe_lane_plan(
-            config,
-            runtime,
-            session_id,
-            &preparation.lane_plan.decision,
-            turn,
-            &session_context,
-            &app_dispatcher,
-            kernel_ctx,
-        )
-        .await;
-        (outcome.result, outcome.terminal_route)
+        .should_use_safe_lane_plan_path(config, turn);
+    let engine = TurnEngine::with_tool_result_payload_summary_limit(
+        preparation.lane_plan.max_tool_steps,
+        payload_summary_limit_chars,
+    );
+    let validation = if use_safe_lane_plan_path {
+        TurnEngine::with_tool_result_payload_summary_limit(usize::MAX, payload_summary_limit_chars)
+            .validate_turn_in_context(turn, &session_context)
     } else {
-        (
-            TurnEngine::with_tool_result_payload_summary_limit(
-                preparation.lane_plan.max_tool_steps,
-                config
-                    .conversation
-                    .tool_result_payload_summary_limit_chars(),
+        engine.validate_turn_in_context(turn, &session_context)
+    };
+    let (turn_result, safe_lane_terminal_route) = match validation {
+        Ok(TurnValidation::FinalText(text)) => (TurnResult::FinalText(text), None),
+        Err(failure) => (TurnResult::ToolDenied(failure), None),
+        Ok(TurnValidation::ToolExecutionRequired) if use_safe_lane_plan_path => {
+            let outcome = execute_turn_with_safe_lane_plan(
+                config,
+                runtime,
+                session_id,
+                &preparation.lane_plan.decision,
+                turn,
+                &session_context,
+                &app_dispatcher,
+                kernel_ctx,
             )
-            .execute_turn_in_context(turn, &session_context, &app_dispatcher, kernel_ctx)
-            .await,
-            None,
-        )
+            .await;
+            (outcome.result, outcome.terminal_route)
+        }
+        Ok(TurnValidation::ToolExecutionRequired) => match kernel_ctx {
+            Some(kernel_ctx) => (
+                engine
+                    .execute_turn_in_context(turn, &session_context, &app_dispatcher, kernel_ctx)
+                    .await,
+                None,
+            ),
+            None => (
+                TurnResult::policy_denied("no_kernel_context", "no_kernel_context"),
+                None,
+            ),
+        },
     };
 
     ProviderTurnLaneExecution {
@@ -3812,6 +3829,9 @@ async fn evaluate_safe_lane_round(
         state.tool_node_max_attempts(),
         state.plan_start_tool_index,
     );
+    let Some(kernel_ctx) = kernel_ctx else {
+        return synthetic_safe_lane_round_without_kernel(&plan);
+    };
     let executor = SafeLanePlanNodeExecutor::new(
         turn.tool_intents.as_slice(),
         session_context,
@@ -3831,6 +3851,43 @@ async fn evaluate_safe_lane_round(
         report,
         tool_outputs,
         tool_output_stats,
+    }
+}
+
+fn synthetic_safe_lane_round_without_kernel(plan: &PlanGraph) -> SafeLaneRoundExecution {
+    let ordered_nodes = plan
+        .nodes
+        .iter()
+        .map(|node| node.id.clone())
+        .collect::<Vec<_>>();
+    let node_id = plan
+        .nodes
+        .iter()
+        .find(|node| matches!(node.kind, PlanNodeKind::Tool))
+        .map(|node| node.id.clone())
+        .unwrap_or_else(|| "tool-1".to_owned());
+    let error = "no_kernel_context".to_owned();
+    SafeLaneRoundExecution {
+        report: PlanRunReport {
+            status: PlanRunStatus::Failed(PlanRunFailure::NodeFailed {
+                node_id: node_id.clone(),
+                attempts_used: 1,
+                last_error_kind: PlanNodeErrorKind::PolicyDenied,
+                last_error: error.clone(),
+            }),
+            ordered_nodes,
+            attempts_used: 1,
+            attempt_events: vec![PlanNodeAttemptEvent {
+                node_id,
+                attempt: 1,
+                success: false,
+                error_kind: Some(PlanNodeErrorKind::PolicyDenied),
+                error: Some(error),
+            }],
+            elapsed_ms: 0,
+        },
+        tool_outputs: Vec::new(),
+        tool_output_stats: SafeLaneToolOutputStats::default(),
     }
 }
 
@@ -4937,7 +4994,7 @@ struct SafeLanePlanNodeExecutor<'a> {
     tool_intents: &'a [ToolIntent],
     session_context: &'a SessionContext,
     app_dispatcher: &'a dyn AppToolDispatcher,
-    kernel_ctx: Option<&'a KernelContext>,
+    kernel_ctx: &'a KernelContext,
     verify_output_non_empty: bool,
     tool_outputs: Mutex<Vec<String>>,
     tool_result_payload_summary_limit_chars: usize,
@@ -4948,7 +5005,7 @@ impl<'a> SafeLanePlanNodeExecutor<'a> {
         tool_intents: &'a [ToolIntent],
         session_context: &'a SessionContext,
         app_dispatcher: &'a dyn AppToolDispatcher,
-        kernel_ctx: Option<&'a KernelContext>,
+        kernel_ctx: &'a KernelContext,
         verify_output_non_empty: bool,
         seed_tool_outputs: Vec<String>,
         tool_result_payload_summary_limit_chars: usize,
@@ -5028,7 +5085,7 @@ async fn execute_single_tool_intent(
     intent: &ToolIntent,
     session_context: &SessionContext,
     app_dispatcher: &dyn AppToolDispatcher,
-    kernel_ctx: Option<&KernelContext>,
+    kernel_ctx: &KernelContext,
     payload_summary_limit_chars: usize,
 ) -> Result<String, PlanNodeError> {
     let engine = TurnEngine::with_tool_result_payload_summary_limit(1, payload_summary_limit_chars);

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1791,7 +1791,9 @@ impl ConversationTurnCoordinator {
             AcpConversationTurnEntryDecision::StayOnProvider => {}
         }
 
-        runtime.bootstrap(config, session_id, kernel_ctx).await?;
+        if let Some(kernel_ctx) = kernel_ctx {
+            runtime.bootstrap(config, session_id, kernel_ctx).await?;
+        }
         let session_context = runtime.session_context(config, session_id, kernel_ctx)?;
         let tool_view = session_context.tool_view.clone();
         let preparation = ProviderTurnPreparation::from_assembled_context(
@@ -1977,6 +1979,9 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
     {
         return Ok(ContextCompactionOutcome::Skipped);
     }
+    let Some(kernel_ctx) = kernel_ctx else {
+        return Ok(ContextCompactionOutcome::Skipped);
+    };
 
     match runtime
         .compact_context(config, session_id, messages, kernel_ctx)
@@ -2405,6 +2410,31 @@ async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
         restore_analytics_turn_checkpoint_progress_status(repair_plan.compaction_status());
 
     if repair_plan.should_run_after_turn() {
+        let Some(kernel_ctx) = kernel_ctx else {
+            after_turn_status = TurnCheckpointProgressStatus::Skipped;
+            if repair_plan.should_run_compaction() {
+                compaction_status = TurnCheckpointProgressStatus::Skipped;
+            }
+            persist_turn_checkpoint_event_value(
+                runtime,
+                session_id,
+                &entry.checkpoint,
+                TurnCheckpointStage::Finalized,
+                TurnCheckpointFinalizationProgress {
+                    after_turn: after_turn_status,
+                    compaction: compaction_status,
+                },
+                None,
+                kernel_ctx,
+            )
+            .await?;
+            return Ok(TurnCheckpointTailRepairOutcome::repaired(
+                action,
+                summary,
+                after_turn_status,
+                compaction_status,
+            ));
+        };
         match runtime
             .after_turn(
                 session_id,
@@ -2436,7 +2466,7 @@ async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
                         step: TurnCheckpointFailureStep::AfterTurn,
                         error: error.clone(),
                     }),
-                    kernel_ctx,
+                    Some(kernel_ctx),
                 )
                 .await?;
                 return Err(error);
@@ -2643,36 +2673,40 @@ async fn finalize_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     .await?;
 
     let after_turn_status = if checkpoint.finalization.runs_after_turn() {
-        match runtime
-            .after_turn(
-                session_id,
-                user_input,
-                tail_phase.reply(),
-                tail_phase.after_turn_messages(),
-                kernel_ctx,
-            )
-            .await
-        {
-            Ok(()) => TurnCheckpointProgressStatus::Completed,
-            Err(error) => {
-                persist_turn_checkpoint_event(
-                    runtime,
+        if let Some(kernel_ctx) = kernel_ctx {
+            match runtime
+                .after_turn(
                     session_id,
-                    checkpoint,
-                    TurnCheckpointStage::FinalizationFailed,
-                    TurnCheckpointFinalizationProgress {
-                        after_turn: TurnCheckpointProgressStatus::Failed,
-                        compaction: TurnCheckpointProgressStatus::Skipped,
-                    },
-                    Some(TurnCheckpointFailure {
-                        step: TurnCheckpointFailureStep::AfterTurn,
-                        error: error.clone(),
-                    }),
+                    user_input,
+                    tail_phase.reply(),
+                    tail_phase.after_turn_messages(),
                     kernel_ctx,
                 )
-                .await?;
-                return Err(error);
+                .await
+            {
+                Ok(()) => TurnCheckpointProgressStatus::Completed,
+                Err(error) => {
+                    persist_turn_checkpoint_event(
+                        runtime,
+                        session_id,
+                        checkpoint,
+                        TurnCheckpointStage::FinalizationFailed,
+                        TurnCheckpointFinalizationProgress {
+                            after_turn: TurnCheckpointProgressStatus::Failed,
+                            compaction: TurnCheckpointProgressStatus::Skipped,
+                        },
+                        Some(TurnCheckpointFailure {
+                            step: TurnCheckpointFailureStep::AfterTurn,
+                            error: error.clone(),
+                        }),
+                        Some(kernel_ctx),
+                    )
+                    .await?;
+                    return Err(error);
+                }
             }
+        } else {
+            TurnCheckpointProgressStatus::Skipped
         }
     } else {
         TurnCheckpointProgressStatus::Skipped

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -605,7 +605,7 @@ impl TurnEngine {
         turn: &ProviderTurn,
         kernel_ctx: &KernelContext,
     ) -> TurnResult {
-        self.execute_turn_in_view(turn, &runtime_tool_view(), kernel_ctx)
+        self.execute_turn_in_view(turn, &runtime_tool_view(), Some(kernel_ctx))
             .await
     }
 
@@ -613,7 +613,7 @@ impl TurnEngine {
         &self,
         turn: &ProviderTurn,
         tool_view: &ToolView,
-        kernel_ctx: &KernelContext,
+        kernel_ctx: Option<&KernelContext>,
     ) -> TurnResult {
         self.execute_turn_in_context(
             turn,
@@ -629,7 +629,7 @@ impl TurnEngine {
         turn: &ProviderTurn,
         session_context: &SessionContext,
         app_dispatcher: &D,
-        kernel_ctx: &KernelContext,
+        kernel_ctx: Option<&KernelContext>,
     ) -> TurnResult {
         match self.validate_turn_in_context(turn, session_context) {
             Ok(TurnValidation::FinalText(text)) => return TurnResult::FinalText(text),
@@ -650,13 +650,16 @@ impl TurnEngine {
             };
             let outcome = match descriptor.execution_kind {
                 ToolExecutionKind::Core => {
+                    let Some(kernel_ctx) = kernel_ctx else {
+                        return TurnResult::policy_denied("no_kernel_context", "no_kernel_context");
+                    };
                     match execute_tool_intent_via_kernel(intent, kernel_ctx).await {
                         Ok(outcome) => outcome,
                         Err(failure) => return turn_result_from_tool_execution_failure(failure),
                     }
                 }
                 ToolExecutionKind::App => match app_dispatcher
-                    .execute_app_tool(session_context, request, Some(kernel_ctx))
+                    .execute_app_tool(session_context, request, kernel_ctx)
                     .await
                 {
                     Ok(outcome) => outcome,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -178,6 +178,12 @@ impl TurnResult {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TurnValidation {
+    FinalText(String),
+    ToolExecutionRequired,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum KernelFailureClass {
     PolicyDenied,
@@ -372,6 +378,51 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
     }
 }
 
+pub(crate) async fn execute_tool_intent_via_kernel(
+    intent: &ToolIntent,
+    kernel_ctx: &KernelContext,
+) -> Result<ToolCoreOutcome, TurnFailure> {
+    let request = ToolCoreRequest {
+        tool_name: crate::tools::canonical_tool_name(intent.tool_name.as_str()).to_owned(),
+        payload: intent.args_json.clone(),
+    };
+    let caps = BTreeSet::from([Capability::InvokeTool]);
+    kernel_ctx
+        .kernel
+        .execute_tool_core(
+            kernel_ctx.pack_id(),
+            &kernel_ctx.token,
+            &caps,
+            None,
+            request,
+        )
+        .await
+        .map_err(|error| {
+            let reason = format!("{error}");
+            match classify_kernel_error(&error) {
+                KernelFailureClass::PolicyDenied => {
+                    TurnFailure::policy_denied("kernel_policy_denied", reason)
+                }
+                KernelFailureClass::RetryableExecution => {
+                    TurnFailure::retryable("tool_execution_failed", reason)
+                }
+                KernelFailureClass::NonRetryable => {
+                    TurnFailure::non_retryable("kernel_execution_failed", reason)
+                }
+            }
+        })
+}
+
+fn turn_result_from_tool_execution_failure(failure: TurnFailure) -> TurnResult {
+    match failure.kind {
+        TurnFailureKind::PolicyDenied => TurnResult::ToolDenied(failure),
+        TurnFailureKind::Retryable | TurnFailureKind::NonRetryable => {
+            TurnResult::ToolError(failure)
+        }
+        TurnFailureKind::Provider => TurnResult::ProviderError(failure),
+    }
+}
+
 #[allow(dead_code)]
 pub(crate) fn format_tool_result_line(intent: &ToolIntent, outcome: &ToolCoreOutcome) -> String {
     format_tool_result_line_with_limit(intent, outcome, TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS)
@@ -485,31 +536,60 @@ impl TurnEngine {
         turn: &ProviderTurn,
         session_context: &SessionContext,
     ) -> TurnResult {
-        // No tool intents → just return the text
+        match self.validate_turn_in_context(turn, session_context) {
+            Ok(TurnValidation::FinalText(text)) => TurnResult::FinalText(text),
+            Err(failure) => TurnResult::ToolDenied(failure),
+            Ok(TurnValidation::ToolExecutionRequired) => {
+                TurnResult::policy_denied("kernel_context_required", "kernel_context_required")
+            }
+        }
+    }
+
+    /// Validate a provider turn and describe whether tool execution is needed.
+    ///
+    /// This phase is pure: it validates the turn shape and tool budget, but it does
+    /// not make runtime binding decisions about whether a kernel is available.
+    pub fn validate_turn(&self, turn: &ProviderTurn) -> Result<TurnValidation, TurnFailure> {
+        self.validate_turn_in_view(turn, &runtime_tool_view())
+    }
+
+    pub fn validate_turn_in_view(
+        &self,
+        turn: &ProviderTurn,
+        tool_view: &ToolView,
+    ) -> Result<TurnValidation, TurnFailure> {
+        self.validate_turn_in_context(turn, &session_context_from_turn(turn, tool_view.clone()))
+    }
+
+    pub fn validate_turn_in_context(
+        &self,
+        turn: &ProviderTurn,
+        session_context: &SessionContext,
+    ) -> Result<TurnValidation, TurnFailure> {
         if turn.tool_intents.is_empty() {
-            return TurnResult::FinalText(turn.assistant_text.clone());
+            return Ok(TurnValidation::FinalText(turn.assistant_text.clone()));
         }
 
-        // Too many tool intents for current step limit
         if turn.tool_intents.len() > self.max_tool_steps {
-            return TurnResult::policy_denied("max_tool_steps_exceeded", "max_tool_steps_exceeded");
+            return Err(TurnFailure::policy_denied(
+                "max_tool_steps_exceeded",
+                "max_tool_steps_exceeded",
+            ));
         }
 
-        // Check each tool intent
         let catalog = tool_catalog();
         for intent in &turn.tool_intents {
             let Some(descriptor) = catalog.resolve(&intent.tool_name) else {
                 let reason = format!("tool_not_found: {}", intent.tool_name);
-                return TurnResult::policy_denied("tool_not_found", reason);
+                return Err(TurnFailure::policy_denied("tool_not_found", reason));
             };
             if !session_context.tool_view.contains(descriptor.name) {
                 let reason = format!("tool_not_visible: {}", intent.tool_name);
-                return TurnResult::policy_denied("tool_not_visible", reason);
+                return Err(TurnFailure::policy_denied("tool_not_visible", reason));
             }
         }
 
-        // All tools validated — execution requires a kernel context
-        TurnResult::policy_denied("kernel_context_required", "kernel_context_required")
+        Ok(TurnValidation::ToolExecutionRequired)
     }
 
     /// Execute a provider turn with policy-gated tool execution through the kernel.
@@ -518,13 +598,12 @@ impl TurnEngine {
     /// 1. No tool intents → `FinalText`
     /// 2. Too many intents → `ToolDenied("max_tool_steps_exceeded")`
     /// 3. Unknown tool → `ToolDenied("tool_not_found: ...")`
-    /// 4. No kernel context → `ToolDenied("no_kernel_context")`
-    /// 5. Policy/capability check via kernel → `ToolDenied`
-    /// 6. Execute tool → map result to `TurnResult`
+    /// 4. Policy/capability check via kernel → `ToolDenied`
+    /// 5. Execute tool → map result to `TurnResult`
     pub async fn execute_turn(
         &self,
         turn: &ProviderTurn,
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> TurnResult {
         self.execute_turn_in_view(turn, &runtime_tool_view(), kernel_ctx)
             .await
@@ -534,7 +613,7 @@ impl TurnEngine {
         &self,
         turn: &ProviderTurn,
         tool_view: &ToolView,
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> TurnResult {
         self.execute_turn_in_context(
             turn,
@@ -550,31 +629,15 @@ impl TurnEngine {
         turn: &ProviderTurn,
         session_context: &SessionContext,
         app_dispatcher: &D,
-        kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: &KernelContext,
     ) -> TurnResult {
-        // No tool intents → just return the text
-        if turn.tool_intents.is_empty() {
-            return TurnResult::FinalText(turn.assistant_text.clone());
+        match self.validate_turn_in_context(turn, session_context) {
+            Ok(TurnValidation::FinalText(text)) => return TurnResult::FinalText(text),
+            Err(failure) => return TurnResult::ToolDenied(failure),
+            Ok(TurnValidation::ToolExecutionRequired) => {}
         }
 
-        // Too many tool intents for current step limit
-        if turn.tool_intents.len() > self.max_tool_steps {
-            return TurnResult::policy_denied("max_tool_steps_exceeded", "max_tool_steps_exceeded");
-        }
-
-        // Check each tool intent is known
         let catalog = tool_catalog();
-        for intent in &turn.tool_intents {
-            let Some(descriptor) = catalog.resolve(&intent.tool_name) else {
-                let reason = format!("tool_not_found: {}", intent.tool_name);
-                return TurnResult::policy_denied("tool_not_found", reason);
-            };
-            if !session_context.tool_view.contains(descriptor.name) {
-                let reason = format!("tool_not_visible: {}", intent.tool_name);
-                return TurnResult::policy_denied("tool_not_visible", reason);
-            }
-        }
-
         let mut outputs = Vec::new();
         for intent in &turn.tool_intents {
             let Some(descriptor) = catalog.resolve(&intent.tool_name) else {
@@ -587,46 +650,13 @@ impl TurnEngine {
             };
             let outcome = match descriptor.execution_kind {
                 ToolExecutionKind::Core => {
-                    let ctx = match kernel_ctx {
-                        Some(ctx) => ctx,
-                        None => {
-                            return TurnResult::policy_denied(
-                                "no_kernel_context",
-                                "no_kernel_context",
-                            );
-                        }
-                    };
-                    let caps = BTreeSet::from([Capability::InvokeTool]);
-                    match ctx
-                        .kernel
-                        .execute_tool_core(ctx.pack_id(), &ctx.token, &caps, None, request)
-                        .await
-                    {
+                    match execute_tool_intent_via_kernel(intent, kernel_ctx).await {
                         Ok(outcome) => outcome,
-                        Err(e) => {
-                            let reason = format!("{e}");
-                            return match classify_kernel_error(&e) {
-                                KernelFailureClass::PolicyDenied => {
-                                    TurnResult::policy_denied("kernel_policy_denied", reason)
-                                }
-                                KernelFailureClass::RetryableExecution => {
-                                    TurnResult::retryable_tool_error(
-                                        "tool_execution_failed",
-                                        reason,
-                                    )
-                                }
-                                KernelFailureClass::NonRetryable => {
-                                    TurnResult::non_retryable_tool_error(
-                                        "kernel_execution_failed",
-                                        reason,
-                                    )
-                                }
-                            };
-                        }
+                        Err(failure) => return turn_result_from_tool_execution_failure(failure),
                     }
                 }
                 ToolExecutionKind::App => match app_dispatcher
-                    .execute_app_tool(session_context, request, kernel_ctx)
+                    .execute_app_tool(session_context, request, Some(kernel_ctx))
                     .await
                 {
                     Ok(outcome) => outcome,

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -13,7 +13,7 @@ use super::persistence::persist_reply_turns_with_mode;
 use super::runtime::{ConversationRuntime, DefaultConversationRuntime};
 use super::turn_budget::{TurnRoundBudget, TurnRoundBudgetDecision};
 use super::turn_engine::{
-    DefaultAppToolDispatcher, ProviderTurn, ToolIntent, TurnEngine, TurnResult,
+    DefaultAppToolDispatcher, ProviderTurn, ToolIntent, TurnEngine, TurnResult, TurnValidation,
 };
 use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ToolDrivenFollowupPayload,
@@ -317,14 +317,24 @@ async fn evaluate_round_kernel(
     let current_tool_name_signature =
         had_tool_intents.then(|| tool_name_signature(&turn.tool_intents));
 
-    let turn_result = TurnEngine::with_tool_result_payload_summary_limit(
+    let engine = TurnEngine::with_tool_result_payload_summary_limit(
         policy.max_tool_steps_per_round,
         config
             .conversation
             .tool_result_payload_summary_limit_chars(),
-    )
-    .execute_turn_in_context(turn, session_context, app_dispatcher, kernel_ctx)
-    .await;
+    );
+    let turn_result = match engine.validate_turn_in_context(turn, session_context) {
+        Ok(TurnValidation::FinalText(text)) => TurnResult::FinalText(text),
+        Err(failure) => TurnResult::ToolDenied(failure),
+        Ok(TurnValidation::ToolExecutionRequired) => match kernel_ctx {
+            Some(kernel_ctx) => {
+                engine
+                    .execute_turn_in_context(turn, session_context, app_dispatcher, kernel_ctx)
+                    .await
+            }
+            None => TurnResult::policy_denied("no_kernel_context", "no_kernel_context"),
+        },
+    };
     let loop_verdict = if let (Some(signature), Some(name_signature)) = (
         current_tool_signature.as_deref(),
         current_tool_name_signature.as_deref(),

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -326,14 +326,11 @@ async fn evaluate_round_kernel(
     let turn_result = match engine.validate_turn_in_context(turn, session_context) {
         Ok(TurnValidation::FinalText(text)) => TurnResult::FinalText(text),
         Err(failure) => TurnResult::ToolDenied(failure),
-        Ok(TurnValidation::ToolExecutionRequired) => match kernel_ctx {
-            Some(kernel_ctx) => {
-                engine
-                    .execute_turn_in_context(turn, session_context, app_dispatcher, kernel_ctx)
-                    .await
-            }
-            None => TurnResult::policy_denied("no_kernel_context", "no_kernel_context"),
-        },
+        Ok(TurnValidation::ToolExecutionRequired) => {
+            engine
+                .execute_turn_in_context(turn, session_context, app_dispatcher, kernel_ctx)
+                .await
+        }
     };
     let loop_verdict = if let (Some(signature), Some(name_signature)) = (
         current_tool_signature.as_deref(),

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -25,9 +25,11 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 ```
 
 **Current coverage:**
-- `shell.exec` — Full policy check (allowlist, denylist, approval gates)
-- `file.read` / `file.write` — Path sandboxing only, no policy engine check (TD-002)
-- Runtime/memory/connector — No policy check
+- `shell.exec` — Kernel-mediated tool execution with capability checks, shell policy extensions, and audit events
+- `file.read` / `file.write` — Kernel-mediated tool execution with filesystem capabilities, file policy extension checks, and audit events
+- Conversation tool turns — Fast-lane and safe-lane inner tool execution now require a bound `KernelContext`; missing kernel authority is rejected at the runtime binding boundary as `no_kernel_context`
+- Memory/runtime/context orchestration — Partially kernelized; some surrounding traits still carry optional kernel context and remain architectural debt rather than full L1 enforcement
+- Connector/ACP/runtime-only analytics — Not uniformly routed through the L1 policy chain yet
 
 ### Capability Tokens
 

--- a/docs/plans/2026-03-15-conversation-lifecycle-kernelization-design.md
+++ b/docs/plans/2026-03-15-conversation-lifecycle-kernelization-design.md
@@ -1,0 +1,201 @@
+# Conversation Lifecycle Kernelization Design
+
+Date: 2026-03-15
+Branch: `feat/issue-45-kernel-policy-unification`
+Scope: phase 2 kernelization of conversation lifecycle runtime interfaces
+Status: approved direction, implementation slice 2
+
+## Problem
+
+Phase 1 made tool execution kernel-mandatory, but the conversation runtime still carries optional
+kernel plumbing through its lifecycle interfaces. The most important remaining drift is in
+`ConversationRuntime` and `ConversationContextEngine`:
+
+1. `bootstrap`
+2. `ingest`
+3. `after_turn`
+4. `compact_context`
+5. `prepare_subagent_spawn`
+6. `on_subagent_ended`
+
+Those methods are not pure helpers. They are lifecycle hooks with side effects, but they still
+accept `Option<&KernelContext>`. That keeps the runtime contract ambiguous:
+
+1. some lifecycle work is conceptually kernel-bound
+2. call sites still pass `None` deep into the trait stack
+3. the trait signatures imply that lifecycle execution without kernel is a normal first-class mode
+
+That is the next architectural mismatch after phase 1.
+
+## Goals
+
+1. Make conversation lifecycle hooks explicitly kernel-bound.
+2. Remove `Option<&KernelContext>` from lifecycle methods on `ConversationRuntime`.
+3. Remove `Option<&KernelContext>` from lifecycle methods on `ConversationContextEngine`.
+4. Move the "no kernel available" decision to the runtime binding boundary instead of the trait
+   boundary.
+5. Preserve existing direct fallback behavior for non-lifecycle paths that are not in scope yet:
+   `build_context`, `build_messages`, `request_turn`, `request_completion`, and `persist_turn`.
+
+## Non-Goals
+
+1. Do not make provider request paths kernel-mandatory in this slice.
+2. Do not make `persist_turn` kernel-mandatory in this slice.
+3. Do not redesign default/legacy context assembly behavior in this slice.
+4. Do not remove all `Option<&KernelContext>` usage from the repository in one patch.
+
+## Current State
+
+### What phase 1 already fixed
+
+1. `TurnEngine` now validates turns separately from tool execution.
+2. Inner fast-lane and safe-lane tool execution now requires `&KernelContext`.
+3. Missing kernel authority is handled at the tool execution binding boundary.
+
+### What still drifts
+
+1. `DefaultConversationRuntime` still forwards `Option<&KernelContext>` through lifecycle hooks.
+2. `persist_and_ingest_turn(...)` still treats ingestion as an optional-kernel trait behavior
+   instead of an explicit bound action.
+3. `maybe_compact_context(...)` and after-turn finalization still enter trait methods with
+   optional kernel state.
+4. lifecycle-oriented test doubles still exercise no-kernel delegation as if that were the desired
+   stable contract.
+
+## Approaches Considered
+
+### A. Change lifecycle trait signatures directly
+
+Make lifecycle methods on `ConversationRuntime` and `ConversationContextEngine` require
+`&KernelContext`, then make call sites explicitly choose:
+
+1. call the lifecycle hook with bound kernel
+2. skip it when no kernel is available
+
+Pros:
+- strongest contract improvement for the smallest conceptual model
+- removes optional kernel plumbing from the real lifecycle seam
+- keeps the binding decision where it belongs: at the caller
+
+Cons:
+- requires touching tests and multiple runtime call sites
+- intentionally changes no-kernel lifecycle semantics
+
+### B. Add parallel kernel-bound traits
+
+Keep current optional trait methods and add a second trait for kernel-bound lifecycle hooks.
+
+Pros:
+- smaller migration risk
+- easier to layer incrementally
+
+Cons:
+- duplicates the contract
+- keeps the old ambiguous trait alive
+- encourages shadow optional paths to persist
+
+### C. Add wrapper helpers only
+
+Leave the signatures alone and just wrap lifecycle calls at a few coordinator sites.
+
+Pros:
+- smallest patch
+
+Cons:
+- does not change the underlying contract
+- leaves ambiguity in every implementation and test double
+- continues to teach the wrong architecture
+
+## Decision
+
+Implement Approach A.
+
+The kernelization goal is to make the contract honest, not merely tidier. Lifecycle hooks are
+kernel-bound actions, so the trait surface should say that directly.
+
+## Target Design
+
+### 1. Lifecycle methods become kernel-bound
+
+The following methods should require `&KernelContext` on both runtime traits:
+
+1. `bootstrap`
+2. `ingest`
+3. `after_turn`
+4. `compact_context`
+5. `prepare_subagent_spawn`
+6. `on_subagent_ended`
+
+This makes lifecycle hooks explicitly different from ambient runtime helpers.
+
+### 2. The binding decision moves upward
+
+Callers that currently hold `Option<&KernelContext>` should make the decision explicitly:
+
+1. if kernel is present, invoke the lifecycle hook
+2. if kernel is absent, skip the hook and keep the rest of the flow running
+
+That creates one truthful boundary instead of pushing optionality down into every implementation.
+
+### 3. Persistence keeps its direct fallback for now
+
+`persist_turn(...)` remains out of scope for this slice because it still underpins direct-memory
+conversation fallback. This slice only changes the extra lifecycle behavior that sits around core
+persistence:
+
+1. turn persistence still runs
+2. lifecycle ingestion becomes kernel-bound
+3. context compaction becomes kernel-bound
+4. after-turn and subagent lifecycle notifications become kernel-bound
+
+### 4. No-kernel lifecycle behavior becomes explicit skip semantics
+
+This slice intentionally changes the no-kernel behavior from "delegate optional lifecycle methods"
+to "skip kernel-bound lifecycle hooks." That means:
+
+1. no-kernel persistence still stores turns through existing direct fallback
+2. no-kernel ingestion does not run
+3. no-kernel compaction does not run
+4. no-kernel after-turn hooks do not run
+5. no-kernel subagent lifecycle hooks do not run
+
+That is the right architecture for a kernel-first runtime: absence of kernel authority is resolved
+once, not smeared through the call graph.
+
+### 5. Tests should prove the new contract
+
+The test suite should stop asserting no-kernel lifecycle delegation. Instead it should prove:
+
+1. kernel-bound lifecycle hooks still delegate correctly when kernel is present
+2. no-kernel persistence still works
+3. no-kernel lifecycle hooks are skipped at the caller boundary
+
+## Why This Is The Right Phase 2
+
+This slice keeps the scope tight but meaningful. It does not overreach into provider request
+kernelization or memory fallback removal, yet it eliminates one of the main remaining places where
+optional kernel context still shapes the architecture.
+
+It also sets up phase 3 cleanly:
+
+1. provider request paths can stay optional or become split explicitly
+2. persistence can later be separated into kernel-bound and direct-fallback surfaces
+3. context assembly can later be split into legacy/direct and kernel-bound implementations without
+   lifecycle ambiguity
+
+## Testing Strategy
+
+1. Add RED tests for runtime lifecycle delegation with required kernel context.
+2. Add RED tests proving no-kernel persistence no longer triggers ingestion/after-turn/compaction
+   hooks.
+3. Re-run targeted conversation tests first.
+4. Re-run full `loongclaw-app` verification after the trait change.
+
+## Acceptance Criteria
+
+1. Lifecycle methods on `ConversationRuntime` and `ConversationContextEngine` no longer accept
+   `Option<&KernelContext>`.
+2. Runtime callers make skip-vs-run lifecycle decisions explicitly.
+3. Direct persistence and context-build fallback behavior remains intact.
+4. Tests cover the new kernel-bound lifecycle semantics.
+5. PR #151 can be updated without expanding scope into provider or persistence contract redesign.

--- a/docs/plans/2026-03-15-conversation-lifecycle-kernelization-implementation-plan.md
+++ b/docs/plans/2026-03-15-conversation-lifecycle-kernelization-implementation-plan.md
@@ -1,0 +1,136 @@
+# Conversation Lifecycle Kernelization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make conversation lifecycle hooks kernel-bound by removing optional kernel context from `ConversationRuntime` and `ConversationContextEngine` lifecycle methods, while keeping direct fallback behavior for context assembly, provider requests, and turn persistence.
+
+**Architecture:** Change lifecycle trait signatures to require `&KernelContext`, then update conversation call sites to make the skip-vs-run decision explicitly at the runtime binding boundary. Keep `build_context`, `build_messages`, `request_turn`, `request_completion`, and `persist_turn` unchanged in this slice.
+
+**Tech Stack:** Rust, async conversation runtime traits, `loongclaw-app` tests, cargo test, cargo clippy
+
+---
+
+### Task 1: Lock phase 2 scope in docs
+
+**Files:**
+- Create: `docs/plans/2026-03-15-conversation-lifecycle-kernelization-design.md`
+- Create: `docs/plans/2026-03-15-conversation-lifecycle-kernelization-implementation-plan.md`
+
+**Step 1: Re-read the lifecycle surfaces**
+
+Run: `rg -n "bootstrap\\(|ingest\\(|after_turn\\(|compact_context\\(|prepare_subagent_spawn\\(|on_subagent_ended\\(" crates/app/src/conversation`
+Expected: all lifecycle call sites and trait declarations are enumerated.
+
+**Step 2: Confirm the new docs exist**
+
+Run: `ls docs/plans/2026-03-15-conversation-lifecycle-kernelization-design.md docs/plans/2026-03-15-conversation-lifecycle-kernelization-implementation-plan.md`
+Expected: both files exist.
+
+### Task 2: Add failing tests for the new lifecycle contract
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing runtime lifecycle delegation test**
+
+Add a test that passes a real `KernelContext` and proves `bootstrap`, `ingest`,
+`prepare_subagent_spawn`, and `on_subagent_ended` still delegate through the runtime.
+
+**Step 2: Write the failing no-kernel skip regression**
+
+Add a focused regression proving that no-kernel persistence still writes turns but no longer calls
+ingest.
+
+**Step 3: Run the targeted tests and confirm RED**
+
+Run: `cargo test -p loongclaw-app default_runtime_delegates_bootstrap_and_ingest_to_context_engine_with_kernel -- --exact --test-threads=1`
+Expected: FAIL because the lifecycle signatures and call sites still accept `Option<&KernelContext>`.
+
+### Task 3: Change lifecycle trait signatures
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/conversation/context_engine.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Change runtime lifecycle methods to require `&KernelContext`**
+
+Update `ConversationRuntime` and `DefaultConversationRuntime` for:
+- `bootstrap`
+- `ingest`
+- `after_turn`
+- `compact_context`
+- `prepare_subagent_spawn`
+- `on_subagent_ended`
+
+**Step 2: Change context-engine lifecycle methods to require `&KernelContext`**
+
+Update `ConversationContextEngine` and boxed forwarding impls for the same lifecycle set.
+
+**Step 3: Update fake runtimes and recording engines**
+
+Adjust test doubles to match the new kernel-bound signatures.
+
+### Task 4: Move skip-vs-run decisions to callers
+
+**Files:**
+- Modify: `crates/app/src/conversation/persistence.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Gate ingestion at the persistence boundary**
+
+Keep `persist_turn(...)` running regardless of kernel, but only call `runtime.ingest(...)` when a
+kernel is present.
+
+**Step 2: Gate bootstrap / after-turn / compaction / subagent lifecycle at callers**
+
+Update runtime call sites so they:
+- call lifecycle hooks with `&KernelContext` when present
+- skip cleanly when kernel is absent
+
+**Step 3: Run targeted lifecycle tests**
+
+Run: `cargo test -p loongclaw-app default_runtime_delegates_ -- --test-threads=1`
+Expected: PASS.
+
+### Task 5: Re-run targeted conversation flows
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs` only if additional coverage is needed
+
+**Step 1: Run turn-finalization and lifecycle-sensitive tests**
+
+Run: `cargo test -p loongclaw-app handle_turn_with_runtime -- --test-threads=1`
+Expected: PASS.
+
+**Step 2: Run any additional checkpoint or subagent lifecycle coverage if needed**
+
+Run: `cargo test -p loongclaw-app turn_checkpoint -- --test-threads=1`
+Expected: PASS if affected.
+
+### Task 6: Run full verification and refresh GitHub delivery
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/conversation/context_engine.rs`
+- Modify: `crates/app/src/conversation/persistence.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+- Create: `docs/plans/2026-03-15-conversation-lifecycle-kernelization-design.md`
+- Create: `docs/plans/2026-03-15-conversation-lifecycle-kernelization-implementation-plan.md`
+
+**Step 1: Run package tests**
+
+Run: `cargo test -p loongclaw-app -- --test-threads=1`
+Expected: PASS.
+
+**Step 2: Run lint**
+
+Run: `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
+Expected: PASS.
+
+**Step 3: Review the scoped diff**
+
+Run: `git diff -- crates/app/src/conversation/runtime.rs crates/app/src/conversation/context_engine.rs crates/app/src/conversation/persistence.rs crates/app/src/conversation/turn_coordinator.rs crates/app/src/conversation/tests.rs docs/plans/2026-03-15-conversation-lifecycle-kernelization-design.md docs/plans/2026-03-15-conversation-lifecycle-kernelization-implementation-plan.md`
+Expected: only the intended lifecycle-kernelization slice is present.

--- a/docs/plans/2026-03-15-kernel-policy-unification-design.md
+++ b/docs/plans/2026-03-15-kernel-policy-unification-design.md
@@ -1,0 +1,227 @@
+# Kernel Policy Unification Design
+
+Date: 2026-03-15
+Branch: `feat/issue-45-kernel-policy-unification`
+Scope: kernel-first unification of tool-execution policy in `alpha-test`
+Status: approved direction, implementation slice 1
+
+## Problem
+
+`alpha-test` already moved the dangerous shell/file policy decisions into the kernel path, but the
+runtime contract is still softer than the architecture claims. The main remaining drift is not
+"missing policy extensions"; it is "kernel context is still optional across hot execution paths."
+
+Today the runtime still mixes three different concerns:
+
+1. turn validation
+2. kernel binding
+3. tool execution
+
+That mixing shows up in several places:
+
+1. `TurnEngine::evaluate_turn(...)` treats "kernel required for execution" as a policy denial
+   instead of a phase boundary.
+2. `TurnEngine::execute_turn(...)` still accepts `Option<&KernelContext>`.
+3. The safe-lane plan executor still threads `Option<&KernelContext>` into per-node tool
+   execution.
+4. Coordinator paths still treat "missing kernel" as a normal late failure case instead of
+   resolving the execution contract before entering the tool runtime.
+
+The result is that the kernel is conceptually authoritative, but operationally optional. That is
+the wrong shape for a kernel-first runtime.
+
+## Goals
+
+1. Make tool execution a kernel-mandatory phase in both fast lane and safe lane.
+2. Separate pure turn validation from kernel-bound execution.
+3. Remove `Option<&KernelContext>` from the inner tool execution surfaces in this slice.
+4. Keep current user-visible failure behavior stable where reasonable, especially
+   `no_kernel_context` and existing policy/error classification.
+5. Create a clean seam that later kernelizes memory, context engines, and provider-adjacent flows
+   without reworking the turn contract again.
+
+## Non-Goals
+
+1. Do not remove every `Option<&KernelContext>` in the repository in one patch.
+2. Do not redesign context-engine, provider, or persistence traits in this slice.
+3. Do not retune lane routing, approval defaults, or safe-lane governor heuristics here.
+4. Do not change audit schema or introduce durable audit persistence here.
+
+## Current State
+
+### What is already correct
+
+1. `crates/app/src/tools/mod.rs` exposes a kernel-bound `execute_tool(...)` entrypoint that
+   requires `&KernelContext`.
+2. `crates/app/src/context.rs` now grants `FilesystemRead` and `FilesystemWrite`.
+3. Shell/file policy extensions are registered into the kernel bootstrap path.
+4. Approval policy defaults already exist in `crates/spec` and are not the missing primitive.
+
+### What is still architecturally wrong
+
+1. `crates/app/src/conversation/turn_engine.rs` still models "missing kernel" inside the execution
+   engine.
+2. `crates/app/src/conversation/turn_coordinator.rs` safe-lane node execution still unwraps an
+   optional kernel per tool node.
+3. Validation and execution are still coupled tightly enough that missing kernel context looks like
+   a late execution failure rather than an unbound runtime.
+
+## Approaches Considered
+
+### A. Broad repository-wide kernel hardening now
+
+Make `KernelContext` mandatory across conversation, provider, context engine, persistence, channel,
+and tool surfaces in one breaking pass.
+
+Pros:
+- cleanest theoretical end state
+- eliminates optional kernel context quickly
+
+Cons:
+- too much surface area for one reviewable change
+- high regression risk in unrelated lanes
+- hard to attribute failures
+
+### B. Mandatory tool-execution kernel first
+
+Treat tool execution as the first hard boundary:
+
+1. validation stays pure
+2. coordinator binds kernel once before entering tool execution
+3. fast-lane and safe-lane tool execution paths require `&KernelContext`
+
+Pros:
+- directly fixes the highest-value control-plane gap
+- small enough to review and verify
+- creates the right contract for follow-on kernelization
+
+Cons:
+- leaves optional kernel context in surrounding traits for now
+- requires transitional adapter logic at the coordinator boundary
+
+### C. Pure helper extraction only
+
+Keep the current signatures and just deduplicate some tool execution code.
+
+Pros:
+- smallest patch
+
+Cons:
+- does not change the contract
+- keeps the kernel optional in the exact places that matter
+- would look cleaner without actually being safer
+
+## Decision
+
+Implement Approach B.
+
+The correct first architecture move is to make tool execution a kernel-mandatory runtime phase.
+That is the narrowest slice that materially strengthens the kernel model without dragging every
+conversation subsystem into the same patch.
+
+## Target Design
+
+### 1. Split turn validation from tool execution
+
+`TurnEngine` should expose a pure validation phase that:
+
+1. returns final text immediately when there are no tool intents
+2. rejects unknown tools and step-budget violations
+3. returns an explicit "tool execution required" result instead of inventing
+   `kernel_context_required`
+
+This keeps validation honest: it validates the turn, not the runtime wiring.
+
+### 2. Make kernel binding explicit at the coordinator boundary
+
+When a validated turn requires tool execution, the coordinator becomes responsible for one explicit
+decision:
+
+1. kernel available -> enter tool execution
+2. kernel unavailable -> synthesize the existing `no_kernel_context` policy denial before any tool
+   execution path begins
+
+This is the correct place for the fallback because it is the actual runtime binding boundary.
+
+### 3. Make inner tool executors require `&KernelContext`
+
+In this slice the following inner surfaces should stop accepting optional kernel context:
+
+1. `TurnEngine` tool-execution entrypoint
+2. safe-lane per-node tool execution helper
+3. safe-lane plan node executor state
+
+That change is the real contract hardening: once execution starts, the kernel is mandatory.
+
+### 4. Share the kernel-bound tool execution path
+
+Fast lane and safe lane should not each rebuild kernel tool execution semantics ad hoc. This slice
+should converge them on one shared execution shape:
+
+1. known tool names only
+2. `InvokeTool` capability set
+3. kernel policy/error classification
+4. shared tool-result formatting
+
+The goal is not a giant abstraction; the goal is one authoritative path for tool execution
+semantics.
+
+### 5. Preserve failure vocabulary in slice 1
+
+This patch should keep existing public/runtime-facing failure codes stable where possible:
+
+1. `tool_not_found`
+2. `max_tool_steps_exceeded`
+3. `no_kernel_context`
+4. `kernel_policy_denied`
+5. `tool_execution_failed`
+6. `kernel_execution_failed`
+
+The architecture changes, but the observable failure taxonomy stays stable enough for existing
+tests, runtime analytics, and user expectations.
+
+## Why This Is Kernel-First
+
+This design makes the kernel the only legal execution substrate for tool-calling turns. The app
+runtime still decides when to enter the tool phase, but once it does, the execution contract is
+hard-bound to `&KernelContext`.
+
+That is closer to Codex's approval/sandbox model than to an operator-product orchestration model:
+
+1. execution policy is a runtime primitive
+2. missing authority is resolved before execution begins
+3. the execution core does not carry shadow optionality
+
+OpenClaw-style operator safety features can still exist above this layer, but they should compose
+with the runtime kernel rather than substitute for it.
+
+## Follow-On Phases
+
+After this slice lands, the next kernelization phases should be:
+
+1. context-engine trait split: kernel-required vs kernel-agnostic operations
+2. provider/runtime telemetry paths: explicit policy-free runtime helpers versus kernel-bound
+   operations
+3. persistence/session-history paths: stop treating kernel access as ambient optional plumbing
+4. channel entrypoints: bootstrap or inject kernel context earlier so hot paths do not branch late
+
+## Testing Strategy
+
+1. Add RED tests for the new validation/execution split in `turn_engine`:
+   - no-tool turn validates to final text
+   - known-tool turn validates to "execution required" instead of `kernel_context_required`
+   - invalid tool still fails validation
+2. Add RED tests for coordinator or safe-lane helpers to prove:
+   - missing kernel is rejected before entering tool execution
+   - safe-lane execution still surfaces `no_kernel_context` from the coordinator boundary
+3. Keep existing tool execution result/error classification tests green.
+4. Run targeted conversation tests first, then broader `loongclaw-app` verification.
+
+## Acceptance Criteria
+
+1. Inner tool execution surfaces no longer accept `Option<&KernelContext>`.
+2. Turn validation no longer uses `kernel_context_required` as a pseudo-policy result.
+3. Fast-lane and safe-lane tool execution both bind kernel authority before entering execution.
+4. Existing failure-code mapping remains stable for runtime behavior.
+5. `docs/SECURITY.md` is updated to describe the current kernel-bound tool execution model instead
+   of the stale pre-unification description.

--- a/docs/plans/2026-03-15-kernel-policy-unification-implementation-plan.md
+++ b/docs/plans/2026-03-15-kernel-policy-unification-implementation-plan.md
@@ -1,0 +1,160 @@
+# Kernel Policy Unification Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make tool-executing conversation paths in `alpha-test` kernel-mandatory by separating turn validation from kernel-bound execution and by removing optional kernel context from the inner fast-lane and safe-lane tool execution surfaces.
+
+**Architecture:** Keep the current coordinator and turn-loop public entrypoints, but refactor the inner tool path into three explicit phases: validate the provider turn, bind kernel authority at the coordinator boundary, then execute tools only through kernel-required helpers. Preserve current failure-code semantics while tightening the runtime contract.
+
+**Tech Stack:** Rust, async conversation runtime traits, `loongclaw-app` tests, cargo test, cargo clippy
+
+---
+
+### Task 1: Lock the design and target scope in docs
+
+**Files:**
+- Create: `docs/plans/2026-03-15-kernel-policy-unification-design.md`
+- Create: `docs/plans/2026-03-15-kernel-policy-unification-implementation-plan.md`
+
+**Step 1: Re-read the current execution hotspots**
+
+Run: `rg -n "evaluate_turn|execute_turn\\(|execute_single_tool_intent|no_kernel_context|kernel_context_required" crates/app/src/conversation`
+Expected: the validation/binding/execution split points are enumerated.
+
+**Step 2: Confirm the new docs exist**
+
+Run: `ls docs/plans/2026-03-15-kernel-policy-unification-design.md docs/plans/2026-03-15-kernel-policy-unification-implementation-plan.md`
+Expected: both files exist.
+
+### Task 2: Write failing tests for the new turn-engine contract
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Add a failing validation test for tool turns**
+
+Add a test asserting that a known tool turn validates to an explicit execution-required state
+instead of returning `kernel_context_required`.
+
+**Step 2: Add a failing validation test for no-tool turns**
+
+Add a test asserting that no-tool turns validate directly to final text.
+
+**Step 3: Run the targeted tests and confirm RED**
+
+Run: `cargo test -p loongclaw-app turn_engine_known_tool_validates_to_execution_required -- --exact --test-threads=1`
+Expected: FAIL because the new validation result type does not exist yet.
+
+### Task 3: Refactor `TurnEngine` into validation plus kernel-bound execution
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Introduce the new validation result type**
+
+Add the smallest new enum needed to represent:
+- final text
+- execution required
+
+Keep failure details in `TurnFailure`.
+
+**Step 2: Replace the current validation API**
+
+Refactor `evaluate_turn(...)` into a pure validation method that:
+- returns final text directly
+- returns execution-required for valid tool turns
+- still denies unknown tools and step-limit violations
+
+**Step 3: Make tool execution kernel-mandatory**
+
+Change the inner execution API so the tool-executing method requires `&KernelContext`.
+
+**Step 4: Run targeted turn-engine tests**
+
+Run: `cargo test -p loongclaw-app turn_engine_ -- --test-threads=1`
+Expected: PASS.
+
+### Task 4: Bind kernel authority explicitly in fast-lane and safe-lane callers
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Add the failing safe-lane/coordinator regression test if needed**
+
+If no existing test covers the new binding point clearly, add one focused regression that proves a
+tool turn without kernel context is denied before execution begins.
+
+**Step 2: Refactor fast-lane execution**
+
+Update `turn_loop.rs` to:
+- validate first
+- require kernel only for execution-required turns
+- preserve `no_kernel_context` as the external denial reason
+
+**Step 3: Refactor safe-lane execution**
+
+Update `turn_coordinator.rs` so:
+- the safe-lane node executor stores `&KernelContext`, not `Option<&KernelContext>`
+- the missing-kernel fallback happens before node execution starts
+
+**Step 4: Run targeted coordinator coverage**
+
+Run: `cargo test -p loongclaw-app handle_turn_with_runtime_safe_lane -- --test-threads=1`
+Expected: PASS.
+
+### Task 5: Update stale security docs
+
+**Files:**
+- Modify: `docs/SECURITY.md`
+
+**Step 1: Reconcile the security model with current code**
+
+Update the "Current coverage" section so it reflects:
+- kernel-bound shell and file policy extensions
+- tool execution as a kernel-mediated path
+- remaining optional-kernel gaps as architectural debt instead of outdated false statements
+
+**Step 2: Check the doc diff**
+
+Run: `git diff -- docs/SECURITY.md`
+Expected: only the intended accuracy updates are present.
+
+### Task 6: Run broader verification and prepare delivery
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+- Modify: `docs/SECURITY.md`
+- Create: `docs/plans/2026-03-15-kernel-policy-unification-design.md`
+- Create: `docs/plans/2026-03-15-kernel-policy-unification-implementation-plan.md`
+
+**Step 1: Run focused crate tests**
+
+Run: `cargo test -p loongclaw-app turn_engine_ -- --test-threads=1`
+Expected: PASS.
+
+**Step 2: Run coordinator-focused tests**
+
+Run: `cargo test -p loongclaw-app handle_turn_with_runtime_safe_lane -- --test-threads=1`
+Expected: PASS.
+
+**Step 3: Run package verification**
+
+Run: `cargo test -p loongclaw-app -- --test-threads=1`
+Expected: PASS.
+
+**Step 4: Run lint**
+
+Run: `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
+Expected: PASS.
+
+**Step 5: Review the final scoped diff**
+
+Run: `git diff -- crates/app/src/conversation/turn_engine.rs crates/app/src/conversation/turn_loop.rs crates/app/src/conversation/turn_coordinator.rs crates/app/src/conversation/tests.rs docs/SECURITY.md docs/plans/2026-03-15-kernel-policy-unification-design.md docs/plans/2026-03-15-kernel-policy-unification-implementation-plan.md`
+Expected: only the intended kernel-policy unification slice is present.


### PR DESCRIPTION
## Summary

- route conversation-turn validation through `TurnEngine` so tool visibility, tool existence, and max-step policy checks share one kernel-policy-aware path
- require a bound `KernelContext` for core tool execution and lifecycle hooks, while preserving app/session tool execution through the app dispatcher when no kernel is available
- align checkpoint repair and runtime/coordinator boundaries with the new contract, and document the kernel-policy unification plan and lifecycle-kernelization design

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:
This PR tightens the conversation runtime around a single validation/execution contract, but it intentionally does not force every no-kernel path through the kernel. The final design is narrower and safer than the initial refactor attempt: core tools and lifecycle hooks are kernel-bound, while app/session tools still execute through `AppToolDispatcher` when the surrounding runtime path has no kernel context. The main regression risk was incorrectly denying those app-tool paths as `no_kernel_context`; the final branch fixes that and adds targeted regression coverage.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
- [x] `cargo test -p loongclaw-app -- --test-threads=1`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Before/after behavior:
- Before: conversation runtime execution, lifecycle hooks, and tool-routing decisions still had multiple partially overlapping policy paths, and the lifecycle/tool seams still accepted optional kernel context in ways that blurred kernel-bound versus direct-fallback behavior.
- After: `TurnEngine` owns validation-first turn gating, core tools and lifecycle hooks require kernel authority, app/session tools remain available through dispatcher-backed no-kernel paths, and checkpoint repair/runtime callers make the kernel-versus-direct boundary explicit.

Additional scenario checks:
- `cargo test -p loongclaw-app handle_turn_with_runtime -- --test-threads=1`
- `cargo test -p loongclaw-app repair_turn_checkpoint_tail -- --test-threads=1`
- `cargo test -p loongclaw-app durable_turn_checkpoint_repair -- --test-threads=1`

## Linked Issues

Closes #45