### PR TITLE
feat(product): productize the first-run assistant journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <h1 align="center">LoongClaw</h1>
 
 <p align="center">
-  <strong>A Rust-first Agentic OS foundation -- stable kernel contracts, strict policy boundaries, pluggable runtime orchestration.</strong>
+  <strong>A Rust-first private assistant runtime: guided onboarding, one-shot ask, repair-first diagnostics, and safe extensible tools on top of a stable Agentic OS foundation.</strong>
 </p>
 
 <p align="center">
@@ -38,14 +38,14 @@
 
 ## Why LoongClaw?
 
-LoongClaw is a layered Agentic OS kernel focused on stable kernel contracts, strict policy boundaries, and pluggable runtime orchestration. Core and business logic are strictly separated:
+LoongClaw is a layered Agentic OS runtime built to feel like a trustworthy private assistant first and an extensible platform second. Core and business logic are strictly separated:
 
 - **Minimal, stable core** -- handles only policy, security, and audit. No business logic in the kernel.
 - **Security cannot be bypassed** -- every tool call, memory operation, and connector invocation is gated by the policy engine. High-risk actions require explicit human authorization.
 - **Business logic lives in extension planes** -- providers, tools, channels, and memory backends are all replaceable adapters that never touch the kernel.
 - **Multi-language plugins** -- supports Rust, WASM, and process plugins in any language. The community can extend freely.
 - **Bidirectional integration** -- can be embedded as a kernel into other systems, or connect to external services via adapters.
-- **Operator-ready product layer** -- onboarding, personalities, memory profiles, and legacy claw import are all first-class runtime capabilities.
+- **Operator-ready product layer** -- `onboard`, `ask`, `chat`, `doctor`, personalities, memory profiles, and legacy claw import are first-class runtime capabilities.
 
 ## Sponsors
 
@@ -62,9 +62,12 @@ LoongClaw is a layered Agentic OS kernel focused on stable kernel contracts, str
 
 ## Alpha-Test Highlights
 
-- `setup` bootstraps a beginner-friendly TOML config and local SQLite memory.
+- `onboard` is the default first-run flow for provider, memory, and channel-ready setup.
+- `ask` gives users a one-shot assistant command for first success without entering a REPL.
 - `chat` provides an interactive CLI channel with sliding-window conversation memory.
-- Core tool runtime currently ships `shell.exec`, `file.read`, and `file.write`.
+- `doctor` and `doctor --fix` are the explicit repair path when the local runtime is unhealthy.
+- Core tool runtime now ships `web.fetch`, `shell.exec`, `file.read`, and `file.write`.
+- Shipped assistant surfaces today are CLI first, with Telegram polling and Feishu webhook as optional channels after the base setup is healthy.
 - Memory-system selection is now a stable builtin-only seam:
   - config: `[memory] system = "builtin"`
   - env: `LOONGCLAW_MEMORY_SYSTEM=builtin`
@@ -199,7 +202,7 @@ cargo install --path crates/daemon
 
 `--onboard` runs `loongclaw onboard` without `--force`, so rerunning this quickstart will stop before overwriting an existing config.
 
-### First Chat in Under 5 Minutes
+### First Answer in Under 5 Minutes
 
 1. Run guided onboarding:
 
@@ -213,7 +216,13 @@ cargo install --path crates/daemon
    export PROVIDER_API_KEY=sk-...
    ```
 
-3. Start chatting:
+3. Get a first one-shot answer:
+
+   ```bash
+   loongclaw ask --message "What can you help me with in this repository?"
+   ```
+
+4. Continue with interactive chat when you want to stay in session:
 
    ```bash
    loongclaw chat
@@ -223,7 +232,7 @@ cargo install --path crates/daemon
    explicitly. Without `--acp` or other ACP-specific chat flags, normal chat stays on the default
    provider/context-engine path.
 
-Run `loongclaw doctor --fix` if anything goes wrong.
+Run `loongclaw doctor --fix` if anything goes wrong, or when onboarding / ask / chat reports a local health issue.
 
 ### Run Tests
 
@@ -390,9 +399,10 @@ Recommended runtime flow:
 
 **MVP Product Layer**
 - `onboard` -- guided first-run with preflight diagnostics
+- `ask` -- one-shot assistant answer and exit
 - `doctor` -- diagnostics with optional safe fixes (`--fix`) and machine-readable output (`--json`)
 - `chat` -- interactive CLI with sliding-window conversation memory
-- Core tools: `shell.exec`, `file.read`, `file.write`, `external_skills.policy`, `external_skills.fetch`, `external_skills.install`, `external_skills.list`, `external_skills.inspect`, `external_skills.invoke`, `external_skills.remove`
+- Core tools: `web.fetch`, `shell.exec`, `file.read`, `file.write`, `external_skills.policy`, `external_skills.fetch`, `external_skills.install`, `external_skills.list`, `external_skills.inspect`, `external_skills.invoke`, `external_skills.remove`
 - Providers: OpenAI-compatible, Volcengine custom endpoint
 - Channels: CLI, Telegram polling, Feishu encrypted webhook
 
@@ -446,6 +456,7 @@ enable only what you need for minimal builds.
 | `memory-sqlite` | SQLite conversation memory |
 | `tool-shell` | `shell.exec` tool |
 | `tool-file` | `file.read` / `file.write` tools |
+| `tool-webfetch` | `web.fetch` tool |
 | `channel-cli` | Interactive CLI channel |
 | `channel-telegram` | Telegram polling adapter |
 | `channel-feishu` | Feishu encrypted webhook adapter |
@@ -479,9 +490,10 @@ cargo build -p loongclaw-daemon --no-default-features --features "channel-cli,pr
 | [Core Beliefs](docs/design-docs/core-beliefs.md) | 10 core engineering principles |
 | [Layered Kernel Design](docs/design-docs/layered-kernel-design.md) | Full L0-L9 layer specification |
 | [Roadmap](docs/ROADMAP.md) | Stage-based milestones and acceptance criteria |
+| [Product Sense](docs/PRODUCT_SENSE.md) | Current MVP journey and user-facing product principles |
 | [Reliability](docs/RELIABILITY.md) | Build and kernel invariants |
 | [Examples](examples/README.md) | Spec files, plugin samples, benchmarks |
-| [Product Specs](docs/product-specs/index.md) | User-facing requirements (in progress) |
+| [Product Specs](docs/product-specs/index.md) | User-facing requirements for onboarding, ask, doctor, channels, and WebChat expectations |
 | [Skills](skills/) | Agent skills (`update-harness.skill`) |
 | [Changelog](CHANGELOG.md) | Release history |
 
@@ -514,7 +526,9 @@ chat_completions_path = "/api/v3/chat/completions"
 ### Tool policy
 
 Shell execution defaults to **deny-unknown** — only explicitly allowed commands run.
-File access is sandboxed to the working directory by default.
+File access is sandboxed to the working directory by default. `web.fetch` is
+enabled in the MVP build, but still blocks localhost, private hosts, and
+special-use destinations unless the operator explicitly relaxes that policy.
 
 ```toml
 [tools]
@@ -522,6 +536,14 @@ shell_default_mode = "deny"                          # "deny" | "allow"
 shell_allow = ["echo", "ls", "git", "cargo"]         # permitted commands
 shell_deny = []                                      # hard-blocked commands
 # file_root = "/home/user/project"                   # defaults to CWD
+
+[tools.web]
+enabled = true
+allowed_domains = ["docs.example.com"]
+blocked_domains = ["*.internal.example"]
+max_bytes = 1048576
+timeout_seconds = 15
+max_redirects = 3
 ```
 
 See [Tool Policy Configuration](docs/configuration/tool-policy.md) for the full reference.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 <h1 align="center">LoongClaw</h1>
 
 <p align="center">
-  <strong>Rust 优先的 Agentic OS 基座 -- 稳定的内核协议、严格的策略边界、即插即用的运行时(runtime)扩展。</strong>
+  <strong>Rust 优先的私有助手运行时：在稳定 Agentic OS 基座之上，提供引导式 onboarding、一次性 ask、修复优先的 doctor，以及安全可扩展的工具能力。</strong>
 </p>
 
 <p align="center">
@@ -38,13 +38,14 @@
 
 ## 什么是 LoongClaw？
 
-LoongClaw 是一个基于Rust构建的 Agentic OS 内核，专注于稳定且轻量的内核协议、严格的策略边界和即插即用的运行时（runtime）扩展，意在实现核心与业务功能的严格分离：
+LoongClaw 是一个基于 Rust 构建的 Agentic OS 运行时，目标是先成为一个可信、可本地运行的私有助手，再成为一个可扩展的平台。核心与业务能力保持严格分离：
 
 - **内核精简稳定** -- 只负责策略、安全和审计，不包含任何额外的业务逻辑，力图保持体积精简，足以在边缘设备上运行
 - **安全边界不可逾越** -- 每个工具调用、内存操作和连接器调用都经过策略引擎管控；高风险操作需要显式人工授权
 - **业务逻辑扩展** -- provider、工具、通道、内存后端都是可替换的适配器扩展，不侵入内核
 - **多语言插件** -- 支持 Rust、WASM及任意语言的进程插件，社区可自由扩展
 - **双向可集成** -- 既能作为内核被其他系统嵌入，也能通过适配器对接外部服务
+- **面向产品的用户入口** -- `onboard`、`ask`、`chat`、`doctor`、人格、记忆档与导入能力都属于一等运行时能力
 
 ## 赞助商
 
@@ -94,7 +95,7 @@ cargo install --path crates/daemon
 
 `--onboard` 现在调用的是不带 `--force` 的 `loongclaw onboard`，因此重复执行这条 quickstart 时会先停止，而不会直接覆盖已有配置。
 
-### 5 分钟内开始首次对话
+### 5 分钟内拿到第一次回答
 
 1. 运行引导式首次配置：
 
@@ -108,7 +109,13 @@ cargo install --path crates/daemon
    export PROVIDER_API_KEY=sk-...
    ```
 
-3. 开始聊天：
+3. 先拿到一次性回答：
+
+   ```bash
+   loongclaw ask --message "你能帮我处理这个仓库里的什么事情？"
+   ```
+
+4. 需要持续会话时，再进入交互式聊天：
 
    ```bash
    loongclaw chat
@@ -117,7 +124,7 @@ cargo install --path crates/daemon
    如果你希望这次 CLI chat 显式走 ACP，可以使用 `loongclaw chat --acp`。没有 `--acp`
    或其他 ACP 专用 chat 参数时，普通聊天仍然保持默认的 provider/context-engine 路径。
 
-遇到问题请运行 `loongclaw doctor --fix`。
+如果 onboarding / ask / chat 遇到本地健康问题，请运行 `loongclaw doctor --fix`。
 
 ### 运行测试
 
@@ -250,9 +257,10 @@ auto_expose_installed = true
 
 **MVP 产品层**
 - `onboard` -- 引导式首次运行，带预检诊断
+- `ask` -- 一次性助手回答后退出
 - `doctor` -- 诊断工具，可选安全修复 (`--fix`) 和机器可读输出 (`--json`)
 - `chat` -- 交互式 CLI，滑动窗口对话记忆
-- 核心工具：`shell.exec`、`file.read`、`file.write`、`external_skills.policy`、`external_skills.fetch`、`external_skills.install`、`external_skills.list`、`external_skills.inspect`、`external_skills.invoke`、`external_skills.remove`
+- 核心工具：`web.fetch`、`shell.exec`、`file.read`、`file.write`、`external_skills.policy`、`external_skills.fetch`、`external_skills.install`、`external_skills.list`、`external_skills.inspect`、`external_skills.invoke`、`external_skills.remove`
 - Provider：OpenAI 兼容、火山引擎自定义端点
 - 通道：CLI、Telegram 轮询、飞书加密 webhook
 - ACP 现在作为独立 control plane 建模，不再混入 provider 或 context engine
@@ -331,6 +339,7 @@ contracts (leaf -- 零内部依赖)
 | `memory-sqlite` | SQLite 对话记忆 |
 | `tool-shell` | `shell.exec` 工具 |
 | `tool-file` | `file.read` / `file.write` 工具 |
+| `tool-webfetch` | `web.fetch` 工具 |
 | `channel-cli` | 交互式 CLI 通道 |
 | `channel-telegram` | Telegram 轮询适配器 |
 | `channel-feishu` | 飞书加密 webhook 适配器 |
@@ -364,9 +373,10 @@ cargo build -p loongclaw-daemon --no-default-features --features "channel-cli,pr
 | [核心信念](docs/design-docs/core-beliefs.md) | 10 条核心工程原则 |
 | [分层内核设计](docs/design-docs/layered-kernel-design.md) | 完整 L0-L9 层规格 |
 | [路线图](docs/ROADMAP.md) | 阶段里程碑和验收标准 |
+| [产品感知](docs/PRODUCT_SENSE.md) | 当前 MVP 用户旅程和产品原则 |
 | [可靠性](docs/RELIABILITY.md) | 构建和内核不变量 |
 | [示例](examples/README.md) | Spec 文件、插件示例、基准测试 |
-| [产品规格](docs/product-specs/index.md) | 面向用户的需求（进行中） |
+| [产品规格](docs/product-specs/index.md) | onboarding、ask、doctor、渠道和 WebChat 预期等面向用户的要求 |
 | [变更日志](CHANGELOG.md) | 发布历史 |
 
 ## 配置
@@ -398,7 +408,8 @@ chat_completions_path = "/api/v3/chat/completions"
 ### 工具策略
 
 Shell 执行默认采用**未知命令拒绝**策略——只有明确列入允许名单的命令才能运行。
-文件访问默认沙箱为进程工作目录。
+文件访问默认沙箱为进程工作目录。`web.fetch` 在 MVP 构建中默认可用，但仍会默认阻断
+localhost、私网和特殊用途地址，除非 operator 显式放宽策略。
 
 ```toml
 [tools]
@@ -406,6 +417,14 @@ shell_default_mode = "deny"                          # "deny" | "allow"
 shell_allow = ["echo", "ls", "git", "cargo"]         # 允许的命令
 shell_deny = []                                      # 硬拒绝的命令
 # file_root = "/home/user/project"                   # 默认为 CWD
+
+[tools.web]
+enabled = true
+allowed_domains = ["docs.example.com"]
+blocked_domains = ["*.internal.example"]
+max_bytes = 1048576
+timeout_seconds = 15
+max_redirects = 3
 ```
 
 验证配置：

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 authors.workspace = true
 
 [features]
-default = ["channel-cli", "channel-telegram", "channel-feishu", "config-toml", "memory-sqlite", "tool-shell", "tool-file", "provider-openai", "provider-anthropic", "provider-bedrock", "provider-volcengine"]
+default = ["channel-cli", "channel-telegram", "channel-feishu", "config-toml", "memory-sqlite", "tool-shell", "tool-file", "tool-webfetch", "provider-openai", "provider-anthropic", "provider-bedrock", "provider-volcengine"]
 channel-cli = []
 channel-telegram = []
 channel-feishu = ["dep:axum", "dep:aes", "dep:cbc"]
@@ -18,6 +18,7 @@ config-toml = ["dep:toml"]
 memory-sqlite = ["dep:rusqlite"]
 tool-shell = []
 tool-file = []
+tool-webfetch = []
 
 [dependencies]
 loongclaw-contracts = { path = "../contracts" }

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -51,115 +51,61 @@ impl CliChatOptions {
     }
 }
 
