### PR TITLE
feat: productize external skills CLI and discovery scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,12 +363,27 @@ Agent-facing tools:
 - `external_skills_remove`
   - Removes a managed installed skill and updates the local index.
 
+Operator-facing CLI:
+
+- `loongclaw skills list [--config PATH] [--json]`
+  - Lists managed installed skills using the current config/runtime guardrails.
+- `loongclaw skills info <skill-id> [--config PATH] [--json]`
+  - Shows structured metadata plus a short `SKILL.md` preview for one installed skill.
+- `loongclaw skills install <path> [--skill-id ID] [--replace] [--config PATH] [--json]`
+  - Installs a local skill directory or `.tgz` / `.tar.gz` archive through the same managed runtime path as `external_skills.install`.
+- `loongclaw skills remove <skill-id> [--config PATH] [--json]`
+  - Removes one managed installed skill from the local index.
+- `loongclaw skills policy get|set|reset [--config PATH] [--json]`
+  - Reads or updates the config-backed external-skills runtime policy with the same policy fields exposed by `external_skills.policy`.
+  - Mutating `set` and `reset` calls require `--approve-policy-update`.
+
 Recommended runtime flow:
 
 1. Download with `external_skills.fetch`
-2. Install with `external_skills.install`
-3. Discover with `external_skills.list`
-4. Load instructions with `external_skills.invoke`
+2. Install with `external_skills.install` or `loongclaw skills install`
+3. Discover with `external_skills.list` or `loongclaw skills list`
+4. Inspect with `external_skills.inspect` or `loongclaw skills info`
+5. Load instructions with `external_skills.invoke`
 
 ## Key Features
 

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -800,7 +800,7 @@ fn parse_optional_domain_list(
     Ok(Some(normalized))
 }
 
-fn normalize_domain_rule(raw: &str) -> Result<String, String> {
+pub(crate) fn normalize_domain_rule(raw: &str) -> Result<String, String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return Err("domain rule cannot be empty".to_owned());

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -424,8 +424,8 @@ pub(super) fn execute_external_skills_install_tool_with_config(
     index.skills.retain(|entry| entry.skill_id != skill_id);
     index.skills.push(InstalledSkillEntry {
         skill_id: skill_id.clone(),
-        display_name,
-        summary,
+        display_name: display_name.clone(),
+        summary: summary.clone(),
         source_kind: source_kind.to_owned(),
         source_path: source_path.display().to_string(),
         install_path: destination_root.display().to_string(),
@@ -447,6 +447,7 @@ pub(super) fn execute_external_skills_install_tool_with_config(
     } else {
         None
     };
+    let replaced = backup_root.is_some();
     if let Some(backup_root) = backup_root.as_ref() {
         fs::rename(&destination_root, backup_root).map_err(|error| {
             format!(
@@ -516,12 +517,14 @@ pub(super) fn execute_external_skills_install_tool_with_config(
             "adapter": "core-tools",
             "tool_name": request.tool_name,
             "skill_id": skill_id,
+            "display_name": display_name,
+            "summary": summary,
             "source_kind": source_kind,
             "source_path": source_path.display().to_string(),
             "install_path": destination_root.display().to_string(),
             "skill_md_path": destination_root.join(DEFAULT_SKILL_FILENAME).display().to_string(),
             "sha256": digest,
-            "replaced": replace,
+            "replaced": replaced,
         }),
     })
 }
@@ -1843,6 +1846,8 @@ mod tests {
 
             assert_eq!(outcome.status, "ok");
             assert_eq!(outcome.payload["skill_id"], "demo-skill");
+            assert_eq!(outcome.payload["display_name"], "Demo Skill");
+            assert_eq!(outcome.payload["replaced"], false);
             assert!(
                 root.join("external-skills-installed")
                     .join("index.json")
@@ -1856,6 +1861,56 @@ mod tests {
                     .exists(),
                 "managed external skill copy should exist"
             );
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn install_replace_reports_actual_replacement_state() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-install-replace");
+            fs::create_dir_all(&root).expect("create fixture root");
+            write_file(
+                &root,
+                "source/demo-skill/SKILL.md",
+                "# Demo Skill\n\nFirst install.\n",
+            );
+            write_file(
+                &root,
+                "source/demo-skill-v2/SKILL.md",
+                "# Demo Skill\n\nReplacement install.\n",
+            );
+            let config = managed_runtime_config(&root);
+
+            let first_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload: json!({
+                        "path": "source/demo-skill",
+                        "replace": true
+                    }),
+                },
+                &config,
+            )
+            .expect("first install with replace flag should succeed");
+            assert_eq!(first_outcome.payload["display_name"], "Demo Skill");
+            assert_eq!(first_outcome.payload["replaced"], false);
+
+            let replace_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload: json!({
+                        "path": "source/demo-skill-v2",
+                        "skill_id": "demo-skill",
+                        "replace": true
+                    }),
+                },
+                &config,
+            )
+            .expect("second install should report a real replacement");
+            assert_eq!(replace_outcome.payload["display_name"], "Demo Skill");
+            assert_eq!(replace_outcome.payload["replaced"], true);
 
             fs::remove_dir_all(&root).ok();
         });

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -45,6 +45,10 @@ pub use kernel_adapter::MvpToolAdapter;
 
 pub(crate) const LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY: &str = "_loongclaw";
 
+pub fn normalize_external_skills_domain_rule(raw: &str) -> Result<String, String> {
+    external_skills::normalize_domain_rule(raw)
+}
+
 tokio::task_local! {
     static TRUSTED_INTERNAL_TOOL_PAYLOAD_TASK: bool;
 }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -47,6 +47,7 @@ mod next_actions;
 mod onboard_cli;
 mod onboard_presentation;
 mod provider_presentation;
