### PR TITLE
fix: harden alpha-test onboarding edge cases

### DIFF
--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -11,6 +11,7 @@ use time::macros::format_description;
 
 const BACKUP_TIMESTAMP_FORMAT: &[FormatItem<'static>] =
     format_description!("[year][month][day]-[hour][minute][second]");
+const ONBOARD_CLEAR_INPUT_TOKEN: &str = ":clear";
 
 #[derive(Debug, Clone)]
 pub(crate) struct OnboardCommandOptions {
@@ -126,6 +127,10 @@ fn print_lines(ui: &mut impl OnboardUi, lines: impl IntoIterator<Item = String>)
 
 fn print_message(ui: &mut impl OnboardUi, line: impl Into<String>) -> CliResult<()> {
     ui.print_line(&line.into())
+}
+
+fn is_explicit_onboard_clear_input(raw: &str) -> bool {
+    raw.trim().eq_ignore_ascii_case(ONBOARD_CLEAR_INPUT_TOKEN)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -272,6 +277,13 @@ impl ReviewFlowStyle {
     const fn header_subtitle(self) -> &'static str {
         crate::onboard_presentation::review_flow_copy(self.presentation_kind()).header_subtitle
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SystemPromptSelection {
+    KeepCurrent,
+    RestoreBuiltIn,
+    Set(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -487,11 +499,9 @@ pub(crate) async fn run_onboard_cli_with_ui(
             resolve_api_key_env_selection(&options, &config, default_api_key_env, ui, context)?;
         apply_selected_api_key_env(&mut config.provider, selected_api_key_env);
 
-        if let Some(system_prompt) =
-            resolve_system_prompt_selection(&options, &config, ui, context)?
-        {
-            config.cli.system_prompt = system_prompt;
-        }
+        let system_prompt_selection =
+            resolve_system_prompt_selection(&options, &config, ui, context)?;
+        apply_selected_system_prompt(&mut config, system_prompt_selection);
     }
 
     let workspace_guidance = context
@@ -909,13 +919,16 @@ fn resolve_api_key_env_selection(
     context: &OnboardRuntimeContext,
 ) -> CliResult<String> {
     if options.non_interactive {
-        return Ok(options
-            .api_key_env
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or(default_api_key_env.as_str())
-            .to_owned());
+        if let Some(api_key_env) = options.api_key_env.as_deref() {
+            if is_explicit_onboard_clear_input(api_key_env) {
+                return Ok(String::new());
+            }
+            let trimmed = api_key_env.trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed.to_owned());
+            }
+        }
+        return Ok(default_api_key_env);
     }
     let initial = options
         .api_key_env
@@ -934,6 +947,9 @@ fn resolve_api_key_env_selection(
         ),
     )?;
     let value = ui.prompt_with_default("API key env var", initial)?;
+    if is_explicit_onboard_clear_input(&value) {
+        return Ok(String::new());
+    }
     Ok(value.trim().to_owned())
 }
 
@@ -953,19 +969,42 @@ fn apply_selected_api_key_env(
     provider.set_api_key_env(Some(selected_api_key_env.to_owned()));
 }
 
+fn apply_selected_system_prompt(
+    config: &mut mvp::config::LoongClawConfig,
+    selection: SystemPromptSelection,
+) {
+    match selection {
+        SystemPromptSelection::KeepCurrent => {}
+        SystemPromptSelection::RestoreBuiltIn => {
+            config.cli.system_prompt = if config.cli.uses_native_prompt_pack() {
+                config.cli.rendered_native_system_prompt()
+            } else {
+                mvp::config::CliChannelConfig::default().system_prompt
+            };
+        }
+        SystemPromptSelection::Set(system_prompt) => {
+            config.cli.system_prompt = system_prompt;
+        }
+    }
+}
+
 fn resolve_system_prompt_selection(
     options: &OnboardCommandOptions,
     config: &mvp::config::LoongClawConfig,
     ui: &mut impl OnboardUi,
     context: &OnboardRuntimeContext,
-) -> CliResult<Option<String>> {
+) -> CliResult<SystemPromptSelection> {
     if options.non_interactive {
-        return Ok(options
-            .system_prompt
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_owned));
+        if let Some(system_prompt) = options.system_prompt.as_deref() {
+            if is_explicit_onboard_clear_input(system_prompt) {
+                return Ok(SystemPromptSelection::RestoreBuiltIn);
+            }
+            let trimmed = system_prompt.trim();
+            if !trimmed.is_empty() {
+                return Ok(SystemPromptSelection::Set(trimmed.to_owned()));
+            }
+        }
+        return Ok(SystemPromptSelection::KeepCurrent);
     }
     let initial = options
         .system_prompt
@@ -983,11 +1022,14 @@ fn resolve_system_prompt_selection(
         ),
     )?;
     let value = ui.prompt_with_default("CLI system prompt", initial)?;
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Ok(None);
+    if is_explicit_onboard_clear_input(&value) {
+        return Ok(SystemPromptSelection::RestoreBuiltIn);
     }
-    Ok(Some(trimmed.to_owned()))
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed == config.cli.system_prompt.trim() {
+        return Ok(SystemPromptSelection::KeepCurrent);
+    }
+    Ok(SystemPromptSelection::Set(trimmed.to_owned()))
 }
 
 async fn run_preflight_checks(
@@ -2654,6 +2696,13 @@ fn render_default_input_hint_line(description: impl AsRef<str>) -> String {
     format!("- press Enter to {}", description.as_ref())
 }
 
+fn render_clear_input_hint_line(description: impl AsRef<str>) -> String {
+    format!(
+        "- type {ONBOARD_CLEAR_INPUT_TOKEN} to {}",
+        description.as_ref()
+    )
+}
+
 fn render_model_selection_default_hint_line(
     config: &mvp::config::LoongClawConfig,
     prompt_default: &str,
@@ -3655,7 +3704,13 @@ fn render_api_key_env_selection_screen_lines_with_style(
         prompt_default,
     )];
     if provider_supports_blank_api_key_env(config) {
-        hint_lines.push("- blank keeps inline or oauth credentials".to_owned());
+        if prompt_default.trim().is_empty() {
+            hint_lines.push("- leave this blank to keep inline or oauth credentials".to_owned());
+        } else {
+            hint_lines.push(render_clear_input_hint_line(
+                "keep inline or oauth credentials",
+            ));
+        }
     }
 
     render_onboard_input_screen(
@@ -3710,7 +3765,11 @@ fn render_system_prompt_selection_screen_lines_with_style(
         vec![format!("- current prompt: {current_prompt_display}")],
         vec![
             render_system_prompt_selection_default_hint_line(config, prompt_default),
-            "- blank keeps the built-in behavior".to_owned(),
+            if prompt_default.trim().is_empty() {
+                "- leave this blank to use the built-in behavior".to_owned()
+            } else {
+                render_clear_input_hint_line("use the built-in behavior")
+            },
         ],
         color_enabled,
     )
@@ -4352,6 +4411,46 @@ fn format_backup_timestamp_at(timestamp: OffsetDateTime) -> CliResult<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+
+    struct TestOnboardUi {
+        inputs: VecDeque<String>,
+    }
+
+    impl TestOnboardUi {
+        fn with_inputs(inputs: impl IntoIterator<Item = impl Into<String>>) -> Self {
+            Self {
+                inputs: inputs.into_iter().map(Into::into).collect(),
+            }
+        }
+    }
+
+    impl OnboardUi for TestOnboardUi {
+        fn print_line(&mut self, _line: &str) -> CliResult<()> {
+            Ok(())
+        }
+
+        fn prompt_with_default(&mut self, _label: &str, default: &str) -> CliResult<String> {
+            Ok(self
+                .inputs
+                .pop_front()
+                .unwrap_or_else(|| default.to_owned()))
+        }
+
+        fn prompt_required(&mut self, _label: &str) -> CliResult<String> {
+            self.inputs
+                .pop_front()
+                .ok_or_else(|| "missing required test input".to_owned())
+        }
+
+        fn prompt_confirm(&mut self, _message: &str, default: bool) -> CliResult<bool> {
+            Ok(self
+                .inputs
+                .pop_front()
+                .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "y" | "yes"))
+                .unwrap_or(default))
+        }
+    }
 
     fn import_candidate_with_domain_status(
         source_kind: crate::migration::ImportSourceKind,
@@ -4419,6 +4518,150 @@ mod tests {
                         .contains("retry chat_completions automatically")
             }),
             "preflight should surface transport review before writing a Responses-compatible config: {checks:#?}"
+        );
+    }
+
+    #[test]
+    fn resolve_api_key_env_selection_accepts_explicit_clear_token_in_interactive_mode() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Openai;
+        config.provider.api_key = Some("inline-secret".to_owned());
+        let mut ui = TestOnboardUi::with_inputs([":clear"]);
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_api_key_env_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            "OPENAI_API_KEY".to_owned(),
+            &mut ui,
+            &context,
+        )
+        .expect("resolve api key env selection");
+
+        assert!(
+            selected.is_empty(),
+            "typing :clear should explicitly clear the api-key env selection instead of persisting the literal token: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_system_prompt_selection_accepts_explicit_clear_token_in_interactive_mode() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.cli.system_prompt = "be terse and code-focused".to_owned();
+        let mut ui = TestOnboardUi::with_inputs([":clear"]);
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_system_prompt_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            &mut ui,
+            &context,
+        )
+        .expect("resolve system prompt selection");
+
+        assert_eq!(
+            selected,
+            SystemPromptSelection::RestoreBuiltIn,
+            "typing :clear should restore the built-in system prompt instead of keeping the literal token"
+        );
+    }
+
+    #[test]
+    fn resolve_system_prompt_selection_keeps_current_prompt_when_interactive_default_is_used() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.cli.system_prompt = "be terse and code-focused".to_owned();
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_system_prompt_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            &mut ui,
+            &context,
+        )
+        .expect("resolve system prompt selection");
+
+        assert_eq!(
+            selected,
+            SystemPromptSelection::KeepCurrent,
+            "using the prompt default should keep the current system prompt when no override is prefilled"
+        );
+    }
+
+    #[test]
+    fn resolve_system_prompt_selection_keeps_prefilled_override_when_interactive_default_is_used() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.cli.system_prompt = "be terse and code-focused".to_owned();
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_system_prompt_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                system_prompt: Some("prefer concise code reviews".to_owned()),
+                skip_model_probe: false,
+            },
+            &config,
+            &mut ui,
+            &context,
+        )
+        .expect("resolve system prompt selection");
+
+        assert_eq!(
+            selected,
+            SystemPromptSelection::Set("prefer concise code reviews".to_owned()),
+            "using the prompt default should still apply a prefilled system prompt override"
+        );
+    }
+
+    #[test]
+    fn apply_selected_system_prompt_restore_uses_rendered_native_prompt() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.cli.system_prompt = "custom review prompt".to_owned();
+        config.cli.system_prompt_addendum = Some("Prefer concrete remediation steps.".to_owned());
+        let expected = config.cli.rendered_native_system_prompt();
+
+        apply_selected_system_prompt(&mut config, SystemPromptSelection::RestoreBuiltIn);
+
+        assert_eq!(
+            config.cli.system_prompt, expected,
+            "restoring the built-in prompt should respect the active native prompt rendering inputs"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -305,6 +305,13 @@ struct ConfigWritePlan {
     backup_path: Option<PathBuf>,
 }
 
+#[derive(Debug, Clone)]
+struct OnboardWriteRecovery {
+    output_preexisted: bool,
+    backup_path: Option<PathBuf>,
+    keep_backup_on_success: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OnboardShortcutKind {
     CurrentSetup,
@@ -478,11 +485,7 @@ pub(crate) async fn run_onboard_cli_with_ui(
         let default_api_key_env = preferred_api_key_env_default(&config);
         let selected_api_key_env =
             resolve_api_key_env_selection(&options, &config, default_api_key_env, ui, context)?;
-        config.provider.api_key_env = if selected_api_key_env.trim().is_empty() {
-            None
-        } else {
-            Some(selected_api_key_env)
-        };
+        apply_selected_api_key_env(&mut config.provider, selected_api_key_env);
 
         if let Some(system_prompt) =
             resolve_system_prompt_selection(&options, &config, ui, context)?
@@ -528,6 +531,10 @@ pub(crate) async fn run_onboard_cli_with_ui(
     let has_warnings = checks
         .iter()
         .any(|check| check.level == OnboardCheckLevel::Warn);
+    let has_blocking_non_interactive_warnings = checks.iter().any(|check| {
+        check.level == OnboardCheckLevel::Warn
+            && !is_explicitly_accepted_non_interactive_warning(check, &options)
+    });
     let existing_output_config = load_existing_output_config(&output_path);
     let skip_config_write = should_skip_config_write(existing_output_config.as_ref(), &config);
 
@@ -543,6 +550,12 @@ pub(crate) async fn run_onboard_cli_with_ui(
         if has_failures {
             return Err(
                 "onboard preflight failed. rerun with --skip-model-probe if your provider blocks model listing during setup"
+                    .to_owned(),
+            );
+        }
+        if has_blocking_non_interactive_warnings {
+            return Err(
+                "onboard preflight failed: unresolved warnings require interactive review; rerun without --non-interactive to inspect and confirm them"
                     .to_owned(),
             );
         }
@@ -584,28 +597,57 @@ pub(crate) async fn run_onboard_cli_with_ui(
         }
     }
 
-    let (path, config_status) = if skip_config_write {
+    let (path, config_status, write_recovery) = if skip_config_write {
         (
             output_path.clone(),
             Some("existing config kept; no changes were needed".to_owned()),
+            None,
         )
     } else {
         let write_plan = resolve_write_plan(&output_path, &options, ui, context)?;
-        prepare_output_path_for_write(&output_path, &write_plan, ui)?;
-        let path = mvp::config::write(options.output.as_deref(), &config, write_plan.force)?;
-        (path, None)
+        let write_recovery = prepare_output_path_for_write(&output_path, &write_plan, ui)?;
+        let path = match mvp::config::write(options.output.as_deref(), &config, write_plan.force) {
+            Ok(path) => path,
+            Err(error) => {
+                return Err(rollback_onboard_write_failure(
+                    &output_path,
+                    &write_recovery,
+                    error,
+                ));
+            }
+        };
+        (path, None, Some(write_recovery))
     };
     #[cfg(feature = "memory-sqlite")]
     let memory_path = {
         let mem_config =
             mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-        mvp::memory::ensure_memory_db_ready(Some(config.memory.resolved_sqlite_path()), &mem_config)
-            .map_err(|error| format!("failed to bootstrap sqlite memory: {error}"))?
+        match mvp::memory::ensure_memory_db_ready(
+            Some(config.memory.resolved_sqlite_path()),
+            &mem_config,
+        ) {
+            Ok(path) => path,
+            Err(error) => {
+                let failure = format!("failed to bootstrap sqlite memory: {error}");
+                if let Some(write_recovery) = write_recovery.as_ref() {
+                    return Err(rollback_onboard_write_failure(
+                        &output_path,
+                        write_recovery,
+                        failure,
+                    ));
+                }
+                return Err(failure);
+            }
+        }
     };
 
     let memory_path_display = Some(memory_path.display().to_string());
     #[cfg(not(feature = "memory-sqlite"))]
     let memory_path_display: Option<String> = None;
+
+    if let Some(write_recovery) = write_recovery.as_ref() {
+        write_recovery.finish_success();
+    }
 
     let success_summary = build_onboarding_success_summary_with_memory(
         &path,
@@ -895,6 +937,22 @@ fn resolve_api_key_env_selection(
     Ok(value.trim().to_owned())
 }
 
+fn apply_selected_api_key_env(
+    provider: &mut mvp::config::ProviderConfig,
+    selected_api_key_env: String,
+) {
+    let selected_api_key_env = selected_api_key_env.trim();
+    if selected_api_key_env.is_empty() {
+        provider.set_api_key_env(None);
+        return;
+    }
+
+    provider.api_key = None;
+    provider.oauth_access_token = None;
+    provider.set_oauth_access_token_env(None);
+    provider.set_api_key_env(Some(selected_api_key_env.to_owned()));
+}
+
 fn resolve_system_prompt_selection(
     options: &OnboardCommandOptions,
     config: &mvp::config::LoongClawConfig,
@@ -1041,6 +1099,15 @@ fn provider_transport_check(config: &mvp::config::LoongClawConfig) -> OnboardChe
         },
         detail: readiness.detail,
     }
+}
+
+fn is_explicitly_accepted_non_interactive_warning(
+    check: &OnboardCheck,
+    options: &OnboardCommandOptions,
+) -> bool {
+    options.skip_model_probe
+        && check.name == "provider model probe"
+        && check.detail == "skipped by --skip-model-probe"
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1500,17 +1567,19 @@ fn select_non_interactive_starting_config(
                 starting_config_selection_from_current_candidate(candidate, current_setup_state)
             })
             .unwrap_or_else(default_starting_config_selection),
-        OnboardEntryChoice::ImportDetectedSetup => import_candidates
-            .into_iter()
-            .next()
-            .map(|candidate| {
-                starting_config_selection_from_import_candidate(
-                    candidate,
-                    all_candidates,
-                    current_setup_state,
-                )
-            })
-            .unwrap_or_else(default_starting_config_selection),
+        OnboardEntryChoice::ImportDetectedSetup => {
+            sort_starting_point_candidates(import_candidates)
+                .into_iter()
+                .map(|candidate| {
+                    starting_config_selection_from_import_candidate(
+                        candidate,
+                        all_candidates,
+                        current_setup_state,
+                    )
+                })
+                .next()
+                .unwrap_or_else(default_starting_config_selection)
+        }
         OnboardEntryChoice::StartFresh => default_starting_config_selection(),
     }
 }
@@ -4148,21 +4217,93 @@ fn prepare_output_path_for_write(
     output_path: &Path,
     plan: &ConfigWritePlan,
     ui: &mut impl OnboardUi,
-) -> CliResult<()> {
-    if let Some(backup_path) = plan.backup_path.as_deref() {
+) -> CliResult<OnboardWriteRecovery> {
+    let output_preexisted = output_path.exists();
+    let keep_backup_on_success = plan.backup_path.is_some();
+    let backup_path = if output_preexisted {
+        Some(
+            plan.backup_path
+                .clone()
+                .unwrap_or(resolve_rollback_backup_path(output_path)?),
+        )
+    } else {
+        None
+    };
+
+    if let Some(backup_path) = backup_path.as_deref() {
         backup_existing_config(output_path, backup_path)?;
+    }
+    if let Some(backup_path) = plan.backup_path.as_deref() {
         print_message(
             ui,
             format!("Backed up existing config to: {}", backup_path.display()),
         )?;
     }
-    Ok(())
+    Ok(OnboardWriteRecovery {
+        output_preexisted,
+        backup_path,
+        keep_backup_on_success,
+    })
 }
 
 pub(crate) fn backup_existing_config(output_path: &Path, backup_path: &Path) -> CliResult<()> {
     fs::copy(output_path, backup_path)
         .map_err(|error| format!("failed to backup config: {error}"))?;
     Ok(())
+}
+
+impl OnboardWriteRecovery {
+    fn rollback(&self, output_path: &Path) -> CliResult<()> {
+        if self.output_preexisted {
+            let backup_path = self
+                .backup_path
+                .as_deref()
+                .ok_or_else(|| "missing rollback backup for existing config".to_owned())?;
+            fs::copy(backup_path, output_path).map_err(|error| {
+                format!(
+                    "failed to restore original config {} from backup {}: {error}",
+                    output_path.display(),
+                    backup_path.display(),
+                )
+            })?;
+            self.finish_success();
+            return Ok(());
+        }
+
+        if output_path.exists() {
+            fs::remove_file(output_path).map_err(|error| {
+                format!(
+                    "failed to remove partial config {} after onboarding failure: {error}",
+                    output_path.display()
+                )
+            })?;
+        }
+        self.finish_success();
+        Ok(())
+    }
+
+    fn finish_success(&self) {
+        if self.keep_backup_on_success {
+            return;
+        }
+        if let Some(backup_path) = self.backup_path.as_deref() {
+            let _ = fs::remove_file(backup_path);
+        }
+    }
+}
+
+fn rollback_onboard_write_failure(
+    output_path: &Path,
+    write_recovery: &OnboardWriteRecovery,
+    failure: impl Into<String>,
+) -> String {
+    let failure = failure.into();
+    match write_recovery.rollback(output_path) {
+        Ok(()) => failure,
+        Err(rollback_error) => {
+            format!("{failure}; additionally failed to restore original config: {rollback_error}")
+        }
+    }
 }
 
 fn resolve_backup_path(original: &Path) -> CliResult<PathBuf> {
@@ -4181,6 +4322,27 @@ fn resolve_backup_path_at(original: &Path, timestamp: OffsetDateTime) -> CliResu
     Ok(parent.join(format!("{}.toml.bak-{}", file_stem, formatted_timestamp)))
 }
 
+fn resolve_rollback_backup_path(original: &Path) -> CliResult<PathBuf> {
+    let now = OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc());
+    resolve_rollback_backup_path_at(original, now)
+}
+
+fn resolve_rollback_backup_path_at(
+    original: &Path,
+    timestamp: OffsetDateTime,
+) -> CliResult<PathBuf> {
+    let parent = original.parent().unwrap_or(Path::new("."));
+    let file_name = original
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "config.toml".to_owned());
+
+    let formatted_timestamp = format_backup_timestamp_at(timestamp)?;
+    Ok(parent.join(format!(
+        ".{file_name}.onboard-rollback-{formatted_timestamp}"
+    )))
+}
+
 fn format_backup_timestamp_at(timestamp: OffsetDateTime) -> CliResult<String> {
     timestamp
         .format(BACKUP_TIMESTAMP_FORMAT)
@@ -4190,6 +4352,53 @@ fn format_backup_timestamp_at(timestamp: OffsetDateTime) -> CliResult<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn import_candidate_with_domain_status(
+        source_kind: crate::migration::ImportSourceKind,
+        source: &str,
+        domains: impl IntoIterator<
+            Item = (
+                crate::migration::SetupDomainKind,
+                crate::migration::PreviewStatus,
+            ),
+        >,
+    ) -> ImportCandidate {
+        ImportCandidate {
+            source_kind,
+            source: source.to_owned(),
+            config: mvp::config::LoongClawConfig::default(),
+            surfaces: Vec::new(),
+            domains: domains
+                .into_iter()
+                .map(|(kind, status)| crate::migration::DomainPreview {
+                    kind,
+                    status,
+                    decision: Some(crate::migration::types::PreviewDecision::UseDetected),
+                    source: source.to_owned(),
+                    summary: format!("{} {}", kind.label(), status.label()),
+                })
+                .collect(),
+            channel_candidates: Vec::new(),
+            workspace_guidance: Vec::new(),
+        }
+    }
+
+    fn recommended_import_entry_options() -> Vec<OnboardEntryOption> {
+        vec![
+            OnboardEntryOption {
+                choice: OnboardEntryChoice::ImportDetectedSetup,
+                label: "Use detected starting point",
+                detail: "detected setup is recommended".to_owned(),
+                recommended: true,
+            },
+            OnboardEntryOption {
+                choice: OnboardEntryChoice::StartFresh,
+                label: "Start fresh",
+                detail: "configure from scratch".to_owned(),
+                recommended: false,
+            },
+        ]
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn run_preflight_checks_includes_provider_transport_review_for_responses_compatibility_mode()
@@ -4210,6 +4419,54 @@ mod tests {
                         .contains("retry chat_completions automatically")
             }),
             "preflight should surface transport review before writing a Responses-compatible config: {checks:#?}"
+        );
+    }
+
+    #[test]
+    fn select_non_interactive_starting_config_uses_sorted_detected_candidate_priority() {
+        let codex_candidate = import_candidate_with_domain_status(
+            crate::migration::ImportSourceKind::CodexConfig,
+            "Codex config at ~/.codex/config.toml",
+            [(
+                crate::migration::SetupDomainKind::Provider,
+                crate::migration::PreviewStatus::Ready,
+            )],
+        );
+        let environment_candidate = import_candidate_with_domain_status(
+            crate::migration::ImportSourceKind::Environment,
+            "your current environment",
+            [
+                (
+                    crate::migration::SetupDomainKind::Provider,
+                    crate::migration::PreviewStatus::Ready,
+                ),
+                (
+                    crate::migration::SetupDomainKind::Channels,
+                    crate::migration::PreviewStatus::Ready,
+                ),
+                (
+                    crate::migration::SetupDomainKind::WorkspaceGuidance,
+                    crate::migration::PreviewStatus::Ready,
+                ),
+            ],
+        );
+        let all_candidates = vec![codex_candidate, environment_candidate];
+
+        let selection = select_non_interactive_starting_config(
+            crate::migration::CurrentSetupState::Absent,
+            &recommended_import_entry_options(),
+            None,
+            all_candidates.clone(),
+            &all_candidates,
+        );
+
+        assert_eq!(
+            selection
+                .review_candidate
+                .as_ref()
+                .map(|candidate| candidate.source_kind),
+            Some(crate::migration::ImportSourceKind::Environment),
+            "non-interactive onboarding should reuse the same sorted detected-candidate priority as the interactive chooser: {selection:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -141,6 +141,13 @@ pub(crate) enum OnboardCheckLevel {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum OnboardNonInteractiveWarningPolicy {
+    #[default]
+    Block,
+    AcceptedBySkipModelProbe,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 struct OnboardCheckCounts {
     pass: usize,
     warn: usize,
@@ -152,6 +159,7 @@ pub(crate) struct OnboardCheck {
     pub(crate) name: &'static str,
     pub(crate) level: OnboardCheckLevel,
     pub(crate) detail: String,
+    pub(crate) non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -541,12 +549,13 @@ pub(crate) async fn run_onboard_cli_with_ui(
     let has_warnings = checks
         .iter()
         .any(|check| check.level == OnboardCheckLevel::Warn);
-    let has_blocking_non_interactive_warnings = checks.iter().any(|check| {
-        check.level == OnboardCheckLevel::Warn
-            && !is_explicitly_accepted_non_interactive_warning(check, &options)
-    });
     let existing_output_config = load_existing_output_config(&output_path);
     let skip_config_write = should_skip_config_write(existing_output_config.as_ref(), &config);
+    let has_blocking_non_interactive_warnings = !skip_config_write
+        && checks.iter().any(|check| {
+            check.level == OnboardCheckLevel::Warn
+                && !is_explicitly_accepted_non_interactive_warning(check, &options)
+        });
 
     if options.non_interactive {
         if !credential_ok {
@@ -1047,12 +1056,15 @@ async fn run_preflight_checks(
             name: "provider model probe",
             level: OnboardCheckLevel::Warn,
             detail: "skipped by --skip-model-probe".to_owned(),
+            non_interactive_warning_policy:
+                OnboardNonInteractiveWarningPolicy::AcceptedBySkipModelProbe,
         });
     } else if !has_credentials {
         checks.push(OnboardCheck {
             name: "provider model probe",
             level: OnboardCheckLevel::Warn,
             detail: "skipped because credentials are missing".to_owned(),
+            non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
         });
     } else {
         match mvp::provider::fetch_available_models(config).await {
@@ -1060,11 +1072,13 @@ async fn run_preflight_checks(
                 name: "provider model probe",
                 level: OnboardCheckLevel::Pass,
                 detail: format!("{} model(s) available", models.len()),
+                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
             }),
             Err(error) => checks.push(OnboardCheck {
                 name: "provider model probe",
                 level: OnboardCheckLevel::Fail,
                 detail: error,
+                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
             }),
         }
     }
@@ -1093,6 +1107,7 @@ pub(crate) fn provider_credential_check(config: &mvp::config::LoongClawConfig) -
             name: "provider credentials",
             level: OnboardCheckLevel::Pass,
             detail: "inline oauth access token configured".to_owned(),
+            non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
         };
     }
 
@@ -1106,6 +1121,7 @@ pub(crate) fn provider_credential_check(config: &mvp::config::LoongClawConfig) -
             name: "provider credentials",
             level: OnboardCheckLevel::Pass,
             detail: "inline api key configured".to_owned(),
+            non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
         };
     }
 
@@ -1117,6 +1133,7 @@ pub(crate) fn provider_credential_check(config: &mvp::config::LoongClawConfig) -
             name: "provider credentials",
             level: OnboardCheckLevel::Pass,
             detail,
+            non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
         };
     }
 