+struct CliTurnRuntime {
+    resolved_path: PathBuf,
+    config: LoongClawConfig,
+    session_id: String,
+    session_address: ConversationSessionAddress,
+    turn_coordinator: ConversationTurnCoordinator,
+    kernel_ctx: crate::KernelContext,
+    explicit_acp_request: bool,
+    effective_bootstrap_mcp_servers: Vec<String>,
+    effective_working_directory: Option<PathBuf>,
+    memory_label: String,
+    #[cfg(feature = "memory-sqlite")]
+    memory_config: MemoryRuntimeConfig,
+}
+
 #[allow(clippy::print_stdout)] // CLI REPL output
 pub async fn run_cli_chat(
     config_path: Option<&str>,
     session_hint: Option<&str>,
     options: &CliChatOptions,
 ) -> CliResult<()> {
-    let (resolved_path, config) = config::load(config_path)?;
-    if !config.cli.enabled {
-        return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
-    }
-
-    crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
-    let kernel_ctx = bootstrap_kernel_context("cli-chat", DEFAULT_TOKEN_TTL_S)?;
+    let runtime =
+        initialize_cli_turn_runtime(config_path, session_hint, options, "cli-chat").await?;
+    print_cli_chat_startup(&runtime, options)?;
 
     #[cfg(feature = "memory-sqlite")]
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-
-    #[cfg(feature = "memory-sqlite")]
-    {
-        let sqlite_path = config.memory.resolved_sqlite_path();
-        let initialized = memory::ensure_memory_db_ready(Some(sqlite_path), &memory_config)
-            .map_err(|error| format!("failed to initialize sqlite memory: {error}"))?;
-        println!(
-            "loongclaw chat started (config={}, memory={})",
-            resolved_path.display(),
-            initialized.display()
-        );
-    }
-    #[cfg(not(feature = "memory-sqlite"))]
-    {
-        println!(
-            "loongclaw chat started (config={}, memory=disabled)",
-            resolved_path.display()
-        );
-    }
-
-    let session_id = session_hint
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("default")
-        .to_owned();
-    let context_engine_selection = resolve_context_engine_selection(&config);
-    let acp_selection = resolve_acp_backend_selection(&config);
-    let dispatch_channels = config.acp.dispatch.allowed_channel_ids()?;
-    let effective_bootstrap_mcp_servers = config
-        .acp
-        .dispatch
-        .bootstrap_mcp_server_names_with_additions(&options.acp_bootstrap_mcp_servers)?;
-    let effective_working_directory = options
-        .acp_working_directory
-        .clone()
-        .or_else(|| config.acp.dispatch.resolved_working_directory());
-    let explicit_acp_request = options.requests_explicit_acp();
-    println!("session={session_id} (type /help for commands, /exit to quit)");
-    println!(
-        "context_engine={} source={}",
-        context_engine_selection.id,
-        context_engine_selection.source.as_str()
-    );
-    println!(
-        "acp_enabled={} dispatch_enabled={} conversation_routing={} allowed_channels={} backend={} source={}",
-        config.acp.enabled,
-        config.acp.dispatch_enabled(),
-        config.acp.dispatch.conversation_routing.as_str(),
-        dispatch_channels.join(","),
-        acp_selection.id,
-        acp_selection.source.as_str()
-    );
-    if explicit_acp_request
-        || !effective_bootstrap_mcp_servers.is_empty()
-        || effective_working_directory.is_some()
-    {
-        let bootstrap_label = if effective_bootstrap_mcp_servers.is_empty() {
-            "-".to_owned()
-        } else {
-            effective_bootstrap_mcp_servers.join(",")
-        };
-        let cwd_label = effective_working_directory
-            .as_ref()
-            .map(|path| path.display().to_string())
-            .unwrap_or_else(|| "-".to_owned());
-        println!(
-            "acp_turn_options explicit={} event_stream={} bootstrap_mcp_servers={bootstrap_label} cwd={cwd_label}",
-            explicit_acp_request, options.acp_event_stream,
-        );
-    }
-    let turn_coordinator = ConversationTurnCoordinator::new();
-
-    #[cfg(feature = "memory-sqlite")]
-    match turn_coordinator
-        .load_turn_checkpoint_diagnostics(&config, &session_id, Some(&kernel_ctx))
+    match runtime
+        .turn_coordinator
+        .load_turn_checkpoint_diagnostics(
+            &runtime.config,
+            &runtime.session_id,
+            Some(&runtime.kernel_ctx),
+        )
         .await
     {
         Ok(diagnostics) => {
-            if let Some(health) = format_turn_checkpoint_startup_health(&session_id, &diagnostics) {
+            if let Some(health) =
+                format_turn_checkpoint_startup_health(&runtime.session_id, &diagnostics)
+            {
                 println!("{health}");
                 if let Some(probe) = diagnostics.runtime_probe() {
                     println!(
                         "{}",
-                        format_turn_checkpoint_runtime_probe(&session_id, probe)
+                        format_turn_checkpoint_runtime_probe(&runtime.session_id, probe)
                     );
                 }
             }
         }
         Err(error) => {
-            println!("turn_checkpoint_health session={session_id} state=unavailable error={error}");
+            println!(
+                "turn_checkpoint_health session={} state=unavailable error={error}",
+                runtime.session_id
+            );
         }
     }
-    let session_address = ConversationSessionAddress::from_session_id(session_id.clone());
     let acp_event_printer = options
         .acp_event_stream
         .then(|| JsonlAcpTurnEventSink::stderr_with_prefix("acp-event> "));
@@ -181,7 +127,7 @@ pub async fn run_cli_chat(
         if input.is_empty() {
             continue;
         }
-        if is_exit_command(&config, input) {
+        if is_exit_command(&runtime.config, input) {
             break;
         }
         if input == "/help" {
@@ -191,51 +137,63 @@ pub async fn run_cli_chat(
         if input == "/history" {
             #[cfg(feature = "memory-sqlite")]
             print_history(
-                &session_id,
-                config.memory.sliding_window,
-                Some(&kernel_ctx),
-                &memory_config,
+                &runtime.session_id,
+                runtime.config.memory.sliding_window,
+                Some(&runtime.kernel_ctx),
+                &runtime.memory_config,
             )
             .await?;
             #[cfg(not(feature = "memory-sqlite"))]
-            print_history(&session_id, config.memory.sliding_window, Some(&kernel_ctx)).await?;
-            continue;
-        }
-        if let Some(limit) = parse_safe_lane_summary_limit(input, config.memory.sliding_window)? {
-            #[cfg(feature = "memory-sqlite")]
-            print_safe_lane_summary(
-                &session_id,
-                limit,
-                &config.conversation,
-                Some(&kernel_ctx),
-                &memory_config,
+            print_history(
+                &runtime.session_id,
+                runtime.config.memory.sliding_window,
+                Some(&runtime.kernel_ctx),
             )
             .await?;
-            #[cfg(not(feature = "memory-sqlite"))]
-            print_safe_lane_summary(&session_id, limit, &config.conversation, Some(&kernel_ctx))
-                .await?;
             continue;
         }
         if let Some(limit) =
-            parse_turn_checkpoint_summary_limit(input, config.memory.sliding_window)?
+            parse_safe_lane_summary_limit(input, runtime.config.memory.sliding_window)?
+        {
+            #[cfg(feature = "memory-sqlite")]
+            print_safe_lane_summary(
+                &runtime.session_id,
+                limit,
+                &runtime.config.conversation,
+                Some(&runtime.kernel_ctx),
+                &runtime.memory_config,
+            )
+            .await?;
+            #[cfg(not(feature = "memory-sqlite"))]
+            print_safe_lane_summary(
+                &runtime.session_id,
+                limit,
+                &runtime.config.conversation,
+                Some(&runtime.kernel_ctx),
+            )
+            .await?;
+            continue;
+        }
+        if let Some(limit) =
+            parse_turn_checkpoint_summary_limit(input, runtime.config.memory.sliding_window)?
         {
             #[cfg(feature = "memory-sqlite")]
             print_turn_checkpoint_summary(
-                &turn_coordinator,
-                &config,
-                &session_id,
+                &runtime.turn_coordinator,
+                &runtime.config,
+                &runtime.session_id,
                 limit,
-                Some(&kernel_ctx),
-                &memory_config,
+                Some(&runtime.kernel_ctx),
+                &runtime.memory_config,
             )
             .await?;
             #[cfg(not(feature = "memory-sqlite"))]
             print_turn_checkpoint_summary(
-                &turn_coordinator,
-                &config,
-                &session_id,
+                &runtime.turn_coordinator,
+                &runtime.config,
+                &runtime.session_id,
                 limit,
-                Some(&kernel_ctx),
+                Some(&runtime.kernel_ctx),
             )
             .await?;
             continue;
@@ -243,52 +201,205 @@ pub async fn run_cli_chat(
         if is_turn_checkpoint_repair_command(input)? {
             #[cfg(feature = "memory-sqlite")]
             print_turn_checkpoint_repair(
-                &turn_coordinator,
-                &config,
-                &session_id,
-                Some(&kernel_ctx),
+                &runtime.turn_coordinator,
+                &runtime.config,
+                &runtime.session_id,
+                Some(&runtime.kernel_ctx),
             )
             .await?;
             #[cfg(not(feature = "memory-sqlite"))]
             print_turn_checkpoint_repair(
-                &turn_coordinator,
-                &config,
-                &session_id,
-                Some(&kernel_ctx),
+                &runtime.turn_coordinator,
+                &runtime.config,
+                &runtime.session_id,
+                Some(&runtime.kernel_ctx),
             )
             .await?;
             continue;
         }
 
-        let acp_options = if explicit_acp_request {
-            AcpConversationTurnOptions::explicit()
-        } else {
-            AcpConversationTurnOptions::automatic()
-        }
-        .with_event_sink(
+        let assistant_text = run_cli_turn(
+            &runtime,
+            input,
+            options,
             acp_event_printer
                 .as_ref()
                 .map(|printer| printer as &dyn AcpTurnEventSink),
         )
-        .with_additional_bootstrap_mcp_servers(&options.acp_bootstrap_mcp_servers)
-        .with_working_directory(options.acp_working_directory.as_deref());
-        let turn_config = reload_cli_turn_config(&config, resolved_path.as_path())?;
-        let assistant_text = turn_coordinator
-            .handle_turn_with_address_and_acp_options(
-                &turn_config,
-                &session_address,
-                input,
-                ProviderErrorMode::InlineMessage,
-                &acp_options,
-                Some(&kernel_ctx),
-            )
-            .await?;
+        .await?;
 
         println!("loongclaw> {assistant_text}");
     }
 
     println!("bye.");
     Ok(())
+}
+
+#[allow(clippy::print_stdout)] // CLI output
+pub async fn run_cli_ask(
+    config_path: Option<&str>,
+    session_hint: Option<&str>,
+    message: &str,
+    options: &CliChatOptions,
+) -> CliResult<()> {
+    let input = message.trim();
+    if input.is_empty() {
+        return Err("ask message must not be empty".to_owned());
+    }
+
+    let runtime =
+        initialize_cli_turn_runtime(config_path, session_hint, options, "cli-ask").await?;
+    let acp_event_printer = options
+        .acp_event_stream
+        .then(|| JsonlAcpTurnEventSink::stderr_with_prefix("acp-event> "));
+    let assistant_text = run_cli_turn(
+        &runtime,
+        input,
+        options,
+        acp_event_printer
+            .as_ref()
+            .map(|printer| printer as &dyn AcpTurnEventSink),
+    )
+    .await?;
+    println!("loongclaw> {assistant_text}");
+    Ok(())
+}
+
+async fn initialize_cli_turn_runtime(
+    config_path: Option<&str>,
+    session_hint: Option<&str>,
+    options: &CliChatOptions,
+    kernel_scope: &'static str,
+) -> CliResult<CliTurnRuntime> {
+    let (resolved_path, config) = config::load(config_path)?;
+    if !config.cli.enabled {
+        return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
+    }
+
+    crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
+    let kernel_ctx = bootstrap_kernel_context(kernel_scope, DEFAULT_TOKEN_TTL_S)?;
+    let explicit_acp_request = options.requests_explicit_acp();
+    let effective_bootstrap_mcp_servers = config
+        .acp
+        .dispatch
+        .bootstrap_mcp_server_names_with_additions(&options.acp_bootstrap_mcp_servers)?;
+    let effective_working_directory = options
+        .acp_working_directory
+        .clone()
+        .or_else(|| config.acp.dispatch.resolved_working_directory());
+    let session_id = session_hint
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("default")
+        .to_owned();
+    let session_address = ConversationSessionAddress::from_session_id(session_id.clone());
+
+    #[cfg(feature = "memory-sqlite")]
+    let (memory_config, memory_label) = {
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let sqlite_path = config.memory.resolved_sqlite_path();
+        let initialized = memory::ensure_memory_db_ready(Some(sqlite_path), &memory_config)
+            .map_err(|error| format!("failed to initialize sqlite memory: {error}"))?;
+        (memory_config, initialized.display().to_string())
+    };
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    let memory_label = "disabled".to_owned();
+
+    Ok(CliTurnRuntime {
+        resolved_path,
+        config,
+        session_id,
+        session_address,
+        turn_coordinator: ConversationTurnCoordinator::new(),
+        kernel_ctx,
+        explicit_acp_request,
+        effective_bootstrap_mcp_servers,
+        effective_working_directory,
+        memory_label,
+        #[cfg(feature = "memory-sqlite")]
+        memory_config,
+    })
+}
+
+#[allow(clippy::print_stdout)] // CLI output
+fn print_cli_chat_startup(runtime: &CliTurnRuntime, options: &CliChatOptions) -> CliResult<()> {
+    let context_engine_selection = resolve_context_engine_selection(&runtime.config);
+    let acp_selection = resolve_acp_backend_selection(&runtime.config);
+    let dispatch_channels = runtime.config.acp.dispatch.allowed_channel_ids()?;
+
+    println!(
+        "loongclaw chat started (config={}, memory={})",
+        runtime.resolved_path.display(),
+        runtime.memory_label
+    );
+    println!(
+        "session={} (type /help for commands, /exit to quit)",
+        runtime.session_id
+    );
+    println!(
+        "context_engine={} source={}",
+        context_engine_selection.id,
+        context_engine_selection.source.as_str()
+    );
+    println!(
+        "acp_enabled={} dispatch_enabled={} conversation_routing={} allowed_channels={} backend={} source={}",
+        runtime.config.acp.enabled,
+        runtime.config.acp.dispatch_enabled(),
+        runtime.config.acp.dispatch.conversation_routing.as_str(),
+        dispatch_channels.join(","),
+        acp_selection.id,
+        acp_selection.source.as_str()
+    );
+    if runtime.explicit_acp_request
+        || !runtime.effective_bootstrap_mcp_servers.is_empty()
+        || runtime.effective_working_directory.is_some()
+    {
+        let bootstrap_label = if runtime.effective_bootstrap_mcp_servers.is_empty() {
+            "-".to_owned()
+        } else {
+            runtime.effective_bootstrap_mcp_servers.join(",")
+        };
+        let cwd_label = runtime
+            .effective_working_directory
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "-".to_owned());
+        println!(
+            "acp_turn_options explicit={} event_stream={} bootstrap_mcp_servers={bootstrap_label} cwd={cwd_label}",
+            runtime.explicit_acp_request, options.acp_event_stream,
+        );
+    }
+
+    Ok(())
+}
+
+async fn run_cli_turn(
+    runtime: &CliTurnRuntime,
+    input: &str,
+    _options: &CliChatOptions,
+    event_sink: Option<&dyn AcpTurnEventSink>,
+) -> CliResult<String> {
+    let turn_config = reload_cli_turn_config(&runtime.config, runtime.resolved_path.as_path())?;
+    let acp_options = if runtime.explicit_acp_request {
+        AcpConversationTurnOptions::explicit()
+    } else {
+        AcpConversationTurnOptions::automatic()
+    }
+    .with_event_sink(event_sink)
+    .with_additional_bootstrap_mcp_servers(&runtime.effective_bootstrap_mcp_servers)
+    .with_working_directory(runtime.effective_working_directory.as_deref());
+    runtime
+        .turn_coordinator
+        .handle_turn_with_address_and_acp_options(
+            &turn_config,
+            &runtime.session_address,
+            input,
+            ProviderErrorMode::InlineMessage,
+            &acp_options,
+            Some(&runtime.kernel_ctx),
+        )
+        .await
 }
 
 fn reload_cli_turn_config(
@@ -1148,6 +1259,15 @@ mod tests {
     #[test]
     fn cli_chat_options_keep_automatic_routing_without_explicit_acp_inputs() {
         assert!(!CliChatOptions::default().requests_explicit_acp());
+    }
+
+    #[tokio::test]
+    async fn run_cli_ask_rejects_empty_message() {
+        let error = run_cli_ask(None, None, "   ", &CliChatOptions::default())
+            .await
+            .expect_err("empty one-shot message should fail");
+
+        assert!(error.contains("ask message must not be empty"));
     }
 
     #[test]

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -45,9 +45,11 @@ pub(crate) use runtime::{normalize_dispatch_account_id, normalize_dispatch_chann
 pub use shared::{CLI_COMMAND_NAME, expand_path};
 #[allow(unused_imports)]
 pub use tools_memory::{
-    DEFAULT_SHELL_ALLOW, ExternalSkillsConfig, GovernedToolApprovalConfig,
-    GovernedToolApprovalMode, MemoryBackendKind, MemoryConfig, MemoryIngestMode, MemoryMode,
-    MemoryProfile, MemorySystemKind, SessionVisibility, ToolConfig,
+    DEFAULT_SHELL_ALLOW, DEFAULT_WEB_FETCH_MAX_BYTES, DEFAULT_WEB_FETCH_MAX_REDIRECTS,
+    DEFAULT_WEB_FETCH_TIMEOUT_SECONDS, ExternalSkillsConfig, GovernedToolApprovalConfig,
+    GovernedToolApprovalMode, MAX_WEB_FETCH_MAX_BYTES, MemoryBackendKind, MemoryConfig,
+    MemoryIngestMode, MemoryMode, MemoryProfile, MemorySystemKind, SessionVisibility, ToolConfig,
+    WebToolConfig,
 };
 
 #[cfg(test)]

--- a/crates/app/src/config/tools_memory.rs
+++ b/crates/app/src/config/tools_memory.rs
@@ -9,6 +9,14 @@ use super::shared::{
 
 pub(crate) const MIN_MEMORY_SLIDING_WINDOW: usize = 1;
 pub(crate) const MAX_MEMORY_SLIDING_WINDOW: usize = 128;
+pub const DEFAULT_WEB_FETCH_MAX_BYTES: usize = 1024 * 1024;
+pub const DEFAULT_WEB_FETCH_TIMEOUT_SECONDS: u64 = 15;
+pub const DEFAULT_WEB_FETCH_MAX_REDIRECTS: usize = 3;
+pub(crate) const MIN_WEB_FETCH_MAX_BYTES: usize = 1024;
+pub const MAX_WEB_FETCH_MAX_BYTES: usize = 5 * 1024 * 1024;
+pub(crate) const MIN_WEB_FETCH_TIMEOUT_SECONDS: usize = 1;
+pub(crate) const MAX_WEB_FETCH_TIMEOUT_SECONDS: usize = 120;
+pub(crate) const MAX_WEB_FETCH_MAX_REDIRECTS: usize = 10;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ToolConfig {
@@ -32,6 +40,8 @@ pub struct ToolConfig {
     pub messages: MessageToolConfig,
     #[serde(default)]
     pub delegate: DelegateToolConfig,
+    #[serde(default)]
+    pub web: WebToolConfig,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -92,6 +102,24 @@ pub struct DelegateToolConfig {
     pub child_tool_allowlist: Vec<String>,
     #[serde(default)]
     pub allow_shell_in_child: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WebToolConfig {
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub allow_private_hosts: bool,
+    #[serde(default)]
+    pub allowed_domains: Vec<String>,
+    #[serde(default)]
+    pub blocked_domains: Vec<String>,
+    #[serde(default = "default_web_fetch_max_bytes")]
+    pub max_bytes: usize,
+    #[serde(default = "default_web_fetch_timeout_seconds")]
+    pub timeout_seconds: u64,
+    #[serde(default = "default_web_fetch_max_redirects")]
+    pub max_redirects: usize,
 }
 
 fn default_shell_default_mode() -> String {
@@ -320,6 +348,7 @@ impl Default for ToolConfig {
             sessions: SessionToolConfig::default(),
             messages: MessageToolConfig::default(),
             delegate: DelegateToolConfig::default(),
+            web: WebToolConfig::default(),
         }
     }
 }
@@ -357,6 +386,20 @@ impl Default for DelegateToolConfig {
     }
 }
 
+impl Default for WebToolConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+            allow_private_hosts: false,
+            allowed_domains: Vec::new(),
+            blocked_domains: Vec::new(),
+            max_bytes: default_web_fetch_max_bytes(),
+            timeout_seconds: default_web_fetch_timeout_seconds(),
+            max_redirects: default_web_fetch_max_redirects(),
+        }
+    }
+}
+
 impl Default for ExternalSkillsConfig {
     fn default() -> Self {
         Self {
@@ -379,7 +422,32 @@ impl ToolConfig {
     }
 
     pub(super) fn validate(&self) -> Vec<ConfigValidationIssue> {
-        Vec::new()
+        let mut issues = Vec::new();
+        if let Err(issue) = validate_numeric_range(
+            "tools.web.max_bytes",
+            self.web.max_bytes,
+            MIN_WEB_FETCH_MAX_BYTES,
+            MAX_WEB_FETCH_MAX_BYTES,
+        ) {
+            issues.push(*issue);
+        }
+        if let Err(issue) = validate_numeric_range(
+            "tools.web.timeout_seconds",
+            self.web.timeout_seconds as usize,
+            MIN_WEB_FETCH_TIMEOUT_SECONDS,
+            MAX_WEB_FETCH_TIMEOUT_SECONDS,
+        ) {
+            issues.push(*issue);
+        }
+        if let Err(issue) = validate_numeric_range(
+            "tools.web.max_redirects",
+            self.web.max_redirects,
+            0,
+            MAX_WEB_FETCH_MAX_REDIRECTS,
+        ) {
+            issues.push(*issue);
+        }
+        issues
     }
 }
 
@@ -394,6 +462,16 @@ impl ExternalSkillsConfig {
 
     pub fn resolved_install_root(&self) -> Option<PathBuf> {
         self.install_root.as_deref().map(expand_path)
+    }
+}
+
+impl WebToolConfig {
+    pub fn normalized_allowed_domains(&self) -> Vec<String> {
+        normalize_domain_entries(&self.allowed_domains)
+    }
+
+    pub fn normalized_blocked_domains(&self) -> Vec<String> {
+        normalize_domain_entries(&self.blocked_domains)
     }
 }
 
@@ -502,6 +580,19 @@ const fn default_delegate_timeout_seconds() -> u64 {
 fn default_delegate_child_tool_allowlist() -> Vec<String> {
     vec!["file.read".to_owned(), "file.write".to_owned()]
 }
+
+const fn default_web_fetch_max_bytes() -> usize {
+    DEFAULT_WEB_FETCH_MAX_BYTES
+}
+
+const fn default_web_fetch_timeout_seconds() -> u64 {
+    DEFAULT_WEB_FETCH_TIMEOUT_SECONDS
+}
+
+const fn default_web_fetch_max_redirects() -> usize {
+    DEFAULT_WEB_FETCH_MAX_REDIRECTS
+}
+
 const fn default_require_download_approval() -> bool {
     true
 }
@@ -559,6 +650,13 @@ mod tests {
             vec!["file.read".to_owned(), "file.write".to_owned()]
         );
         assert!(!config.delegate.allow_shell_in_child);
+        assert!(config.web.enabled);
+        assert!(!config.web.allow_private_hosts);
+        assert!(config.web.allowed_domains.is_empty());
+        assert!(config.web.blocked_domains.is_empty());
+        assert_eq!(config.web.timeout_seconds, 15);
+        assert_eq!(config.web.max_bytes, 1_048_576);
+        assert_eq!(config.web.max_redirects, 3);
     }
 
     #[cfg(feature = "config-toml")]
@@ -612,6 +710,37 @@ child_tool_allowlist = ["file.read", "shell.exec"]
             parsed.tools.delegate.child_tool_allowlist,
             vec!["file.read".to_owned(), "shell.exec".to_owned()]
         );
+    }
+
+    #[cfg(feature = "config-toml")]
+    #[test]
+    fn tool_config_parses_web_fetch_controls_from_toml() {
+        let raw = r#"
+[tools.web]
+enabled = false
+allow_private_hosts = true
+allowed_domains = ["Docs.Example.com", "docs.example.com"]
+blocked_domains = ["internal.example", " INTERNAL.EXAMPLE "]
+timeout_seconds = 9
+max_bytes = 262144
+max_redirects = 1
+"#;
+        let parsed =
+            toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
+
+        assert!(!parsed.tools.web.enabled);
+        assert!(parsed.tools.web.allow_private_hosts);
+        assert_eq!(
+            parsed.tools.web.normalized_allowed_domains(),
+            vec!["docs.example.com".to_owned()]
+        );
+        assert_eq!(
+            parsed.tools.web.normalized_blocked_domains(),
+            vec!["internal.example".to_owned()]
+        );
+        assert_eq!(parsed.tools.web.timeout_seconds, 9);
+        assert_eq!(parsed.tools.web.max_bytes, 262144);
+        assert_eq!(parsed.tools.web.max_redirects, 1);
     }
 
     #[test]
@@ -749,6 +878,47 @@ child_tool_allowlist = ["file.read", "shell.exec"]
                 .resolved_install_root()
                 .expect("install root should resolve")
                 .ends_with("demo-skills")
+        );
+    }
+
+    #[test]
+    fn web_tool_defaults_to_safe_public_fetch_mode() {
+        let config = WebToolConfig::default();
+        assert!(config.enabled);
+        assert!(!config.allow_private_hosts);
+        assert!(config.allowed_domains.is_empty());
+        assert!(config.blocked_domains.is_empty());
+        assert_eq!(config.timeout_seconds, 15);
+        assert_eq!(config.max_bytes, 1_048_576);
+        assert_eq!(config.max_redirects, 3);
+    }
+
+    #[test]
+    fn web_tool_normalized_domains_are_lowercase_and_deduped() {
+        let config = WebToolConfig {
+            enabled: true,
+            allow_private_hosts: false,
+            allowed_domains: vec![
+                "Docs.Example.com".to_owned(),
+                "docs.example.com".to_owned(),
+                "  api.example.com ".to_owned(),
+            ],
+            blocked_domains: vec![
+                "internal.example".to_owned(),
+                " INTERNAL.EXAMPLE ".to_owned(),
+            ],
+            timeout_seconds: 15,
+            max_bytes: 1_048_576,
+            max_redirects: 3,
+        };
+
+        assert_eq!(
+            config.normalized_allowed_domains(),
+            vec!["api.example.com".to_owned(), "docs.example.com".to_owned()]
+        );
+        assert_eq!(
+            config.normalized_blocked_domains(),
+            vec!["internal.example".to_owned()]
         );
     }
 }

--- a/crates/app/src/runtime_env.rs
+++ b/crates/app/src/runtime_env.rs
@@ -50,6 +50,34 @@ pub fn initialize_runtime_environment(
         config.tools.resolved_file_root().display().to_string(),
     );
     set_env_var(
+        "LOONGCLAW_WEB_FETCH_ENABLED",
+        bool_env(config.tools.web.enabled),
+    );
+    set_env_var(
+        "LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS",
+        bool_env(config.tools.web.allow_private_hosts),
+    );
+    set_env_var(
+        "LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS",
+        config.tools.web.normalized_allowed_domains().join(","),
+    );
+    set_env_var(
+        "LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS",
+        config.tools.web.normalized_blocked_domains().join(","),
+    );
+    set_env_var(
+        "LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS",
+        config.tools.web.timeout_seconds.to_string(),
+    );
+    set_env_var(
+        "LOONGCLAW_WEB_FETCH_MAX_BYTES",
+        config.tools.web.max_bytes.to_string(),
+    );
+    set_env_var(
+        "LOONGCLAW_WEB_FETCH_MAX_REDIRECTS",
+        config.tools.web.max_redirects.to_string(),
+    );
+    set_env_var(
         "LOONGCLAW_EXTERNAL_SKILLS_ENABLED",
         bool_env(config.external_skills.enabled),
     );
@@ -101,6 +129,25 @@ pub fn initialize_runtime_environment(
         shell_default_mode: crate::tools::shell_policy_ext::ShellPolicyDefault::parse(
             &config.tools.shell_default_mode,
         ),
+        web_fetch: crate::tools::runtime_config::WebFetchRuntimePolicy {
+            enabled: config.tools.web.enabled,
+            allow_private_hosts: config.tools.web.allow_private_hosts,
+            allowed_domains: config
+                .tools
+                .web
+                .normalized_allowed_domains()
+                .into_iter()
+                .collect(),
+            blocked_domains: config
+                .tools
+                .web
+                .normalized_blocked_domains()
+                .into_iter()
+                .collect(),
+            timeout_seconds: config.tools.web.timeout_seconds,
+            max_bytes: config.tools.web.max_bytes,
+            max_redirects: config.tools.web.max_redirects,
+        },
         external_skills: crate::tools::runtime_config::ExternalSkillsRuntimePolicy {
             enabled: config.external_skills.enabled,
             require_download_approval: config.external_skills.require_download_approval,
@@ -158,6 +205,13 @@ mod tests {
         config.memory.summary_max_chars = 900;
         config.memory.profile_note = Some("Imported NanoBot preferences".to_owned());
         config.tools.file_root = Some("/tmp/loongclaw-runtime-file-root".to_owned());
+        config.tools.web.enabled = false;
+        config.tools.web.allow_private_hosts = true;
+        config.tools.web.allowed_domains = vec!["docs.example.com".to_owned()];
+        config.tools.web.blocked_domains = vec!["internal.example".to_owned()];
+        config.tools.web.timeout_seconds = 9;
+        config.tools.web.max_bytes = 262_144;
+        config.tools.web.max_redirects = 1;
         config.external_skills.enabled = true;
         config.external_skills.allowed_domains = vec!["skills.sh".to_owned()];
         let config_path = PathBuf::from("/tmp/loongclaw-runtime-env.toml");
@@ -200,6 +254,46 @@ mod tests {
                 .as_deref(),
             Some("skills.sh")
         );
+        assert_eq!(
+            std::env::var("LOONGCLAW_WEB_FETCH_ENABLED").ok().as_deref(),
+            Some("false")
+        );
+        assert_eq!(
+            std::env::var("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS")
+                .ok()
+                .as_deref(),
+            Some("true")
+        );
+        assert_eq!(
+            std::env::var("LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS")
+                .ok()
+                .as_deref(),
+            Some("docs.example.com")
+        );
+        assert_eq!(
+            std::env::var("LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS")
+                .ok()
+                .as_deref(),
+            Some("internal.example")
+        );
+        assert_eq!(
+            std::env::var("LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS")
+                .ok()
+                .as_deref(),
+            Some("9")
+        );
+        assert_eq!(
+            std::env::var("LOONGCLAW_WEB_FETCH_MAX_BYTES")
+                .ok()
+                .as_deref(),
+            Some("262144")
+        );
+        assert_eq!(
+            std::env::var("LOONGCLAW_WEB_FETCH_MAX_REDIRECTS")
+                .ok()
+                .as_deref(),
+            Some("1")
+        );
 
         crate::process_env::remove_var("LOONGCLAW_CONFIG_PATH");
         crate::process_env::remove_var("LOONGCLAW_MEMORY_BACKEND");
@@ -218,5 +312,12 @@ mod tests {
         crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS");
         crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_INSTALL_ROOT");
         crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ENABLED");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_MAX_BYTES");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_MAX_REDIRECTS");
     }
 }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -446,6 +446,19 @@ pub fn tool_catalog() -> ToolCatalog {
         });
     }
 
+    #[cfg(feature = "tool-webfetch")]
+    {
+        descriptors.push(ToolDescriptor {
+            name: "web.fetch",
+            provider_name: "web_fetch",
+            aliases: &["web_fetch"],
+            description: "Fetch a public web page with SSRF-safe guards and readable extraction",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            provider_definition_builder: web_fetch_definition,
+        });
+    }
+
     descriptors.sort_by(|left, right| left.name.cmp(right.name));
     ToolCatalog { descriptors }
 }
@@ -550,6 +563,7 @@ fn tool_is_enabled_for_runtime_view(tool_name: &str, config: &ToolConfig) -> boo
         | "session_wait" => config.sessions.enabled,
         "sessions_send" => config.messages.enabled,
         "delegate" | "delegate_async" => config.delegate.enabled,
+        "web.fetch" => config.web.enabled,
         _ => true,
     }
 }
@@ -887,6 +901,38 @@ fn file_write_definition(descriptor: &ToolDescriptor) -> Value {
                     }
                 },
                 "required": ["path", "content"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn web_fetch_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "HTTP or HTTPS URL to fetch."
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": ["readable_text", "raw_text"],
+                        "description": "How to render the response body. Defaults to `readable_text`."
+                    },
+                    "max_bytes": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": crate::config::MAX_WEB_FETCH_MAX_BYTES,
+                        "description": "Optional per-call read limit in bytes. Cannot exceed the configured runtime max."
+                    }
+                },
+                "required": ["url"],
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -23,6 +23,8 @@ pub mod runtime_config;
 mod session;
 mod shell;
 pub mod shell_policy_ext;
