### PR TITLE
feat(approval): rebuild lifecycle attention surfaces

### DIFF
--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -45,8 +45,9 @@ pub(crate) use runtime::{normalize_dispatch_account_id, normalize_dispatch_chann
 pub use shared::{CLI_COMMAND_NAME, expand_path};
 #[allow(unused_imports)]
 pub use tools_memory::{
-    DEFAULT_SHELL_ALLOW, ExternalSkillsConfig, MemoryBackendKind, MemoryConfig, MemoryIngestMode,
-    MemoryMode, MemoryProfile, MemorySystemKind, SessionVisibility, ToolConfig,
+    DEFAULT_SHELL_ALLOW, ExternalSkillsConfig, GovernedToolApprovalConfig,
+    GovernedToolApprovalMode, MemoryBackendKind, MemoryConfig, MemoryIngestMode, MemoryMode,
+    MemoryProfile, MemorySystemKind, SessionVisibility, ToolConfig,
 };
 
 #[cfg(test)]

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -25,11 +25,32 @@ pub struct ToolConfig {
     #[serde(default = "default_shell_default_mode")]
     pub shell_default_mode: String,
     #[serde(default)]
+    pub approval: GovernedToolApprovalConfig,
+    #[serde(default)]
     pub sessions: SessionToolConfig,
     #[serde(default)]
     pub messages: MessageToolConfig,
     #[serde(default)]
     pub delegate: DelegateToolConfig,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum GovernedToolApprovalMode {
+    #[default]
+    Disabled,
+    MediumBalanced,
+    Strict,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GovernedToolApprovalConfig {
+    #[serde(default)]
+    pub mode: GovernedToolApprovalMode,
+    #[serde(default)]
+    pub approved_calls: Vec<String>,
+    #[serde(default)]
+    pub denied_calls: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -295,9 +316,20 @@ impl Default for ToolConfig {
             shell_allow: default_shell_allow(),
             shell_deny: Vec::new(),
             shell_default_mode: default_shell_default_mode(),
+            approval: GovernedToolApprovalConfig::default(),
             sessions: SessionToolConfig::default(),
             messages: MessageToolConfig::default(),
             delegate: DelegateToolConfig::default(),
+        }
+    }
+}
+
+impl Default for GovernedToolApprovalConfig {
+    fn default() -> Self {
+        Self {
+            mode: GovernedToolApprovalMode::Disabled,
+            approved_calls: Vec::new(),
+            denied_calls: Vec::new(),
         }
     }
 }
@@ -511,6 +543,9 @@ mod tests {
         assert!(config.shell_allow.is_empty());
         assert!(config.shell_deny.is_empty());
         assert_eq!(config.shell_default_mode, "deny");
+        assert_eq!(config.approval.mode, GovernedToolApprovalMode::Disabled);
+        assert!(config.approval.approved_calls.is_empty());
+        assert!(config.approval.denied_calls.is_empty());
         assert!(config.sessions.enabled);
         assert_eq!(config.sessions.visibility, SessionVisibility::Children);
         assert_eq!(config.sessions.list_limit, 100);
@@ -530,6 +565,11 @@ mod tests {
     #[test]
     fn tool_config_parses_session_runtime_controls_from_toml() {
         let raw = r#"
+[tools.approval]
+mode = "strict"
+approved_calls = ["tool:delegate_async"]
+denied_calls = ["tool:session_cancel"]
+
 [tools.sessions]
 visibility = "self"
 list_limit = 12
@@ -548,6 +588,15 @@ child_tool_allowlist = ["file.read", "shell.exec"]
         let parsed =
             toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
 
+        assert_eq!(parsed.tools.approval.mode, GovernedToolApprovalMode::Strict);
+        assert_eq!(
+            parsed.tools.approval.approved_calls,
+            vec!["tool:delegate_async".to_owned()]
+        );
+        assert_eq!(
+            parsed.tools.approval.denied_calls,
+            vec!["tool:session_cancel".to_owned()]
+        );
         assert_eq!(
             parsed.tools.sessions.visibility,
             SessionVisibility::SelfOnly

--- a/crates/app/src/conversation/integration_tests.rs
+++ b/crates/app/src/conversation/integration_tests.rs
@@ -502,6 +502,7 @@ mod tests {
                 );
             }
             other @ (TurnResult::FinalText(_)
+            | TurnResult::NeedsApproval(_)
             | TurnResult::ToolError(_)
             | TurnResult::ProviderError(_)) => {
                 panic!("expected ToolDenied with FilesystemWrite, got: {other:?}")

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -6066,6 +6066,7 @@ fn turn_engine_denies_known_tool_outside_restricted_view() {
             );
         }
         other @ TurnResult::FinalText(_)
+        | other @ TurnResult::NeedsApproval(_)
         | other @ TurnResult::ToolError(_)
         | other @ TurnResult::ProviderError(_) => {
             panic!("expected ToolDenied, got {:?}", other)
@@ -6146,6 +6147,7 @@ async fn turn_engine_routes_app_tools_through_dispatcher() {
             );
         }
         other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::NeedsApproval(_)
         | other @ TurnResult::ToolError(_)
         | other @ TurnResult::ProviderError(_) => {
             panic!("expected FinalText, got: {other:?}")
@@ -6909,6 +6911,7 @@ async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
             );
         }
         other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::NeedsApproval(_)
         | other @ TurnResult::ToolError(_)
         | other @ TurnResult::ProviderError(_) => panic!("unexpected result: {other:?}"),
     }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -9604,6 +9604,455 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
+async fn handle_turn_with_runtime_approval_request_resolve_replays_delegate_for_approve_once() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-approval-resolve", "approve-once")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-delegate-1".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-delegate-parent".to_owned(),
+        tool_call_id: "call-delegate-parent".to_owned(),
+        tool_name: "delegate".to_owned(),
+        approval_key: "tool:delegate".to_owned(),
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "parent_session_id": Value::Null,
+            "turn_id": "turn-delegate-parent",
+            "tool_call_id": "call-delegate-parent",
+            "tool_name": "delegate",
+            "args_json": {
+                "task": "child task",
+                "label": "research-subtask"
+            },
+            "source": "provider_tool_call",
+            "execution_kind": "app"
+        }),
+        governance_snapshot_json: json!({
+            "governance_scope": "topology_mutation",
+            "risk_class": "high",
+            "approval_mode": "policy_driven",
+            "rule_id": "governed_tool_requires_approval",
+            "reason": "operator approval required before running `delegate`"
+        }),
+    })
+    .expect("seed approval request");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "resolving approval".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "approval_request_resolve".to_owned(),
+                    args_json: json!({
+                        "approval_request_id": "apr-delegate-1",
+                        "decision": "approve_once"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-approval-resolve".to_owned(),
+                    tool_call_id: "call-approval-resolve".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Child final output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("approval resolve reply");
+
+    assert!(
+        reply.contains("\"tool\":\"approval_request_resolve\""),
+        "expected raw approval resolve tool output, got: {reply}"
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let request = repo
+        .load_approval_request("apr-delegate-1")
+        .expect("load approval request")
+        .expect("approval request row");
+    assert_eq!(
+        request.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert_eq!(
+        request.decision,
+        Some(crate::session::repository::ApprovalDecision::ApproveOnce)
+    );
+    assert_eq!(
+        request.resolved_by_session_id.as_deref(),
+        Some("root-session")
+    );
+    assert!(request.executed_at.is_some());
+    assert!(request.last_error.is_none(), "request={request:?}");
+    assert!(
+        repo.load_approval_grant("root-session", "tool:delegate")
+            .expect("load grant")
+            .is_none()
+    );
+
+    let child = repo
+        .list_visible_sessions("root-session")
+        .expect("list visible sessions")
+        .into_iter()
+        .find(|session| session.parent_session_id.as_deref() == Some("root-session"))
+        .expect("child session summary");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Completed
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses_root_grant() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-approval-resolve", "approve-always")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-delegate-always".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-delegate-parent".to_owned(),
+        tool_call_id: "call-delegate-parent".to_owned(),
+        tool_name: "delegate".to_owned(),
+        approval_key: "tool:delegate".to_owned(),
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "parent_session_id": Value::Null,
+            "turn_id": "turn-delegate-parent",
+            "tool_call_id": "call-delegate-parent",
+            "tool_name": "delegate",
+            "args_json": {
+                "task": "child task",
+                "label": "research-subtask"
+            },
+            "source": "provider_tool_call",
+            "execution_kind": "app"
+        }),
+        governance_snapshot_json: json!({
+            "governance_scope": "topology_mutation",
+            "risk_class": "high",
+            "approval_mode": "policy_driven",
+            "rule_id": "governed_tool_requires_approval",
+            "reason": "operator approval required before running `delegate`"
+        }),
+    })
+    .expect("seed approval request");
+
+    let approval_runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "resolving approval".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "approval_request_resolve".to_owned(),
+                    args_json: json!({
+                        "approval_request_id": "apr-delegate-always",
+                        "decision": "approve_always"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-approval-resolve".to_owned(),
+                    tool_call_id: "call-approval-resolve".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "approval resolved".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let approval_reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &approval_runtime,
+            None,
+        )
+        .await
+        .expect("approval resolve reply");
+
+    assert!(
+        approval_reply.contains("\"tool\":\"approval_request_resolve\""),
+        "expected raw approval resolve tool output, got: {approval_reply}"
+    );
+
+    let resolved = repo
+        .load_approval_request("apr-delegate-always")
+        .expect("load approval request")
+        .expect("approval request row");
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert_eq!(
+        resolved.decision,
+        Some(crate::session::repository::ApprovalDecision::ApproveAlways)
+    );
+    assert!(
+        repo.load_approval_grant("root-session", "tool:delegate")
+            .expect("load grant")
+            .is_some()
+    );
+
+    let granted_runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "delegating with grant".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "second child task",
+                        "label": "granted-subtask"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-after-grant".to_owned(),
+                    tool_call_id: "call-after-grant".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "granted child output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+
+    let granted_reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &granted_runtime,
+            None,
+        )
+        .await
+        .expect("granted delegate reply");
+
+    assert!(
+        granted_reply.contains("\"tool\":\"delegate\""),
+        "expected raw delegate tool output after stored grant, got: {granted_reply}"
+    );
+    assert!(
+        !granted_reply.contains("[tool_approval_required]"),
+        "grant-backed delegate call should not request approval again, got: {granted_reply}"
+    );
+
+    let requests = repo
+        .list_approval_requests_for_session("root-session", None)
+        .expect("list approval requests");
+    assert_eq!(
+        requests.len(),
+        1,
+        "grant-backed delegate call should not create a second approval request"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_approval_request_resolve_deny_does_not_replay_delegate() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-approval-resolve", "deny")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-delegate-deny".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-delegate-parent".to_owned(),
+        tool_call_id: "call-delegate-parent".to_owned(),
+        tool_name: "delegate".to_owned(),
+        approval_key: "tool:delegate".to_owned(),
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "parent_session_id": Value::Null,
+            "turn_id": "turn-delegate-parent",
+            "tool_call_id": "call-delegate-parent",
+            "tool_name": "delegate",
+            "args_json": {
+                "task": "child task",
+                "label": "research-subtask"
+            },
+            "source": "provider_tool_call",
+            "execution_kind": "app"
+        }),
+        governance_snapshot_json: json!({
+            "governance_scope": "topology_mutation",
+            "risk_class": "high",
+            "approval_mode": "policy_driven",
+            "rule_id": "governed_tool_requires_approval",
+            "reason": "operator approval required before running `delegate`"
+        }),
+    })
+    .expect("seed approval request");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "denying approval".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "approval_request_resolve".to_owned(),
+                    args_json: json!({
+                        "approval_request_id": "apr-delegate-deny",
+                        "decision": "deny"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-approval-deny".to_owned(),
+                    tool_call_id: "call-approval-deny".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "denied".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("approval deny reply");
+
+    assert!(
+        reply.contains("\"tool\":\"approval_request_resolve\""),
+        "expected raw approval resolve tool output, got: {reply}"
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
+
+    let request = repo
+        .load_approval_request("apr-delegate-deny")
+        .expect("load approval request")
+        .expect("approval request row");
+    assert_eq!(
+        request.status,
+        crate::session::repository::ApprovalRequestStatus::Denied
+    );
+    assert_eq!(
+        request.decision,
+        Some(crate::session::repository::ApprovalDecision::Deny)
+    );
+    assert_eq!(
+        request.resolved_by_session_id.as_deref(),
+        Some("root-session")
+    );
+    assert!(request.executed_at.is_none(), "request={request:?}");
+    assert!(request.last_error.is_none(), "request={request:?}");
+    assert!(
+        repo.load_approval_grant("root-session", "tool:delegate")
+            .expect("load grant")
+            .is_none()
+    );
+    assert!(
+        repo.list_visible_sessions("root-session")
+            .expect("list visible sessions")
+            .into_iter()
+            .all(|session| session.parent_session_id.as_deref() != Some("root-session")),
+        "deny should not replay the stored delegate call"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
 async fn handle_turn_with_runtime_delegate_async_queue_failure_rolls_back_child_creation() {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -9369,6 +9369,106 @@ async fn handle_turn_with_runtime_executes_sessions_send_via_default_dispatcher(
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
+async fn handle_turn_with_runtime_requires_approval_before_delegate_execution() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-delegate-approval", "normal-lane")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "delegate".to_owned(),
+                    args_json: json!({
+                        "task": "child task",
+                        "label": "research-subtask"
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "root-session".to_owned(),
+                    turn_id: "turn-delegate-parent".to_owned(),
+                    tool_call_id: "call-delegate-parent".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Child final output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "delegate this task",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            None,
+        )
+        .await
+        .expect("approval reply");
+
+    assert!(
+        reply.contains("[tool_approval_required]"),
+        "expected approval marker, got: {reply}"
+    );
+    assert!(
+        reply.contains("tool: delegate"),
+        "expected delegate tool detail, got: {reply}"
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let requests = repo
+        .list_approval_requests_for_session("root-session", None)
+        .expect("list approval requests");
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].tool_name, "delegate");
+    assert!(
+        reply.contains(requests[0].approval_request_id.as_str()),
+        "reply should surface approval request id, got: {reply}"
+    );
+    assert!(
+        repo.list_visible_sessions("root-session")
+            .expect("list sessions")
+            .into_iter()
+            .all(|session| session.parent_session_id.as_deref() != Some("root-session")),
+        "delegate child session should not be created before approval"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
 async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3,6 +3,8 @@ use std::any::Any;
 use std::collections::BTreeSet;
 #[cfg(feature = "memory-sqlite")]
 use std::panic::AssertUnwindSafe;
+#[cfg(feature = "memory-sqlite")]
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 #[cfg(feature = "memory-sqlite")]
@@ -86,8 +88,10 @@ use crate::session::recovery::{
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
-    CreateSessionWithEventRequest, FinalizeSessionTerminalRequest, NewSessionRecord, SessionKind,
-    SessionRepository, SessionState, TransitionSessionWithEventIfCurrentRequest,
+    ApprovalDecision, ApprovalRequestRecord, ApprovalRequestStatus, CreateSessionWithEventRequest,
+    FinalizeSessionTerminalRequest, NewApprovalGrantRecord, NewSessionRecord, SessionKind,
+    SessionRepository, SessionState, TransitionApprovalRequestIfCurrentRequest,
+    TransitionSessionWithEventIfCurrentRequest,
 };
 
 #[derive(Default)]
@@ -2763,6 +2767,332 @@ async fn apply_resolved_provider_turn<R: ConversationRuntime + ?Sized>(
         .await
 }
 
+fn effective_tool_config_for_session(
+    tool_config: &crate::config::ToolConfig,
+    session_context: &SessionContext,
+) -> crate::config::ToolConfig {
+    let mut tool_config = tool_config.clone();
+    if session_context.parent_session_id.is_some() {
+        tool_config.sessions.visibility = crate::config::SessionVisibility::SelfOnly;
+    }
+    tool_config
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct CoordinatorApprovalResolutionRuntime<'a, R: ?Sized> {
+    config: &'a LoongClawConfig,
+    runtime: &'a R,
+    fallback: &'a DefaultAppToolDispatcher,
+    kernel_ctx: Option<&'a KernelContext>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl<R> CoordinatorApprovalResolutionRuntime<'_, R>
+where
+    R: ConversationRuntime + ?Sized,
+{
+    fn current_epoch_s() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs() as i64)
+            .unwrap_or(0)
+    }
+
+    fn replay_request(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<loongclaw_contracts::ToolCoreRequest, String> {
+        let execution_kind = approval_request
+            .request_payload_json
+            .get("execution_kind")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "approval_request_invalid_payload: missing execution_kind".to_owned())?;
+        if execution_kind != "app" {
+            return Err(format!(
+                "approval_request_invalid_execution_kind: expected `app`, got `{execution_kind}`"
+            ));
+        }
+
+        let tool_name = approval_request
+            .request_payload_json
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| "approval_request_invalid_payload: missing tool_name".to_owned())?;
+        let payload = approval_request
+            .request_payload_json
+            .get("args_json")
+            .cloned()
+            .ok_or_else(|| "approval_request_invalid_payload: missing args_json".to_owned())?;
+
+        Ok(loongclaw_contracts::ToolCoreRequest {
+            tool_name: tool_name.to_owned(),
+            payload,
+        })
+    }
+
+    async fn replay_approved_request(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+        let replay_request = self.replay_request(approval_request)?;
+        let session_context = self
+            .runtime
+            .session_context(self.config, &approval_request.session_id, self.kernel_ctx)
+            .map_err(|error| format!("load approval request session context failed: {error}"))?;
+
+        match crate::tools::canonical_tool_name(replay_request.tool_name.as_str()) {
+            "delegate" => {
+                execute_delegate_tool(
+                    self.config,
+                    self.runtime,
+                    &session_context,
+                    replay_request.payload,
+                    self.kernel_ctx,
+                )
+                .await
+            }
+            "delegate_async" => {
+                execute_delegate_async_tool(
+                    self.config,
+                    self.runtime,
+                    &session_context,
+                    replay_request.payload,
+                )
+                .await
+            }
+            _ => {
+                self.fallback
+                    .execute_app_tool(&session_context, replay_request, self.kernel_ctx)
+                    .await
+            }
+        }
+    }
+
+    async fn execute_approved_request(
+        &self,
+        repo: &SessionRepository,
+        approval_request_id: &str,
+    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
+        let executing = repo
+            .transition_approval_request_if_current(
+                approval_request_id,
+                TransitionApprovalRequestIfCurrentRequest {
+                    expected_status: ApprovalRequestStatus::Approved,
+                    next_status: ApprovalRequestStatus::Executing,
+                    decision: None,
+                    resolved_by_session_id: None,
+                    executed_at: None,
+                    last_error: None,
+                },
+            )?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_not_approved: `{approval_request_id}` is no longer approved"
+                )
+            })?;
+
+        match self.replay_approved_request(&executing).await {
+            Ok(resumed_tool_output) => {
+                let executed = repo
+                    .transition_approval_request_if_current(
+                        approval_request_id,
+                        TransitionApprovalRequestIfCurrentRequest {
+                            expected_status: ApprovalRequestStatus::Executing,
+                            next_status: ApprovalRequestStatus::Executed,
+                            decision: None,
+                            resolved_by_session_id: None,
+                            executed_at: Some(Self::current_epoch_s()),
+                            last_error: None,
+                        },
+                    )?
+                    .ok_or_else(|| {
+                        format!(
+                            "approval_request_not_executing: `{approval_request_id}` is no longer executing"
+                        )
+                    })?;
+                Ok(crate::tools::approval::ApprovalResolutionOutcome {
+                    approval_request: executed,
+                    resumed_tool_output: Some(resumed_tool_output),
+                })
+            }
+            Err(error) => {
+                let _ = repo.transition_approval_request_if_current(
+                    approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Executing,
+                        next_status: ApprovalRequestStatus::Executed,
+                        decision: None,
+                        resolved_by_session_id: None,
+                        executed_at: Some(Self::current_epoch_s()),
+                        last_error: Some(error.clone()),
+                    },
+                )?;
+                Err(error)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl<R> crate::tools::approval::ApprovalResolutionRuntime
+    for CoordinatorApprovalResolutionRuntime<'_, R>
+where
+    R: ConversationRuntime + ?Sized,
+{
+    async fn resolve_approval_request(
+        &self,
+        request: crate::tools::approval::ApprovalResolutionRequest,
+    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&self.config.memory);
+        let repo = SessionRepository::new(&memory_config)?;
+        let approval_request = repo
+            .load_approval_request(&request.approval_request_id)?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_not_found: `{}`",
+                    request.approval_request_id
+                )
+            })?;
+
+        let is_visible = match request.visibility {
+            crate::config::SessionVisibility::SelfOnly => {
+                request.current_session_id == approval_request.session_id
+            }
+            crate::config::SessionVisibility::Children => {
+                request.current_session_id == approval_request.session_id
+                    || repo.is_session_visible(
+                        &request.current_session_id,
+                        &approval_request.session_id,
+                    )?
+            }
+        };
+        if !is_visible {
+            return Err(format!(
+                "visibility_denied: session `{}` is not visible from `{}`",
+                approval_request.session_id, request.current_session_id
+            ));
+        }
+
+        match request.decision {
+            ApprovalDecision::Deny => {
+                let resolved = match repo.transition_approval_request_if_current(
+                    &request.approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Pending,
+                        next_status: ApprovalRequestStatus::Denied,
+                        decision: Some(ApprovalDecision::Deny),
+                        resolved_by_session_id: Some(request.current_session_id.clone()),
+                        executed_at: None,
+                        last_error: None,
+                    },
+                )? {
+                    Some(resolved) => resolved,
+                    None => {
+                        let latest = repo
+                            .load_approval_request(&request.approval_request_id)?
+                            .ok_or_else(|| {
+                                format!(
+                                    "approval_request_not_found: `{}`",
+                                    request.approval_request_id
+                                )
+                            })?;
+                        return Err(format!(
+                            "approval_request_not_pending: `{}` is already {}",
+                            request.approval_request_id,
+                            latest.status.as_str()
+                        ));
+                    }
+                };
+                Ok(crate::tools::approval::ApprovalResolutionOutcome {
+                    approval_request: resolved,
+                    resumed_tool_output: None,
+                })
+            }
+            ApprovalDecision::ApproveOnce => {
+                let approved = match repo.transition_approval_request_if_current(
+                    &request.approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Pending,
+                        next_status: ApprovalRequestStatus::Approved,
+                        decision: Some(ApprovalDecision::ApproveOnce),
+                        resolved_by_session_id: Some(request.current_session_id.clone()),
+                        executed_at: None,
+                        last_error: None,
+                    },
+                )? {
+                    Some(approved) => approved,
+                    None => {
+                        let latest = repo
+                            .load_approval_request(&request.approval_request_id)?
+                            .ok_or_else(|| {
+                                format!(
+                                    "approval_request_not_found: `{}`",
+                                    request.approval_request_id
+                                )
+                            })?;
+                        return Err(format!(
+                            "approval_request_not_pending: `{}` is already {}",
+                            request.approval_request_id,
+                            latest.status.as_str()
+                        ));
+                    }
+                };
+                let _ = approved;
+                self.execute_approved_request(&repo, &request.approval_request_id)
+                    .await
+            }
+            ApprovalDecision::ApproveAlways => {
+                let approved = match repo.transition_approval_request_if_current(
+                    &request.approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Pending,
+                        next_status: ApprovalRequestStatus::Approved,
+                        decision: Some(ApprovalDecision::ApproveAlways),
+                        resolved_by_session_id: Some(request.current_session_id.clone()),
+                        executed_at: None,
+                        last_error: None,
+                    },
+                )? {
+                    Some(approved) => approved,
+                    None => {
+                        let latest = repo
+                            .load_approval_request(&request.approval_request_id)?
+                            .ok_or_else(|| {
+                                format!(
+                                    "approval_request_not_found: `{}`",
+                                    request.approval_request_id
+                                )
+                            })?;
+                        return Err(format!(
+                            "approval_request_not_pending: `{}` is already {}",
+                            request.approval_request_id,
+                            latest.status.as_str()
+                        ));
+                    }
+                };
+                let grant_scope_session_id = repo
+                    .lineage_root_session_id(&approved.session_id)?
+                    .ok_or_else(|| {
+                        format!(
+                            "approval_request_session_not_found: `{}`",
+                            approved.session_id
+                        )
+                    })?;
+                repo.upsert_approval_grant(NewApprovalGrantRecord {
+                    scope_session_id: grant_scope_session_id,
+                    approval_key: approved.approval_key.clone(),
+                    created_by_session_id: Some(request.current_session_id.clone()),
+                })?;
+                self.execute_approved_request(&repo, &request.approval_request_id)
+                    .await
+            }
+        }
+    }
+}
+
 struct CoordinatorAppToolDispatcher<'a, R: ?Sized> {
     config: &'a LoongClawConfig,
     runtime: &'a R,