+mod skills_cli;
 mod source_presentation;
 #[cfg(test)]
 pub(crate) use loongclaw_spec::programmatic::{
@@ -331,6 +332,15 @@ enum Commands {
         /// Skip provider model probing during diagnostics
         #[arg(long, default_value_t = false)]
         skip_model_probe: bool,
+    },
+    /// Manage installed external skills through an operator-facing CLI surface
+    Skills {
+        #[arg(long, global = true)]
+        config: Option<String>,
+        #[arg(long, global = true, default_value_t = false)]
+        json: bool,
+        #[command(subcommand)]
+        command: skills_cli::SkillsCommands,
     },
     /// List compiled channel surfaces, aliases, and readiness status
     Channels {
@@ -706,6 +716,15 @@ async fn main() {
             })
             .await
         }
+        Commands::Skills {
+            config,
+            json,
+            command,
+        } => skills_cli::run_skills_cli(skills_cli::SkillsCommandOptions {
+            config,
+            json,
+            command,
+        }),
         Commands::Channels { config, json } => run_channels_cli(config.as_deref(), json),
         Commands::ListModels { config, json } => run_list_models_cli(config.as_deref(), json).await,
         Commands::ListContextEngines { config, json } => {

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -1,0 +1,531 @@
+use clap::Subcommand;
+use kernel::{ToolCoreOutcome, ToolCoreRequest};
+use loongclaw_app as mvp;
+use loongclaw_spec::CliResult;
+use serde_json::{Map, Value, json};
+use std::{collections::BTreeSet, path::Path};
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SkillsCommands {
+    /// List installed managed external skills
+    List,
+    /// Inspect one installed managed external skill
+    #[command(visible_alias = "inspect")]
+    Info { skill_id: String },
+    /// Install a managed external skill from a local directory or archive
+    Install {
+        path: String,
+        #[arg(long)]
+        skill_id: Option<String>,
+        #[arg(long, default_value_t = false)]
+        replace: bool,
+    },
+    /// Remove an installed managed external skill
+    Remove { skill_id: String },
+    /// Inspect or update persisted runtime policy for external skills
+    Policy {
+        #[command(subcommand)]
+        command: SkillsPolicyCommands,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SkillsPolicyCommands {
+    /// Show the persisted external-skills runtime policy
+    #[command(visible_alias = "show")]
+    Get,
+    /// Persist one or more external-skills runtime policy fields into config
+    Set {
+        #[arg(long)]
+        enabled: Option<bool>,
+        #[arg(long)]
+        require_download_approval: Option<bool>,
+        #[arg(long = "allow-domain")]
+        allowed_domains: Vec<String>,
+        #[arg(long, default_value_t = false)]
+        clear_allowed_domains: bool,
+        #[arg(long = "block-domain")]
+        blocked_domains: Vec<String>,
+        #[arg(long, default_value_t = false)]
+        clear_blocked_domains: bool,
+        #[arg(long, default_value_t = false)]
+        approve_policy_update: bool,
+    },
+    /// Reset persisted external-skills policy fields back to config defaults
+    Reset {
+        #[arg(long, default_value_t = false)]
+        approve_policy_update: bool,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SkillsCommandOptions {
+    pub config: Option<String>,
+    pub json: bool,
+    pub command: SkillsCommands,
+}
+
+#[derive(Debug)]
+pub(crate) struct SkillsCommandExecution {
+    pub resolved_config_path: String,
+    pub outcome: ToolCoreOutcome,
+}
+
+pub(crate) fn run_skills_cli(options: SkillsCommandOptions) -> CliResult<()> {
+    let as_json = options.json;
+    let execution = execute_skills_command(options)?;
+    if as_json {
+        let pretty = serde_json::to_string_pretty(&skills_cli_json(&execution))
+            .map_err(|error| format!("serialize skills CLI output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_skills_cli_text(&execution)?);
+    Ok(())
+}
+
+pub(crate) fn execute_skills_command(
+    options: SkillsCommandOptions,
+) -> CliResult<SkillsCommandExecution> {
+    let (resolved_path, mut config) = mvp::config::load(options.config.as_deref())?;
+    let outcome = match options.command {
+        SkillsCommands::Policy { command } => {
+            execute_policy_command(&resolved_path, &mut config, command)?
+        }
+        command @ (SkillsCommands::List
+        | SkillsCommands::Info { .. }
+        | SkillsCommands::Install { .. }
+        | SkillsCommands::Remove { .. }) => {
+            let tool_runtime_config =
+                mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+                    &config,
+                    Some(&resolved_path),
+                );
+            let request = build_skills_tool_request(command)?;
+            mvp::tools::execute_tool_core_with_config(request, &tool_runtime_config)?
+        }
+    };
+    Ok(SkillsCommandExecution {
+        resolved_config_path: resolved_path.display().to_string(),
+        outcome,
+    })
+}
+
+fn build_skills_tool_request(command: SkillsCommands) -> CliResult<ToolCoreRequest> {
+    match command {
+        SkillsCommands::List => Ok(ToolCoreRequest {
+            tool_name: "external_skills.list".to_owned(),
+            payload: json!({}),
+        }),
+        SkillsCommands::Info { skill_id } => Ok(ToolCoreRequest {
+            tool_name: "external_skills.inspect".to_owned(),
+            payload: json!({
+                "skill_id": skill_id,
+            }),
+        }),
+        SkillsCommands::Install {
+            path,
+            skill_id,
+            replace,
+        } => {
+            let mut payload = Map::new();
+            payload.insert("path".to_owned(), json!(path));
+            payload.insert("replace".to_owned(), json!(replace));
+            if let Some(skill_id) = skill_id {
+                payload.insert("skill_id".to_owned(), json!(skill_id));
+            }
+            Ok(ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: Value::Object(payload),
+            })
+        }
+        SkillsCommands::Remove { skill_id } => Ok(ToolCoreRequest {
+            tool_name: "external_skills.remove".to_owned(),
+            payload: json!({
+                "skill_id": skill_id,
+            }),
+        }),
+        SkillsCommands::Policy { .. } => {
+            Err("skills policy requests are handled directly by the daemon CLI".to_owned())
+        }
+    }
+}
+
+fn execute_policy_command(
+    resolved_path: &Path,
+    config: &mut mvp::config::LoongClawConfig,
+    command: SkillsPolicyCommands,
+) -> CliResult<ToolCoreOutcome> {
+    match command {
+        SkillsPolicyCommands::Get => Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "daemon-cli",
+                "tool_name": "skills.policy",
+                "action": "get",
+                "persisted": true,
+                "policy": persistent_policy_payload(config),
+            }),
+        }),
+        SkillsPolicyCommands::Reset {
+            approve_policy_update,
+        } => {
+            require_policy_update_approval(approve_policy_update)?;
+            let defaults = mvp::config::ExternalSkillsConfig::default();
+            config.external_skills.enabled = defaults.enabled;
+            config.external_skills.require_download_approval = defaults.require_download_approval;
+            config.external_skills.allowed_domains = defaults.allowed_domains;
+            config.external_skills.blocked_domains = defaults.blocked_domains;
+            persist_config_update(resolved_path, config)?;
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "adapter": "daemon-cli",
+                    "tool_name": "skills.policy",
+                    "action": "reset",
+                    "persisted": true,
+                    "config_updated": true,
+                    "policy": persistent_policy_payload(config),
+                }),
+            })
+        }
+        SkillsPolicyCommands::Set {
+            enabled,
+            require_download_approval,
+            allowed_domains,
+            clear_allowed_domains,
+            blocked_domains,
+            clear_blocked_domains,
+            approve_policy_update,
+        } => {
+            if clear_allowed_domains && !allowed_domains.is_empty() {
+                return Err(
+                    "skills policy set cannot combine --allow-domain with --clear-allowed-domains"
+                        .to_owned(),
+                );
+            }
+            if clear_blocked_domains && !blocked_domains.is_empty() {
+                return Err(
+                    "skills policy set cannot combine --block-domain with --clear-blocked-domains"
+                        .to_owned(),
+                );
+            }
+
+            let has_mutation = enabled.is_some()
+                || require_download_approval.is_some()
+                || clear_allowed_domains
+                || !allowed_domains.is_empty()
+                || clear_blocked_domains
+                || !blocked_domains.is_empty();
+            if !has_mutation {
+                return Err("skills policy set requires at least one mutation flag".to_owned());
+            }
+            require_policy_update_approval(approve_policy_update)?;
+
+            if let Some(enabled) = enabled {
+                config.external_skills.enabled = enabled;
+            }
+            if let Some(require_download_approval) = require_download_approval {
+                config.external_skills.require_download_approval = require_download_approval;
+            }
+            if clear_allowed_domains {
+                config.external_skills.allowed_domains.clear();
+            } else if !allowed_domains.is_empty() {
+                config.external_skills.allowed_domains = normalize_domain_inputs(allowed_domains);
+            }
+            if clear_blocked_domains {
+                config.external_skills.blocked_domains.clear();
+            } else if !blocked_domains.is_empty() {
+                config.external_skills.blocked_domains = normalize_domain_inputs(blocked_domains);
+            }
+
+            persist_config_update(resolved_path, config)?;
+
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "adapter": "daemon-cli",
+                    "tool_name": "skills.policy",
+                    "action": "set",
+                    "persisted": true,
+                    "config_updated": true,
+                    "policy": persistent_policy_payload(config),
+                }),
+            })
+        }
+    }
+}
+
+fn require_policy_update_approval(approved: bool) -> CliResult<()> {
+    if approved {
+        return Ok(());
+    }
+    Err(
+        "skills policy update requires explicit authorization; pass --approve-policy-update"
+            .to_owned(),
+    )
+}
+
+fn persist_config_update(
+    resolved_path: &Path,
+    config: &mvp::config::LoongClawConfig,
+) -> CliResult<()> {
+    let path = resolved_path.to_string_lossy();
+    mvp::config::write(Some(path.as_ref()), config, true).map(|_| ())
+}
+
+fn persistent_policy_payload(config: &mvp::config::LoongClawConfig) -> Value {
+    json!({
+        "enabled": config.external_skills.enabled,
+        "require_download_approval": config.external_skills.require_download_approval,
+        "allowed_domains": config.external_skills.normalized_allowed_domains(),
+        "blocked_domains": config.external_skills.normalized_blocked_domains(),
+        "install_root": config
+            .external_skills
+            .resolved_install_root()
+            .map(|path| path.display().to_string()),
+        "auto_expose_installed": config.external_skills.auto_expose_installed,
+    })
+}
+
+fn normalize_domain_inputs(entries: Vec<String>) -> Vec<String> {
+    let mut normalized = BTreeSet::new();
+    for entry in entries {
+        let value = entry.trim().to_ascii_lowercase();
+        if !value.is_empty() {
+            normalized.insert(value);
+        }
+    }
+    normalized.into_iter().collect()
+}
+
+fn skills_cli_json(execution: &SkillsCommandExecution) -> Value {
+    json!({
+        "config": execution.resolved_config_path,
+        "status": execution.outcome.status,
+        "result": execution.outcome.payload,
+    })
+}
+
+fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<String> {
+    let payload = &execution.outcome.payload;
+    let tool_name = payload
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .unwrap_or("external_skills");
+    let mut lines = vec![format!("config={}", execution.resolved_config_path)];
+
+    match tool_name {
+        "external_skills.list" => {
+            let skills = payload
+                .get("skills")
+                .and_then(Value::as_array)
+                .ok_or_else(|| "skills list payload missing `skills` array".to_owned())?;
+            if skills.is_empty() {
+                lines.push("skills: (none)".to_owned());
+            } else {
+                lines.push("skills:".to_owned());
+                for skill in skills {
+                    let skill_id = skill
+                        .get("skill_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or("<unknown>");
+                    let active = if skill.get("active").and_then(Value::as_bool).unwrap_or(true) {
+                        "active"
+                    } else {
+                        "inactive"
+                    };
+                    let display_name = skill
+                        .get("display_name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("-");
+                    let summary = skill.get("summary").and_then(Value::as_str).unwrap_or("-");
+                    lines.push(format!(
+                        "- {skill_id} [{active}] display_name={display_name} summary={summary}"
+                    ));
+                }
+            }
+        }
+        "external_skills.inspect" => {
+            let skill = payload
+                .get("skill")
+                .and_then(Value::as_object)
+                .ok_or_else(|| "skills info payload missing `skill` object".to_owned())?;
+            lines.push(format!(
+                "skill_id={}",
+                skill.get("skill_id").and_then(Value::as_str).unwrap_or("-")
+            ));
+            lines.push(format!(
+                "display_name={}",
+                skill
+                    .get("display_name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "active={}",
+                skill.get("active").and_then(Value::as_bool).unwrap_or(true)
+            ));
+            lines.push(format!(
+                "install_path={}",
+                skill
+                    .get("install_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "skill_md_path={}",
+                skill
+                    .get("skill_md_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "sha256={}",
+                skill.get("sha256").and_then(Value::as_str).unwrap_or("-")
+            ));
+            lines.push("instructions_preview:".to_owned());
+            lines.push(
+                payload
+                    .get("instructions_preview")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+                    .to_owned(),
+            );
+        }
+        "external_skills.install" => {
+            lines.push(format!(
+                "installed skill_id={}",
+                payload
+                    .get("skill_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "display_name={}",
+                payload
+                    .get("display_name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "source_path={}",
+                payload
+                    .get("source_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "install_path={}",
+                payload
+                    .get("install_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "replaced={}",
+                payload
+                    .get("replaced")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            ));
+        }
+        "external_skills.remove" => {
+            lines.push(format!(
+                "removed skill_id={}",
+                payload
+                    .get("skill_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+        }
+        "external_skills.policy" | "skills.policy" => {
+            let policy = payload
+                .get("policy")
+                .and_then(Value::as_object)
+                .ok_or_else(|| "skills policy payload missing `policy` object".to_owned())?;
+            lines.push(format!(
+                "policy_action={}",
+                payload
+                    .get("action")
+                    .and_then(Value::as_str)
+                    .unwrap_or("get")
+            ));
+            lines.push(format!(
+                "persisted={}",
+                payload
+                    .get("persisted")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true)
+            ));
+            lines.push(format!(
+                "config_updated={}",
+                payload
+                    .get("config_updated")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            ));
+            lines.push(format!(
+                "enabled={}",
+                policy
+                    .get("enabled")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            ));
+            lines.push(format!(
+                "require_download_approval={}",
+                policy
+                    .get("require_download_approval")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true)
+            ));
+            lines.push(format!(
+                "allowed_domains={}",
+                render_string_list(policy.get("allowed_domains"))
+            ));
+            lines.push(format!(
+                "blocked_domains={}",
+                render_string_list(policy.get("blocked_domains"))
+            ));
+            lines.push(format!(
+                "install_root={}",
+                policy
+                    .get("install_root")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "auto_expose_installed={}",
+                policy
+                    .get("auto_expose_installed")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true)
+            ));
+        }
+        other => {
+            lines.push(format!("tool={other}"));
+            lines.push(payload.to_string());
+        }
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_string_list(value: Option<&Value>) -> String {
+    value
+        .and_then(Value::as_array)
+        .map(|items| {
+            let rendered = items
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(",");
+            if rendered.is_empty() {
+                "-".to_owned()
+            } else {
+                rendered
+            }
+        })
+        .unwrap_or_else(|| "-".to_owned())
+}

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -232,12 +232,16 @@ fn execute_policy_command(
             if clear_allowed_domains {
                 config.external_skills.allowed_domains.clear();
             } else if !allowed_domains.is_empty() {
-                config.external_skills.allowed_domains = normalize_domain_inputs(allowed_domains);
+                config.external_skills.allowed_domains =
+                    normalize_domain_inputs(allowed_domains)
+                        .map_err(|error| format!("invalid --allow-domain value: {error}"))?;
             }
             if clear_blocked_domains {
                 config.external_skills.blocked_domains.clear();
             } else if !blocked_domains.is_empty() {
-                config.external_skills.blocked_domains = normalize_domain_inputs(blocked_domains);
+                config.external_skills.blocked_domains =
+                    normalize_domain_inputs(blocked_domains)
+                        .map_err(|error| format!("invalid --block-domain value: {error}"))?;
             }
 
             persist_config_update(resolved_path, config)?;
@@ -289,18 +293,16 @@ fn persistent_policy_payload(config: &mvp::config::LoongClawConfig) -> Value {
     })
 }
 
-fn normalize_domain_inputs(entries: Vec<String>) -> Vec<String> {
+fn normalize_domain_inputs(entries: Vec<String>) -> Result<Vec<String>, String> {
     let mut normalized = BTreeSet::new();
     for entry in entries {
-        let value = entry.trim().to_ascii_lowercase();
-        if !value.is_empty() {
-            normalized.insert(value);
-        }
+        let value = mvp::tools::normalize_external_skills_domain_rule(&entry)?;
+        normalized.insert(value);
     }
-    normalized.into_iter().collect()
+    Ok(normalized.into_iter().collect())
 }
 
-fn skills_cli_json(execution: &SkillsCommandExecution) -> Value {
+pub(crate) fn skills_cli_json(execution: &SkillsCommandExecution) -> Value {
     json!({
         "config": execution.resolved_config_path,
         "status": execution.outcome.status,
@@ -308,7 +310,7 @@ fn skills_cli_json(execution: &SkillsCommandExecution) -> Value {
     })
 }
 
-fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<String> {
+pub(crate) fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<String> {
     let payload = &execution.outcome.payload;
     let tool_name = payload
         .get("tool_name")

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -80,6 +80,7 @@ mod import_cli;
 mod migration;
 mod onboard_cli;
 mod programmatic;
+mod skills_cli;
 mod spec_runtime;
 mod spec_runtime_bridge;
 

--- a/crates/daemon/src/tests/skills_cli.rs
+++ b/crates/daemon/src/tests/skills_cli.rs
@@ -162,6 +162,26 @@ fn execute_skills_command_installs_lists_inspects_and_removes_skill() {
         "resolved config path should be returned for CLI rendering"
     );
     assert_eq!(install.outcome.payload["skill_id"], "demo-skill");
+    assert_eq!(install.outcome.payload["display_name"], "Demo Skill");
+    assert_eq!(install.outcome.payload["replaced"], false);
+
+    let replace_install =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Install {
+                path: "source/demo-skill".to_owned(),
+                skill_id: None,
+                replace: true,
+            },
+        })
+        .expect("skills replace should succeed");
+    assert_eq!(replace_install.outcome.payload["skill_id"], "demo-skill");
+    assert_eq!(
+        replace_install.outcome.payload["display_name"],
+        "Demo Skill"
+    );
+    assert_eq!(replace_install.outcome.payload["replaced"], true);
 
     let list = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
         config: Some(config_path.display().to_string()),

--- a/crates/daemon/src/tests/skills_cli.rs
+++ b/crates/daemon/src/tests/skills_cli.rs
@@ -1,0 +1,425 @@
+use super::*;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+}
+
+fn write_file(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent directory");
+    }
+    fs::write(path, content).expect("write fixture");
+}
+
+fn write_external_skills_config(root: &Path, enabled: bool) -> PathBuf {
+    fs::create_dir_all(root).expect("create fixture root");
+    let config_path = root.join("loongclaw.toml");
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.tools.file_root = Some(root.display().to_string());
+    config.external_skills.enabled = enabled;
+    config.external_skills.install_root = Some(root.join("managed-skills").display().to_string());
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write config fixture");
+    config_path
+}
+
+#[test]
+fn skills_install_cli_parses_global_flags_after_subcommand() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "skills",
+        "install",
+        "source/demo-skill",
+        "--skill-id",
+        "release-skill",
+        "--replace",
+        "--json",
+        "--config",
+        "/tmp/loongclaw.toml",
+    ])
+    .expect("skills install CLI should parse");
+
+    match cli.command {
+        Some(Commands::Skills {
+            config,
+            json,
+            command,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(json);
+            match command {
+                crate::skills_cli::SkillsCommands::Install {
+                    path,
+                    skill_id,
+                    replace,
+                } => {
+                    assert_eq!(path, "source/demo-skill");
+                    assert_eq!(skill_id.as_deref(), Some("release-skill"));
+                    assert!(replace);
+                }
+                other @ crate::skills_cli::SkillsCommands::List
+                | other @ crate::skills_cli::SkillsCommands::Info { .. }
+                | other @ crate::skills_cli::SkillsCommands::Remove { .. }
+                | other @ crate::skills_cli::SkillsCommands::Policy { .. } => {
+                    panic!("unexpected skills subcommand parsed: {other:?}")
+                }
+            }
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn skills_policy_set_cli_parses_domain_and_approval_flags() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "skills",
+        "policy",
+        "set",
+        "--enabled",
+        "true",
+        "--require-download-approval",
+        "false",
+        "--allow-domain",
+        "skills.sh",
+        "--allow-domain",
+        "clawhub.io",
+        "--block-domain",
+        "*.evil.example",
+        "--approve-policy-update",
+    ])
+    .expect("skills policy set CLI should parse");
+
+    match cli.command {
+        Some(Commands::Skills { command, .. }) => match command {
+            crate::skills_cli::SkillsCommands::Policy { command } => match command {
+                crate::skills_cli::SkillsPolicyCommands::Set {
+                    enabled,
+                    require_download_approval,
+                    allowed_domains,
+                    blocked_domains,
+                    approve_policy_update,
+                    clear_allowed_domains,
+                    clear_blocked_domains,
+                } => {
+                    assert_eq!(enabled, Some(true));
+                    assert_eq!(require_download_approval, Some(false));
+                    assert_eq!(allowed_domains, vec!["skills.sh", "clawhub.io"]);
+                    assert_eq!(blocked_domains, vec!["*.evil.example"]);
+                    assert!(approve_policy_update);
+                    assert!(!clear_allowed_domains);
+                    assert!(!clear_blocked_domains);
+                }
+                other @ crate::skills_cli::SkillsPolicyCommands::Get
+                | other @ crate::skills_cli::SkillsPolicyCommands::Reset { .. } => {
+                    panic!("unexpected policy subcommand parsed: {other:?}")
+                }
+            },
+            other @ crate::skills_cli::SkillsCommands::List
+            | other @ crate::skills_cli::SkillsCommands::Info { .. }
+            | other @ crate::skills_cli::SkillsCommands::Install { .. }
+            | other @ crate::skills_cli::SkillsCommands::Remove { .. } => {
+                panic!("unexpected skills subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn execute_skills_command_installs_lists_inspects_and_removes_skill() {
+    let root = unique_temp_dir("loongclaw-skills-cli-install");
+    let config_path = write_external_skills_config(&root, true);
+    write_file(
+        &root,
+        "source/demo-skill/SKILL.md",
+        "# Demo Skill\n\nUse this skill when release discipline matters.\n",
+    );
+
+    let install =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Install {
+                path: "source/demo-skill".to_owned(),
+                skill_id: None,
+                replace: false,
+            },
+        })
+        .expect("skills install should succeed");
+    assert!(
+        install.resolved_config_path.ends_with("loongclaw.toml"),
+        "resolved config path should be returned for CLI rendering"
+    );
+    assert_eq!(install.outcome.payload["skill_id"], "demo-skill");
+
+    let list = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+        config: Some(config_path.display().to_string()),
+        json: false,
+        command: crate::skills_cli::SkillsCommands::List,
+    })
+    .expect("skills list should succeed");
+    assert_eq!(list.outcome.payload["skills"][0]["skill_id"], "demo-skill");
+    assert_eq!(
+        list.outcome.payload["skills"][0]["display_name"],
+        "Demo Skill"
+    );
+
+    let info = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+        config: Some(config_path.display().to_string()),
+        json: false,
+        command: crate::skills_cli::SkillsCommands::Info {
+            skill_id: "demo-skill".to_owned(),
+        },
+    })
+    .expect("skills info should succeed");
+    assert_eq!(info.outcome.payload["skill"]["skill_id"], "demo-skill");
+    assert!(
+        info.outcome.payload["instructions_preview"]
+            .as_str()
+            .expect("instructions preview should be text")
+            .contains("release discipline"),
+        "inspect path should surface a preview of SKILL.md"
+    );
+
+    let remove =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Remove {
+                skill_id: "demo-skill".to_owned(),
+            },
+        })
+        .expect("skills remove should succeed");
+    assert_eq!(remove.outcome.payload["removed"], true);
+
+    let list_after_remove =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::List,
+        })
+        .expect("skills list after remove should succeed");
+    assert_eq!(
+        list_after_remove.outcome.payload["skills"],
+        serde_json::json!([])
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn execute_skills_command_policy_round_trips_persisted_config() {
+    let root = unique_temp_dir("loongclaw-skills-cli-policy");
+    let config_path = write_external_skills_config(&root, false);
+    let config_string = config_path.display().to_string();
+    let install_root = root.join("managed-skills").display().to_string();
+
+    let initial =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_string.clone()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Policy {
+                command: crate::skills_cli::SkillsPolicyCommands::Get,
+            },
+        })
+        .expect("policy get should succeed");
+    assert_eq!(initial.outcome.payload["persisted"], true);
+    assert_eq!(initial.outcome.payload["policy"]["enabled"], false);
+    assert_eq!(
+        initial.outcome.payload["policy"]["require_download_approval"],
+        true
+    );
+    assert_eq!(
+        initial.outcome.payload["policy"]["allowed_domains"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        initial.outcome.payload["policy"]["blocked_domains"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        initial.outcome.payload["policy"]["install_root"],
+        install_root
+    );
+
+    let set = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+        config: Some(config_string.clone()),
+        json: false,
+        command: crate::skills_cli::SkillsCommands::Policy {
+            command: crate::skills_cli::SkillsPolicyCommands::Set {
+                enabled: Some(true),
+                require_download_approval: Some(false),
+                allowed_domains: vec![
+                    " Skills.SH ".to_owned(),
+                    "clawhub.io".to_owned(),
+                    "skills.sh".to_owned(),
+                ],
+                clear_allowed_domains: false,
+                blocked_domains: vec!["*.EVIL.example".to_owned(), "*.evil.example".to_owned()],
+                clear_blocked_domains: false,
+                approve_policy_update: true,
+            },
+        },
+    })
+    .expect("policy set should succeed");
+    assert_eq!(set.outcome.payload["persisted"], true);
+    assert_eq!(set.outcome.payload["config_updated"], true);
+    assert_eq!(set.outcome.payload["policy"]["enabled"], true);
+    assert_eq!(
+        set.outcome.payload["policy"]["require_download_approval"],
+        false
+    );
+    assert_eq!(
+        set.outcome.payload["policy"]["allowed_domains"],
+        serde_json::json!(["clawhub.io", "skills.sh"])
+    );
+    assert_eq!(
+        set.outcome.payload["policy"]["blocked_domains"],
+        serde_json::json!(["*.evil.example"])
+    );
+
+    let (_, reloaded) =
+        mvp::config::load(Some(config_string.as_str())).expect("reload updated config");
+    assert!(reloaded.external_skills.enabled);
+    assert!(!reloaded.external_skills.require_download_approval);
+    assert_eq!(
+        reloaded.external_skills.allowed_domains,
+        vec!["clawhub.io".to_owned(), "skills.sh".to_owned()]
+    );
+    assert_eq!(
+        reloaded.external_skills.blocked_domains,
+        vec!["*.evil.example".to_owned()]
+    );
+    assert_eq!(
+        reloaded.external_skills.install_root.as_deref(),
+        Some(install_root.as_str())
+    );
+    assert!(reloaded.external_skills.auto_expose_installed);
+
+    let reset =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_string.clone()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Policy {
+                command: crate::skills_cli::SkillsPolicyCommands::Reset {
+                    approve_policy_update: true,
+                },
+            },
+        })
+        .expect("policy reset should succeed");
+    assert_eq!(reset.outcome.payload["persisted"], true);
+    assert_eq!(reset.outcome.payload["config_updated"], true);
+    assert_eq!(reset.outcome.payload["policy"]["enabled"], false);
+    assert_eq!(
+        reset.outcome.payload["policy"]["require_download_approval"],
+        true
+    );
+    assert_eq!(
+        reset.outcome.payload["policy"]["allowed_domains"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        reset.outcome.payload["policy"]["blocked_domains"],
+        serde_json::json!([])
+    );
+
+    let final_get =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_string),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Policy {
+                command: crate::skills_cli::SkillsPolicyCommands::Get,
+            },
+        })
+        .expect("policy get after reset should succeed");
+    assert_eq!(final_get.outcome.payload["policy"]["enabled"], false);
+    assert_eq!(
+        final_get.outcome.payload["policy"]["require_download_approval"],
+        true
+    );
+    assert_eq!(
+        final_get.outcome.payload["policy"]["allowed_domains"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        final_get.outcome.payload["policy"]["blocked_domains"],
+        serde_json::json!([])
+    );
+
+    let (_, reloaded_after_reset) = mvp::config::load(Some(config_path.to_string_lossy().as_ref()))
+        .expect("reload reset config");
+    assert!(!reloaded_after_reset.external_skills.enabled);
+    assert!(
+        reloaded_after_reset
+            .external_skills
+            .require_download_approval
+    );
+    assert!(
+        reloaded_after_reset
+            .external_skills
+            .allowed_domains
+            .is_empty()
+    );
+    assert!(
+        reloaded_after_reset
+            .external_skills
+            .blocked_domains
+            .is_empty()
+    );
+    assert_eq!(
+        reloaded_after_reset.external_skills.install_root.as_deref(),
+        Some(install_root.as_str())
+    );
+    assert!(reloaded_after_reset.external_skills.auto_expose_installed);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn execute_skills_command_policy_set_requires_explicit_approval() {
+    let root = unique_temp_dir("loongclaw-skills-cli-policy-approval");
+    let config_path = write_external_skills_config(&root, false);
+    let config_string = config_path.display().to_string();
+
+    let error =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_string.as_str().to_owned()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Policy {
+                command: crate::skills_cli::SkillsPolicyCommands::Set {
+                    enabled: Some(true),
+                    require_download_approval: None,
+                    allowed_domains: Vec::new(),
+                    clear_allowed_domains: false,
+                    blocked_domains: Vec::new(),
+                    clear_blocked_domains: false,
+                    approve_policy_update: false,
+                },
+            },
+        })
+        .expect_err("policy set should require explicit approval");
+    assert!(
+        error.contains("--approve-policy-update"),
+        "approval error should direct operators to the explicit authorization flag: {error}"
+    );
+
+    let (_, reloaded) =
+        mvp::config::load(Some(config_string.as_str())).expect("reload unchanged config");
+    assert!(!reloaded.external_skills.enabled);
+    assert!(reloaded.external_skills.require_download_approval);
+    assert!(reloaded.external_skills.allowed_domains.is_empty());
+    assert!(reloaded.external_skills.blocked_domains.is_empty());
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/crates/daemon/src/tests/skills_cli.rs
+++ b/crates/daemon/src/tests/skills_cli.rs
@@ -407,6 +407,52 @@ fn execute_skills_command_policy_round_trips_persisted_config() {
 }
 
 #[test]
+fn execute_skills_command_policy_set_normalizes_domain_rules_for_persistence() {
+    let root = unique_temp_dir("loongclaw-skills-cli-policy-domain-rules");
+    let config_path = write_external_skills_config(&root, false);
+    let config_string = config_path.display().to_string();
+
+    let set = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+        config: Some(config_string.clone()),
+        json: false,
+        command: crate::skills_cli::SkillsCommands::Policy {
+            command: crate::skills_cli::SkillsPolicyCommands::Set {
+                enabled: Some(true),
+                require_download_approval: None,
+                allowed_domains: vec!["https://Skills.SH/catalog".to_owned()],
+                clear_allowed_domains: false,
+                blocked_domains: vec!["HTTPS://evil.example/download".to_owned()],
+                clear_blocked_domains: false,
+                approve_policy_update: true,
+            },
+        },
+    })
+    .expect("policy set should normalize domain rules before writing config");
+
+    assert_eq!(
+        set.outcome.payload["policy"]["allowed_domains"],
+        serde_json::json!(["skills.sh"])
+    );
+    assert_eq!(
+        set.outcome.payload["policy"]["blocked_domains"],
+        serde_json::json!(["evil.example"])
+    );
+
+    let (_, reloaded) =
+        mvp::config::load(Some(config_string.as_str())).expect("reload normalized config");
+    assert_eq!(
+        reloaded.external_skills.allowed_domains,
+        vec!["skills.sh".to_owned()]
+    );
+    assert_eq!(
+        reloaded.external_skills.blocked_domains,
+        vec!["evil.example".to_owned()]
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn execute_skills_command_policy_set_requires_explicit_approval() {
     let root = unique_temp_dir("loongclaw-skills-cli-policy-approval");
     let config_path = write_external_skills_config(&root, false);
@@ -442,4 +488,88 @@ fn execute_skills_command_policy_set_requires_explicit_approval() {
     assert!(reloaded.external_skills.blocked_domains.is_empty());
 
     fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn execute_skills_command_policy_set_rejects_invalid_domain_rules() {
+    let root = unique_temp_dir("loongclaw-skills-cli-policy-invalid-domain");
+    let config_path = write_external_skills_config(&root, false);
+    let config_string = config_path.display().to_string();
+
+    let error =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_string.clone()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Policy {
+                command: crate::skills_cli::SkillsPolicyCommands::Set {
+                    enabled: Some(true),
+                    require_download_approval: None,
+                    allowed_domains: vec!["not-a-domain".to_owned()],
+                    clear_allowed_domains: false,
+                    blocked_domains: Vec::new(),
+                    clear_blocked_domains: false,
+                    approve_policy_update: true,
+                },
+            },
+        })
+        .expect_err("policy set should reject malformed domain rules");
+    assert!(
+        error.contains("invalid --allow-domain value"),
+        "error should identify the invalid domain flag: {error}"
+    );
+
+    let (_, reloaded) =
+        mvp::config::load(Some(config_string.as_str())).expect("reload unchanged config");
+    assert!(!reloaded.external_skills.enabled);
+    assert!(reloaded.external_skills.allowed_domains.is_empty());
+    assert!(reloaded.external_skills.blocked_domains.is_empty());
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn render_skills_cli_text_surfaces_operator_install_summary() {
+    let rendered =
+        crate::skills_cli::render_skills_cli_text(&crate::skills_cli::SkillsCommandExecution {
+            resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+            outcome: kernel::ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: serde_json::json!({
+                    "tool_name": "external_skills.install",
+                    "skill_id": "demo-skill",
+                    "display_name": "Demo Skill",
+                    "source_path": "/tmp/source/demo-skill",
+                    "install_path": "/tmp/managed/demo-skill",
+                    "replaced": true
+                }),
+            },
+        })
+        .expect("install payload should render");
+
+    assert!(rendered.contains("config=/tmp/loongclaw.toml"));
+    assert!(rendered.contains("installed skill_id=demo-skill"));
+    assert!(rendered.contains("display_name=Demo Skill"));
+    assert!(rendered.contains("replaced=true"));
+}
+
+#[test]
+fn skills_cli_json_wraps_config_status_and_result_payload() {
+    let rendered = crate::skills_cli::skills_cli_json(&crate::skills_cli::SkillsCommandExecution {
+        resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+        outcome: kernel::ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: serde_json::json!({
+                "tool_name": "skills.policy",
+                "action": "get",
+                "policy": {
+                    "enabled": true
+                }
+            }),
+        },
+    });
+
+    assert_eq!(rendered["config"], "/tmp/loongclaw.toml");
+    assert_eq!(rendered["status"], "ok");
+    assert_eq!(rendered["result"]["tool_name"], "skills.policy");
+    assert_eq!(rendered["result"]["policy"]["enabled"], true);
 }