@@ -1127,6 +1144,7 @@ pub(crate) fn provider_credential_check(config: &mvp::config::LoongClawConfig) -
         name: "provider credentials",
         level: OnboardCheckLevel::Warn,
         detail,
+        non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
     }
 }
 
@@ -1140,6 +1158,7 @@ fn provider_transport_check(config: &mvp::config::LoongClawConfig) -> OnboardChe
             mvp::config::ProviderTransportReadinessLevel::Unsupported => OnboardCheckLevel::Fail,
         },
         detail: readiness.detail,
+        non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
     }
 }
 
@@ -1148,8 +1167,10 @@ fn is_explicitly_accepted_non_interactive_warning(
     options: &OnboardCommandOptions,
 ) -> bool {
     options.skip_model_probe
-        && check.name == "provider model probe"
-        && check.detail == "skipped by --skip-model-probe"
+        && matches!(
+            check.non_interactive_warning_policy,
+            OnboardNonInteractiveWarningPolicy::AcceptedBySkipModelProbe
+        )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1288,16 +1309,19 @@ pub(crate) fn directory_preflight_check(name: &'static str, target: &Path) -> On
                 name,
                 level: OnboardCheckLevel::Pass,
                 detail: target.display().to_string(),
+                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
             },
             Ok(_) => OnboardCheck {
                 name,
                 level: OnboardCheckLevel::Fail,
                 detail: format!("{} exists but is not a directory", target.display()),
+                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
             },
             Err(error) => OnboardCheck {
                 name,
                 level: OnboardCheckLevel::Fail,
                 detail: format!("failed to inspect {}: {error}", target.display()),
+                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
             },
         };
     }