@@ -2793,6 +3123,36 @@ where
         kernel_ctx: Option<&KernelContext>,
     ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
         match crate::tools::canonical_tool_name(request.tool_name.as_str()) {
+            "approval_request_resolve" => {
+                #[cfg(not(feature = "memory-sqlite"))]
+                {
+                    let _ = (session_context, kernel_ctx);
+                    Err("approval tools require sqlite memory support (enable feature `memory-sqlite`)"
+                        .to_owned())
+                }
+
+                #[cfg(feature = "memory-sqlite")]
+                {
+                    let memory_config =
+                        MemoryRuntimeConfig::from_memory_config(&self.config.memory);
+                    let effective_tool_config =
+                        effective_tool_config_for_session(&self.config.tools, session_context);
+                    let approval_runtime = CoordinatorApprovalResolutionRuntime {
+                        config: self.config,
+                        runtime: self.runtime,
+                        fallback: self.fallback,
+                        kernel_ctx,
+                    };
+                    crate::tools::approval::execute_approval_tool_with_runtime_support(
+                        request,
+                        &session_context.session_id,
+                        &memory_config,
+                        &effective_tool_config,
+                        Some(&approval_runtime),
+                    )
+                    .await
+                }
+            }
             "delegate" => {
                 execute_delegate_tool(
                     self.config,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -76,8 +76,8 @@ use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ReplyResolutionMode, ToolDrivenFollowupKind,
     ToolDrivenFollowupPayload, ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase,
     build_tool_driven_followup_tail, decide_provider_turn_request_action,
-    request_completion_with_raw_fallback, tool_result_contains_truncation_signal,
-    user_requested_raw_tool_output,
+    format_approval_required_reply, request_completion_with_raw_fallback,
+    tool_result_contains_truncation_signal, user_requested_raw_tool_output,
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::session::recovery::{
@@ -963,6 +963,7 @@ struct TurnLaneExecutionSnapshot {
 #[serde(rename_all = "snake_case")]
 enum TurnCheckpointResultKind {
     FinalText,
+    NeedsApproval,
     ToolDenied,
     ToolError,
     ProviderError,
@@ -2127,6 +2128,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
 fn turn_checkpoint_result_kind(result: &TurnResult) -> TurnCheckpointResultKind {
     match result {
         TurnResult::FinalText(_) => TurnCheckpointResultKind::FinalText,
+        TurnResult::NeedsApproval(_) => TurnCheckpointResultKind::NeedsApproval,
         TurnResult::ToolDenied(_) => TurnCheckpointResultKind::ToolDenied,
         TurnResult::ToolError(_) => TurnCheckpointResultKind::ToolError,
         TurnResult::ProviderError(_) => TurnCheckpointResultKind::ProviderError,
@@ -5043,6 +5045,9 @@ async fn execute_single_tool_intent(
         .await
     {
         TurnResult::FinalText(output) => Ok(output),
+        TurnResult::NeedsApproval(requirement) => Err(PlanNodeError::policy_denied(
+            format_approval_required_reply("", &requirement),
+        )),
         TurnResult::ToolDenied(failure) => Err(PlanNodeError::policy_denied(failure.reason)),
         TurnResult::ToolError(failure) => Err(PlanNodeError {
             kind: match failure.kind {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2774,6 +2774,18 @@ impl<R> AppToolDispatcher for CoordinatorAppToolDispatcher<'_, R>
 where
     R: ConversationRuntime + ?Sized,
 {
+    async fn maybe_require_approval(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<Option<super::turn_engine::ApprovalRequirement>, String> {
+        self.fallback
+            .maybe_require_approval(session_context, intent, descriptor, kernel_ctx)
+            .await
+    }
+
     async fn execute_app_tool(
         &self,
         session_context: &SessionContext,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -20,8 +20,8 @@ use crate::session::repository::{
 };
 use crate::tools::{
     ToolApprovalMode, ToolExecutionKind, ToolView, delegate_child_tool_view_for_config,
-    delegate_child_tool_view_for_config_with_delegate, runtime_tool_view,
-    governance_profile_for_descriptor, runtime_tool_view_for_config, tool_catalog,
+    delegate_child_tool_view_for_config_with_delegate, governance_profile_for_descriptor,
+    runtime_tool_view, runtime_tool_view_for_config, tool_catalog,
 };
 
 use super::runtime::SessionContext;
@@ -501,7 +501,10 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
 
             let approval_request_id =
                 governed_approval_request_id(session_context, descriptor.name, intent);
-            let reason = format!("operator approval required before running `{}`", descriptor.name);
+            let reason = format!(
+                "operator approval required before running `{}`",
+                descriptor.name
+            );
             let rule_id = "governed_tool_requires_approval";
             let request_payload_json = json!({
                 "session_id": session_context.session_id,
@@ -524,7 +527,7 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                 "reason": reason,
             });
             let stored = repo.ensure_approval_request(NewApprovalRequestRecord {
-                approval_request_id: approval_request_id.clone(),
+                approval_request_id,
                 session_id: session_context.session_id.clone(),
                 turn_id: intent.turn_id.clone(),
                 tool_call_id: intent.tool_call_id.clone(),
@@ -992,7 +995,12 @@ mod tests {
                     .approval_request_id
                     .expect("approval request id should be present")
             }
-            other => panic!("expected NeedsApproval, got {other:?}"),
+            other @ TurnResult::FinalText(_)
+            | other @ TurnResult::ToolDenied(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_) => {
+                panic!("expected NeedsApproval, got {other:?}")
+            }
         };
 
         let stored = repo
@@ -1037,13 +1045,23 @@ mod tests {
             TurnResult::NeedsApproval(requirement) => requirement
                 .approval_request_id
                 .expect("first approval request id"),
-            other => panic!("expected first NeedsApproval, got {other:?}"),
+            other @ TurnResult::FinalText(_)
+            | other @ TurnResult::ToolDenied(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_) => {
+                panic!("expected first NeedsApproval, got {other:?}")
+            }
         };
         let second_request_id = match second {
             TurnResult::NeedsApproval(requirement) => requirement
                 .approval_request_id
                 .expect("second approval request id"),
-            other => panic!("expected second NeedsApproval, got {other:?}"),
+            other @ TurnResult::FinalText(_)
+            | other @ TurnResult::ToolDenied(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_) => {
+                panic!("expected second NeedsApproval, got {other:?}")
+            }
         };
 
         assert_eq!(first_request_id, second_request_id);

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -8,16 +8,20 @@ use loongclaw_contracts::{
     Capability, KernelError, ToolCoreOutcome, ToolCoreRequest, ToolPlaneError,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
 
-use crate::config::{LoongClawConfig, SessionVisibility, ToolConfig};
+use crate::config::{GovernedToolApprovalMode, LoongClawConfig, SessionVisibility, ToolConfig};
 use crate::context::KernelContext;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
-use crate::session::repository::{SessionKind, SessionRepository};
+use crate::session::repository::{
+    NewApprovalRequestRecord, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+};
 use crate::tools::{
-    ToolExecutionKind, ToolView, delegate_child_tool_view_for_config,
+    ToolApprovalMode, ToolExecutionKind, ToolView, delegate_child_tool_view_for_config,
     delegate_child_tool_view_for_config_with_delegate, runtime_tool_view,
-    runtime_tool_view_for_config, tool_catalog,
+    governance_profile_for_descriptor, runtime_tool_view_for_config, tool_catalog,
 };
 
 use super::runtime::SessionContext;
@@ -54,6 +58,42 @@ pub struct ToolOutcome {
     pub error_code: Option<String>,
     pub human_reason: Option<String>,
     pub audit_event_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalRequirementKind {
+    KernelContextRequired,
+    GovernedTool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalRequirement {
+    pub kind: ApprovalRequirementKind,
+    pub reason: String,
+    pub rule_id: String,
+    pub tool_name: Option<String>,
+    pub approval_key: Option<String>,
+    pub approval_request_id: Option<String>,
+}
+
+impl ApprovalRequirement {
+    pub fn governed_tool(
+        tool_name: impl Into<String>,
+        approval_key: impl Into<String>,
+        reason: impl Into<String>,
+        rule_id: impl Into<String>,
+        approval_request_id: Option<String>,
+    ) -> Self {
+        Self {
+            kind: ApprovalRequirementKind::GovernedTool,
+            reason: reason.into(),
+            rule_id: rule_id.into(),
+            tool_name: Some(tool_name.into()),
+            approval_key: Some(approval_key.into()),
+            approval_request_id,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -146,6 +186,7 @@ impl fmt::Display for TurnFailure {
 #[derive(Debug, Clone)]
 pub enum TurnResult {
     FinalText(String),
+    NeedsApproval(ApprovalRequirement),
     ToolDenied(TurnFailure),
     ToolError(TurnFailure),
     ProviderError(TurnFailure),
@@ -170,7 +211,7 @@ impl TurnResult {
 
     pub fn failure(&self) -> Option<&TurnFailure> {
         match self {
-            TurnResult::FinalText(_) => None,
+            TurnResult::FinalText(_) | TurnResult::NeedsApproval(_) => None,
             TurnResult::ToolDenied(failure)
             | TurnResult::ToolError(failure)
             | TurnResult::ProviderError(failure) => Some(failure),
@@ -200,6 +241,16 @@ pub(crate) fn classify_kernel_error(error: &KernelError) -> KernelFailureClass {
 
 #[async_trait]
 pub trait AppToolDispatcher: Send + Sync {
+    async fn maybe_require_approval(
+        &self,
+        _session_context: &SessionContext,
+        _intent: &ToolIntent,
+        _descriptor: &crate::tools::ToolDescriptor,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> Result<Option<ApprovalRequirement>, String> {
+        Ok(None)
+    }
+
     async fn execute_app_tool(
         &self,
         session_context: &SessionContext,
@@ -321,6 +372,46 @@ impl DefaultAppToolDispatcher {
         )
         .await
     }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn lineage_root_session_id(
+        repo: &SessionRepository,
+        session_context: &SessionContext,
+    ) -> Result<String, String> {
+        let mut current_session_id = session_context.session_id.clone();
+        let mut visited = BTreeSet::new();
+
+        loop {
+            if !visited.insert(current_session_id.clone()) {
+                return Err(format!(
+                    "session_lineage_cycle_detected: `{current_session_id}` reappeared while resolving approval grant scope"
+                ));
+            }
+            let Some(session) = repo.load_session(&current_session_id)? else {
+                return Ok(current_session_id);
+            };
+            match session.parent_session_id {
+                Some(parent_session_id) => current_session_id = parent_session_id,
+                None => return Ok(current_session_id),
+            }
+        }
+    }
+}
+
+fn governed_approval_request_id(
+    session_context: &SessionContext,
+    tool_name: &str,
+    intent: &ToolIntent,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(session_context.session_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(intent.turn_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(intent.tool_call_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(tool_name.as_bytes());
+    format!("apr_{:x}", hasher.finalize())
 }
 
 impl Default for DefaultAppToolDispatcher {
@@ -331,6 +422,128 @@ impl Default for DefaultAppToolDispatcher {
 
 #[async_trait]
 impl AppToolDispatcher for DefaultAppToolDispatcher {
+    async fn maybe_require_approval(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+        _kernel_ctx: Option<&KernelContext>,
+    ) -> Result<Option<ApprovalRequirement>, String> {
+        #[cfg(not(feature = "memory-sqlite"))]
+        {
+            let _ = (session_context, intent, descriptor);
+            Ok(None)
+        }
+
+        #[cfg(feature = "memory-sqlite")]
+        {
+            let governance = governance_profile_for_descriptor(descriptor);
+            if descriptor.execution_kind != ToolExecutionKind::App
+                || governance.approval_mode != ToolApprovalMode::PolicyDriven
+            {
+                return Ok(None);
+            }
+
+            let requires_approval = match self.tool_config.approval.mode {
+                GovernedToolApprovalMode::Disabled => false,
+                GovernedToolApprovalMode::MediumBalanced => {
+                    governance.risk_class == crate::tools::ToolRiskClass::High
+                }
+                GovernedToolApprovalMode::Strict => true,
+            };
+            if !requires_approval {
+                return Ok(None);
+            }
+
+            let approval_key = format!("tool:{}", descriptor.name);
+            if self
+                .tool_config
+                .approval
+                .approved_calls
+                .iter()
+                .any(|entry| entry == &approval_key)
+            {
+                return Ok(None);
+            }
+            if self
+                .tool_config
+                .approval
+                .denied_calls
+                .iter()
+                .any(|entry| entry == &approval_key)
+            {
+                return Err(format!(
+                    "app_tool_denied: governed tool `{approval_key}` is denied by approval policy"
+                ));
+            }
+
+            let repo = SessionRepository::new(&self.memory_config)?;
+            let kind = if session_context.parent_session_id.is_some() {
+                SessionKind::DelegateChild
+            } else {
+                SessionKind::Root
+            };
+            let _ = repo.ensure_session(NewSessionRecord {
+                session_id: session_context.session_id.clone(),
+                kind,
+                parent_session_id: session_context.parent_session_id.clone(),
+                label: None,
+                state: SessionState::Ready,
+            })?;
+
+            let scope_session_id = Self::lineage_root_session_id(&repo, session_context)?;
+            if repo
+                .load_approval_grant(&scope_session_id, &approval_key)?
+                .is_some()
+            {
+                return Ok(None);
+            }
+
+            let approval_request_id =
+                governed_approval_request_id(session_context, descriptor.name, intent);
+            let reason = format!("operator approval required before running `{}`", descriptor.name);
+            let rule_id = "governed_tool_requires_approval";
+            let request_payload_json = json!({
+                "session_id": session_context.session_id,
+                "parent_session_id": session_context.parent_session_id,
+                "turn_id": intent.turn_id,
+                "tool_call_id": intent.tool_call_id,
+                "tool_name": descriptor.name,
+                "args_json": intent.args_json,
+                "source": intent.source,
+                "execution_kind": match descriptor.execution_kind {
+                    ToolExecutionKind::Core => "core",
+                    ToolExecutionKind::App => "app",
+                },
+            });
+            let governance_snapshot_json = json!({
+                "governance_scope": governance.scope.as_str(),
+                "risk_class": governance.risk_class.as_str(),
+                "approval_mode": governance.approval_mode.as_str(),
+                "rule_id": rule_id,
+                "reason": reason,
+            });
+            let stored = repo.ensure_approval_request(NewApprovalRequestRecord {
+                approval_request_id: approval_request_id.clone(),
+                session_id: session_context.session_id.clone(),
+                turn_id: intent.turn_id.clone(),
+                tool_call_id: intent.tool_call_id.clone(),
+                tool_name: descriptor.name.to_owned(),
+                approval_key: approval_key.clone(),
+                request_payload_json,
+                governance_snapshot_json,
+            })?;
+
+            Ok(Some(ApprovalRequirement::governed_tool(
+                descriptor.name,
+                approval_key,
+                reason,
+                rule_id,
+                Some(stored.approval_request_id),
+            )))
+        }
+    }
+
     async fn execute_app_tool(
         &self,
         session_context: &SessionContext,
@@ -625,30 +838,52 @@ impl TurnEngine {
                         }
                     }
                 }
-                ToolExecutionKind::App => match app_dispatcher
-                    .execute_app_tool(session_context, request, kernel_ctx)
-                    .await
-                {
-                    Ok(outcome) => outcome,
-                    Err(reason) if reason.starts_with("tool_not_visible:") => {
-                        return TurnResult::policy_denied("tool_not_visible", reason);
-                    }
-                    Err(reason)
-                        if reason.starts_with("tool_not_found:")
-                            || reason.starts_with("app_tool_not_found:") =>
+                ToolExecutionKind::App => {
+                    match app_dispatcher
+                        .maybe_require_approval(session_context, intent, descriptor, kernel_ctx)
+                        .await
                     {
-                        return TurnResult::policy_denied("tool_not_found", reason);
+                        Ok(Some(requirement)) => return TurnResult::NeedsApproval(requirement),
+                        Ok(None) => {}
+                        Err(reason) if reason.starts_with("app_tool_denied:") => {
+                            return TurnResult::policy_denied("app_tool_denied", reason);
+                        }
+                        Err(reason) => {
+                            return TurnResult::non_retryable_tool_error(
+                                "app_tool_preflight_failed",
+                                reason,
+                            );
+                        }
                     }
-                    Err(reason) if reason.starts_with("app_tool_disabled:") => {
-                        return TurnResult::policy_denied("app_tool_disabled", reason);
+
+                    match app_dispatcher
+                        .execute_app_tool(session_context, request, kernel_ctx)
+                        .await
+                    {
+                        Ok(outcome) => outcome,
+                        Err(reason) if reason.starts_with("tool_not_visible:") => {
+                            return TurnResult::policy_denied("tool_not_visible", reason);
+                        }
+                        Err(reason)
+                            if reason.starts_with("tool_not_found:")
+                                || reason.starts_with("app_tool_not_found:") =>
+                        {
+                            return TurnResult::policy_denied("tool_not_found", reason);
+                        }
+                        Err(reason) if reason.starts_with("app_tool_disabled:") => {
+                            return TurnResult::policy_denied("app_tool_disabled", reason);
+                        }
+                        Err(reason) if reason.starts_with("app_tool_denied:") => {
+                            return TurnResult::policy_denied("app_tool_denied", reason);
+                        }
+                        Err(reason) => {
+                            return TurnResult::non_retryable_tool_error(
+                                "app_tool_execution_failed",
+                                reason,
+                            );
+                        }
                     }
-                    Err(reason) => {
-                        return TurnResult::non_retryable_tool_error(
-                            "app_tool_execution_failed",
-                            reason,
-                        );
-                    }
-                },
+                }
             };
 
             outputs.push(format_tool_result_line_with_limit(
@@ -669,4 +904,154 @@ fn session_context_from_turn(turn: &ProviderTurn, tool_view: ToolView) -> Sessio
         .map(|intent| intent.session_id.as_str())
         .unwrap_or("default");
     SessionContext::root_with_tool_view(session_id, tool_view)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::config::{GovernedToolApprovalMode, ToolConfig};
+    use crate::session::repository::{
+        ApprovalRequestStatus, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    };
+
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        let base = std::env::temp_dir().join(format!(
+            "loongclaw-turn-engine-approval-{test_name}-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&base);
+        let db_path = base.join("memory.sqlite3");
+        let _ = fs::remove_file(&db_path);
+        MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+            ..MemoryRuntimeConfig::default()
+        }
+    }
+
+    fn delegate_async_turn(session_id: &str, turn_id: &str, tool_call_id: &str) -> ProviderTurn {
+        ProviderTurn {
+            assistant_text: "queueing child delegate".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "delegate_async".to_owned(),
+                args_json: json!({
+                    "task": "inspect the child task"
+                }),
+                source: "assistant".to_owned(),
+                session_id: session_id.to_owned(),
+                turn_id: turn_id.to_owned(),
+                tool_call_id: tool_call_id.to_owned(),
+            }],
+            raw_meta: json!({}),
+        }
+    }
+
+    #[tokio::test]
+    async fn governed_tool_approval_request_is_persisted_for_delegate_async() {
+        let memory_config = isolated_memory_config("persist");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let mut tool_config = ToolConfig::default();
+        tool_config.approval.mode = GovernedToolApprovalMode::Strict;
+        let tool_view = runtime_tool_view_for_config(&tool_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &delegate_async_turn("root-session", "turn-1", "call-1"),
+                &session_context,
+                &dispatcher,
+                None,
+            )
+            .await;
+
+        let approval_request_id = match result {
+            TurnResult::NeedsApproval(requirement) => {
+                assert_eq!(requirement.tool_name.as_deref(), Some("delegate_async"));
+                assert_eq!(
+                    requirement.approval_key.as_deref(),
+                    Some("tool:delegate_async")
+                );
+                assert_eq!(
+                    requirement.rule_id.as_str(),
+                    "governed_tool_requires_approval"
+                );
+                requirement
+                    .approval_request_id
+                    .expect("approval request id should be present")
+            }
+            other => panic!("expected NeedsApproval, got {other:?}"),
+        };
+
+        let stored = repo
+            .load_approval_request(&approval_request_id)
+            .expect("load approval request")
+            .expect("approval request row");
+        assert_eq!(stored.status, ApprovalRequestStatus::Pending);
+        assert_eq!(stored.tool_name, "delegate_async");
+        assert_eq!(stored.tool_call_id, "call-1");
+        assert_eq!(stored.turn_id, "turn-1");
+        assert_eq!(stored.approval_key, "tool:delegate_async");
+    }
+
+    #[tokio::test]
+    async fn governed_tool_approval_request_reuses_deterministic_id_for_same_blocked_call() {
+        let memory_config = isolated_memory_config("reuse");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let mut tool_config = ToolConfig::default();
+        tool_config.approval.mode = GovernedToolApprovalMode::Strict;
+        let tool_view = runtime_tool_view_for_config(&tool_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+        let turn = delegate_async_turn("root-session", "turn-reuse", "call-reuse");
+
+        let first = TurnEngine::new(4)
+            .execute_turn_in_context(&turn, &session_context, &dispatcher, None)
+            .await;
+        let second = TurnEngine::new(4)
+            .execute_turn_in_context(&turn, &session_context, &dispatcher, None)
+            .await;
+
+        let first_request_id = match first {
+            TurnResult::NeedsApproval(requirement) => requirement
+                .approval_request_id
+                .expect("first approval request id"),
+            other => panic!("expected first NeedsApproval, got {other:?}"),
+        };
+        let second_request_id = match second {
+            TurnResult::NeedsApproval(requirement) => requirement
+                .approval_request_id
+                .expect("second approval request id"),
+            other => panic!("expected second NeedsApproval, got {other:?}"),
+        };
+
+        assert_eq!(first_request_id, second_request_id);
+
+        let requests = repo
+            .list_approval_requests_for_session("root-session", None)
+            .expect("list approval requests");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].approval_request_id, first_request_id);
+    }
 }

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -553,6 +553,16 @@ fn tool_round_outcome(turn_result: &TurnResult) -> Option<ToolRoundOutcome> {
             fingerprint: text_fingerprint("tool_final_text", text),
             failed: false,
         }),
+        TurnResult::NeedsApproval(requirement) => Some(ToolRoundOutcome {
+            fingerprint: text_fingerprint(
+                "tool_approval_required",
+                requirement
+                    .approval_request_id
+                    .as_deref()
+                    .unwrap_or(requirement.reason.as_str()),
+            ),
+            failed: false,
+        }),
         TurnResult::ToolDenied(reason) => Some(ToolRoundOutcome {
             fingerprint: text_fingerprint("tool_denied", reason),
             failed: true,

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -2,7 +2,7 @@ use super::super::config::LoongClawConfig;
 use super::ProviderErrorMode;
 use super::persistence::format_provider_error_reply;
 use super::runtime::ConversationRuntime;
-use super::turn_engine::{ProviderTurn, TurnResult};
+use super::turn_engine::{ApprovalRequirement, ApprovalRequirementKind, ProviderTurn, TurnResult};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -193,6 +193,10 @@ impl<'a> ToolDrivenReplyKernel<'a> {
                 self.assistant_preface,
                 text.as_str(),
             ])),
+            TurnResult::NeedsApproval(requirement) => Some(format_approval_required_reply(
+                self.assistant_preface,
+                requirement,
+            )),
             TurnResult::ToolDenied(failure) | TurnResult::ToolError(failure) => {
                 Some(join_non_empty_lines(&[
                     self.assistant_preface,
@@ -211,6 +215,7 @@ impl<'a> ToolDrivenReplyKernel<'a> {
             TurnResult::FinalText(text) => {
                 Some(ToolDrivenFollowupPayload::ToolResult { text: text.clone() })
             }
+            TurnResult::NeedsApproval(_) => None,
             TurnResult::ToolDenied(failure) | TurnResult::ToolError(failure) => {
                 Some(ToolDrivenFollowupPayload::ToolFailure {
                     reason: failure.reason.clone(),
@@ -265,6 +270,9 @@ pub fn compose_assistant_reply(
                 text
             }
         }
+        TurnResult::NeedsApproval(requirement) => {
+            format_approval_required_reply(assistant_preface, &requirement)
+        }
         TurnResult::ToolDenied(failure) => {
             join_non_empty_lines(&[assistant_preface, failure.reason.as_str()])
         }
@@ -276,6 +284,34 @@ pub fn compose_assistant_reply(
             join_non_empty_lines(&[assistant_preface, inline.as_str()])
         }
     }
+}
+
+pub fn format_approval_required_reply(
+    assistant_preface: &str,
+    requirement: &ApprovalRequirement,
+) -> String {
+    let mut lines = Vec::new();
+    let marker = match requirement.kind {
+        ApprovalRequirementKind::GovernedTool => "[tool_approval_required]",
+        ApprovalRequirementKind::KernelContextRequired => "[approval_required]",
+    };
+    lines.push(marker.to_owned());
+    if let Some(tool_name) = requirement.tool_name.as_deref() {
+        lines.push(format!("tool: {tool_name}"));
+    }
+    if let Some(request_id) = requirement.approval_request_id.as_deref() {
+        lines.push(format!("request_id: {request_id}"));
+    }
+    if let Some(approval_key) = requirement.approval_key.as_deref() {
+        lines.push(format!("approval_key: {approval_key}"));
+    }
+    lines.push(format!("rule_id: {}", requirement.rule_id));
+    lines.push(format!("reason: {}", requirement.reason));
+    if requirement.kind == ApprovalRequirementKind::GovernedTool {
+        lines.push("allowed_decisions: approve_once, approve_always, deny".to_owned());
+    }
+    let body = lines.join("\n");
+    join_non_empty_lines(&[assistant_preface, body.as_str()])
 }
 
 pub fn tool_result_contains_truncation_signal(tool_result_text: &str) -> bool {
@@ -608,7 +644,9 @@ fn parse_external_skill_invoke_context_line(line: &str) -> Option<ExternalSkillI
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::conversation::turn_engine::{TurnFailure, TurnResult};
+    use crate::conversation::turn_engine::{
+        ApprovalRequirement, ApprovalRequirementKind, TurnFailure, TurnResult,
+    };
     use serde_json::json;
 
     #[test]
@@ -628,6 +666,29 @@ mod tests {
             TurnResult::ToolError(TurnFailure::retryable("tool_error", "temporary failure")),
         );
         assert_eq!(reply, "preface\ntemporary failure");
+    }
+
+    #[test]
+    fn compose_assistant_reply_formats_governed_tool_approval_requirement() {
+        let reply = compose_assistant_reply(
+            "preface",
+            true,
+            TurnResult::NeedsApproval(ApprovalRequirement {
+                kind: ApprovalRequirementKind::GovernedTool,
+                reason: "operator approval required for governed tool".to_owned(),
+                rule_id: "governed_tool_requires_approval".to_owned(),
+                tool_name: Some("delegate_async".to_owned()),
+                approval_key: Some("tool:delegate_async".to_owned()),
+                approval_request_id: Some("apr_123".to_owned()),
+            }),
+        );
+
+        assert!(reply.contains("[tool_approval_required]"));
+        assert!(reply.contains("delegate_async"));
+        assert!(reply.contains("apr_123"));
+        assert!(reply.contains("approve_once"));
+        assert!(reply.contains("approve_always"));
+        assert!(reply.contains("deny"));
     }
 
     #[test]
@@ -846,6 +907,29 @@ mod tests {
                 payload: ToolDrivenFollowupPayload::ToolFailure {
                     reason: "temporary failure".to_owned(),
                 },
+            }
+        );
+    }
+
+    #[test]
+    fn tool_driven_reply_phase_finalizes_approval_requirement_directly() {
+        let result = TurnResult::NeedsApproval(ApprovalRequirement {
+            kind: ApprovalRequirementKind::GovernedTool,
+            reason: "operator approval required for governed tool".to_owned(),
+            rule_id: "governed_tool_requires_approval".to_owned(),
+            tool_name: Some("delegate_async".to_owned()),
+            approval_key: Some("tool:delegate_async".to_owned()),
+            approval_request_id: Some("apr_direct".to_owned()),
+        });
+        let phase = ToolDrivenReplyPhase::new("preface", true, false, &result);
+
+        assert_eq!(phase.resolution_mode(), ReplyResolutionMode::Direct);
+        assert_eq!(phase.followup_kind(), None);
+        assert_eq!(phase.raw_reply(), Some("preface\n[tool_approval_required]\ntool: delegate_async\nrequest_id: apr_direct\napproval_key: tool:delegate_async\nrule_id: governed_tool_requires_approval\nreason: operator approval required for governed tool\nallowed_decisions: approve_once, approve_always, deny"));
+        assert_eq!(
+            phase.decision(),
+            &ToolDrivenReplyBaseDecision::FinalizeDirect {
+                reply: "preface\n[tool_approval_required]\ntool: delegate_async\nrequest_id: apr_direct\napproval_key: tool:delegate_async\nrule_id: governed_tool_requires_approval\nreason: operator approval required for governed tool\nallowed_decisions: approve_once, approve_always, deny".to_owned(),
             }
         );
     }

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -925,7 +925,12 @@ mod tests {
 
         assert_eq!(phase.resolution_mode(), ReplyResolutionMode::Direct);
         assert_eq!(phase.followup_kind(), None);
-        assert_eq!(phase.raw_reply(), Some("preface\n[tool_approval_required]\ntool: delegate_async\nrequest_id: apr_direct\napproval_key: tool:delegate_async\nrule_id: governed_tool_requires_approval\nreason: operator approval required for governed tool\nallowed_decisions: approve_once, approve_always, deny"));
+        assert_eq!(
+            phase.raw_reply(),
+            Some(
+                "preface\n[tool_approval_required]\ntool: delegate_async\nrequest_id: apr_direct\napproval_key: tool:delegate_async\nrule_id: governed_tool_requires_approval\nreason: operator approval required for governed tool\nallowed_decisions: approve_once, approve_always, deny"
+            )
+        );
         assert_eq!(
             phase.decision(),
             &ToolDrivenReplyBaseDecision::FinalizeDirect {

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -102,8 +102,8 @@ impl PromptWindowQueryDiagnostics {
 }
 
 const SUMMARY_FORMAT_VERSION: i64 = 1;
-const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 3;
-const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 6;
+const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 4;
+const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 9;
 const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
 const SQLITE_PREPARED_STATEMENT_CACHE_CAPACITY: usize = 16;
 const SQL_INSERT_TURN: &str = "INSERT INTO turns(session_id, session_turn_index, role, content, ts) VALUES (?1, ?2, ?3, ?4, ?5)";
@@ -141,11 +141,14 @@ const SQL_COUNT_CURRENT_SCHEMA_OBJECTS: &str = "SELECT COUNT(*)
                         'turns',
                         'memory_session_state',
                         'memory_summary_checkpoints',
-                        'memory_summary_checkpoint_bodies'
+                        'memory_summary_checkpoint_bodies',
+                        'approval_requests',
+                        'approval_grants'
                     ))
                 OR (type = 'index' AND name IN (
                         'idx_turns_session_id',
-                        'idx_turns_session_turn_index'
+                        'idx_turns_session_turn_index',
+                        'idx_approval_requests_session_status_requested_at'
                     ))";
 const SQL_QUERY_RECENT_PROMPT_TURNS_WITH_CHECKPOINT_META: &str = "SELECT turns.id,
              turns.role,
@@ -999,6 +1002,33 @@ fn open_sqlite_connection_with_diagnostics(
                 REFERENCES memory_summary_checkpoints(session_id) ON DELETE CASCADE,
               summary_body TEXT NOT NULL
             );
+            CREATE TABLE IF NOT EXISTS approval_requests(
+              approval_request_id TEXT PRIMARY KEY,
+              session_id TEXT NOT NULL,
+              turn_id TEXT NOT NULL,
+              tool_call_id TEXT NOT NULL,
+              tool_name TEXT NOT NULL,
+              approval_key TEXT NOT NULL,
+              status TEXT NOT NULL,
+              decision TEXT NULL,
+              request_payload_json TEXT NOT NULL,
+              governance_snapshot_json TEXT NOT NULL,
+              requested_at INTEGER NOT NULL,
+              resolved_at INTEGER NULL,
+              resolved_by_session_id TEXT NULL,
+              executed_at INTEGER NULL,
+              last_error TEXT NULL
+            );
+            CREATE TABLE IF NOT EXISTS approval_grants(
+              scope_session_id TEXT NOT NULL,
+              approval_key TEXT NOT NULL,
+              created_by_session_id TEXT NULL,
+              created_at INTEGER NOT NULL,
+              updated_at INTEGER NOT NULL,
+              PRIMARY KEY(scope_session_id, approval_key)
+            );
+            CREATE INDEX IF NOT EXISTS idx_approval_requests_session_status_requested_at
+              ON approval_requests(session_id, status, requested_at DESC, approval_request_id);
             ",
         )
         .map_err(|error| format!("initialize sqlite memory schema failed: {error}"))?;
@@ -1007,6 +1037,7 @@ fn open_sqlite_connection_with_diagnostics(
 
     if user_version < SQLITE_MEMORY_SCHEMA_VERSION {
         ensure_turn_session_index_and_state_metadata(&conn)?;
+        ensure_approval_lifecycle_tables(&conn)?;
         ensure_summary_checkpoint_storage_layout(&conn)?;
         write_sqlite_user_version(&conn, SQLITE_MEMORY_SCHEMA_VERSION)?;
     }
@@ -1138,6 +1169,46 @@ fn ensure_turn_session_index_and_state_metadata(conn: &Connection) -> Result<(),
         [],
     )
     .map_err(|error| format!("remove stale session turn count metadata failed: {error}"))?;
+
+    Ok(())
+}
+
+fn ensure_approval_lifecycle_tables(conn: &Connection) -> Result<(), String> {
+    #[cfg(test)]
+    test_support::record_sqlite_schema_repair("approval_lifecycle");
+
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS approval_requests(
+          approval_request_id TEXT PRIMARY KEY,
+          session_id TEXT NOT NULL,
+          turn_id TEXT NOT NULL,
+          tool_call_id TEXT NOT NULL,
+          tool_name TEXT NOT NULL,
+          approval_key TEXT NOT NULL,
+          status TEXT NOT NULL,
+          decision TEXT NULL,
+          request_payload_json TEXT NOT NULL,
+          governance_snapshot_json TEXT NOT NULL,
+          requested_at INTEGER NOT NULL,
+          resolved_at INTEGER NULL,
+          resolved_by_session_id TEXT NULL,
+          executed_at INTEGER NULL,
+          last_error TEXT NULL
+        );
+        CREATE TABLE IF NOT EXISTS approval_grants(
+          scope_session_id TEXT NOT NULL,
+          approval_key TEXT NOT NULL,
+          created_by_session_id TEXT NULL,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          PRIMARY KEY(scope_session_id, approval_key)
+        );
+        CREATE INDEX IF NOT EXISTS idx_approval_requests_session_status_requested_at
+          ON approval_requests(session_id, status, requested_at DESC, approval_request_id);
+        ",
+    )
+    .map_err(|error| format!("ensure approval lifecycle storage failed: {error}"))?;
 
     Ok(())
 }

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -804,6 +804,35 @@ impl SessionRepository {
         Ok(depth)
     }
 
+    pub fn lineage_root_session_id(&self, session_id: &str) -> Result<Option<String>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let mut seen = BTreeSet::new();
+        let mut next_session_id = Some(session_id);
+
+        while let Some(current_session_id) = next_session_id {
+            if !seen.insert(current_session_id.clone()) {
+                return Err(format!(
+                    "session_lineage_cycle_detected: `{current_session_id}` reappeared while computing lineage root"
+                ));
+            }
+            let session = match self.load_session(&current_session_id)? {
+                Some(session) => session,
+                None if seen.len() == 1 => return Ok(None),
+                None => {
+                    return Err(format!(
+                        "session_lineage_broken: missing parent row for `{current_session_id}`"
+                    ));
+                }
+            };
+            match session.parent_session_id {
+                Some(parent_session_id) => next_session_id = Some(parent_session_id),
+                None => return Ok(Some(session.session_id)),
+            }
+        }
+
+        Ok(None)
+    }
+
     pub fn list_recent_events(
         &self,
         session_id: &str,
@@ -2455,6 +2484,52 @@ mod tests {
     }
 
     #[test]
+    fn lineage_root_session_id_returns_root_for_delegate_descendants() {
+        let config = isolated_memory_config("lineage-root");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.create_session(NewSessionRecord {
+            session_id: "grandchild-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("child-session".to_owned()),
+            label: Some("Grandchild".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create grandchild");
+
+        assert_eq!(
+            repo.lineage_root_session_id("root-session")
+                .expect("root lineage root"),
+            Some("root-session".to_owned())
+        );
+        assert_eq!(
+            repo.lineage_root_session_id("grandchild-session")
+                .expect("grandchild lineage root"),
+            Some("root-session".to_owned())
+        );
+        assert_eq!(
+            repo.lineage_root_session_id("missing-session")
+                .expect("missing lineage root"),
+            None
+        );
+    }
+
+    #[test]
     fn list_visible_sessions_includes_descendant_delegate_chain() {
         let config = isolated_memory_config("descendant-visibility");
         let repo = SessionRepository::new(&config).expect("repository");
@@ -3082,7 +3157,10 @@ mod tests {
             .expect("transition result");
         assert_eq!(approved.status, ApprovalRequestStatus::Approved);
         assert_eq!(approved.decision, Some(ApprovalDecision::ApproveOnce));
-        assert_eq!(approved.resolved_by_session_id.as_deref(), Some("root-session"));
+        assert_eq!(
+            approved.resolved_by_session_id.as_deref(),
+            Some("root-session")
+        );
         assert!(approved.resolved_at.is_some());
         assert!(approved.executed_at.is_none());
         assert!(approved.last_error.is_none());

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -93,6 +93,127 @@ pub struct SessionTerminalOutcomeRecord {
     pub recorded_at: i64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalRequestStatus {
+    Pending,
+    Approved,
+    Executing,
+    Executed,
+    Denied,
+    Expired,
+    Cancelled,
+}
+
+impl ApprovalRequestStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Approved => "approved",
+            Self::Executing => "executing",
+            Self::Executed => "executed",
+            Self::Denied => "denied",
+            Self::Expired => "expired",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    fn from_db(value: &str) -> Result<Self, String> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "approved" => Ok(Self::Approved),
+            "executing" => Ok(Self::Executing),
+            "executed" => Ok(Self::Executed),
+            "denied" => Ok(Self::Denied),
+            "expired" => Ok(Self::Expired),
+            "cancelled" => Ok(Self::Cancelled),
+            _ => Err(format!("unknown approval request status `{value}`")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalDecision {
+    ApproveOnce,
+    ApproveAlways,
+    Deny,
+}
+
+impl ApprovalDecision {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ApproveOnce => "approve_once",
+            Self::ApproveAlways => "approve_always",
+            Self::Deny => "deny",
+        }
+    }
+
+    fn from_db(value: &str) -> Result<Self, String> {
+        match value {
+            "approve_once" => Ok(Self::ApproveOnce),
+            "approve_always" => Ok(Self::ApproveAlways),
+            "deny" => Ok(Self::Deny),
+            _ => Err(format!("unknown approval decision `{value}`")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ApprovalRequestRecord {
+    pub approval_request_id: String,
+    pub session_id: String,
+    pub turn_id: String,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub approval_key: String,
+    pub status: ApprovalRequestStatus,
+    pub decision: Option<ApprovalDecision>,
+    pub request_payload_json: Value,
+    pub governance_snapshot_json: Value,
+    pub requested_at: i64,
+    pub resolved_at: Option<i64>,
+    pub resolved_by_session_id: Option<String>,
+    pub executed_at: Option<i64>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NewApprovalRequestRecord {
+    pub approval_request_id: String,
+    pub session_id: String,
+    pub turn_id: String,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub approval_key: String,
+    pub request_payload_json: Value,
+    pub governance_snapshot_json: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TransitionApprovalRequestIfCurrentRequest {
+    pub expected_status: ApprovalRequestStatus,
+    pub next_status: ApprovalRequestStatus,
+    pub decision: Option<ApprovalDecision>,
+    pub resolved_by_session_id: Option<String>,
+    pub executed_at: Option<i64>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApprovalGrantRecord {
+    pub scope_session_id: String,
+    pub approval_key: String,
+    pub created_by_session_id: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewApprovalGrantRecord {
+    pub scope_session_id: String,
+    pub approval_key: String,
+    pub created_by_session_id: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionSummaryRecord {
     pub session_id: String,
@@ -722,6 +843,365 @@ impl SessionRepository {
         Self::load_terminal_outcome_with_conn(&conn, &session_id)
     }
 
+    pub fn ensure_approval_request(
+        &self,
+        record: NewApprovalRequestRecord,
+    ) -> Result<ApprovalRequestRecord, String> {
+        let approval_request_id =
+            normalize_required_text(&record.approval_request_id, "approval_request_id")?;
+        let session_id = normalize_required_text(&record.session_id, "session_id")?;
+        let turn_id = normalize_required_text(&record.turn_id, "turn_id")?;
+        let tool_call_id = normalize_required_text(&record.tool_call_id, "tool_call_id")?;
+        let tool_name = normalize_required_text(&record.tool_name, "tool_name")?;
+        let approval_key = normalize_required_text(&record.approval_key, "approval_key")?;
+        if self.load_session(&session_id)?.is_none() {
+            return Err(format!("session `{session_id}` not found"));
+        }
+
+        let encoded_request_payload = serde_json::to_string(&record.request_payload_json)
+            .map_err(|error| format!("encode approval request payload failed: {error}"))?;
+        let encoded_governance_snapshot =
+            serde_json::to_string(&record.governance_snapshot_json)
+                .map_err(|error| format!("encode approval governance snapshot failed: {error}"))?;
+        let requested_at = unix_ts_now();
+        let conn = self.open_connection()?;
+        match conn.execute(
+            "INSERT INTO approval_requests(
+                approval_request_id,
+                session_id,
+                turn_id,
+                tool_call_id,
+                tool_name,
+                approval_key,
+                status,
+                decision,
+                request_payload_json,
+                governance_snapshot_json,
+                requested_at,
+                resolved_at,
+                resolved_by_session_id,
+                executed_at,
+                last_error
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8, ?9, ?10, NULL, NULL, NULL, NULL)",
+            params![
+                approval_request_id,
+                session_id,
+                turn_id,
+                tool_call_id,
+                tool_name,
+                approval_key,
+                ApprovalRequestStatus::Pending.as_str(),
+                encoded_request_payload,
+                encoded_governance_snapshot,
+                requested_at,
+            ],
+        ) {
+            Ok(_) => {}
+            Err(error) if error.to_string().contains("UNIQUE constraint failed") => {
+                return self
+                    .load_approval_request(&approval_request_id)?
+                    .ok_or_else(|| {
+                        format!(
+                            "approval request `{approval_request_id}` missing after concurrent insert"
+                        )
+                    });
+            }
+            Err(error) => return Err(format!("insert approval request row failed: {error}")),
+        }
+
+        self.load_approval_request(&approval_request_id)?
+            .ok_or_else(|| {
+                format!("approval request `{approval_request_id}` disappeared after insert")
+            })
+    }
+
+    pub fn load_approval_request(
+        &self,
+        approval_request_id: &str,
+    ) -> Result<Option<ApprovalRequestRecord>, String> {
+        let approval_request_id =
+            normalize_required_text(approval_request_id, "approval_request_id")?;
+        let conn = self.open_connection()?;
+        let raw = conn
+            .query_row(
+                "SELECT
+                    approval_request_id,
+                    session_id,
+                    turn_id,
+                    tool_call_id,
+                    tool_name,
+                    approval_key,
+                    status,
+                    decision,
+                    request_payload_json,
+                    governance_snapshot_json,
+                    requested_at,
+                    resolved_at,
+                    resolved_by_session_id,
+                    executed_at,
+                    last_error
+                 FROM approval_requests
+                 WHERE approval_request_id = ?1",
+                params![approval_request_id],
+                |row| {
+                    Ok(RawApprovalRequestRecord {
+                        approval_request_id: row.get(0)?,
+                        session_id: row.get(1)?,
+                        turn_id: row.get(2)?,
+                        tool_call_id: row.get(3)?,
+                        tool_name: row.get(4)?,
+                        approval_key: row.get(5)?,
+                        status: row.get(6)?,
+                        decision: row.get(7)?,
+                        request_payload_json: row.get(8)?,
+                        governance_snapshot_json: row.get(9)?,
+                        requested_at: row.get(10)?,
+                        resolved_at: row.get(11)?,
+                        resolved_by_session_id: row.get(12)?,
+                        executed_at: row.get(13)?,
+                        last_error: row.get(14)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|error| format!("load approval request row failed: {error}"))?;
+        raw.map(ApprovalRequestRecord::try_from_raw).transpose()
+    }
+
+    pub fn list_approval_requests_for_session(
+        &self,
+        session_id: &str,
+        status: Option<ApprovalRequestStatus>,
+    ) -> Result<Vec<ApprovalRequestRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        let mut requests = Vec::new();
+        match status {
+            Some(status) => {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT
+                            approval_request_id,
+                            session_id,
+                            turn_id,
+                            tool_call_id,
+                            tool_name,
+                            approval_key,
+                            status,
+                            decision,
+                            request_payload_json,
+                            governance_snapshot_json,
+                            requested_at,
+                            resolved_at,
+                            resolved_by_session_id,
+                            executed_at,
+                            last_error
+                         FROM approval_requests
+                         WHERE session_id = ?1 AND status = ?2
+                         ORDER BY requested_at DESC, approval_request_id ASC",
+                    )
+                    .map_err(|error| {
+                        format!("prepare approval request list query failed: {error}")
+                    })?;
+                let rows = stmt
+                    .query_map(params![session_id, status.as_str()], |row| {
+                        Ok(RawApprovalRequestRecord {
+                            approval_request_id: row.get(0)?,
+                            session_id: row.get(1)?,
+                            turn_id: row.get(2)?,
+                            tool_call_id: row.get(3)?,
+                            tool_name: row.get(4)?,
+                            approval_key: row.get(5)?,
+                            status: row.get(6)?,
+                            decision: row.get(7)?,
+                            request_payload_json: row.get(8)?,
+                            governance_snapshot_json: row.get(9)?,
+                            requested_at: row.get(10)?,
+                            resolved_at: row.get(11)?,
+                            resolved_by_session_id: row.get(12)?,
+                            executed_at: row.get(13)?,
+                            last_error: row.get(14)?,
+                        })
+                    })
+                    .map_err(|error| format!("query approval request list failed: {error}"))?;
+                for row in rows {
+                    let raw = row
+                        .map_err(|error| format!("decode approval request row failed: {error}"))?;
+                    requests.push(ApprovalRequestRecord::try_from_raw(raw)?);
+                }
+            }
+            None => {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT
+                            approval_request_id,
+                            session_id,
+                            turn_id,
+                            tool_call_id,
+                            tool_name,
+                            approval_key,
+                            status,
+                            decision,
+                            request_payload_json,
+                            governance_snapshot_json,
+                            requested_at,
+                            resolved_at,
+                            resolved_by_session_id,
+                            executed_at,
+                            last_error
+                         FROM approval_requests
+                         WHERE session_id = ?1
+                         ORDER BY requested_at DESC, approval_request_id ASC",
+                    )
+                    .map_err(|error| {
+                        format!("prepare approval request list query failed: {error}")
+                    })?;
+                let rows = stmt
+                    .query_map(params![session_id], |row| {
+                        Ok(RawApprovalRequestRecord {
+                            approval_request_id: row.get(0)?,
+                            session_id: row.get(1)?,
+                            turn_id: row.get(2)?,
+                            tool_call_id: row.get(3)?,
+                            tool_name: row.get(4)?,
+                            approval_key: row.get(5)?,
+                            status: row.get(6)?,
+                            decision: row.get(7)?,
+                            request_payload_json: row.get(8)?,
+                            governance_snapshot_json: row.get(9)?,
+                            requested_at: row.get(10)?,
+                            resolved_at: row.get(11)?,
+                            resolved_by_session_id: row.get(12)?,
+                            executed_at: row.get(13)?,
+                            last_error: row.get(14)?,
+                        })
+                    })
+                    .map_err(|error| format!("query approval request list failed: {error}"))?;
+                for row in rows {
+                    let raw = row
+                        .map_err(|error| format!("decode approval request row failed: {error}"))?;
+                    requests.push(ApprovalRequestRecord::try_from_raw(raw)?);
+                }
+            }
+        }
+        Ok(requests)
+    }
+
+    pub fn transition_approval_request_if_current(
+        &self,
+        approval_request_id: &str,
+        request: TransitionApprovalRequestIfCurrentRequest,
+    ) -> Result<Option<ApprovalRequestRecord>, String> {
+        let approval_request_id =
+            normalize_required_text(approval_request_id, "approval_request_id")?;
+        let resolved_by_session_id = normalize_optional_text(request.resolved_by_session_id);
+        let last_error = normalize_optional_text(request.last_error);
+        let decision = request.decision.map(ApprovalDecision::as_str);
+        let resolution_ts = matches!(
+            request.next_status,
+            ApprovalRequestStatus::Approved | ApprovalRequestStatus::Denied
+        )
+        .then(unix_ts_now);
+        let conn = self.open_connection()?;
+        let affected = conn
+            .execute(
+                "UPDATE approval_requests
+                 SET status = ?3,
+                     decision = CASE WHEN ?4 IS NULL THEN decision ELSE ?4 END,
+                     resolved_at = CASE WHEN ?5 IS NULL THEN resolved_at ELSE ?5 END,
+                     resolved_by_session_id = CASE WHEN ?6 IS NULL THEN resolved_by_session_id ELSE ?6 END,
+                     executed_at = CASE WHEN ?7 IS NULL THEN executed_at ELSE ?7 END,
+                     last_error = ?8
+                 WHERE approval_request_id = ?1 AND status = ?2",
+                params![
+                    approval_request_id,
+                    request.expected_status.as_str(),
+                    request.next_status.as_str(),
+                    decision,
+                    resolution_ts,
+                    resolved_by_session_id,
+                    request.executed_at,
+                    last_error,
+                ],
+            )
+            .map_err(|error| format!("conditionally update approval request failed: {error}"))?;
+        if affected == 0 {
+            return Ok(None);
+        }
+
+        self.load_approval_request(&approval_request_id)?
+            .map(Some)
+            .ok_or_else(|| {
+                format!("approval request `{approval_request_id}` missing after conditional update")
+            })
+    }
+
+    pub fn upsert_approval_grant(
+        &self,
+        record: NewApprovalGrantRecord,
+    ) -> Result<ApprovalGrantRecord, String> {
+        let scope_session_id =
+            normalize_required_text(&record.scope_session_id, "scope_session_id")?;
+        let approval_key = normalize_required_text(&record.approval_key, "approval_key")?;
+        if self.load_session(&scope_session_id)?.is_none() {
+            return Err(format!("session `{scope_session_id}` not found"));
+        }
+        let created_by_session_id = normalize_optional_text(record.created_by_session_id);
+        let ts = unix_ts_now();
+        let conn = self.open_connection()?;
+        conn.execute(
+            "INSERT INTO approval_grants(
+                scope_session_id,
+                approval_key,
+                created_by_session_id,
+                created_at,
+                updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(scope_session_id, approval_key) DO UPDATE SET
+                created_by_session_id = COALESCE(excluded.created_by_session_id, approval_grants.created_by_session_id),
+                updated_at = excluded.updated_at",
+            params![scope_session_id, approval_key, created_by_session_id, ts, ts],
+        )
+        .map_err(|error| format!("upsert approval grant failed: {error}"))?;
+
+        self.load_approval_grant(&scope_session_id, &approval_key)?
+            .ok_or_else(|| {
+                format!(
+                    "approval grant `{}:{}` disappeared after upsert",
+                    scope_session_id, approval_key
+                )
+            })
+    }
+
+    pub fn load_approval_grant(
+        &self,
+        scope_session_id: &str,
+        approval_key: &str,
+    ) -> Result<Option<ApprovalGrantRecord>, String> {
+        let scope_session_id = normalize_required_text(scope_session_id, "scope_session_id")?;
+        let approval_key = normalize_required_text(approval_key, "approval_key")?;
+        let conn = self.open_connection()?;
+        let raw = conn
+            .query_row(
+                "SELECT scope_session_id, approval_key, created_by_session_id, created_at, updated_at
+                 FROM approval_grants
+                 WHERE scope_session_id = ?1 AND approval_key = ?2",
+                params![scope_session_id, approval_key],
+                |row| {
+                    Ok(RawApprovalGrantRecord {
+                        scope_session_id: row.get(0)?,
+                        approval_key: row.get(1)?,
+                        created_by_session_id: row.get(2)?,
+                        created_at: row.get(3)?,
+                        updated_at: row.get(4)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|error| format!("load approval grant failed: {error}"))?;
+        raw.map(ApprovalGrantRecord::try_from_raw).transpose()
+    }
+
     pub fn upsert_terminal_outcome(
         &self,
         session_id: &str,
@@ -1343,6 +1823,34 @@ struct RawSessionTerminalOutcomeRecord {
     recorded_at: i64,
 }
 
+#[derive(Debug)]
+struct RawApprovalRequestRecord {
+    approval_request_id: String,
+    session_id: String,
+    turn_id: String,
+    tool_call_id: String,
+    tool_name: String,
+    approval_key: String,
+    status: String,
+    decision: Option<String>,
+    request_payload_json: String,
+    governance_snapshot_json: String,
+    requested_at: i64,
+    resolved_at: Option<i64>,
+    resolved_by_session_id: Option<String>,
+    executed_at: Option<i64>,
+    last_error: Option<String>,
+}
+
+#[derive(Debug)]
+struct RawApprovalGrantRecord {
+    scope_session_id: String,
+    approval_key: String,
+    created_by_session_id: Option<String>,
+    created_at: i64,
+    updated_at: i64,
+}
+
 impl SessionRecord {
     fn try_from_raw(raw: RawSessionRecord) -> Result<Self, String> {
         Ok(Self {
@@ -1399,6 +1907,46 @@ impl SessionTerminalOutcomeRecord {
                 format!("decode session terminal outcome payload failed: {error}")
             })?,
             recorded_at: raw.recorded_at,
+        })
+    }
+}
+
+impl ApprovalRequestRecord {
+    fn try_from_raw(raw: RawApprovalRequestRecord) -> Result<Self, String> {
+        Ok(Self {
+            approval_request_id: raw.approval_request_id,
+            session_id: raw.session_id,
+            turn_id: raw.turn_id,
+            tool_call_id: raw.tool_call_id,
+            tool_name: raw.tool_name,
+            approval_key: raw.approval_key,
+            status: ApprovalRequestStatus::from_db(&raw.status)?,
+            decision: raw
+                .decision
+                .as_deref()
+                .map(ApprovalDecision::from_db)
+                .transpose()?,
+            request_payload_json: serde_json::from_str(&raw.request_payload_json)
+                .map_err(|error| format!("decode approval request payload failed: {error}"))?,
+            governance_snapshot_json: serde_json::from_str(&raw.governance_snapshot_json)
+                .map_err(|error| format!("decode approval governance snapshot failed: {error}"))?,
+            requested_at: raw.requested_at,
+            resolved_at: raw.resolved_at,
+            resolved_by_session_id: raw.resolved_by_session_id,
+            executed_at: raw.executed_at,
+            last_error: raw.last_error,
+        })
+    }
+}
+
+impl ApprovalGrantRecord {
+    fn try_from_raw(raw: RawApprovalGrantRecord) -> Result<Self, String> {
+        Ok(Self {
+            scope_session_id: raw.scope_session_id,
+            approval_key: raw.approval_key,
+            created_by_session_id: raw.created_by_session_id,
+            created_at: raw.created_at,
+            updated_at: raw.updated_at,
         })
     }
 }
@@ -2360,6 +2908,336 @@ mod tests {
                 .expect("last recent event")
                 .event_kind,
             "delegate_completed"
+        );
+    }
+
+    #[test]
+    fn approval_request_repository_persists_pending_request() {
+        let config = isolated_memory_config("approval-request-create");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+
+        let created = repo
+            .ensure_approval_request(NewApprovalRequestRecord {
+                approval_request_id: "apr_123".to_owned(),
+                session_id: "root-session".to_owned(),
+                turn_id: "turn-123".to_owned(),
+                tool_call_id: "call-123".to_owned(),
+                tool_name: "delegate_async".to_owned(),
+                approval_key: "tool:delegate_async".to_owned(),
+                request_payload_json: json!({
+                    "tool_name": "delegate_async",
+                    "payload": {
+                        "task": "inspect child issue"
+                    }
+                }),
+                governance_snapshot_json: json!({
+                    "reason": "governed_tool_requires_approval",
+                    "rule_id": "medium_balanced_delegate_async"
+                }),
+            })
+            .expect("persist approval request");
+
+        assert_eq!(created.approval_request_id, "apr_123");
+        assert_eq!(created.session_id, "root-session");
+        assert_eq!(created.tool_name, "delegate_async");
+        assert_eq!(created.approval_key, "tool:delegate_async");
+        assert_eq!(created.status, ApprovalRequestStatus::Pending);
+        assert_eq!(created.decision, None);
+        assert_eq!(
+            created.request_payload_json["payload"]["task"],
+            "inspect child issue"
+        );
+        assert_eq!(
+            created.governance_snapshot_json["rule_id"],
+            "medium_balanced_delegate_async"
+        );
+        assert!(created.resolved_at.is_none());
+        assert!(created.executed_at.is_none());
+        assert!(created.last_error.is_none());
+
+        let loaded = repo
+            .load_approval_request("apr_123")
+            .expect("load approval request")
+            .expect("approval request row");
+        assert_eq!(loaded, created);
+    }
+
+    #[test]
+    fn approval_request_repository_duplicate_create_returns_existing_row() {
+        let config = isolated_memory_config("approval-request-idempotent");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+
+        let first = repo
+            .ensure_approval_request(NewApprovalRequestRecord {
+                approval_request_id: "apr_duplicate".to_owned(),
+                session_id: "root-session".to_owned(),
+                turn_id: "turn-1".to_owned(),
+                tool_call_id: "call-1".to_owned(),
+                tool_name: "delegate".to_owned(),
+                approval_key: "tool:delegate".to_owned(),
+                request_payload_json: json!({
+                    "tool_name": "delegate",
+                    "payload": {
+                        "task": "original"
+                    }
+                }),
+                governance_snapshot_json: json!({
+                    "reason": "first_reason",
+                    "rule_id": "first_rule"
+                }),
+            })
+            .expect("persist first approval request");
+        let second = repo
+            .ensure_approval_request(NewApprovalRequestRecord {
+                approval_request_id: "apr_duplicate".to_owned(),
+                session_id: "root-session".to_owned(),
+                turn_id: "turn-2".to_owned(),
+                tool_call_id: "call-2".to_owned(),
+                tool_name: "delegate_async".to_owned(),
+                approval_key: "tool:delegate_async".to_owned(),
+                request_payload_json: json!({
+                    "tool_name": "delegate_async",
+                    "payload": {
+                        "task": "should_be_ignored"
+                    }
+                }),
+                governance_snapshot_json: json!({
+                    "reason": "second_reason",
+                    "rule_id": "second_rule"
+                }),
+            })
+            .expect("persist second approval request");
+
+        assert_eq!(second.approval_request_id, first.approval_request_id);
+        assert_eq!(second.turn_id, first.turn_id);
+        assert_eq!(second.tool_call_id, first.tool_call_id);
+        assert_eq!(second.tool_name, first.tool_name);
+        assert_eq!(second.approval_key, first.approval_key);
+        assert_eq!(second.request_payload_json, first.request_payload_json);
+        assert_eq!(
+            second.governance_snapshot_json,
+            first.governance_snapshot_json
+        );
+    }
+
+    #[test]
+    fn approval_request_repository_transitions_status_if_current() {
+        let config = isolated_memory_config("approval-request-transition");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+
+        repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id: "apr-transition".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-1".to_owned(),
+            tool_call_id: "call-1".to_owned(),
+            tool_name: "delegate".to_owned(),
+            approval_key: "tool:delegate".to_owned(),
+            request_payload_json: json!({
+                "tool_name": "delegate"
+            }),
+            governance_snapshot_json: json!({
+                "reason": "requires_review",
+                "rule_id": "delegate_review"
+            }),
+        })
+        .expect("persist approval request");
+
+        let approved = repo
+            .transition_approval_request_if_current(
+                "apr-transition",
+                TransitionApprovalRequestIfCurrentRequest {
+                    expected_status: ApprovalRequestStatus::Pending,
+                    next_status: ApprovalRequestStatus::Approved,
+                    decision: Some(ApprovalDecision::ApproveOnce),
+                    resolved_by_session_id: Some("root-session".to_owned()),
+                    executed_at: None,
+                    last_error: None,
+                },
+            )
+            .expect("transition approval request")
+            .expect("transition result");
+        assert_eq!(approved.status, ApprovalRequestStatus::Approved);
+        assert_eq!(approved.decision, Some(ApprovalDecision::ApproveOnce));
+        assert_eq!(approved.resolved_by_session_id.as_deref(), Some("root-session"));
+        assert!(approved.resolved_at.is_some());
+        assert!(approved.executed_at.is_none());
+        assert!(approved.last_error.is_none());
+
+        let noop = repo
+            .transition_approval_request_if_current(
+                "apr-transition",
+                TransitionApprovalRequestIfCurrentRequest {
+                    expected_status: ApprovalRequestStatus::Pending,
+                    next_status: ApprovalRequestStatus::Denied,
+                    decision: Some(ApprovalDecision::Deny),
+                    resolved_by_session_id: Some("root-session".to_owned()),
+                    executed_at: None,
+                    last_error: Some("should not apply".to_owned()),
+                },
+            )
+            .expect("stale transition should not error");
+        assert!(noop.is_none());
+    }
+
+    #[test]
+    fn approval_request_repository_persists_session_scoped_runtime_grant() {
+        let config = isolated_memory_config("approval-grant-upsert");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+
+        let created = repo
+            .upsert_approval_grant(NewApprovalGrantRecord {
+                scope_session_id: "root-session".to_owned(),
+                approval_key: "tool:delegate_async".to_owned(),
+                created_by_session_id: Some("operator-session".to_owned()),
+            })
+            .expect("upsert approval grant");
+        assert_eq!(created.scope_session_id, "root-session");
+        assert_eq!(created.approval_key, "tool:delegate_async");
+        assert_eq!(
+            created.created_by_session_id.as_deref(),
+            Some("operator-session")
+        );
+
+        let loaded = repo
+            .load_approval_grant("root-session", "tool:delegate_async")
+            .expect("load approval grant")
+            .expect("approval grant row");
+        assert_eq!(loaded, created);
+    }
+
+    #[test]
+    fn approval_request_repository_lists_requests_for_session_and_status() {
+        let config = isolated_memory_config("approval-request-list");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child session");
+
+        repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id: "apr-root-pending".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-root-pending".to_owned(),
+            tool_call_id: "call-root-pending".to_owned(),
+            tool_name: "delegate".to_owned(),
+            approval_key: "tool:delegate".to_owned(),
+            request_payload_json: json!({
+                "tool_name": "delegate"
+            }),
+            governance_snapshot_json: json!({
+                "rule_id": "root_pending"
+            }),
+        })
+        .expect("persist root pending request");
+        repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id: "apr-root-approved".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-root-approved".to_owned(),
+            tool_call_id: "call-root-approved".to_owned(),
+            tool_name: "delegate_async".to_owned(),
+            approval_key: "tool:delegate_async".to_owned(),
+            request_payload_json: json!({
+                "tool_name": "delegate_async"
+            }),
+            governance_snapshot_json: json!({
+                "rule_id": "root_approved"
+            }),
+        })
+        .expect("persist root approved request");
+        repo.transition_approval_request_if_current(
+            "apr-root-approved",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveAlways),
+                resolved_by_session_id: Some("root-session".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition root approved request")
+        .expect("approved root request");
+        repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id: "apr-child-pending".to_owned(),
+            session_id: "child-session".to_owned(),
+            turn_id: "turn-child-pending".to_owned(),
+            tool_call_id: "call-child-pending".to_owned(),
+            tool_name: "delegate".to_owned(),
+            approval_key: "tool:delegate".to_owned(),
+            request_payload_json: json!({
+                "tool_name": "delegate"
+            }),
+            governance_snapshot_json: json!({
+                "rule_id": "child_pending"
+            }),
+        })
+        .expect("persist child pending request");
+
+        let all_root_requests = repo
+            .list_approval_requests_for_session("root-session", None)
+            .expect("list root approval requests");
+        assert_eq!(all_root_requests.len(), 2);
+        let root_ids = all_root_requests
+            .iter()
+            .map(|record| record.approval_request_id.as_str())
+            .collect::<Vec<_>>();
+        assert!(root_ids.contains(&"apr-root-pending"));
+        assert!(root_ids.contains(&"apr-root-approved"));
+
+        let pending_root_requests = repo
+            .list_approval_requests_for_session(
+                "root-session",
+                Some(ApprovalRequestStatus::Pending),
+            )
+            .expect("list pending root approval requests");
+        assert_eq!(pending_root_requests.len(), 1);
+        assert_eq!(
+            pending_root_requests[0].approval_request_id,
+            "apr-root-pending"
         );
     }
 }

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -1,0 +1,1569 @@
+use async_trait::async_trait;
+use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+use serde_json::{Value, json};
+#[cfg(feature = "memory-sqlite")]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(feature = "memory-sqlite")]
+use crate::config::SessionVisibility;
+use crate::config::ToolConfig;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{
+    ApprovalDecision, ApprovalGrantRecord, ApprovalRequestRecord, ApprovalRequestStatus,
+    SessionRepository,
+};
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ApprovalRequestsListRequest {
+    session_id: Option<String>,
+    status: Option<ApprovalRequestStatus>,
+    grant_attention: Option<GrantAttentionFilter>,
+    limit: usize,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ApprovalRequestResolveRequest {
+    approval_request_id: String,
+    decision: ApprovalDecision,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone)]
+pub(crate) struct ApprovalResolutionRequest {
+    pub current_session_id: String,
+    pub approval_request_id: String,
+    pub decision: ApprovalDecision,
+    pub visibility: SessionVisibility,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone)]
+pub(crate) struct ApprovalResolutionOutcome {
+    pub approval_request: ApprovalRequestRecord,
+    pub resumed_tool_output: Option<ToolCoreOutcome>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+pub(crate) trait ApprovalResolutionRuntime: Send + Sync {
+    async fn resolve_approval_request(
+        &self,
+        request: ApprovalResolutionRequest,
+    ) -> Result<ApprovalResolutionOutcome, String>;
+}
+
+#[cfg(feature = "memory-sqlite")]
+const APPROVAL_GRANT_REVIEW_STALE_AFTER_SECONDS: i64 = 60 * 60 * 24 * 30;
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum AttentionSeverity {
+    Medium,
+    High,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl AttentionSeverity {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone)]
+struct AttentionSignal {
+    source: &'static str,
+    kind: &'static str,
+    severity: AttentionSeverity,
+    action: &'static str,
+    detail: Option<String>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl AttentionSignal {
+    fn to_json(&self) -> Value {
+        json!({
+            "source": self.source,
+            "kind": self.kind,
+            "severity": self.severity.as_str(),
+            "action": self.action,
+            "detail": self.detail,
+        })
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GrantAttentionState {
+    NotApplicable,
+    Clean,
+    MissingGrant,
+    ReviewStale,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl GrantAttentionState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::NotApplicable => "not_applicable",
+            Self::Clean => "clean",
+            Self::MissingGrant => "missing_grant",
+            Self::ReviewStale => "review_stale",
+        }
+    }
+
+    fn needs_attention(self) -> bool {
+        matches!(self, Self::MissingGrant | Self::ReviewStale)
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GrantAttentionFilter {
+    NeedsAttention,
+    MissingGrant,
+    ReviewStale,
+    Clean,
+    NotApplicable,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl GrantAttentionFilter {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::NeedsAttention => "needs_attention",
+            Self::MissingGrant => "missing_grant",
+            Self::ReviewStale => "review_stale",
+            Self::Clean => "clean",
+            Self::NotApplicable => "not_applicable",
+        }
+    }
+
+    fn matches(self, state: GrantAttentionState) -> bool {
+        match self {
+            Self::NeedsAttention => state.needs_attention(),
+            Self::MissingGrant => state == GrantAttentionState::MissingGrant,
+            Self::ReviewStale => state == GrantAttentionState::ReviewStale,
+            Self::Clean => state == GrantAttentionState::Clean,
+            Self::NotApplicable => state == GrantAttentionState::NotApplicable,
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone)]
+struct DerivedAttentionView {
+    execution_signals: Vec<AttentionSignal>,
+    grant_signals: Vec<AttentionSignal>,
+    grant_state: GrantAttentionState,
+    grant_scope_session_id: Option<String>,
+    grant_record: Option<ApprovalGrantRecord>,
+    grant_age_seconds: Option<i64>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl DerivedAttentionView {
+    fn combined_signals(&self) -> Vec<AttentionSignal> {
+        let mut signals = self.execution_signals.clone();
+        signals.extend(self.grant_signals.clone());
+        signals
+    }
+
+    fn needs_attention(&self) -> bool {
+        !self.execution_signals.is_empty() || !self.grant_signals.is_empty()
+    }
+
+    fn highest_severity(&self) -> Option<AttentionSeverity> {
+        self.combined_signals()
+            .into_iter()
+            .map(|signal| signal.severity)
+            .max()
+    }
+
+    fn highest_severity_str(&self) -> &'static str {
+        self.highest_severity()
+            .map(AttentionSeverity::as_str)
+            .unwrap_or("none")
+    }
+
+    fn primary_action(&self) -> Option<&'static str> {
+        let mut signals = self.combined_signals();
+        signals.sort_by(|left, right| {
+            right
+                .severity
+                .cmp(&left.severity)
+                .then_with(|| left.kind.cmp(right.kind))
+        });
+        signals.first().map(|signal| signal.action)
+    }
+
+    fn source_category(&self) -> &'static str {
+        match (
+            self.execution_signals.is_empty(),
+            self.grant_signals.is_empty(),
+        ) {
+            (false, false) => "combined",
+            (false, true) => "execution_only",
+            (true, false) => "grant_only",
+            (true, true) => "none",
+        }
+    }
+
+    fn reason_kinds(&self) -> Vec<&'static str> {
+        self.combined_signals()
+            .into_iter()
+            .map(|signal| signal.kind)
+            .collect()
+    }
+
+    fn execution_state(&self) -> &'static str {
+        if self
+            .execution_signals
+            .iter()
+            .any(|signal| signal.kind == "resumed_execution_failed")
+        {
+            "resume_failed"
+        } else if self
+            .execution_signals
+            .iter()
+            .any(|signal| signal.kind == "resume_incomplete")
+        {
+            "resume_incomplete"
+        } else if self
+            .execution_signals
+            .iter()
+            .any(|signal| signal.kind == "pending_operator_decision")
+        {
+            "pending_decision"
+        } else {
+            "clean"
+        }
+    }
+
+    fn execution_integrity_json(&self) -> Value {
+        json!({
+            "state": self.execution_state(),
+            "needs_attention": !self.execution_signals.is_empty(),
+            "signals": self.execution_signals.iter().map(AttentionSignal::to_json).collect::<Vec<_>>(),
+            "highest_escalation_level": self
+                .execution_signals
+                .iter()
+                .map(|signal| signal.severity)
+                .max()
+                .map(AttentionSeverity::as_str)
+                .unwrap_or("none"),
+        })
+    }
+
+    fn grant_review_json(&self) -> Value {
+        json!({
+            "state": self.grant_state.as_str(),
+            "needs_attention": self.grant_state.needs_attention(),
+            "scope_session_id": self.grant_scope_session_id,
+            "grant_exists": self.grant_record.is_some(),
+            "grant_created_by_session_id": self
+                .grant_record
+                .as_ref()
+                .and_then(|grant| grant.created_by_session_id.clone()),
+            "grant_created_at": self.grant_record.as_ref().map(|grant| grant.created_at),
+            "grant_updated_at": self.grant_record.as_ref().map(|grant| grant.updated_at),
+            "grant_age_seconds": self.grant_age_seconds,
+            "review_stale_after_seconds": self
+                .grant_record
+                .as_ref()
+                .map(|_| APPROVAL_GRANT_REVIEW_STALE_AFTER_SECONDS),
+            "signals": self.grant_signals.iter().map(AttentionSignal::to_json).collect::<Vec<_>>(),
+        })
+    }
+
+    fn grant_attention_json(&self) -> Value {
+        json!({
+            "state": self.grant_state.as_str(),
+            "needs_attention": self.grant_state.needs_attention(),
+            "signals": self.grant_signals.iter().map(AttentionSignal::to_json).collect::<Vec<_>>(),
+            "highest_escalation_level": self
+                .grant_signals
+                .iter()
+                .map(|signal| signal.severity)
+                .max()
+                .map(AttentionSeverity::as_str)
+                .unwrap_or("none"),
+        })
+    }
+
+    fn attention_json(&self) -> Value {
+        let signals = self.combined_signals();
+        let mut sources = Vec::new();
+        for source in ["execution", "grant"] {
+            if signals.iter().any(|signal| signal.source == source) {
+                sources.push(source);
+            }
+        }
+        json!({
+            "needs_attention": self.needs_attention(),
+            "sources": sources,
+            "signals": signals.iter().map(AttentionSignal::to_json).collect::<Vec<_>>(),
+            "highest_escalation_level": self.highest_severity_str(),
+            "primary_action": self.primary_action(),
+        })
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone)]
+struct ApprovalRequestView {
+    record: ApprovalRequestRecord,
+    attention: DerivedAttentionView,
+}
+
+pub fn execute_approval_tool_with_policies(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (request, current_session_id, config, tool_config);
+        return Err(
+            "approval tools require sqlite memory support (enable feature `memory-sqlite`)"
+                .to_owned(),
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        if !tool_config.sessions.enabled {
+            return Err("app_tool_disabled: session tools are disabled by config".to_owned());
+        }
+        match request.tool_name.as_str() {
+            "approval_requests_list" => execute_approval_requests_list(
+                request.payload,
+                current_session_id,
+                config,
+                tool_config,
+            ),
+            "approval_request_status" => execute_approval_request_status(
+                request.payload,
+                current_session_id,
+                config,
+                tool_config,
+            ),
+            "approval_request_resolve" => {
+                Err("app_tool_requires_runtime_support: approval_request_resolve".to_owned())
+            }
+            other => Err(format!(
+                "app_tool_not_found: unknown approval tool `{other}`"
+            )),
+        }
+    }
+}
+
+pub async fn execute_approval_tool_with_runtime_support(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    runtime: Option<&(dyn ApprovalResolutionRuntime + '_)>,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (request, current_session_id, config, tool_config, runtime);
+        return Err(
+            "approval tools require sqlite memory support (enable feature `memory-sqlite`)"
+                .to_owned(),
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        if !tool_config.sessions.enabled {
+            return Err("app_tool_disabled: session tools are disabled by config".to_owned());
+        }
+        match request.tool_name.as_str() {
+            "approval_request_resolve" => {
+                let runtime =
+                    runtime.ok_or_else(|| "approval_request_runtime_not_configured".to_owned())?;
+                execute_approval_request_resolve(
+                    request.payload,
+                    current_session_id,
+                    config,
+                    tool_config,
+                    runtime,
+                )
+                .await
+            }
+            _ => execute_approval_tool_with_policies(
+                request,
+                current_session_id,
+                config,
+                tool_config,
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_approval_requests_list(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let repo = SessionRepository::new(config)?;
+    let request = parse_approval_requests_list_request(&payload, tool_config)?;
+    let target_session_ids = match request.session_id.as_deref() {
+        Some(session_id) => {
+            ensure_visible(
+                &repo,
+                current_session_id,
+                session_id,
+                tool_config.sessions.visibility,
+            )?;
+            vec![session_id.to_owned()]
+        }
+        None => visible_session_ids(&repo, current_session_id, tool_config.sessions.visibility)?,
+    };
+
+    let mut requests = Vec::new();
+    for session_id in &target_session_ids {
+        requests.extend(repo.list_approval_requests_for_session(session_id, request.status)?);
+    }
+
+    let mut request_views = Vec::new();
+    for record in requests {
+        let attention = derive_attention_view(&repo, &record)?;
+        if request
+            .grant_attention
+            .is_some_and(|filter| !filter.matches(attention.grant_state))
+        {
+            continue;
+        }
+        request_views.push(ApprovalRequestView { record, attention });
+    }
+
+    request_views.sort_by(|left, right| {
+        right
+            .record
+            .requested_at
+            .cmp(&left.record.requested_at)
+            .then_with(|| {
+                left.record
+                    .approval_request_id
+                    .cmp(&right.record.approval_request_id)
+            })
+    });
+
+    let matched_count = request_views.len();
+    let attention_summary = approval_attention_summary_json(&request_views);
+    request_views.truncate(request.limit);
+    let returned_count = request_views.len();
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "current_session_id": current_session_id,
+            "filter": {
+                "session_id": request.session_id,
+                "status": request.status.map(ApprovalRequestStatus::as_str),
+                "grant_attention": request.grant_attention.map(GrantAttentionFilter::as_str),
+                "limit": request.limit,
+            },
+            "visible_session_ids": target_session_ids,
+            "matched_count": matched_count,
+            "returned_count": returned_count,
+            "attention_summary": attention_summary,
+            "requests": request_views
+                .iter()
+                .map(approval_request_summary_json)
+                .collect::<Vec<_>>(),
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_approval_request_status(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let approval_request_id = required_payload_string(&payload, "approval_request_id")?;
+    let repo = SessionRepository::new(config)?;
+    let request = repo
+        .load_approval_request(&approval_request_id)?
+        .ok_or_else(|| format!("approval_request_not_found: `{approval_request_id}`"))?;
+    ensure_visible(
+        &repo,
+        current_session_id,
+        &request.session_id,
+        tool_config.sessions.visibility,
+    )?;
+    let attention = derive_attention_view(&repo, &request)?;
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "current_session_id": current_session_id,
+            "approval_request": approval_request_detail_json(&request, &attention),
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn execute_approval_request_resolve(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    runtime: &(dyn ApprovalResolutionRuntime + '_),
+) -> Result<ToolCoreOutcome, String> {
+    let request = parse_approval_request_resolve_request(&payload)?;
+    let outcome = runtime
+        .resolve_approval_request(ApprovalResolutionRequest {
+            current_session_id: current_session_id.to_owned(),
+            approval_request_id: request.approval_request_id,
+            decision: request.decision,
+            visibility: tool_config.sessions.visibility,
+        })
+        .await?;
+    let repo = SessionRepository::new(config)?;
+    let attention = derive_attention_view(&repo, &outcome.approval_request)?;
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "current_session_id": current_session_id,
+            "approval_request": approval_request_detail_json(&outcome.approval_request, &attention),
+            "resumed_tool_output": outcome.resumed_tool_output,
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn unix_ts_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn derive_attention_view(
+    repo: &SessionRepository,
+    record: &ApprovalRequestRecord,
+) -> Result<DerivedAttentionView, String> {
+    let mut execution_signals = Vec::new();
+    match record.status {
+        ApprovalRequestStatus::Pending => execution_signals.push(AttentionSignal {
+            source: "execution",
+            kind: "pending_operator_decision",
+            severity: AttentionSeverity::Medium,
+            action: "resolve_request",
+            detail: Some("approval request is waiting for an operator decision".to_owned()),
+        }),
+        ApprovalRequestStatus::Approved | ApprovalRequestStatus::Executing => {
+            execution_signals.push(AttentionSignal {
+                source: "execution",
+                kind: "resume_incomplete",
+                severity: AttentionSeverity::High,
+                action: "inspect_replay_state",
+                detail: Some(
+                    "approval request left the queue without reaching a terminal execution state"
+                        .to_owned(),
+                ),
+            });
+        }
+        ApprovalRequestStatus::Executed if record.last_error.is_some() => {
+            execution_signals.push(AttentionSignal {
+                source: "execution",
+                kind: "resumed_execution_failed",
+                severity: AttentionSeverity::High,
+                action: "inspect_failed_replay",
+                detail: record.last_error.clone(),
+            });
+        }
+        ApprovalRequestStatus::Executed
+        | ApprovalRequestStatus::Denied
+        | ApprovalRequestStatus::Expired
+        | ApprovalRequestStatus::Cancelled => {}
+    }
+
+    let grant_scope_session_id = repo.lineage_root_session_id(&record.session_id)?;
+    let grant_record = match grant_scope_session_id.as_deref() {
+        Some(scope_session_id) => {
+            repo.load_approval_grant(scope_session_id, &record.approval_key)?
+        }
+        None => None,
+    };
+    let grant_age_seconds = grant_record
+        .as_ref()
+        .map(|grant| unix_ts_now().saturating_sub(grant.updated_at).max(0));
+
+    let (grant_state, grant_signals) = match record.decision {
+        Some(ApprovalDecision::ApproveAlways) => match (&grant_record, grant_age_seconds) {
+            (None, _) => (
+                GrantAttentionState::MissingGrant,
+                vec![AttentionSignal {
+                    source: "grant",
+                    kind: "missing_runtime_grant",
+                    severity: AttentionSeverity::High,
+                    action: "repair_runtime_grant",
+                    detail: Some(
+                        "approve_always was recorded without a durable runtime grant".to_owned(),
+                    ),
+                }],
+            ),
+            (Some(_), Some(age_seconds))
+                if age_seconds > APPROVAL_GRANT_REVIEW_STALE_AFTER_SECONDS =>
+            {
+                (
+                    GrantAttentionState::ReviewStale,
+                    vec![AttentionSignal {
+                        source: "grant",
+                        kind: "stale_runtime_grant_review",
+                        severity: AttentionSeverity::Medium,
+                        action: "review_runtime_grant",
+                        detail: Some(format!(
+                            "runtime grant review age {age_seconds}s exceeds {}s",
+                            APPROVAL_GRANT_REVIEW_STALE_AFTER_SECONDS
+                        )),
+                    }],
+                )
+            }
+            _ => (GrantAttentionState::Clean, Vec::new()),
+        },
+        _ => (GrantAttentionState::NotApplicable, Vec::new()),
+    };
+
+    Ok(DerivedAttentionView {
+        execution_signals,
+        grant_signals,
+        grant_state,
+        grant_scope_session_id,
+        grant_record,
+        grant_age_seconds,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_attention_summary_json(requests: &[ApprovalRequestView]) -> Value {
+    let mut execution_only = 0usize;
+    let mut grant_only = 0usize;
+    let mut combined = 0usize;
+    let mut none = 0usize;
+    let mut reasons = std::collections::BTreeMap::<String, usize>::new();
+    let mut actions = std::collections::BTreeMap::<String, usize>::new();
+    let mut tools = std::collections::BTreeMap::<String, usize>::new();
+    let mut sessions = std::collections::BTreeMap::<String, usize>::new();
+
+    for request in requests {
+        match request.attention.source_category() {
+            "execution_only" => execution_only += 1,
+            "grant_only" => grant_only += 1,
+            "combined" => combined += 1,
+            _ => none += 1,
+        }
+        if request.attention.needs_attention() {
+            *tools.entry(request.record.tool_name.clone()).or_default() += 1;
+            *sessions
+                .entry(request.record.session_id.clone())
+                .or_default() += 1;
+        }
+        for reason in request.attention.reason_kinds() {
+            *reasons.entry(reason.to_owned()).or_default() += 1;
+        }
+        let mut request_actions = request
+            .attention
+            .combined_signals()
+            .into_iter()
+            .map(|signal| signal.action)
+            .collect::<Vec<_>>();
+        request_actions.sort_unstable();
+        request_actions.dedup();
+        for action in request_actions {
+            *actions.entry(action.to_owned()).or_default() += 1;
+        }
+    }
+
+    fn sorted_counts(counts: std::collections::BTreeMap<String, usize>, label: &str) -> Vec<Value> {
+        let mut items: Vec<(String, usize)> = counts.into_iter().collect();
+        items.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+        items
+            .into_iter()
+            .map(|(value, count)| json!({ label: value, "count": count }))
+            .collect()
+    }
+
+    json!({
+        "needs_attention_count": requests
+            .iter()
+            .filter(|request| request.attention.needs_attention())
+            .count(),
+        "source_breakdown": {
+            "execution_only": execution_only,
+            "grant_only": grant_only,
+            "combined": combined,
+            "none": none,
+        },
+        "hotspots": {
+            "by_reason": sorted_counts(reasons, "reason"),
+            "by_action": sorted_counts(actions, "action"),
+            "by_tool": sorted_counts(tools, "tool_name"),
+            "by_session": sorted_counts(sessions, "session_id"),
+        },
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_summary_json(view: &ApprovalRequestView) -> Value {
+    let record = &view.record;
+    json!({
+        "approval_request_id": record.approval_request_id,
+        "session_id": record.session_id,
+        "turn_id": record.turn_id,
+        "tool_call_id": record.tool_call_id,
+        "tool_name": record.tool_name,
+        "approval_key": record.approval_key,
+        "status": record.status.as_str(),
+        "decision": record.decision.map(|decision| decision.as_str()),
+        "requested_at": record.requested_at,
+        "resolved_at": record.resolved_at,
+        "resolved_by_session_id": record.resolved_by_session_id,
+        "executed_at": record.executed_at,
+        "last_error": record.last_error,
+        "reason": record
+            .governance_snapshot_json
+            .get("reason")
+            .and_then(Value::as_str),
+        "rule_id": record
+            .governance_snapshot_json
+            .get("rule_id")
+            .and_then(Value::as_str),
+        "execution_integrity": view.attention.execution_integrity_json(),
+        "grant_review": view.attention.grant_review_json(),
+        "grant_attention": view.attention.grant_attention_json(),
+        "attention": view.attention.attention_json(),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_detail_json(
+    record: &ApprovalRequestRecord,
+    attention: &DerivedAttentionView,
+) -> Value {
+    json!({
+        "approval_request_id": record.approval_request_id,
+        "session_id": record.session_id,
+        "turn_id": record.turn_id,
+        "tool_call_id": record.tool_call_id,
+        "tool_name": record.tool_name,
+        "approval_key": record.approval_key,
+        "status": record.status.as_str(),
+        "decision": record.decision.map(|decision| decision.as_str()),
+        "requested_at": record.requested_at,
+        "resolved_at": record.resolved_at,
+        "resolved_by_session_id": record.resolved_by_session_id,
+        "executed_at": record.executed_at,
+        "last_error": record.last_error,
+        "request_payload": record.request_payload_json,
+        "governance_snapshot": record.governance_snapshot_json,
+        "execution_integrity": attention.execution_integrity_json(),
+        "grant_review": attention.grant_review_json(),
+        "grant_attention": attention.grant_attention_json(),
+        "attention": attention.attention_json(),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_requests_list_request(
+    payload: &Value,
+    tool_config: &ToolConfig,
+) -> Result<ApprovalRequestsListRequest, String> {
+    Ok(ApprovalRequestsListRequest {
+        session_id: optional_payload_string(payload, "session_id"),
+        status: optional_payload_approval_request_status(payload, "status")?,
+        grant_attention: optional_payload_grant_attention_filter(payload, "grant_attention")?,
+        limit: optional_payload_limit(
+            payload,
+            "limit",
+            tool_config.sessions.list_limit,
+            tool_config.sessions.list_limit,
+        ),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_request_resolve_request(
+    payload: &Value,
+) -> Result<ApprovalRequestResolveRequest, String> {
+    Ok(ApprovalRequestResolveRequest {
+        approval_request_id: required_payload_string(payload, "approval_request_id")?,
+        decision: parse_approval_decision(&required_payload_string(payload, "decision")?)?,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn visible_session_ids(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    visibility: SessionVisibility,
+) -> Result<Vec<String>, String> {
+    match visibility {
+        SessionVisibility::SelfOnly => Ok(vec![current_session_id.to_owned()]),
+        SessionVisibility::Children => Ok(repo
+            .list_visible_sessions(current_session_id)?
+            .into_iter()
+            .map(|session| session.session_id)
+            .collect()),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn ensure_visible(
+    repo: &SessionRepository,
+    current_session_id: &str,
+    target_session_id: &str,
+    visibility: SessionVisibility,
+) -> Result<(), String> {
+    let is_visible = match visibility {
+        SessionVisibility::SelfOnly => current_session_id == target_session_id,
+        SessionVisibility::Children => {
+            current_session_id == target_session_id
+                || repo.is_session_visible(current_session_id, target_session_id)?
+        }
+    };
+    if is_visible {
+        return Ok(());
+    }
+    Err(format!(
+        "visibility_denied: session `{target_session_id}` is not visible from `{current_session_id}`"
+    ))
+}
+
+fn required_payload_string(payload: &Value, field: &str) -> Result<String, String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| format!("approval tool requires payload.{field}"))
+}
+
+fn optional_payload_string(payload: &Value, field: &str) -> Option<String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn optional_payload_limit(payload: &Value, field: &str, default: usize, max: usize) -> usize {
+    payload
+        .get(field)
+        .and_then(Value::as_u64)
+        .map(|value| value.clamp(1, max as u64) as usize)
+        .unwrap_or(default)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_approval_request_status(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ApprovalRequestStatus>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_approval_request_status(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_grant_attention_filter(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<GrantAttentionFilter>, String> {
+    optional_payload_string(payload, field)
+        .map(|value| parse_grant_attention_filter(value.as_str()))
+        .transpose()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_request_status(value: &str) -> Result<ApprovalRequestStatus, String> {
+    match value {
+        "pending" => Ok(ApprovalRequestStatus::Pending),
+        "approved" => Ok(ApprovalRequestStatus::Approved),
+        "executing" => Ok(ApprovalRequestStatus::Executing),
+        "executed" => Ok(ApprovalRequestStatus::Executed),
+        "denied" => Ok(ApprovalRequestStatus::Denied),
+        "expired" => Ok(ApprovalRequestStatus::Expired),
+        "cancelled" => Ok(ApprovalRequestStatus::Cancelled),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown status `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_grant_attention_filter(value: &str) -> Result<GrantAttentionFilter, String> {
+    match value {
+        "needs_attention" => Ok(GrantAttentionFilter::NeedsAttention),
+        "missing_grant" => Ok(GrantAttentionFilter::MissingGrant),
+        "review_stale" => Ok(GrantAttentionFilter::ReviewStale),
+        "clean" => Ok(GrantAttentionFilter::Clean),
+        "not_applicable" => Ok(GrantAttentionFilter::NotApplicable),
+        _ => Err(format!(
+            "approval_requests_list_invalid_request: unknown grant_attention `{value}`"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_approval_decision(value: &str) -> Result<ApprovalDecision, String> {
+    match value {
+        "approve_once" => Ok(ApprovalDecision::ApproveOnce),
+        "approve_always" => Ok(ApprovalDecision::ApproveAlways),
+        "deny" => Ok(ApprovalDecision::Deny),
+        _ => Err(format!(
+            "approval_request_resolve_invalid_request: unknown decision `{value}`"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use loongclaw_contracts::ToolCoreRequest;
+    #[cfg(feature = "memory-sqlite")]
+    use rusqlite::{Connection, params};
+    use serde_json::Value;
+    use serde_json::json;
+
+    use crate::config::ToolConfig;
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::repository::{
+        ApprovalDecision, ApprovalRequestStatus, NewApprovalGrantRecord, NewApprovalRequestRecord,
+        NewSessionRecord, SessionKind, SessionRepository, SessionState,
+        TransitionApprovalRequestIfCurrentRequest,
+    };
+
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        let base = std::env::temp_dir().join(format!(
+            "loongclaw-approval-tools-{test_name}-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&base);
+        let db_path = base.join("memory.sqlite3");
+        let _ = fs::remove_file(&db_path);
+        MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+            ..MemoryRuntimeConfig::default()
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn seed_session(
+        repo: &SessionRepository,
+        session_id: &str,
+        kind: SessionKind,
+        parent_session_id: Option<&str>,
+    ) {
+        repo.create_session(NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind,
+            parent_session_id: parent_session_id.map(str::to_owned),
+            label: Some(session_id.to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create session");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn seed_request(
+        repo: &SessionRepository,
+        approval_request_id: &str,
+        session_id: &str,
+        tool_name: &str,
+        rule_id: &str,
+    ) {
+        repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id: approval_request_id.to_owned(),
+            session_id: session_id.to_owned(),
+            turn_id: format!("turn-{approval_request_id}"),
+            tool_call_id: format!("call-{approval_request_id}"),
+            tool_name: tool_name.to_owned(),
+            approval_key: format!("tool:{tool_name}"),
+            request_payload_json: json!({
+                "session_id": session_id,
+                "tool_name": tool_name,
+                "args_json": {
+                    "task": format!("run-{approval_request_id}")
+                },
+            }),
+            governance_snapshot_json: json!({
+                "reason": format!("approval required for {tool_name}"),
+                "rule_id": rule_id,
+            }),
+        })
+        .expect("seed approval request");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn approve_request(
+        repo: &SessionRepository,
+        approval_request_id: &str,
+        decision: ApprovalDecision,
+        resolved_by_session_id: &str,
+    ) {
+        repo.transition_approval_request_if_current(
+            approval_request_id,
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(decision),
+                resolved_by_session_id: Some(resolved_by_session_id.to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("approve request")
+        .expect("approval request should be pending");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn mark_request_executed(
+        repo: &SessionRepository,
+        approval_request_id: &str,
+        last_error: Option<&str>,
+    ) {
+        repo.transition_approval_request_if_current(
+            approval_request_id,
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Approved,
+                next_status: ApprovalRequestStatus::Executed,
+                decision: None,
+                resolved_by_session_id: None,
+                executed_at: Some(1),
+                last_error: last_error.map(str::to_owned),
+            },
+        )
+        .expect("mark request executed")
+        .expect("approval request should be approved");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn seed_runtime_grant(repo: &SessionRepository, scope_session_id: &str, approval_key: &str) {
+        repo.upsert_approval_grant(NewApprovalGrantRecord {
+            scope_session_id: scope_session_id.to_owned(),
+            approval_key: approval_key.to_owned(),
+            created_by_session_id: Some(scope_session_id.to_owned()),
+        })
+        .expect("seed runtime grant");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn age_runtime_grant(
+        config: &MemoryRuntimeConfig,
+        scope_session_id: &str,
+        approval_key: &str,
+        updated_at: i64,
+    ) {
+        let db_path = config
+            .sqlite_path
+            .as_ref()
+            .expect("sqlite path")
+            .to_path_buf();
+        let conn = Connection::open(db_path).expect("open sqlite connection");
+        conn.execute(
+            "UPDATE approval_grants
+             SET created_at = ?1, updated_at = ?1
+             WHERE scope_session_id = ?2 AND approval_key = ?3",
+            params![updated_at, scope_session_id, approval_key],
+        )
+        .expect("age runtime grant");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_returns_only_visible_requests() {
+        let config = isolated_memory_config("approval-query-list-visible");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+        seed_session(&repo, "hidden-root", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-root-visible",
+            "root-session",
+            "delegate_async",
+            "rule-root",
+        );
+        seed_request(
+            &repo,
+            "apr-child-visible",
+            "child-session",
+            "delegate",
+            "rule-child",
+        );
+        seed_request(
+            &repo,
+            "apr-hidden",
+            "hidden-root",
+            "delegate_async",
+            "rule-hidden",
+        );
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({}),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["matched_count"], 2);
+        assert_eq!(outcome.payload["returned_count"], 2);
+        assert_eq!(
+            outcome.payload["attention_summary"]["needs_attention_count"],
+            2
+        );
+        assert_eq!(
+            outcome.payload["attention_summary"]["source_breakdown"]["execution_only"],
+            2
+        );
+        let requests = outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        let request_ids = requests
+            .iter()
+            .filter_map(|item| item.get("approval_request_id"))
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>();
+        assert!(request_ids.contains(&"apr-root-visible"));
+        assert!(request_ids.contains(&"apr-child-visible"));
+        assert!(!request_ids.contains(&"apr-hidden"));
+        assert_eq!(
+            requests[0]["attention"]["signals"][0]["source"],
+            "execution"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_status_returns_full_visible_request_detail() {
+        let config = isolated_memory_config("approval-query-status-visible");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+        seed_request(
+            &repo,
+            "apr-child-visible",
+            "child-session",
+            "delegate_async",
+            "governed_tool_requires_approval",
+        );
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-child-visible",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome");
+
+        assert_eq!(outcome.status, "ok");
+        let request = &outcome.payload["approval_request"];
+        assert_eq!(request["approval_request_id"], "apr-child-visible");
+        assert_eq!(request["session_id"], "child-session");
+        assert_eq!(request["tool_name"], "delegate_async");
+        assert_eq!(request["approval_key"], "tool:delegate_async");
+        assert_eq!(request["status"], "pending");
+        assert_eq!(
+            request["governance_snapshot"]["rule_id"],
+            "governed_tool_requires_approval"
+        );
+        assert_eq!(request["request_payload"]["tool_name"], "delegate_async");
+        assert_eq!(
+            request["request_payload"]["args_json"]["task"],
+            "run-apr-child-visible"
+        );
+        assert_eq!(request["execution_integrity"]["state"], "pending_decision");
+        assert_eq!(request["grant_review"]["state"], "not_applicable");
+        assert_eq!(request["attention"]["sources"], json!(["execution"]));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_status_rejects_hidden_request() {
+        let config = isolated_memory_config("approval-query-status-hidden");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(&repo, "hidden-root", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-hidden",
+            "hidden-root",
+            "delegate_async",
+            "rule-hidden",
+        );
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-hidden",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("hidden approval request should be rejected");
+
+        assert!(
+            error.contains("visibility_denied"),
+            "expected visibility_denied, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_attention_status_exposes_source_tagged_signals() {
+        let config = isolated_memory_config("approval-attention-status");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-attention-status",
+            "root-session",
+            "delegate",
+            "governed_tool_requires_approval",
+        );
+        approve_request(
+            &repo,
+            "apr-attention-status",
+            ApprovalDecision::ApproveAlways,
+            "root-session",
+        );
+        mark_request_executed(
+            &repo,
+            "apr-attention-status",
+            Some("delegate replay failed"),
+        );
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-attention-status",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome");
+
+        let request = &outcome.payload["approval_request"];
+        assert_eq!(request["execution_integrity"]["state"], "resume_failed");
+        assert_eq!(request["grant_review"]["state"], "missing_grant");
+        assert_eq!(request["grant_attention"]["needs_attention"], true);
+        assert_eq!(request["attention"]["needs_attention"], true);
+        assert_eq!(
+            request["attention"]["sources"],
+            json!(["execution", "grant"])
+        );
+        let sources = request["attention"]["signals"]
+            .as_array()
+            .expect("attention signals");
+        assert!(sources.iter().any(|signal| signal["source"] == "execution"));
+        assert!(sources.iter().any(|signal| signal["source"] == "grant"));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_attention_list_summarizes_execution_grant_and_combined_hotspots() {
+        let config = isolated_memory_config("approval-attention-summary");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        seed_request(
+            &repo,
+            "apr-execution-only",
+            "root-session",
+            "delegate",
+            "rule-execution",
+        );
+
+        seed_request(
+            &repo,
+            "apr-grant-only",
+            "root-session",
+            "delegate_async",
+            "rule-grant-only",
+        );
+        approve_request(
+            &repo,
+            "apr-grant-only",
+            ApprovalDecision::ApproveAlways,
+            "root-session",
+        );
+        mark_request_executed(&repo, "apr-grant-only", None);
+
+        seed_request(
+            &repo,
+            "apr-combined",
+            "root-session",
+            "session_cancel",
+            "rule-combined",
+        );
+        approve_request(
+            &repo,
+            "apr-combined",
+            ApprovalDecision::ApproveAlways,
+            "root-session",
+        );
+        mark_request_executed(&repo, "apr-combined", Some("delegate replay failed"));
+
+        seed_request(
+            &repo,
+            "apr-clean-grant",
+            "root-session",
+            "session_recover",
+            "rule-clean",
+        );
+        approve_request(
+            &repo,
+            "apr-clean-grant",
+            ApprovalDecision::ApproveAlways,
+            "root-session",
+        );
+        mark_request_executed(&repo, "apr-clean-grant", None);
+        seed_runtime_grant(&repo, "root-session", "tool:session_recover");
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({}),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome");
+
+        assert_eq!(
+            outcome.payload["attention_summary"]["needs_attention_count"],
+            3
+        );
+        assert_eq!(
+            outcome.payload["attention_summary"]["source_breakdown"]["execution_only"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["attention_summary"]["source_breakdown"]["grant_only"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["attention_summary"]["source_breakdown"]["combined"],
+            1
+        );
+        let reasons = outcome.payload["attention_summary"]["hotspots"]["by_reason"]
+            .as_array()
+            .expect("reason hotspots");
+        assert!(
+            reasons
+                .iter()
+                .any(|item| item["reason"] == "pending_operator_decision")
+        );
+        assert!(
+            reasons
+                .iter()
+                .any(|item| item["reason"] == "missing_runtime_grant")
+        );
+        assert!(
+            reasons
+                .iter()
+                .any(|item| item["reason"] == "resumed_execution_failed")
+        );
+        let actions = outcome.payload["attention_summary"]["hotspots"]["by_action"]
+            .as_array()
+            .expect("action hotspots");
+        assert!(
+            actions
+                .iter()
+                .any(|item| item["action"] == "resolve_request")
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|item| item["action"] == "repair_runtime_grant")
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|item| item["action"] == "inspect_failed_replay")
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_grant_attention_filter_selects_grant_side_requests() {
+        let config = isolated_memory_config("approval-grant-filter");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        seed_request(
+            &repo,
+            "apr-execution-only",
+            "root-session",
+            "delegate",
+            "rule-execution",
+        );
+
+        seed_request(
+            &repo,
+            "apr-grant-attention",
+            "root-session",
+            "delegate",
+            "rule-grant-attention",
+        );
+        approve_request(
+            &repo,
+            "apr-grant-attention",
+            ApprovalDecision::ApproveAlways,
+            "root-session",
+        );
+        mark_request_executed(&repo, "apr-grant-attention", None);
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_attention": "needs_attention"
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome");
+
+        assert_eq!(outcome.payload["matched_count"], 1);
+        assert_eq!(
+            outcome.payload["filter"]["grant_attention"],
+            "needs_attention"
+        );
+        let requests = outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["approval_request_id"], "apr-grant-attention");
+        assert_eq!(requests[0]["grant_review"]["state"], "missing_grant");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_grant_attention_filter_rejects_unknown_values() {
+        let config = isolated_memory_config("approval-grant-filter-invalid");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-invalid-filter",
+            "root-session",
+            "delegate",
+            "rule-invalid-filter",
+        );
+
+        let error = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({
+                    "grant_attention": "unknown"
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect_err("invalid grant attention filter should fail");
+
+        assert!(
+            error.contains("unknown grant_attention `unknown`"),
+            "expected invalid grant attention error, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_attention_grant_review_marks_stale_runtime_grants() {
+        let config = isolated_memory_config("approval-grant-review-stale");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-stale-grant",
+            "root-session",
+            "delegate",
+            "rule-stale-grant",
+        );
+        approve_request(
+            &repo,
+            "apr-stale-grant",
+            ApprovalDecision::ApproveAlways,
+            "root-session",
+        );
+        mark_request_executed(&repo, "apr-stale-grant", None);
+        seed_runtime_grant(&repo, "root-session", "tool:delegate");
+        age_runtime_grant(&config, "root-session", "tool:delegate", 0);
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-stale-grant",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome");
+
+        assert_eq!(
+            outcome.payload["approval_request"]["grant_review"]["state"],
+            "review_stale"
+        );
+        assert_eq!(
+            outcome.payload["approval_request"]["grant_attention"]["needs_attention"],
+            true
+        );
+    }
+}

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -284,6 +284,33 @@ pub fn tool_catalog() -> ToolCatalog {
             provider_definition_builder: provider_switch_definition,
         },
         ToolDescriptor {
+            name: "approval_request_resolve",
+            provider_name: "approval_request_resolve",
+            aliases: &[],
+            description: "Resolve one visible governed tool approval request",
+            execution_kind: ToolExecutionKind::App,
+            availability: runtime_session_tool_availability(),
+            provider_definition_builder: approval_request_resolve_definition,
+        },
+        ToolDescriptor {
+            name: "approval_request_status",
+            provider_name: "approval_request_status",
+            aliases: &[],
+            description: "Inspect full detail for a visible governed tool approval request",
+            execution_kind: ToolExecutionKind::App,
+            availability: runtime_session_tool_availability(),
+            provider_definition_builder: approval_request_status_definition,
+        },
+        ToolDescriptor {
+            name: "approval_requests_list",
+            provider_name: "approval_requests_list",
+            aliases: &[],
+            description: "List visible governed tool approval requests across the current session scope",
+            execution_kind: ToolExecutionKind::App,
+            availability: runtime_session_tool_availability(),
+            provider_definition_builder: approval_requests_list_definition,
+        },
+        ToolDescriptor {
             name: "delegate",
             provider_name: "delegate",
             aliases: &[],
@@ -510,10 +537,17 @@ pub fn delegate_child_tool_view_for_config_with_delegate(
 
 fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> bool {
     match tool_name {
-        "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_archive" | "session_cancel" | "session_recover" | "session_wait" => {
-            config.sessions.enabled
-        }
+        "approval_request_resolve"
+        | "approval_request_status"
+        | "approval_requests_list"
+        | "sessions_list"
+        | "sessions_history"
+        | "session_status"
+        | "session_events"
+        | "session_archive"
+        | "session_cancel"
+        | "session_recover"
+        | "session_wait" => config.sessions.enabled,
         "sessions_send" => config.messages.enabled,
         "delegate" | "delegate_async" => config.delegate.enabled,
         _ => true,
@@ -883,6 +917,84 @@ fn shell_exec_definition(descriptor: &ToolDescriptor) -> Value {
                     }
                 },
                 "required": ["command"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn approval_request_resolve_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "approval_request_id": {
+                        "type": "string",
+                        "description": "Visible approval request identifier to resolve."
+                    },
+                    "decision": {
+                        "type": "string",
+                        "enum": ["approve_once", "approve_always", "deny"],
+                        "description": "Operator decision for the pending approval request."
+                    }
+                },
+                "required": ["approval_request_id", "decision"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn approval_request_status_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "approval_request_id": {
+                        "type": "string",
+                        "description": "Visible approval request identifier to inspect in detail."
+                    }
+                },
+                "required": ["approval_request_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn approval_requests_list_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional visible session identifier to scope approval requests to one session."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["pending", "approved", "executing", "executed", "denied", "expired", "cancelled"],
+                        "description": "Optional approval request status filter."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "description": "Maximum visible approval requests to return after filtering."
+                    }
+                },
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -16,6 +16,86 @@ pub enum ToolAvailability {
     Planned,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolGovernanceScope {
+    Routine,
+    TopologyMutation,
+}
+
+impl ToolGovernanceScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Routine => "routine",
+            Self::TopologyMutation => "topology_mutation",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolRiskClass {
+    Low,
+    Elevated,
+    High,
+}
+
+impl ToolRiskClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Elevated => "elevated",
+            Self::High => "high",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolApprovalMode {
+    Never,
+    PolicyDriven,
+}
+
+impl ToolApprovalMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Never => "never",
+            Self::PolicyDriven => "policy_driven",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolGovernanceProfile {
+    pub scope: ToolGovernanceScope,
+    pub risk_class: ToolRiskClass,
+    pub approval_mode: ToolApprovalMode,
+}
+
+pub fn governance_profile_for_tool_name(tool_name: &str) -> ToolGovernanceProfile {
+    match tool_name {
+        "delegate" | "delegate_async" => ToolGovernanceProfile {
+            scope: ToolGovernanceScope::TopologyMutation,
+            risk_class: ToolRiskClass::High,
+            approval_mode: ToolApprovalMode::PolicyDriven,
+        },
+        "session_archive" | "session_cancel" | "session_recover" | "sessions_send" => {
+            ToolGovernanceProfile {
+                scope: ToolGovernanceScope::Routine,
+                risk_class: ToolRiskClass::Elevated,
+                approval_mode: ToolApprovalMode::PolicyDriven,
+            }
+        }
+        _ => ToolGovernanceProfile {
+            scope: ToolGovernanceScope::Routine,
+            risk_class: ToolRiskClass::Low,
+            approval_mode: ToolApprovalMode::Never,
+        },
+    }
+}
+
+pub fn governance_profile_for_descriptor(descriptor: &ToolDescriptor) -> ToolGovernanceProfile {
+    governance_profile_for_tool_name(descriptor.name)
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ToolDescriptor {
     pub name: &'static str,

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -9,6 +9,7 @@ use crate::KernelContext;
 use crate::config::ToolConfig;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 
+pub(crate) mod approval;
 mod catalog;
 mod claw_import;
 pub(crate) mod delegate;
@@ -74,6 +75,14 @@ pub fn execute_app_tool_with_config(
     };
 
     match canonical_name {
+        "approval_requests_list" | "approval_request_status" | "approval_request_resolve" => {
+            approval::execute_approval_tool_with_policies(
+                request,
+                current_session_id,
+                memory_config,
+                tool_config,
+            )
+        }
         "sessions_list" | "sessions_history" | "session_status" | "session_events"
         | "session_archive" | "session_cancel" | "session_recover" => {
             session::execute_session_tool_with_policies(
@@ -464,6 +473,15 @@ mod tests {
     #[test]
     fn capability_snapshot_lists_all_tools_when_all_features_enabled() {
         let snapshot = capability_snapshot();
+        assert!(snapshot.contains(
+            "- approval_request_resolve: Resolve one visible governed tool approval request"
+        ));
+        assert!(snapshot.contains(
+            "- approval_request_status: Inspect full detail for a visible governed tool approval request"
+        ));
+        assert!(snapshot.contains(
+            "- approval_requests_list: List visible governed tool approval requests across the current session scope"
+        ));
         assert!(
             snapshot.contains(
                 "- claw.import: Import legacy Claw configs into native LoongClaw settings"
@@ -520,31 +538,42 @@ mod tests {
         );
         assert!(snapshot.contains("- shell.exec: Execute shell commands"));
 
-        // Verify sorted order: claw.import < delegate* < external_skills.* < file.* < provider.switch < session_* < sessions_* < shell.exec
+        // Verify sorted order matches the catalog snapshot emitted to providers.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
-        assert_eq!(lines.len(), 22);
-        assert!(lines[0].starts_with("- claw.import"));
-        assert!(lines[1].starts_with("- delegate"));
-        assert!(lines[2].starts_with("- delegate_async"));
-        assert!(lines[3].starts_with("- external_skills.fetch"));
-        assert!(lines[4].starts_with("- external_skills.inspect"));
-        assert!(lines[5].starts_with("- external_skills.install"));
-        assert!(lines[6].starts_with("- external_skills.invoke"));
-        assert!(lines[7].starts_with("- external_skills.list"));
-        assert!(lines[8].starts_with("- external_skills.policy"));
-        assert!(lines[9].starts_with("- external_skills.remove"));
-        assert!(lines[10].starts_with("- file.read"));
-        assert!(lines[11].starts_with("- file.write"));
-        assert!(lines[12].starts_with("- provider.switch"));
-        assert!(lines[13].starts_with("- session_archive"));
-        assert!(lines[14].starts_with("- session_cancel"));
-        assert!(lines[15].starts_with("- session_events"));
-        assert!(lines[16].starts_with("- session_recover"));
-        assert!(lines[17].starts_with("- session_status"));
-        assert!(lines[18].starts_with("- session_wait"));
-        assert!(lines[19].starts_with("- sessions_history"));
-        assert!(lines[20].starts_with("- sessions_list"));
-        assert!(lines[21].starts_with("- shell.exec"));
+        let ordered_prefixes = vec![
+            "- approval_request_resolve",
+            "- approval_request_status",
+            "- approval_requests_list",
+            "- claw.import",
+            "- delegate",
+            "- delegate_async",
+            "- external_skills.fetch",
+            "- external_skills.inspect",
+            "- external_skills.install",
+            "- external_skills.invoke",
+            "- external_skills.list",
+            "- external_skills.policy",
+            "- external_skills.remove",
+            "- file.read",
+            "- file.write",
+            "- provider.switch",
+            "- session_archive",
+            "- session_cancel",
+            "- session_events",
+            "- session_recover",
+            "- session_status",
+            "- session_wait",
+            "- sessions_history",
+            "- sessions_list",
+            "- shell.exec",
+        ];
+        assert_eq!(lines.len(), ordered_prefixes.len());
+        for (line, prefix) in lines.iter().zip(ordered_prefixes) {
+            assert!(
+                line.starts_with(prefix),
+                "expected `{prefix}`, got `{line}`"
+            );
+        }
     }
 
     #[cfg(all(
@@ -555,8 +584,11 @@ mod tests {
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 22);
+        assert_eq!(entries.len(), 25);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
+        assert!(names.contains(&"approval_request_resolve"));
+        assert!(names.contains(&"approval_request_status"));
+        assert!(names.contains(&"approval_requests_list"));
         assert!(names.contains(&"claw.import"));
         assert!(names.contains(&"delegate"));
         assert!(names.contains(&"delegate_async"));
@@ -615,7 +647,7 @@ mod tests {
         let defs = try_provider_tool_definitions_for_view(&planned_root_tool_view())
             .expect("all tools should now be advertisable");
 
-        assert_eq!(defs.len(), 23);
+        assert_eq!(defs.len(), 26);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -624,6 +656,9 @@ mod tests {
         let view = runtime_tool_view_for_config(&crate::config::ToolConfig::default());
 
         for tool_name in [
+            "approval_request_resolve",
+            "approval_request_status",
+            "approval_requests_list",
             "delegate",
             "delegate_async",
             "session_archive",
@@ -711,7 +746,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 22);
+        assert_eq!(defs.len(), 25);
 
         let names: Vec<&str> = defs
             .iter()
@@ -722,6 +757,9 @@ mod tests {
         assert_eq!(
             names,
             vec![
+                "approval_request_resolve",
+                "approval_request_status",
+                "approval_requests_list",
                 "claw_import",
                 "delegate",
                 "delegate_async",
@@ -824,6 +862,23 @@ mod tests {
         assert!(properties.contains_key("task"));
         assert!(properties.contains_key("label"));
         assert!(properties.contains_key("timeout_seconds"));
+    }
+
+    #[test]
+    fn provider_tool_definitions_include_approval_request_resolve_when_enabled() {
+        let defs = try_provider_tool_definitions_for_view(&runtime_tool_view_for_config(
+            &crate::config::ToolConfig::default(),
+        ))
+        .expect("runtime-visible tool schemas");
+        let approval_request_resolve = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "approval_request_resolve")
+            .expect("approval_request_resolve definition");
+        let properties = approval_request_resolve["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("approval_request_resolve properties");
+        assert!(properties.contains_key("approval_request_id"));
+        assert!(properties.contains_key("decision"));
     }
 
     #[test]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -24,8 +24,10 @@ mod shell;
 pub mod shell_policy_ext;
 
 pub use catalog::{
-    ToolAvailability, ToolCatalog, ToolDescriptor, ToolExecutionKind, ToolView,
+    ToolApprovalMode, ToolAvailability, ToolCatalog, ToolDescriptor, ToolExecutionKind,
+    ToolGovernanceProfile, ToolGovernanceScope, ToolRiskClass, ToolView,
     delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
+    governance_profile_for_descriptor, governance_profile_for_tool_name,
     planned_delegate_child_tool_view, planned_root_tool_view, runtime_tool_view,
     runtime_tool_view_for_config, tool_catalog,
 };

--- a/docs/plans/2026-03-15-issue-128-approval-attention-rebuild-design.md
+++ b/docs/plans/2026-03-15-issue-128-approval-attention-rebuild-design.md
@@ -1,0 +1,263 @@
+# Issue 128 Approval Attention Rebuild Design
+
+## Goal
+
+Rebuild the approval request lifecycle and operator attention surface for issue `#128` directly on
+top of current `alpha-test`, then expose a mergeable, auditable tool surface that fits the modern
+session/runtime architecture.
+
+## Problem
+
+The closed PR `#129` tried to extend an approval system that no longer matches current
+`alpha-test`. Its branch is structurally stale against today's session/runtime contracts and cannot
+be repaired with a mechanical rebase.
+
+At the same time, issue `#128` is still valid at the product level: operators need a canonical
+approval queue, request status inspection, decision resolution, and a single attention view that
+combines execution-side and grant-side signals.
+
+Current `alpha-test` already provides useful foundations:
+
+- session persistence and lineage in `crates/app/src/session/repository.rs`
+- app-tool routing via `DefaultAppToolDispatcher`
+- session visibility rules used by existing session tools
+- conversation persistence hooks and durable `session_events`
+
+What it still does not provide is the governed approval lifecycle itself:
+
+- no durable approval request record
+- no durable runtime grant record
+- no approval tool surface
+- no operator attention union view
+- no automatic resume path after operator approval
+
+## Constraints
+
+- `alpha-test` is the source of truth.
+- The rebuild must align with current app-tool/session architecture instead of reviving removed
+  request-approval codepaths.
+- The implementation must stay auditable and avoid hardcoded one-off behavior.
+- TDD is required: failing tests first, then minimal implementation.
+- Validation must include targeted tests, formatting, clippy, and full workspace tests before any
+  GitHub delivery step.
+
+## Approaches Considered
+
+### Approach A: Event-only attention reconstruction
+
+Represent approval state purely by replaying `session_events`, then expose a thin query view that
+derives pending requests and attention heuristics from event history.
+
+Pros:
+
+- smallest immediate patch
+- maximally reuses existing event storage
+
+Cons:
+
+- request identity and lifecycle remain implicit
+- idempotent operator resolution becomes fragile
+- grant persistence is awkward
+- attention semantics become heuristic rather than authoritative
+
+### Approach B: Minimal durable lifecycle plus derived attention
+
+Add explicit durable approval request and runtime grant records, wire `TurnEngine` and app-tool
+runtime to materialize and resolve those records, then derive canonical attention summaries from
+durable state plus lifecycle events.
+
+Pros:
+
+- explicit request state machine
+- stable request IDs and replay-safe resolution
+- real `approve_once` / `approve_always` / `deny` behavior
+- attention can be derived from authoritative lifecycle state
+- fits current `SessionRepository` and session-tool visibility model
+
+Cons:
+
+- moderate scope
+- requires runtime support for post-approval execution
+
+### Approach C: Full port of the old attention-heavy PR surface
+
+Port the old large `approval.rs` implementation and its full filter/summarization matrix into
+current `alpha-test`.
+
+Pros:
+
+- richest surface immediately
+
+Cons:
+
+- highest drift risk
+- old implementation assumes removed contracts and stale modules
+- several integrity signals in the old code rely on bounded event windows and weaker invariants
+
+## Recommendation
+
+Use Approach B.
+
+This is the smallest slice that restores a truthful approval runtime while still solving the
+operator problem from issue `#128`. It preserves the "few thick primitives" design direction:
+
+- one durable request object
+- one durable runtime grant object
+- one narrow approval tool surface
+- one canonical attention view derived from execution and grant signals
+
+The old PR remains reference material only, not a port target.
+
+## Proposed Architecture
+
+### 1. Durable approval request and grant state in `SessionRepository`
+
+Extend the SQLite-backed control-plane store with two approval-specific tables:
+
+- `approval_requests`
+- `approval_grants`
+
+`approval_requests` stores the lifecycle of a blocked governed tool call, including:
+
+- deterministic `approval_request_id`
+- session, turn, and tool-call correlation
+- canonical tool name and approval key
+- request payload snapshot for replay
+- governance snapshot for auditability
+- explicit status and decision fields
+- timestamps for request, resolution, and execution
+- last error for failed resumed execution
+
+`approval_grants` stores session-lineage-scoped runtime grants for `approve_always`.
+
+The repository remains the single durable backend. No separate approval repository layer is needed
+for this slice.
+
+### 2. Governed approval materialization inside `TurnEngine`
+
+When a governed tool call requires approval, `TurnEngine` should:
+
+- compute a deterministic approval request ID from session/turn/tool identity
+- persist or reuse the pending request
+- persist approval lifecycle events in the session log
+- return a structured approval requirement instead of only a free-form denial string
+
+This preserves idempotency and gives the turn loop enough information to render a truthful operator
+message with the request ID.
+
+### 3. Narrow approval tool surface
+
+Add three app tools:
+
+- `approval_requests_list`
+- `approval_request_status`
+- `approval_request_resolve`
+
+These tools must follow the same visibility rules as the existing session tools, so operators can
+inspect or resolve only requests that are visible from the current session lineage.
+
+`approval_request_resolve` must support:
+
+- `approve_once`
+- `approve_always`
+- `deny`
+
+### 4. Automatic replay after approval
+
+`approval_request_resolve` should be wired through runtime support so the original blocked tool call
+can be resumed without asking the model to regenerate it.
+
+Expected replay flow:
+
+- `pending -> approved`
+- optionally persist a runtime grant for `approve_always`
+- `approved -> executing`
+- resume the original tool request with an approval bypass scoped to that request or grant
+- `executing -> executed` on success
+- keep explicit failure evidence and `last_error` on resumed execution failure
+
+### 5. Canonical attention model
+
+Attention should be derived, not independently persisted.
+
+Each approval request should expose:
+
+- `execution_integrity`
+- `grant_review`
+- `grant_attention`
+- `attention`
+
+The canonical `attention` view is a union of source-tagged signals from:
+
+- execution-side lifecycle/integrity state
+- grant-side durability/review state
+
+The first implementation does not need the entire historical filter matrix from old PR `#129`.
+It should provide the parts that directly solve issue `#128`:
+
+- per-request canonical attention view
+- explicit execution/grant source tagging
+- unified list-level attention summaries
+- hotspot summaries by reason/action/tool/session
+- explicit grant-side filters alongside existing status/session filters
+
+## Attention Semantics
+
+### Execution-side attention
+
+Execution-side attention should cover:
+
+- resumed execution failed
+- resumed execution is stuck or incomplete
+- replay outcome indicates follow-up inspection is needed
+
+### Grant-side attention
+
+Grant-side attention should cover:
+
+- `approve_always` should have produced a durable grant but no grant exists
+- durable grant exists but review age is stale/overdue
+
+### Canonical union
+
+List and status responses should expose both the source-specific structures and a merged
+`attention` block containing:
+
+- `needs_attention`
+- `sources`
+- `signals`
+- `highest_escalation_level`
+
+This preserves triage value without hiding whether the problem is execution-side or grant-side.
+
+## Scope Boundaries
+
+Included in this slice:
+
+- durable approval requests
+- durable runtime grants
+- query/status/resolve approval tools
+- automatic replay after approval
+- canonical attention view and useful summaries/filters
+- tests and docs updates needed to support the new lifecycle
+
+Not included in this slice:
+
+- cross-kernel approval runtime unification
+- UI/channel-native approval workflows
+- config file rewrites for `approve_always`
+- speculative global grants outside current session lineage
+
+## Validation Strategy
+
+The work should land in explicit red-green slices:
+
+1. repository schema and lifecycle tests
+2. turn-engine approval request materialization tests
+3. approval tool query tests
+4. approval resolve and replay tests
+5. attention summary/filter tests
+6. formatting, clippy, and full workspace tests
+
+The final GitHub delivery must link the replacement PR to issue `#128` and treat closed PR `#129`
+as superseded by a fresh reconstruction rather than a revived branch.

--- a/docs/plans/2026-03-15-issue-128-approval-attention-rebuild.md
+++ b/docs/plans/2026-03-15-issue-128-approval-attention-rebuild.md
@@ -1,0 +1,341 @@
+# Issue 128 Approval Attention Rebuild Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Rebuild the governed approval request lifecycle and operator attention surface for issue
+`#128` on current `alpha-test`, including durable request/grant persistence, operator resolution,
+automatic replay, and unified attention summaries.
+
+**Architecture:** Extend the SQLite-backed `SessionRepository` with explicit approval request and
+grant records, materialize approval-required tool calls from `TurnEngine`, expose a narrow
+approval app-tool surface, and derive a canonical attention union view from lifecycle execution and
+grant audit state.
+
+**Tech Stack:** Rust, Tokio, serde/serde_json, rusqlite, existing conversation runtime and session
+tool infrastructure, cargo test, cargo fmt, cargo clippy.
+
+---
+
+### Task 1: Lock durable approval storage with failing repository tests
+
+**Files:**
+- Modify: `crates/app/src/memory/sqlite.rs`
+- Modify: `crates/app/src/session/repository.rs`
+
+**Step 1: Write the failing tests**
+
+Add repository tests that expect:
+
+- `approval_requests` persists a new pending request
+- duplicate create for the same deterministic request ID returns the same row
+- request status transitions are conditional and explicit
+- `approval_grants` persists a session-scoped runtime grant
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app approval_request_repository_ -- --nocapture --test-threads=1
+```
+
+Expected: FAIL because approval storage does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- SQLite schema for `approval_requests`
+- SQLite schema for `approval_grants`
+- repository structs and methods for create/load/list/transition request records
+- repository methods for upsert/load grant records
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app approval_request_repository_ -- --nocapture --test-threads=1
+```
+
+Expected: PASS.
+
+### Task 2: Materialize approval-required governed tool calls in `TurnEngine`
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that expect:
+
+- a governed tool call that requires approval creates a durable pending request
+- repeated blocking of the same call reuses the deterministic request ID
+- the turn result carries structured approval requirement data including request ID, tool name,
+  approval key, reason, and rule ID
+- the turn loop renders a truthful approval-required reply containing the request ID
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app governed_tool_approval_request_ turn_loop_renders_tool_approval_required -- --nocapture --test-threads=1
+```
+
+Expected: FAIL because approval-required lifecycle support does not exist.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- structured approval requirement/result types
+- deterministic request ID generation
+- approval request persistence on the governed-tool approval path
+- turn-loop rendering that surfaces the request ID
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app governed_tool_approval_request_ turn_loop_renders_tool_approval_required -- --nocapture --test-threads=1
+```
+
+Expected: PASS.
+
+### Task 3: Add failing approval tool query tests
+
+**Files:**
+- Create: `crates/app/src/tools/approval.rs`
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that expect:
+
+- `approval_requests_list` returns only visible approval requests
+- `approval_request_status` returns a full request snapshot for a visible request
+- hidden requests are rejected
+- query responses include source-specific attention blocks and a canonical union block
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app approval_request_tool_query_ -- --nocapture --test-threads=1
+```
+
+Expected: FAIL because the approval tool surface does not exist.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- approval tool module and catalog descriptors
+- list and status handlers with session visibility enforcement
+- request JSON rendering that includes execution/grant/union attention structures
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app approval_request_tool_query_ -- --nocapture --test-threads=1
+```
+
+Expected: PASS.
+
+### Task 4: Add failing approval resolution tests for deny and replay flows
+
+**Files:**
+- Modify: `crates/app/src/tools/approval.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that expect:
+
+- `approval_request_resolve` with `deny` moves the request to `denied`
+- non-pending requests fail closed on duplicate resolve
+- `approve_once` resumes the original blocked tool call and records lifecycle events
+- resumed execution failure records `last_error` and attention-worthy evidence
+- `approve_always` writes a lineage-scoped runtime grant and replays the request
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app approval_request_resolve_ approval_request_resume_ approval_request_always_grant_ -- --nocapture --test-threads=1
+```
+
+Expected: FAIL because resolve/replay support is not wired yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- runtime-backed `approval_request_resolve`
+- conditional transitions through `pending -> approved/denied -> executing -> executed`
+- runtime grant persistence for `approve_always`
+- replay support for the original blocked tool call without re-entering the approval-required path
+- explicit lifecycle events for resolve, replay start, replay success, and replay failure
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app approval_request_resolve_ approval_request_resume_ approval_request_always_grant_ -- --nocapture --test-threads=1
+```
+
+Expected: PASS.
+
+### Task 5: Add failing operator attention summary and filter tests
+
+**Files:**
+- Modify: `crates/app/src/tools/approval.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+- Modify: `crates/app/src/session/repository.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that expect:
+
+- list responses include unified `attention_summary`
+- attention summaries separate execution-only, grant-only, and combined hotspots
+- grant-side filters work explicitly alongside status/session filters
+- per-request status exposes canonical attention signals with source tags
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app approval_request_attention_ approval_request_tool_query_list_ -- --nocapture --test-threads=1
+```
+
+Expected: FAIL because the current list/status responses do not derive canonical attention.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- execution-side attention derivation
+- grant-side attention derivation
+- canonical union attention block
+- list-level summaries and hotspot counts by reason/action/tool/session
+- explicit grant attention filters and stable validation errors for unsupported filter values
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app approval_request_attention_ approval_request_tool_query_list_ -- --nocapture --test-threads=1
+```
+
+Expected: PASS.
+
+### Task 6: Refresh docs and capability snapshots if the approval tool surface changes them
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: relevant docs only if test failures or snapshot expectations require it
+
+**Step 1: Write the failing test**
+
+Add or update tests that assert:
+
+- approval tools appear in runtime tool snapshots only when available
+- provider-facing capability descriptions remain consistent with the new tool surface
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app tool_snapshot approval_request_tool -- --nocapture --test-threads=1
+```
+
+Expected: FAIL if the exposed surface is not reflected in catalog/snapshot outputs.
+
+**Step 3: Write minimal implementation**
+
+Update tool catalog definitions, visibility-driven snapshots, and any necessary docs text so the
+advertised tool surface matches runtime behavior.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app tool_snapshot approval_request_tool -- --nocapture --test-threads=1
+```
+
+Expected: PASS.
+
+### Task 7: Run full verification and prepare GitHub delivery
+
+**Files:**
+- Review only the files touched above
+
+**Step 1: Run formatting**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: PASS.
+
+**Step 2: Run clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: PASS.
+
+**Step 3: Run full tests**
+
+Run:
+
+```bash
+cargo test --workspace --all-features
+```
+
+Expected: PASS.
+
+**Step 4: Inspect the exact diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+git diff
+```
+
+Expected: only approval-lifecycle/attention rebuild files plus any required docs/tests.
+
+**Step 5: Commit**
+
+Create clean task-scoped commits after verifying the diff is isolated.
+
+**Step 6: Push and open PR**
+
+Push to `fork-chumyin`, open a new PR against `loongclaw-ai/loongclaw:alpha-test`, follow the
+repository PR template, and include `Closes #128` if the final implementation fully resolves the
+issue.


### PR DESCRIPTION
## Summary

- rebuild the governed approval request lifecycle on current `alpha-test`, including durable request persistence, durable grants, and runtime-backed resolution/replay
- add `approval_requests_list`, `approval_request_status`, and `approval_request_resolve` as the operator-facing approval surface for visible sessions
- expose canonical operator attention data with `execution_integrity`, `grant_review`, `grant_attention`, unified `attention`, and list-level hotspot summaries
- this change is needed so operators can resolve and audit governed tool approvals from one consistent, replay-safe surface instead of reconstructing lifecycle and attention state by hand

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

scope note: this stays inside the approval/session runtime surface and its regression coverage, but it intentionally spans persistence, coordinator replay, and tool definitions because the old branch was no longer compatible with current `alpha-test`.

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

risk note: this changes operator-facing approval lifecycle semantics, replay behavior, and attention summaries for governed tools.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [ ] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

validation note: the full workspace test run covers the new approval query, resolve, replay, and attention regression suites added in this branch.

## Linked Issues

Closes #128