### PR TITLE
refactor: land runtime binding normalization stack on alpha-test

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -1392,7 +1392,9 @@ pub(super) async fn process_inbound_with_provider(
             &message.text,
             ProviderErrorMode::Propagate,
             &acp_options,
-            kernel_ctx,
+            crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
+                kernel_ctx,
+            ),
             ingress.as_ref(),
         )
         .await

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -141,7 +141,11 @@ pub async fn run_cli_chat(
 
     #[cfg(feature = "memory-sqlite")]
     match turn_coordinator
-        .load_turn_checkpoint_diagnostics(&config, &session_id, Some(&kernel_ctx))
+        .load_turn_checkpoint_diagnostics(
+            &config,
+            &session_id,
+            crate::conversation::ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
         .await
     {
         Ok(diagnostics) => {
@@ -280,7 +284,7 @@ pub async fn run_cli_chat(
                 input,
                 ProviderErrorMode::InlineMessage,
                 &acp_options,
-                Some(&kernel_ctx),
+                crate::conversation::ConversationRuntimeBinding::kernel(&kernel_ctx),
             )
             .await?;
 
@@ -469,8 +473,15 @@ async fn print_safe_lane_summary(
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
-        let summary =
-            load_safe_lane_event_summary(session_id, limit, kernel_ctx, memory_config).await?;
+        let summary = load_safe_lane_event_summary(
+            session_id,
+            limit,
+            crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
+                kernel_ctx,
+            ),
+            memory_config,
+        )
+        .await?;
         println!(
             "{}",
             format_safe_lane_summary(session_id, limit, conversation_config, &summary)
@@ -498,7 +509,14 @@ async fn print_turn_checkpoint_summary(
     #[cfg(feature = "memory-sqlite")]
     {
         let diagnostics = turn_coordinator
-            .load_turn_checkpoint_diagnostics_with_limit(config, session_id, limit, kernel_ctx)
+            .load_turn_checkpoint_diagnostics_with_limit(
+                config,
+                session_id,
+                limit,
+                crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
+                    kernel_ctx,
+                ),
+            )
             .await?;
         println!(
             "{}",
@@ -525,7 +543,13 @@ async fn print_turn_checkpoint_repair(
     #[cfg(feature = "memory-sqlite")]
     {
         let outcome = turn_coordinator
-            .repair_turn_checkpoint_tail(config, session_id, kernel_ctx)
+            .repair_turn_checkpoint_tail(
+                config,
+                session_id,
+                crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
+                    kernel_ctx,
+                ),
+            )
             .await?;
         println!("{}", format_turn_checkpoint_repair(session_id, &outcome));
         Ok(())

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -10,6 +10,8 @@ use crate::{CliResult, KernelContext};
 use crate::memory;
 use std::collections::BTreeSet;
 
+use super::runtime_binding::ConversationRuntimeBinding;
+
 pub const CONTEXT_ENGINE_API_VERSION: u16 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -164,9 +166,9 @@ pub trait ConversationContextEngine: Send + Sync {
         config: &LoongClawConfig,
         session_id: &str,
         include_system_prompt: bool,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
-        self.assemble_messages(config, session_id, include_system_prompt, kernel_ctx)
+        self.assemble_messages(config, session_id, include_system_prompt, binding)
             .await
             .map(AssembledConversationContext::from_messages)
     }
@@ -176,7 +178,7 @@ pub trait ConversationContextEngine: Send + Sync {
         config: &LoongClawConfig,
         session_id: &str,
         include_system_prompt: bool,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>>;
 }
 
@@ -271,10 +273,10 @@ where
         config: &LoongClawConfig,
         session_id: &str,
         include_system_prompt: bool,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
         self.as_ref()
-            .assemble_context(config, session_id, include_system_prompt, kernel_ctx)
+            .assemble_context(config, session_id, include_system_prompt, binding)
             .await
     }
 
@@ -283,10 +285,10 @@ where
         config: &LoongClawConfig,
         session_id: &str,
         include_system_prompt: bool,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>> {
         self.as_ref()
-            .assemble_messages(config, session_id, include_system_prompt, kernel_ctx)
+            .assemble_messages(config, session_id, include_system_prompt, binding)
             .await
     }
 }
@@ -316,9 +318,9 @@ impl ConversationContextEngine for DefaultContextEngine {
         config: &LoongClawConfig,
         session_id: &str,
         include_system_prompt: bool,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>> {
-        if kernel_ctx.is_none() {
+        if !binding.is_kernel_bound() {
             return crate::provider::build_messages_for_session(
                 config,
                 session_id,
@@ -331,7 +333,7 @@ impl ConversationContextEngine for DefaultContextEngine {
 
         #[cfg(feature = "memory-sqlite")]
         {
-            let turns = load_memory_window(config, session_id, kernel_ctx).await?;
+            let turns = load_memory_window(config, session_id, binding).await?;
             for turn in turns {
                 crate::provider::push_history_message(
                     &mut messages,
@@ -343,7 +345,7 @@ impl ConversationContextEngine for DefaultContextEngine {
 
         #[cfg(not(feature = "memory-sqlite"))]
         {
-            let _ = (session_id, kernel_ctx);
+            let _ = (session_id, binding);
         }
 
         Ok(messages)
@@ -365,7 +367,7 @@ impl ConversationContextEngine for LegacyContextEngine {
         config: &LoongClawConfig,
         session_id: &str,
         include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>> {
         crate::provider::build_messages_for_session(config, session_id, include_system_prompt)
     }
@@ -375,11 +377,11 @@ impl ConversationContextEngine for LegacyContextEngine {
 async fn load_memory_window(
     config: &LoongClawConfig,
     session_id: &str,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<Vec<memory::WindowTurn>> {
     use std::collections::BTreeSet;
 
-    if let Some(ctx) = kernel_ctx {
+    if let Some(ctx) = binding.kernel_context() {
         let request = memory::build_window_request(session_id, config.memory.sliding_window);
         let caps = BTreeSet::from([Capability::MemoryRead]);
         let outcome = ctx

--- a/crates/app/src/conversation/context_engine_registry.rs
+++ b/crates/app/src/conversation/context_engine_registry.rs
@@ -137,7 +137,8 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::Value;
 
-    use crate::{KernelContext, config::LoongClawConfig};
+    use super::super::runtime_binding::ConversationRuntimeBinding;
+    use crate::config::LoongClawConfig;
 
     use super::super::context_engine::ContextEngineCapability;
     use super::*;
@@ -155,7 +156,7 @@ mod tests {
             _config: &LoongClawConfig,
             _session_id: &str,
             _include_system_prompt: bool,
-            _kernel_ctx: Option<&KernelContext>,
+            _binding: ConversationRuntimeBinding<'_>,
         ) -> CliResult<Vec<Value>> {
             Ok(Vec::new())
         }

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -8,6 +8,7 @@ pub mod plan_executor;
 pub mod plan_ir;
 pub mod plan_verifier;
 mod runtime;
+mod runtime_binding;
 mod safe_lane_failure;
 mod session_address;
 mod session_history;
@@ -49,6 +50,7 @@ pub use runtime::{
     ConversationRuntime, DefaultConversationRuntime, SessionContext,
     collect_context_engine_runtime_snapshot, resolve_context_engine_selection,
 };
+pub use runtime_binding::ConversationRuntimeBinding;
 pub use safe_lane_failure::{
     SafeLaneFailureCode, SafeLaneFailureRouteDecision, SafeLaneFailureRouteSource,
     SafeLaneTerminalRouteSnapshot, classify_safe_lane_plan_failure,

--- a/crates/app/src/conversation/persistence.rs
+++ b/crates/app/src/conversation/persistence.rs
@@ -1,7 +1,6 @@
 use serde_json::{Value, json};
 
 use crate::CliResult;
-use crate::KernelContext;
 use crate::acp::{
     AcpTurnResult, PersistedAcpRuntimeEventContext, build_persisted_runtime_event_records,
 };
@@ -10,6 +9,7 @@ use crate::memory::{
 };
 
 use super::runtime::ConversationRuntime;
+use super::runtime_binding::ConversationRuntimeBinding;
 use super::turn_engine::{ToolDecision, ToolOutcome};
 use super::turn_shared::ReplyPersistenceMode;
 
@@ -22,17 +22,10 @@ pub(super) async fn persist_success_turns<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     user_input: &str,
     assistant_reply: &str,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
-    persist_and_ingest_turn(runtime, session_id, "user", user_input, kernel_ctx).await?;
-    persist_and_ingest_turn(
-        runtime,
-        session_id,
-        "assistant",
-        assistant_reply,
-        kernel_ctx,
-    )
-    .await?;
+    persist_and_ingest_turn(runtime, session_id, "user", user_input, binding).await?;
+    persist_and_ingest_turn(runtime, session_id, "assistant", assistant_reply, binding).await?;
     Ok(())
 }
 
@@ -42,15 +35,14 @@ pub(super) async fn persist_reply_turns_with_mode<R: ConversationRuntime + ?Size
     user_input: &str,
     assistant_reply: &str,
     persistence_mode: ReplyPersistenceMode,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
     match persistence_mode {
         ReplyPersistenceMode::Success => {
-            persist_success_turns(runtime, session_id, user_input, assistant_reply, kernel_ctx)
-                .await
+            persist_success_turns(runtime, session_id, user_input, assistant_reply, binding).await
         }
         ReplyPersistenceMode::InlineProviderError => {
-            persist_error_turns(runtime, session_id, user_input, assistant_reply, kernel_ctx).await
+            persist_error_turns(runtime, session_id, user_input, assistant_reply, binding).await
         }
     }
 }
@@ -67,14 +59,14 @@ pub(super) async fn persist_tool_decision<R: ConversationRuntime + ?Sized>(
     turn_id: &str,
     tool_call_id: &str,
     decision: &ToolDecision,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
     let content = build_tool_decision_content(
         turn_id,
         tool_call_id,
         serde_json::to_value(decision).map_err(|e| format!("serialize tool decision: {e}"))?,
     );
-    persist_and_ingest_turn(runtime, session_id, "assistant", &content, kernel_ctx).await
+    persist_and_ingest_turn(runtime, session_id, "assistant", &content, binding).await
 }
 
 /// Persist a tool outcome as a structured JSON assistant message.
@@ -89,14 +81,14 @@ pub(super) async fn persist_tool_outcome<R: ConversationRuntime + ?Sized>(
     turn_id: &str,
     tool_call_id: &str,
     outcome: &ToolOutcome,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
     let content = build_tool_outcome_content(
         turn_id,
         tool_call_id,
         serde_json::to_value(outcome).map_err(|e| format!("serialize tool outcome: {e}"))?,
     );
-    persist_and_ingest_turn(runtime, session_id, "assistant", &content, kernel_ctx).await
+    persist_and_ingest_turn(runtime, session_id, "assistant", &content, binding).await
 }
 
 pub(super) async fn persist_error_turns<R: ConversationRuntime + ?Sized>(
@@ -104,17 +96,10 @@ pub(super) async fn persist_error_turns<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     user_input: &str,
     synthetic_reply: &str,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
-    persist_and_ingest_turn(runtime, session_id, "user", user_input, kernel_ctx).await?;
-    persist_and_ingest_turn(
-        runtime,
-        session_id,
-        "assistant",
-        synthetic_reply,
-        kernel_ctx,
-    )
-    .await?;
+    persist_and_ingest_turn(runtime, session_id, "user", user_input, binding).await?;
+    persist_and_ingest_turn(runtime, session_id, "assistant", synthetic_reply, binding).await?;
     Ok(())
 }
 
@@ -123,17 +108,10 @@ pub(super) async fn persist_success_turns_raw<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     user_input: &str,
     assistant_reply: &str,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
-    persist_turn_only(runtime, session_id, "user", user_input, kernel_ctx).await?;
-    persist_turn_only(
-        runtime,
-        session_id,
-        "assistant",
-        assistant_reply,
-        kernel_ctx,
-    )
-    .await?;
+    persist_turn_only(runtime, session_id, "user", user_input, binding).await?;
+    persist_turn_only(runtime, session_id, "assistant", assistant_reply, binding).await?;
     Ok(())
 }
 
@@ -143,16 +121,15 @@ pub(super) async fn persist_reply_turns_raw_with_mode<R: ConversationRuntime + ?
     user_input: &str,
     assistant_reply: &str,
     persistence_mode: ReplyPersistenceMode,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
     match persistence_mode {
         ReplyPersistenceMode::Success => {
-            persist_success_turns_raw(runtime, session_id, user_input, assistant_reply, kernel_ctx)
+            persist_success_turns_raw(runtime, session_id, user_input, assistant_reply, binding)
                 .await
         }
         ReplyPersistenceMode::InlineProviderError => {
-            persist_error_turns_raw(runtime, session_id, user_input, assistant_reply, kernel_ctx)
-                .await
+            persist_error_turns_raw(runtime, session_id, user_input, assistant_reply, binding).await
         }
     }
 }
@@ -162,17 +139,10 @@ pub(super) async fn persist_error_turns_raw<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     user_input: &str,
     synthetic_reply: &str,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
-    persist_turn_only(runtime, session_id, "user", user_input, kernel_ctx).await?;
-    persist_turn_only(
-        runtime,
-        session_id,
-        "assistant",
-        synthetic_reply,
-        kernel_ctx,
-    )
-    .await?;
+    persist_turn_only(runtime, session_id, "user", user_input, binding).await?;
+    persist_turn_only(runtime, session_id, "assistant", synthetic_reply, binding).await?;
     Ok(())
 }
 
@@ -181,12 +151,12 @@ async fn persist_and_ingest_turn<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     role: &str,
     content: &str,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
     runtime
-        .persist_turn(session_id, role, content, kernel_ctx)
+        .persist_turn(session_id, role, content, binding)
         .await?;
-    if let Some(kernel_ctx) = kernel_ctx {
+    if let Some(kernel_ctx) = binding.kernel_context() {
         runtime
             .ingest(
                 session_id,
@@ -206,11 +176,11 @@ pub(super) async fn persist_conversation_event<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     event_name: &str,
     payload: Value,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
     let content = build_conversation_event_content(event_name, payload);
     runtime
-        .persist_turn(session_id, "assistant", &content, kernel_ctx)
+        .persist_turn(session_id, "assistant", &content, binding)
         .await
 }
 
@@ -221,18 +191,12 @@ pub(super) async fn persist_acp_runtime_events<R: ConversationRuntime + ?Sized>(
     events: &[Value],
     result: Option<&AcpTurnResult>,
     error: Option<&str>,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
     let records = build_persisted_runtime_event_records(context, events, result, error);
     for record in records {
-        persist_conversation_event(
-            runtime,
-            session_id,
-            record.event,
-            record.payload,
-            kernel_ctx,
-        )
-        .await?;
+        persist_conversation_event(runtime, session_id, record.event, record.payload, binding)
+            .await?;
     }
     Ok(())
 }
@@ -242,9 +206,9 @@ async fn persist_turn_only<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     role: &str,
     content: &str,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
     runtime
-        .persist_turn(session_id, role, content, kernel_ctx)
+        .persist_turn(session_id, role, content, binding)
         .await
 }

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -584,7 +584,14 @@ where
         messages: &[Value],
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
-        provider::request_completion(config, messages, binding.kernel_context()).await
+        provider::request_completion(
+            config,
+            messages,
+            provider::ProviderRuntimeBinding::from_optional_kernel_context(
+                binding.kernel_context(),
+            ),
+        )
+        .await
     }
 
     async fn request_turn(
@@ -594,7 +601,15 @@ where
         tool_view: &ToolView,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ProviderTurn> {
-        provider::request_turn_in_view(config, messages, tool_view, binding.kernel_context()).await
+        provider::request_turn_in_view(
+            config,
+            messages,
+            tool_view,
+            provider::ProviderRuntimeBinding::from_optional_kernel_context(
+                binding.kernel_context(),
+            ),
+        )
+        .await
     }
 
     async fn persist_turn(

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -137,7 +137,7 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
             request.label,
             &request.task,
             request.timeout_seconds,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await;
         Ok(())

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -9,7 +9,7 @@ use crate::CliResult;
 use crate::KernelContext;
 use crate::tools::{
     ToolView, delegate_child_tool_view_for_config,
-    delegate_child_tool_view_for_config_with_delegate, runtime_tool_view_for_config,
+    delegate_child_tool_view_for_config_with_delegate,
 };
 
 use super::super::memory;
@@ -291,7 +291,9 @@ pub trait ConversationRuntime: Send + Sync {
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ToolView> {
         let _ = (session_id, binding);
-        Ok(runtime_tool_view_for_config(&config.tools))
+        Ok(crate::tools::runtime_tool_view_from_loongclaw_config(
+            config,
+        ))
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -9,7 +9,7 @@ use crate::CliResult;
 use crate::KernelContext;
 use crate::tools::{
     ToolView, delegate_child_tool_view_for_config,
-    delegate_child_tool_view_for_config_with_delegate,
+    delegate_child_tool_view_for_config_with_delegate, runtime_tool_view_for_config,
 };
 
 use super::super::memory;

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -22,6 +22,7 @@ use super::context_engine_registry::{
     DEFAULT_CONTEXT_ENGINE_ID, context_engine_id_from_env, describe_context_engine,
     list_context_engine_metadata, resolve_context_engine,
 };
+use super::runtime_binding::ConversationRuntimeBinding;
 use super::turn_engine::ProviderTurn;
 
 #[cfg(feature = "memory-sqlite")]
@@ -275,11 +276,11 @@ pub trait ConversationRuntime: Send + Sync {
         &self,
         config: &LoongClawConfig,
         session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<SessionContext> {
         Ok(SessionContext::root_with_tool_view(
             session_id,
-            self.tool_view(config, session_id, kernel_ctx)?,
+            self.tool_view(config, session_id, binding)?,
         ))
     }
 
@@ -287,12 +288,10 @@ pub trait ConversationRuntime: Send + Sync {
         &self,
         config: &LoongClawConfig,
         session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ToolView> {
-        let _ = (session_id, kernel_ctx);
-        Ok(crate::tools::runtime_tool_view_from_loongclaw_config(
-            config,
-        ))
+        let _ = (session_id, binding);
+        Ok(runtime_tool_view_for_config(&config.tools))
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -326,15 +325,15 @@ pub trait ConversationRuntime: Send + Sync {
         config: &LoongClawConfig,
         session_id: &str,
         include_system_prompt: bool,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
-        let session_context = self.session_context(config, session_id, kernel_ctx)?;
+        let session_context = self.session_context(config, session_id, binding)?;
         self.build_messages(
             config,
             session_id,
             include_system_prompt,
             &session_context.tool_view,
-            kernel_ctx,
+            binding,
         )
         .await
         .map(AssembledConversationContext::from_messages)
@@ -345,14 +344,14 @@ pub trait ConversationRuntime: Send + Sync {
         session_id: &str,
         include_system_prompt: bool,
         tool_view: &ToolView,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>>;
 
     async fn request_completion(
         &self,
         config: &LoongClawConfig,
         messages: &[Value],
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String>;
 
     async fn request_turn(
@@ -360,7 +359,7 @@ pub trait ConversationRuntime: Send + Sync {
         config: &LoongClawConfig,
         messages: &[Value],
         tool_view: &ToolView,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ProviderTurn>;
 
     async fn persist_turn(
@@ -368,7 +367,7 @@ pub trait ConversationRuntime: Send + Sync {
         session_id: &str,
         role: &str,
         content: &str,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<()>;
 
     async fn after_turn(
@@ -420,9 +419,9 @@ where
         &self,
         config: &LoongClawConfig,
         session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<SessionContext> {
-        let tool_view = self.tool_view(config, session_id, kernel_ctx)?;
+        let tool_view = self.tool_view(config, session_id, binding)?;
 
         #[cfg(feature = "memory-sqlite")]
         {
@@ -460,7 +459,7 @@ where
         &self,
         config: &LoongClawConfig,
         session_id: &str,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ToolView> {
         #[cfg(feature = "memory-sqlite")]
         {
@@ -538,12 +537,12 @@ where
         config: &LoongClawConfig,
         session_id: &str,
         include_system_prompt: bool,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
-        let session_context = self.session_context(config, session_id, kernel_ctx)?;
+        let session_context = self.session_context(config, session_id, binding)?;
         let mut assembled = self
             .context_engine
-            .assemble_context(config, session_id, include_system_prompt, kernel_ctx)
+            .assemble_context(config, session_id, include_system_prompt, binding)
             .await?;
         apply_system_prompt_addition(
             &mut assembled.messages,
@@ -565,9 +564,9 @@ where
         session_id: &str,
         include_system_prompt: bool,
         tool_view: &ToolView,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>> {
-        self.build_context(config, session_id, include_system_prompt, kernel_ctx)
+        self.build_context(config, session_id, include_system_prompt, binding)
             .await
             .map(|mut assembled| {
                 apply_tool_view_to_system_prompt_if_needed(
@@ -583,9 +582,9 @@ where
         &self,
         config: &LoongClawConfig,
         messages: &[Value],
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
-        provider::request_completion(config, messages, kernel_ctx).await
+        provider::request_completion(config, messages, binding.kernel_context()).await
     }
 
     async fn request_turn(
@@ -593,9 +592,9 @@ where
         config: &LoongClawConfig,
         messages: &[Value],
         tool_view: &ToolView,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ProviderTurn> {
-        provider::request_turn_in_view(config, messages, tool_view, kernel_ctx).await
+        provider::request_turn_in_view(config, messages, tool_view, binding.kernel_context()).await
     }
 
     async fn persist_turn(
@@ -603,9 +602,9 @@ where
         session_id: &str,
         role: &str,
         content: &str,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<()> {
-        if let Some(ctx) = kernel_ctx {
+        if let Some(ctx) = binding.kernel_context() {
             let request = memory::build_append_turn_request(session_id, role, content);
             let caps = BTreeSet::from([Capability::MemoryWrite]);
             ctx.kernel

--- a/crates/app/src/conversation/runtime_binding.rs
+++ b/crates/app/src/conversation/runtime_binding.rs
@@ -1,0 +1,36 @@
+use crate::KernelContext;
+
+#[derive(Clone, Copy, Default)]
+pub enum ConversationRuntimeBinding<'a> {
+    Kernel(&'a KernelContext),
+    #[default]
+    Direct,
+}
+
+impl<'a> ConversationRuntimeBinding<'a> {
+    pub fn from_optional_kernel_context(kernel_ctx: Option<&'a KernelContext>) -> Self {
+        match kernel_ctx {
+            Some(kernel_ctx) => Self::Kernel(kernel_ctx),
+            None => Self::Direct,
+        }
+    }
+
+    pub fn kernel(kernel_ctx: &'a KernelContext) -> Self {
+        Self::Kernel(kernel_ctx)
+    }
+
+    pub const fn direct() -> Self {
+        Self::Direct
+    }
+
+    pub fn kernel_context(self) -> Option<&'a KernelContext> {
+        match self {
+            Self::Kernel(kernel_ctx) => Some(kernel_ctx),
+            Self::Direct => None,
+        }
+    }
+
+    pub const fn is_kernel_bound(self) -> bool {
+        matches!(self, Self::Kernel(_))
+    }
+}

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -7,7 +7,6 @@ use loongclaw_contracts::{Capability, MemoryCoreRequest};
 use serde_json::{Value, json};
 
 use crate::CliResult;
-use crate::KernelContext;
 #[cfg(feature = "memory-sqlite")]
 use crate::memory;
 #[cfg(feature = "memory-sqlite")]
@@ -17,6 +16,7 @@ use super::analytics::{
     SafeLaneEventSummary, TurnCheckpointEventSummary, summarize_safe_lane_events,
     summarize_turn_checkpoint_history,
 };
+use super::runtime_binding::ConversationRuntimeBinding;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TurnCheckpointLatestEntry {
@@ -63,13 +63,13 @@ impl TurnCheckpointHistorySnapshot {
 pub async fn load_turn_checkpoint_event_summary(
     session_id: &str,
     limit: usize,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<TurnCheckpointEventSummary> {
     #[cfg(feature = "memory-sqlite")]
     {
         Ok(
-            load_turn_checkpoint_history_snapshot(session_id, limit, kernel_ctx, memory_config)
+            load_turn_checkpoint_history_snapshot(session_id, limit, binding, memory_config)
                 .await?
                 .into_summary(),
         )
@@ -77,7 +77,7 @@ pub async fn load_turn_checkpoint_event_summary(
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = (session_id, limit, kernel_ctx);
+        let _ = (session_id, limit, binding);
         Err("turn checkpoint summary unavailable: memory-sqlite feature disabled".to_owned())
     }
 }
@@ -85,18 +85,14 @@ pub async fn load_turn_checkpoint_event_summary(
 pub async fn load_safe_lane_event_summary(
     session_id: &str,
     limit: usize,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<SafeLaneEventSummary> {
     #[cfg(feature = "memory-sqlite")]
     {
-        let assistant_contents = load_assistant_contents_from_session_window(
-            session_id,
-            limit,
-            kernel_ctx,
-            memory_config,
-        )
-        .await?;
+        let assistant_contents =
+            load_assistant_contents_from_session_window(session_id, limit, binding, memory_config)
+                .await?;
         Ok(summarize_safe_lane_events(
             assistant_contents.iter().map(String::as_str),
         ))
@@ -104,7 +100,7 @@ pub async fn load_safe_lane_event_summary(
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = (session_id, limit, kernel_ctx);
+        let _ = (session_id, limit, binding);
         Err("safe-lane summary unavailable: memory-sqlite feature disabled".to_owned())
     }
 }
@@ -112,13 +108,13 @@ pub async fn load_safe_lane_event_summary(
 pub(crate) async fn load_latest_turn_checkpoint_entry(
     session_id: &str,
     limit: usize,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<Option<TurnCheckpointLatestEntry>> {
     #[cfg(feature = "memory-sqlite")]
     {
         Ok(
-            load_turn_checkpoint_history_snapshot(session_id, limit, kernel_ctx, memory_config)
+            load_turn_checkpoint_history_snapshot(session_id, limit, binding, memory_config)
                 .await?
                 .into_latest_entry(),
         )
@@ -126,7 +122,7 @@ pub(crate) async fn load_latest_turn_checkpoint_entry(
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = (session_id, limit, kernel_ctx);
+        let _ = (session_id, limit, binding);
         Err("turn checkpoint entry unavailable: memory-sqlite feature disabled".to_owned())
     }
 }
@@ -135,11 +131,11 @@ pub(crate) async fn load_latest_turn_checkpoint_entry(
 pub(crate) async fn load_turn_checkpoint_history_snapshot(
     session_id: &str,
     limit: usize,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<TurnCheckpointHistorySnapshot> {
     let assistant_contents =
-        load_assistant_contents_from_session_window(session_id, limit, kernel_ctx, memory_config)
+        load_assistant_contents_from_session_window(session_id, limit, binding, memory_config)
             .await?;
     Ok(build_turn_checkpoint_history_snapshot(&assistant_contents))
 }
@@ -148,10 +144,10 @@ pub(crate) async fn load_turn_checkpoint_history_snapshot(
 pub(crate) async fn load_assistant_contents_from_session_window(
     session_id: &str,
     limit: usize,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<Vec<String>> {
-    if let Some(ctx) = kernel_ctx {
+    if let Some(ctx) = binding.kernel_context() {
         let request = MemoryCoreRequest {
             operation: memory::MEMORY_OP_WINDOW.to_owned(),
             payload: json!({

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -60,6 +60,51 @@ struct FakeRuntime {
     compact_calls: Mutex<Vec<(String, usize)>>,
 }
 
+struct TraitDefaultToolViewRuntime;
+
+#[async_trait]
+impl ConversationRuntime for TraitDefaultToolViewRuntime {
+    async fn build_messages(
+        &self,
+        _config: &LoongClawConfig,
+        _session_id: &str,
+        _include_system_prompt: bool,
+        _tool_view: &crate::tools::ToolView,
+        _binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<Vec<Value>> {
+        Ok(Vec::new())
+    }
+
+    async fn request_completion(
+        &self,
+        _config: &LoongClawConfig,
+        _messages: &[Value],
+        _binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<String> {
+        Err("trait default tool view test should not request a completion".to_owned())
+    }
+
+    async fn request_turn(
+        &self,
+        _config: &LoongClawConfig,
+        _messages: &[Value],
+        _tool_view: &crate::tools::ToolView,
+        _binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<ProviderTurn> {
+        Err("trait default tool view test should not request a provider turn".to_owned())
+    }
+
+    async fn persist_turn(
+        &self,
+        _session_id: &str,
+        _role: &str,
+        _content: &str,
+        _binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<()> {
+        Ok(())
+    }
+}
+
 #[cfg(feature = "memory-sqlite")]
 #[derive(Default)]
 struct FakeAsyncDelegateSpawner {
@@ -1616,6 +1661,32 @@ async fn default_runtime_prefers_env_context_engine_over_config() {
 
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0]["content"], "stub-env-context-engine");
+}
+
+#[cfg(feature = "feishu-integration")]
+#[test]
+fn conversation_runtime_trait_default_tool_view_includes_runtime_discovered_feishu_tools() {
+    let runtime = TraitDefaultToolViewRuntime;
+    let config = LoongClawConfig {
+        feishu: crate::config::FeishuChannelConfig {
+            enabled: true,
+            app_id: Some("test-feishu-app-id".to_owned()),
+            app_secret: Some("test-feishu-app-secret".to_owned()),
+            ..crate::config::FeishuChannelConfig::default()
+        },
+        ..test_config()
+    };
+
+    let tool_view = runtime
+        .tool_view(
+            &config,
+            "session-feishu-runtime-tools",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("trait default tool view");
+
+    assert!(tool_view.contains("feishu.whoami"));
+    assert!(tool_view.contains("feishu.messages.send"));
 }
 
 #[tokio::test]
@@ -11387,8 +11458,7 @@ async fn handle_turn_with_runtime_executes_session_wait_via_default_dispatcher()
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_dispatcher_when_kernel_bound()
- {
+async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_dispatcher() {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
         unique_acp_test_id("conversation-session-tools", "safe-lane")
@@ -11435,7 +11505,6 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_d
         Ok("unused".to_owned()),
     );
     let coordinator = ConversationTurnCoordinator::new();
-    let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
 
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -11444,7 +11513,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_d
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::kernel(&kernel_ctx),
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("safe-lane handle turn success");
@@ -11461,8 +11530,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_d
 
 #[cfg(all(feature = "memory-sqlite", feature = "channel-telegram"))]
 #[tokio::test]
-async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_dispatcher_when_kernel_bound()
- {
+async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_dispatcher() {
     let (base_url, request_rx, server) = spawn_telegram_send_server_once();
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
@@ -11520,7 +11588,6 @@ async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_d
         Ok("unused".to_owned()),
     );
     let coordinator = ConversationTurnCoordinator::new();
-    let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
 
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -11529,7 +11596,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_d
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::kernel(&kernel_ctx),
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("safe-lane handle turn success");
@@ -11562,8 +11629,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_d
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_safe_lane_executes_session_wait_via_default_dispatcher_when_kernel_bound()
- {
+async fn handle_turn_with_runtime_safe_lane_executes_session_wait_via_default_dispatcher() {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
         unique_acp_test_id("conversation-session-wait", "safe-lane")
@@ -11622,7 +11688,6 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_wait_via_default_di
         Ok("unused".to_owned()),
     );
     let coordinator = ConversationTurnCoordinator::new();
-    let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
 
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -11631,7 +11696,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_wait_via_default_di
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::kernel(&kernel_ctx),
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("safe-lane handle turn success");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -145,7 +145,7 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
             request.label,
             &request.task,
             request.timeout_seconds,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await;
         Ok(())
@@ -1634,7 +1634,7 @@ async fn handle_turn_with_runtime_success_with_kernel_runs_lifecycle_hooks() {
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&kernel_ctx),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("handle turn success");
@@ -1718,7 +1718,7 @@ async fn handle_turn_with_runtime_success_without_kernel_skips_lifecycle_hooks()
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("handle turn success without kernel");
@@ -1788,7 +1788,7 @@ async fn persist_turn_provider_turns_expose_typed_canonical_records() {
             "hello canonical memory",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("provider turn should succeed");
@@ -1840,7 +1840,7 @@ async fn handle_turn_with_runtime_keeps_provider_path_by_default_when_acp_enable
             "hello from channel",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("default handle_turn should stay on provider path");
@@ -1879,7 +1879,7 @@ async fn handle_turn_with_runtime_routes_explicit_acp_turns_through_acp() {
                 routing_intent: AcpRoutingIntent::Explicit,
                 ..AcpConversationTurnOptions::default()
             },
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("explicit ACP turn should route through ACP");
@@ -2015,7 +2015,7 @@ async fn persist_turn_explicit_acp_routing_exposes_typed_canonical_records() {
                 routing_intent: AcpRoutingIntent::Explicit,
                 ..AcpConversationTurnOptions::default()
             },
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("explicit ACP turn should succeed");
@@ -2090,7 +2090,7 @@ async fn handle_turn_with_runtime_merges_additional_acp_bootstrap_mcp_servers_fr
                 additional_bootstrap_mcp_servers: Some(extra_servers.as_slice()),
                 ..AcpConversationTurnOptions::default()
             },
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("ACP-routed turn with additional bootstrap MCP servers should succeed");
@@ -2138,7 +2138,7 @@ async fn handle_turn_with_runtime_applies_acp_turn_provenance_metadata() {
                 },
                 ..AcpConversationTurnOptions::default()
             },
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("ACP-routed turn with provenance should succeed");
@@ -2207,7 +2207,7 @@ async fn handle_turn_with_runtime_applies_acp_working_directory_from_options() {
                 working_directory: Some(working_directory.as_path()),
                 ..AcpConversationTurnOptions::default()
             },
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("ACP-routed turn with working directory should succeed");
@@ -2259,7 +2259,7 @@ async fn handle_turn_with_runtime_falls_back_to_dispatch_acp_working_directory()
                 routing_intent: AcpRoutingIntent::Explicit,
                 ..AcpConversationTurnOptions::default()
             },
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("ACP-routed turn should inherit dispatch working directory");
@@ -2305,7 +2305,7 @@ async fn handle_turn_with_runtime_uses_provider_path_when_acp_dispatch_is_disabl
             "hello provider path",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("provider path should remain available when ACP dispatch is disabled");
@@ -2351,7 +2351,7 @@ async fn handle_turn_with_runtime_explicit_acp_request_bypasses_dispatch_gate() 
                 routing_intent: AcpRoutingIntent::Explicit,
                 ..AcpConversationTurnOptions::default()
             },
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("explicit ACP requests should bypass automatic dispatch gating");
@@ -2382,7 +2382,7 @@ async fn handle_turn_with_runtime_explicit_acp_request_fails_closed_when_acp_is_
                 routing_intent: AcpRoutingIntent::Explicit,
                 ..AcpConversationTurnOptions::default()
             },
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("inline mode should synthesize a clear ACP-disabled reply");
@@ -2416,7 +2416,7 @@ async fn handle_turn_with_runtime_routes_only_agent_prefixed_sessions_when_confi
             "should stay on provider path",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("non-prefixed session should stay on provider path");
@@ -2429,7 +2429,7 @@ async fn handle_turn_with_runtime_routes_only_agent_prefixed_sessions_when_confi
             "should route through ACP",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("prefixed session should route through ACP");
@@ -2495,7 +2495,7 @@ async fn persist_turn_automatic_acp_routing_exposes_typed_canonical_records() {
             "hello automatic canonical",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("automatic ACP turn should succeed");
@@ -2558,7 +2558,7 @@ async fn handle_turn_with_runtime_automatic_acp_routing_bypasses_context_engine_
             "route automatically through ACP",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("automatic ACP turn should succeed");
@@ -2635,7 +2635,7 @@ async fn handle_turn_with_runtime_routes_only_allowed_channels_into_acp() {
             "hello telegram",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("telegram session should route through ACP");
@@ -2674,7 +2674,7 @@ async fn handle_turn_with_runtime_routes_only_allowed_channels_into_acp() {
             "hello feishu",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("feishu session should stay on provider path");
@@ -2713,7 +2713,7 @@ async fn handle_turn_with_runtime_and_address_routes_structured_channel_scope_in
             "hello structured route",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("structured channel address should route through ACP");
@@ -2791,7 +2791,7 @@ async fn handle_turn_with_runtime_and_address_enforces_account_and_thread_dispat
             "hello allowed",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("thread-bound allowed address should route through ACP");
@@ -2804,7 +2804,7 @@ async fn handle_turn_with_runtime_and_address_enforces_account_and_thread_dispat
             "hello blocked",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("root conversation should stay on provider path");
@@ -2863,7 +2863,7 @@ async fn handle_turn_with_runtime_formats_acp_errors_inline_when_requested() {
                 routing_intent: AcpRoutingIntent::Explicit,
                 ..AcpConversationTurnOptions::default()
             },
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("ACP inline error mode should synthesize a reply");
@@ -2908,7 +2908,7 @@ async fn handle_turn_with_runtime_reuses_shared_acp_session_between_turns() {
                 routing_intent: AcpRoutingIntent::Explicit,
                 ..AcpConversationTurnOptions::default()
             },
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("first ACP-routed turn");
@@ -2923,7 +2923,7 @@ async fn handle_turn_with_runtime_reuses_shared_acp_session_between_turns() {
                 routing_intent: AcpRoutingIntent::Explicit,
                 ..AcpConversationTurnOptions::default()
             },
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("second ACP-routed turn");
@@ -2973,7 +2973,7 @@ async fn handle_turn_with_runtime_persists_acp_runtime_events_when_enabled() {
                 routing_intent: AcpRoutingIntent::Explicit,
                 ..AcpConversationTurnOptions::default()
             },
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("ACP-routed turn with runtime events should succeed");
@@ -3079,7 +3079,7 @@ async fn handle_turn_with_runtime_streams_acp_runtime_events_to_external_sink_wi
             ProviderErrorMode::Propagate,
             &runtime,
             &acp_options,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("ACP-routed turn with external event sink should succeed");
@@ -3148,7 +3148,7 @@ async fn handle_turn_with_runtime_streams_and_persists_acp_runtime_events_when_b
             ProviderErrorMode::Propagate,
             &runtime,
             &acp_options,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("ACP-routed turn with external sink and persistence should succeed");
@@ -3202,7 +3202,7 @@ async fn handle_turn_with_runtime_skips_compaction_when_disabled() {
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("handle turn success");
@@ -3234,7 +3234,7 @@ async fn handle_turn_with_runtime_skips_compaction_below_min_messages() {
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("handle turn success");
@@ -3267,7 +3267,7 @@ async fn handle_turn_with_runtime_skips_compaction_below_token_threshold() {
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("handle turn success");
@@ -3301,7 +3301,7 @@ async fn handle_turn_with_runtime_compacts_when_token_threshold_reached() {
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&kernel_ctx),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("handle turn success");
@@ -3331,7 +3331,7 @@ async fn handle_turn_with_runtime_compaction_error_is_ignored_when_fail_open() {
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&kernel_ctx),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("fail-open mode should keep turn successful");
@@ -3360,7 +3360,7 @@ async fn handle_turn_with_runtime_compaction_error_propagates_when_fail_closed()
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&kernel_ctx),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect_err("fail-closed mode should propagate compaction error");
@@ -3389,7 +3389,7 @@ async fn handle_turn_with_runtime_persists_turn_checkpoint_events_for_successful
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&kernel_ctx),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("success path should persist checkpoint events");
@@ -3459,7 +3459,7 @@ async fn handle_turn_with_runtime_persists_turn_checkpoint_events_for_inline_pro
             "hello",
             ProviderErrorMode::InlineMessage,
             &runtime,
-            Some(&kernel_ctx),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("inline provider error should persist checkpoint events");
@@ -3510,7 +3510,7 @@ async fn handle_turn_with_runtime_persists_turn_checkpoint_event_for_propagated_
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect_err("propagated provider error should still persist checkpoint event");
@@ -3560,7 +3560,7 @@ async fn handle_turn_with_runtime_persists_failed_turn_checkpoint_when_compactio
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&kernel_ctx),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect_err("compaction failure should still persist failed checkpoint event");
@@ -3599,7 +3599,7 @@ async fn handle_turn_with_runtime_propagates_error_without_persisting_reply_turn
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect_err("propagate mode should return error");
@@ -3651,7 +3651,7 @@ async fn handle_turn_with_runtime_inline_mode_returns_synthetic_reply_and_persis
             "hello",
             ProviderErrorMode::InlineMessage,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("inline mode should return synthetic reply");
@@ -3739,7 +3739,7 @@ async fn handle_turn_with_runtime_tool_turn_uses_natural_language_completion_by_
             "read and summarize note.md",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&harness.kernel_ctx),
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
         )
         .await
         .expect("tool turn should succeed");
@@ -3802,7 +3802,7 @@ async fn handle_turn_with_runtime_tool_turn_raw_request_skips_second_pass_comple
             "read note.md and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&harness.kernel_ctx),
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
         )
         .await
         .expect("tool turn should succeed");
@@ -3886,7 +3886,7 @@ async fn handle_turn_with_runtime_provider_switch_tool_updates_provider_for_foll
             "switch to deepseek and continue",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&harness.kernel_ctx),
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
         )
         .await
         .expect("provider switch turn should succeed");
@@ -3950,7 +3950,7 @@ async fn handle_turn_with_runtime_honors_configured_tool_result_summary_limit_on
             "read large-note.md and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&harness.kernel_ctx),
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
         )
         .await
         .expect("tool turn should succeed");
@@ -4023,7 +4023,7 @@ async fn handle_turn_with_runtime_honors_configured_tool_result_summary_limit_on
             "deploy production safely and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&harness.kernel_ctx),
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
         )
         .await
         .expect("safe-lane plan turn should succeed");
@@ -4099,7 +4099,7 @@ async fn handle_turn_with_runtime_safe_lane_honors_configured_tool_step_budget()
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("safe lane should execute with configured step budget");
@@ -4155,7 +4155,7 @@ async fn handle_turn_with_runtime_safe_lane_plan_path_bypasses_turn_step_limit()
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("safe lane plan path should return inline tool error");
@@ -4202,7 +4202,7 @@ async fn handle_turn_with_runtime_safe_lane_plan_persists_runtime_events_when_en
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("safe lane plan should produce a reply");
@@ -4328,7 +4328,7 @@ async fn handle_turn_with_runtime_safe_lane_plan_skips_runtime_events_when_disab
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("safe lane plan should produce a reply");
@@ -4387,7 +4387,7 @@ async fn handle_turn_with_runtime_safe_lane_plan_emits_kernel_runtime_audit_even
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&harness.kernel_ctx),
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
         )
         .await
         .expect("safe lane plan should produce a reply");
@@ -4478,7 +4478,7 @@ async fn handle_turn_with_runtime_safe_lane_plan_does_not_emit_kernel_runtime_au
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&harness.kernel_ctx),
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
         )
         .await
         .expect("safe lane plan should produce a reply");
@@ -4604,7 +4604,7 @@ async fn handle_turn_with_runtime_safe_lane_plan_replans_after_transient_tool_fa
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&ctx),
+            ConversationRuntimeBinding::kernel(&ctx),
         )
         .await
         .expect("safe lane plan should recover via bounded replan");
@@ -4821,7 +4821,7 @@ async fn handle_turn_with_runtime_safe_lane_backpressure_guard_blocks_retry_stor
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&ctx),
+            ConversationRuntimeBinding::kernel(&ctx),
         )
         .await
         .expect("safe lane should fail-fast under backpressure guard");
@@ -4958,7 +4958,7 @@ async fn handle_turn_with_runtime_safe_lane_verify_non_retryable_failure_skips_r
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&ctx),
+            ConversationRuntimeBinding::kernel(&ctx),
         )
         .await
         .expect("safe lane should return verify failure");
@@ -5193,7 +5193,7 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_forces_no_replan() 
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&ctx),
+            ConversationRuntimeBinding::kernel(&ctx),
         )
         .await
         .expect("safe lane should fail without replan under governor");
@@ -5425,7 +5425,7 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_requests_extended_h
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&ctx),
+            ConversationRuntimeBinding::kernel(&ctx),
         )
         .await
         .expect("safe lane turn should complete");
@@ -5601,7 +5601,7 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_falls_back_to_confi
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&ctx),
+            ConversationRuntimeBinding::kernel(&ctx),
         )
         .await
         .expect("safe lane should use sqlite governor fallback history");
@@ -5771,7 +5771,7 @@ async fn handle_turn_with_runtime_safe_lane_replans_failed_subgraph_only() {
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&ctx),
+            ConversationRuntimeBinding::kernel(&ctx),
         )
         .await
         .expect("safe lane should recover by replaying only failed subgraph");
@@ -5820,7 +5820,7 @@ async fn handle_turn_with_runtime_tool_denial_returns_inline_reply_even_in_propa
             "read note.md",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("tool denial should still return inline assistant text");
@@ -5879,7 +5879,7 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
             "read note.md",
             ProviderErrorMode::Propagate,
             &runtime,
-            Some(&harness.kernel_ctx),
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
         )
         .await
         .expect("tool error should still return inline assistant text");
@@ -5936,7 +5936,7 @@ async fn handle_turn_with_runtime_tool_failure_completion_error_uses_raw_reason_
             "read note.md",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("fallback should still return assistant text");
@@ -7641,7 +7641,7 @@ async fn load_turn_checkpoint_event_summary_prefers_kernel_memory_window_when_co
     let summary = load_turn_checkpoint_event_summary(
         "session-k-turn-checkpoint",
         96,
-        Some(&ctx),
+        ConversationRuntimeBinding::kernel(&ctx),
         &mem_config,
     )
     .await
@@ -7905,9 +7905,14 @@ async fn load_turn_checkpoint_event_summary_reads_recovery_state_from_sqlite_his
     )
     .expect("persist failed checkpoint");
 
-    let summary = load_turn_checkpoint_event_summary(session_id, 32, None, &mem_config)
-        .await
-        .expect("load checkpoint event summary");
+    let summary = load_turn_checkpoint_event_summary(
+        session_id,
+        32,
+        ConversationRuntimeBinding::direct(),
+        &mem_config,
+    )
+    .await
+    .expect("load checkpoint event summary");
 
     assert_eq!(summary.checkpoint_events, 2);
     assert_eq!(
@@ -8015,7 +8020,12 @@ async fn repair_turn_checkpoint_tail_with_runtime_finalizes_pending_checkpoint()
         test_kernel_context_with_memory("test-turn-checkpoint-repair-pending", &mem_config);
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
         .await
         .expect("repair pending checkpoint");
 
@@ -8118,7 +8128,12 @@ async fn repair_turn_checkpoint_tail_with_runtime_requires_manual_repair_without
     let coordinator = ConversationTurnCoordinator::new();
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("repair should fail closed when identity is missing");
 
@@ -8230,7 +8245,12 @@ async fn repair_turn_checkpoint_tail_with_runtime_preserves_safe_lane_override_r
     let coordinator = ConversationTurnCoordinator::new();
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("repair should downgrade to manual inspection");
 
@@ -8321,7 +8341,12 @@ async fn repair_turn_checkpoint_tail_with_runtime_requires_manual_repair_on_iden
     let coordinator = ConversationTurnCoordinator::new();
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("repair should fail closed on mismatched visible tail");
 
@@ -8423,7 +8448,12 @@ async fn repair_turn_checkpoint_tail_with_runtime_retries_failed_compaction_only
         test_kernel_context_with_memory("test-turn-checkpoint-repair-compaction", &mem_config);
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
         .await
         .expect("repair failed compaction checkpoint");
 
@@ -8541,7 +8571,12 @@ async fn repair_turn_checkpoint_tail_rebuilds_original_finalization_context_for_
     );
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
         .await
         .expect("repair should replay compaction against original finalization context");
 
@@ -8648,7 +8683,12 @@ async fn repair_turn_checkpoint_tail_prefers_checkpoint_estimate_for_compaction_
     );
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
         .await
         .expect("repair should reuse checkpoint estimate for compaction retry");
 
@@ -8751,7 +8791,12 @@ async fn probe_turn_checkpoint_tail_runtime_gate_reports_preparation_content_mis
     let coordinator = ConversationTurnCoordinator::new();
 
     let probe = coordinator
-        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(&config, session_id, &runtime, None)
+        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("runtime probe should succeed")
         .expect("fingerprint drift should produce a runtime probe");
@@ -8848,7 +8893,12 @@ async fn probe_turn_checkpoint_tail_runtime_gate_returns_none_when_repair_not_ne
     let coordinator = ConversationTurnCoordinator::new();
 
     let probe = coordinator
-        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(&config, session_id, &runtime, None)
+        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("not-needed probe should succeed");
 
@@ -8938,7 +8988,12 @@ async fn probe_turn_checkpoint_tail_runtime_gate_returns_none_for_summary_manual
     let coordinator = ConversationTurnCoordinator::new();
 
     let probe = coordinator
-        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(&config, session_id, &runtime, None)
+        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("summary-manual probe should succeed");
 
@@ -9030,7 +9085,12 @@ async fn probe_turn_checkpoint_tail_runtime_gate_returns_none_for_runnable_repai
     let coordinator = ConversationTurnCoordinator::new();
 
     let probe = coordinator
-        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(&config, session_id, &runtime, None)
+        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("runnable probe should succeed");
 
@@ -9123,7 +9183,11 @@ async fn load_turn_checkpoint_diagnostics_with_runtime_preserves_summary_manual_
 
     let diagnostics = coordinator
         .load_turn_checkpoint_diagnostics_with_runtime_and_limit(
-            &config, session_id, 12, &runtime, None,
+            &config,
+            session_id,
+            12,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("diagnostics should load");
@@ -9239,7 +9303,11 @@ async fn load_turn_checkpoint_diagnostics_with_runtime_preserves_summary_assessm
 
     let diagnostics = coordinator
         .load_turn_checkpoint_diagnostics_with_runtime_and_limit(
-            &config, session_id, 12, &runtime, None,
+            &config,
+            session_id,
+            12,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("diagnostics should load");
@@ -9363,7 +9431,7 @@ async fn load_turn_checkpoint_diagnostics_uses_single_kernel_window_snapshot_for
             session_id,
             12,
             &runtime,
-            Some(&ctx),
+            ConversationRuntimeBinding::kernel(&ctx),
         )
         .await
         .expect("diagnostics should load from one kernel window snapshot");
@@ -9428,7 +9496,7 @@ async fn handle_turn_with_runtime_passes_restricted_tool_view_into_provider_requ
             "hello",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("handle turn success");
@@ -9500,7 +9568,7 @@ async fn handle_turn_with_runtime_executes_session_tools_via_default_dispatcher(
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("handle turn success");
@@ -9586,7 +9654,7 @@ async fn handle_turn_with_runtime_executes_sessions_send_via_default_dispatcher(
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("handle turn success");
@@ -9794,7 +9862,7 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("delegate handle turn success");
@@ -10384,7 +10452,7 @@ async fn handle_turn_with_runtime_delegate_async_queue_failure_rolls_back_child_
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("delegate_async queue failure reply");
@@ -10465,7 +10533,7 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
                 "show raw json tool output",
                 ProviderErrorMode::Propagate,
                 &runtime,
-                None,
+                ConversationRuntimeBinding::direct(),
             )
             .await
     });
@@ -10599,7 +10667,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_is_observable_aft
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("delegate_async reply");
@@ -10712,7 +10780,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_panic_is_observable_after
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("delegate_async reply");
@@ -10839,7 +10907,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_persistence_recov
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("delegate_async reply");
@@ -10974,7 +11042,7 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_by_defa
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("nested delegate denial reply");
@@ -11065,7 +11133,7 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_b
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             runtime.as_ref(),
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("nested delegate_async denial reply");
@@ -11193,7 +11261,7 @@ async fn handle_turn_with_runtime_delegate_child_can_reenter_when_max_depth_allo
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("nested delegate success");
@@ -11297,7 +11365,7 @@ async fn handle_turn_with_runtime_executes_session_wait_via_default_dispatcher()
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("handle turn success");
@@ -11373,7 +11441,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_d
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("safe-lane handle turn success");
@@ -11456,7 +11524,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_d
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("safe-lane handle turn success");
@@ -11556,7 +11624,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_wait_via_default_di
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("safe-lane handle turn success");
@@ -11652,7 +11720,12 @@ async fn repair_turn_checkpoint_tail_requires_manual_repair_on_preparation_conte
     let coordinator = ConversationTurnCoordinator::new();
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("context drift should downgrade to manual repair");
 
@@ -11765,7 +11838,12 @@ async fn repair_turn_checkpoint_tail_requires_manual_repair_on_preparation_conte
     let coordinator = ConversationTurnCoordinator::new();
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("content drift should downgrade to manual repair");
 
@@ -11878,7 +11956,12 @@ async fn repair_turn_checkpoint_tail_requires_manual_repair_on_malformed_prepara
     let coordinator = ConversationTurnCoordinator::new();
 
     let outcome = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, None)
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("malformed preparation should downgrade to manual repair");
 
@@ -11981,7 +12064,12 @@ async fn repair_turn_checkpoint_tail_with_runtime_persists_failed_after_turn_rep
     );
 
     let error = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
         .await
         .expect_err("after_turn repair should fail closed");
     assert!(error.contains("repair after_turn failed"));
@@ -12091,7 +12179,12 @@ async fn repair_turn_checkpoint_tail_with_runtime_persists_failed_compaction_rep
     );
 
     let error = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
         .await
         .expect_err("compaction repair should fail closed");
     assert!(error.contains("repair compaction failed"));
@@ -12199,7 +12292,12 @@ async fn durable_turn_checkpoint_repair_persists_finalized_checkpoint_and_repeat
     );
 
     let first = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
         .await
         .expect("first durable repair should succeed");
     assert_eq!(first.status().as_str(), "repaired");
@@ -12215,9 +12313,14 @@ async fn durable_turn_checkpoint_repair_persists_finalized_checkpoint_and_repeat
     );
     assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 1);
 
-    let summary_after_first = load_turn_checkpoint_event_summary(session_id, 32, None, &mem_config)
-        .await
-        .expect("load summary after first durable repair");
+    let summary_after_first = load_turn_checkpoint_event_summary(
+        session_id,
+        32,
+        ConversationRuntimeBinding::direct(),
+        &mem_config,
+    )
+    .await
+    .expect("load summary after first durable repair");
     assert_eq!(summary_after_first.checkpoint_events, 2);
     assert_eq!(
         summary_after_first.latest_stage,
@@ -12235,7 +12338,12 @@ async fn durable_turn_checkpoint_repair_persists_finalized_checkpoint_and_repeat
     assert!(!summary_after_first.requires_recovery);
 
     let second = coordinator
-        .repair_turn_checkpoint_tail_with_runtime(&config, session_id, &runtime, Some(&kernel_ctx))
+        .repair_turn_checkpoint_tail_with_runtime(
+            &config,
+            session_id,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
         .await
         .expect("second durable repair should be a noop");
     assert_eq!(second.status().as_str(), "not_needed");
@@ -12256,10 +12364,14 @@ async fn durable_turn_checkpoint_repair_persists_finalized_checkpoint_and_repeat
         "repeated repair must not rerun compaction"
     );
 
-    let summary_after_second =
-        load_turn_checkpoint_event_summary(session_id, 32, None, &mem_config)
-            .await
-            .expect("load summary after second durable repair");
+    let summary_after_second = load_turn_checkpoint_event_summary(
+        session_id,
+        32,
+        ConversationRuntimeBinding::direct(),
+        &mem_config,
+    )
+    .await
+    .expect("load summary after second durable repair");
     assert_eq!(summary_after_second.checkpoint_events, 2);
     assert_eq!(
         summary_after_second.latest_stage,
@@ -12348,7 +12460,7 @@ async fn durable_turn_checkpoint_repair_persists_failed_terminal_checkpoint_then
             &config,
             session_id,
             &failing_runtime,
-            Some(&kernel_ctx),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect_err("first durable repair should persist failure and return error");
@@ -12370,10 +12482,14 @@ async fn durable_turn_checkpoint_repair_persists_failed_terminal_checkpoint_then
         1
     );
 
-    let summary_after_failure =
-        load_turn_checkpoint_event_summary(session_id, 32, None, &mem_config)
-            .await
-            .expect("load summary after durable failure");
+    let summary_after_failure = load_turn_checkpoint_event_summary(
+        session_id,
+        32,
+        ConversationRuntimeBinding::direct(),
+        &mem_config,
+    )
+    .await
+    .expect("load summary after durable failure");
     assert_eq!(summary_after_failure.checkpoint_events, 2);
     assert_eq!(
         summary_after_failure.latest_stage,
@@ -12410,7 +12526,7 @@ async fn durable_turn_checkpoint_repair_persists_failed_terminal_checkpoint_then
             &config,
             session_id,
             &retry_runtime,
-            Some(&kernel_ctx),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("second durable repair should recover");
@@ -12435,9 +12551,14 @@ async fn durable_turn_checkpoint_repair_persists_failed_terminal_checkpoint_then
         1
     );
 
-    let summary_after_retry = load_turn_checkpoint_event_summary(session_id, 32, None, &mem_config)
-        .await
-        .expect("load summary after durable retry");
+    let summary_after_retry = load_turn_checkpoint_event_summary(
+        session_id,
+        32,
+        ConversationRuntimeBinding::direct(),
+        &mem_config,
+    )
+    .await
+    .expect("load summary after durable retry");
     assert_eq!(summary_after_retry.checkpoint_events, 3);
     assert_eq!(
         summary_after_retry.latest_stage,
@@ -12459,7 +12580,7 @@ async fn durable_turn_checkpoint_repair_persists_failed_terminal_checkpoint_then
             &config,
             session_id,
             &retry_runtime,
-            Some(&kernel_ctx),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("finalized durable repair should stay noop");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -6365,7 +6365,8 @@ async fn turn_engine_routes_direct_binding_to_app_dispatcher() {
                 "expected direct binding payload in output, got: {text}"
             );
         }
-        other @ TurnResult::ToolDenied(_)
+        other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolDenied(_)
         | other @ TurnResult::ToolError(_)
         | other @ TurnResult::ProviderError(_) => {
             panic!("expected FinalText, got: {other:?}")
@@ -9763,7 +9764,7 @@ async fn handle_turn_with_runtime_requires_approval_before_delegate_execution() 
             "delegate this task",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("approval reply");
@@ -10026,7 +10027,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_replays_delegate_for_
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("approval resolve reply");
@@ -10169,7 +10170,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &approval_runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("approval resolve reply");
@@ -10232,7 +10233,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &granted_runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("granted delegate reply");
@@ -10344,7 +10345,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_deny_does_not_replay_
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("approval deny reply");
@@ -11386,7 +11387,8 @@ async fn handle_turn_with_runtime_executes_session_wait_via_default_dispatcher()
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_dispatcher() {
+async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_dispatcher_when_kernel_bound()
+ {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
         unique_acp_test_id("conversation-session-tools", "safe-lane")
@@ -11433,6 +11435,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_d
         Ok("unused".to_owned()),
     );
     let coordinator = ConversationTurnCoordinator::new();
+    let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
 
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -11441,7 +11444,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_d
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("safe-lane handle turn success");
@@ -11458,7 +11461,8 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_d
 
 #[cfg(all(feature = "memory-sqlite", feature = "channel-telegram"))]
 #[tokio::test]
-async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_dispatcher() {
+async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_dispatcher_when_kernel_bound()
+ {
     let (base_url, request_rx, server) = spawn_telegram_send_server_once();
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
@@ -11516,6 +11520,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_d
         Ok("unused".to_owned()),
     );
     let coordinator = ConversationTurnCoordinator::new();
+    let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
 
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -11524,7 +11529,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_d
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("safe-lane handle turn success");
@@ -11557,7 +11562,8 @@ async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_d
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_safe_lane_executes_session_wait_via_default_dispatcher() {
+async fn handle_turn_with_runtime_safe_lane_executes_session_wait_via_default_dispatcher_when_kernel_bound()
+ {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
         unique_acp_test_id("conversation-session-wait", "safe-lane")
@@ -11616,6 +11622,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_wait_via_default_di
         Ok("unused".to_owned()),
     );
     let coordinator = ConversationTurnCoordinator::new();
+    let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
 
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -11624,7 +11631,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_wait_via_default_di
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("safe-lane handle turn success");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -257,7 +257,7 @@ impl ConversationContextEngine for StubContextEngine {
         _config: &LoongClawConfig,
         _session_id: &str,
         _include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>> {
         Ok(vec![json!({
             "role": "system",
@@ -277,7 +277,7 @@ impl ConversationContextEngine for StubEnvContextEngine {
         _config: &LoongClawConfig,
         _session_id: &str,
         _include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>> {
         Ok(vec![json!({
             "role": "system",
@@ -301,7 +301,7 @@ impl ConversationContextEngine for StubSystemPromptAdditionEngine {
         _config: &LoongClawConfig,
         _session_id: &str,
         _include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
         Ok(AssembledConversationContext {
             messages: vec![json!({
@@ -318,7 +318,7 @@ impl ConversationContextEngine for StubSystemPromptAdditionEngine {
         _config: &LoongClawConfig,
         _session_id: &str,
         _include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>> {
         Ok(vec![json!({
             "role": "system",
@@ -402,7 +402,7 @@ impl ConversationContextEngine for RecordingLifecycleContextEngine {
         _config: &LoongClawConfig,
         _session_id: &str,
         _include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>> {
         Ok(Vec::new())
     }
@@ -797,11 +797,11 @@ impl ConversationRuntime for FakeRuntime {
         &self,
         config: &LoongClawConfig,
         session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<crate::tools::ToolView> {
         match self.tool_view_override.clone() {
             Some(tool_view) => Ok(tool_view),
-            None => DefaultConversationRuntime::default().tool_view(config, session_id, kernel_ctx),
+            None => DefaultConversationRuntime::default().tool_view(config, session_id, binding),
         }
     }
 
@@ -848,7 +848,7 @@ impl ConversationRuntime for FakeRuntime {
         _session_id: &str,
         include_system_prompt: bool,
         tool_view: &crate::tools::ToolView,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>> {
         self.built_tool_views
             .lock()
@@ -869,7 +869,7 @@ impl ConversationRuntime for FakeRuntime {
         _config: &LoongClawConfig,
         session_id: &str,
         include_system_prompt: bool,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
         self.build_context_calls
             .lock()
@@ -889,7 +889,7 @@ impl ConversationRuntime for FakeRuntime {
         &self,
         config: &LoongClawConfig,
         messages: &[Value],
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let mut calls = self.completion_calls.lock().expect("completion calls lock");
         *calls += 1;
@@ -915,7 +915,7 @@ impl ConversationRuntime for FakeRuntime {
         config: &LoongClawConfig,
         messages: &[Value],
         tool_view: &crate::tools::ToolView,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ProviderTurn> {
         let mut calls = self.turn_calls.lock().expect("turn calls lock");
         *calls += 1;
@@ -945,7 +945,7 @@ impl ConversationRuntime for FakeRuntime {
         session_id: &str,
         role: &str,
         content: &str,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<()> {
         #[cfg(feature = "memory-sqlite")]
         if let Some(config) = self.durable_memory_config.as_ref() {
@@ -1050,11 +1050,18 @@ fn test_kernel_context_with_memory(
 #[tokio::test]
 async fn default_runtime_supports_injected_context_engine() {
     let runtime = DefaultConversationRuntime::with_context_engine(StubContextEngine);
+    let binding = crate::conversation::ConversationRuntimeBinding::direct();
     let tool_view = runtime
-        .tool_view(&test_config(), "session-injected", None)
+        .tool_view(&test_config(), "session-injected", binding)
         .expect("default runtime tool view");
     let messages = runtime
-        .build_messages(&test_config(), "session-injected", true, &tool_view, None)
+        .build_messages(
+            &test_config(),
+            "session-injected",
+            true,
+            &tool_view,
+            binding,
+        )
         .await
         .expect("build messages via injected context engine");
 
@@ -1069,11 +1076,18 @@ async fn default_runtime_can_resolve_context_engine_from_registry() {
         .expect("register context engine");
     let runtime = DefaultConversationRuntime::from_engine_id(Some("stub-registry"))
         .expect("resolve context engine from registry");
+    let binding = crate::conversation::ConversationRuntimeBinding::direct();
     let tool_view = runtime
-        .tool_view(&test_config(), "session-registry", None)
+        .tool_view(&test_config(), "session-registry", binding)
         .expect("default runtime tool view");
     let messages = runtime
-        .build_messages(&test_config(), "session-registry", true, &tool_view, None)
+        .build_messages(
+            &test_config(),
+            "session-registry",
+            true,
+            &tool_view,
+            binding,
+        )
         .await
         .expect("build messages via registry context engine");
 
@@ -1093,11 +1107,12 @@ async fn default_runtime_prefers_configured_context_engine_when_env_not_set() {
 
     let runtime = DefaultConversationRuntime::from_config_or_env(&config)
         .expect("resolve context engine from config");
+    let binding = ConversationRuntimeBinding::direct();
     let tool_view = runtime
-        .tool_view(&config, "session-config", None)
+        .tool_view(&config, "session-config", binding)
         .expect("configured runtime tool view");
     let messages = runtime
-        .build_messages(&config, "session-config", true, &tool_view, None)
+        .build_messages(&config, "session-config", true, &tool_view, binding)
         .await
         .expect("build messages via configured context engine");
 
@@ -1117,9 +1132,10 @@ fn default_runtime_exposes_context_engine_metadata() {
 async fn default_runtime_build_messages_respects_restricted_tool_view() {
     let runtime = DefaultConversationRuntime::default();
     let view = crate::tools::ToolView::from_tool_names(["file.read"]);
+    let binding = ConversationRuntimeBinding::direct();
 
     let messages = runtime
-        .build_messages(&test_config(), "noop-session", true, &view, None)
+        .build_messages(&test_config(), "noop-session", true, &view, binding)
         .await
         .expect("build messages");
 
@@ -1164,7 +1180,11 @@ fn default_runtime_tool_view_uses_persisted_delegate_child_restrictions() {
 
     let runtime = DefaultConversationRuntime::default();
     let child_view = runtime
-        .tool_view(&config, "child-session", None)
+        .tool_view(
+            &config,
+            "child-session",
+            ConversationRuntimeBinding::direct(),
+        )
         .expect("child tool view");
 
     assert!(child_view.contains("file.read"));
@@ -1198,7 +1218,11 @@ fn default_runtime_tool_view_denies_delegate_for_broken_lineage_child() {
 
     let runtime = DefaultConversationRuntime::default();
     let child_view = runtime
-        .tool_view(&config, "child-session", None)
+        .tool_view(
+            &config,
+            "child-session",
+            ConversationRuntimeBinding::direct(),
+        )
         .expect("child tool view");
 
     assert!(child_view.contains("file.read"));
@@ -1241,7 +1265,11 @@ fn default_runtime_session_context_uses_persisted_parent_session_id() {
 
     let runtime = DefaultConversationRuntime::default();
     let session_context = runtime
-        .session_context(&config, "child-session", None)
+        .session_context(
+            &config,
+            "child-session",
+            ConversationRuntimeBinding::direct(),
+        )
         .expect("session context");
 
     assert_eq!(session_context.session_id, "child-session");
@@ -1319,8 +1347,9 @@ async fn default_runtime_delegates_subagent_lifecycle_to_context_engine_with_ker
 #[tokio::test]
 async fn default_runtime_build_context_applies_system_prompt_addition() {
     let runtime = DefaultConversationRuntime::with_context_engine(StubSystemPromptAdditionEngine);
+    let binding = crate::conversation::ConversationRuntimeBinding::direct();
     let assembled = runtime
-        .build_context(&test_config(), "session-system-addition", true, None)
+        .build_context(&test_config(), "session-system-addition", true, binding)
         .await
         .expect("build context with system prompt addition");
 
@@ -1364,7 +1393,12 @@ async fn default_runtime_build_context_matches_builtin_summary_projection() {
         .expect("append turn 4 should succeed");
 
     let assembled = runtime
-        .build_context(&config, &session_id, true, None)
+        .build_context(
+            &config,
+            &session_id,
+            true,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("build context from default runtime");
     let provider_messages = crate::provider::build_messages_for_session(&config, &session_id, true)
@@ -1406,7 +1440,12 @@ async fn default_runtime_build_context_explicit_builtin_system_preserves_profile
         .expect("append turn should succeed");
 
     let assembled = runtime
-        .build_context(&config, &session_id, true, None)
+        .build_context(
+            &config,
+            &session_id,
+            true,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("build context from default runtime");
     let provider_messages = crate::provider::build_messages_for_session(&config, &session_id, true)
@@ -1458,7 +1497,12 @@ async fn default_runtime_build_context_fail_open_memory_derivation_preserves_rec
         .expect("append turn 3 should succeed");
 
     let assembled = runtime
-        .build_context(&config, &session_id, true, None)
+        .build_context(
+            &config,
+            &session_id,
+            true,
+            ConversationRuntimeBinding::direct(),
+        )
         .await
         .expect("build context should stay available when memory derivation degrades");
 
@@ -1561,11 +1605,12 @@ async fn default_runtime_prefers_env_context_engine_over_config() {
 
     let runtime = DefaultConversationRuntime::from_config_or_env(&config)
         .expect("resolve context engine from env override");
+    let binding = ConversationRuntimeBinding::direct();
     let tool_view = runtime
-        .tool_view(&config, "session-env-priority", None)
+        .tool_view(&config, "session-env-priority", binding)
         .expect("env-selected runtime tool view");
     let messages = runtime
-        .build_messages(&config, "session-env-priority", true, &tool_view, None)
+        .build_messages(&config, "session-env-priority", true, &tool_view, binding)
         .await
         .expect("build messages via env-selected context engine");
 
@@ -6157,7 +6202,7 @@ async fn turn_engine_routes_app_tools_through_dispatcher() {
             &self,
             session_context: &crate::conversation::SessionContext,
             request: ToolCoreRequest,
-            _kernel_ctx: Option<&KernelContext>,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
         ) -> Result<ToolCoreOutcome, String> {
             self.calls.lock().expect("dispatcher calls lock").push((
                 session_context.session_id.clone(),
@@ -6198,7 +6243,7 @@ async fn turn_engine_routes_app_tools_through_dispatcher() {
             &turn,
             &session_context,
             &dispatcher,
-            Some(&kernel_ctx),
+            crate::conversation::ConversationRuntimeBinding::kernel(&kernel_ctx),
             None,
         )
         .await;
@@ -6235,6 +6280,105 @@ async fn turn_engine_routes_app_tools_through_dispatcher() {
             .expect("dispatcher calls lock")
             .as_slice(),
         &[("root-session".to_owned(), "sessions_list".to_owned())]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_routes_direct_binding_to_app_dispatcher() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct BindingRecordingAppDispatcher {
+        bindings: Mutex<Vec<bool>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for BindingRecordingAppDispatcher {
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.bindings
+                .lock()
+                .expect("dispatcher bindings lock")
+                .push(binding.is_kernel_bound());
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool_name": request.tool_name,
+                    "binding_scope": if binding.is_kernel_bound() {
+                        "kernel"
+                    } else {
+                        "direct"
+                    },
+                }),
+            })
+        }
+    }
+
+    let dispatcher = BindingRecordingAppDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![ToolIntent {
+            tool_name: "sessions_list".to_owned(),
+            args_json: json!({}),
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-app-direct".to_owned(),
+            tool_call_id: "call-app-direct".to_owned(),
+        }],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &dispatcher,
+            crate::conversation::ConversationRuntimeBinding::direct(),
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            let line = text.lines().next().expect("tool result line should exist");
+            let payload = line
+                .strip_prefix("[ok] ")
+                .expect("tool result line should keep [ok] prefix");
+            let envelope: Value =
+                serde_json::from_str(payload).expect("tool result envelope should be json");
+            assert_eq!(envelope["tool"], "sessions_list");
+            assert!(
+                envelope["payload_summary"]
+                    .as_str()
+                    .expect("payload summary should be text")
+                    .contains("\"binding_scope\":\"direct\""),
+                "expected direct binding payload in output, got: {text}"
+            );
+        }
+        other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected FinalText, got: {other:?}")
+        }
+    }
+
+    assert_eq!(
+        dispatcher
+            .bindings
+            .lock()
+            .expect("dispatcher bindings lock")
+            .as_slice(),
+        &[false]
     );
 }
 
@@ -6294,7 +6438,7 @@ async fn default_app_tool_dispatcher_executes_session_wait_for_visible_terminal_
                     "timeout_ms": 50
                 }),
             },
-            None,
+            crate::conversation::ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("session_wait outcome");
@@ -6353,7 +6497,7 @@ async fn child_session_hidden_session_wait_is_rejected_by_default_dispatcher() {
                     "timeout_ms": 10
                 }),
             },
-            None,
+            crate::conversation::ConversationRuntimeBinding::direct(),
         )
         .await
         .expect_err("child should not execute hidden session_wait");
@@ -6413,7 +6557,7 @@ async fn child_session_hidden_sessions_send_is_rejected_by_default_dispatcher() 
                     "text": "hello"
                 }),
             },
-            None,
+            crate::conversation::ConversationRuntimeBinding::direct(),
         )
         .await
         .expect_err("child should not execute hidden sessions_send");
@@ -6459,7 +6603,7 @@ async fn sessions_send_rejects_unknown_target_session() {
                     "text": "hello"
                 }),
             },
-            None,
+            crate::conversation::ConversationRuntimeBinding::direct(),
         )
         .await
         .expect_err("unknown session target must be rejected");
@@ -6513,7 +6657,7 @@ async fn sessions_send_rejects_delegate_child_target() {
                     "text": "hello"
                 }),
             },
-            None,
+            crate::conversation::ConversationRuntimeBinding::direct(),
         )
         .await
         .expect_err("delegate child target must be rejected");
@@ -7102,13 +7246,27 @@ async fn turn_engine_persists_tool_lifecycle_events() {
         audit_event_id: Some("audit-001".to_owned()),
     };
 
-    persist_tool_decision(&runtime, "sess-1", "turn-1", "call-1", &decision, None)
-        .await
-        .expect("persist decision");
+    persist_tool_decision(
+        &runtime,
+        "sess-1",
+        "turn-1",
+        "call-1",
+        &decision,
+        ConversationRuntimeBinding::direct(),
+    )
+    .await
+    .expect("persist decision");
 
-    persist_tool_outcome(&runtime, "sess-1", "turn-1", "call-1", &outcome, None)
-        .await
-        .expect("persist outcome");
+    persist_tool_outcome(
+        &runtime,
+        "sess-1",
+        "turn-1",
+        "call-1",
+        &outcome,
+        ConversationRuntimeBinding::direct(),
+    )
+    .await
+    .expect("persist outcome");
 
     let persisted = runtime.persisted.lock().expect("persisted lock");
     assert_eq!(persisted.len(), 2, "expected two persisted records");
@@ -7196,6 +7354,23 @@ fn build_kernel_context_with_window_turns(
     };
 
     (ctx, invocations)
+}
+
+#[test]
+fn conversation_runtime_binding_direct_reports_no_kernel_context() {
+    let binding = crate::conversation::ConversationRuntimeBinding::direct();
+
+    assert!(!binding.is_kernel_bound());
+    assert!(binding.kernel_context().is_none());
+}
+
+#[test]
+fn conversation_runtime_binding_kernel_exposes_bound_context() {
+    let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
+    let binding = crate::conversation::ConversationRuntimeBinding::kernel(&kernel_ctx);
+
+    assert!(binding.is_kernel_bound());
+    assert!(binding.kernel_context().is_some());
 }
 
 fn build_kernel_context_with_window_turn_sequence(
@@ -7315,10 +7490,11 @@ impl CoreMemoryAdapter for SequencedTestMemoryAdapter {
 async fn persist_turn_routes_through_kernel_when_context_provided() {
     let audit = Arc::new(InMemoryAuditSink::default());
     let (ctx, invocations) = build_kernel_context(audit.clone());
+    let binding = crate::conversation::ConversationRuntimeBinding::kernel(&ctx);
 
     let runtime = DefaultConversationRuntime::default();
     runtime
-        .persist_turn("session-k1", "user", "kernel-hello", Some(&ctx))
+        .persist_turn("session-k1", "user", "kernel-hello", binding)
         .await
         .expect("persist via kernel");
 
@@ -7353,11 +7529,12 @@ async fn build_messages_routes_memory_window_through_kernel_when_context_provide
     let (ctx, invocations) = build_kernel_context(audit.clone());
     let runtime = DefaultConversationRuntime::default();
     let config = test_config();
+    let binding = crate::conversation::ConversationRuntimeBinding::kernel(&ctx);
     let tool_view = runtime
-        .tool_view(&config, "session-k-window", Some(&ctx))
+        .tool_view(&config, "session-k-window", binding)
         .expect("kernel window tool view");
     let messages = runtime
-        .build_messages(&config, "session-k-window", true, &tool_view, Some(&ctx))
+        .build_messages(&config, "session-k-window", true, &tool_view, binding)
         .await
         .expect("build messages via kernel");
 
@@ -7503,7 +7680,12 @@ async fn persist_turn_without_memory_sqlite_is_noop_with_kernel_context() {
         .expect("bootstrap kernel context without memory-sqlite");
     let runtime = DefaultConversationRuntime::default();
     runtime
-        .persist_turn("session-k0", "user", "no-memory", Some(&ctx))
+        .persist_turn(
+            "session-k0",
+            "user",
+            "no-memory",
+            ConversationRuntimeBinding::kernel(&ctx),
+        )
         .await
         .expect("persist should be no-op when memory-sqlite is disabled");
 }
@@ -7595,7 +7777,7 @@ async fn persisted_turn_checkpoint_events_survive_reload_without_polluting_promp
             session_id,
             true,
             &crate::tools::runtime_tool_view_for_config(&config.tools),
-            None,
+            ConversationRuntimeBinding::direct(),
         )
         .await
         .expect("reload prompt history");

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4378,14 +4378,11 @@ async fn evaluate_safe_lane_round(
         state.tool_node_max_attempts(),
         state.plan_start_tool_index,
     );
-    let Some(kernel_ctx) = binding.kernel_context() else {
-        return synthetic_safe_lane_round_without_kernel(&plan);
-    };
     let executor = SafeLanePlanNodeExecutor::new(
         turn.tool_intents.as_slice(),
         session_context,
         app_dispatcher,
-        Some(kernel_ctx),
+        binding.kernel_context(),
         ingress,
         config.conversation.safe_lane_verify_output_non_empty,
         state.seed_tool_outputs.clone(),
@@ -4401,39 +4398,6 @@ async fn evaluate_safe_lane_round(
         report,
         tool_outputs,
         tool_output_stats,
-    }
-}
-
-fn synthetic_safe_lane_round_without_kernel(plan: &PlanGraph) -> SafeLaneRoundExecution {
-    let ordered_nodes = plan
-        .nodes
-        .iter()
-        .map(|node| node.id.clone())
-        .collect::<Vec<_>>();
-    let failed_node_id = plan
-        .nodes
-        .iter()
-        .find(|node| matches!(node.kind, PlanNodeKind::Tool))
-        .or_else(|| plan.nodes.first())
-        .map(|node| node.id.clone())
-        .unwrap_or_else(|| "tool-1".to_owned());
-    let failure = PlanRunFailure::NodeFailed {
-        node_id: failed_node_id,
-        attempts_used: 1,
-        last_error_kind: PlanNodeErrorKind::PolicyDenied,
-        last_error: "no_kernel_context".to_owned(),
-    };
-
-    SafeLaneRoundExecution {
-        report: PlanRunReport {
-            status: PlanRunStatus::Failed(failure),
-            ordered_nodes,
-            attempts_used: 1,
-            attempt_events: Vec::new(),
-            elapsed_ms: 0,
-        },
-        tool_outputs: Vec::new(),
-        tool_output_stats: summarize_safe_lane_tool_output_stats(&[]),
     }
 }
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -893,7 +893,7 @@ impl ProviderTurnContinuePhase {
         runtime: &R,
         preparation: &ProviderTurnPreparation,
         user_input: &str,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> String {
         resolve_provider_turn_reply(
             runtime,
@@ -902,7 +902,7 @@ impl ProviderTurnContinuePhase {
             &self.lane_execution,
             &self.reply_phase,
             user_input,
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -1187,7 +1187,7 @@ impl<'a> ProviderTurnTerminalPhase<'a> {
         runtime: &R,
         session_id: &str,
         user_input: &str,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         match self {
             Self::PersistReply(phase) => {
@@ -1198,7 +1198,7 @@ impl<'a> ProviderTurnTerminalPhase<'a> {
                     user_input,
                     &phase.tail_phase,
                     phase.checkpoint,
-                    kernel_ctx,
+                    binding,
                 )
                 .await
             }
@@ -1207,7 +1207,7 @@ impl<'a> ProviderTurnTerminalPhase<'a> {
                     runtime,
                     session_id,
                     phase.checkpoint,
-                    kernel_ctx,
+                    binding,
                 )
                 .await?;
                 Err(phase.error.to_owned())
@@ -1339,7 +1339,7 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         user_input: &str,
         error_mode: ProviderErrorMode,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::automatic();
         self.handle_turn_with_acp_options(
@@ -1348,7 +1348,7 @@ impl ConversationTurnCoordinator {
             user_input,
             error_mode,
             &acp_options,
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -1385,7 +1385,7 @@ impl ConversationTurnCoordinator {
         user_input: &str,
         error_mode: ProviderErrorMode,
         acp_options: &AcpConversationTurnOptions<'_>,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let address = ConversationSessionAddress::from_session_id(session_id);
         self.handle_turn_with_address_and_acp_options(
@@ -1394,7 +1394,7 @@ impl ConversationTurnCoordinator {
             user_input,
             error_mode,
             acp_options,
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -1403,10 +1403,10 @@ impl ConversationTurnCoordinator {
         &self,
         config: &LoongClawConfig,
         session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointTailRepairOutcome> {
         let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
-        self.repair_turn_checkpoint_tail_with_runtime(config, session_id, &runtime, kernel_ctx)
+        self.repair_turn_checkpoint_tail_with_runtime(config, session_id, &runtime, binding)
             .await
     }
 
@@ -1414,7 +1414,7 @@ impl ConversationTurnCoordinator {
         &self,
         config: &LoongClawConfig,
         session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointDiagnostics> {
         let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
         self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
@@ -1422,7 +1422,7 @@ impl ConversationTurnCoordinator {
             session_id,
             config.memory.sliding_window,
             &runtime,
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -1432,11 +1432,11 @@ impl ConversationTurnCoordinator {
         config: &LoongClawConfig,
         session_id: &str,
         limit: usize,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointDiagnostics> {
         let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
         self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
-            config, session_id, limit, &runtime, kernel_ctx,
+            config, session_id, limit, &runtime, binding,
         )
         .await
     }
@@ -1445,7 +1445,7 @@ impl ConversationTurnCoordinator {
         &self,
         config: &LoongClawConfig,
         session_id: &str,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
         let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
         self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
@@ -1453,7 +1453,7 @@ impl ConversationTurnCoordinator {
             session_id,
             config.memory.sliding_window,
             &runtime,
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -1463,11 +1463,11 @@ impl ConversationTurnCoordinator {
         config: &LoongClawConfig,
         session_id: &str,
         limit: usize,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
         let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
         self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
-            config, session_id, limit, &runtime, kernel_ctx,
+            config, session_id, limit, &runtime, binding,
         )
         .await
     }
@@ -1479,7 +1479,7 @@ impl ConversationTurnCoordinator {
         user_input: &str,
         error_mode: ProviderErrorMode,
         acp_event_sink: Option<&dyn AcpTurnEventSink>,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::from_event_sink(acp_event_sink);
         self.handle_turn_with_acp_options(
@@ -1488,7 +1488,7 @@ impl ConversationTurnCoordinator {
             user_input,
             error_mode,
             &acp_options,
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -1499,7 +1499,7 @@ impl ConversationTurnCoordinator {
         address: &ConversationSessionAddress,
         user_input: &str,
         error_mode: ProviderErrorMode,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::automatic();
         self.handle_turn_with_address_and_acp_options(
@@ -1508,7 +1508,7 @@ impl ConversationTurnCoordinator {
             user_input,
             error_mode,
             &acp_options,
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -1520,7 +1520,7 @@ impl ConversationTurnCoordinator {
         user_input: &str,
         error_mode: ProviderErrorMode,
         acp_event_sink: Option<&dyn AcpTurnEventSink>,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::from_event_sink(acp_event_sink);
         self.handle_turn_with_address_and_acp_options(
@@ -1529,7 +1529,7 @@ impl ConversationTurnCoordinator {
             user_input,
             error_mode,
             &acp_options,
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -1565,7 +1565,7 @@ impl ConversationTurnCoordinator {
         user_input: &str,
         error_mode: ProviderErrorMode,
         acp_options: &AcpConversationTurnOptions<'_>,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
@@ -1575,7 +1575,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             &runtime,
             acp_options,
-            kernel_ctx,
+            binding,
             None,
         )
         .await
@@ -1588,7 +1588,7 @@ impl ConversationTurnCoordinator {
         user_input: &str,
         error_mode: ProviderErrorMode,
         runtime: &R,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::automatic();
         self.handle_turn_with_runtime_and_acp_options(
@@ -1598,7 +1598,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             runtime,
             &acp_options,
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -1633,7 +1633,7 @@ impl ConversationTurnCoordinator {
         config: &LoongClawConfig,
         session_id: &str,
         runtime: &R,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointTailRepairOutcome> {
         #[cfg(feature = "memory-sqlite")]
         {
@@ -1641,7 +1641,7 @@ impl ConversationTurnCoordinator {
             let Some(entry) = load_latest_turn_checkpoint_entry(
                 session_id,
                 config.memory.sliding_window,
-                kernel_ctx,
+                binding,
                 &memory_config,
             )
             .await?
@@ -1649,12 +1649,12 @@ impl ConversationTurnCoordinator {
                 return Ok(TurnCheckpointTailRepairOutcome::no_checkpoint());
             };
 
-            repair_turn_checkpoint_tail_entry(config, runtime, session_id, &entry, kernel_ctx).await
+            repair_turn_checkpoint_tail_entry(config, runtime, session_id, &entry, binding).await
         }
 
         #[cfg(not(feature = "memory-sqlite"))]
         {
-            let _ = (config, session_id, runtime, kernel_ctx);
+            let _ = (config, session_id, runtime, binding);
             Err("turn checkpoint repair unavailable: memory-sqlite feature disabled".to_owned())
         }
     }
@@ -1667,19 +1667,15 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         limit: usize,
         runtime: &R,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointDiagnostics> {
         #[cfg(feature = "memory-sqlite")]
         {
             let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-            let (summary, latest_entry) = load_turn_checkpoint_history_snapshot(
-                session_id,
-                limit,
-                kernel_ctx,
-                &memory_config,
-            )
-            .await?
-            .into_summary_and_latest_entry();
+            let (summary, latest_entry) =
+                load_turn_checkpoint_history_snapshot(session_id, limit, binding, &memory_config)
+                    .await?
+                    .into_summary_and_latest_entry();
             let recovery = TurnCheckpointRecoveryAssessment::from_summary(&summary);
             let runtime_probe = match recovery.action() {
                 TurnCheckpointRecoveryAction::None
@@ -1690,7 +1686,7 @@ impl ConversationTurnCoordinator {
                     match latest_entry.as_ref() {
                         Some(entry) => {
                             probe_turn_checkpoint_tail_runtime_gate_entry(
-                                config, runtime, session_id, entry, kernel_ctx,
+                                config, runtime, session_id, entry, binding,
                             )
                             .await?
                         }
@@ -1707,7 +1703,7 @@ impl ConversationTurnCoordinator {
 
         #[cfg(not(feature = "memory-sqlite"))]
         {
-            let _ = (config, session_id, limit, runtime, kernel_ctx);
+            let _ = (config, session_id, limit, runtime, binding);
             Err(
                 "turn checkpoint diagnostics unavailable: memory-sqlite feature disabled"
                     .to_owned(),
@@ -1722,14 +1718,14 @@ impl ConversationTurnCoordinator {
         config: &LoongClawConfig,
         session_id: &str,
         runtime: &R,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
         self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             config,
             session_id,
             config.memory.sliding_window,
             runtime,
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -1742,19 +1738,19 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         limit: usize,
         runtime: &R,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
         #[cfg(feature = "memory-sqlite")]
         {
             probe_turn_checkpoint_tail_runtime_gate_entry_with_limit(
-                config, runtime, session_id, limit, kernel_ctx,
+                config, runtime, session_id, limit, binding,
             )
             .await
         }
 
         #[cfg(not(feature = "memory-sqlite"))]
         {
-            let _ = (config, session_id, runtime, kernel_ctx);
+            let _ = (config, session_id, runtime, binding);
             Err(
                 "turn checkpoint runtime probe unavailable: memory-sqlite feature disabled"
                     .to_owned(),
@@ -1770,7 +1766,7 @@ impl ConversationTurnCoordinator {
         error_mode: ProviderErrorMode,
         runtime: &R,
         acp_options: &AcpConversationTurnOptions<'_>,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let address = ConversationSessionAddress::from_session_id(session_id);
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
@@ -1780,7 +1776,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             runtime,
             acp_options,
-            kernel_ctx,
+            binding,
             None,
         )
         .await
@@ -1794,7 +1790,7 @@ impl ConversationTurnCoordinator {
         error_mode: ProviderErrorMode,
         runtime: &R,
         acp_event_sink: Option<&dyn AcpTurnEventSink>,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::from_event_sink(acp_event_sink);
         self.handle_turn_with_runtime_and_acp_options(
@@ -1804,7 +1800,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             runtime,
             &acp_options,
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -1816,7 +1812,7 @@ impl ConversationTurnCoordinator {
         user_input: &str,
         error_mode: ProviderErrorMode,
         runtime: &R,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::automatic();
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
@@ -1826,7 +1822,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             runtime,
             &acp_options,
-            kernel_ctx,
+            binding,
             None,
         )
         .await
@@ -1842,7 +1838,7 @@ impl ConversationTurnCoordinator {
         error_mode: ProviderErrorMode,
         runtime: &R,
         acp_options: &AcpConversationTurnOptions<'_>,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
             config,
@@ -1878,8 +1874,6 @@ impl ConversationTurnCoordinator {
                     ProviderErrorMode::Propagate => Err(error),
                     ProviderErrorMode::InlineMessage => {
                         let synthetic = format_provider_error_reply(&error);
-                        let binding =
-                            ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
                         persist_reply_turns_raw_with_mode(
                             runtime,
                             session_id,
@@ -1902,15 +1896,14 @@ impl ConversationTurnCoordinator {
                         error_mode,
                         runtime,
                         acp_options,
-                        kernel_ctx,
+                        binding,
                     )
                     .await;
             }
             AcpConversationTurnEntryDecision::StayOnProvider => {}
         }
 
-        let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
-        if let Some(kernel_ctx) = kernel_ctx {
+        if let Some(kernel_ctx) = binding.kernel_context() {
             runtime.bootstrap(config, session_id, kernel_ctx).await?;
         }
         let session_context = runtime.session_context(config, session_id, binding)?;
@@ -1935,7 +1928,7 @@ impl ConversationTurnCoordinator {
                 .request_turn(config, &preparation.session.messages, &tool_view, binding)
                 .await,
             error_mode,
-            kernel_ctx,
+            binding,
             ingress,
         )
         .await;
@@ -1947,7 +1940,7 @@ impl ConversationTurnCoordinator {
             user_input,
             &preparation,
             &resolved_turn,
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -1991,7 +1984,7 @@ impl ConversationTurnCoordinator {
         error_mode: ProviderErrorMode,
         runtime: &R,
         acp_event_sink: Option<&dyn AcpTurnEventSink>,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::from_event_sink(acp_event_sink);
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
@@ -2001,7 +1994,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             runtime,
             &acp_options,
-            kernel_ctx,
+            binding,
             None,
         )
         .await
@@ -2015,7 +2008,7 @@ impl ConversationTurnCoordinator {
         error_mode: ProviderErrorMode,
         runtime: &R,
         acp_options: &AcpConversationTurnOptions<'_>,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let session_id = address.session_id.as_str();
         let executed =
@@ -2026,7 +2019,6 @@ impl ConversationTurnCoordinator {
         match executed.outcome {
             AcpConversationTurnExecutionOutcome::Succeeded(success) => {
                 let reply = success.result.output_text.clone();
-                let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
                 persist_reply_turns_raw_with_mode(
                     runtime,
                     session_id,
@@ -2051,7 +2043,6 @@ impl ConversationTurnCoordinator {
                 Ok(reply)
             }
             AcpConversationTurnExecutionOutcome::Failed(failure) => {
-                let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
                 if config.acp.emit_runtime_events {
                     let _ = persist_acp_runtime_events(
                         runtime,
@@ -2091,7 +2082,7 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     messages: &[Value],
     estimated_tokens: Option<usize>,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<ContextCompactionOutcome> {
     let estimated_tokens = estimated_tokens.or_else(|| estimate_tokens(messages));
     if !config
@@ -2100,7 +2091,7 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
     {
         return Ok(ContextCompactionOutcome::Skipped);
     }
-    let Some(kernel_ctx) = kernel_ctx else {
+    let Some(kernel_ctx) = binding.kernel_context() else {
         return Ok(ContextCompactionOutcome::Skipped);
     };
 
@@ -2171,7 +2162,7 @@ async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
     preparation: &ProviderTurnPreparation,
     result: CliResult<ProviderTurn>,
     error_mode: ProviderErrorMode,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
 ) -> ResolvedProviderTurn {
     match decide_provider_turn_request_action(result, error_mode) {
@@ -2182,12 +2173,12 @@ async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
                 session_id,
                 preparation,
                 turn,
-                kernel_ctx,
+                binding,
                 ingress,
             )
             .await;
             let reply = continue_phase
-                .resolve_reply(runtime, preparation, user_input, kernel_ctx)
+                .resolve_reply(runtime, preparation, user_input, binding)
                 .await;
             let checkpoint = continue_phase.checkpoint(preparation, user_input, reply.as_str());
             ResolvedProviderTurn::persist_reply(reply, checkpoint)
@@ -2208,7 +2199,7 @@ async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     preparation: &ProviderTurnPreparation,
     turn: ProviderTurn,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
 ) -> ProviderTurnContinuePhase {
     let tool_intents = turn.tool_intents.len();
@@ -2218,7 +2209,7 @@ async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
         session_id,
         preparation,
         &turn,
-        kernel_ctx,
+        binding,
         ingress,
     )
     .await;
@@ -2234,7 +2225,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     lane_execution: &ProviderTurnLaneExecution,
     phase: &ToolDrivenReplyPhase,
     user_input: &str,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> String {
     match phase.decision() {
         ToolDrivenReplyBaseDecision::FinalizeDirect { reply } => reply.clone(),
@@ -2252,7 +2243,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                 runtime,
                 config,
                 &follow_up_messages,
-                kernel_ctx,
+                binding,
                 raw_reply.as_str(),
             )
             .await
@@ -2316,7 +2307,7 @@ async fn persist_turn_checkpoint_event<R: ConversationRuntime + ?Sized>(
     stage: TurnCheckpointStage,
     progress: TurnCheckpointFinalizationProgress,
     failure: Option<TurnCheckpointFailure>,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
     let checkpoint = serde_json::to_value(checkpoint)
         .map_err(|error| format!("serialize turn checkpoint failed: {error}"))?;
@@ -2327,7 +2318,7 @@ async fn persist_turn_checkpoint_event<R: ConversationRuntime + ?Sized>(
         stage,
         progress,
         failure,
-        kernel_ctx,
+        binding,
     )
     .await
 }
@@ -2339,9 +2330,8 @@ async fn persist_turn_checkpoint_event_value<R: ConversationRuntime + ?Sized>(
     stage: TurnCheckpointStage,
     progress: TurnCheckpointFinalizationProgress,
     failure: Option<TurnCheckpointFailure>,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
-    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
     persist_conversation_event(
         runtime,
         session_id,
@@ -2500,11 +2490,11 @@ async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
     runtime: &R,
     session_id: &str,
     entry: &super::session_history::TurnCheckpointLatestEntry,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<TurnCheckpointTailRepairOutcome> {
     let summary = &entry.summary;
     let (action, repair_plan, resume_input) = match load_turn_checkpoint_tail_runtime_eligibility(
-        config, runtime, session_id, entry, kernel_ctx,
+        config, runtime, session_id, entry, binding,
     )
     .await?
     {
@@ -2543,7 +2533,7 @@ async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
         restore_analytics_turn_checkpoint_progress_status(repair_plan.compaction_status());
 
     if repair_plan.should_run_after_turn() {
-        let Some(kernel_ctx) = kernel_ctx else {
+        let Some(kernel_ctx) = binding.kernel_context() else {
             after_turn_status = TurnCheckpointProgressStatus::Skipped;
             if repair_plan.should_run_compaction() {
                 compaction_status = TurnCheckpointProgressStatus::Skipped;
@@ -2558,7 +2548,7 @@ async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
                     compaction: compaction_status,
                 },
                 None,
-                kernel_ctx,
+                binding,
             )
             .await?;
             return Ok(TurnCheckpointTailRepairOutcome::repaired(
@@ -2599,7 +2589,7 @@ async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
                         step: TurnCheckpointFailureStep::AfterTurn,
                         error: error.clone(),
                     }),
-                    Some(kernel_ctx),
+                    binding,
                 )
                 .await?;
                 return Err(error);
@@ -2614,7 +2604,7 @@ async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
             session_id,
             &resume_input.messages,
             resume_input.estimated_tokens,
-            kernel_ctx,
+            binding,
         )
         .await
         {
@@ -2635,7 +2625,7 @@ async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
                         step: TurnCheckpointFailureStep::Compaction,
                         error: error.clone(),
                     }),
-                    kernel_ctx,
+                    binding,
                 )
                 .await?;
                 return Err(error);
@@ -2653,7 +2643,7 @@ async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
             compaction: compaction_status,
         },
         None,
-        kernel_ctx,
+        binding,
     )
     .await?;
 
@@ -2671,12 +2661,10 @@ async fn probe_turn_checkpoint_tail_runtime_gate_entry<R: ConversationRuntime + 
     runtime: &R,
     session_id: &str,
     entry: &super::session_history::TurnCheckpointLatestEntry,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-    match load_turn_checkpoint_tail_runtime_eligibility(
-        config, runtime, session_id, entry, kernel_ctx,
-    )
-    .await?
+    match load_turn_checkpoint_tail_runtime_eligibility(config, runtime, session_id, entry, binding)
+        .await?
     {
         TurnCheckpointTailRuntimeEligibility::Manual {
             action,
@@ -2699,7 +2687,7 @@ async fn load_turn_checkpoint_tail_runtime_eligibility<R: ConversationRuntime + 
     runtime: &R,
     session_id: &str,
     entry: &super::session_history::TurnCheckpointLatestEntry,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<TurnCheckpointTailRuntimeEligibility> {
     let summary = &entry.summary;
     let recovery = TurnCheckpointRecoveryAssessment::from_summary(summary);
@@ -2721,7 +2709,6 @@ async fn load_turn_checkpoint_tail_runtime_eligibility<R: ConversationRuntime + 
     }
 
     let repair_plan = build_turn_checkpoint_repair_plan(summary);
-    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
     let assembled = runtime
         .build_context(config, session_id, true, binding)
         .await?;
@@ -2747,15 +2734,15 @@ async fn probe_turn_checkpoint_tail_runtime_gate_entry_with_limit<
     runtime: &R,
     session_id: &str,
     limit: usize,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let Some(entry) =
-        load_latest_turn_checkpoint_entry(session_id, limit, kernel_ctx, &memory_config).await?
+        load_latest_turn_checkpoint_entry(session_id, limit, binding, &memory_config).await?
     else {
         return Ok(None);
     };
-    probe_turn_checkpoint_tail_runtime_gate_entry(config, runtime, session_id, &entry, kernel_ctx)
+    probe_turn_checkpoint_tail_runtime_gate_entry(config, runtime, session_id, &entry, binding)
         .await
 }
 
@@ -2780,12 +2767,11 @@ async fn finalize_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     user_input: &str,
     tail_phase: &ProviderTurnReplyTailPhase,
     checkpoint: &TurnCheckpointSnapshot,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<String> {
     let Some(persistence_mode) = checkpoint.finalization.persistence_mode() else {
         return Ok(tail_phase.reply().to_owned());
     };
-    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
     persist_reply_turns_with_mode(
         runtime,
         session_id,
@@ -2803,12 +2789,12 @@ async fn finalize_provider_turn_reply<R: ConversationRuntime + ?Sized>(
         TurnCheckpointStage::PostPersist,
         TurnCheckpointFinalizationProgress::pending(checkpoint),
         None,
-        kernel_ctx,
+        binding,
     )
     .await?;
 
     let after_turn_status = if checkpoint.finalization.runs_after_turn() {
-        if let Some(kernel_ctx) = kernel_ctx {
+        if let Some(kernel_ctx) = binding.kernel_context() {
             match runtime
                 .after_turn(
                     session_id,
@@ -2834,7 +2820,7 @@ async fn finalize_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                             step: TurnCheckpointFailureStep::AfterTurn,
                             error: error.clone(),
                         }),
-                        Some(kernel_ctx),
+                        binding,
                     )
                     .await?;
                     return Err(error);
@@ -2853,7 +2839,7 @@ async fn finalize_provider_turn_reply<R: ConversationRuntime + ?Sized>(
             session_id,
             tail_phase.after_turn_messages(),
             tail_phase.estimated_tokens(),
-            kernel_ctx,
+            binding,
         )
         .await
         {
@@ -2872,7 +2858,7 @@ async fn finalize_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                         step: TurnCheckpointFailureStep::Compaction,
                         error: error.clone(),
                     }),
-                    kernel_ctx,
+                    binding,
                 )
                 .await?;
                 return Err(error);
@@ -2891,7 +2877,7 @@ async fn finalize_provider_turn_reply<R: ConversationRuntime + ?Sized>(
             compaction: compaction_status,
         },
         None,
-        kernel_ctx,
+        binding,
     )
     .await?;
     Ok(tail_phase.reply().to_owned())
@@ -2901,7 +2887,7 @@ async fn persist_resolved_provider_error_checkpoint<R: ConversationRuntime + ?Si
     runtime: &R,
     session_id: &str,
     checkpoint: &TurnCheckpointSnapshot,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
     persist_turn_checkpoint_event(
         runtime,
@@ -2910,7 +2896,7 @@ async fn persist_resolved_provider_error_checkpoint<R: ConversationRuntime + ?Si
         TurnCheckpointStage::Finalized,
         TurnCheckpointFinalizationProgress::pending(checkpoint),
         None,
-        kernel_ctx,
+        binding,
     )
     .await
 }
@@ -2922,11 +2908,11 @@ async fn apply_resolved_provider_turn<R: ConversationRuntime + ?Sized>(
     user_input: &str,
     preparation: &ProviderTurnPreparation,
     resolved: &ResolvedProviderTurn,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<String> {
     resolved
         .terminal_phase(&preparation.session)
-        .apply(config, runtime, session_id, user_input, kernel_ctx)
+        .apply(config, runtime, session_id, user_input, binding)
         .await
 }
 
@@ -3322,7 +3308,7 @@ where
                     self.runtime,
                     session_context,
                     request.payload,
-                    binding.kernel_context(),
+                    binding,
                 )
                 .await
             }
@@ -3350,7 +3336,7 @@ async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
     runtime: &R,
     session_context: &SessionContext,
     payload: Value,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
     if !config.tools.delegate.enabled {
         return Err("app_tool_disabled: delegate is disabled by config".to_owned());
@@ -3397,7 +3383,7 @@ async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
         child_label,
         &delegate_request.task,
         delegate_request.timeout_seconds,
-        kernel_ctx,
+        binding,
     )
     .await
 }
@@ -3478,7 +3464,7 @@ async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
     _runtime: &R,
     _session_context: &SessionContext,
     _payload: Value,
-    _kernel_ctx: Option<&KernelContext>,
+    _binding: ConversationRuntimeBinding<'_>,
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
     Err("delegate requires sqlite memory support (enable feature `memory-sqlite`)".to_owned())
 }
@@ -3504,7 +3490,7 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
     child_label: Option<String>,
     user_input: &str,
     timeout_seconds: u64,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
     let repo = SessionRepository::new(&MemoryRuntimeConfig::from_memory_config(&config.memory))?;
     let start = Instant::now();
@@ -3515,7 +3501,7 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
             user_input,
             ProviderErrorMode::Propagate,
             runtime,
-            kernel_ctx,
+            binding,
         ))
         .catch_unwind()
         .await
@@ -3892,13 +3878,12 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     preparation: &ProviderTurnPreparation,
     turn: &ProviderTurn,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
 ) -> ProviderTurnLaneExecution {
     let had_tool_intents = !turn.tool_intents.is_empty();
     let assistant_preface = turn.assistant_text.clone();
     let lane = preparation.lane_plan.decision.lane;
-    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
     let session_context = match runtime.session_context(config, session_id, binding) {
         Ok(session_context) => session_context,
         Err(error) => {
@@ -3949,7 +3934,7 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
                 turn,
                 &session_context,
                 &app_dispatcher,
-                kernel_ctx,
+                binding,
                 ingress,
             )
             .await;
@@ -3987,11 +3972,11 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
     turn: &ProviderTurn,
     session_context: &SessionContext,
     app_dispatcher: &dyn AppToolDispatcher,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
 ) -> SafeLaneTurnOutcome {
     let governor_history_signals =
-        load_safe_lane_history_signals_for_governor(config, session_id, kernel_ctx).await;
+        load_safe_lane_history_signals_for_governor(config, session_id, binding).await;
     let governor = decide_safe_lane_session_governor(config, &governor_history_signals);
 
     emit_safe_lane_event(
@@ -4007,7 +3992,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
             "tool_intents": turn.tool_intents.len(),
             "session_governor": governor.as_json(),
         }),
-        kernel_ctx,
+        binding,
     )
     .await;
 
@@ -4030,7 +4015,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                         .safe_lane_verify_anchor_escalation_after_failures(),
                     "metrics": state.metrics.as_json(),
                 }),
-                kernel_ctx,
+                binding,
             )
             .await;
         }
@@ -4051,7 +4036,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                 "session_governor": state.governor.as_json(),
                 "metrics": state.metrics.as_json(),
             }),
-            kernel_ctx,
+            binding,
         )
         .await;
 
@@ -4061,7 +4046,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
             turn,
             session_context,
             app_dispatcher,
-            kernel_ctx,
+            binding,
             ingress,
             &state,
         )
@@ -4091,7 +4076,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                         .as_json(),
                         "metrics": state.metrics.as_json(),
                     }),
-                    kernel_ctx,
+                    binding,
                 )
                 .await;
                 let tool_output = round_execution.tool_outputs.join("\n");
@@ -4120,7 +4105,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                             .as_json(),
                             "metrics": state.metrics.as_json(),
                         }),
-                        kernel_ctx,
+                        binding,
                     )
                     .await;
                     return SafeLaneTurnOutcome::without_terminal_route(TurnResult::FinalText(
@@ -4174,7 +4159,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                         .as_json(),
                         "metrics": state.metrics.as_json(),
                     }),
-                    kernel_ctx,
+                    binding,
                 )
                 .await;
 
@@ -4211,7 +4196,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                                 .as_json(),
                                 "metrics": state.metrics.as_json(),
                             }),
-                            kernel_ctx,
+                            binding,
                         )
                         .await;
                         return SafeLaneTurnOutcome::with_terminal_route(result, verify_route);
@@ -4244,7 +4229,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                                 .as_json(),
                                 "metrics": state.metrics.as_json(),
                             }),
-                            kernel_ctx,
+                            binding,
                         )
                         .await;
                     }
@@ -4288,7 +4273,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                         .as_json(),
                         "metrics": state.metrics.as_json(),
                     }),
-                    kernel_ctx,
+                    binding,
                 )
                 .await;
                 let (next_start_tool_index, next_seed_outputs) = if route.should_replan() {
@@ -4335,7 +4320,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                                 .as_json(),
                                 "metrics": state.metrics.as_json(),
                             }),
-                            kernel_ctx,
+                            binding,
                         )
                         .await;
                         return SafeLaneTurnOutcome::with_terminal_route(result, route);
@@ -4370,7 +4355,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                                 .as_json(),
                                 "metrics": state.metrics.as_json(),
                             }),
-                            kernel_ctx,
+                            binding,
                         )
                         .await;
                     }
@@ -4388,7 +4373,7 @@ async fn evaluate_safe_lane_round(
     turn: &ProviderTurn,
     session_context: &SessionContext,
     app_dispatcher: &dyn AppToolDispatcher,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
     state: &SafeLanePlanLoopState,
 ) -> SafeLaneRoundExecution {
@@ -4399,6 +4384,9 @@ async fn evaluate_safe_lane_round(
         state.tool_node_max_attempts(),
         state.plan_start_tool_index,
     );
+    let Some(kernel_ctx) = binding.kernel_context() else {
+        return synthetic_safe_lane_round_without_kernel(&plan);
+    };
     let executor = SafeLanePlanNodeExecutor::new(
         turn.tool_intents.as_slice(),
         session_context,
@@ -4428,14 +4416,13 @@ async fn emit_safe_lane_event<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     event_name: &str,
     payload: Value,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) {
     if !should_emit_safe_lane_event(config, event_name, &payload) {
         return;
     }
-    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
     let _ = persist_conversation_event(runtime, session_id, event_name, payload, binding).await;
-    if let Some(ctx) = kernel_ctx {
+    if let Some(ctx) = binding.kernel_context() {
         let _ = ctx.kernel.record_audit_event(
             Some(ctx.agent_id()),
             AuditEventKind::PlaneInvoked {
@@ -4934,7 +4921,7 @@ fn decide_safe_lane_session_governor(
 async fn load_safe_lane_history_signals_for_governor(
     config: &LoongClawConfig,
     session_id: &str,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> SafeLaneGovernorHistorySignals {
     if !config.conversation.safe_lane_session_governor_enabled {
         return SafeLaneGovernorHistorySignals::default();
@@ -4949,7 +4936,7 @@ async fn load_safe_lane_history_signals_for_governor(
         if let Ok(assistant_contents) = load_assistant_contents_from_session_window(
             session_id,
             window_turns,
-            kernel_ctx,
+            binding,
             &memory_config,
         )
         .await

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1359,7 +1359,7 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         user_input: &str,
         error_mode: ProviderErrorMode,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::automatic();
@@ -1372,7 +1372,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             &runtime,
             &acp_options,
-            kernel_ctx,
+            binding,
             ingress,
         )
         .await
@@ -1541,7 +1541,7 @@ impl ConversationTurnCoordinator {
         user_input: &str,
         error_mode: ProviderErrorMode,
         acp_options: &AcpConversationTurnOptions<'_>,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
     ) -> CliResult<String> {
         let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
@@ -1552,7 +1552,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             &runtime,
             acp_options,
-            kernel_ctx,
+            binding,
             ingress,
         )
         .await
@@ -1610,7 +1610,7 @@ impl ConversationTurnCoordinator {
         user_input: &str,
         error_mode: ProviderErrorMode,
         runtime: &R,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::automatic();
@@ -1622,7 +1622,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             runtime,
             &acp_options,
-            kernel_ctx,
+            binding,
             ingress,
         )
         .await
@@ -1847,7 +1847,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             runtime,
             acp_options,
-            kernel_ctx,
+            binding,
             None,
         )
         .await
@@ -1863,7 +1863,7 @@ impl ConversationTurnCoordinator {
         error_mode: ProviderErrorMode,
         runtime: &R,
         acp_options: &AcpConversationTurnOptions<'_>,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
     ) -> CliResult<String> {
         let session_id = address.session_id.as_str();
@@ -1909,7 +1909,7 @@ impl ConversationTurnCoordinator {
         let session_context = runtime.session_context(config, session_id, binding)?;
         let tool_view = session_context.tool_view.clone();
         let visible_ingress = ingress.filter(|value| value.has_contextual_hints());
-        emit_turn_ingress_event(runtime, session_id, visible_ingress, kernel_ctx).await;
+        emit_turn_ingress_event(runtime, session_id, visible_ingress, binding).await;
         let preparation = ProviderTurnPreparation::from_assembled_context(
             config,
             runtime
@@ -2932,7 +2932,7 @@ struct CoordinatorApprovalResolutionRuntime<'a, R: ?Sized> {
     config: &'a LoongClawConfig,
     runtime: &'a R,
     fallback: &'a DefaultAppToolDispatcher,
-    kernel_ctx: Option<&'a KernelContext>,
+    binding: ConversationRuntimeBinding<'a>,
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -2988,7 +2988,7 @@ where
         let replay_request = self.replay_request(approval_request)?;
         let session_context = self
             .runtime
-            .session_context(self.config, &approval_request.session_id, self.kernel_ctx)
+            .session_context(self.config, &approval_request.session_id, self.binding)
             .map_err(|error| format!("load approval request session context failed: {error}"))?;
 
         match crate::tools::canonical_tool_name(replay_request.tool_name.as_str()) {
@@ -2998,7 +2998,7 @@ where
                     self.runtime,
                     &session_context,
                     replay_request.payload,
-                    self.kernel_ctx,
+                    self.binding,
                 )
                 .await
             }
@@ -3013,7 +3013,7 @@ where
             }
             _ => {
                 self.fallback
-                    .execute_app_tool(&session_context, replay_request, self.kernel_ctx)
+                    .execute_app_tool(&session_context, replay_request, self.binding)
                     .await
             }
         }
@@ -3275,7 +3275,7 @@ where
             "approval_request_resolve" => {
                 #[cfg(not(feature = "memory-sqlite"))]
                 {
-                    let _ = (session_context, kernel_ctx);
+                    let _ = (session_context, binding);
                     Err("approval tools require sqlite memory support (enable feature `memory-sqlite`)"
                         .to_owned())
                 }
@@ -3290,7 +3290,7 @@ where
                         config: self.config,
                         runtime: self.runtime,
                         fallback: self.fallback,
-                        kernel_ctx,
+                        binding,
                     };
                     crate::tools::approval::execute_approval_tool_with_runtime_support(
                         request,
@@ -3942,13 +3942,7 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         }
         Ok(TurnValidation::ToolExecutionRequired) => (
             engine
-                .execute_turn_in_context(
-                    turn,
-                    &session_context,
-                    &app_dispatcher,
-                    binding,
-                    ingress,
-                )
+                .execute_turn_in_context(turn, &session_context, &app_dispatcher, binding, ingress)
                 .await,
             None,
         ),
@@ -4391,7 +4385,7 @@ async fn evaluate_safe_lane_round(
         turn.tool_intents.as_slice(),
         session_context,
         app_dispatcher,
-        kernel_ctx,
+        Some(kernel_ctx),
         ingress,
         config.conversation.safe_lane_verify_output_non_empty,
         state.seed_tool_outputs.clone(),
@@ -4407,6 +4401,39 @@ async fn evaluate_safe_lane_round(
         report,
         tool_outputs,
         tool_output_stats,
+    }
+}
+
+fn synthetic_safe_lane_round_without_kernel(plan: &PlanGraph) -> SafeLaneRoundExecution {
+    let ordered_nodes = plan
+        .nodes
+        .iter()
+        .map(|node| node.id.clone())
+        .collect::<Vec<_>>();
+    let failed_node_id = plan
+        .nodes
+        .iter()
+        .find(|node| matches!(node.kind, PlanNodeKind::Tool))
+        .or_else(|| plan.nodes.first())
+        .map(|node| node.id.clone())
+        .unwrap_or_else(|| "tool-1".to_owned());
+    let failure = PlanRunFailure::NodeFailed {
+        node_id: failed_node_id,
+        attempts_used: 1,
+        last_error_kind: PlanNodeErrorKind::PolicyDenied,
+        last_error: "no_kernel_context".to_owned(),
+    };
+
+    SafeLaneRoundExecution {
+        report: PlanRunReport {
+            status: PlanRunStatus::Failed(failure),
+            ordered_nodes,
+            attempts_used: 1,
+            attempt_events: Vec::new(),
+            elapsed_ms: 0,
+        },
+        tool_outputs: Vec::new(),
+        tool_output_stats: summarize_safe_lane_tool_output_stats(&[]),
     }
 }
 
@@ -4442,7 +4469,7 @@ async fn emit_turn_ingress_event<R: ConversationRuntime + ?Sized>(
     runtime: &R,
     session_id: &str,
     ingress: Option<&ConversationIngressContext>,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) {
     let Some(ingress) = ingress else {
         return;
@@ -4452,7 +4479,7 @@ async fn emit_turn_ingress_event<R: ConversationRuntime + ?Sized>(
         session_id,
         "turn_ingress",
         ingress.as_event_payload(),
-        kernel_ctx,
+        binding,
     )
     .await;
 }

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -58,6 +58,7 @@ use super::runtime::{
     AsyncDelegateSpawnRequest, AsyncDelegateSpawner, ConversationRuntime,
     DefaultConversationRuntime, SessionContext,
 };
+use super::runtime_binding::ConversationRuntimeBinding;
 use super::safe_lane_failure::{
     SafeLaneFailureCode, SafeLaneFailureRouteDecision, SafeLaneFailureRouteSource,
     classify_safe_lane_plan_failure,
@@ -1877,13 +1878,15 @@ impl ConversationTurnCoordinator {
                     ProviderErrorMode::Propagate => Err(error),
                     ProviderErrorMode::InlineMessage => {
                         let synthetic = format_provider_error_reply(&error);
+                        let binding =
+                            ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
                         persist_reply_turns_raw_with_mode(
                             runtime,
                             session_id,
                             user_input,
                             &synthetic,
                             ReplyPersistenceMode::InlineProviderError,
-                            kernel_ctx,
+                            binding,
                         )
                         .await?;
                         Ok(synthetic)
@@ -1906,17 +1909,18 @@ impl ConversationTurnCoordinator {
             AcpConversationTurnEntryDecision::StayOnProvider => {}
         }
 
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
         if let Some(kernel_ctx) = kernel_ctx {
             runtime.bootstrap(config, session_id, kernel_ctx).await?;
         }
-        let session_context = runtime.session_context(config, session_id, kernel_ctx)?;
+        let session_context = runtime.session_context(config, session_id, binding)?;
         let tool_view = session_context.tool_view.clone();
         let visible_ingress = ingress.filter(|value| value.has_contextual_hints());
         emit_turn_ingress_event(runtime, session_id, visible_ingress, kernel_ctx).await;
         let preparation = ProviderTurnPreparation::from_assembled_context(
             config,
             runtime
-                .build_context(config, session_id, true, kernel_ctx)
+                .build_context(config, session_id, true, binding)
                 .await?,
             user_input,
             visible_ingress,
@@ -1928,12 +1932,7 @@ impl ConversationTurnCoordinator {
             user_input,
             &preparation,
             runtime
-                .request_turn(
-                    config,
-                    &preparation.session.messages,
-                    &tool_view,
-                    kernel_ctx,
-                )
+                .request_turn(config, &preparation.session.messages, &tool_view, binding)
                 .await,
             error_mode,
             kernel_ctx,
@@ -2027,13 +2026,14 @@ impl ConversationTurnCoordinator {
         match executed.outcome {
             AcpConversationTurnExecutionOutcome::Succeeded(success) => {
                 let reply = success.result.output_text.clone();
+                let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
                 persist_reply_turns_raw_with_mode(
                     runtime,
                     session_id,
                     user_input,
                     &reply,
                     ReplyPersistenceMode::Success,
-                    kernel_ctx,
+                    binding,
                 )
                 .await?;
                 if config.acp.emit_runtime_events {
@@ -2044,13 +2044,14 @@ impl ConversationTurnCoordinator {
                         &success.runtime_events,
                         Some(&success.result),
                         None,
-                        kernel_ctx,
+                        binding,
                     )
                     .await;
                 }
                 Ok(reply)
             }
             AcpConversationTurnExecutionOutcome::Failed(failure) => {
+                let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
                 if config.acp.emit_runtime_events {
                     let _ = persist_acp_runtime_events(
                         runtime,
@@ -2059,7 +2060,7 @@ impl ConversationTurnCoordinator {
                         &failure.runtime_events,
                         None,
                         Some(failure.error.as_str()),
-                        kernel_ctx,
+                        binding,
                     )
                     .await;
                 }
@@ -2073,7 +2074,7 @@ impl ConversationTurnCoordinator {
                             user_input,
                             &synthetic,
                             ReplyPersistenceMode::InlineProviderError,
-                            kernel_ctx,
+                            binding,
                         )
                         .await?;
                         Ok(synthetic)
@@ -2340,6 +2341,7 @@ async fn persist_turn_checkpoint_event_value<R: ConversationRuntime + ?Sized>(
     failure: Option<TurnCheckpointFailure>,
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<()> {
+    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
     persist_conversation_event(
         runtime,
         session_id,
@@ -2351,7 +2353,7 @@ async fn persist_turn_checkpoint_event_value<R: ConversationRuntime + ?Sized>(
             "finalization_progress": progress,
             "failure": failure,
         }),
-        kernel_ctx,
+        binding,
     )
     .await
 }
@@ -2719,8 +2721,9 @@ async fn load_turn_checkpoint_tail_runtime_eligibility<R: ConversationRuntime + 
     }
 
     let repair_plan = build_turn_checkpoint_repair_plan(summary);
+    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
     let assembled = runtime
-        .build_context(config, session_id, true, kernel_ctx)
+        .build_context(config, session_id, true, binding)
         .await?;
     match TurnCheckpointRepairResumeInput::from_assembled_context(assembled, &entry.checkpoint) {
         Ok(resume_input) => Ok(TurnCheckpointTailRuntimeEligibility::Runnable {
@@ -2782,13 +2785,14 @@ async fn finalize_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     let Some(persistence_mode) = checkpoint.finalization.persistence_mode() else {
         return Ok(tail_phase.reply().to_owned());
     };
+    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
     persist_reply_turns_with_mode(
         runtime,
         session_id,
         user_input,
         tail_phase.reply(),
         persistence_mode,
-        kernel_ctx,
+        binding,
     )
     .await?;
 
@@ -3279,7 +3283,7 @@ where
         &self,
         session_context: &SessionContext,
         request: loongclaw_contracts::ToolCoreRequest,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
         match crate::tools::canonical_tool_name(request.tool_name.as_str()) {
             "approval_request_resolve" => {
@@ -3318,7 +3322,7 @@ where
                     self.runtime,
                     session_context,
                     request.payload,
-                    kernel_ctx,
+                    binding.kernel_context(),
                 )
                 .await
             }
@@ -3333,7 +3337,7 @@ where
             }
             _ => {
                 self.fallback
-                    .execute_app_tool(session_context, request, kernel_ctx)
+                    .execute_app_tool(session_context, request, binding)
                     .await
             }
         }
@@ -3894,7 +3898,8 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
     let had_tool_intents = !turn.tool_intents.is_empty();
     let assistant_preface = turn.assistant_text.clone();
     let lane = preparation.lane_plan.decision.lane;
-    let session_context = match runtime.session_context(config, session_id, kernel_ctx) {
+    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
+    let session_context = match runtime.session_context(config, session_id, binding) {
         Ok(session_context) => session_context,
         Err(error) => {
             return ProviderTurnLaneExecution {
@@ -3956,7 +3961,7 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
                     turn,
                     &session_context,
                     &app_dispatcher,
-                    kernel_ctx,
+                    binding,
                     ingress,
                 )
                 .await,
@@ -4428,7 +4433,8 @@ async fn emit_safe_lane_event<R: ConversationRuntime + ?Sized>(
     if !should_emit_safe_lane_event(config, event_name, &payload) {
         return;
     }
-    let _ = persist_conversation_event(runtime, session_id, event_name, payload, kernel_ctx).await;
+    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
+    let _ = persist_conversation_event(runtime, session_id, event_name, payload, binding).await;
     if let Some(ctx) = kernel_ctx {
         let _ = ctx.kernel.record_audit_event(
             Some(ctx.agent_id()),
@@ -5646,7 +5652,13 @@ async fn execute_single_tool_intent(
     };
 
     match engine
-        .execute_turn_in_context(&turn, session_context, app_dispatcher, kernel_ctx, ingress)
+        .execute_turn_in_context(
+            &turn,
+            session_context,
+            app_dispatcher,
+            ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx),
+            ingress,
+        )
         .await
     {
         TurnResult::FinalText(output) => Ok(output),

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1044,7 +1044,7 @@ mod tests {
                 &delegate_async_turn("root-session", "turn-1", "call-1"),
                 &session_context,
                 &dispatcher,
-                None,
+                ConversationRuntimeBinding::direct(),
                 None,
             )
             .await;

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -23,6 +23,7 @@ use crate::tools::{
 };
 
 use super::runtime::SessionContext;
+use super::runtime_binding::ConversationRuntimeBinding;
 
 use super::ingress::{ConversationIngressContext, inject_internal_tool_ingress};
 
@@ -261,7 +262,7 @@ pub trait AppToolDispatcher: Send + Sync {
         &self,
         session_context: &SessionContext,
         request: ToolCoreRequest,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> Result<ToolCoreOutcome, String>;
 }
 
@@ -273,7 +274,7 @@ impl AppToolDispatcher for NoopAppToolDispatcher {
         &self,
         _session_context: &SessionContext,
         request: ToolCoreRequest,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> Result<ToolCoreOutcome, String> {
         Err(format!("app_tool_not_implemented: {}", request.tool_name))
     }
@@ -557,7 +558,7 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
         &self,
         session_context: &SessionContext,
         request: ToolCoreRequest,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> Result<ToolCoreOutcome, String> {
         let canonical_tool_name = crate::tools::canonical_tool_name(request.tool_name.as_str());
         let effective_tool_view = self.effective_tool_view_for_session(session_context)?;
@@ -812,21 +813,25 @@ impl TurnEngine {
         turn: &ProviderTurn,
         kernel_ctx: &KernelContext,
     ) -> TurnResult {
-        self.execute_turn_in_view(turn, &runtime_tool_view(), Some(kernel_ctx))
-            .await
+        self.execute_turn_in_view(
+            turn,
+            &runtime_tool_view(),
+            ConversationRuntimeBinding::kernel(kernel_ctx),
+        )
+        .await
     }
 
     pub async fn execute_turn_in_view(
         &self,
         turn: &ProviderTurn,
         tool_view: &ToolView,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> TurnResult {
         self.execute_turn_in_context(
             turn,
             &session_context_from_turn(turn, tool_view.clone()),
             &DefaultAppToolDispatcher::runtime(),
-            kernel_ctx,
+            binding,
             None,
         )
         .await
@@ -835,14 +840,14 @@ impl TurnEngine {
     pub async fn execute_turn_with_ingress(
         &self,
         turn: &ProviderTurn,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
     ) -> TurnResult {
         self.execute_turn_in_context(
             turn,
             &session_context_from_turn(turn, runtime_tool_view()),
             &DefaultAppToolDispatcher::runtime(),
-            kernel_ctx,
+            binding,
             ingress,
         )
         .await
@@ -853,7 +858,7 @@ impl TurnEngine {
         turn: &ProviderTurn,
         session_context: &SessionContext,
         app_dispatcher: &D,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
     ) -> TurnResult {
         match self.validate_turn_in_context(turn, session_context) {
@@ -880,7 +885,7 @@ impl TurnEngine {
             };
             let outcome = match resolved_tool.execution_kind {
                 ToolExecutionKind::Core => {
-                    let Some(kernel_ctx) = kernel_ctx else {
+                    let Some(kernel_ctx) = binding.kernel_context() else {
                         return TurnResult::policy_denied("no_kernel_context", "no_kernel_context");
                     };
                     match execute_tool_intent_via_kernel(
@@ -904,6 +909,7 @@ impl TurnEngine {
                             reason,
                         );
                     };
+                    let kernel_ctx = binding.kernel_context();
                     match app_dispatcher
                         .maybe_require_approval(session_context, intent, descriptor, kernel_ctx)
                         .await
@@ -922,7 +928,7 @@ impl TurnEngine {
                     }
 
                     match app_dispatcher
-                        .execute_app_tool(session_context, request, kernel_ctx)
+                        .execute_app_tool(session_context, request, binding)
                         .await
                     {
                         Ok(outcome) => outcome,
@@ -1098,10 +1104,22 @@ mod tests {
         let turn = delegate_async_turn("root-session", "turn-reuse", "call-reuse");
 
         let first = TurnEngine::new(4)
-            .execute_turn_in_context(&turn, &session_context, &dispatcher, None, None)
+            .execute_turn_in_context(
+                &turn,
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::direct(),
+                None,
+            )
             .await;
         let second = TurnEngine::new(4)
-            .execute_turn_in_context(&turn, &session_context, &dispatcher, None, None)
+            .execute_turn_in_context(
+                &turn,
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::direct(),
+                None,
+            )
             .await;
 
         let first_request_id = match first {

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -4,7 +4,6 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use serde_json::{Value, json};
 
 use crate::CliResult;
-use crate::KernelContext;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 
 use super::super::config::LoongClawConfig;
@@ -91,11 +90,11 @@ impl ConversationTurnLoop {
         session_id: &str,
         user_input: &str,
         error_mode: ProviderErrorMode,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
         self.handle_turn_with_runtime(
-            config, session_id, user_input, error_mode, &runtime, kernel_ctx,
+            config, session_id, user_input, error_mode, &runtime, binding,
         )
         .await
     }
@@ -107,10 +106,9 @@ impl ConversationTurnLoop {
         user_input: &str,
         error_mode: ProviderErrorMode,
         runtime: &R,
-        kernel_ctx: Option<&KernelContext>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let policy = TurnLoopPolicy::from_config(config);
-        let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
         let session_context = runtime.session_context(config, session_id, binding)?;
         let tool_view = session_context.tool_view.clone();
         let app_dispatcher = DefaultAppToolDispatcher::with_config(
@@ -142,7 +140,7 @@ impl ConversationTurnLoop {
                             reply,
                             persistence_mode: ReplyPersistenceMode::InlineProviderError,
                         },
-                        kernel_ctx,
+                        binding,
                     )
                     .await;
                 }
@@ -152,7 +150,7 @@ impl ConversationTurnLoop {
                         session_id,
                         user_input,
                         TurnLoopTerminalAction::ReturnError { error },
-                        kernel_ctx,
+                        binding,
                     )
                     .await;
                 }
@@ -184,12 +182,12 @@ impl ConversationTurnLoop {
                 &mut session,
                 user_input,
                 decision,
-                kernel_ctx,
+                binding,
             )
             .await?
             {
                 return apply_turn_loop_terminal_action(
-                    runtime, session_id, user_input, action, kernel_ctx,
+                    runtime, session_id, user_input, action, binding,
                 )
                 .await;
             }
@@ -200,7 +198,7 @@ impl ConversationTurnLoop {
             session_id,
             user_input,
             build_round_limit_terminal_action(session.last_raw_reply.as_str()),
-            kernel_ctx,
+            binding,
         )
         .await
     }
@@ -223,7 +221,7 @@ async fn resolve_round_kernel_terminal_action<R: ConversationRuntime + ?Sized>(
     session: &mut TurnLoopSessionState,
     user_input: &str,
     decision: RoundKernelDecision,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<Option<TurnLoopTerminalAction>> {
     match decision {
         RoundKernelDecision::ContinueWithFollowup(followup) => {
@@ -245,7 +243,7 @@ async fn resolve_round_kernel_terminal_action<R: ConversationRuntime + ?Sized>(
                 runtime,
                 config,
                 &session.messages,
-                kernel_ctx,
+                binding,
                 raw_reply.as_str(),
             )
             .await;
@@ -262,9 +260,8 @@ async fn apply_turn_loop_terminal_action<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     user_input: &str,
     action: TurnLoopTerminalAction,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<String> {
-    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
     match action {
         TurnLoopTerminalAction::PersistReply {
             reply,

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -11,6 +11,7 @@ use super::super::config::LoongClawConfig;
 use super::ProviderErrorMode;
 use super::persistence::persist_reply_turns_with_mode;
 use super::runtime::{ConversationRuntime, DefaultConversationRuntime};
+use super::runtime_binding::ConversationRuntimeBinding;
 use super::turn_budget::{TurnRoundBudget, TurnRoundBudgetDecision};
 use super::turn_engine::{
     DefaultAppToolDispatcher, ProviderTurn, ToolIntent, TurnEngine, TurnResult, TurnValidation,
@@ -109,7 +110,8 @@ impl ConversationTurnLoop {
         kernel_ctx: Option<&KernelContext>,
     ) -> CliResult<String> {
         let policy = TurnLoopPolicy::from_config(config);
-        let session_context = runtime.session_context(config, session_id, kernel_ctx)?;
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
+        let session_context = runtime.session_context(config, session_id, binding)?;
         let tool_view = session_context.tool_view.clone();
         let app_dispatcher = DefaultAppToolDispatcher::with_config(
             MemoryRuntimeConfig::from_memory_config(&config.memory),
@@ -117,7 +119,7 @@ impl ConversationTurnLoop {
         );
         let mut session = initialize_turn_loop_session(
             runtime
-                .build_messages(config, session_id, true, &tool_view, kernel_ctx)
+                .build_messages(config, session_id, true, &tool_view, binding)
                 .await?,
             user_input,
             &policy,
@@ -126,7 +128,7 @@ impl ConversationTurnLoop {
         for round_index in 0..policy.max_rounds {
             let turn = match decide_provider_turn_request_action(
                 runtime
-                    .request_turn(config, &session.messages, &tool_view, kernel_ctx)
+                    .request_turn(config, &session.messages, &tool_view, binding)
                     .await,
                 error_mode,
             ) {
@@ -162,7 +164,7 @@ impl ConversationTurnLoop {
                 &turn,
                 &session_context,
                 &app_dispatcher,
-                kernel_ctx,
+                binding,
                 &mut session.loop_supervisor,
             )
             .await;
@@ -262,6 +264,7 @@ async fn apply_turn_loop_terminal_action<R: ConversationRuntime + ?Sized>(
     action: TurnLoopTerminalAction,
     kernel_ctx: Option<&KernelContext>,
 ) -> CliResult<String> {
+    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
     match action {
         TurnLoopTerminalAction::PersistReply {
             reply,
@@ -273,7 +276,7 @@ async fn apply_turn_loop_terminal_action<R: ConversationRuntime + ?Sized>(
                 user_input,
                 &reply,
                 persistence_mode,
-                kernel_ctx,
+                binding,
             )
             .await?;
             Ok(reply)
@@ -309,7 +312,7 @@ async fn evaluate_round_kernel(
     turn: &ProviderTurn,
     session_context: &super::runtime::SessionContext,
     app_dispatcher: &DefaultAppToolDispatcher,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     loop_supervisor: &mut ToolLoopSupervisor,
 ) -> RoundKernelEvaluation {
     let had_tool_intents = !turn.tool_intents.is_empty();
@@ -328,7 +331,7 @@ async fn evaluate_round_kernel(
         Err(failure) => TurnResult::ToolDenied(failure),
         Ok(TurnValidation::ToolExecutionRequired) => {
             engine
-                .execute_turn_in_context(turn, session_context, app_dispatcher, kernel_ctx, None)
+                .execute_turn_in_context(turn, session_context, app_dispatcher, binding, None)
                 .await
         }
     };

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -8,7 +8,6 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::CliResult;
-use crate::KernelContext;
 
 pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
 pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
@@ -543,10 +542,9 @@ pub async fn request_completion_with_raw_fallback<R: ConversationRuntime + ?Size
     runtime: &R,
     config: &LoongClawConfig,
     messages: &[Value],
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     raw_reply: &str,
 ) -> String {
-    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
     match runtime.request_completion(config, messages, binding).await {
         Ok(final_reply) => {
             let trimmed = final_reply.trim();

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -2,6 +2,7 @@ use super::super::config::LoongClawConfig;
 use super::ProviderErrorMode;
 use super::persistence::format_provider_error_reply;
 use super::runtime::ConversationRuntime;
+use super::runtime_binding::ConversationRuntimeBinding;
 use super::turn_engine::{ApprovalRequirement, ApprovalRequirementKind, ProviderTurn, TurnResult};
 use serde::Serialize;
 use serde_json::Value;
@@ -545,10 +546,8 @@ pub async fn request_completion_with_raw_fallback<R: ConversationRuntime + ?Size
     kernel_ctx: Option<&KernelContext>,
     raw_reply: &str,
 ) -> String {
-    match runtime
-        .request_completion(config, messages, kernel_ctx)
-        .await
-    {
+    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
+    match runtime.request_completion(config, messages, binding).await {
         Ok(final_reply) => {
             let trimmed = final_reply.trim();
             if trimmed.is_empty() {

--- a/crates/app/src/provider/failover_telemetry_runtime.rs
+++ b/crates/app/src/provider/failover_telemetry_runtime.rs
@@ -5,10 +5,10 @@ use std::sync::{Mutex, OnceLock};
 
 use loongclaw_kernel::AuditEventKind;
 
-use crate::KernelContext;
 use crate::config::ProviderConfig;
 
 use super::failover::ProviderFailoverSnapshot;
+use super::runtime_binding::ProviderRuntimeBinding;
 
 #[derive(Debug, Clone)]
 struct ProviderFailoverEvent {
@@ -135,7 +135,7 @@ fn build_provider_failover_event(
 }
 
 pub(super) fn record_provider_failover_audit_event(
-    kernel_ctx: Option<&KernelContext>,
+    binding: ProviderRuntimeBinding<'_>,
     provider: &ProviderConfig,
     snapshot: &ProviderFailoverSnapshot,
     try_next_model: bool,
@@ -155,7 +155,7 @@ pub(super) fn record_provider_failover_audit_event(
     );
     record_provider_failover_metrics(&event);
 
-    let Some(ctx) = kernel_ctx else {
+    let Some(ctx) = binding.kernel_context() else {
         return;
     };
     let _ = ctx.kernel.record_audit_event(

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 #[cfg(test)]
 use tokio::time::sleep;
 
-use crate::{CliResult, KernelContext};
+use crate::CliResult;
 
 use super::config::LoongClawConfig;
 #[cfg(test)]
@@ -38,9 +38,11 @@ mod request_message_runtime;
 mod request_payload_runtime;
 mod request_planner;
 mod request_session_runtime;
+mod runtime_binding;
 mod shape;
 mod transport;
 
+pub use runtime_binding::ProviderRuntimeBinding;
 pub use shape::extract_provider_turn;
 
 #[cfg(test)]
@@ -163,12 +165,12 @@ pub fn build_messages_for_session(
 pub async fn request_completion(
     config: &LoongClawConfig,
     messages: &[Value],
-    kernel_ctx: Option<&KernelContext>,
+    binding: ProviderRuntimeBinding<'_>,
 ) -> CliResult<String> {
     let session = prepare_provider_request_session(config).await?;
     request_across_model_candidates(
         &config.provider,
-        kernel_ctx,
+        binding,
         &session.auth_profiles,
         session.profile_state_policy.as_ref(),
         &session.model_candidates,
@@ -195,13 +197,13 @@ pub async fn request_completion(
 pub async fn request_turn(
     config: &LoongClawConfig,
     messages: &[Value],
-    kernel_ctx: Option<&KernelContext>,
+    binding: ProviderRuntimeBinding<'_>,
 ) -> CliResult<crate::conversation::turn_engine::ProviderTurn> {
     request_turn_in_view(
         config,
         messages,
         &crate::tools::runtime_tool_view(),
-        kernel_ctx,
+        binding,
     )
     .await
 }
@@ -210,7 +212,7 @@ pub async fn request_turn_in_view(
     config: &LoongClawConfig,
     messages: &[Value],
     tool_view: &crate::tools::ToolView,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ProviderRuntimeBinding<'_>,
 ) -> CliResult<crate::conversation::turn_engine::ProviderTurn> {
     let session = prepare_provider_request_session(config).await?;
     let tool_runtime_config =
@@ -224,7 +226,7 @@ pub async fn request_turn_in_view(
     };
     request_across_model_candidates(
         &config.provider,
-        kernel_ctx,
+        binding,
         &session.auth_profiles,
         session.profile_state_policy.as_ref(),
         &session.model_candidates,

--- a/crates/app/src/provider/request_failover_runtime.rs
+++ b/crates/app/src/provider/request_failover_runtime.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-use crate::{CliResult, KernelContext, config::ProviderConfig};
+use crate::{CliResult, config::ProviderConfig};
 
 use super::auth_profile_runtime::ProviderAuthProfile;
 use super::failover::ModelRequestError;
@@ -12,10 +12,11 @@ use super::profile_health_runtime::{
     ProviderProfileStatePolicy, mark_provider_profile_failure, mark_provider_profile_success,
     prioritize_provider_auth_profiles_by_health,
 };
+use super::runtime_binding::ProviderRuntimeBinding;
 
 pub(super) async fn request_across_model_candidates<T, F, Fut>(
     provider: &ProviderConfig,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ProviderRuntimeBinding<'_>,
     auth_profiles: &[ProviderAuthProfile],
     profile_state_policy: Option<&ProviderProfileStatePolicy>,
     model_candidates: &[String],
@@ -54,7 +55,7 @@ where
                         ..
                     } = model_error;
                     record_provider_failover_audit_event(
-                        kernel_ctx,
+                        binding,
                         provider,
                         &snapshot,
                         try_next_model,

--- a/crates/app/src/provider/runtime_binding.rs
+++ b/crates/app/src/provider/runtime_binding.rs
@@ -1,0 +1,36 @@
+use crate::KernelContext;
+
+#[derive(Clone, Copy, Default)]
+pub enum ProviderRuntimeBinding<'a> {
+    Kernel(&'a KernelContext),
+    #[default]
+    Direct,
+}
+
+impl<'a> ProviderRuntimeBinding<'a> {
+    pub fn from_optional_kernel_context(kernel_ctx: Option<&'a KernelContext>) -> Self {
+        match kernel_ctx {
+            Some(kernel_ctx) => Self::Kernel(kernel_ctx),
+            None => Self::Direct,
+        }
+    }
+
+    pub fn kernel(kernel_ctx: &'a KernelContext) -> Self {
+        Self::Kernel(kernel_ctx)
+    }
+
+    pub const fn direct() -> Self {
+        Self::Direct
+    }
+
+    pub fn kernel_context(self) -> Option<&'a KernelContext> {
+        match self {
+            Self::Kernel(kernel_ctx) => Some(kernel_ctx),
+            Self::Direct => None,
+        }
+    }
+
+    pub const fn is_kernel_bound(self) -> bool {
+        matches!(self, Self::Kernel(_))
+    }
+}

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::KernelContext;
 use crate::config::{LoongClawConfig, ProviderConfig, ReasoningEffort};
 use crate::test_support::ScopedEnv;
 use loongclaw_contracts::{Capability, ExecutionRoute, HarnessKind};
@@ -1860,7 +1861,7 @@ async fn responses_completion_falls_back_to_chat_completions_for_compatible_endp
             "role": "user",
             "content": "ping"
         })],
-        None,
+        ProviderRuntimeBinding::direct(),
     )
     .await
     .expect("compatible responses transport should retry chat-completions automatically");
@@ -1943,7 +1944,7 @@ async fn responses_turn_falls_back_to_chat_completions_for_compatible_endpoints(
             "role": "user",
             "content": "turn ping"
         })],
-        None,
+        ProviderRuntimeBinding::direct(),
     )
     .await
     .expect("turn requests should retry chat-completions when Responses is rejected");
@@ -2039,7 +2040,7 @@ fn provider_failover_audit_event_records_structured_payload() {
     };
 
     record_provider_failover_audit_event(
-        Some(&kernel_ctx),
+        ProviderRuntimeBinding::kernel(&kernel_ctx),
         &provider,
         &snapshot,
         true,
@@ -2116,7 +2117,16 @@ fn provider_failover_audit_event_is_noop_without_kernel_context() {
     let provider = ProviderConfig::default();
     let before = audit.snapshot().len();
 
-    record_provider_failover_audit_event(None, &provider, &snapshot, false, false, 0, 1, true);
+    record_provider_failover_audit_event(
+        ProviderRuntimeBinding::direct(),
+        &provider,
+        &snapshot,
+        false,
+        false,
+        0,
+        1,
+        true,
+    );
 
     let after = audit.snapshot().len();
     assert_eq!(after, before);
@@ -2135,7 +2145,16 @@ fn provider_failover_metrics_record_even_without_kernel_context() {
     };
     let provider = ProviderConfig::default();
 
-    record_provider_failover_audit_event(None, &provider, &snapshot, false, false, 0, 1, true);
+    record_provider_failover_audit_event(
+        ProviderRuntimeBinding::direct(),
+        &provider,
+        &snapshot,
+        false,
+        false,
+        0,
+        1,
+        true,
+    );
 
     let after = provider_failover_metrics_snapshot();
     let reason_before = before
@@ -2184,7 +2203,16 @@ fn provider_failover_metrics_track_continue_path() {
         ..ProviderConfig::default()
     };
 
-    record_provider_failover_audit_event(None, &provider, &snapshot, true, true, 1, 4, false);
+    record_provider_failover_audit_event(
+        ProviderRuntimeBinding::direct(),
+        &provider,
+        &snapshot,
+        true,
+        true,
+        1,
+        4,
+        false,
+    );
 
     let after = provider_failover_metrics_snapshot();
     let reason_before = before.by_reason.get("rate_limited").copied().unwrap_or(0);

--- a/crates/daemon/src/tests/import_cli.rs
+++ b/crates/daemon/src/tests/import_cli.rs
@@ -1356,7 +1356,7 @@ requires_openai_auth = true
             "role": "user",
             "content": "ping"
         })],
-        None,
+        mvp::provider::ProviderRuntimeBinding::direct(),
     )
     .await
     .expect("imported config should support a provider completion request");
@@ -1492,7 +1492,7 @@ requires_openai_auth = true
             "role": "user",
             "content": "ping"
         })],
-        None,
+        mvp::provider::ProviderRuntimeBinding::direct(),
     )
     .await
     .expect("imported config should send chat completions to the custom endpoint");
@@ -1610,7 +1610,7 @@ requires_openai_auth = true
             "role": "user",
             "content": "ping"
         })],
-        None,
+        mvp::provider::ProviderRuntimeBinding::direct(),
     )
     .await
     .expect("imported config should fallback from Responses to chat-completions for turn requests");

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -28,12 +28,17 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 - `shell.exec` — Kernel-mediated tool execution with capability checks, shell policy extensions, and audit events
 - `file.read` / `file.write` — Kernel-mediated tool execution with filesystem capabilities, file policy extension checks, and audit events
 - Conversation tool turns — Fast-lane and safe-lane inner tool execution now flow through an explicit `ConversationRuntimeBinding` (`Kernel` or `Direct`); core tools require a bound `KernelContext`, and missing authority is rejected at the binding boundary as `no_kernel_context`
-- Memory/runtime/context orchestration — The conversation module now carries `ConversationRuntimeBinding` end-to-end across runtime, context, persistence, turn coordination, loop followup, history, and app-dispatch seams. Raw optional kernel context is now pushed out to outer integration boundaries and lower non-conversation leaf helpers, which remain architectural debt rather than full L1 enforcement
+- Memory/runtime/context orchestration — The conversation module now carries `ConversationRuntimeBinding` end-to-end across runtime, context, persistence, turn coordination, loop followup, history, and app-dispatch seams
+- Provider request/failover orchestration — Provider request entrypoints and failover telemetry now use an explicit `ProviderRuntimeBinding` (`Kernel` or `Direct`). Provider failover metrics record in both modes, while kernel-backed audit emission only occurs when provider execution is explicitly kernel-bound
+- Outer integration wrappers — Raw optional kernel context is now limited to explicit integration boundaries such as `channel::process_inbound_with_provider`, which immediately normalize into a binding-first runtime seam instead of carrying shadow authority semantics deeper into the runtime
 - Connector/ACP/runtime-only analytics — Not uniformly routed through the L1 policy chain yet
 
 **Conversation runtime binding note:**
 - The binding makes the high-level execution mode explicit: `Kernel` means the turn is allowed to call kernel-mediated core tools; `Direct` means conversation orchestration may continue, but kernel-only tool execution must fail closed.
 - This removes ambiguity from conversation traits and dispatcher seams where `None` previously overloaded multiple meanings such as "direct mode", "not wired yet", or "forgot to pass kernel authority".
+
+**Provider runtime binding note:**
+- The provider binding makes provider governance explicit without importing conversation-layer semantics into provider code. `Kernel` means failover/audit behavior may emit kernel-backed audit events; `Direct` means provider execution is intentionally running without that authority while still recording in-process failover metrics.
 
 ### Capability Tokens
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -28,7 +28,7 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 - `shell.exec` — Kernel-mediated tool execution with capability checks, shell policy extensions, and audit events
 - `file.read` / `file.write` — Kernel-mediated tool execution with filesystem capabilities, file policy extension checks, and audit events
 - Conversation tool turns — Fast-lane and safe-lane inner tool execution now flow through an explicit `ConversationRuntimeBinding` (`Kernel` or `Direct`); core tools require a bound `KernelContext`, and missing authority is rejected at the binding boundary as `no_kernel_context`
-- Memory/runtime/context orchestration — Conversation-layer runtime, context, persistence, turn-engine, and app-dispatcher seams now normalize optional kernel access into the explicit runtime binding. Lower-level provider and connector surfaces still carry some raw optional kernel context and remain architectural debt rather than full L1 enforcement
+- Memory/runtime/context orchestration — The conversation module now carries `ConversationRuntimeBinding` end-to-end across runtime, context, persistence, turn coordination, loop followup, history, and app-dispatch seams. Raw optional kernel context is now pushed out to outer integration boundaries and lower non-conversation leaf helpers, which remain architectural debt rather than full L1 enforcement
 - Connector/ACP/runtime-only analytics — Not uniformly routed through the L1 policy chain yet
 
 **Conversation runtime binding note:**

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -27,9 +27,13 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 **Current coverage:**
 - `shell.exec` — Kernel-mediated tool execution with capability checks, shell policy extensions, and audit events
 - `file.read` / `file.write` — Kernel-mediated tool execution with filesystem capabilities, file policy extension checks, and audit events
-- Conversation tool turns — Fast-lane and safe-lane inner tool execution now require a bound `KernelContext`; missing kernel authority is rejected at the runtime binding boundary as `no_kernel_context`
-- Memory/runtime/context orchestration — Partially kernelized; some surrounding traits still carry optional kernel context and remain architectural debt rather than full L1 enforcement
+- Conversation tool turns — Fast-lane and safe-lane inner tool execution now flow through an explicit `ConversationRuntimeBinding` (`Kernel` or `Direct`); core tools require a bound `KernelContext`, and missing authority is rejected at the binding boundary as `no_kernel_context`
+- Memory/runtime/context orchestration — Conversation-layer runtime, context, persistence, turn-engine, and app-dispatcher seams now normalize optional kernel access into the explicit runtime binding. Lower-level provider and connector surfaces still carry some raw optional kernel context and remain architectural debt rather than full L1 enforcement
 - Connector/ACP/runtime-only analytics — Not uniformly routed through the L1 policy chain yet
+
+**Conversation runtime binding note:**
+- The binding makes the high-level execution mode explicit: `Kernel` means the turn is allowed to call kernel-mediated core tools; `Direct` means conversation orchestration may continue, but kernel-only tool execution must fail closed.
+- This removes ambiguity from conversation traits and dispatcher seams where `None` previously overloaded multiple meanings such as "direct mode", "not wired yet", or "forgot to pass kernel authority".
 
 ### Capability Tokens
 

--- a/docs/plans/2026-03-15-conversation-binding-normalization-design.md
+++ b/docs/plans/2026-03-15-conversation-binding-normalization-design.md
@@ -1,0 +1,146 @@
+# Conversation Binding Normalization Design
+
+Date: 2026-03-15
+Scope: follow-up kernel-first refactor after issues #45, #154
+
+## Problem
+
+Issue #154 introduced `ConversationRuntimeBinding` at the main conversation
+runtime seams, but the conversation module still exposes mixed contracts.
+
+The remaining inconsistencies are concentrated in:
+
+1. public conversation entrypoints such as `ConversationTurnLoop` and
+   `ConversationTurnCoordinator`
+2. conversation diagnostics and history helpers in `session_history.rs`
+3. helper paths that still accept `Option<&KernelContext>` only to normalize it
+   immediately into `ConversationRuntimeBinding`
+4. shared followup helpers that still accept optional kernel context only to
+   forward the explicit binding into runtime completion
+
+That means the architecture is better than before, but not yet internally
+consistent. A caller still has to remember which conversation-layer APIs are
+binding-first and which still overload `None` to mean one of several things.
+
+## Goals
+
+1. Complete conversation-layer normalization so conversation-facing APIs expose
+   explicit direct-versus-kernel-bound execution mode.
+2. Preserve behavior:
+   - direct provider fallback still works
+   - kernel-backed memory/history windows still run when bound
+   - direct history fallback still works when unbound
+   - core-tool execution still fails closed without kernel authority
+3. Keep the slice reviewable and isolated from provider/ACP leaf work.
+
+## Non-goals
+
+1. Do not sweep the provider module in this slice.
+2. Do not redesign failover telemetry or provider auth/profile selection.
+3. Do not force ACP internals onto a new binding type here.
+
+## Alternatives Considered
+
+### A. Stop after #154
+
+Rejected. The conversation module would continue exposing mixed contracts, which
+keeps the remaining ambiguity exactly where orchestration code is most likely to
+drift.
+
+### B. Normalize provider and conversation leftovers together
+
+Rejected. That would turn one clean follow-up into a cross-module refactor while
+the stacked base PRs are still open.
+
+### C. Finish conversation-layer normalization first
+
+Recommended. It produces a clean, explicit conversation contract and leaves the
+provider/ACP follow-up with a smaller, better-defined boundary.
+
+## Proposed Design
+
+Use `ConversationRuntimeBinding` as the canonical execution-mode type across the
+rest of the conversation module.
+
+In practice this means:
+
+1. conversation entrypoints accept or derive a binding instead of propagating
+   raw `Option<&KernelContext>`
+2. conversation diagnostics/history helpers accept binding directly
+3. any leaf helper that still truly needs `Option<&KernelContext>` gets it only
+   from `binding.kernel_context()`
+
+## Scope of Replacement
+
+This slice should cover the remaining conversation-layer seams:
+
+1. `conversation/turn_loop.rs`
+   - public runtime entrypoints
+   - terminal action helpers
+   - round evaluation helpers
+2. `conversation/turn_coordinator.rs`
+   - public orchestration entrypoints
+   - checkpoint/diagnostic helpers
+   - reply resolution and event persistence helpers that currently normalize
+     optional kernel context internally
+3. `conversation/session_history.rs`
+   - turn checkpoint summary loading
+   - safe-lane event summary loading
+   - memory-window backed history fallback helpers
+4. `conversation/turn_shared.rs`
+   - shared completion fallback helpers used by the loop/coordinator paths
+
+## Binding Rules
+
+### 1. Conversation layer
+
+The conversation layer should speak in terms of:
+
+1. `ConversationRuntimeBinding::Kernel`
+2. `ConversationRuntimeBinding::Direct`
+
+This is where architectural intent matters most.
+
+### 2. Leaf conversions
+
+Leaf helpers may still use `Option<&KernelContext>` temporarily when:
+
+1. they call older provider helpers not yet normalized
+2. they branch between kernel-backed memory windows and direct fallback
+
+The key rule is that the conversion happens at the leaf, not at the
+conversation-facing seam.
+
+## Expected Behavioral Outcome
+
+Behavior after this refactor should stay the same:
+
+1. `handle_turn*` and related conversation entrypoints still support direct
+   fallback when intentionally unbound
+2. history and diagnostics helpers still prefer kernel-backed memory windows
+   when bound
+3. history and diagnostics helpers still fall back to direct memory access when
+   unbound
+4. provider leaf helpers can remain unchanged for now
+
+The change is architectural clarity: the conversation module will no longer mix
+explicit binding seams with raw optional-kernel seams.
+
+## Test Strategy
+
+Add regression coverage that proves:
+
+1. conversation entrypoints continue to work in both direct and kernel-bound
+   mode after signature normalization
+2. history summary helpers still prefer kernel memory when bound
+3. history summary helpers still read sqlite/direct state when unbound
+4. no behavior changes leak into turn execution and checkpoint diagnostics
+
+## Why This Slice Matters
+
+Kernel-first architecture is not complete when only the middle of the call graph
+is explicit. The public conversation contract and its internal orchestration
+helpers also need to declare whether they are running kernel-bound or direct.
+
+Once that is true, the next provider/ACP cleanup can start from a stable,
+uniform conversation boundary instead of inheriting a partially normalized one.

--- a/docs/plans/2026-03-15-conversation-binding-normalization-implementation-plan.md
+++ b/docs/plans/2026-03-15-conversation-binding-normalization-implementation-plan.md
@@ -1,0 +1,151 @@
+# Conversation Binding Normalization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Complete conversation-layer runtime binding normalization so the remaining conversation entrypoints and history helpers use `ConversationRuntimeBinding` instead of raw optional kernel context.
+
+**Architecture:** Keep the scope inside the conversation module. Move the remaining `turn_loop`, `turn_coordinator`, `session_history`, and shared followup-helper seams onto `ConversationRuntimeBinding`, and only convert back to `Option<&KernelContext>` at lower-level leaf helpers that have not been normalized yet.
+
+**Tech Stack:** Rust, async-trait, Tokio tests, GitHub issue-first workflow
+
+---
+
+### Task 1: Normalize session history helpers onto `ConversationRuntimeBinding`
+
+**Files:**
+- Modify: `crates/app/src/conversation/session_history.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add or adapt tests so history-summary helpers are called with
+`ConversationRuntimeBinding::kernel(...)` and `ConversationRuntimeBinding::direct()`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app load_turn_checkpoint_event_summary -- --test-threads=1`
+
+Expected: FAIL because the helper signatures still accept `Option<&KernelContext>`.
+
+**Step 3: Write minimal implementation**
+
+Update the session-history APIs and internal helpers to accept
+`ConversationRuntimeBinding` and convert to optional kernel context only at the
+memory-window leaf.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app load_turn_checkpoint_event_summary -- --test-threads=1`
+
+Expected: PASS
+
+### Task 2: Normalize remaining `ConversationTurnLoop` seams
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/conversation/turn_shared.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Adapt turn-loop entrypoint tests to call the explicit binding-based APIs or to
+exercise the normalized internal helpers through binding-based paths.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app handle_turn_with_runtime -- --test-threads=1`
+
+Expected: FAIL due to remaining optional-kernel conversation seams.
+
+**Step 3: Write minimal implementation**
+
+Move the remaining turn-loop seams to `ConversationRuntimeBinding` while
+preserving the public direct fallback behavior.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app handle_turn_with_runtime -- --test-threads=1`
+
+Expected: PASS
+
+### Task 3: Normalize remaining `ConversationTurnCoordinator` seams
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Adapt coordinator and checkpoint-diagnostics tests to use binding-based entry
+and helper calls where those seams are still raw optional kernel context.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+- `cargo test -p loongclaw-app repair_turn_checkpoint -- --test-threads=1`
+- `cargo test -p loongclaw-app load_turn_checkpoint_diagnostics -- --test-threads=1`
+- `cargo test -p loongclaw-app probe_turn_checkpoint_tail_runtime_gate -- --test-threads=1`
+
+Expected: FAIL because coordinator helper signatures still expose optional
+kernel context.
+
+**Step 3: Write minimal implementation**
+
+Normalize the remaining coordinator entrypoints and helper paths to
+`ConversationRuntimeBinding`, converting back to optional kernel context only at
+provider/history leaves that have not been normalized yet.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+- `cargo test -p loongclaw-app repair_turn_checkpoint -- --test-threads=1`
+- `cargo test -p loongclaw-app load_turn_checkpoint_diagnostics -- --test-threads=1`
+- `cargo test -p loongclaw-app probe_turn_checkpoint_tail_runtime_gate -- --test-threads=1`
+
+Expected: PASS
+
+### Task 4: Update docs and finish verification
+
+**Files:**
+- Modify: `docs/SECURITY.md`
+- Modify: `docs/plans/2026-03-15-conversation-binding-normalization-design.md`
+- Modify: `docs/plans/2026-03-15-conversation-binding-normalization-implementation-plan.md`
+
+**Step 1: Update docs**
+
+Clarify that the conversation module is now fully normalized around the explicit
+runtime binding, while provider/ACP leaf helpers remain future follow-up work.
+
+**Step 2: Run targeted verification**
+
+Run:
+- `cargo test -p loongclaw-app load_turn_checkpoint_event_summary -- --test-threads=1`
+- `cargo test -p loongclaw-app handle_turn_with_runtime -- --test-threads=1`
+- `cargo test -p loongclaw-app repair_turn_checkpoint -- --test-threads=1`
+- `cargo test -p loongclaw-app load_turn_checkpoint_diagnostics -- --test-threads=1`
+- `cargo test -p loongclaw-app probe_turn_checkpoint_tail_runtime_gate -- --test-threads=1`
+
+Expected: PASS
+
+**Step 3: Run full verification**
+
+Run:
+- `cargo fmt --all`
+- `cargo fmt --all -- --check`
+- `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
+- `cargo test -p loongclaw-app -- --test-threads=1`
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-03-15-conversation-binding-normalization-design.md \
+        docs/plans/2026-03-15-conversation-binding-normalization-implementation-plan.md \
+        docs/SECURITY.md \
+        crates/app/src/conversation/session_history.rs \
+        crates/app/src/conversation/turn_loop.rs \
+        crates/app/src/conversation/turn_coordinator.rs \
+        crates/app/src/conversation/tests.rs
+git commit -m "refactor: normalize remaining conversation runtime binding seams"
+```

--- a/docs/plans/2026-03-15-conversation-binding-normalization-implementation-plan.md
+++ b/docs/plans/2026-03-15-conversation-binding-normalization-implementation-plan.md
@@ -1,7 +1,5 @@
 # Conversation Binding Normalization Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Complete conversation-layer runtime binding normalization so the remaining conversation entrypoints and history helpers use `ConversationRuntimeBinding` instead of raw optional kernel context.
 
 **Architecture:** Keep the scope inside the conversation module. Move the remaining `turn_loop`, `turn_coordinator`, `session_history`, and shared followup-helper seams onto `ConversationRuntimeBinding`, and only convert back to `Option<&KernelContext>` at lower-level leaf helpers that have not been normalized yet.

--- a/docs/plans/2026-03-15-conversation-runtime-binding-design.md
+++ b/docs/plans/2026-03-15-conversation-runtime-binding-design.md
@@ -1,0 +1,158 @@
+# Conversation Runtime Binding Design
+
+Date: 2026-03-15
+Scope: follow-up kernel-first refactor after issue #45 / PR #151
+
+## Problem
+
+The conversation stack still encodes a real architectural distinction as raw
+`Option<&KernelContext>` values. That shape is too weak for the current runtime:
+
+1. `None` can mean "intentional direct fallback path"
+2. `None` can mean "no kernel authority, so core execution must be denied"
+3. `None` can also mean "this helper does not care"
+
+Those meanings are not interchangeable, but the type surface makes them look the
+same. The previous kernel-policy unification slice fixed the highest-risk
+behavioral bug by restoring no-kernel app/session tool execution while keeping
+core-tool execution kernel-bound. Even after that fix, the high-level
+conversation/runtime APIs still ask every caller to reconstruct the same meaning
+from a bare optional reference.
+
+That leaves the next refactor hazard in place: future callers can accidentally
+route a direct-fallback path into a kernel-required seam, or vice versa, without
+the API pushing back clearly enough.
+
+## Goals
+
+1. Replace raw optional kernel references with an explicit conversation-scoped
+   binding type at the high-level runtime seams.
+2. Preserve current behavior:
+   - core tools stay kernel-bound
+   - lifecycle hooks stay kernel-bound
+   - app/session tools still execute through dispatcher-backed no-kernel paths
+   - provider request and persistence fallback paths remain available when the
+     conversation runtime intentionally runs without a kernel
+3. Keep this slice reviewable and local to the conversation module instead of
+   sweeping the full repository.
+
+## Non-goals
+
+1. Do not force all provider, connector, ACP, or analytics paths through the
+   kernel in this slice.
+2. Do not remove every `Option<&KernelContext>` in the repository.
+3. Do not redesign the kernel policy chain or app-tool dispatcher behavior.
+
+## Alternatives Considered
+
+### A. Keep `Option<&KernelContext>` and rely on comments/tests
+
+Rejected. The problem is not missing commentary. The problem is that the API
+surface does not encode the architectural intent strongly enough.
+
+### B. Require `&KernelContext` everywhere immediately
+
+Rejected. That would either break deliberate direct-fallback paths or expand
+this follow-up into a much larger, mixed-purpose architecture change.
+
+### C. Introduce a conversation-scoped binding type
+
+Recommended. This keeps the current behavior but makes caller intent explicit at
+the conversation/runtime layer. It also creates a stable seam for later work
+that may further tighten policy routing without breaking behavior now.
+
+## Proposed Design
+
+Introduce a new conversation-scoped binding type:
+
+- `ConversationRuntimeBinding::Kernel(&KernelContext)`
+- `ConversationRuntimeBinding::Direct`
+
+The type should live in the conversation module and expose small helper methods
+such as:
+
+- `kernel(...)`
+- `direct()`
+- `kernel_context() -> Option<&KernelContext>`
+- `is_kernel_bound()`
+
+The important property is semantic, not mechanical: callers stop passing a raw
+optional reference and instead declare which conversation-runtime mode they are
+using.
+
+## Binding Rules
+
+### 1. Kernel-bound paths
+
+These paths already require kernel authority and should stay that way:
+
+1. core tool execution
+2. lifecycle hooks (`bootstrap`, `ingest`, `after_turn`, `compact_context`,
+   subagent lifecycle hooks)
+3. memory-window reads when the default context engine uses kernel-backed memory
+
+For these actions, the binding type is a transport type, not a relaxation. Code
+that truly requires kernel authority should still demand a concrete
+`&KernelContext` at the point of execution.
+
+### 2. Direct-fallback paths
+
+These paths intentionally remain available without a kernel:
+
+1. provider request / completion dispatch
+2. direct persistence fallback
+3. app/session tool dispatch through `AppToolDispatcher`
+4. legacy context assembly paths
+
+The binding type should make those paths explicit rather than implicit.
+
+## Scope of Replacement
+
+This slice should replace raw `Option<&KernelContext>` with the binding type in
+conversation-layer APIs where the distinction is architectural:
+
+1. `ConversationRuntime`
+2. `ConversationContextEngine` context assembly methods
+3. persistence helpers in `conversation/persistence.rs`
+4. turn loop / turn coordinator orchestration helpers
+5. `TurnEngine` app-tool dispatcher boundary and execution helpers
+
+It is acceptable for lower-level provider helpers to continue accepting
+`Option<&KernelContext>` internally for now. The conversation layer can convert
+the explicit binding back into an optional reference at those lower seams until
+those modules get their own dedicated cleanup.
+
+## Expected Behavioral Outcome
+
+Behavior should remain the same after this refactor:
+
+1. no-kernel app/session tools still work
+2. no-kernel provider/persistence fallback still works
+3. core tools still deny with `no_kernel_context`
+4. lifecycle hooks still run only when kernel-bound
+
+The change is that these outcomes will now be routed through APIs that say
+directly whether a call is using kernel authority or direct fallback.
+
+## Test Strategy
+
+Add regression coverage that specifically proves:
+
+1. the new binding type preserves existing no-kernel app/session tool execution
+2. the binding type preserves direct-fallback context assembly and persistence
+3. kernel-bound paths still use the kernel when bound
+4. core tools still deny without kernel authority
+
+This should include at least one turn-engine level test and one runtime/context
+or persistence level test that exercise the new explicit binding shape.
+
+## Why This Slice Matters
+
+Kernel-first architecture does not only mean "more places use the kernel." It
+also means the runtime contract clearly distinguishes:
+
+1. actions that are kernel-authorized
+2. actions that are intentionally direct fallback
+
+Without that distinction encoded in the type surface, the architecture remains
+easy to misuse even if current behavior happens to pass tests.

--- a/docs/plans/2026-03-15-conversation-runtime-binding-implementation-plan.md
+++ b/docs/plans/2026-03-15-conversation-runtime-binding-implementation-plan.md
@@ -1,7 +1,5 @@
 # Conversation Runtime Binding Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Replace raw optional kernel context propagation at conversation/runtime boundaries with an explicit conversation runtime binding type while preserving current behavior.
 
 **Architecture:** Add a conversation-scoped binding enum that explicitly represents kernel-bound versus direct-fallback execution. Thread that type through the conversation runtime, context assembly, persistence helpers, turn loop, turn coordinator, and app-tool dispatcher boundaries, while keeping lower-level provider helpers behaviorally unchanged by converting the binding to an optional kernel reference only at the leaf.

--- a/docs/plans/2026-03-15-conversation-runtime-binding-implementation-plan.md
+++ b/docs/plans/2026-03-15-conversation-runtime-binding-implementation-plan.md
@@ -1,0 +1,153 @@
+# Conversation Runtime Binding Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace raw optional kernel context propagation at conversation/runtime boundaries with an explicit conversation runtime binding type while preserving current behavior.
+
+**Architecture:** Add a conversation-scoped binding enum that explicitly represents kernel-bound versus direct-fallback execution. Thread that type through the conversation runtime, context assembly, persistence helpers, turn loop, turn coordinator, and app-tool dispatcher boundaries, while keeping lower-level provider helpers behaviorally unchanged by converting the binding to an optional kernel reference only at the leaf.
+
+**Tech Stack:** Rust, async-trait, Tokio test framework, GitHub issue-first workflow
+
+---
+
+### Task 1: Add the binding type and wire it into public conversation exports
+
+**Files:**
+- Create: `crates/app/src/conversation/runtime_binding.rs`
+- Modify: `crates/app/src/conversation/mod.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that construct the binding type and assert:
+- `direct()` is not kernel-bound
+- `kernel(&ctx)` is kernel-bound
+- `kernel_context()` returns the expected optional reference
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app conversation_runtime_binding -- --test-threads=1`
+
+Expected: FAIL because the binding type and tests do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create the binding type, expose the helper methods, and re-export it from
+`conversation/mod.rs`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app conversation_runtime_binding -- --test-threads=1`
+
+Expected: PASS
+
+### Task 2: Move conversation runtime/context/persistence surfaces to the binding type
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/conversation/context_engine.rs`
+- Modify: `crates/app/src/conversation/persistence.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add regression tests that use the explicit binding type for:
+- direct-fallback context assembly
+- kernel-bound persistence / memory-window behavior where already covered
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app 'default_runtime_|kernel_' -- --test-threads=1`
+
+Expected: FAIL due to signature mismatches or missing binding-based call paths.
+
+**Step 3: Write minimal implementation**
+
+Update runtime/context/persistence APIs to accept the binding type and convert
+to `Option<&KernelContext>` only at lower-level leaf helpers where needed.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app 'default_runtime_|kernel_' -- --test-threads=1`
+
+Expected: PASS
+
+### Task 3: Move turn-engine and orchestration boundaries to the binding type
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add a turn-engine or dispatcher-focused regression test that proves:
+- app tools receive explicit direct binding without kernel
+- core tools still deny when the binding is direct
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app 'turn_engine_|handle_turn_with_runtime_' -- --test-threads=1`
+
+Expected: FAIL because the new binding type is not threaded through execution yet.
+
+**Step 3: Write minimal implementation**
+
+Update `AppToolDispatcher`, `TurnEngine`, turn loop, and turn coordinator to use
+the explicit binding type instead of raw optional kernel references.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app 'turn_engine_|handle_turn_with_runtime_' -- --test-threads=1`
+
+Expected: PASS
+
+### Task 4: Update docs and finish verification
+
+**Files:**
+- Modify: `docs/SECURITY.md`
+- Modify: `docs/plans/2026-03-15-conversation-runtime-binding-design.md`
+- Modify: `docs/plans/2026-03-15-conversation-runtime-binding-implementation-plan.md`
+
+**Step 1: Update docs**
+
+Reflect that the conversation layer now uses an explicit runtime binding rather
+than bare optional kernel references for high-level execution routing.
+
+**Step 2: Run targeted verification**
+
+Run:
+- `cargo test -p loongclaw-app conversation_runtime_binding -- --test-threads=1`
+- `cargo test -p loongclaw-app turn_engine_ -- --test-threads=1`
+- `cargo test -p loongclaw-app handle_turn_with_runtime -- --test-threads=1`
+
+Expected: PASS
+
+**Step 3: Run full verification**
+
+Run:
+- `cargo fmt --all`
+- `cargo fmt --all -- --check`
+- `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
+- `cargo test -p loongclaw-app -- --test-threads=1`
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-03-15-conversation-runtime-binding-design.md \
+        docs/plans/2026-03-15-conversation-runtime-binding-implementation-plan.md \
+        docs/SECURITY.md \
+        crates/app/src/conversation/mod.rs \
+        crates/app/src/conversation/runtime_binding.rs \
+        crates/app/src/conversation/runtime.rs \
+        crates/app/src/conversation/context_engine.rs \
+        crates/app/src/conversation/persistence.rs \
+        crates/app/src/conversation/turn_engine.rs \
+        crates/app/src/conversation/turn_loop.rs \
+        crates/app/src/conversation/turn_coordinator.rs \
+        crates/app/src/conversation/tests.rs
+git commit -m "refactor: add explicit conversation runtime binding"
+```

--- a/docs/plans/2026-03-15-provider-binding-normalization-design.md
+++ b/docs/plans/2026-03-15-provider-binding-normalization-design.md
@@ -1,0 +1,149 @@
+# Provider Binding Normalization Design
+
+Date: 2026-03-15
+Scope: follow-up kernel-first refactor after issues #15, #154, #157, #167
+
+## Problem
+
+Conversation orchestration is now explicit about runtime authority through
+`ConversationRuntimeBinding`, but the provider layer still collapses that
+authority back into raw `Option<&KernelContext>`.
+
+The remaining seams are concentrated in:
+
+1. `provider::request_completion`
+2. `provider::request_turn`
+3. `provider::request_turn_in_view`
+4. `request_failover_runtime::request_across_model_candidates`
+5. `failover_telemetry_runtime::record_provider_failover_audit_event`
+
+That means a provider caller still has to overload `None` with several
+different meanings:
+
+1. intentional direct provider execution
+2. missing kernel authority for governed failover telemetry
+3. an outer boundary that has not committed to either mode yet
+
+This weakens the kernel-first architecture story exactly where retry/failover
+behavior and audit authority should be explicit.
+
+## Goals
+
+1. Replace raw optional-kernel provider request seams with an explicit provider
+   binding type.
+2. Preserve current provider behavior:
+   - direct provider execution still works
+   - failover metrics still record in both modes
+   - kernel-backed audit events still emit when authority is present
+3. Keep the slice narrow and reviewable by avoiding broader provider abstraction
+   redesign in this PR.
+
+## Non-goals
+
+1. Do not redesign provider transport, payload shaping, or model selection.
+2. Do not fold the broader provider abstraction debt from issue #15 into this
+   slice.
+3. Do not sweep outer integration boundaries such as channel entrypoints unless
+   a trivial wrapper cleanup naturally falls out.
+
+## Alternatives Considered
+
+### A. Keep `Option<&KernelContext>` in provider code
+
+Rejected. The API shape remains ambiguous and reintroduces the same shadow-path
+problem already being removed from conversation orchestration.
+
+### B. Reuse `ConversationRuntimeBinding` directly inside provider
+
+Rejected. It would leak conversation-layer semantics into provider code and
+invert the dependency story. Provider request/failover logic should describe its
+own authority contract instead of depending on a higher-level orchestration
+binding type.
+
+### C. Introduce a provider-specific explicit binding
+
+Recommended. It keeps the authority contract explicit while preserving a clean
+layer boundary: conversation code translates into provider semantics at the
+conversation-to-provider seam, and provider internals no longer need to infer
+meaning from `Option<&KernelContext>`.
+
+## Proposed Design
+
+Add a provider-scoped binding type, `ProviderRuntimeBinding`, with the same
+two-state shape as the conversation binding but provider-specific semantics:
+
+1. `Kernel` means provider failover/audit behavior is running with kernel-backed
+   authority.
+2. `Direct` means provider execution is intentionally running without that
+   authority.
+
+The provider layer uses the binding only where it is architecturally relevant:
+
+1. provider request entrypoints accept `ProviderRuntimeBinding`
+2. request failover orchestration forwards the binding without converting it
+3. failover telemetry converts to `binding.kernel_context()` only at the audit
+   emission leaf
+
+## Why Not Share One Generic Binding Type?
+
+This slice should not introduce a new generic runtime-binding abstraction across
+multiple modules. That would expand the change from a clean provider follow-up
+into a broader cross-layer design exercise.
+
+Using separate explicit binding types keeps semantics local:
+
+1. conversation binding answers "is this turn kernel-bound or direct?"
+2. provider binding answers "is this provider request governed by kernel-backed
+   failover/audit authority or direct?"
+
+Those answers are related, but they are not the same contract.
+
+## Translation Boundary
+
+The conversion should happen at the existing conversation-to-provider seam in
+`conversation/runtime.rs`.
+
+That keeps responsibilities clean:
+
+1. conversation runtime remains authoritative for turn execution mode
+2. provider runtime becomes authoritative for provider request governance mode
+3. outer integration boundaries such as `channel::process_inbound_with_provider`
+   can stay optional until they reach a binding-first seam
+
+## Expected Behavioral Outcome
+
+Behavior should remain stable:
+
+1. direct provider requests continue to work for direct conversation/runtime
+   flows
+2. provider failover metrics still record in both direct and kernel-bound modes
+3. provider failover audit events still emit only when kernel authority is
+   present
+4. conversation runtime no longer has to collapse an explicit binding back into
+   an optional kernel reference before calling provider code
+
+The change is architectural clarity, not a new provider policy.
+
+## Test Strategy
+
+Add or adapt tests that prove:
+
+1. public provider request APIs still support direct execution using the new
+   explicit binding
+2. failover audit events are still emitted when provider execution is
+   kernel-bound
+3. failover metrics still record when provider execution is direct
+4. conversation-runtime provider calls still preserve direct-versus-kernel-bound
+   behavior after translation
+5. downstream crates that call the public provider APIs, such as daemon import
+   tests, are updated to the explicit binding contract
+
+## Why This Slice Matters
+
+Kernel-first architecture is not just about routing core tools through the
+kernel. It also requires the remaining authority-bearing call boundaries to be
+explicit about when they are governed and when they are intentionally direct.
+
+Finishing this provider seam removes one of the last raw optional-kernel
+contracts from the main `app` runtime path and sets up later ACP/channel work on
+top of a cleaner, more uniform inner runtime contract.

--- a/docs/plans/2026-03-15-provider-binding-normalization-implementation-plan.md
+++ b/docs/plans/2026-03-15-provider-binding-normalization-implementation-plan.md
@@ -1,7 +1,5 @@
 # Provider Binding Normalization Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Replace the remaining raw optional-kernel provider request and
 failover seams with an explicit provider runtime binding while preserving direct
 provider execution and kernel-backed failover audit behavior.
@@ -32,8 +30,8 @@ instead of raw optional kernel context.
 **Step 2: Run test to verify it fails**
 
 Run:
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_failover_audit_event_records_structured_payload -- --test-threads=1`
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_failover_metrics_record_even_without_kernel_context -- --test-threads=1`
+- `cargo test -p loongclaw-app provider_failover_audit_event_records_structured_payload -- --test-threads=1`
+- `cargo test -p loongclaw-app provider_failover_metrics_record_even_without_kernel_context -- --test-threads=1`
 
 Expected: FAIL because provider APIs still accept `Option<&KernelContext>`.
 
@@ -63,9 +61,9 @@ they use the explicit provider binding.
 **Step 2: Run test to verify it fails**
 
 Run:
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app responses_completion_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app responses_turn_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_failover_metrics_track_continue_path -- --test-threads=1`
+- `cargo test -p loongclaw-app responses_completion_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
+- `cargo test -p loongclaw-app responses_turn_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
+- `cargo test -p loongclaw-app provider_failover_metrics_track_continue_path -- --test-threads=1`
 
 Expected: FAIL until the provider request/failover signatures accept
 `ProviderRuntimeBinding`.
@@ -95,7 +93,7 @@ and kernel-bound provider calls through the existing binding-based runtime path.
 **Step 2: Run test to verify it fails**
 
 Run:
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app conversation_runtime_binding_direct_reports_no_kernel_context -- --test-threads=1`
+- `cargo test -p loongclaw-app conversation_runtime_binding_direct_reports_no_kernel_context -- --test-threads=1`
 
 Expected: FAIL only if a new translation helper/test is introduced; otherwise
 this task is compile-time coverage plus targeted provider regression coverage.
@@ -127,20 +125,20 @@ still limited to explicit boundary wrappers such as channel entrypoints.
 **Step 2: Run targeted verification**
 
 Run:
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app responses_completion_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app responses_turn_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_failover_audit_event_records_structured_payload -- --test-threads=1`
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_failover_metrics_record_even_without_kernel_context -- --test-threads=1`
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_failover_metrics_track_continue_path -- --test-threads=1`
+- `cargo test -p loongclaw-app responses_completion_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
+- `cargo test -p loongclaw-app responses_turn_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
+- `cargo test -p loongclaw-app provider_failover_audit_event_records_structured_payload -- --test-threads=1`
+- `cargo test -p loongclaw-app provider_failover_metrics_record_even_without_kernel_context -- --test-threads=1`
+- `cargo test -p loongclaw-app provider_failover_metrics_track_continue_path -- --test-threads=1`
 
 Expected: PASS
 
 **Step 3: Run full verification**
 
 Run:
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all -- --check`
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo clippy --workspace --all-targets --all-features -- -D warnings`
-- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test --workspace --all-features -- --test-threads=1`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features -- --test-threads=1`
 
 Expected: PASS
 

--- a/docs/plans/2026-03-15-provider-binding-normalization-implementation-plan.md
+++ b/docs/plans/2026-03-15-provider-binding-normalization-implementation-plan.md
@@ -1,0 +1,161 @@
+# Provider Binding Normalization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the remaining raw optional-kernel provider request and
+failover seams with an explicit provider runtime binding while preserving direct
+provider execution and kernel-backed failover audit behavior.
+
+**Architecture:** Add a provider-scoped `ProviderRuntimeBinding` type, thread it
+through provider request entrypoints and failover telemetry helpers, and perform
+the conversation-to-provider translation at `conversation/runtime.rs`. Keep
+outer channel integration optional for now, and only convert back to
+`Option<&KernelContext>` at the audit-emission leaf.
+
+**Tech Stack:** Rust, Tokio tests, GitHub issue-first workflow
+
+---
+
+### Task 1: Add the provider-scoped runtime binding type
+
+**Files:**
+- Create: `crates/app/src/provider/runtime_binding.rs`
+- Modify: `crates/app/src/provider/mod.rs`
+- Test: `crates/app/src/provider/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add or adapt provider tests so they call provider request/failover helpers with
+`ProviderRuntimeBinding::direct()` and `ProviderRuntimeBinding::kernel(...)`
+instead of raw optional kernel context.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_failover_audit_event_records_structured_payload -- --test-threads=1`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_failover_metrics_record_even_without_kernel_context -- --test-threads=1`
+
+Expected: FAIL because provider APIs still accept `Option<&KernelContext>`.
+
+**Step 3: Write minimal implementation**
+
+Create `ProviderRuntimeBinding` with explicit constructors/helpers and re-export
+it from `provider/mod.rs`.
+
+**Step 4: Run test to verify it passes**
+
+Run the same commands and expect PASS.
+
+### Task 2: Normalize provider request and failover seams
+
+**Files:**
+- Modify: `crates/app/src/provider/mod.rs`
+- Modify: `crates/app/src/provider/request_failover_runtime.rs`
+- Modify: `crates/app/src/provider/failover_telemetry_runtime.rs`
+- Test: `crates/app/src/provider/tests.rs`
+- Test: `crates/daemon/src/tests/import_cli.rs`
+
+**Step 1: Write the failing test**
+
+Adapt the request/failover tests that currently pass `None` or `Some(&ctx)` so
+they use the explicit provider binding.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app responses_completion_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app responses_turn_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_failover_metrics_track_continue_path -- --test-threads=1`
+
+Expected: FAIL until the provider request/failover signatures accept
+`ProviderRuntimeBinding`.
+
+**Step 3: Write minimal implementation**
+
+Thread `ProviderRuntimeBinding` through the public provider request entrypoints,
+failover orchestration, and failover telemetry helper. Only the audit leaf
+should ask the binding for an optional kernel context. Update downstream test
+callers that intentionally exercise direct provider execution.
+
+**Step 4: Run test to verify it passes**
+
+Run the same commands and expect PASS.
+
+### Task 3: Translate at the conversation-to-provider boundary
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+If needed, adapt or add a conversation-runtime test that exercises both direct
+and kernel-bound provider calls through the existing binding-based runtime path.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app conversation_runtime_binding_direct_reports_no_kernel_context -- --test-threads=1`
+
+Expected: FAIL only if a new translation helper/test is introduced; otherwise
+this task is compile-time coverage plus targeted provider regression coverage.
+
+**Step 3: Write minimal implementation**
+
+Translate `ConversationRuntimeBinding` into `ProviderRuntimeBinding` at the
+conversation runtime call sites instead of forwarding raw optional kernel
+context.
+
+**Step 4: Run test to verify it passes**
+
+Run the same targeted command if a new test was added; otherwise rely on
+provider and workspace verification.
+
+### Task 4: Update security docs and finish verification
+
+**Files:**
+- Modify: `docs/SECURITY.md`
+- Modify: `docs/plans/2026-03-15-provider-binding-normalization-design.md`
+- Modify: `docs/plans/2026-03-15-provider-binding-normalization-implementation-plan.md`
+
+**Step 1: Update docs**
+
+Clarify that provider request/failover seams now use an explicit provider
+runtime binding, while the remaining optional-kernel outer integration seam is
+still limited to explicit boundary wrappers such as channel entrypoints.
+
+**Step 2: Run targeted verification**
+
+Run:
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app responses_completion_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app responses_turn_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_failover_audit_event_records_structured_payload -- --test-threads=1`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_failover_metrics_record_even_without_kernel_context -- --test-threads=1`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-app provider_failover_metrics_track_continue_path -- --test-threads=1`
+
+Expected: PASS
+
+**Step 3: Run full verification**
+
+Run:
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all -- --check`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `/Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test --workspace --all-features -- --test-threads=1`
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add docs/SECURITY.md \
+        docs/plans/2026-03-15-provider-binding-normalization-design.md \
+        docs/plans/2026-03-15-provider-binding-normalization-implementation-plan.md \
+        crates/app/src/conversation/runtime.rs \
+        crates/app/src/provider/failover_telemetry_runtime.rs \
+        crates/app/src/provider/mod.rs \
+        crates/app/src/provider/request_failover_runtime.rs \
+        crates/app/src/provider/runtime_binding.rs \
+        crates/app/src/provider/tests.rs \
+        crates/daemon/src/tests/import_cli.rs
+git commit -m "refactor: normalize provider runtime binding seams"
+```

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-15T11:46:15Z
+- Generated at: 2026-03-15T15:25:33Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -13,7 +13,7 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3020 | 3600 | 580 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1478 | 3700 | 2222 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
-| provider_mod | `crates/app/src/provider/mod.rs` | 281 | 1000 | 719 | 7 | 20 | 13 | n/a | n/a | N/A | n/a |
+| provider_mod | `crates/app/src/provider/mod.rs` | 283 | 1000 | 717 | 7 | 20 | 13 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 312 | 650 | 338 | 15 | 16 | 1 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
@@ -40,7 +40,7 @@
 
 <!-- arch-hotspot key=spec_runtime lines=3020 functions=47 -->
 <!-- arch-hotspot key=spec_execution lines=1478 functions=23 -->
-<!-- arch-hotspot key=provider_mod lines=281 functions=7 -->
+<!-- arch-hotspot key=provider_mod lines=283 functions=7 -->
 <!-- arch-hotspot key=memory_mod lines=312 functions=15 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- land the conversation and provider runtime binding normalization stack on `alpha-test`
- preserve direct safe-lane app-tool execution while keeping kernel-only boundaries explicit
- refresh regression coverage plus design/security docs so the shipped runtime contract and tool surface stay aligned

This PR intentionally lands the prerequisite stack for `#154`, `#157`, and `#167` together with the issue-45 no-kernel safety work so `alpha-test` can review and take the final runtime contract as one unit.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

- this changes authority-bearing runtime seams that affect direct versus kernel-bound execution across conversation orchestration and provider failover/audit paths
- behavior is intended to remain stable: direct provider execution still works, safe-lane app tools still execute without a kernel binding, and kernel-backed audit emission only happens when execution is explicitly kernel-bound
- the main review risk is stack depth and boundary normalization across conversation and provider entrypoints rather than intentional semantic churn

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional targeted checks:
- `cargo test -p loongclaw-app conversation::tests::conversation_runtime_trait_default_tool_view_includes_runtime_discovered_feishu_tools --features feishu-integration -- --exact`
- `cargo test -p loongclaw-app handle_turn_with_runtime_safe_lane_executes_`
- `cargo test -p loongclaw-app responses_completion_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
- `cargo test -p loongclaw-app responses_turn_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`

## Linked Issues

Refs #45
Closes #154
Closes #157
Closes #167