### PR DESCRIPTION
## Summary

- Expand the external-skills operator surface from managed-only inventory to resolved discovery across `managed`, `user`, and `project` scopes for both core tools and `loongclaw skills`.
- Add deterministic precedence (`managed > user > project`), report lower-priority duplicates as `shadowed_skills`, and surface `scope` / `source_path` metadata for operator debugging.
- Probe project skills from the active workspace up to `file_root`, discover user skills from `~/.agents/skills`, `~/.codex/skills`, and `~/.claude/skills`, and follow symlinked user/project skill directories while keeping managed installs strict.
- Refresh CLI/help/catalog/README descriptions to match the resolved discovery model and harden regression coverage for isolation-sensitive skills tests.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:
- `external_skills.list`, `external_skills.inspect`, `external_skills.invoke`, and the `loongclaw skills list/info` CLI now resolve one active skill per `skill_id` across multiple scopes instead of exposing only managed installs.
- Discovery intentionally follows symlinked user/project skill directories to match real local skill layouts and Codex-style symlinked skill homes, but managed installs remain strict and continue rejecting symlinked install roots and `SKILL.md` files.
- Precedence and probe order are deterministic so operators can debug collisions through `shadowed_skills` instead of relying on ambient filesystem order.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional scenario checks:
- `<local-absolute-path> test -p loongclaw-app external_skills -- --nocapture`
- `<local-absolute-path> test -p loongclaw-daemon skills_cli -- --nocapture`
- `<local-absolute-path> test -p loongclaw-app capability_snapshot_lists_all_tools_when_all_features_enabled -- --nocapture`