@@ -1309,6 +1333,7 @@ pub(crate) fn directory_preflight_check(name: &'static str, target: &Path) -> On
                 name,
                 level: OnboardCheckLevel::Fail,
                 detail: format!("no existing parent found for {}", target.display()),
+                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
             };
         };
         ancestor = parent;
@@ -1319,16 +1344,19 @@ pub(crate) fn directory_preflight_check(name: &'static str, target: &Path) -> On
             name,
             level: OnboardCheckLevel::Pass,
             detail: format!("would create under {}", ancestor.display()),
+            non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
         },
         Ok(_) => OnboardCheck {
             name,
             level: OnboardCheckLevel::Fail,
             detail: format!("{} exists but is not a directory", ancestor.display()),
+            non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
         },
         Err(error) => OnboardCheck {
             name,
             level: OnboardCheckLevel::Fail,
             detail: format!("failed to inspect {}: {error}", ancestor.display()),
+            non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
         },
     }
 }
@@ -1347,6 +1375,7 @@ pub(crate) fn collect_channel_preflight_checks(
                 crate::migration::channels::ChannelCheckLevel::Fail => OnboardCheckLevel::Fail,
             },
             detail: check.detail,
+            non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
         })
         .collect()
 }
@@ -4666,6 +4695,33 @@ mod tests {
     }
 
     #[test]