+#[cfg(feature = "tool-webfetch")]
+mod web_fetch;
 
 pub use catalog::{
     ToolApprovalMode, ToolAvailability, ToolCatalog, ToolDescriptor, ToolExecutionKind,
@@ -239,6 +241,8 @@ pub fn execute_tool_core_with_config(
         "provider.switch" => {
             provider_switch::execute_provider_switch_tool_with_config(request, config)
         }
+        #[cfg(feature = "tool-webfetch")]
+        "web.fetch" => web_fetch::execute_web_fetch_tool_with_config(request, config),
         _ => Err(format!(
             "tool_not_found: unknown tool `{}`",
             request.tool_name
@@ -381,6 +385,13 @@ fn _shape_examples() -> BTreeMap<&'static str, Value> {
                 "path": "notes.txt",
                 "content": "hello",
                 "create_dirs": true
+            }),
+        ),
+        (
+            "web.fetch",
+            json!({
+                "url": "https://docs.example.com/page",
+                "mode": "readable_text"
             }),
         ),
     ])
@@ -537,6 +548,9 @@ mod tests {
             snapshot.contains("- sessions_list: List visible sessions and their high-level state")
         );
         assert!(snapshot.contains("- shell.exec: Execute shell commands"));
+        assert!(snapshot.contains(
+            "- web.fetch: Fetch a public web page with SSRF-safe guards and readable extraction"
+        ));
 
         // Verify sorted order matches the catalog snapshot emitted to providers.
         let lines: Vec<&str> = snapshot.lines().skip(1).collect();
