### PR TITLE
fix(conversation): restore safe-lane no-kernel session tool execution

### DIFF
--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10630,7 +10630,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_d
         .handle_turn_with_runtime(
             &config,
             "root-session",
-            "deploy safely and show raw json tool output",
+            "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
             None,
@@ -10713,7 +10713,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_d
         .handle_turn_with_runtime(
             &config,
             "controller-root",
-            "deploy safely and show raw json tool output",
+            "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
             None,
@@ -10813,7 +10813,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_wait_via_default_di
         .handle_turn_with_runtime(
             &config,
             "root-session",
-            "deploy safely and show raw json tool output",
+            "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
             None,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -41,8 +41,8 @@ use super::persistence::{
     persist_reply_turns_raw_with_mode, persist_reply_turns_with_mode,
 };
 use super::plan_executor::{
-    PlanExecutor, PlanNodeAttemptEvent, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor,
-    PlanRunFailure, PlanRunReport, PlanRunStatus,
+    PlanExecutor, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor, PlanRunFailure,
+    PlanRunReport, PlanRunStatus,
 };
 use super::plan_ir::{
     PLAN_GRAPH_VERSION, PlanBudget, PlanEdge, PlanGraph, PlanNode, PlanNodeKind, RiskTier,
@@ -3857,9 +3857,6 @@ async fn evaluate_safe_lane_round(
         state.tool_node_max_attempts(),
         state.plan_start_tool_index,
     );
-    let Some(kernel_ctx) = kernel_ctx else {
-        return synthetic_safe_lane_round_without_kernel(&plan);
-    };
     let executor = SafeLanePlanNodeExecutor::new(
         turn.tool_intents.as_slice(),
         session_context,
@@ -3879,43 +3876,6 @@ async fn evaluate_safe_lane_round(
         report,
         tool_outputs,
         tool_output_stats,
-    }
-}
-
-fn synthetic_safe_lane_round_without_kernel(plan: &PlanGraph) -> SafeLaneRoundExecution {
-    let ordered_nodes = plan
-        .nodes
-        .iter()
-        .map(|node| node.id.clone())
-        .collect::<Vec<_>>();
-    let node_id = plan
-        .nodes
-        .iter()
-        .find(|node| matches!(node.kind, PlanNodeKind::Tool))
-        .map(|node| node.id.clone())
-        .unwrap_or_else(|| "tool-1".to_owned());
-    let error = "no_kernel_context".to_owned();
-    SafeLaneRoundExecution {
-        report: PlanRunReport {
-            status: PlanRunStatus::Failed(PlanRunFailure::NodeFailed {
-                node_id: node_id.clone(),
-                attempts_used: 1,
-                last_error_kind: PlanNodeErrorKind::PolicyDenied,
-                last_error: error.clone(),
-            }),
-            ordered_nodes,
-            attempts_used: 1,
-            attempt_events: vec![PlanNodeAttemptEvent {
-                node_id,
-                attempt: 1,
-                success: false,
-                error_kind: Some(PlanNodeErrorKind::PolicyDenied),
-                error: Some(error),
-            }],
-            elapsed_ms: 0,
-        },
-        tool_outputs: Vec::new(),
-        tool_output_stats: SafeLaneToolOutputStats::default(),
     }
 }
 
@@ -5022,7 +4982,7 @@ struct SafeLanePlanNodeExecutor<'a> {
     tool_intents: &'a [ToolIntent],
     session_context: &'a SessionContext,
     app_dispatcher: &'a dyn AppToolDispatcher,
-    kernel_ctx: &'a KernelContext,
+    kernel_ctx: Option<&'a KernelContext>,
     verify_output_non_empty: bool,
     tool_outputs: Mutex<Vec<String>>,
     tool_result_payload_summary_limit_chars: usize,
@@ -5033,7 +4993,7 @@ impl<'a> SafeLanePlanNodeExecutor<'a> {
         tool_intents: &'a [ToolIntent],
         session_context: &'a SessionContext,
         app_dispatcher: &'a dyn AppToolDispatcher,
-        kernel_ctx: &'a KernelContext,
+        kernel_ctx: Option<&'a KernelContext>,
         verify_output_non_empty: bool,
         seed_tool_outputs: Vec<String>,
         tool_result_payload_summary_limit_chars: usize,
@@ -5113,7 +5073,7 @@ async fn execute_single_tool_intent(
     intent: &ToolIntent,
     session_context: &SessionContext,
     app_dispatcher: &dyn AppToolDispatcher,
-    kernel_ctx: &KernelContext,
+    kernel_ctx: Option<&KernelContext>,
     payload_summary_limit_chars: usize,
 ) -> Result<String, PlanNodeError> {
     let engine = TurnEngine::with_tool_result_payload_summary_limit(1, payload_summary_limit_chars);
@@ -5124,7 +5084,7 @@ async fn execute_single_tool_intent(
     };
 
     match engine
-        .execute_turn_in_context(&turn, session_context, app_dispatcher, Some(kernel_ctx))
+        .execute_turn_in_context(&turn, session_context, app_dispatcher, kernel_ctx)
         .await
     {
         TurnResult::FinalText(output) => Ok(output),


### PR DESCRIPTION
## Summary

- allow safe-lane plan execution to keep an optional `KernelContext` all the way through node execution instead of failing the whole round up front
- restore the fast-lane contract for no-kernel app/session tools while preserving explicit `no_kernel_context` failures for kernel-only tools
- harden the safe-lane session-tool regressions so the tests actually cross the safe-lane threshold

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

- this is a fix-forward for #151 after a real post-merge regression on safe-lane no-kernel session/app tool execution
- the root cause was a round-level `no_kernel_context` short-circuit in `evaluate_safe_lane_round`, which bypassed the existing per-tool execution-kind logic
- the fix makes safe-lane match the fast-lane dispatcher contract so tool-kind checks happen at execution time instead of being masked at round entry

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

additional targeted checks:
- `cargo test -p loongclaw-app handle_turn_with_runtime_safe_lane -- --test-threads=1`
- `cargo test -p loongclaw-app --all-features handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_dispatcher -- --test-threads=1`

## Linked Issues

Closes #45