+    fn accepted_non_interactive_warnings_do_not_depend_on_display_text() {
+        let check = OnboardCheck {
+            name: "provider model probe",
+            level: OnboardCheckLevel::Warn,
+            detail: "display text changed".to_owned(),
+            non_interactive_warning_policy:
+                OnboardNonInteractiveWarningPolicy::AcceptedBySkipModelProbe,
+        };
+        let options = OnboardCommandOptions {
+            output: None,
+            force: false,
+            non_interactive: true,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            system_prompt: None,
+            skip_model_probe: true,
+        };
+
+        assert!(
+            is_explicitly_accepted_non_interactive_warning(&check, &options),
+            "non-interactive warning acceptance should follow structured policy rather than fragile display strings"
+        );
+    }
+
+    #[test]
     fn select_non_interactive_starting_config_uses_sorted_detected_candidate_priority() {
         let codex_candidate = import_candidate_with_domain_status(
             crate::migration::ImportSourceKind::CodexConfig,
@@ -4738,6 +4794,30 @@ mod tests {
         assert_eq!(
             path,
             PathBuf::from("/tmp/loongclaw.toml.bak-20260314-012345")
+        );
+    }
+
+    #[test]
+    fn rollback_removes_partial_first_write_config() {
+        let output_path = std::env::temp_dir().join(format!(
+            "loongclaw-first-write-rollback-{}.toml",
+            std::process::id()
+        ));
+        fs::write(&output_path, "partial = true\n").expect("write partial config");
+
+        let recovery = OnboardWriteRecovery {
+            output_preexisted: false,
+            backup_path: None,
+            keep_backup_on_success: false,
+        };
+
+        recovery
+            .rollback(&output_path)
+            .expect("first-write rollback should succeed");
+
+        assert!(
+            !output_path.exists(),
+            "first-write rollback should remove the partially written config"
         );
     }
 }

--- a/crates/daemon/src/tests/onboard_cli.rs
+++ b/crates/daemon/src/tests/onboard_cli.rs
@@ -662,6 +662,83 @@ async fn non_interactive_api_key_env_override_clears_existing_inline_api_key() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn non_interactive_api_key_env_clear_keeps_existing_inline_credential() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("non-interactive-api-key-env-clear-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+
+    let mut existing = mvp::config::LoongClawConfig::default();
+    existing.provider.model = "openai/gpt-5.1-codex".to_owned();
+    existing.provider.api_key = Some("inline-secret".to_owned());
+    existing.provider.api_key_env = Some("OPENAI_API_KEY".to_owned());
+    mvp::config::write(Some(output.to_string_lossy().as_ref()), &existing, true)
+        .expect("write existing config with inline credential and env binding");
+
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.force = true;
+    options.skip_model_probe = true;
+    options.model = Some("openai/gpt-5.1-codex".to_owned());
+    options.api_key_env = Some(":clear".to_owned());
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect("explicit clear token should keep the existing inline credential");
+
+    let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
+    assert!(
+        !raw.contains("OPENAI_API_KEY"),
+        "explicit clear token should remove the api-key env binding in non-interactive onboarding: {raw}"
+    );
+
+    let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
+        .expect("load written onboarding config");
+    assert_eq!(
+        config.provider.api_key.as_deref(),
+        Some("inline-secret"),
+        "explicit clear token should preserve the existing inline provider credential"
+    );
+    assert_eq!(config.provider.api_key_env, None);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_system_prompt_clear_restores_builtin_prompt() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("non-interactive-system-prompt-clear-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+
+    let mut existing = mvp::config::LoongClawConfig::default();
+    existing.provider.model = "openai/gpt-5.1-codex".to_owned();
+    existing.provider.api_key = Some("inline-secret".to_owned());
+    existing.cli.system_prompt = "custom review prompt".to_owned();
+    mvp::config::write(Some(output.to_string_lossy().as_ref()), &existing, true)
+        .expect("write existing config with custom system prompt");
+
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.force = true;
+    options.skip_model_probe = true;
+    options.model = Some("openai/gpt-5.1-codex".to_owned());
+    options.system_prompt = Some(":clear".to_owned());
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect("explicit clear token should restore the built-in system prompt");
+
+    let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
+        .expect("load written onboarding config");
+    assert_eq!(
+        config.cli.system_prompt,
+        mvp::config::CliChannelConfig::default().system_prompt,
+        "non-interactive clear token should restore the built-in CLI system prompt"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn interactive_onboard_clear_token_keeps_inline_provider_credential() {
     let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let output_path = unique_temp_path("interactive-clear-inline-credential.toml");

--- a/crates/daemon/src/tests/onboard_cli.rs
+++ b/crates/daemon/src/tests/onboard_cli.rs
@@ -613,6 +613,89 @@ async fn non_interactive_api_key_env_override_clears_existing_inline_api_key() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn interactive_onboard_clear_token_keeps_inline_provider_credential() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let output_path = unique_temp_path("interactive-clear-inline-credential.toml");
+    let mut existing = mvp::config::LoongClawConfig::default();
+    existing.provider.model = "gpt-4.1".to_owned();
+    existing.provider.api_key = Some("inline-secret".to_owned());
+    existing.provider.api_key_env = Some("OPENAI_API_KEY".to_owned());
+    mvp::config::write(output_path.to_str(), &existing, true).expect("write existing config");
+
+    let transcript = run_scripted_onboard_flow(
+        crate::onboard_cli::OnboardCommandOptions {
+            output: output_path.to_str().map(str::to_owned),
+            force: false,
+            non_interactive: false,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            system_prompt: None,
+            skip_model_probe: true,
+        },
+        ["1", "2", "openai", "gpt-4.1", ":clear", "", "y", "y", "o"],
+        None,
+        None,
+    )
+    .await
+    .expect("run scripted onboarding with explicit credential clear token");
+
+    let raw = std::fs::read_to_string(&output_path).expect("read written onboarding config");
+    assert!(
+        !raw.contains("OPENAI_API_KEY"),
+        "explicit :clear should remove the api-key env binding instead of persisting it: {raw}"
+    );
+
+    let (_, config) =
+        mvp::config::load(output_path.to_str()).expect("load interactive onboarding config");
+    assert_eq!(
+        config.provider.api_key.as_deref(),
+        Some("inline-secret"),
+        "explicit :clear should keep the existing inline provider credential in the saved config: {transcript:#?}"
+    );
+    assert_eq!(config.provider.api_key_env, None);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn interactive_onboard_clear_token_restores_builtin_system_prompt() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let output_path = unique_temp_path("interactive-clear-system-prompt.toml");
+    let mut existing = mvp::config::LoongClawConfig::default();
+    existing.provider.model = "gpt-4.1".to_owned();
+    existing.provider.api_key = Some("inline-secret".to_owned());
+    existing.cli.system_prompt = "custom review prompt".to_owned();
+    mvp::config::write(output_path.to_str(), &existing, true).expect("write existing config");
+
+    run_scripted_onboard_flow(
+        crate::onboard_cli::OnboardCommandOptions {
+            output: output_path.to_str().map(str::to_owned),
+            force: false,
+            non_interactive: false,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            system_prompt: None,
+            skip_model_probe: true,
+        },
+        ["1", "2", "openai", "gpt-4.1", "", ":clear", "y", "y", "o"],
+        None,
+        None,
+    )
+    .await
+    .expect("run scripted onboarding with explicit system-prompt clear token");
+
+    let (_, config) =
+        mvp::config::load(output_path.to_str()).expect("load interactive onboarding config");
+    assert_eq!(
+        config.cli.system_prompt,
+        mvp::config::CliChannelConfig::default().system_prompt,
+        "explicit :clear should restore the built-in CLI system prompt"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn non_interactive_onboard_uses_the_same_detected_starting_point_order_as_interactive_default()
  {
     let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
@@ -3418,8 +3501,8 @@ fn onboard_api_key_env_screen_explains_suggested_env_and_blank_behavior() {
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("blank keeps inline or oauth credentials")),
-        "credential-env screen should explain when leaving the field blank is valid: {lines:#?}"
+            .any(|line| line == "- type :clear to keep inline or oauth credentials"),
+        "credential-env screen should explain the explicit clear token when Enter uses a non-empty default: {lines:#?}"
     );
 }
 
@@ -3535,8 +3618,8 @@ fn onboard_system_prompt_screen_explains_blank_behavior() {
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("blank keeps the built-in behavior")),
-        "system-prompt screen should explain the blank-value behavior clearly: {lines:#?}"
+            .any(|line| line == "- type :clear to use the built-in behavior"),
+        "system-prompt screen should explain how to restore the built-in behavior when Enter keeps the current prompt: {lines:#?}"
     );
 }
 

--- a/crates/daemon/src/tests/onboard_cli.rs
+++ b/crates/daemon/src/tests/onboard_cli.rs
@@ -8,6 +8,8 @@
 use super::*;
 use std::collections::VecDeque;
 use std::ffi::OsString;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener};
 use std::path::PathBuf;
 use std::sync::MutexGuard;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -152,9 +154,12 @@ impl ScriptedOnboardUi {
     }
 
     fn next_input(&mut self, label: &str) -> crate::CliResult<String> {
-        self.inputs
-            .pop_front()
-            .ok_or_else(|| format!("missing scripted input for {label}"))
+        self.inputs.pop_front().ok_or_else(|| {
+            format!(
+                "missing scripted input for {label}; transcript so far:\n{}",
+                self.outputs.join("\n")
+            )
+        })
     }
 }
 
@@ -194,12 +199,24 @@ async fn run_scripted_onboard_flow(
     workspace_root: Option<PathBuf>,
     codex_config_path: Option<PathBuf>,
 ) -> crate::CliResult<Vec<String>> {
+    run_scripted_onboard_flow_with_context(
+        options,
+        inputs,
+        crate::onboard_cli::OnboardRuntimeContext::new_for_tests(
+            80,
+            workspace_root,
+            codex_config_path,
+        ),
+    )
+    .await
+}
+
+async fn run_scripted_onboard_flow_with_context(
+    options: crate::onboard_cli::OnboardCommandOptions,
+    inputs: impl IntoIterator<Item = impl Into<String>>,
+    context: crate::onboard_cli::OnboardRuntimeContext,
+) -> crate::CliResult<Vec<String>> {
     let mut ui = ScriptedOnboardUi::new(inputs);
-    let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(
-        80,
-        workspace_root,
-        codex_config_path,
-    );
     crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context).await?;
     Ok(ui.transcript())
 }