@@ -566,6 +580,7 @@ mod tests {
             "- sessions_history",
             "- sessions_list",
             "- shell.exec",
+            "- web.fetch",
         ];
         assert_eq!(lines.len(), ordered_prefixes.len());
         for (line, prefix) in lines.iter().zip(ordered_prefixes) {
@@ -584,7 +599,7 @@ mod tests {
     #[test]
     fn tool_registry_returns_all_known_tools() {
         let entries = tool_registry();
-        assert_eq!(entries.len(), 25);
+        assert_eq!(entries.len(), 26);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"approval_request_resolve"));
         assert!(names.contains(&"approval_request_status"));
@@ -611,6 +626,7 @@ mod tests {
         assert!(names.contains(&"session_wait"));
         assert!(names.contains(&"sessions_history"));
         assert!(names.contains(&"sessions_list"));
+        assert!(names.contains(&"web.fetch"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
@@ -647,7 +663,7 @@ mod tests {
         let defs = try_provider_tool_definitions_for_view(&planned_root_tool_view())
             .expect("all tools should now be advertisable");
 
-        assert_eq!(defs.len(), 26);
+        assert_eq!(defs.len(), 27);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -681,6 +697,16 @@ mod tests {
             !view.contains(tool_name),
             "expected runtime view to keep `{tool_name}` hidden"
         );
+        assert!(view.contains("web.fetch"));
+    }
+
+    #[test]
+    fn runtime_tool_view_hides_web_fetch_when_disabled() {
+        let mut config = crate::config::ToolConfig::default();
+        config.web.enabled = false;
+
+        let root_view = runtime_tool_view_for_config(&config);
+        assert!(!root_view.contains("web.fetch"));
     }
 
     #[test]
@@ -746,7 +772,7 @@ mod tests {
     #[test]
     fn provider_tool_definitions_are_stable_and_complete() {
         let defs = provider_tool_definitions();
-        assert_eq!(defs.len(), 25);
+        assert_eq!(defs.len(), 26);
 
         let names: Vec<&str> = defs
             .iter()
@@ -781,7 +807,8 @@ mod tests {
                 "session_wait",
                 "sessions_history",
                 "sessions_list",
-                "shell_exec"
+                "shell_exec",
+                "web_fetch",
             ]
         );
 
@@ -900,6 +927,29 @@ mod tests {
     }
 
     #[test]
+    fn provider_tool_definitions_include_web_fetch_when_enabled() {
+        let defs = try_provider_tool_definitions_for_view(&runtime_tool_view_for_config(
+            &crate::config::ToolConfig::default(),
+        ))
+        .expect("runtime-visible tool schemas");
+        let web_fetch = defs
+            .iter()
+            .find(|item| item["function"]["name"] == "web_fetch")
+            .expect("web_fetch definition");
+        let properties = web_fetch["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("web_fetch properties");
+        assert!(properties.contains_key("url"));
+        assert!(properties.contains_key("mode"));
+        assert!(properties.contains_key("max_bytes"));
+        assert_eq!(
+            properties["max_bytes"]["maximum"],
+            json!(5 * 1024 * 1024),
+            "web.fetch schema should advertise the compile-time hard cap instead of the default runtime limit"
+        );
+    }
+
+    #[test]
     fn canonical_tool_name_maps_known_aliases() {
         assert_eq!(canonical_tool_name("claw_import"), "claw.import");
         assert_eq!(
@@ -935,6 +985,7 @@ mod tests {
         assert_eq!(canonical_tool_name("provider_switch"), "provider.switch");
         assert_eq!(canonical_tool_name("shell_exec"), "shell.exec");
         assert_eq!(canonical_tool_name("shell"), "shell.exec");
+        assert_eq!(canonical_tool_name("web_fetch"), "web.fetch");
         assert_eq!(canonical_tool_name("file.read"), "file.read");
     }
 
@@ -965,6 +1016,8 @@ mod tests {
         assert!(is_known_tool_name("shell.exec"));
         assert!(is_known_tool_name("shell_exec"));
         assert!(is_known_tool_name("shell"));
+        assert!(is_known_tool_name("web.fetch"));
+        assert!(is_known_tool_name("web_fetch"));
         assert!(!is_known_tool_name("nonexistent.tool"));
     }
 

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -27,6 +27,31 @@ impl Default for ExternalSkillsRuntimePolicy {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebFetchRuntimePolicy {
+    pub enabled: bool,
+    pub allow_private_hosts: bool,
+    pub allowed_domains: BTreeSet<String>,
+    pub blocked_domains: BTreeSet<String>,
+    pub timeout_seconds: u64,
+    pub max_bytes: usize,
+    pub max_redirects: usize,
+}
+
+impl Default for WebFetchRuntimePolicy {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            allow_private_hosts: false,
+            allowed_domains: BTreeSet::new(),
+            blocked_domains: BTreeSet::new(),
+            timeout_seconds: crate::config::DEFAULT_WEB_FETCH_TIMEOUT_SECONDS,
+            max_bytes: crate::config::DEFAULT_WEB_FETCH_MAX_BYTES,
+            max_redirects: crate::config::DEFAULT_WEB_FETCH_MAX_REDIRECTS,
+        }
+    }
+}
+
 /// Typed runtime configuration for tool executors.
 ///
 /// Replaces per-call `std::env::var` lookups with a single read from a
@@ -38,6 +63,7 @@ pub struct ToolRuntimeConfig {
     pub shell_deny: BTreeSet<String>,
     pub shell_default_mode: ShellPolicyDefault,
     pub config_path: Option<PathBuf>,
+    pub web_fetch: WebFetchRuntimePolicy,
     pub external_skills: ExternalSkillsRuntimePolicy,
 }
 
@@ -52,6 +78,7 @@ impl Default for ToolRuntimeConfig {
             shell_deny: BTreeSet::new(),
             shell_default_mode: ShellPolicyDefault::Deny,
             config_path: None,
+            web_fetch: WebFetchRuntimePolicy::default(),
             external_skills: ExternalSkillsRuntimePolicy::default(),
         }
     }
@@ -67,6 +94,19 @@ impl ToolRuntimeConfig {
         let config_path = std::env::var("LOONGCLAW_CONFIG_PATH")
             .ok()
             .map(PathBuf::from);
+        let web_fetch_enabled = parse_env_bool("LOONGCLAW_WEB_FETCH_ENABLED").unwrap_or(true);
+        let web_fetch_allow_private_hosts =
+            parse_env_bool("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS").unwrap_or(false);
+        let web_fetch_allowed_domains =
+            parse_env_domain_list("LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS");
+        let web_fetch_blocked_domains =
+            parse_env_domain_list("LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS");
+        let web_fetch_timeout_seconds = parse_env_u64("LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS")
+            .unwrap_or(crate::config::DEFAULT_WEB_FETCH_TIMEOUT_SECONDS);
+        let web_fetch_max_bytes = parse_env_usize("LOONGCLAW_WEB_FETCH_MAX_BYTES")
+            .unwrap_or(crate::config::DEFAULT_WEB_FETCH_MAX_BYTES);
+        let web_fetch_max_redirects = parse_env_usize("LOONGCLAW_WEB_FETCH_MAX_REDIRECTS")
+            .unwrap_or(crate::config::DEFAULT_WEB_FETCH_MAX_REDIRECTS);
         let enabled = parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_ENABLED").unwrap_or(false);
         let require_download_approval =
             parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL").unwrap_or(true);
@@ -81,6 +121,15 @@ impl ToolRuntimeConfig {
         Self {
             file_root,
             config_path,
+            web_fetch: WebFetchRuntimePolicy {
+                enabled: web_fetch_enabled,
+                allow_private_hosts: web_fetch_allow_private_hosts,
+                allowed_domains: web_fetch_allowed_domains,
+                blocked_domains: web_fetch_blocked_domains,
+                timeout_seconds: web_fetch_timeout_seconds,
+                max_bytes: web_fetch_max_bytes,
+                max_redirects: web_fetch_max_redirects,
+            },
             external_skills: ExternalSkillsRuntimePolicy {
                 enabled,
                 require_download_approval,
@@ -103,6 +152,18 @@ fn parse_env_bool(key: &str) -> Option<bool> {
             _ => None,
         }
     })
+}
+
+fn parse_env_u64(key: &str) -> Option<u64> {
+    std::env::var(key)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+}
+
+fn parse_env_usize(key: &str) -> Option<usize> {
+    std::env::var(key)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
 }
 
 fn parse_env_domain_list(key: &str) -> BTreeSet<String> {
@@ -146,6 +207,13 @@ mod tests {
         let config = ToolRuntimeConfig::default();
         assert!(config.file_root.is_none());
         assert!(config.config_path.is_none());
+        assert!(config.web_fetch.enabled);
+        assert!(!config.web_fetch.allow_private_hosts);
+        assert!(config.web_fetch.allowed_domains.is_empty());
+        assert!(config.web_fetch.blocked_domains.is_empty());
+        assert_eq!(config.web_fetch.timeout_seconds, 15);
+        assert_eq!(config.web_fetch.max_bytes, 1_048_576);
+        assert_eq!(config.web_fetch.max_redirects, 3);
         assert!(!config.external_skills.enabled);
         assert!(config.external_skills.require_download_approval);
         assert!(config.external_skills.allowed_domains.is_empty());
@@ -170,6 +238,15 @@ mod tests {
             shell_allow: BTreeSet::from(["git".to_owned(), "cargo".to_owned()]),
             file_root: Some(PathBuf::from("/tmp/test-root")),
             config_path: Some(PathBuf::from("/tmp/test-root/loongclaw.toml")),
+            web_fetch: WebFetchRuntimePolicy {
+                enabled: false,
+                allow_private_hosts: true,
+                allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+                blocked_domains: BTreeSet::from(["internal.example".to_owned()]),
+                timeout_seconds: 9,
+                max_bytes: 262_144,
+                max_redirects: 1,
+            },
             external_skills: ExternalSkillsRuntimePolicy {
                 enabled: true,
                 require_download_approval: false,
@@ -188,6 +265,23 @@ mod tests {
             config.config_path,
             Some(PathBuf::from("/tmp/test-root/loongclaw.toml"))
         );
+        assert!(!config.web_fetch.enabled);
+        assert!(config.web_fetch.allow_private_hosts);
+        assert!(
+            config
+                .web_fetch
+                .allowed_domains
+                .contains("docs.example.com")
+        );
+        assert!(
+            config
+                .web_fetch
+                .blocked_domains
+                .contains("internal.example")
+        );
+        assert_eq!(config.web_fetch.timeout_seconds, 9);
+        assert_eq!(config.web_fetch.max_bytes, 262_144);
+        assert_eq!(config.web_fetch.max_redirects, 1);
         assert!(config.external_skills.enabled);
         assert!(!config.external_skills.require_download_approval);
         assert!(config.external_skills.allowed_domains.contains("skills.sh"));
@@ -235,6 +329,16 @@ mod tests {
 
     #[test]
     fn from_env_parses_external_skills_policy() {
+        crate::process_env::set_var("LOONGCLAW_WEB_FETCH_ENABLED", "false");
+        crate::process_env::set_var("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS", "true");
+        crate::process_env::set_var(
+            "LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS",
+            "docs.example.com,api.example.com",
+        );
+        crate::process_env::set_var("LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS", "internal.example");
+        crate::process_env::set_var("LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS", "9");
+        crate::process_env::set_var("LOONGCLAW_WEB_FETCH_MAX_BYTES", "262144");
+        crate::process_env::set_var("LOONGCLAW_WEB_FETCH_MAX_REDIRECTS", "1");
         crate::process_env::set_var("LOONGCLAW_EXTERNAL_SKILLS_ENABLED", "true");
         crate::process_env::set_var(
             "LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL",
@@ -255,6 +359,24 @@ mod tests {
         crate::process_env::set_var("LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED", "false");
 
         let config = ToolRuntimeConfig::from_env();
+        assert!(!config.web_fetch.enabled);
+        assert!(config.web_fetch.allow_private_hosts);
+        assert!(
+            config
+                .web_fetch
+                .allowed_domains
+                .contains("docs.example.com")
+        );
+        assert!(config.web_fetch.allowed_domains.contains("api.example.com"));
+        assert!(
+            config
+                .web_fetch
+                .blocked_domains
+                .contains("internal.example")
+        );
+        assert_eq!(config.web_fetch.timeout_seconds, 9);
+        assert_eq!(config.web_fetch.max_bytes, 262_144);
+        assert_eq!(config.web_fetch.max_redirects, 1);
         assert!(config.external_skills.enabled);
         assert!(!config.external_skills.require_download_approval);
         assert!(config.external_skills.allowed_domains.contains("skills.sh"));
@@ -276,6 +398,13 @@ mod tests {
         );
         assert!(!config.external_skills.auto_expose_installed);
 
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ENABLED");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_MAX_BYTES");
+        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_MAX_REDIRECTS");
         crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_ENABLED");
         crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL");
         crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS");
@@ -305,5 +434,26 @@ mod tests {
             Some(PathBuf::from("/tmp/managed-skills"))
         );
         assert!(!policy.auto_expose_installed);
+    }
+
+    #[test]
+    fn web_fetch_policy_struct_construction() {
+        let policy = WebFetchRuntimePolicy {
+            enabled: false,
+            allow_private_hosts: true,
+            allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+            blocked_domains: BTreeSet::from(["internal.example".to_owned()]),
+            timeout_seconds: 9,
+            max_bytes: 262_144,
+            max_redirects: 1,
+        };
+
+        assert!(!policy.enabled);
+        assert!(policy.allow_private_hosts);
+        assert!(policy.allowed_domains.contains("docs.example.com"));
+        assert!(policy.blocked_domains.contains("internal.example"));
+        assert_eq!(policy.timeout_seconds, 9);
+        assert_eq!(policy.max_bytes, 262_144);
+        assert_eq!(policy.max_redirects, 1);
     }
 }

--- a/crates/app/src/tools/web_fetch.rs
+++ b/crates/app/src/tools/web_fetch.rs
@@ -1,0 +1,798 @@
+use std::collections::BTreeSet;
+
+use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+use serde_json::{Map, Value, json};
+
+pub(super) fn execute_web_fetch_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "tool-webfetch"))]
+    {
+        let _ = (request, config);
+        return Err(
+            "web.fetch tool is disabled in this build (enable feature `tool-webfetch`)".to_owned(),
+        );
+    }
+
+    #[cfg(feature = "tool-webfetch")]
+    {
+        execute_web_fetch_tool_enabled(request, config)
+    }
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn execute_web_fetch_tool_enabled(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    use reqwest::blocking::Client;
+    use reqwest::header::{CONTENT_TYPE, LOCATION};
+    use std::io::Read;
+    use std::time::Duration;
+
+    if !config.web_fetch.enabled {
+        return Err("web.fetch is disabled by config.tools.web.enabled=false".to_owned());
+    }
+
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "web.fetch payload must be an object".to_owned())?;
+    let raw_url = payload
+        .get("url")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "web.fetch requires payload.url".to_owned())?;
+    let mode = parse_render_mode(payload)?;
+    let max_bytes = parse_max_bytes(payload, config.web_fetch.max_bytes)?;
+
+    let client = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(config.web_fetch.timeout_seconds))
+        .user_agent("LoongClaw-WebFetch/0.1")
+        .build()
+        .map_err(|error| format!("failed to build HTTP client for web.fetch: {error}"))?;
+
+    let mut current_url = reqwest::Url::parse(raw_url)
+        .map_err(|error| format!("invalid web.fetch url `{raw_url}`: {error}"))?;
+    let mut current_host = validate_fetch_target(&current_url, &config.web_fetch)?;
+    let mut redirect_count = 0usize;
+
+    loop {
+        let response = client
+            .get(current_url.clone())
+            .send()
+            .map_err(|error| format!("web.fetch request failed: {error}"))?;
+
+        if response.status().is_redirection() {
+            if redirect_count >= config.web_fetch.max_redirects {
+                return Err(format!(
+                    "web.fetch exceeded redirect limit ({})",
+                    config.web_fetch.max_redirects
+                ));
+            }
+
+            let location = response
+                .headers()
+                .get(LOCATION)
+                .ok_or_else(|| {
+                    format!(
+                        "web.fetch received redirect status {} without Location header",
+                        response.status()
+                    )
+                })?
+                .to_str()
+                .map_err(|error| {
+                    format!("web.fetch redirect Location header was invalid: {error}")
+                })?;
+            let next_url = current_url
+                .join(location)
+                .map_err(|error| format!("web.fetch failed to resolve redirect target: {error}"))?;
+            current_host = validate_fetch_target(&next_url, &config.web_fetch)?;
+            current_url = next_url;
+            redirect_count += 1;
+            continue;
+        }
+
+        if !response.status().is_success() {
+            return Err(format!(
+                "web.fetch returned non-success status {} for `{}`",
+                response.status(),
+                current_url
+            ));
+        }
+
+        let status_code = response.status().as_u16();
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(|value| value.to_owned());
+
+        let mut body = Vec::new();
+        let mut limited_reader = response.take((max_bytes as u64).saturating_add(1));
+        limited_reader
+            .read_to_end(&mut body)
+            .map_err(|error| format!("failed to read web.fetch response body: {error}"))?;
+        if body.len() > max_bytes {
+            return Err(format!(
+                "web.fetch response exceeded max_bytes limit ({max_bytes} bytes)"
+            ));
+        }
+
+        let raw_text = String::from_utf8_lossy(&body).into_owned();
+        let is_html = looks_like_html(content_type.as_deref(), raw_text.as_str());
+        if mode == RenderMode::ReadableText
+            && !is_html
+            && response_is_probably_binary(content_type.as_deref(), &body)
+        {
+            return Err(
+                "web.fetch readable_text mode only supports text-like responses; binary bodies are not returned"
+                    .to_owned(),
+            );
+        }
+        let title = is_html
+            .then(|| extract_html_title(raw_text.as_str()))
+            .flatten();
+        let content = match mode {
+            RenderMode::ReadableText if is_html => extract_readable_text_from_html(&raw_text),
+            RenderMode::ReadableText | RenderMode::RawText => raw_text.trim().to_owned(),
+        };
+
+        return Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "core-tools",
+                "tool_name": request.tool_name,
+                "requested_url": raw_url,
+                "final_url": current_url.as_str(),
+                "host": current_host,
+                "status_code": status_code,
+                "content_type": content_type,
+                "mode": mode.as_str(),
+                "content": content,
+                "title": title,
+                "bytes_downloaded": body.len(),
+                "redirect_count": redirect_count,
+            }),
+        });
+    }
+}
+
+#[cfg(feature = "tool-webfetch")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RenderMode {
+    ReadableText,
+    RawText,
+}
+
+#[cfg(feature = "tool-webfetch")]
+impl RenderMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadableText => "readable_text",
+            Self::RawText => "raw_text",
+        }
+    }
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn parse_render_mode(payload: &Map<String, Value>) -> Result<RenderMode, String> {
+    let Some(value) = payload.get("mode") else {
+        return Ok(RenderMode::ReadableText);
+    };
+
+    let raw = value
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "web.fetch payload.mode must be a string".to_owned())?;
+
+    match raw {
+        "readable_text" | "text" => Ok(RenderMode::ReadableText),
+        "raw_text" | "raw" => Ok(RenderMode::RawText),
+        _ => Err(
+            "web.fetch payload.mode must be one of `readable_text`, `raw_text`, `text`, or `raw`"
+                .to_owned(),
+        ),
+    }
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn parse_max_bytes(payload: &Map<String, Value>, configured_max: usize) -> Result<usize, String> {
+    let Some(value) = payload.get("max_bytes") else {
+        return Ok(configured_max);
+    };
+
+    let parsed = value
+        .as_u64()
+        .ok_or_else(|| "web.fetch payload.max_bytes must be an integer".to_owned())?;
+    if parsed == 0 {
+        return Err("web.fetch payload.max_bytes must be >= 1".to_owned());
+    }
+    let parsed = usize::try_from(parsed)
+        .map_err(|error| format!("invalid web.fetch max_bytes `{parsed}`: {error}"))?;
+    if parsed > configured_max {
+        return Err(format!(
+            "web.fetch payload.max_bytes exceeds configured limit ({configured_max} bytes)"
+        ));
+    }
+    Ok(parsed)
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn validate_fetch_target(
+    url: &reqwest::Url,
+    policy: &super::runtime_config::WebFetchRuntimePolicy,
+) -> Result<String, String> {
+    use std::net::{IpAddr, ToSocketAddrs};
+
+    match url.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(format!(
+                "web.fetch requires http or https url, got scheme `{other}`"
+            ));
+        }
+    }
+
+    let host = url
+        .host_str()
+        .map(str::to_ascii_lowercase)
+        .ok_or_else(|| format!("web.fetch url `{url}` has no host"))?;
+
+    if let Some(rule) = first_matching_domain_rule(&host, &policy.blocked_domains) {
+        return Err(format!(
+            "web.fetch blocked host `{host}` because it matches blocked domain rule `{rule}`"
+        ));
+    }
+    if !policy.allowed_domains.is_empty()
+        && first_matching_domain_rule(&host, &policy.allowed_domains).is_none()
+    {
+        return Err(format!(
+            "web.fetch denied host `{host}` because it is not in allowed_domains"
+        ));
+    }
+
+    if policy.allow_private_hosts {
+        return Ok(host);
+    }
+
+    if host == "localhost" {
+        return Err("web.fetch blocked private or special-use host `localhost`".to_owned());
+    }
+
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if is_private_or_special_ip(ip) {
+            return Err(format!(
+                "web.fetch blocked private or special-use address `{ip}`"
+            ));
+        }
+        return Ok(host);
+    }
+
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| format!("web.fetch url `{url}` has no known port"))?;
+    let addrs = (host.as_str(), port)
+        .to_socket_addrs()
+        .map_err(|error| format!("web.fetch failed to resolve host `{host}`: {error}"))?;
+
+    let mut saw_addr = false;
+    for addr in addrs {
+        saw_addr = true;
+        if is_private_or_special_ip(addr.ip()) {
+            return Err(format!(
+                "web.fetch blocked private or special-use address `{}` for host `{host}`",
+                addr.ip()
+            ));
+        }
+    }
+
+    if !saw_addr {
+        return Err(format!("web.fetch resolved no addresses for host `{host}`"));
+    }
+
+    Ok(host)
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn first_matching_domain_rule<'a>(host: &str, rules: &'a BTreeSet<String>) -> Option<&'a str> {
+    rules
+        .iter()
+        .find(|rule| domain_rule_matches(host, rule.as_str()))
+        .map(String::as_str)
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn domain_rule_matches(host: &str, rule: &str) -> bool {
+    if let Some(suffix) = rule.strip_prefix("*.") {
+        return host == suffix || host.ends_with(&format!(".{suffix}"));
+    }
+    host == rule
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn is_private_or_special_ip(ip: std::net::IpAddr) -> bool {
+    use std::net::IpAddr;
+
+    match ip {
+        IpAddr::V4(ipv4) => is_private_or_special_ipv4(ipv4),
+        IpAddr::V6(ipv6) => is_private_or_special_ipv6(ipv6),
+    }
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn is_private_or_special_ipv4(ip: std::net::Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    let first = octets[0];
+    let second = octets[1];
+    let third = octets[2];
+
+    ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_broadcast()
+        || ip.is_documentation()
+        || ip.is_unspecified()
+        || ip.is_multicast()
+        || first == 0
+        || (first == 100 && (64..=127).contains(&second))
+        || (first == 192 && second == 0)
+        || (first == 198 && matches!(second, 18 | 19))
+        || (first == 198 && second == 51 && third == 100)
+        || (first == 203 && second == 0 && third == 113)
+        || first >= 240
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn is_private_or_special_ipv6(ip: std::net::Ipv6Addr) -> bool {
+    if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
+        return true;
+    }
+
+    if let Some(mapped) = ip.to_ipv4_mapped() {
+        return is_private_or_special_ipv4(mapped);
+    }
+
+    let segments = ip.segments();
+    ((segments[0] & 0xfe00) == 0xfc00)
+        || ((segments[0] & 0xffc0) == 0xfe80)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn looks_like_html(content_type: Option<&str>, body: &str) -> bool {
+    if let Some(content_type) = content_type {
+        let lowered = content_type.to_ascii_lowercase();
+        if lowered.contains("text/html") || lowered.contains("application/xhtml+xml") {
+            return true;
+        }
+    }
+
+    let lowered = body.to_ascii_lowercase();
+    lowered.contains("<html") || lowered.contains("<body") || lowered.contains("<!doctype html")
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn response_is_probably_binary(content_type: Option<&str>, body: &[u8]) -> bool {
+    if body.is_empty() {
+        return false;
+    }
+
+    if let Some(content_type) = content_type {
+        let lowered = content_type.to_ascii_lowercase();
+        if lowered.starts_with("text/")
+            || lowered.contains("json")
+            || lowered.contains("xml")
+            || lowered.contains("javascript")
+            || lowered.contains("x-www-form-urlencoded")
+            || lowered.contains("yaml")
+            || lowered.contains("csv")
+        {
+            return false;
+        }
+
+        if lowered.contains("octet-stream")
+            || lowered.contains("pdf")
+            || lowered.contains("zip")
+            || lowered.starts_with("image/")
+            || lowered.starts_with("audio/")
+            || lowered.starts_with("video/")
+        {
+            return true;
+        }
+    }
+
+    let sample = body.get(..body.len().min(512)).unwrap_or(body);
+    if sample.contains(&0) {
+        return true;
+    }
+
+    let control_count = sample
+        .iter()
+        .filter(|&&byte| {
+            ((byte < 0x20) && !matches!(byte, b'\n' | b'\r' | b'\t' | 0x0c)) || byte == 0x7f
+        })
+        .count();
+    control_count.saturating_mul(8) > sample.len()
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn extract_html_title(html: &str) -> Option<String> {
+    extract_tag_inner_text(html, "title").and_then(|value| {
+        let collapsed = collapse_whitespace(&decode_basic_entities(value.trim()));
+        (!collapsed.is_empty()).then_some(collapsed)
+    })
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn extract_readable_text_from_html(html: &str) -> String {
+    let mut sanitized = strip_tag_block(html, "script");
+    sanitized = strip_tag_block(&sanitized, "style");
+    sanitized = strip_tag_block(&sanitized, "noscript");
+    sanitized = strip_tag_block(&sanitized, "head");
+    let text = strip_tags(&sanitized);
+    collapse_whitespace(&decode_basic_entities(&text))
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn strip_tag_block(input: &str, tag: &str) -> String {
+    let open = format!("<{tag}");
+    let close = format!("</{tag}>");
+    let mut output = input.to_owned();
+
+    loop {
+        let lowered = output.to_ascii_lowercase();
+        let Some(start) = lowered.find(&open) else {
+            break;
+        };
+        let Some(close_start_rel) = lowered[start..].find(&close) else {
+            break;
+        };
+        let close_start = start + close_start_rel;
+        let Some(close_end_rel) = lowered[close_start..].find('>') else {
+            break;
+        };
+        let end = close_start + close_end_rel + 1;
+        output.replace_range(start..end, " ");
+    }
+
+    output
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn extract_tag_inner_text<'a>(input: &'a str, tag: &str) -> Option<&'a str> {
+    let lowered = input.to_ascii_lowercase();
+    let open = format!("<{tag}");
+    let close = format!("</{tag}>");
+    let start = lowered.find(&open)?;
+    let open_end = start + lowered[start..].find('>')? + 1;
+    let end = lowered[open_end..].find(&close)? + open_end;
+    Some(&input[open_end..end])
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn strip_tags(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut in_tag = false;
+
+    for ch in input.chars() {
+        match ch {
+            '<' => {
+                in_tag = true;
+                if !output.ends_with(' ') {
+                    output.push(' ');
+                }
+            }
+            '>' => {
+                in_tag = false;
+                if !output.ends_with(' ') {
+                    output.push(' ');
+                }
+            }
+            _ if !in_tag => output.push(ch),
+            _ => {}
+        }
+    }
+
+    output
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn decode_basic_entities(input: &str) -> String {
+    input
+        .replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+}
+
+#[cfg(feature = "tool-webfetch")]
+fn collapse_whitespace(input: &str) -> String {
+    input.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(all(test, feature = "tool-webfetch"))]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn request(payload: Value) -> ToolCoreRequest {
+        ToolCoreRequest {
+            tool_name: "web.fetch".to_owned(),
+            payload,
+        }
+    }
+
+    fn local_runtime_config() -> super::super::runtime_config::ToolRuntimeConfig {
+        let mut config = super::super::runtime_config::ToolRuntimeConfig::default();
+        config.web_fetch.allow_private_hosts = true;
+        config
+    }
+
+    fn spawn_http_server(responder: impl Fn(String) -> String + Send + Sync + 'static) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .unwrap_or_else(|error| panic!("bind test server: {error}"));
+        let address = listener
+            .local_addr()
+            .unwrap_or_else(|error| panic!("local addr: {error}"));
+        thread::spawn(move || {
+            let (mut stream, _) = listener
+                .accept()
+                .unwrap_or_else(|error| panic!("accept request: {error}"));
+            let mut buffer = [0_u8; 4096];
+            let read = stream
+                .read(&mut buffer)
+                .unwrap_or_else(|error| panic!("read request: {error}"));
+            let request =
+                String::from_utf8_lossy(buffer.get(..read).unwrap_or(&buffer)).into_owned();
+            let response = responder(request);
+            stream
+                .write_all(response.as_bytes())
+                .unwrap_or_else(|error| panic!("write response: {error}"));
+            stream.flush().ok();
+        });
+
+        format!("http://{}", address)
+    }
+
+    fn ok_response(content_type: &str, body: &str) -> String {
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    fn redirect_response(location: &str) -> String {
+        format!(
+            "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        )
+    }
+
+    #[test]
+    fn web_fetch_requires_enabled_runtime() {
+        let mut config = super::super::runtime_config::ToolRuntimeConfig::default();
+        config.web_fetch.enabled = false;
+
+        let error = execute_web_fetch_tool_with_config(
+            request(json!({"url": "https://example.com"})),
+            &config,
+        )
+        .expect_err("disabled runtime should block web.fetch");
+
+        assert!(error.contains("config.tools.web.enabled=false"));
+    }
+
+    #[test]
+    fn web_fetch_requires_object_payload() {
+        let error = execute_web_fetch_tool_with_config(
+            request(json!("https://example.com")),
+            &super::super::runtime_config::ToolRuntimeConfig::default(),
+        )
+        .expect_err("non-object payload should be rejected");
+
+        assert!(error.contains("payload must be an object"));
+    }
+
+    #[test]
+    fn web_fetch_requires_url() {
+        let error = execute_web_fetch_tool_with_config(
+            request(json!({})),
+            &super::super::runtime_config::ToolRuntimeConfig::default(),
+        )
+        .expect_err("missing url should be rejected");
+
+        assert!(error.contains("requires payload.url"));
+    }
+
+    #[test]
+    fn web_fetch_rejects_non_http_scheme() {
+        let error = execute_web_fetch_tool_with_config(
+            request(json!({"url": "file:///etc/passwd"})),
+            &super::super::runtime_config::ToolRuntimeConfig::default(),
+        )
+        .expect_err("non-http scheme should be rejected");
+
+        assert!(error.contains("requires http or https"));
+    }
+
+    #[test]
+    fn web_fetch_rejects_private_hosts_by_default() {
+        let error = execute_web_fetch_tool_with_config(
+            request(json!({"url": "http://127.0.0.1:8080"})),
+            &super::super::runtime_config::ToolRuntimeConfig::default(),
+        )
+        .expect_err("private host should be blocked");
+
+        assert!(error.contains("private or special-use"));
+    }
+
+    #[test]
+    fn web_fetch_enforces_allow_and_block_domain_rules() {
+        let mut allowlist_config = super::super::runtime_config::ToolRuntimeConfig::default();
+        allowlist_config
+            .web_fetch
+            .allowed_domains
+            .insert("docs.example.com".to_owned());
+
+        let allowed_error = execute_web_fetch_tool_with_config(
+            request(json!({"url": "https://api.example.com/reference"})),
+            &allowlist_config,
+        )
+        .expect_err("host outside allowlist should be rejected");
+
+        assert!(allowed_error.contains("not in allowed_domains"));
+
+        let mut blocklist_config = super::super::runtime_config::ToolRuntimeConfig::default();
+        blocklist_config
+            .web_fetch
+            .blocked_domains
+            .insert("*.example.com".to_owned());
+
+        let blocked_error = execute_web_fetch_tool_with_config(
+            request(json!({"url": "https://docs.example.com/reference"})),
+            &blocklist_config,
+        )
+        .expect_err("blocked host should be rejected");
+
+        assert!(blocked_error.contains("matches blocked domain rule"));
+    }
+
+    #[test]
+    fn web_fetch_allows_local_html_fixture_and_extracts_readable_text() {
+        let url = spawn_http_server(|_request| {
+            ok_response(
+                "text/html; charset=utf-8",
+                "<html><head><title>Demo Page</title><style>.hidden{display:none}</style><script>window.alert('x')</script></head><body><h1>Hello world</h1><p>LoongClaw fetches docs.</p></body></html>",
+            )
+        });
+
+        let outcome = super::super::execute_tool_core_with_config(
+            request(json!({"url": url})),
+            &local_runtime_config(),
+        )
+        .expect("local HTML fixture should fetch");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tool_name"], "web.fetch");
+        assert_eq!(outcome.payload["mode"], "readable_text");
+        assert_eq!(outcome.payload["title"], "Demo Page");
+        let content = outcome.payload["content"]
+            .as_str()
+            .expect("content should be string");
+        assert!(content.contains("Hello world"));
+        assert!(content.contains("LoongClaw fetches docs."));
+        assert!(!content.contains("window.alert"));
+    }
+
+    #[test]
+    fn web_fetch_enforces_max_bytes_limit() {
+        let body = "x".repeat(128);
+        let url = spawn_http_server(move |_request| ok_response("text/plain", &body));
+        let mut config = local_runtime_config();
+        config.web_fetch.max_bytes = 32;
+
+        let error = execute_web_fetch_tool_with_config(request(json!({"url": url})), &config)
+            .expect_err("oversized body should be rejected");
+
+        assert!(error.contains("exceeded max_bytes limit"));
+    }
+
+    #[test]
+    fn web_fetch_rejects_binary_body_in_readable_mode() {
+        let url =
+            spawn_http_server(|_request| ok_response("application/octet-stream", "\0PNG\x01\x02"));
+
+        let error = execute_web_fetch_tool_with_config(
+            request(json!({"url": url})),
+            &local_runtime_config(),
+        )
+        .expect_err("binary body should be rejected in readable mode");
+
+        assert!(error.contains("readable_text mode only supports text-like responses"));
+    }
+
+    #[test]
+    fn web_fetch_follows_redirects_with_revalidation() {
+        let target_url = spawn_http_server(|_request| ok_response("text/plain", "final body"));
+        let redirect_target = target_url.clone();
+        let redirect_url = spawn_http_server(move |_request| redirect_response(&redirect_target));
+
+        let outcome = execute_web_fetch_tool_with_config(
+            request(json!({"url": redirect_url})),
+            &local_runtime_config(),
+        )
+        .expect("redirected local fetch should succeed");
+
+        assert_eq!(outcome.payload["redirect_count"], 1);
+        assert_eq!(
+            outcome.payload["final_url"],
+            reqwest::Url::parse(&target_url)
+                .expect("target url")
+                .to_string()
+        );
+        assert_eq!(outcome.payload["content"], "final body");
+    }
+
+    #[test]
+    fn web_fetch_rejects_redirect_without_location_header() {
+        let url = spawn_http_server(|_request| {
+            "HTTP/1.1 302 Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_owned()
+        });
+
+        let error = execute_web_fetch_tool_with_config(
+            request(json!({"url": url})),
+            &local_runtime_config(),
+        )
+        .expect_err("redirect without location should fail");
+
+        assert!(error.contains("without Location header"));
+    }
+
+    #[test]
+    fn web_fetch_raw_text_mode_preserves_non_html_body() {
+        let url =
+            spawn_http_server(|_request| ok_response("application/json", "{\n  \"ok\": true\n}"));
+
+        let outcome = execute_web_fetch_tool_with_config(
+            request(json!({"url": url, "mode": "raw_text"})),
+            &local_runtime_config(),
+        )
+        .expect("raw_text mode should preserve body");
+
+        assert_eq!(outcome.payload["mode"], "raw_text");
+        assert_eq!(outcome.payload["content"], "{\n  \"ok\": true\n}");
+    }
+
+    #[test]
+    fn web_fetch_rejects_invalid_mode() {
+        let error = execute_web_fetch_tool_with_config(
+            request(json!({"url": "https://example.com", "mode": "markdown"})),
+            &super::super::runtime_config::ToolRuntimeConfig::default(),
+        )
+        .expect_err("invalid mode should fail");
+
+        assert!(error.contains("payload.mode must be one of"));
+    }
+
+    #[test]
+    fn web_fetch_policy_can_allow_localhost_targets() {
+        let policy = super::super::runtime_config::WebFetchRuntimePolicy {
+            allow_private_hosts: true,
+            ..super::super::runtime_config::WebFetchRuntimePolicy::default()
+        };
+        let url = reqwest::Url::parse("http://localhost:8080").expect("url");
+
+        let host = validate_fetch_target(&url, &policy).expect("localhost should be allowed");
+
+        assert_eq!(host, "localhost");
+    }
+}

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -19,6 +19,7 @@ config-toml = ["loongclaw-app/config-toml"]
 memory-sqlite = ["loongclaw-app/memory-sqlite"]
 tool-shell = ["loongclaw-app/tool-shell"]
 tool-file = ["loongclaw-app/tool-file"]
+tool-webfetch = ["loongclaw-app/tool-webfetch"]
 
 [dependencies]
 clap.workspace = true

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -430,6 +430,26 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
+    #[command(
+        about = "Run one non-interactive assistant turn",
+        long_about = "Run one non-interactive one-shot assistant turn.\n\nUse this when you want a fast answer without entering the interactive `loongclaw chat` REPL. The command reuses the normal CLI conversation runtime, session memory, provider selection, and ACP options."
+    )]
+    Ask {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long)]
+        session: Option<String>,
+        #[arg(long)]
+        message: String,
+        #[arg(long, default_value_t = false)]
+        acp: bool,
+        #[arg(long, default_value_t = false)]
+        acp_event_stream: bool,
+        #[arg(long = "acp-bootstrap-mcp-server")]
+        acp_bootstrap_mcp_server: Vec<String>,
+        #[arg(long = "acp-cwd")]
+        acp_cwd: Option<String>,
+    },
     /// Start interactive CLI chat channel with sliding-window memory
     Chat {
         #[arg(long)]
@@ -745,6 +765,26 @@ async fn main() {
             backend,
             json,
         } => run_acp_doctor_cli(config.as_deref(), backend.as_deref(), json).await,
+        Commands::Ask {
+            config,
+            session,
+            message,
+            acp,
+            acp_event_stream,
+            acp_bootstrap_mcp_server,
+            acp_cwd,
+        } => {
+            run_ask_cli(
+                config.as_deref(),
+                session.as_deref(),
+                &message,
+                acp,
+                acp_event_stream,
+                &acp_bootstrap_mcp_server,
+                acp_cwd.as_deref(),
+            )
+            .await
+        }
         Commands::Chat {
             config,
             session,
@@ -1897,7 +1937,30 @@ async fn run_chat_cli(
     acp_bootstrap_mcp_server: &[String],
     acp_cwd: Option<&str>,
 ) -> CliResult<()> {
-    let options = mvp::chat::CliChatOptions {
+    let options = build_cli_chat_options(acp, acp_event_stream, acp_bootstrap_mcp_server, acp_cwd);
+    mvp::chat::run_cli_chat(config_path, session, &options).await
+}
+
+async fn run_ask_cli(
+    config_path: Option<&str>,
+    session: Option<&str>,
+    message: &str,
+    acp: bool,
+    acp_event_stream: bool,
+    acp_bootstrap_mcp_server: &[String],
+    acp_cwd: Option<&str>,
+) -> CliResult<()> {
+    let options = build_cli_chat_options(acp, acp_event_stream, acp_bootstrap_mcp_server, acp_cwd);
+    mvp::chat::run_cli_ask(config_path, session, message, &options).await
+}
+
+fn build_cli_chat_options(
+    acp: bool,
+    acp_event_stream: bool,
+    acp_bootstrap_mcp_server: &[String],
+    acp_cwd: Option<&str>,
+) -> mvp::chat::CliChatOptions {
+    mvp::chat::CliChatOptions {
         acp_requested: acp,
         acp_event_stream,
         acp_bootstrap_mcp_servers: acp_bootstrap_mcp_server.to_vec(),
@@ -1905,8 +1968,7 @@ async fn run_chat_cli(
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(std::path::PathBuf::from),
-    };
-    mvp::chat::run_cli_chat(config_path, session, &options).await
+    }
 }
 
 fn run_acp_event_summary_cli(

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -158,6 +158,81 @@ fn cli_onboard_help_mentions_detected_reusable_settings() {
 }
 
 #[test]
+fn cli_ask_help_mentions_one_shot_assistant_usage() {
+    let mut command = Cli::command();
+    let ask = command
+        .find_subcommand_mut("ask")
+        .expect("ask subcommand should exist");
+    let mut help = Vec::new();
+    ask.write_long_help(&mut help).expect("render ask help");
+    let help = String::from_utf8(help).expect("help should be utf8");
+
+    assert!(
+        help.contains("one-shot"),
+        "ask help should describe the non-interactive one-shot flow: {help}"
+    );
+    assert!(
+        help.contains("--message <MESSAGE>"),
+        "ask help should require an inline message input: {help}"
+    );
+    assert!(
+        help.contains("loongclaw chat"),
+        "ask help should point users to chat for the interactive path: {help}"
+    );
+}
+
+#[test]
+fn ask_cli_accepts_message_session_and_acp_flags() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "ask",
+        "--message",
+        "Summarize this repository",
+        "--session",
+        "telegram:42",
+        "--acp",
+        "--acp-event-stream",
+        "--acp-bootstrap-mcp-server",
+        "filesystem",
+        "--acp-cwd",
+        "/workspace/project",
+    ])
+    .expect("ask CLI should parse one-shot flags");
+
+    match cli.command {
+        Some(Commands::Ask {
+            message,
+            session,
+            acp,
+            acp_event_stream,
+            acp_bootstrap_mcp_server,
+            acp_cwd,
+            ..
+        }) => {
+            assert_eq!(message, "Summarize this repository");
+            assert_eq!(session.as_deref(), Some("telegram:42"));
+            assert!(acp);
+            assert!(acp_event_stream);
+            assert_eq!(acp_bootstrap_mcp_server, vec!["filesystem".to_owned()]);
+            assert_eq!(acp_cwd.as_deref(), Some("/workspace/project"));
+        }
+        other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn ask_cli_requires_message_flag() {
+    let error =
+        Cli::try_parse_from(["loongclaw", "ask"]).expect_err("ask without --message should fail");
+    let rendered = error.to_string();
+
+    assert!(
+        rendered.contains("--message <MESSAGE>"),
+        "parse failure should mention the required message flag: {rendered}"
+    );
+}
+
+#[test]
 fn resolve_validate_output_defaults_to_text() {
     let resolved = resolve_validate_output(false, None).expect("resolve default output");
     assert_eq!(resolved, ValidateConfigOutput::Text);

--- a/docs/PRODUCT_SENSE.md
+++ b/docs/PRODUCT_SENSE.md
@@ -1,41 +1,63 @@
 # Product Sense
 
-User experience principles and product thinking for LoongClaw.
+User-experience principles and product direction for the current LoongClaw MVP.
 
 ## Target Users
 
-LoongClaw is an AI agent runtime. Its users are:
+LoongClaw is not only a runtime for developers. The current MVP is aimed at:
 
-1. **Developers** integrating AI agents into applications via channels (CLI, Telegram, Feishu)
-2. **Platform operators** deploying and managing agent runtimes
-3. **Plugin authors** extending agent capabilities through tools, connectors, and memory backends
+1. **Individuals and operators** who want a private assistant they can run locally and trust.
+2. **Channel operators** who want the same assistant behavior to show up in CLI, Telegram, and Feishu.
+3. **Developers and extension authors** who need stable seams for providers, tools, channels, and memory.
 
 ## Product Principles
 
-1. **Safe by default** — No capability is granted without explicit token. New users start in the most restrictive mode.
-2. **Progressive disclosure** — Simple things should be simple. Advanced configuration exists but doesn't obstruct the common path.
-3. **Transparent execution** — Users can always see what the agent is doing, why it was allowed, and what was denied. The audit trail is the receipt.
-4. **Channel-agnostic experience** — Core agent behavior is identical across CLI, Telegram, Feishu. Channel-specific affordances layer on top.
-5. **Fail loud, not silent** — Errors surface to the user with actionable context. Silent drops are bugs.
+1. **First value fast** — a new user should get to a useful assistant answer quickly, not after reading implementation docs.
+2. **Safe by default** — visible capabilities must still honor policy, approval, and audit boundaries.
+3. **Assistant-first surfaces** — user-facing capability should feel like “my assistant can do this”, not only “the platform exposes an adapter”.
+4. **Progressive disclosure** — `onboard`, `ask`, `chat`, and `doctor` carry the common path; advanced config stays available without taking over the story.
+5. **One runtime, many surfaces** — CLI ask, interactive chat, and future surfaces should share the same conversation, memory, tool, and provider semantics.
+6. **Fail loud with a repair path** — when setup or runtime health breaks, LoongClaw must point users toward `doctor` instead of leaving them in silent failure.
+
+## Current MVP Journey
+
+The current product contract is:
+
+1. Install LoongClaw.
+2. Run `loongclaw onboard`.
+3. Set provider credentials.
+4. Get first value through either:
+   - `loongclaw ask --message "..."`
+   - `loongclaw chat`
+5. If anything is broken, use `loongclaw doctor` or `loongclaw doctor --fix`.
+6. Enable Telegram or Feishu only after the base CLI flow is healthy.
+
+This keeps the first-run journey legible while preserving the existing runtime architecture.
 
 ## Product Specifications
 
 See [Product Specs Index](product-specs/index.md) for detailed user-facing requirements:
 
+- [Onboarding](product-specs/onboarding.md) — first-run setup and handoff to first success
+- [One-Shot Ask](product-specs/one-shot-ask.md) — non-interactive assistant fast path
+- [Doctor](product-specs/doctor.md) — diagnostics and safe repair expectations
+- [Channel Setup](product-specs/channel-setup.md) — configuring shipped assistant surfaces
+- [WebChat](product-specs/webchat.md) — expectations for the browser-facing chat surface
 - [Memory Profiles](product-specs/memory-profiles.md) — memory access patterns
-- [Prompt and Personality](product-specs/prompt-and-personality.md) — prompt engineering constraints
+- [Prompt And Personality](product-specs/prompt-and-personality.md) — prompt engineering constraints
 
 ## User-Facing Commands
 
-The daemon binary (`loongclaw`) exposes:
+The primary daemon surfaces are:
 
 | Command | Purpose |
 |---------|---------|
-| `setup` | First-run configuration |
-| `onboard` | Guided onboarding flow |
-| `doctor` | Diagnostic health checks |
+| `onboard` | Guided first-run setup, detection, and configuration |
+| `ask` | One-shot assistant answer and exit |
 | `chat` | Interactive CLI conversation |
-| `run-spec` | Execute deterministic test specs |
+| `doctor` | Health diagnostics with optional safe repair |
+| `import-claw` | Power-user migration/import path |
+| `telegram-serve` / `feishu-serve` | Service channels once the base setup is healthy |
 
 ## See Also
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -273,13 +273,16 @@ Focus: ship a low-friction daily-usable daemon entry for non-developers.
 Delivered in current baseline:
 
 - `onboard` command as the primary first-run configuration and diagnostics flow
+- `ask` command as the one-shot assistant fast path
 - `chat` command as baseline CLI channel
+- `doctor` repair loop with `--fix` and machine-readable output
 - first-party Telegram polling channel adapter
 - first-party Feishu webhook channel adapter
 - SQLite-backed conversation memory with sliding-window retrieval
-- core tool execution for `shell.exec`, `file.read`, `file.write`
+- core tool execution for `shell.exec`, `file.read`, `file.write`, `web.fetch`
 - one-command source install scripts (`scripts/install.sh`, `scripts/install.ps1`)
 - Cargo feature flags for MVP packaging controls
+- product specs for onboarding, one-shot ask, doctor, channel setup, and WebChat expectations
 - modular channel/provider architecture for extension-safe evolution:
   - `app/channel/feishu/*` split into adapter/payload/webhook layers
   - Feishu encrypted webhook payload decrypt lane with signature verification
@@ -298,12 +301,15 @@ Remaining deliverables:
   - prebuilt binaries
   - one-command onboarding on macOS/Linux/Windows
   - guided onboarding flow and diagnostics
+- browser-facing assistant surface:
+  - WebChat implementation
+  - browser/web automation beyond `web.fetch`
 
 Acceptance criteria:
 
-- a new user can install and complete first successful chat in <= 5 minutes
+- a new user can install and complete a first successful `ask` or `chat` in <= 5 minutes
 - local memory persistence is stable across process restarts
-- shell/file tools obey policy constraints and emit auditable outcomes
+- shell/file/web tools obey policy constraints and emit auditable outcomes
 - channel/provider modules can be toggled by feature flags without core code edits
 
 ## Quality Gate Matrix (Always On)

--- a/docs/plans/2026-03-15-first-run-assistant-journey-design.md
+++ b/docs/plans/2026-03-15-first-run-assistant-journey-design.md
@@ -1,0 +1,205 @@
+# First-Run Assistant Journey Design
+
+## Problem
+
+The current `alpha-test` baseline exposes a capable runtime, but the MVP still feels more like a
+developer platform than an assistant product. The visible happy path is thin:
+
+- first-run messaging still centers on `chat` plus internal runtime primitives
+- the tool surface that users can immediately recognize is weak
+- product specs cover personality and memory, but not the operational user journeys that decide
+  whether the product feels coherent on day one
+
+Compared with OpenClaw, the biggest product gap is not deep architecture. It is missing visible,
+legible assistant behavior and missing specs for the first-run journey.
+
+## Goal
+
+Ship one narrow productization slice that makes the MVP feel more like an assistant:
+
+1. Add a one-shot `loongclaw ask --message ...` command for fast first success.
+2. Add a built-in `web.fetch` tool as the first user-visible web capability.
+3. Add product specs for onboarding, doctor, channel setup, WebChat expectations, and one-shot ask.
+4. Refresh README and product docs so the first-run path is `onboard -> ask/chat`.
+
+## Non-Goals
+
+- full browser automation
+- cron, webhook orchestration, or node-based workflow parity
+- new channel implementations
+- redesigning the conversation runtime or ACP architecture
+- broad runtime refactors unrelated to the first-run product story
+
+## Constraints
+
+- Reuse the current `alpha-test` architecture instead of introducing a parallel product lane.
+- Keep safe defaults intact. User-visible capability must still be policy-governed and auditable.
+- Preserve the current conversation turn coordinator as the core execution path.
+- Make docs and product specs describe actual shipped behavior, not roadmap aspirations.
+
+## Approach Options
+
+### Option A: Full browser automation first
+
+Pros:
+
+- matches the most obvious OpenClaw differentiator
+- highly visible to users
+
+Cons:
+
+- much larger surface area: browser runtime, sandbox policy, navigation UX, tests, docs
+- high schedule and regression risk for the current MVP
+- likely to spill beyond one clean PR
+
+### Option B: SSRF-safe `web.fetch` first, browser later
+
+Pros:
+
+- still gives users a clearly legible web capability
+- fits existing tool architecture cleanly
+- can be shipped with strong safety defaults and deterministic tests
+- pairs naturally with a one-shot `ask` flow
+
+Cons:
+
+- less flashy than full browser automation
+- does not yet cover interactive browsing or page actions
+
+### Option C: Docs/specs only
+
+Pros:
+
+- fastest to land
+- reduces UX drift
+
+Cons:
+
+- does not solve the visible capability gap
+- leaves the MVP feeling abstract despite better documentation
+
+## Decision
+
+Choose Option B.
+
+This is the highest-leverage MVP slice because it improves the first user experience without
+forcing a large runtime expansion. `web.fetch` is the right first visible capability because it is
+easy to explain, useful immediately, and consistent with the project's security posture.
+
+## Design
+
+### 1. One-shot ask
+
+Add a new daemon subcommand:
+
+```bash
+loongclaw ask --message "Summarize this repo"
+```
+
+Behavior:
+
+- shares the same startup/config/runtime initialization as `chat`
+- executes exactly one assistant turn through `ConversationTurnCoordinator`
+- prints a single `loongclaw> ...` response and exits
+- respects the same session selection, provider selection, ACP options, and memory behavior as CLI
+  chat
+
+Implementation direction:
+
+- keep `ConversationTurnCoordinator::handle_turn_with_address_and_acp_options(...)` as the single
+  turn engine
+- extract shared CLI bootstrap logic from `run_cli_chat(...)`
+- add `run_cli_ask(...)` beside the chat CLI implementation
+- keep new public API surface minimal
+
+### 2. Built-in `web.fetch`
+
+Add a new runtime tool named `web.fetch`.
+
+Behavior:
+
+- fetches a remote page over HTTP(S)
+- blocks localhost, loopback, private, link-local, reserved, and unspecified IP targets by default
+- rejects redirects unless every redirect target also passes validation
+- caps response size and request time
+- returns readable content plus metadata instead of raw unsafe HTML
+
+Planned user value:
+
+- agent can fetch and read documentation/articles/pages
+- users can see a concrete, understandable capability in tool catalogs and docs
+
+Safety model:
+
+- enabled through `[tools.web]`
+- enabled in the MVP build, with strict runtime limits and host validation by default
+- policy includes allow/block domain controls plus private-host protection
+- tests may use an explicit config override to allow local hosts without weakening production
+  defaults
+
+### 3. Product specs
+
+Add missing product specs so UX does not drift:
+
+- onboarding: first-run setup and first success path
+- doctor: repair-oriented diagnostics expectations
+- channel setup: how a user understands and configures channel surfaces
+- WebChat: expectations for the future browser-facing chat surface, kept aligned with current MVP
+- one-shot ask: contract for the new CLI fast path
+
+### 4. Product-facing docs
+
+Update README and product docs to reflect shipped behavior:
+
+- first-run path becomes `onboard`, then `ask` or `chat`
+- user-facing command table replaces stale `setup`
+- visible tool surface highlights `web.fetch`
+- docs explain that browser/web automation is staged, with `web.fetch` as the current MVP web
+  capability
+
+## Testing Strategy
+
+Follow TDD for each slice:
+
+1. write failing CLI tests for `ask`
+2. implement minimal `ask` path until tests pass
+3. write failing config/catalog/execution tests for `web.fetch`
+4. implement minimal safe executor until tests pass
+5. update docs/specs and verify command/help surfaces stay aligned
+
+Verification target:
+
+- targeted Rust tests for daemon CLI and app tool surfaces
+- formatting
+- broader package tests where the changed seams require them
+
+## Risks And Mitigations
+
+### Risk: `ask` forks from `chat`
+
+Mitigation:
+
+- extract shared bootstrap logic once
+- reuse the existing single-turn coordinator path
+
+### Risk: `web.fetch` weakens SSRF protections for tests
+
+Mitigation:
+
+- keep production default strict
+- add an explicit local-test override in config/runtime policy
+- test the validator separately from the relaxed integration path
+
+### Risk: docs drift from shipped capability
+
+Mitigation:
+
+- update product specs, product sense, roadmap references, and README in the same PR
+
+## Acceptance Criteria
+
+- `loongclaw ask --message ...` exists and reuses the normal CLI conversation runtime
+- `web.fetch` is exposed in the runtime tool catalog, provider schemas, and capability snapshot
+- `web.fetch` enforces SSRF-safe defaults and runtime limits
+- product specs cover onboarding, doctor, channel setup, WebChat, and one-shot ask
+- README and product docs describe the real first-run path and visible capability story

--- a/docs/plans/2026-03-15-first-run-assistant-journey-implementation-plan.md
+++ b/docs/plans/2026-03-15-first-run-assistant-journey-implementation-plan.md
@@ -1,0 +1,320 @@
+# First-Run Assistant Journey Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Productize the first-run LoongClaw assistant journey by adding `loongclaw ask`, shipping a built-in SSRF-safe `web.fetch` tool, and aligning product-facing docs/specs with the real MVP path.
+
+**Architecture:** Reuse the current CLI conversation bootstrap and turn coordinator for `ask`; extend the existing tool config/catalog/runtime execution plane for `web.fetch`; update product docs in the same PR so the shipped behavior and documented journey stay aligned.
+
+**Tech Stack:** Rust, clap, serde, reqwest blocking client, existing LoongClaw config/runtime/tool abstractions, Markdown docs.
+
+---
+
+### Task 1: Add the `ask` CLI surface
+
+**Files:**
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/daemon/src/tests/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add CLI/help tests that prove:
+
+- `ask` exists as a subcommand
+- help text explains it as a one-shot CLI prompt
+- `--message` is required
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon cli_ask`
+
+Expected: FAIL because the `ask` subcommand/help does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- Add `Commands::Ask` in `crates/daemon/src/main.rs`
+- wire subcommand dispatch to a new `run_ask_cli(...)`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon cli_ask`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/daemon/src/main.rs crates/daemon/src/tests/mod.rs
+git commit -m "feat(cli): add ask command surface"
+```
+
+### Task 2: Reuse chat bootstrap for one-shot ask
+
+**Files:**
+- Modify: `crates/app/src/chat.rs`
+- Test: `crates/app/src/chat.rs`
+- Modify: `crates/daemon/src/main.rs`
+
+**Step 1: Write the failing test**
+
+Add app-level unit tests that prove a new one-shot path:
+
+- resolves the session hint like `chat`
+- prints a single assistant reply and exits
+- rejects disabled CLI config the same way as `chat`
+
+Prefer testing extracted helper behavior instead of end-to-end stdin plumbing.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app cli_ask`
+
+Expected: FAIL because the one-shot helper/path does not exist.
+
+**Step 3: Write minimal implementation**
+
+- extract shared CLI bootstrap from `run_cli_chat(...)`
+- add `run_cli_ask(config_path, session_hint, message, options)`
+- call `ConversationTurnCoordinator::handle_turn_with_address_and_acp_options(...)`
+- print `loongclaw> {assistant_text}` once and exit
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app cli_ask`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/chat.rs crates/daemon/src/main.rs
+git commit -m "feat(cli): implement one-shot ask flow"
+```
+
+### Task 3: Add `tools.web` config and runtime policy
+
+**Files:**
+- Modify: `crates/app/src/config/tools_memory.rs`
+- Modify: `crates/app/src/runtime_env.rs`
+- Modify: `crates/app/src/tools/runtime_config.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+
+- `ToolConfig` includes a default `web` section
+- TOML parsing accepts `tools.web.enabled`, domain allow/block rules, limits, and local-host override
+- runtime environment exports the matching env vars/runtime policy
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app tools_memory:: runtime_env:: tool_runtime_config::`
+
+Expected: FAIL because the `web` policy fields are not defined yet.
+
+**Step 3: Write minimal implementation**
+
+- add `WebToolConfig` to `ToolConfig`
+- add `WebFetchRuntimePolicy` to `ToolRuntimeConfig`
+- export env/runtime state from `initialize_runtime_environment(...)`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app tools_memory:: runtime_env:: tool_runtime_config::`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/config/tools_memory.rs crates/app/src/runtime_env.rs crates/app/src/tools/runtime_config.rs
+git commit -m "feat(tools): add web fetch runtime policy"
+```
+
+### Task 4: Expose `web.fetch` in the tool catalog
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+
+- `web.fetch` appears in the runtime tool view when enabled
+- provider tool definitions include the `web_fetch` schema
+- capability snapshot / tool registry mention `web.fetch`
+- alias canonicalization accepts `web_fetch`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app tools::`
+
+Expected: FAIL because `web.fetch` is not registered or advertised yet.
+
+**Step 3: Write minimal implementation**
+
+- add a tool descriptor and provider schema in `catalog.rs`
+- gate runtime view exposure on `config.tools.web.enabled`
+- extend canonical-name handling and tool registry expectations in `tools/mod.rs`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app tools::`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/catalog.rs crates/app/src/tools/mod.rs
+git commit -m "feat(tools): advertise web fetch capability"
+```
+
+### Task 5: Implement the `web.fetch` executor
+
+**Files:**
+- Create: `crates/app/src/tools/web_fetch.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Test: `crates/app/src/tools/web_fetch.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+
+- disabled runtime blocks `web.fetch`
+- private/loopback/local/reserved targets are denied by default
+- explicit local-test override can allow localhost for integration tests
+- redirects are rejected or revalidated safely
+- response size/time limits are enforced
+- readable content is returned with unsafe/script/style noise removed
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app web_fetch`
+
+Expected: FAIL because the executor does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- validate URL scheme/host
+- resolve DNS/IP targets and block unsafe ranges by default
+- execute request with bounded redirect handling and timeout
+- cap response bytes
+- extract readable text/metadata
+- route dispatch in `execute_tool_core_with_config(...)`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app web_fetch`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/tools/web_fetch.rs crates/app/src/tools/mod.rs
+git commit -m "feat(tools): implement ssrf-safe web fetch"
+```
+
+### Task 6: Refresh product specs and first-run docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/PRODUCT_SENSE.md`
+- Modify: `docs/product-specs/index.md`
+- Create: `docs/product-specs/onboarding.md`
+- Create: `docs/product-specs/doctor.md`
+- Create: `docs/product-specs/channel-setup.md`
+- Create: `docs/product-specs/webchat.md`
+- Create: `docs/product-specs/one-shot-ask.md`
+
+**Step 1: Write the failing test**
+
+Use document assertions by checking:
+
+- product spec index links the new specs
+- product sense command table includes `ask` and removes stale `setup`
+- README quick start uses `onboard` then `ask/chat`
+- README visible tools section mentions `web.fetch`
+
+**Step 2: Run test to verify it fails**
+
+Run: `rg -n "setup|ask|web.fetch|onboarding|doctor|channel setup|WebChat" README.md docs/PRODUCT_SENSE.md docs/product-specs`
+
+Expected: current docs are incomplete or stale.
+
+**Step 3: Write minimal implementation**
+
+- add the missing product specs
+- update existing docs to reflect shipped behavior
+
+**Step 4: Run test to verify it passes**
+
+Run: `rg -n "setup|ask|web.fetch|onboarding|doctor|channel setup|WebChat" README.md docs/PRODUCT_SENSE.md docs/product-specs`
+
+Expected: docs/specs align with the new first-run path.
+
+**Step 5: Commit**
+
+```bash
+git add README.md docs/PRODUCT_SENSE.md docs/product-specs docs/plans/2026-03-15-first-run-assistant-journey-design.md docs/plans/2026-03-15-first-run-assistant-journey-implementation-plan.md
+git commit -m "docs(product): define first-run assistant journey"
+```
+
+### Task 7: Verify, publish, and open PR
+
+**Files:**
+- Modify if needed: `.github/PULL_REQUEST_TEMPLATE.md` only for reference, not content changes
+
+**Step 1: Run focused verification**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon cli_ask
+cargo test -p loongclaw-app cli_ask
+cargo test -p loongclaw-app web_fetch
+```
+
+Expected: PASS
+
+**Step 2: Run broader verification**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo test -p loongclaw-app
+cargo test -p loongclaw-daemon
+```
+
+Expected: PASS
+
+**Step 3: Inspect clean delivery state**
+
+Run:
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```
+
+Expected: only task-scoped changes remain.
+
+**Step 4: Push and open PR**
+
+- push branch to `fork-chumyin`
+- open PR against `loongclaw-ai/loongclaw:alpha-test`
+- use repository PR template
+- include `Closes #163`
+- mention that `web.fetch` advances the product track in `#41`
+
+**Step 5: Final confirmation**
+
+Report:
+
+- verification commands executed
+- tests that passed
+- PR URL

--- a/docs/product-specs/channel-setup.md
+++ b/docs/product-specs/channel-setup.md
@@ -1,0 +1,27 @@
+# Channel Setup
+
+## User Story
+
+As a user who wants LoongClaw outside the terminal, I want channel setup to be
+legible so that I know which surfaces are available today and what each one
+needs.
+
+## Acceptance Criteria
+
+- [ ] Product docs clearly distinguish the shipped MVP surfaces:
+      CLI as the default surface, plus Telegram and Feishu as optional channels.
+- [ ] Channel setup guidance describes required credentials, config toggles, and
+      the command used to run each shipped channel.
+- [ ] Channel setup never implies a channel is ready until its required
+      credentials and runtime prerequisites are satisfied.
+- [ ] Channel-specific failures surface enough context for the operator to know
+      which channel or account failed and how to recover.
+- [ ] Channel setup guidance keeps the base CLI assistant path independent, so a
+      user can still succeed with `ask` or `chat` before enabling service
+      channels.
+
+## Out of Scope
+
+- Shipping new channels in this spec
+- Broad cross-channel inbox or routing UX
+- Full remote pairing flows for unshipped surfaces

--- a/docs/product-specs/doctor.md
+++ b/docs/product-specs/doctor.md
@@ -1,0 +1,25 @@
+# Doctor
+
+## User Story
+
+As a LoongClaw operator, I want a clear diagnostics and repair command so that I
+can recover a broken setup without reverse-engineering runtime internals.
+
+## Acceptance Criteria
+
+- [ ] `loongclaw doctor` reports the health of the local assistant runtime in
+      user-facing language.
+- [ ] `loongclaw doctor --fix` only applies safe, local repair actions and
+      explains what it changed.
+- [ ] `loongclaw doctor --json` produces stable machine-readable output for
+      automation and support tooling.
+- [ ] When `onboard`, `ask`, `chat`, or channel setup hits a common health
+      failure, the CLI points users toward `doctor`.
+- [ ] Doctor checks cover the current MVP path: config presence, provider
+      readiness, SQLite memory readiness, and shipped channel prerequisites.
+
+## Out of Scope
+
+- Fully automatic repair for arbitrary operator customizations
+- Remote fleet management
+- Replacing onboarding as the preferred first-run path

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -8,8 +8,18 @@ Product specs describe **what** the product does from the user's perspective, no
 
 ## Specs
 
+- [Onboarding](onboarding.md)
+- [One-Shot Ask](one-shot-ask.md)
+- [Doctor](doctor.md)
+- [Channel Setup](channel-setup.md)
+- [WebChat](webchat.md)
 - [Prompt And Personality](prompt-and-personality.md)
 - [Memory Profiles](memory-profiles.md)
+
+## Notes
+
+- `Onboarding`, `One-Shot Ask`, `Doctor`, and `Channel Setup` define the shipped first-run and support journey for the current MVP.
+- `WebChat` is an expectation-setting spec for the next user-facing surface. It should not be documented as generally available before the implementation exists.
 
 Template for new specs:
 

--- a/docs/product-specs/onboarding.md
+++ b/docs/product-specs/onboarding.md
@@ -1,0 +1,27 @@
+# Onboarding
+
+## User Story
+
+As a first-time LoongClaw user, I want a guided setup flow so that I can reach a
+working assistant without editing raw config or guessing which command comes
+next.
+
+## Acceptance Criteria
+
+- [ ] `loongclaw onboard` is the default first-run path called out in product docs.
+- [ ] Onboarding detects reusable provider, channel, or workspace settings when
+      available and explains what it found before writing config.
+- [ ] The happy path ends with explicit next-step guidance for:
+      `loongclaw ask --message "..."` and `loongclaw chat`.
+- [ ] Rerunning onboarding does not silently overwrite an existing config unless
+      the user explicitly opts into a destructive path such as `--force`.
+- [ ] Onboarding uses the same provider, memory, and channel configuration
+      surfaces that the runtime uses after setup.
+- [ ] When preflight checks fail, onboarding points users to `loongclaw doctor`
+      or `loongclaw doctor --fix` as the repair path.
+
+## Out of Scope
+
+- Packaging and installer distribution strategy
+- Full channel pairing or browser-based setup UIs
+- Arbitrary advanced config editing during first run

--- a/docs/product-specs/one-shot-ask.md
+++ b/docs/product-specs/one-shot-ask.md
@@ -1,0 +1,24 @@
+# One-Shot Ask
+
+## User Story
+
+As a first-time or script-oriented user, I want a one-shot assistant command so
+that I can get an answer immediately without entering an interactive shell.
+
+## Acceptance Criteria
+
+- [ ] LoongClaw exposes `loongclaw ask --message "..."` as a first-class CLI
+      command.
+- [ ] `ask` reuses the same config load, provider routing, memory behavior, and
+      ACP options as CLI chat.
+- [ ] `ask` rejects empty or whitespace-only messages before starting a turn.
+- [ ] `ask` prints one assistant response and exits without REPL-only prompts or
+      slash-command behavior.
+- [ ] `ask` help text points users toward `loongclaw chat` for interactive
+      follow-up.
+
+## Out of Scope
+
+- Interactive history navigation
+- REPL slash commands
+- A separate one-shot runtime distinct from chat

--- a/docs/product-specs/webchat.md
+++ b/docs/product-specs/webchat.md
@@ -1,0 +1,25 @@
+# WebChat
+
+## User Story
+
+As a prospective LoongClaw user, I want a browser-facing chat surface so that I
+can use the assistant without staying in a terminal.
+
+## Acceptance Criteria
+
+- [ ] Product docs state clearly whether WebChat is shipped, experimental, or
+      planned. The MVP must not advertise it as generally available before it
+      exists.
+- [ ] Until WebChat ships, first-run docs direct users to `ask` and `chat`
+      instead of implying a browser UI already exists.
+- [ ] When WebChat does ship, it must reuse the same conversation, provider,
+      tool, and memory semantics as CLI ask/chat rather than creating a separate
+      assistant runtime.
+- [ ] WebChat is treated as the next user-facing surface after the base CLI
+      path, not as a replacement for onboarding or doctor.
+
+## Out of Scope
+
+- Implementing WebChat in this change set
+- Dashboard or multi-user admin controls
+- Mobile or desktop companion apps


### PR DESCRIPTION
## Summary

- Add `loongclaw ask --message ...` as a one-shot assistant CLI path that reuses the existing chat runtime/bootstrap and ACP/session options.
- Ship `web.fetch` as a built-in SSRF-safe core tool with config/env/runtime policy, provider schema, capability snapshot exposure, and regression coverage.
- Refine guided onboarding UX so first-run users get a clearer staged flow: a deterministic single recommendation, structured provider/model/credential/personality/memory/review steps, preset personalities, restored memory-profile selection, env-var-name-only credential prompts, and more explicit next-action guidance.
- Refresh `README.md`, `README.zh-CN.md`, and product specs so docs match the shipped first-run journey.

## Scope

- [ ] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

- `ask` remains a thin wrapper around the existing CLI turn runtime, not a second conversation execution path.
- `web.fetch` stays SSRF-safe by default: only `http/https`, private/special-use hosts blocked, redirects revalidated hop-by-hop, response size capped, and readable mode rejects binary payloads.
- Interactive onboarding intentionally keeps raw prompt editing off the happy path; advanced full prompt overrides remain available via `--system-prompt` or config.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [ ] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional validation details:

- `env CARGO_TARGET_DIR=<local-absolute-path> cargo test -p loongclaw-daemon -- --test-threads=1`

Before/after behavior and regression notes:

- Before: first-run onboarding still exposed raw inline system-prompt editing, personality and memory-profile selection had disappeared from the guided path, credential input could be mistaken for a real secret value, and next-step guidance was less explicit.
- After: guided onboarding uses clearer staged screens, preset personalities, restored memory-profile selection, env-var-name-only credential input, a deterministic single recommended entry path, and `loongclaw ask` as the primary first-run smoke test.
- `crates/daemon/src/tests/onboard_cli.rs` now covers recommendation stability, alphabetical start-fresh catalogs, credential env-var wording, personality preset rendering without prompt dumps, memory-profile selection, and success-summary next-action ordering/details.
- Process-global env handling remains serialized through the existing runtime-env test helpers in the daemon test suite.

## Linked Issues

Closes #171
Closes #163
Advances #41