Config/runtime behavior notes:
- Before: `external_skills.list|inspect|invoke` and `loongclaw skills list|info` only surfaced managed installs, so real project/user skill directories were invisible and duplicate skill ids could not be debugged through the product surface.
- After: the operator and tool surfaces resolve skills across managed/user/project scopes, expose `scope`, `source_path`, and `shadowed_skills`, and use a deterministic `managed > user > project` precedence model.
- Regression coverage: `discovery_resolves_managed_user_and_project_scopes_with_shadowed_duplicates`, `discovery_follows_symlinked_user_skill_directories`, `capability_snapshot_lists_resolved_project_and_user_external_skills_once`, `execute_skills_command_list_reports_scopes_and_shadowed_skills`, `list_and_invoke_installed_skill_return_managed_metadata`, `remove_installed_skill_clears_managed_entry`, `tampered_index_metadata_is_rehydrated_from_managed_skill_markdown`, `execute_skills_command_installs_lists_inspects_and_removes_skill`.
- Process-global env restoration: app tests serialize env updates with `crate::test_support::ScopedEnv`; daemon CLI tests serialize env updates with `SkillsCliEnvironmentGuard`; discovery-sensitive cases use isolated temporary `HOME` directories and clean them up during teardown.

## Linked Issues

Refs #159

This PR covers issue #159 slices 1-2 (operator CLI plus layered discovery/precedence). Per-skill metadata contracts, migration-to-install bridging, and registry/update/sync workflows remain follow-on work.