@@ -223,6 +240,62 @@ fn extract_success_section_lines(transcript: &[String]) -> Vec<String> {
         .position(|line| line == "onboarding complete")
         .expect("transcript should include success section");
     transcript[start..].to_vec()
+}
+
+fn start_local_model_probe_server(
+    expected_requests: usize,
+) -> (SocketAddr, std::thread::JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider test listener");
+    let addr = listener.local_addr().expect("local addr");
+    let server = std::thread::spawn(move || {
+        let mut requests = Vec::new();
+        for _ in 0..expected_requests {
+            let (mut stream, _) = listener.accept().expect("accept local provider request");
+            let mut request_buf = [0_u8; 8192];
+            let len = stream.read(&mut request_buf).expect("read request");
+            let request = String::from_utf8_lossy(&request_buf[..len]).to_string();
+            requests.push(request.clone());
+
+            let (status_line, body) = if request.starts_with("GET /v1/models ") {
+                (
+                    "HTTP/1.1 200 OK",
+                    r#"{"data":[{"id":"openai/gpt-5.1-codex"}]}"#.to_owned(),
+                )
+            } else {
+                (
+                    "HTTP/1.1 404 Not Found",
+                    r#"{"error":{"message":"unexpected request"}}"#.to_owned(),
+                )
+            };
+
+            let response = format!(
+                "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        }
+        requests
+    });
+    (addr, server)
+}
+
+fn default_non_interactive_onboard_options(
+    output: &std::path::Path,
+) -> crate::onboard_cli::OnboardCommandOptions {
+    crate::onboard_cli::OnboardCommandOptions {
+        output: Some(output.display().to_string()),
+        force: false,
+        non_interactive: true,
+        accept_risk: true,
+        provider: None,
+        model: None,
+        api_key_env: None,
+        system_prompt: None,
+        skip_model_probe: false,
+    }
 }
 
 #[test]
@@ -355,6 +428,373 @@ fn non_interactive_requires_explicit_risk_acknowledgement() {
         .expect("risk gate should pass after acknowledgement");
     crate::onboard_cli::validate_non_interactive_risk_gate(false, false)
         .expect("interactive mode should not require explicit flag");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_onboard_rejects_unresolved_preflight_warnings() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("non-interactive-warning-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+
+    let (addr, server) = start_local_model_probe_server(1);
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.base_url = format!("http://{addr}");
+    config.provider.model = "openai/gpt-5.1-codex".to_owned();
+    config.provider.wire_api = mvp::config::ProviderWireApi::Responses;
+    config.provider.api_key = Some("test-openai-key".to_owned());
+    mvp::config::write(Some(output.to_string_lossy().as_ref()), &config, true)
+        .expect("write existing config");
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    let error = crate::onboard_cli::run_onboard_cli_with_ui(
+        default_non_interactive_onboard_options(&output),
+        &mut ui,
+        &context,
+    )
+    .await
+    .expect_err("non-interactive onboarding should stop on unresolved warnings");
+
+    assert!(
+        error.contains("unresolved") && error.contains("warning"),
+        "unexpected warning-gate error: {error}"
+    );
+
+    let requests = server.join().expect("join local provider server");
+    assert!(
+        requests.iter().any(|request| {
+            let normalized = request.to_ascii_lowercase();
+            request.starts_with("GET /v1/models ")
+                && normalized.contains("authorization: bearer test-openai-key")
+        }),
+        "warning reproduction should still perform the model probe before the warning gate: {requests:#?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_onboard_allows_explicit_skip_model_probe_warning() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("non-interactive-skip-model-probe-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", "test-openai-key");
+    }
+
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.skip_model_probe = true;
+    options.model = Some("openai/gpt-5.1-codex".to_owned());
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect("explicitly skipped model probe should not block non-interactive onboarding");
+
+    let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
+    assert!(
+        raw.contains("api_key = \"${OPENAI_API_KEY}\""),
+        "onboarding should persist the default provider credential as a canonical env reference: {raw}"
+    );
+    assert!(
+        !raw.contains("api_key_env"),
+        "canonical onboarding config should not persist the legacy api_key_env field: {raw}"
+    );
+
+    let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
+        .expect("load written onboarding config");
+    assert_eq!(config.provider.model, "openai/gpt-5.1-codex");
+    assert_eq!(
+        config.provider.api_key.as_deref(),
+        Some("${OPENAI_API_KEY}")
+    );
+    assert_eq!(
+        config.provider.api_key(),
+        Some("test-openai-key".to_owned()),
+        "loaded config should still resolve the canonical env reference at runtime"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_api_key_env_override_clears_existing_oauth_credentials() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("non-interactive-api-key-env-override-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", "test-openai-key");
+    }
+
+    let mut existing = mvp::config::LoongClawConfig::default();
+    existing.provider.model = "openai/gpt-5.1-codex".to_owned();
+    existing.provider.oauth_access_token = Some("${OPENAI_CODEX_OAUTH_TOKEN}".to_owned());
+    mvp::config::write(Some(output.to_string_lossy().as_ref()), &existing, true)
+        .expect("write existing config with oauth credential");
+
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.force = true;
+    options.skip_model_probe = true;
+    options.api_key_env = Some("OPENAI_API_KEY".to_owned());
+    options.model = Some("openai/gpt-5.1-codex".to_owned());
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect("explicit api key env override should succeed");
+
+    let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
+    assert!(
+        raw.contains("api_key = \"${OPENAI_API_KEY}\""),
+        "api key env override should persist the selected api key source: {raw}"
+    );
+    assert!(
+        !raw.contains("OPENAI_CODEX_OAUTH_TOKEN"),
+        "api key env override should clear stale oauth credentials instead of keeping both sources: {raw}"
+    );
+
+    let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
+        .expect("load written onboarding config");
+    assert_eq!(config.provider.oauth_access_token, None);
+    assert_eq!(
+        config.provider.api_key.as_deref(),
+        Some("${OPENAI_API_KEY}"),
+        "reloaded config should keep only the selected api key credential source"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_api_key_env_override_clears_existing_inline_api_key() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("non-interactive-inline-api-key-override-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", "test-openai-key");
+    }
+
+    let mut existing = mvp::config::LoongClawConfig::default();
+    existing.provider.model = "openai/gpt-5.1-codex".to_owned();
+    existing.provider.api_key = Some("inline-secret".to_owned());
+    mvp::config::write(Some(output.to_string_lossy().as_ref()), &existing, true)
+        .expect("write existing config with inline api key");
+
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.force = true;
+    options.skip_model_probe = true;
+    options.api_key_env = Some("OPENAI_API_KEY".to_owned());
+    options.model = Some("openai/gpt-5.1-codex".to_owned());
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect("explicit api key env override should succeed");
+
+    let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
+    assert!(
+        raw.contains("api_key = \"${OPENAI_API_KEY}\""),
+        "api key env override should persist the selected api key source: {raw}"
+    );
+    assert!(
+        !raw.contains("inline-secret"),
+        "api key env override should remove the old inline secret instead of persisting both credential forms: {raw}"
+    );
+
+    let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
+        .expect("load written onboarding config");
+    assert_eq!(
+        config.provider.api_key.as_deref(),
+        Some("${OPENAI_API_KEY}"),
+        "reloaded config should keep only the selected api key env reference"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_onboard_uses_the_same_detected_starting_point_order_as_interactive_default()
+ {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", "openai-test-token");
+        std::env::set_var("DEEPSEEK_API_KEY", "deepseek-test-token");
+    }
+
+    let root = unique_temp_path("non-interactive-starting-point-order");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let interactive_output = root.join("interactive.toml");
+    let non_interactive_output = root.join("non-interactive.toml");
+
+    let (addr, server) = start_local_model_probe_server(2);
+
+    let z_openai_codex = root.join("z-openai.toml");
+    std::fs::write(
+        &z_openai_codex,
+        format!(
+            r#"
+model_provider = "openai"
+model = "openai/gpt-5.1-codex"
+
+[model_providers.openai]
+base_url = "http://{addr}"
+wire_api = "chat_completions"
+requires_openai_auth = true
+"#
+        ),
+    )
+    .expect("write openai codex config");
+
+    let a_deepseek_codex = root.join("a-deepseek.toml");
+    std::fs::write(
+        &a_deepseek_codex,
+        format!(
+            r#"
+model_provider = "deepseek"
+model = "deepseek-chat"
+
+[model_providers.deepseek]
+base_url = "http://{addr}"
+wire_api = "chat_completions"
+requires_openai_auth = true
+"#
+        ),
+    )
+    .expect("write deepseek codex config");
+
+    let codex_paths = vec![z_openai_codex.clone(), a_deepseek_codex.clone()];
+    let interactive_context =
+        crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, codex_paths.clone());
+    let interactive_transcript = run_scripted_onboard_flow_with_context(
+        crate::onboard_cli::OnboardCommandOptions {
+            output: Some(interactive_output.display().to_string()),
+            force: false,
+            non_interactive: false,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            system_prompt: None,
+            skip_model_probe: false,
+        },
+        vec![
+            "1".to_owned(),
+            "1".to_owned(),
+            "1".to_owned(),
+            "y".to_owned(),
+        ],
+        interactive_context,
+    )
+    .await
+    .expect("run interactive onboarding");
+
+    let (_, interactive_config) = mvp::config::load(Some(
+        interactive_output
+            .to_str()
+            .expect("interactive output path should be valid utf-8"),
+    ))
+    .expect("load interactive onboarding config");
+    assert_eq!(
+        interactive_config.provider.kind,
+        mvp::config::ProviderKind::Deepseek,
+        "interactive default should follow the sorted starting-point order and pick the alphabetically first detected source: {interactive_transcript:#?}"
+    );
+    assert_eq!(interactive_config.provider.model, "deepseek-chat");
+
+    let non_interactive_context =
+        crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, codex_paths);
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    crate::onboard_cli::run_onboard_cli_with_ui(
+        crate::onboard_cli::OnboardCommandOptions {
+            output: Some(non_interactive_output.display().to_string()),
+            force: false,
+            non_interactive: true,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            system_prompt: None,
+            skip_model_probe: false,
+        },
+        &mut ui,
+        &non_interactive_context,
+    )
+    .await
+    .expect("run non-interactive onboarding");
+
+    let (_, non_interactive_config) = mvp::config::load(Some(
+        non_interactive_output
+            .to_str()
+            .expect("non-interactive output path should be valid utf-8"),
+    ))
+    .expect("load non-interactive onboarding config");
+    assert_eq!(
+        non_interactive_config.provider.kind, interactive_config.provider.kind,
+        "non-interactive onboarding should reuse the same detected starting-point ordering as the interactive default"
+    );
+    assert_eq!(
+        non_interactive_config.provider.model,
+        interactive_config.provider.model
+    );
+
+    let requests = server.join().expect("join local provider server");
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.starts_with("GET /v1/models "))
+            .count(),
+        2,
+        "both onboarding runs should probe exactly one selected provider each: {requests:#?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn onboard_restores_original_config_when_memory_bootstrap_fails_after_write() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("memory-bootstrap-rollback-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+    let invalid_sqlite_dir = root.join("memory-dir");
+    std::fs::create_dir_all(&invalid_sqlite_dir).expect("create invalid sqlite directory");
+
+    let (addr, server) = start_local_model_probe_server(1);
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.base_url = format!("http://{addr}");
+    config.provider.model = "openai/gpt-5.1-codex".to_owned();
+    config.provider.api_key = Some("test-openai-key".to_owned());
+    config.memory.sqlite_path = invalid_sqlite_dir.display().to_string();
+    mvp::config::write(Some(output.to_string_lossy().as_ref()), &config, true)
+        .expect("write existing config");
+    let original_body = std::fs::read_to_string(&output).expect("read original config");
+
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.force = true;
+    options.model = Some("gpt-4.1-mini".to_owned());
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    let error = crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect_err("memory bootstrap failure should abort onboarding");
+
+    assert!(
+        error.contains("failed to bootstrap sqlite memory"),
+        "unexpected bootstrap failure error: {error}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&output).expect("read config after rollback"),
+        original_body,
+        "onboarding should restore the original config when post-write bootstrap fails"
+    );
+
+    let requests = server.join().expect("join local provider server");
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.starts_with("GET /v1/models ")),
+        "post-write rollback path should still reach the provider model probe before bootstrap: {requests:#?}"
+    );
 }
 
 #[test]

--- a/crates/daemon/src/tests/onboard_cli.rs
+++ b/crates/daemon/src/tests/onboard_cli.rs
@@ -447,15 +447,14 @@ async fn non_interactive_onboard_rejects_unresolved_preflight_warnings() {
     mvp::config::write(Some(output.to_string_lossy().as_ref()), &config, true)
         .expect("write existing config");
 
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.system_prompt = Some("force a pending write".to_owned());
+
     let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
     let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
-    let error = crate::onboard_cli::run_onboard_cli_with_ui(
-        default_non_interactive_onboard_options(&output),
-        &mut ui,
-        &context,
-    )
-    .await
-    .expect_err("non-interactive onboarding should stop on unresolved warnings");
+    let error = crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect_err("non-interactive onboarding should stop on unresolved warnings");
 
     assert!(
         error.contains("unresolved") && error.contains("warning"),
@@ -470,6 +469,56 @@ async fn non_interactive_onboard_rejects_unresolved_preflight_warnings() {
                 && normalized.contains("authorization: bearer test-openai-key")
         }),
         "warning reproduction should still perform the model probe before the warning gate: {requests:#?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_onboard_keeps_matching_existing_config_despite_persistent_warnings() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("non-interactive-warning-noop-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+    unsafe {
+        std::env::set_var("DEEPSEEK_API_KEY", "test-deepseek-key");
+    }
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.kind = mvp::config::ProviderKind::Deepseek;
+    config.provider.model = "deepseek-chat".to_owned();
+    config.provider.wire_api = mvp::config::ProviderWireApi::Responses;
+    config.provider.api_key_env = Some("DEEPSEEK_API_KEY".to_owned());
+    mvp::config::write(Some(output.to_string_lossy().as_ref()), &config, true)
+        .expect("write existing config");
+
+    let raw = std::fs::read_to_string(&output).expect("read written config");
+    let legacy_raw = raw.replace(
+        "api_key = \"${DEEPSEEK_API_KEY}\"",
+        "api_key_env = \"DEEPSEEK_API_KEY\"",
+    );
+    std::fs::write(&output, legacy_raw).expect("rewrite config to legacy api_key_env form");
+    let original_body = std::fs::read_to_string(&output).expect("read original config");
+
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.skip_model_probe = true;
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect("matching existing config should stay a successful no-op even when persistent warnings remain");
+
+    assert_eq!(
+        std::fs::read_to_string(&output).expect("read config after no-op"),
+        original_body,
+        "no-op onboarding should not rewrite the existing config just to re-encode the same settings"
+    );
+    let transcript = ui.transcript();
+    assert!(
+        transcript
+            .iter()
+            .any(|line| line.contains("existing config kept; no changes were needed")),
+        "successful no-op path should still report that the existing config was reused: {:#?}",
+        transcript
     );
 }
 
@@ -3841,16 +3890,22 @@ fn onboard_preflight_screen_summarizes_status_counts_and_guidance() {
             name: "provider credentials",
             level: crate::onboard_cli::OnboardCheckLevel::Pass,
             detail: "OPENAI_API_KEY is available".to_owned(),
+            non_interactive_warning_policy:
+                crate::onboard_cli::OnboardNonInteractiveWarningPolicy::Block,
         },
         crate::onboard_cli::OnboardCheck {
             name: "provider model probe",
             level: crate::onboard_cli::OnboardCheckLevel::Fail,
             detail: "provider rejected the model list".to_owned(),
+            non_interactive_warning_policy:
+                crate::onboard_cli::OnboardNonInteractiveWarningPolicy::Block,
         },
         crate::onboard_cli::OnboardCheck {
             name: "telegram channel",
             level: crate::onboard_cli::OnboardCheckLevel::Warn,
             detail: "enabled but bot token is missing".to_owned(),
+            non_interactive_warning_policy:
+                crate::onboard_cli::OnboardNonInteractiveWarningPolicy::Block,
         },
     ];
 
@@ -3910,6 +3965,8 @@ fn onboard_preflight_screen_omits_continue_cancel_choices_when_all_checks_are_gr
         name: "provider credentials",
         level: crate::onboard_cli::OnboardCheckLevel::Pass,
         detail: "OPENAI_API_KEY is available".to_owned(),
+        non_interactive_warning_policy:
+            crate::onboard_cli::OnboardNonInteractiveWarningPolicy::Block,
     }];
 
     let lines = crate::onboard_cli::render_preflight_summary_screen_lines(&checks, 80);
@@ -3940,6 +3997,8 @@ fn onboard_preflight_screen_falls_back_to_stacked_rows_when_details_overflow() {
         detail:
             "provider rejected the model list because the configured endpoint requires a different compatibility mode"
                 .to_owned(),
+        non_interactive_warning_policy:
+            crate::onboard_cli::OnboardNonInteractiveWarningPolicy::Block,
     }];
 
     let lines = crate::onboard_cli::render_preflight_summary_screen_lines(&checks, 80);
@@ -3963,6 +4022,8 @@ fn current_setup_preflight_screen_uses_quick_review_progress_copy() {
         name: "provider credentials",
         level: crate::onboard_cli::OnboardCheckLevel::Pass,
         detail: "OPENAI_API_KEY is available".to_owned(),
+        non_interactive_warning_policy:
+            crate::onboard_cli::OnboardNonInteractiveWarningPolicy::Block,
     }];
 
     let lines =
@@ -3986,6 +4047,8 @@ fn detected_setup_preflight_screen_uses_quick_review_progress_copy() {
         name: "provider credentials",
         level: crate::onboard_cli::OnboardCheckLevel::Pass,
         detail: "OPENAI_API_KEY is available".to_owned(),
+        non_interactive_warning_policy:
+            crate::onboard_cli::OnboardNonInteractiveWarningPolicy::Block,
     }];
 
     let lines =


### PR DESCRIPTION
## Summary

- Allow non-interactive onboarding to accept the explicit `--skip-model-probe` warning while still blocking any other unresolved preflight warnings when a write is actually needed, and keep matching existing configs as successful no-op runs even if persistent warnings remain.
- Clear stale inline/OAuth provider credentials when onboarding switches to an API-key env source, and add an explicit `:clear` action on interactive onboarding screens so operators can intentionally fall back to inline/OAuth credentials or the built-in CLI system prompt when Enter would otherwise reuse a non-empty default.
- Align non-interactive detected-starting-point selection with the interactive sorted chooser, decouple accepted non-interactive warning handling from fragile display-text matching, and roll back config writes if sqlite bootstrap fails after the file write.
- This is needed because latest `alpha-test` still had headless onboarding dead ends, stale credential persistence, prompt-copy/behavior mismatches around non-empty defaults, no-op failure paths, and post-write recovery gaps.

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

- The non-interactive warning gate now exempts only warnings explicitly tagged as accepted by `--skip-model-probe`; all other warnings still force an interactive review path when onboarding would otherwise mutate config state.
- Matching existing configs now short-circuit to the existing-config-kept no-op path even if persistent warnings remain, because onboarding is not introducing new risk in that branch.
- Interactive onboarding keeps Enter mapped to the shown default or prefilled value and introduces `:clear` as the explicit action for falling back to inline/OAuth credentials or the built-in prompt when the current default is non-empty.
- Credential-source overrides now clear superseded provider secrets before persistence, which changes onboarding behavior intentionally so the selected source is the only provider credential form that remains.
- System-prompt clear actions now restore the rendered built-in/native prompt instead of silently leaving the previous custom prompt in place.
- Config writes now keep a rollback recovery record until sqlite bootstrap succeeds, then clean up transient rollback backups on success.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional validation notes:

- Added regressions for explicit `--skip-model-probe` acceptance, acceptance-policy decoupling from display text, non-interactive no-op reuse of matching existing configs under persistent warnings, clearing stale OAuth credentials, clearing stale inline API keys, interactive `:clear` fallback for credential-source and system-prompt prompts, non-interactive `:clear` fallback for those same knobs, matching interactive detected-starting-point ordering, first-write rollback cleanup, and restoring the original config when sqlite bootstrap fails after write.
- Before: `--skip-model-probe` still blocked non-interactive onboarding, warning acceptance depended on exact display strings, matching existing configs could still fail as non-interactive warning dead ends, `--api-key-env` could leave stale provider secrets behind, interactive fallback copy implied blank-input behavior that the prompt primitive could not actually perform with non-empty defaults, and post-write bootstrap failures could leave the config mutated.
- After: only explicitly accepted probe-skip warnings are bypassed, existing matching configs complete through the no-op kept-config path, the selected API-key env becomes the sole persisted provider credential form, interactive and non-interactive fallback actions use explicit `:clear` semantics where needed, non-interactive selection matches the interactive sorted default, and post-write bootstrap failures restore the previous or partial config state.
- Tests that mutate process-global env continue to serialize access through `DetectedEnvironmentGuard::without_detected_environment()` and the daemon test environment lock.

## Linked Issues

Closes #161
