### PR TITLE
feat: resolve external skills across managed user and project scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Operator-facing CLI:
   - Removes one managed installed skill from the local index.
 - `loongclaw skills policy get|set|reset [--config PATH] [--json]`
   - Reads or updates the config-backed external-skills runtime policy with the same policy fields exposed by `external_skills.policy`.
+  - Mutating `set` and `reset` calls require `--approve-policy-update`.
 
 Recommended runtime flow:
 

--- a/README.md
+++ b/README.md
@@ -363,12 +363,26 @@ Agent-facing tools:
 - `external_skills_remove`
   - Removes a managed installed skill and updates the local index.
 
+Operator-facing CLI:
+
+- `loongclaw skills list [--config PATH] [--json]`
+  - Lists managed installed skills using the current config/runtime guardrails.
+- `loongclaw skills info <skill-id> [--config PATH] [--json]`
+  - Shows structured metadata plus a short `SKILL.md` preview for one installed skill.
+- `loongclaw skills install <path> [--skill-id ID] [--replace] [--config PATH] [--json]`
+  - Installs a local skill directory or `.tgz` / `.tar.gz` archive through the same managed runtime path as `external_skills.install`.
+- `loongclaw skills remove <skill-id> [--config PATH] [--json]`
+  - Removes one managed installed skill from the local index.
+- `loongclaw skills policy get|set|reset [--config PATH] [--json]`
+  - Reads or updates the config-backed external-skills runtime policy with the same policy fields exposed by `external_skills.policy`.
+
 Recommended runtime flow:
 
 1. Download with `external_skills.fetch`
-2. Install with `external_skills.install`
-3. Discover with `external_skills.list`
-4. Load instructions with `external_skills.invoke`
+2. Install with `external_skills.install` or `loongclaw skills install`
+3. Discover with `external_skills.list` or `loongclaw skills list`
+4. Inspect with `external_skills.inspect` or `loongclaw skills info`
+5. Load instructions with `external_skills.invoke`
 
 ## Key Features
 

--- a/README.md
+++ b/README.md
@@ -355,20 +355,23 @@ Agent-facing tools:
   - Accepts a directory containing `SKILL.md` or a local `.tgz` / `.tar.gz` archive.
   - Installs the skill under `<tools.file_root>/external-skills-installed/` by default.
 - `external_skills_list`
-  - Lists managed installed skills that are available for invocation.
+  - Lists resolved external skills across `managed`, `user`, and `project` scopes.
+  - Reports lower-priority duplicates under `shadowed_skills` so operators can debug precedence.
 - `external_skills_inspect`
-  - Returns metadata and a short preview for an installed skill.
+  - Returns metadata and a short preview for the resolved skill plus any shadowed duplicates with the same `skill_id`.
 - `external_skills_invoke`
-  - Loads an installed skill's `SKILL.md` instructions into the conversation loop.
+  - Loads the resolved skill's `SKILL.md` instructions into the conversation loop.
 - `external_skills_remove`
   - Removes a managed installed skill and updates the local index.
 
 Operator-facing CLI:
 
 - `loongclaw skills list [--config PATH] [--json]`
-  - Lists managed installed skills using the current config/runtime guardrails.
+  - Lists resolved external skills across `managed`, `user`, and `project` scopes using the current config/runtime guardrails.
+  - Includes `shadowed skills` in text output and `shadowed_skills` in JSON output when duplicate ids are hidden by precedence.
 - `loongclaw skills info <skill-id> [--config PATH] [--json]`
-  - Shows structured metadata plus a short `SKILL.md` preview for one installed skill.
+  - Shows structured metadata plus a short `SKILL.md` preview for one resolved skill.
+  - Includes any lower-priority duplicates that were shadowed by the selected skill.
 - `loongclaw skills install <path> [--skill-id ID] [--replace] [--config PATH] [--json]`
   - Installs a local skill directory or `.tgz` / `.tar.gz` archive through the same managed runtime path as `external_skills.install`.
 - `loongclaw skills remove <skill-id> [--config PATH] [--json]`
@@ -382,6 +385,9 @@ Recommended runtime flow:
 1. Download with `external_skills.fetch`
 2. Install with `external_skills.install` or `loongclaw skills install`
 3. Discover with `external_skills.list` or `loongclaw skills list`
+   - Resolution order is `managed > user > project`
+   - Project discovery probes `.agents/skills`, `.codex/skills`, `.claude/skills`, and `skills/`
+   - User discovery probes `~/.agents/skills`, `~/.codex/skills`, and `~/.claude/skills`
 4. Inspect with `external_skills.inspect` or `loongclaw skills info`
 5. Load instructions with `external_skills.invoke`
 

--- a/crates/app/src/runtime_env.rs
+++ b/crates/app/src/runtime_env.rs
@@ -2,6 +2,47 @@ use std::path::Path;
 
 use crate::config::LoongClawConfig;
 
+pub fn build_tool_runtime_config(
+    config: &LoongClawConfig,
+    resolved_config_path: Option<&Path>,
+) -> crate::tools::runtime_config::ToolRuntimeConfig {
+    crate::tools::runtime_config::ToolRuntimeConfig {
+        shell_allow: config
+            .tools
+            .shell_allow
+            .iter()
+            .map(|value| value.to_ascii_lowercase())
+            .collect(),
+        shell_deny: config
+            .tools
+            .shell_deny
+            .iter()
+            .map(|value| value.to_ascii_lowercase())
+            .collect(),
+        file_root: Some(config.tools.resolved_file_root()),
+        config_path: resolved_config_path.map(Path::to_path_buf),
+        shell_default_mode: crate::tools::shell_policy_ext::ShellPolicyDefault::parse(
+            &config.tools.shell_default_mode,
+        ),
+        external_skills: crate::tools::runtime_config::ExternalSkillsRuntimePolicy {
+            enabled: config.external_skills.enabled,
+            require_download_approval: config.external_skills.require_download_approval,
+            allowed_domains: config
+                .external_skills
+                .normalized_allowed_domains()
+                .into_iter()
+                .collect(),
+            blocked_domains: config
+                .external_skills
+                .normalized_blocked_domains()
+                .into_iter()
+                .collect(),
+            install_root: config.external_skills.resolved_install_root(),
+            auto_expose_installed: config.external_skills.auto_expose_installed,
+        },
+    }
+}
+
 pub fn initialize_runtime_environment(
     config: &LoongClawConfig,
     resolved_config_path: Option<&Path>,
@@ -83,41 +124,7 @@ pub fn initialize_runtime_environment(
         bool_env(config.external_skills.auto_expose_installed),
     );
 
-    let tool_rt = crate::tools::runtime_config::ToolRuntimeConfig {
-        shell_allow: config
-            .tools
-            .shell_allow
-            .iter()
-            .map(|value| value.to_ascii_lowercase())
-            .collect(),
-        shell_deny: config
-            .tools
-            .shell_deny
-            .iter()
-            .map(|value| value.to_ascii_lowercase())
-            .collect(),
-        file_root: Some(config.tools.resolved_file_root()),
-        config_path: resolved_config_path.map(Path::to_path_buf),
-        shell_default_mode: crate::tools::shell_policy_ext::ShellPolicyDefault::parse(
-            &config.tools.shell_default_mode,
-        ),
-        external_skills: crate::tools::runtime_config::ExternalSkillsRuntimePolicy {
-            enabled: config.external_skills.enabled,
-            require_download_approval: config.external_skills.require_download_approval,
-            allowed_domains: config
-                .external_skills
-                .normalized_allowed_domains()
-                .into_iter()
-                .collect(),
-            blocked_domains: config
-                .external_skills
-                .normalized_blocked_domains()
-                .into_iter()
-                .collect(),
-            install_root: config.external_skills.resolved_install_root(),
-            auto_expose_installed: config.external_skills.auto_expose_installed,
-        },
-    };
+    let tool_rt = build_tool_runtime_config(config, resolved_config_path);
     let _ = crate::tools::runtime_config::init_tool_runtime_config(tool_rt);
 
     let memory_rt =

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -224,7 +224,7 @@ pub fn tool_catalog() -> ToolCatalog {
             name: "external_skills.inspect",
             provider_name: "external_skills_inspect",
             aliases: &[],
-            description: "Read metadata for an installed external skill",
+            description: "Read metadata for a resolved external skill across managed, user, and project scopes",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             provider_definition_builder: external_skills_inspect_definition,
@@ -242,7 +242,7 @@ pub fn tool_catalog() -> ToolCatalog {
             name: "external_skills.invoke",
             provider_name: "external_skills_invoke",
             aliases: &[],
-            description: "Load an installed external skill into the conversation loop",
+            description: "Load a resolved external skill into the conversation loop",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             provider_definition_builder: external_skills_invoke_definition,
@@ -251,7 +251,7 @@ pub fn tool_catalog() -> ToolCatalog {
             name: "external_skills.list",
             provider_name: "external_skills_list",
             aliases: &[],
-            description: "List managed external skills available for invocation",
+            description: "List resolved external skills across managed, user, and project scopes",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             provider_definition_builder: external_skills_list_definition,
@@ -734,13 +734,13 @@ fn external_skills_inspect_definition(descriptor: &ToolDescriptor) -> Value {
         "type": "function",
         "function": {
             "name": descriptor.provider_name,
-            "description": "Read metadata and a short preview for an installed external skill.",
+            "description": "Read metadata and a short preview for a resolved external skill across managed, user, and project scopes.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "skill_id": {
                         "type": "string",
-                        "description": "Managed external skill identifier."
+                        "description": "Resolved external skill identifier."
                     }
                 },
                 "required": ["skill_id"],
@@ -784,13 +784,13 @@ fn external_skills_invoke_definition(descriptor: &ToolDescriptor) -> Value {
         "type": "function",
         "function": {
             "name": descriptor.provider_name,
-            "description": "Load an installed external skill's SKILL.md instructions into the conversation loop.",
+            "description": "Load a resolved external skill's SKILL.md instructions into the conversation loop across managed, user, and project scopes.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "skill_id": {
                         "type": "string",
-                        "description": "Managed external skill identifier."
+                        "description": "Resolved external skill identifier."
                     }
                 },
                 "required": ["skill_id"],
@@ -805,7 +805,7 @@ fn external_skills_list_definition(descriptor: &ToolDescriptor) -> Value {
         "type": "function",
         "function": {
             "name": descriptor.provider_name,
-            "description": "List managed external skills available for invocation.",
+            "description": "List resolved external skills available for invocation across managed, user, and project scopes.",
             "parameters": {
                 "type": "object",
                 "properties": {},

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fs,
     io::{ErrorKind, Read},
     path::{Path, PathBuf},
@@ -21,6 +21,21 @@ const DEFAULT_INDEX_FILENAME: &str = "index.json";
 const DEFAULT_MAX_DOWNLOAD_BYTES: usize = 5 * 1024 * 1024;
 const HARD_MAX_DOWNLOAD_BYTES: usize = 20 * 1024 * 1024;
 const INSTALLED_SKILL_SNAPSHOT_HINT: &str = "installed managed external skill; use external_skills.inspect or external_skills.invoke for details";
+const USER_SKILL_SNAPSHOT_HINT: &str =
+    "user external skill; use external_skills.inspect or external_skills.invoke for details";
+const PROJECT_SKILL_SNAPSHOT_HINT: &str =
+    "project external skill; use external_skills.inspect or external_skills.invoke for details";
+const PROJECT_DISCOVERY_DIRS: [(&str, usize); 4] = [
+    (".agents/skills", 0),
+    (".codex/skills", 1),
+    (".claude/skills", 2),
+    ("skills", 3),
+];
+const USER_DISCOVERY_DIRS: [(&str, usize); 3] = [
+    (".agents/skills", 0),
+    (".codex/skills", 1),
+    (".claude/skills", 2),
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct InstalledSkillEntry {
@@ -39,6 +54,57 @@ struct InstalledSkillEntry {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct InstalledSkillIndex {
     skills: Vec<InstalledSkillEntry>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+enum DiscoveredSkillScope {
+    Managed,
+    User,
+    Project,
+}
+
+impl DiscoveredSkillScope {
+    const fn precedence_rank(self) -> usize {
+        match self {
+            Self::Managed => 0,
+            Self::User => 1,
+            Self::Project => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct DiscoveredSkillEntry {
+    skill_id: String,
+    display_name: String,
+    summary: String,
+    scope: DiscoveredSkillScope,
+    source_kind: String,
+    source_path: String,
+    skill_md_path: String,
+    sha256: String,
+    active: bool,
+    install_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct SkillFrontmatter {
+    name: Option<String>,
+    description: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct DiscoveredSkillCandidate {
+    entry: DiscoveredSkillEntry,
+    probe_rank: usize,
+    root_rank: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+struct SkillDiscoveryInventory {
+    skills: Vec<DiscoveredSkillEntry>,
+    shadowed_skills: Vec<DiscoveredSkillEntry>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -389,7 +455,7 @@ pub(super) fn execute_external_skills_install_tool_with_config(
         .and_then(|value| (!value.is_empty()).then_some(value))
         .map(normalize_skill_id)
         .transpose()?
-        .unwrap_or_else(|| derive_skill_id(&skill_root));
+        .unwrap_or_else(|| derive_skill_id_from_markdown(&skill_root, skill_markdown.as_str()));
     let display_name = derive_skill_display_name(skill_markdown.as_str(), skill_id.as_str());
     let summary = derive_skill_summary(skill_markdown.as_str());
 
@@ -534,19 +600,14 @@ pub(super) fn execute_external_skills_list_tool_with_config(
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
     require_enabled_runtime_policy(config)?;
-    let install_root = resolve_install_root(config);
-    let index = load_installed_skill_index(&install_root)?;
-    let skills = index
-        .skills
-        .into_iter()
-        .map(|entry| rehydrate_installed_skill_entry(&install_root, entry))
-        .collect::<Result<Vec<_>, _>>()?;
+    let inventory = discover_skill_inventory(config)?;
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
             "adapter": "core-tools",
             "tool_name": request.tool_name,
-            "skills": skills,
+            "skills": inventory.skills,
+            "shadowed_skills": inventory.shadowed_skills,
         }),
     })
 }
@@ -568,15 +629,21 @@ pub(super) fn execute_external_skills_inspect_tool_with_config(
 
     require_enabled_runtime_policy(config)?;
 
-    let install_root = resolve_install_root(config);
-    let (entry, instructions) = load_installed_skill_material(&install_root, skill_id)?;
+    let inventory = discover_skill_inventory(config)?;
+    let skill = resolve_discovered_skill(&inventory, skill_id)?;
+    let instructions = load_discovered_skill_markdown(config, &skill)?;
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
             "adapter": "core-tools",
             "tool_name": request.tool_name,
-            "skill": entry,
+            "skill": skill,
             "instructions_preview": build_preview(instructions.as_str(), 240),
+            "shadowed_skills": inventory
+                .shadowed_skills
+                .into_iter()
+                .filter(|entry| entry.skill_id == skill_id)
+                .collect::<Vec<_>>(),
         }),
     })
 }
@@ -598,23 +665,25 @@ pub(super) fn execute_external_skills_invoke_tool_with_config(
 
     require_enabled_runtime_policy(config)?;
 
-    let install_root = resolve_install_root(config);
-    let (entry, instructions) = load_installed_skill_material(&install_root, skill_id)?;
-    if !entry.active {
+    let skill = resolve_discovered_skill(&discover_skill_inventory(config)?, skill_id)?;
+    if !skill.active {
         return Err(format!(
             "external skill `{skill_id}` is installed but inactive"
         ));
     }
+    let instructions = load_discovered_skill_markdown(config, &skill)?;
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
             "adapter": "core-tools",
             "tool_name": request.tool_name,
-            "skill_id": entry.skill_id,
-            "display_name": entry.display_name,
-            "summary": entry.summary,
-            "install_path": entry.install_path,
-            "skill_md_path": entry.skill_md_path,
+            "skill_id": skill.skill_id,
+            "display_name": skill.display_name,
+            "summary": skill.summary,
+            "scope": skill.scope,
+            "source_path": skill.source_path,
+            "install_path": skill.install_path,
+            "skill_md_path": skill.skill_md_path,
             "instructions": instructions,
             "invocation_summary": format!(
                 "Loaded external skill `{}`. Apply the instructions in `SKILL.md` before continuing the task.",
@@ -800,7 +869,7 @@ fn parse_optional_domain_list(
     Ok(Some(normalized))
 }
 
-fn normalize_domain_rule(raw: &str) -> Result<String, String> {
+pub(crate) fn normalize_domain_rule(raw: &str) -> Result<String, String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return Err("domain rule cannot be empty".to_owned());
@@ -1167,6 +1236,14 @@ fn derive_skill_id(root: &Path) -> String {
     normalize_skill_id(fallback).unwrap_or_else(|_| "external-skill".to_owned())
 }
 
+fn derive_skill_id_from_markdown(root: &Path, skill_markdown: &str) -> String {
+    parse_skill_frontmatter(skill_markdown)
+        .name
+        .as_deref()
+        .and_then(|name| normalize_skill_id(name).ok())
+        .unwrap_or_else(|| derive_skill_id(root))
+}
+
 fn normalize_skill_id(raw: &str) -> Result<String, String> {
     let mut normalized = String::new();
     let mut last_dash = false;
@@ -1198,7 +1275,8 @@ fn normalize_skill_id(raw: &str) -> Result<String, String> {
 }
 
 fn derive_skill_display_name(skill_markdown: &str, fallback: &str) -> String {
-    for line in skill_markdown.lines() {
+    let frontmatter = parse_skill_frontmatter(skill_markdown);
+    for line in skill_content_lines(skill_markdown) {
         let trimmed = line.trim();
         if let Some(title) = trimmed.strip_prefix("# ") {
             let title = title.trim();
@@ -1207,11 +1285,22 @@ fn derive_skill_display_name(skill_markdown: &str, fallback: &str) -> String {
             }
         }
     }
+    if let Some(name) = frontmatter.name
+        && !name.is_empty()
+    {
+        return name;
+    }
     fallback.to_owned()
 }
 
 fn derive_skill_summary(skill_markdown: &str) -> String {
-    for line in skill_markdown.lines() {
+    let frontmatter = parse_skill_frontmatter(skill_markdown);
+    if let Some(description) = frontmatter.description
+        && !description.is_empty()
+    {
+        return build_preview(description.as_str(), 120);
+    }
+    for line in skill_content_lines(skill_markdown) {
         let trimmed = line.trim();
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
@@ -1219,6 +1308,63 @@ fn derive_skill_summary(skill_markdown: &str) -> String {
         return build_preview(trimmed, 120);
     }
     "No summary provided.".to_owned()
+}
+
+fn parse_skill_frontmatter(skill_markdown: &str) -> SkillFrontmatter {
+    let mut lines = skill_markdown.lines();
+    if lines.next().map(str::trim) != Some("---") {
+        return SkillFrontmatter::default();
+    }
+
+    let mut frontmatter = SkillFrontmatter::default();
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed == "---" {
+            break;
+        }
+        if let Some(value) = parse_frontmatter_scalar(trimmed, "name") {
+            frontmatter.name = Some(value);
+            continue;
+        }
+        if let Some(value) = parse_frontmatter_scalar(trimmed, "description") {
+            frontmatter.description = Some(value);
+        }
+    }
+    frontmatter
+}
+
+fn parse_frontmatter_scalar(line: &str, key: &str) -> Option<String> {
+    let raw = line.strip_prefix(key)?.strip_prefix(':')?.trim();
+    let unquoted = raw
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .or_else(|| {
+            raw.strip_prefix('\'')
+                .and_then(|value| value.strip_suffix('\''))
+        })
+        .unwrap_or(raw)
+        .trim();
+    (!unquoted.is_empty()).then(|| unquoted.to_owned())
+}
+
+fn skill_content_lines(skill_markdown: &str) -> impl Iterator<Item = &str> {
+    let mut in_frontmatter = false;
+    let mut frontmatter_started = false;
+    skill_markdown.lines().filter(move |line| {
+        let trimmed = line.trim();
+        if !frontmatter_started && trimmed == "---" {
+            frontmatter_started = true;
+            in_frontmatter = true;
+            return false;
+        }
+        if in_frontmatter {
+            if trimmed == "---" {
+                in_frontmatter = false;
+            }
+            return false;
+        }
+        true
+    })
 }
 
 fn build_preview(content: &str, max_chars: usize) -> String {
@@ -1371,6 +1517,60 @@ fn installed_skill_by_id(
         .ok_or_else(|| format!("external skill `{skill_id}` is not installed"))
 }
 
+fn discover_skill_inventory(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<SkillDiscoveryInventory, String> {
+    let mut grouped = BTreeMap::<String, Vec<DiscoveredSkillCandidate>>::new();
+    for candidate in discover_managed_skill_candidates(config)?
+        .into_iter()
+        .chain(discover_user_skill_candidates()?)
+        .chain(discover_project_skill_candidates(config)?)
+    {
+        grouped
+            .entry(candidate.entry.skill_id.clone())
+            .or_default()
+            .push(candidate);
+    }
+
+    let mut inventory = SkillDiscoveryInventory::default();
+    for mut candidates in grouped.into_values() {
+        candidates.sort_by(|left, right| {
+            left.entry
+                .scope
+                .precedence_rank()
+                .cmp(&right.entry.scope.precedence_rank())
+                .then_with(|| left.probe_rank.cmp(&right.probe_rank))
+                .then_with(|| left.root_rank.cmp(&right.root_rank))
+                .then_with(|| left.entry.source_path.cmp(&right.entry.source_path))
+        });
+
+        let winner_index = candidates
+            .iter()
+            .position(|candidate| candidate.entry.active)
+            .unwrap_or(0);
+        let winner = candidates.remove(winner_index);
+        inventory.skills.push(winner.entry);
+        inventory
+            .shadowed_skills
+            .extend(candidates.into_iter().map(|candidate| candidate.entry));
+    }
+
+    inventory
+        .skills
+        .sort_by(|left, right| left.skill_id.cmp(&right.skill_id));
+    inventory.shadowed_skills.sort_by(|left, right| {
+        left.skill_id
+            .cmp(&right.skill_id)
+            .then_with(|| {
+                left.scope
+                    .precedence_rank()
+                    .cmp(&right.scope.precedence_rank())
+            })
+            .then_with(|| left.source_path.cmp(&right.source_path))
+    });
+    Ok(inventory)
+}
+
 pub(super) fn installed_skill_snapshot_lines_with_config(
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<Vec<String>, String> {
@@ -1378,20 +1578,254 @@ pub(super) fn installed_skill_snapshot_lines_with_config(
     if !policy.enabled || !policy.auto_expose_installed {
         return Ok(Vec::new());
     }
-    let install_root = resolve_install_root(config);
-    let index = load_installed_skill_index(&install_root)?;
-    Ok(index
+    Ok(discover_skill_inventory(config)?
         .skills
         .into_iter()
         .filter_map(|entry| {
             if !entry.active {
                 return None;
             }
-            rehydrate_installed_skill_entry(&install_root, entry)
-                .ok()
-                .map(|entry| format!("- {}: {}", entry.skill_id, INSTALLED_SKILL_SNAPSHOT_HINT))
+            let hint = match entry.scope {
+                DiscoveredSkillScope::Managed => INSTALLED_SKILL_SNAPSHOT_HINT,
+                DiscoveredSkillScope::User => USER_SKILL_SNAPSHOT_HINT,
+                DiscoveredSkillScope::Project => PROJECT_SKILL_SNAPSHOT_HINT,
+            };
+            Some(format!("- {}: {}", entry.skill_id, hint))
         })
         .collect())
+}
+
+fn discover_managed_skill_candidates(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<Vec<DiscoveredSkillCandidate>, String> {
+    let install_root = resolve_install_root(config);
+    let index = load_installed_skill_index(&install_root)?;
+    index
+        .skills
+        .into_iter()
+        .map(|entry| {
+            let entry = rehydrate_installed_skill_entry(&install_root, entry)?;
+            Ok(DiscoveredSkillCandidate {
+                probe_rank: 0,
+                root_rank: 0,
+                entry: DiscoveredSkillEntry {
+                    skill_id: entry.skill_id,
+                    display_name: entry.display_name,
+                    summary: entry.summary,
+                    scope: DiscoveredSkillScope::Managed,
+                    source_kind: entry.source_kind,
+                    source_path: entry.source_path,
+                    skill_md_path: entry.skill_md_path,
+                    sha256: entry.sha256,
+                    active: entry.active,
+                    install_path: Some(entry.install_path),
+                },
+            })
+        })
+        .collect()
+}
+
+fn discover_user_skill_candidates() -> Result<Vec<DiscoveredSkillCandidate>, String> {
+    let Some(home_root) = user_home_dir() else {
+        return Ok(Vec::new());
+    };
+    discover_scoped_skill_candidates(
+        &[home_root],
+        DiscoveredSkillScope::User,
+        &USER_DISCOVERY_DIRS,
+    )
+}
+
+fn discover_project_skill_candidates(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<Vec<DiscoveredSkillCandidate>, String> {
+    discover_scoped_skill_candidates(
+        &project_discovery_probe_roots(config),
+        DiscoveredSkillScope::Project,
+        &PROJECT_DISCOVERY_DIRS,
+    )
+}
+
+fn discover_scoped_skill_candidates(
+    probe_roots: &[PathBuf],
+    scope: DiscoveredSkillScope,
+    dir_specs: &[(&str, usize)],
+) -> Result<Vec<DiscoveredSkillCandidate>, String> {
+    let mut candidates = Vec::new();
+    let mut seen = BTreeSet::new();
+    for (probe_rank, probe_root) in probe_roots.iter().enumerate() {
+        for (relative_dir, root_rank) in dir_specs {
+            let container = probe_root.join(relative_dir);
+            if !container.is_dir() {
+                continue;
+            }
+            for skill_root in find_discoverable_skill_roots(&container) {
+                let skill_md_path = skill_root.join(DEFAULT_SKILL_FILENAME);
+                let key = skill_md_path.display().to_string();
+                if !seen.insert(key.clone()) {
+                    continue;
+                }
+                let skill_markdown = load_directory_skill_markdown(&skill_root)?;
+                let skill_id = derive_skill_id_from_markdown(&skill_root, skill_markdown.as_str());
+                candidates.push(DiscoveredSkillCandidate {
+                    probe_rank,
+                    root_rank: *root_rank,
+                    entry: DiscoveredSkillEntry {
+                        skill_id: skill_id.clone(),
+                        display_name: derive_skill_display_name(
+                            skill_markdown.as_str(),
+                            skill_id.as_str(),
+                        ),
+                        summary: derive_skill_summary(skill_markdown.as_str()),
+                        scope,
+                        source_kind: "directory".to_owned(),
+                        source_path: skill_root.display().to_string(),
+                        skill_md_path: key,
+                        sha256: format!("{:x}", Sha256::digest(skill_markdown.as_bytes())),
+                        active: true,
+                        install_path: None,
+                    },
+                });
+            }
+        }
+    }
+    Ok(candidates)
+}
+
+fn project_discovery_probe_roots(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Vec<PathBuf> {
+    let Some(project_root) = config
+        .file_root
+        .clone()
+        .or_else(|| std::env::current_dir().ok())
+    else {
+        return Vec::new();
+    };
+
+    let mut roots = Vec::new();
+    if let Ok(current_dir) = std::env::current_dir()
+        && current_dir.starts_with(&project_root)
+    {
+        let mut next = Some(current_dir.as_path());
+        while let Some(path) = next {
+            roots.push(path.to_path_buf());
+            if path == project_root.as_path() {
+                break;
+            }
+            next = path.parent();
+        }
+    } else {
+        roots.push(project_root);
+    }
+
+    let mut seen = BTreeSet::new();
+    roots.retain(|root| seen.insert(root.display().to_string()));
+    roots
+}
+
+fn user_home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+fn resolve_discovered_skill(
+    inventory: &SkillDiscoveryInventory,
+    skill_id: &str,
+) -> Result<DiscoveredSkillEntry, String> {
+    inventory
+        .skills
+        .iter()
+        .find(|entry| entry.skill_id == skill_id)
+        .cloned()
+        .ok_or_else(|| format!("external skill `{skill_id}` is not available"))
+}
+
+fn load_discovered_skill_markdown(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    skill: &DiscoveredSkillEntry,
+) -> Result<String, String> {
+    match skill.scope {
+        DiscoveredSkillScope::Managed => {
+            let install_root = resolve_install_root(config);
+            let (_entry, instructions) =
+                load_installed_skill_material(&install_root, skill.skill_id.as_str())?;
+            Ok(instructions)
+        }
+        DiscoveredSkillScope::User | DiscoveredSkillScope::Project => {
+            load_directory_skill_markdown(Path::new(&skill.source_path))
+        }
+    }
+}
+
+fn load_directory_skill_markdown(skill_root: &Path) -> Result<String, String> {
+    let metadata = fs::metadata(skill_root).map_err(|error| {
+        format!(
+            "failed to inspect external skill source {}: {error}",
+            skill_root.display()
+        )
+    })?;
+    if !metadata.is_dir() {
+        return Err(format!(
+            "external skill source {} must be a directory",
+            skill_root.display()
+        ));
+    }
+    let skill_md_path = skill_root.join(DEFAULT_SKILL_FILENAME);
+    if !skill_md_path.is_file() {
+        return Err(format!(
+            "external skill source {} is missing `{DEFAULT_SKILL_FILENAME}`",
+            skill_root.display()
+        ));
+    }
+    fs::read_to_string(&skill_md_path).map_err(|error| {
+        format!(
+            "failed to read external skill source {}: {error}",
+            skill_md_path.display()
+        )
+    })
+}
+
+fn find_discoverable_skill_roots(root: &Path) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let mut visited = BTreeSet::new();
+    visit_discoverable_skill_roots(root, &mut roots, &mut visited);
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
+fn visit_discoverable_skill_roots(
+    root: &Path,
+    roots: &mut Vec<PathBuf>,
+    visited: &mut BTreeSet<String>,
+) {
+    let canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let key = canonical.display().to_string();
+    if !visited.insert(key) {
+        return;
+    }
+
+    let Ok(metadata) = fs::metadata(&canonical) else {
+        return;
+    };
+    if metadata.is_file() || !metadata.is_dir() {
+        return;
+    }
+
+    let skill_md_path = canonical.join(DEFAULT_SKILL_FILENAME);
+    if skill_md_path.is_file() {
+        roots.push(canonical);
+        return;
+    }
+
+    let Ok(entries) = fs::read_dir(&canonical) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        visit_discoverable_skill_roots(&entry.path(), roots, visited);
+    }
 }
 
 fn contains_regular_skill_markdown(root: &Path) -> Result<bool, String> {
@@ -1538,7 +1972,7 @@ mod tests {
 
     fn with_policy_test_lock<T>(f: impl FnOnce() -> T) -> T {
         let lock = POLICY_TEST_LOCK.get_or_init(|| Mutex::new(()));
-        let _guard = lock.lock().expect("policy test lock");
+        let _guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         f()
     }
 
@@ -1588,6 +2022,27 @@ mod tests {
             .unwrap_or_default()
             .as_nanos();
         std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    struct ScopedHomeFixture {
+        _env: crate::test_support::ScopedEnv,
+        path: PathBuf,
+    }
+
+    impl ScopedHomeFixture {
+        fn new(prefix: &str) -> Self {
+            let path = unique_temp_dir(prefix);
+            fs::create_dir_all(&path).expect("create isolated home");
+            let mut env = crate::test_support::ScopedEnv::new();
+            env.set("HOME", &path);
+            Self { _env: env, path }
+        }
+    }
+
+    impl Drop for ScopedHomeFixture {
+        fn drop(&mut self) {
+            fs::remove_dir_all(&self.path).ok();
+        }
     }
 
     fn write_file(root: &Path, relative: &str, content: &str) {
@@ -1822,6 +2277,24 @@ mod tests {
     }
 
     #[test]
+    fn policy_test_lock_recovers_after_mutex_poison() {
+        let panic_result = std::thread::spawn(|| {
+            with_policy_test_lock(|| {
+                panic!("poison policy lock for test");
+            });
+        })
+        .join();
+
+        assert!(panic_result.is_err(), "setup thread should poison the lock");
+
+        let recovered = std::panic::catch_unwind(|| with_policy_test_lock(|| ()));
+        assert!(
+            recovered.is_ok(),
+            "with_policy_test_lock should recover from a poisoned mutex"
+        );
+    }
+
+    #[test]
     fn install_from_directory_writes_managed_index_and_copy() {
         with_managed_runtime_test(|| {
             let root = unique_temp_dir("loongclaw-ext-skill-install-dir");
@@ -2006,6 +2479,7 @@ mod tests {
         with_managed_runtime_test(|| {
             let root = unique_temp_dir("loongclaw-ext-skill-list-invoke");
             fs::create_dir_all(&root).expect("create fixture root");
+            let _home = ScopedHomeFixture::new("loongclaw-ext-skill-list-invoke-home");
             write_file(
                 &root,
                 "source/demo-skill/SKILL.md",
@@ -2033,7 +2507,16 @@ mod tests {
             )
             .expect("list should succeed");
             assert_eq!(list_outcome.status, "ok");
-            assert_eq!(list_outcome.payload["skills"][0]["skill_id"], "demo-skill");
+            assert!(
+                list_outcome.payload["skills"]
+                    .as_array()
+                    .expect("skills should be an array")
+                    .iter()
+                    .any(|skill| {
+                        skill["skill_id"] == "demo-skill" && skill["scope"] == "managed"
+                    }),
+                "managed install should appear in resolved skills list"
+            );
 
             let invoke_outcome = crate::tools::execute_tool_core_with_config(
                 ToolCoreRequest {
@@ -2055,6 +2538,233 @@ mod tests {
             );
 
             fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn discovery_resolves_managed_user_and_project_scopes_with_shadowed_duplicates() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-discovery-precedence");
+            let home = unique_temp_dir("loongclaw-ext-skill-discovery-home");
+            fs::create_dir_all(&root).expect("create fixture root");
+            fs::create_dir_all(&home).expect("create home root");
+
+            write_file(
+                &root,
+                "source/demo-skill/SKILL.md",
+                "# Managed Demo Skill\n\nManaged install should win precedence.\n",
+            );
+            write_file(
+                &root,
+                ".agents/skills/demo-skill/SKILL.md",
+                "---\nname: demo-skill\ndescription: Project-scoped demo skill.\n---\n\n# Project Demo Skill\n\nProject copy should be shadowed by managed.\n",
+            );
+            write_file(
+                &root,
+                ".claude/skills/project-only/SKILL.md",
+                "---\nname: project-only\ndescription: Project-only skill.\n---\n\nProject-only instructions.\n",
+            );
+            write_file(
+                &home,
+                ".agents/skills/demo-skill/SKILL.md",
+                "---\nname: demo-skill\ndescription: User-scoped demo skill.\n---\n\n# User Demo Skill\n\nUser copy should be shadowed by managed.\n",
+            );
+            write_file(
+                &home,
+                ".agents/skills/user-only/SKILL.md",
+                "---\nname: user-only\ndescription: User-only skill.\n---\n\nUser-only instructions.\n",
+            );
+
+            let config = managed_runtime_config(&root);
+            let mut env = crate::test_support::ScopedEnv::new();
+            env.set("HOME", &home);
+
+            crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload: json!({
+                        "path": "source/demo-skill"
+                    }),
+                },
+                &config,
+            )
+            .expect("install should succeed");
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("list should succeed");
+            let skills = list_outcome.payload["skills"]
+                .as_array()
+                .expect("skills should be an array");
+            assert_eq!(
+                skills.len(),
+                3,
+                "resolved list should contain one entry per skill id"
+            );
+            assert!(
+                skills.iter().any(|skill| {
+                    skill["skill_id"] == "demo-skill"
+                        && skill["scope"] == "managed"
+                        && skill["display_name"] == "Managed Demo Skill"
+                }),
+                "managed skill should win precedence in resolved list: {skills:?}"
+            );
+            assert!(
+                skills.iter().any(|skill| {
+                    skill["skill_id"] == "project-only"
+                        && skill["scope"] == "project"
+                        && skill["summary"] == "Project-only skill."
+                }),
+                "project-only skill should be discovered from project scope: {skills:?}"
+            );
+            assert!(
+                skills.iter().any(|skill| {
+                    skill["skill_id"] == "user-only"
+                        && skill["scope"] == "user"
+                        && skill["summary"] == "User-only skill."
+                }),
+                "user-only skill should be discovered from user scope: {skills:?}"
+            );
+
+            let shadowed = list_outcome.payload["shadowed_skills"]
+                .as_array()
+                .expect("shadowed_skills should be an array");
+            assert_eq!(
+                shadowed.len(),
+                2,
+                "duplicate lower-priority skills should be reported as shadowed"
+            );
+            assert!(
+                shadowed
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "demo-skill" && skill["scope"] == "user"),
+                "user duplicate should be shadowed by managed precedence: {shadowed:?}"
+            );
+            assert!(
+                shadowed
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "demo-skill" && skill["scope"] == "project"),
+                "project duplicate should be shadowed by managed precedence: {shadowed:?}"
+            );
+
+            let inspect_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.inspect".to_owned(),
+                    payload: json!({
+                        "skill_id": "demo-skill"
+                    }),
+                },
+                &config,
+            )
+            .expect("inspect should resolve the managed winner");
+            assert_eq!(inspect_outcome.payload["skill"]["scope"], "managed");
+            assert_eq!(
+                inspect_outcome.payload["skill"]["display_name"],
+                "Managed Demo Skill"
+            );
+            assert_eq!(
+                inspect_outcome.payload["shadowed_skills"]
+                    .as_array()
+                    .expect("inspect should include shadowed duplicates")
+                    .len(),
+                2
+            );
+
+            let user_invoke = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.invoke".to_owned(),
+                    payload: json!({
+                        "skill_id": "user-only"
+                    }),
+                },
+                &config,
+            )
+            .expect("invoke should resolve user-only skills");
+            assert_eq!(user_invoke.payload["scope"], "user");
+            assert!(
+                user_invoke.payload["instructions"]
+                    .as_str()
+                    .expect("instructions should be text")
+                    .contains("User-only instructions"),
+                "invoke should load user-scope instructions"
+            );
+
+            let project_invoke = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.invoke".to_owned(),
+                    payload: json!({
+                        "skill_id": "project-only"
+                    }),
+                },
+                &config,
+            )
+            .expect("invoke should resolve project-only skills");
+            assert_eq!(project_invoke.payload["scope"], "project");
+            assert!(
+                project_invoke.payload["instructions"]
+                    .as_str()
+                    .expect("instructions should be text")
+                    .contains("Project-only instructions"),
+                "invoke should load project-scope instructions"
+            );
+
+            fs::remove_dir_all(&root).ok();
+            fs::remove_dir_all(&home).ok();
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discovery_follows_symlinked_user_skill_directories() {
+        with_managed_runtime_test(|| {
+            use std::os::unix::fs::symlink;
+
+            let root = unique_temp_dir("loongclaw-ext-skill-discovery-symlink-root");
+            let home = unique_temp_dir("loongclaw-ext-skill-discovery-symlink-home");
+            let shared = unique_temp_dir("loongclaw-ext-skill-discovery-symlink-target");
+            fs::create_dir_all(&root).expect("create fixture root");
+            fs::create_dir_all(home.join(".agents/skills")).expect("create user skills root");
+            fs::create_dir_all(&shared).expect("create shared skill root");
+            write_file(
+                &shared,
+                "portable-skill/SKILL.md",
+                "---\nname: portable-skill\ndescription: Symlinked user skill.\n---\n\nPortable instructions.\n",
+            );
+            symlink(
+                shared.join("portable-skill"),
+                home.join(".agents/skills/portable-skill"),
+            )
+            .expect("create user skill symlink");
+
+            let mut env = crate::test_support::ScopedEnv::new();
+            env.set("HOME", &home);
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &managed_runtime_config(&root),
+            )
+            .expect("symlinked user skills should be discoverable");
+            assert!(
+                list_outcome.payload["skills"]
+                    .as_array()
+                    .expect("skills should be an array")
+                    .iter()
+                    .any(|skill| {
+                        skill["skill_id"] == "portable-skill" && skill["scope"] == "user"
+                    }),
+                "symlinked user skill should appear in resolved discovery output"
+            );
+
+            fs::remove_dir_all(&root).ok();
+            fs::remove_dir_all(&home).ok();
+            fs::remove_dir_all(&shared).ok();
         });
     }
 
@@ -2105,6 +2815,7 @@ mod tests {
         with_managed_runtime_test(|| {
             let root = unique_temp_dir("loongclaw-ext-skill-remove");
             fs::create_dir_all(&root).expect("create fixture root");
+            let _home = ScopedHomeFixture::new("loongclaw-ext-skill-remove-home");
             write_file(
                 &root,
                 "source/demo-skill/SKILL.md",
@@ -2347,6 +3058,7 @@ mod tests {
         with_managed_runtime_test(|| {
             let root = unique_temp_dir("loongclaw-ext-skill-index-metadata");
             fs::create_dir_all(&root).expect("create fixture root");
+            let _home = ScopedHomeFixture::new("loongclaw-ext-skill-index-metadata-home");
             write_file(
                 &root,
                 "source/demo-skill/SKILL.md",
@@ -2387,15 +3099,18 @@ mod tests {
                 &config,
             )
             .expect("list should succeed with rehydrated metadata");
+            let demo_skill = list_outcome.payload["skills"]
+                .as_array()
+                .expect("skills should be an array")
+                .iter()
+                .find(|skill| skill["skill_id"] == "demo-skill")
+                .expect("managed demo-skill should remain discoverable");
+            assert_eq!(demo_skill["display_name"], "Demo Skill");
             assert_eq!(
-                list_outcome.payload["skills"][0]["display_name"],
-                "Demo Skill"
-            );
-            assert_eq!(
-                list_outcome.payload["skills"][0]["summary"],
+                demo_skill["summary"],
                 "Prefer evidence over stale index metadata."
             );
-            assert_ne!(list_outcome.payload["skills"][0]["sha256"], "forged-digest");
+            assert_ne!(demo_skill["sha256"], "forged-digest");
 
             let invoke_outcome = crate::tools::execute_tool_core_with_config(
                 ToolCoreRequest {

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -424,8 +424,8 @@ pub(super) fn execute_external_skills_install_tool_with_config(
     index.skills.retain(|entry| entry.skill_id != skill_id);
     index.skills.push(InstalledSkillEntry {
         skill_id: skill_id.clone(),
-        display_name,
-        summary,
+        display_name: display_name.clone(),
+        summary: summary.clone(),
         source_kind: source_kind.to_owned(),
         source_path: source_path.display().to_string(),
         install_path: destination_root.display().to_string(),
@@ -447,6 +447,7 @@ pub(super) fn execute_external_skills_install_tool_with_config(
     } else {
         None
     };
+    let replaced = backup_root.is_some();
     if let Some(backup_root) = backup_root.as_ref() {
         fs::rename(&destination_root, backup_root).map_err(|error| {
             format!(
@@ -516,12 +517,14 @@ pub(super) fn execute_external_skills_install_tool_with_config(
             "adapter": "core-tools",
             "tool_name": request.tool_name,
             "skill_id": skill_id,
+            "display_name": display_name,
+            "summary": summary,
             "source_kind": source_kind,
             "source_path": source_path.display().to_string(),
             "install_path": destination_root.display().to_string(),
             "skill_md_path": destination_root.join(DEFAULT_SKILL_FILENAME).display().to_string(),
             "sha256": digest,
-            "replaced": replace,
+            "replaced": replaced,
         }),
     })
 }
@@ -1843,6 +1846,8 @@ mod tests {
 
             assert_eq!(outcome.status, "ok");
             assert_eq!(outcome.payload["skill_id"], "demo-skill");
+            assert_eq!(outcome.payload["display_name"], "Demo Skill");
+            assert_eq!(outcome.payload["replaced"], false);
             assert!(
                 root.join("external-skills-installed")
                     .join("index.json")
@@ -1856,6 +1861,56 @@ mod tests {
                     .exists(),
                 "managed external skill copy should exist"
             );
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn install_replace_reports_actual_replacement_state() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-install-replace");
+            fs::create_dir_all(&root).expect("create fixture root");
+            write_file(
+                &root,
+                "source/demo-skill/SKILL.md",
+                "# Demo Skill\n\nFirst install.\n",
+            );
+            write_file(
+                &root,
+                "source/demo-skill-v2/SKILL.md",
+                "# Demo Skill\n\nReplacement install.\n",
+            );
+            let config = managed_runtime_config(&root);
+
+            let first_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload: json!({
+                        "path": "source/demo-skill",
+                        "replace": true
+                    }),
+                },
+                &config,
+            )
+            .expect("first install with replace flag should succeed");
+            assert_eq!(first_outcome.payload["display_name"], "Demo Skill");
+            assert_eq!(first_outcome.payload["replaced"], false);
+
+            let replace_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload: json!({
+                        "path": "source/demo-skill-v2",
+                        "skill_id": "demo-skill",
+                        "replace": true
+                    }),
+                },
+                &config,
+            )
+            .expect("second install should report a real replacement");
+            assert_eq!(replace_outcome.payload["display_name"], "Demo Skill");
+            assert_eq!(replace_outcome.payload["replaced"], true);
 
             fs::remove_dir_all(&root).ok();
         });

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -1544,11 +1544,7 @@ fn discover_skill_inventory(
                 .then_with(|| left.entry.source_path.cmp(&right.entry.source_path))
         });
 
-        let winner_index = candidates
-            .iter()
-            .position(|candidate| candidate.entry.active)
-            .unwrap_or(0);
-        let winner = candidates.remove(winner_index);
+        let winner = candidates.remove(0);
         inventory.skills.push(winner.entry);
         inventory
             .shadowed_skills
@@ -1665,7 +1661,10 @@ fn discover_scoped_skill_candidates(
                 if !seen.insert(key.clone()) {
                     continue;
                 }
-                let skill_markdown = load_directory_skill_markdown(&skill_root)?;
+                let skill_markdown = match load_directory_skill_markdown(&skill_root) {
+                    Ok(md) => md,
+                    Err(_) => continue,
+                };
                 let skill_id = derive_skill_id_from_markdown(&skill_root, skill_markdown.as_str());
                 candidates.push(DiscoveredSkillCandidate {
                     probe_rank,

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -34,6 +34,10 @@ pub use catalog::{
 };
 pub use kernel_adapter::MvpToolAdapter;
 
+pub fn normalize_external_skill_domain_rule(raw: &str) -> Result<String, String> {
+    external_skills::normalize_domain_rule(raw)
+}
+
 /// Execute a tool request, routing through the kernel for
 /// policy enforcement and audit recording.
 ///
@@ -465,6 +469,98 @@ mod tests {
         fs::remove_dir_all(&root).ok();
     }
 
+    #[test]
+    fn capability_snapshot_lists_resolved_project_and_user_external_skills_once() {
+        use std::{
+            fs,
+            path::{Path, PathBuf},
+            time::{SystemTime, UNIX_EPOCH},
+        };
+
+        fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        }
+
+        fn write_file(root: &Path, relative: &str, content: &str) {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent directory");
+            }
+            fs::write(path, content).expect("write fixture");
+        }
+
+        let root = unique_temp_dir("loongclaw-tool-capability-snapshot-discovery");
+        let home = unique_temp_dir("loongclaw-tool-capability-snapshot-home");
+        fs::create_dir_all(&root).expect("create fixture root");
+        fs::create_dir_all(&home).expect("create home root");
+
+        write_file(
+            &root,
+            "skills/demo-skill/SKILL.md",
+            "---\nname: demo-skill\ndescription: Project-scoped snapshot skill.\n---\n\nProject snapshot instructions.\n",
+        );
+        write_file(
+            &home,
+            ".agents/skills/user-only/SKILL.md",
+            "---\nname: user-only\ndescription: User-scoped snapshot skill.\n---\n\nUser snapshot instructions.\n",
+        );
+        write_file(
+            &root,
+            "source/demo-skill/SKILL.md",
+            "# Managed Snapshot Skill\n\nManaged install should win snapshot precedence.\n",
+        );
+
+        let config = runtime_config::ToolRuntimeConfig {
+            file_root: Some(root.clone()),
+            config_path: None,
+            external_skills: runtime_config::ExternalSkillsRuntimePolicy {
+                enabled: true,
+                require_download_approval: true,
+                allowed_domains: BTreeSet::new(),
+                blocked_domains: BTreeSet::new(),
+                install_root: None,
+                auto_expose_installed: true,
+            },
+            ..runtime_config::ToolRuntimeConfig::default()
+        };
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("HOME", &home);
+
+        execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": "source/demo-skill"
+                }),
+            },
+            &config,
+        )
+        .expect("install should succeed");
+
+        let snapshot = capability_snapshot_with_config(&config);
+        assert!(snapshot.contains("[available_external_skills]"));
+        assert_eq!(
+            snapshot.matches("- demo-skill").count(),
+            1,
+            "resolved snapshot should not duplicate shadowed skills: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("demo-skill"),
+            "managed duplicate should still appear in snapshot: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("user-only"),
+            "user-scoped skills should be exposed in snapshot: {snapshot}"
+        );
+
+        fs::remove_dir_all(&root).ok();
+        fs::remove_dir_all(&home).ok();
+    }
+
     #[cfg(all(
         feature = "tool-file",
         feature = "tool-shell",
@@ -495,14 +591,14 @@ mod tests {
         assert!(snapshot.contains("- external_skills.install: Install a managed external skill from a local directory or archive"));
         assert!(
             snapshot.contains(
-                "- external_skills.inspect: Read metadata for an installed external skill"
+                "- external_skills.inspect: Read metadata for a resolved external skill across managed, user, and project scopes"
             )
         );
         assert!(snapshot.contains(
-            "- external_skills.invoke: Load an installed external skill into the conversation loop"
+            "- external_skills.invoke: Load a resolved external skill into the conversation loop"
         ));
         assert!(snapshot.contains(
-            "- external_skills.list: List managed external skills available for invocation"
+            "- external_skills.list: List resolved external skills across managed, user, and project scopes"
         ));
         assert!(snapshot.contains("- external_skills.policy: Read/update external skills domain allow/block policy at runtime"));
         assert!(snapshot.contains(

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -46,6 +46,7 @@ mod next_actions;
 mod onboard_cli;
 mod onboard_presentation;
 mod provider_presentation;
+mod skills_cli;
 mod source_presentation;
 #[cfg(test)]
 pub(crate) use loongclaw_spec::programmatic::{
@@ -330,6 +331,15 @@ enum Commands {
         /// Skip provider model probing during diagnostics
         #[arg(long, default_value_t = false)]
         skip_model_probe: bool,
+    },
+    /// Manage installed external skills through an operator-facing CLI surface
+    Skills {
+        #[arg(long, global = true)]
+        config: Option<String>,
+        #[arg(long, global = true, default_value_t = false)]
+        json: bool,
+        #[command(subcommand)]
+        command: skills_cli::SkillsCommands,
     },
     /// List compiled channel surfaces, aliases, and readiness status
     Channels {
@@ -684,6 +694,15 @@ async fn main() {
             })
             .await
         }
+        Commands::Skills {
+            config,
+            json,
+            command,
+        } => skills_cli::run_skills_cli(skills_cli::SkillsCommandOptions {
+            config,
+            json,
+            command,
+        }),
         Commands::Channels { config, json } => run_channels_cli(config.as_deref(), json),
         Commands::ListModels { config, json } => run_list_models_cli(config.as_deref(), json).await,
         Commands::ListContextEngines { config, json } => {

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -7,9 +7,9 @@ use std::{collections::BTreeSet, path::Path};
 
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SkillsCommands {
-    /// List installed managed external skills
+    /// List discovered external skills across managed, user, and project scopes
     List,
-    /// Inspect one installed managed external skill
+    /// Inspect one resolved external skill
     #[command(visible_alias = "inspect")]
     Info { skill_id: String },
     /// Install a managed external skill from a local directory or archive
@@ -229,12 +229,14 @@ fn execute_policy_command(
             if clear_allowed_domains {
                 config.external_skills.allowed_domains.clear();
             } else if !allowed_domains.is_empty() {
-                config.external_skills.allowed_domains = normalize_domain_inputs(allowed_domains);
+                config.external_skills.allowed_domains =
+                    normalize_domain_inputs("--allow-domain", allowed_domains)?;
             }
             if clear_blocked_domains {
                 config.external_skills.blocked_domains.clear();
             } else if !blocked_domains.is_empty() {
-                config.external_skills.blocked_domains = normalize_domain_inputs(blocked_domains);
+                config.external_skills.blocked_domains =
+                    normalize_domain_inputs("--block-domain", blocked_domains)?;
             }
 
             persist_config_update(resolved_path, config)?;
@@ -286,15 +288,14 @@ fn persistent_policy_payload(config: &mvp::config::LoongClawConfig) -> Value {
     })
 }
 
-fn normalize_domain_inputs(entries: Vec<String>) -> Vec<String> {
+fn normalize_domain_inputs(flag: &str, entries: Vec<String>) -> CliResult<Vec<String>> {
     let mut normalized = BTreeSet::new();
     for entry in entries {
-        let value = entry.trim().to_ascii_lowercase();
-        if !value.is_empty() {
-            normalized.insert(value);
-        }
+        let value = mvp::tools::normalize_external_skill_domain_rule(entry.as_str())
+            .map_err(|error| format!("invalid domain rule for {flag}: {error}"))?;
+        normalized.insert(value);
     }
-    normalized.into_iter().collect()
+    Ok(normalized.into_iter().collect())
 }
 
 fn skills_cli_json(execution: &SkillsCommandExecution) -> Value {
@@ -305,7 +306,7 @@ fn skills_cli_json(execution: &SkillsCommandExecution) -> Value {
     })
 }
 
-fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<String> {
+pub(crate) fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<String> {
     let payload = &execution.outcome.payload;
     let tool_name = payload
         .get("tool_name")
@@ -324,23 +325,17 @@ fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<Strin
             } else {
                 lines.push("skills:".to_owned());
                 for skill in skills {
-                    let skill_id = skill
-                        .get("skill_id")
-                        .and_then(Value::as_str)
-                        .unwrap_or("<unknown>");
-                    let active = if skill.get("active").and_then(Value::as_bool).unwrap_or(true) {
-                        "active"
-                    } else {
-                        "inactive"
-                    };
-                    let display_name = skill
-                        .get("display_name")
-                        .and_then(Value::as_str)
-                        .unwrap_or("-");
-                    let summary = skill.get("summary").and_then(Value::as_str).unwrap_or("-");
-                    lines.push(format!(
-                        "- {skill_id} [{active}] display_name={display_name} summary={summary}"
-                    ));
+                    lines.push(format!("- {}", render_skill_summary_line(skill)));
+                }
+            }
+            let shadowed = payload
+                .get("shadowed_skills")
+                .and_then(Value::as_array)
+                .ok_or_else(|| "skills list payload missing `shadowed_skills` array".to_owned())?;
+            if !shadowed.is_empty() {
+                lines.push("shadowed skills:".to_owned());
+                for skill in shadowed {
+                    lines.push(format!("- {}", render_skill_summary_line(skill)));
                 }
             }
         }
@@ -361,8 +356,19 @@ fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<Strin
                     .unwrap_or("-")
             ));
             lines.push(format!(
+                "scope={}",
+                skill.get("scope").and_then(Value::as_str).unwrap_or("-")
+            ));
+            lines.push(format!(
                 "active={}",
                 skill.get("active").and_then(Value::as_bool).unwrap_or(true)
+            ));
+            lines.push(format!(
+                "source_path={}",
+                skill
+                    .get("source_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
             ));
             lines.push(format!(
                 "install_path={}",
@@ -390,6 +396,16 @@ fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<Strin
                     .unwrap_or("-")
                     .to_owned(),
             );
+            let shadowed = payload
+                .get("shadowed_skills")
+                .and_then(Value::as_array)
+                .ok_or_else(|| "skills info payload missing `shadowed_skills` array".to_owned())?;
+            if !shadowed.is_empty() {
+                lines.push("shadowed skills:".to_owned());
+                for shadowed_skill in shadowed {
+                    lines.push(format!("- {}", render_skill_summary_line(shadowed_skill)));
+                }
+            }
         }
         "external_skills.install" => {
             lines.push(format!(
@@ -525,4 +541,23 @@ fn render_string_list(value: Option<&Value>) -> String {
             }
         })
         .unwrap_or_else(|| "-".to_owned())
+}
+
+fn render_skill_summary_line(skill: &Value) -> String {
+    let skill_id = skill
+        .get("skill_id")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+    let active = if skill.get("active").and_then(Value::as_bool).unwrap_or(true) {
+        "active"
+    } else {
+        "inactive"
+    };
+    let scope = skill.get("scope").and_then(Value::as_str).unwrap_or("-");
+    let display_name = skill
+        .get("display_name")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let summary = skill.get("summary").and_then(Value::as_str).unwrap_or("-");
+    format!("{skill_id} [{active}] scope={scope} display_name={display_name} summary={summary}")
 }

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -1,0 +1,528 @@
+use clap::Subcommand;
+use kernel::{ToolCoreOutcome, ToolCoreRequest};
+use loongclaw_app as mvp;
+use loongclaw_spec::CliResult;
+use serde_json::{Map, Value, json};
+use std::{collections::BTreeSet, path::Path};
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SkillsCommands {
+    /// List installed managed external skills
+    List,
+    /// Inspect one installed managed external skill
+    #[command(visible_alias = "inspect")]
+    Info { skill_id: String },
+    /// Install a managed external skill from a local directory or archive
+    Install {
+        path: String,
+        #[arg(long)]
+        skill_id: Option<String>,
+        #[arg(long, default_value_t = false)]
+        replace: bool,
+    },
+    /// Remove an installed managed external skill
+    Remove { skill_id: String },
+    /// Inspect or update persisted runtime policy for external skills
+    Policy {
+        #[command(subcommand)]
+        command: SkillsPolicyCommands,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SkillsPolicyCommands {
+    /// Show the persisted external-skills runtime policy
+    #[command(visible_alias = "show")]
+    Get,
+    /// Persist one or more external-skills runtime policy fields into config
+    Set {
+        #[arg(long)]
+        enabled: Option<bool>,
+        #[arg(long)]
+        require_download_approval: Option<bool>,
+        #[arg(long = "allow-domain")]
+        allowed_domains: Vec<String>,
+        #[arg(long, default_value_t = false)]
+        clear_allowed_domains: bool,
+        #[arg(long = "block-domain")]
+        blocked_domains: Vec<String>,
+        #[arg(long, default_value_t = false)]
+        clear_blocked_domains: bool,
+        #[arg(long, default_value_t = false)]
+        approve_policy_update: bool,
+    },
+    /// Reset persisted external-skills policy fields back to config defaults
+    Reset {
+        #[arg(long, default_value_t = false)]
+        approve_policy_update: bool,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SkillsCommandOptions {
+    pub config: Option<String>,
+    pub json: bool,
+    pub command: SkillsCommands,
+}
+
+#[derive(Debug)]
+pub(crate) struct SkillsCommandExecution {
+    pub resolved_config_path: String,
+    pub outcome: ToolCoreOutcome,
+}
+
+pub(crate) fn run_skills_cli(options: SkillsCommandOptions) -> CliResult<()> {
+    let as_json = options.json;
+    let execution = execute_skills_command(options)?;
+    if as_json {
+        let pretty = serde_json::to_string_pretty(&skills_cli_json(&execution))
+            .map_err(|error| format!("serialize skills CLI output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_skills_cli_text(&execution)?);
+    Ok(())
+}
+
+pub(crate) fn execute_skills_command(
+    options: SkillsCommandOptions,
+) -> CliResult<SkillsCommandExecution> {
+    let (resolved_path, mut config) = mvp::config::load(options.config.as_deref())?;
+    let outcome = match options.command {
+        SkillsCommands::Policy { command } => {
+            execute_policy_command(&resolved_path, &mut config, command)?
+        }
+        command @ (SkillsCommands::List
+        | SkillsCommands::Info { .. }
+        | SkillsCommands::Install { .. }
+        | SkillsCommands::Remove { .. }) => {
+            let tool_runtime_config =
+                mvp::runtime_env::build_tool_runtime_config(&config, Some(&resolved_path));
+            let request = build_skills_tool_request(command)?;
+            mvp::tools::execute_tool_core_with_config(request, &tool_runtime_config)?
+        }
+    };
+    Ok(SkillsCommandExecution {
+        resolved_config_path: resolved_path.display().to_string(),
+        outcome,
+    })
+}
+
+fn build_skills_tool_request(command: SkillsCommands) -> CliResult<ToolCoreRequest> {
+    match command {
+        SkillsCommands::List => Ok(ToolCoreRequest {
+            tool_name: "external_skills.list".to_owned(),
+            payload: json!({}),
+        }),
+        SkillsCommands::Info { skill_id } => Ok(ToolCoreRequest {
+            tool_name: "external_skills.inspect".to_owned(),
+            payload: json!({
+                "skill_id": skill_id,
+            }),
+        }),
+        SkillsCommands::Install {
+            path,
+            skill_id,
+            replace,
+        } => {
+            let mut payload = Map::new();
+            payload.insert("path".to_owned(), json!(path));
+            payload.insert("replace".to_owned(), json!(replace));
+            if let Some(skill_id) = skill_id {
+                payload.insert("skill_id".to_owned(), json!(skill_id));
+            }
+            Ok(ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: Value::Object(payload),
+            })
+        }
+        SkillsCommands::Remove { skill_id } => Ok(ToolCoreRequest {
+            tool_name: "external_skills.remove".to_owned(),
+            payload: json!({
+                "skill_id": skill_id,
+            }),
+        }),
+        SkillsCommands::Policy { .. } => {
+            Err("skills policy requests are handled directly by the daemon CLI".to_owned())
+        }
+    }
+}
+
+fn execute_policy_command(
+    resolved_path: &Path,
+    config: &mut mvp::config::LoongClawConfig,
+    command: SkillsPolicyCommands,
+) -> CliResult<ToolCoreOutcome> {
+    match command {
+        SkillsPolicyCommands::Get => Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "daemon-cli",
+                "tool_name": "skills.policy",
+                "action": "get",
+                "persisted": true,
+                "policy": persistent_policy_payload(config),
+            }),
+        }),
+        SkillsPolicyCommands::Reset {
+            approve_policy_update,
+        } => {
+            require_policy_update_approval(approve_policy_update)?;
+            let defaults = mvp::config::ExternalSkillsConfig::default();
+            config.external_skills.enabled = defaults.enabled;
+            config.external_skills.require_download_approval = defaults.require_download_approval;
+            config.external_skills.allowed_domains = defaults.allowed_domains;
+            config.external_skills.blocked_domains = defaults.blocked_domains;
+            persist_config_update(resolved_path, config)?;
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "adapter": "daemon-cli",
+                    "tool_name": "skills.policy",
+                    "action": "reset",
+                    "persisted": true,
+                    "config_updated": true,
+                    "policy": persistent_policy_payload(config),
+                }),
+            })
+        }
+        SkillsPolicyCommands::Set {
+            enabled,
+            require_download_approval,
+            allowed_domains,
+            clear_allowed_domains,
+            blocked_domains,
+            clear_blocked_domains,
+            approve_policy_update,
+        } => {
+            if clear_allowed_domains && !allowed_domains.is_empty() {
+                return Err(
+                    "skills policy set cannot combine --allow-domain with --clear-allowed-domains"
+                        .to_owned(),
+                );
+            }
+            if clear_blocked_domains && !blocked_domains.is_empty() {
+                return Err(
+                    "skills policy set cannot combine --block-domain with --clear-blocked-domains"
+                        .to_owned(),
+                );
+            }
+
+            let has_mutation = enabled.is_some()
+                || require_download_approval.is_some()
+                || clear_allowed_domains
+                || !allowed_domains.is_empty()
+                || clear_blocked_domains
+                || !blocked_domains.is_empty();
+            if !has_mutation {
+                return Err("skills policy set requires at least one mutation flag".to_owned());
+            }
+            require_policy_update_approval(approve_policy_update)?;
+
+            if let Some(enabled) = enabled {
+                config.external_skills.enabled = enabled;
+            }
+            if let Some(require_download_approval) = require_download_approval {
+                config.external_skills.require_download_approval = require_download_approval;
+            }
+            if clear_allowed_domains {
+                config.external_skills.allowed_domains.clear();
+            } else if !allowed_domains.is_empty() {
+                config.external_skills.allowed_domains = normalize_domain_inputs(allowed_domains);
+            }
+            if clear_blocked_domains {
+                config.external_skills.blocked_domains.clear();
+            } else if !blocked_domains.is_empty() {
+                config.external_skills.blocked_domains = normalize_domain_inputs(blocked_domains);
+            }
+
+            persist_config_update(resolved_path, config)?;
+
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "adapter": "daemon-cli",
+                    "tool_name": "skills.policy",
+                    "action": "set",
+                    "persisted": true,
+                    "config_updated": true,
+                    "policy": persistent_policy_payload(config),
+                }),
+            })
+        }
+    }
+}
+
+fn require_policy_update_approval(approved: bool) -> CliResult<()> {
+    if approved {
+        return Ok(());
+    }
+    Err(
+        "skills policy update requires explicit authorization; pass --approve-policy-update"
+            .to_owned(),
+    )
+}
+
+fn persist_config_update(
+    resolved_path: &Path,
+    config: &mvp::config::LoongClawConfig,
+) -> CliResult<()> {
+    let path = resolved_path.to_string_lossy();
+    mvp::config::write(Some(path.as_ref()), config, true).map(|_| ())
+}
+
+fn persistent_policy_payload(config: &mvp::config::LoongClawConfig) -> Value {
+    json!({
+        "enabled": config.external_skills.enabled,
+        "require_download_approval": config.external_skills.require_download_approval,
+        "allowed_domains": config.external_skills.normalized_allowed_domains(),
+        "blocked_domains": config.external_skills.normalized_blocked_domains(),
+        "install_root": config
+            .external_skills
+            .resolved_install_root()
+            .map(|path| path.display().to_string()),
+        "auto_expose_installed": config.external_skills.auto_expose_installed,
+    })
+}
+
+fn normalize_domain_inputs(entries: Vec<String>) -> Vec<String> {
+    let mut normalized = BTreeSet::new();
+    for entry in entries {
+        let value = entry.trim().to_ascii_lowercase();
+        if !value.is_empty() {
+            normalized.insert(value);
+        }
+    }
+    normalized.into_iter().collect()
+}
+
+fn skills_cli_json(execution: &SkillsCommandExecution) -> Value {
+    json!({
+        "config": execution.resolved_config_path,
+        "status": execution.outcome.status,
+        "result": execution.outcome.payload,
+    })
+}
+
+fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<String> {
+    let payload = &execution.outcome.payload;
+    let tool_name = payload
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .unwrap_or("external_skills");
+    let mut lines = vec![format!("config={}", execution.resolved_config_path)];
+
+    match tool_name {
+        "external_skills.list" => {
+            let skills = payload
+                .get("skills")
+                .and_then(Value::as_array)
+                .ok_or_else(|| "skills list payload missing `skills` array".to_owned())?;
+            if skills.is_empty() {
+                lines.push("skills: (none)".to_owned());
+            } else {
+                lines.push("skills:".to_owned());
+                for skill in skills {
+                    let skill_id = skill
+                        .get("skill_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or("<unknown>");
+                    let active = if skill.get("active").and_then(Value::as_bool).unwrap_or(true) {
+                        "active"
+                    } else {
+                        "inactive"
+                    };
+                    let display_name = skill
+                        .get("display_name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("-");
+                    let summary = skill.get("summary").and_then(Value::as_str).unwrap_or("-");
+                    lines.push(format!(
+                        "- {skill_id} [{active}] display_name={display_name} summary={summary}"
+                    ));
+                }
+            }
+        }
+        "external_skills.inspect" => {
+            let skill = payload
+                .get("skill")
+                .and_then(Value::as_object)
+                .ok_or_else(|| "skills info payload missing `skill` object".to_owned())?;
+            lines.push(format!(
+                "skill_id={}",
+                skill.get("skill_id").and_then(Value::as_str).unwrap_or("-")
+            ));
+            lines.push(format!(
+                "display_name={}",
+                skill
+                    .get("display_name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "active={}",
+                skill.get("active").and_then(Value::as_bool).unwrap_or(true)
+            ));
+            lines.push(format!(
+                "install_path={}",
+                skill
+                    .get("install_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "skill_md_path={}",
+                skill
+                    .get("skill_md_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "sha256={}",
+                skill.get("sha256").and_then(Value::as_str).unwrap_or("-")
+            ));
+            lines.push("instructions_preview:".to_owned());
+            lines.push(
+                payload
+                    .get("instructions_preview")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+                    .to_owned(),
+            );
+        }
+        "external_skills.install" => {
+            lines.push(format!(
+                "installed skill_id={}",
+                payload
+                    .get("skill_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "display_name={}",
+                payload
+                    .get("display_name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "source_path={}",
+                payload
+                    .get("source_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "install_path={}",
+                payload
+                    .get("install_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "replaced={}",
+                payload
+                    .get("replaced")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            ));
+        }
+        "external_skills.remove" => {
+            lines.push(format!(
+                "removed skill_id={}",
+                payload
+                    .get("skill_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+        }
+        "external_skills.policy" | "skills.policy" => {
+            let policy = payload
+                .get("policy")
+                .and_then(Value::as_object)
+                .ok_or_else(|| "skills policy payload missing `policy` object".to_owned())?;
+            lines.push(format!(
+                "policy_action={}",
+                payload
+                    .get("action")
+                    .and_then(Value::as_str)
+                    .unwrap_or("get")
+            ));
+            lines.push(format!(
+                "persisted={}",
+                payload
+                    .get("persisted")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true)
+            ));
+            lines.push(format!(
+                "config_updated={}",
+                payload
+                    .get("config_updated")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            ));
+            lines.push(format!(
+                "enabled={}",
+                policy
+                    .get("enabled")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            ));
+            lines.push(format!(
+                "require_download_approval={}",
+                policy
+                    .get("require_download_approval")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true)
+            ));
+            lines.push(format!(
+                "allowed_domains={}",
+                render_string_list(policy.get("allowed_domains"))
+            ));
+            lines.push(format!(
+                "blocked_domains={}",
+                render_string_list(policy.get("blocked_domains"))
+            ));
+            lines.push(format!(
+                "install_root={}",
+                policy
+                    .get("install_root")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "auto_expose_installed={}",
+                policy
+                    .get("auto_expose_installed")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true)
+            ));
+        }
+        other => {
+            lines.push(format!("tool={other}"));
+            lines.push(payload.to_string());
+        }
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_string_list(value: Option<&Value>) -> String {
+    value
+        .and_then(Value::as_array)
+        .map(|items| {
+            let rendered = items
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(",");
+            if rendered.is_empty() {
+                "-".to_owned()
+            } else {
+                rendered
+            }
+        })
+        .unwrap_or_else(|| "-".to_owned())
+}

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -78,6 +78,7 @@ mod import_cli;
 mod migration;
 mod onboard_cli;
 mod programmatic;
+mod skills_cli;
 mod spec_runtime;
 mod spec_runtime_bridge;
 

--- a/crates/daemon/src/tests/skills_cli.rs
+++ b/crates/daemon/src/tests/skills_cli.rs
@@ -1,7 +1,16 @@
+#![allow(unsafe_code)]
+#![allow(
+    clippy::disallowed_methods,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::undocumented_unsafe_blocks
+)]
+
 use super::*;
 use std::{
+    ffi::OsString,
     fs,
     path::{Path, PathBuf},
+    sync::MutexGuard,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -31,6 +40,45 @@ fn write_external_skills_config(root: &Path, enabled: bool) -> PathBuf {
     mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
         .expect("write config fixture");
     config_path
+}
+
+struct SkillsCliEnvironmentGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: Vec<(String, Option<OsString>)>,
+}
+
+impl SkillsCliEnvironmentGuard {
+    fn set(pairs: &[(&str, Option<&str>)]) -> Self {
+        let lock = super::lock_daemon_test_environment();
+        let mut saved = Vec::new();
+        for (key, value) in pairs {
+            saved.push(((*key).to_owned(), std::env::var_os(key)));
+            match value {
+                Some(value) => unsafe {
+                    std::env::set_var(key, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(key);
+                },
+            }
+        }
+        Self { _lock: lock, saved }
+    }
+}
+
+impl Drop for SkillsCliEnvironmentGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..).rev() {
+            match value {
+                Some(value) => unsafe {
+                    std::env::set_var(&key, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(&key);
+                },
+            }
+        }
+    }
 }
 
 #[test]
@@ -139,7 +187,10 @@ fn skills_policy_set_cli_parses_domain_and_approval_flags() {
 #[test]
 fn execute_skills_command_installs_lists_inspects_and_removes_skill() {
     let root = unique_temp_dir("loongclaw-skills-cli-install");
+    let home = unique_temp_dir("loongclaw-skills-cli-install-home");
     let config_path = write_external_skills_config(&root, true);
+    fs::create_dir_all(&home).expect("create home root");
+    let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
     write_file(
         &root,
         "source/demo-skill/SKILL.md",
@@ -189,11 +240,13 @@ fn execute_skills_command_installs_lists_inspects_and_removes_skill() {
         command: crate::skills_cli::SkillsCommands::List,
     })
     .expect("skills list should succeed");
-    assert_eq!(list.outcome.payload["skills"][0]["skill_id"], "demo-skill");
-    assert_eq!(
-        list.outcome.payload["skills"][0]["display_name"],
-        "Demo Skill"
-    );
+    let listed_demo_skill = list.outcome.payload["skills"]
+        .as_array()
+        .expect("skills should be an array")
+        .iter()
+        .find(|skill| skill["skill_id"] == "demo-skill")
+        .expect("managed skill should appear in CLI list");
+    assert_eq!(listed_demo_skill["display_name"], "Demo Skill");
 
     let info = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
         config: Some(config_path.display().to_string()),
@@ -236,6 +289,63 @@ fn execute_skills_command_installs_lists_inspects_and_removes_skill() {
     );
 
     fs::remove_dir_all(&root).ok();
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn execute_skills_command_list_reports_scopes_and_shadowed_skills() {
+    let root = unique_temp_dir("loongclaw-skills-cli-scopes");
+    let home = unique_temp_dir("loongclaw-skills-cli-home");
+    let config_path = write_external_skills_config(&root, true);
+    fs::create_dir_all(&home).expect("create home root");
+    write_file(
+        &root,
+        "source/demo-skill/SKILL.md",
+        "# Managed Demo Skill\n\nManaged CLI install should win precedence.\n",
+    );
+    write_file(
+        &root,
+        ".agents/skills/demo-skill/SKILL.md",
+        "---\nname: demo-skill\ndescription: Project CLI demo skill.\n---\n\nProject CLI copy should be shadowed.\n",
+    );
+    let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
+
+    crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+        config: Some(config_path.display().to_string()),
+        json: false,
+        command: crate::skills_cli::SkillsCommands::Install {
+            path: "source/demo-skill".to_owned(),
+            skill_id: None,
+            replace: false,
+        },
+    })
+    .expect("skills install should succeed");
+
+    let list = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+        config: Some(config_path.display().to_string()),
+        json: false,
+        command: crate::skills_cli::SkillsCommands::List,
+    })
+    .expect("skills list should succeed");
+    assert_eq!(list.outcome.payload["skills"][0]["skill_id"], "demo-skill");
+    assert_eq!(list.outcome.payload["skills"][0]["scope"], "managed");
+    assert_eq!(
+        list.outcome.payload["shadowed_skills"][0]["scope"],
+        "project"
+    );
+    let rendered =
+        crate::skills_cli::render_skills_cli_text(&list).expect("text rendering should succeed");
+    assert!(
+        rendered.contains("scope=managed"),
+        "CLI text should show resolved scope: {rendered}"
+    );
+    assert!(
+        rendered.contains("shadowed skills:"),
+        "CLI text should render shadowed entries for operator debugging: {rendered}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+    fs::remove_dir_all(&home).ok();
 }
 
 #[test]
@@ -438,6 +548,42 @@ fn execute_skills_command_policy_set_requires_explicit_approval() {
         mvp::config::load(Some(config_string.as_str())).expect("reload unchanged config");
     assert!(!reloaded.external_skills.enabled);
     assert!(reloaded.external_skills.require_download_approval);
+    assert!(reloaded.external_skills.allowed_domains.is_empty());
+    assert!(reloaded.external_skills.blocked_domains.is_empty());
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn execute_skills_command_policy_set_rejects_invalid_domain_rules() {
+    let root = unique_temp_dir("loongclaw-skills-cli-policy-invalid-domains");
+    let config_path = write_external_skills_config(&root, false);
+    let config_string = config_path.display().to_string();
+
+    let error =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_string.as_str().to_owned()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Policy {
+                command: crate::skills_cli::SkillsPolicyCommands::Set {
+                    enabled: None,
+                    require_download_approval: None,
+                    allowed_domains: vec!["https://skills.sh/demo.tgz".to_owned()],
+                    clear_allowed_domains: false,
+                    blocked_domains: vec!["not-a-domain".to_owned()],
+                    clear_blocked_domains: false,
+                    approve_policy_update: true,
+                },
+            },
+        })
+        .expect_err("policy set should reject invalid domain rules");
+    assert!(
+        error.contains("invalid domain rule"),
+        "invalid domain error should point operators at the malformed rule: {error}"
+    );
+
+    let (_, reloaded) =
+        mvp::config::load(Some(config_string.as_str())).expect("reload unchanged config");
     assert!(reloaded.external_skills.allowed_domains.is_empty());
     assert!(reloaded.external_skills.blocked_domains.is_empty());
 

--- a/crates/daemon/src/tests/skills_cli.rs
+++ b/crates/daemon/src/tests/skills_cli.rs
@@ -162,6 +162,26 @@ fn execute_skills_command_installs_lists_inspects_and_removes_skill() {
         "resolved config path should be returned for CLI rendering"
     );
     assert_eq!(install.outcome.payload["skill_id"], "demo-skill");
+    assert_eq!(install.outcome.payload["display_name"], "Demo Skill");
+    assert_eq!(install.outcome.payload["replaced"], false);
+
+    let replace_install =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Install {
+                path: "source/demo-skill".to_owned(),
+                skill_id: None,
+                replace: true,
+            },
+        })
+        .expect("skills replace should succeed");
+    assert_eq!(replace_install.outcome.payload["skill_id"], "demo-skill");
+    assert_eq!(
+        replace_install.outcome.payload["display_name"],
+        "Demo Skill"
+    );
+    assert_eq!(replace_install.outcome.payload["replaced"], true);
 
     let list = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
         config: Some(config_path.display().to_string()),

--- a/crates/daemon/src/tests/skills_cli.rs
+++ b/crates/daemon/src/tests/skills_cli.rs
@@ -1,0 +1,425 @@
+use super::*;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+}
+
+fn write_file(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent directory");
+    }
+    fs::write(path, content).expect("write fixture");
+}
+
+fn write_external_skills_config(root: &Path, enabled: bool) -> PathBuf {
+    fs::create_dir_all(root).expect("create fixture root");
+    let config_path = root.join("loongclaw.toml");
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.tools.file_root = Some(root.display().to_string());
+    config.external_skills.enabled = enabled;
+    config.external_skills.install_root = Some(root.join("managed-skills").display().to_string());
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write config fixture");
+    config_path
+}
+
+#[test]
+fn skills_install_cli_parses_global_flags_after_subcommand() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "skills",
+        "install",
+        "source/demo-skill",
+        "--skill-id",
+        "release-skill",
+        "--replace",
+        "--json",
+        "--config",
+        "/tmp/loongclaw.toml",
+    ])
+    .expect("skills install CLI should parse");
+
+    match cli.command {
+        Some(Commands::Skills {
+            config,
+            json,
+            command,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(json);
+            match command {
+                crate::skills_cli::SkillsCommands::Install {
+                    path,
+                    skill_id,
+                    replace,
+                } => {
+                    assert_eq!(path, "source/demo-skill");
+                    assert_eq!(skill_id.as_deref(), Some("release-skill"));
+                    assert!(replace);
+                }
+                other @ crate::skills_cli::SkillsCommands::List
+                | other @ crate::skills_cli::SkillsCommands::Info { .. }
+                | other @ crate::skills_cli::SkillsCommands::Remove { .. }
+                | other @ crate::skills_cli::SkillsCommands::Policy { .. } => {
+                    panic!("unexpected skills subcommand parsed: {other:?}")
+                }
+            }
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn skills_policy_set_cli_parses_domain_and_approval_flags() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "skills",
+        "policy",
+        "set",
+        "--enabled",
+        "true",
+        "--require-download-approval",
+        "false",
+        "--allow-domain",
+        "skills.sh",
+        "--allow-domain",
+        "clawhub.io",
+        "--block-domain",
+        "*.evil.example",
+        "--approve-policy-update",
+    ])
+    .expect("skills policy set CLI should parse");
+
+    match cli.command {
+        Some(Commands::Skills { command, .. }) => match command {
+            crate::skills_cli::SkillsCommands::Policy { command } => match command {
+                crate::skills_cli::SkillsPolicyCommands::Set {
+                    enabled,
+                    require_download_approval,
+                    allowed_domains,
+                    blocked_domains,
+                    approve_policy_update,
+                    clear_allowed_domains,
+                    clear_blocked_domains,
+                } => {
+                    assert_eq!(enabled, Some(true));
+                    assert_eq!(require_download_approval, Some(false));
+                    assert_eq!(allowed_domains, vec!["skills.sh", "clawhub.io"]);
+                    assert_eq!(blocked_domains, vec!["*.evil.example"]);
+                    assert!(approve_policy_update);
+                    assert!(!clear_allowed_domains);
+                    assert!(!clear_blocked_domains);
+                }
+                other @ crate::skills_cli::SkillsPolicyCommands::Get
+                | other @ crate::skills_cli::SkillsPolicyCommands::Reset { .. } => {
+                    panic!("unexpected policy subcommand parsed: {other:?}")
+                }
+            },
+            other @ crate::skills_cli::SkillsCommands::List
+            | other @ crate::skills_cli::SkillsCommands::Info { .. }
+            | other @ crate::skills_cli::SkillsCommands::Install { .. }
+            | other @ crate::skills_cli::SkillsCommands::Remove { .. } => {
+                panic!("unexpected skills subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn execute_skills_command_installs_lists_inspects_and_removes_skill() {
+    let root = unique_temp_dir("loongclaw-skills-cli-install");
+    let config_path = write_external_skills_config(&root, true);
+    write_file(
+        &root,
+        "source/demo-skill/SKILL.md",
+        "# Demo Skill\n\nUse this skill when release discipline matters.\n",
+    );
+
+    let install =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Install {
+                path: "source/demo-skill".to_owned(),
+                skill_id: None,
+                replace: false,
+            },
+        })
+        .expect("skills install should succeed");
+    assert!(
+        install.resolved_config_path.ends_with("loongclaw.toml"),
+        "resolved config path should be returned for CLI rendering"
+    );
+    assert_eq!(install.outcome.payload["skill_id"], "demo-skill");
+
+    let list = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+        config: Some(config_path.display().to_string()),
+        json: false,
+        command: crate::skills_cli::SkillsCommands::List,
+    })
+    .expect("skills list should succeed");
+    assert_eq!(list.outcome.payload["skills"][0]["skill_id"], "demo-skill");
+    assert_eq!(
+        list.outcome.payload["skills"][0]["display_name"],
+        "Demo Skill"
+    );
+
+    let info = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+        config: Some(config_path.display().to_string()),
+        json: false,
+        command: crate::skills_cli::SkillsCommands::Info {
+            skill_id: "demo-skill".to_owned(),
+        },
+    })
+    .expect("skills info should succeed");
+    assert_eq!(info.outcome.payload["skill"]["skill_id"], "demo-skill");
+    assert!(
+        info.outcome.payload["instructions_preview"]
+            .as_str()
+            .expect("instructions preview should be text")
+            .contains("release discipline"),
+        "inspect path should surface a preview of SKILL.md"
+    );
+
+    let remove =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Remove {
+                skill_id: "demo-skill".to_owned(),
+            },
+        })
+        .expect("skills remove should succeed");
+    assert_eq!(remove.outcome.payload["removed"], true);
+
+    let list_after_remove =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::List,
+        })
+        .expect("skills list after remove should succeed");
+    assert_eq!(
+        list_after_remove.outcome.payload["skills"],
+        serde_json::json!([])
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn execute_skills_command_policy_round_trips_persisted_config() {
+    let root = unique_temp_dir("loongclaw-skills-cli-policy");
+    let config_path = write_external_skills_config(&root, false);
+    let config_string = config_path.display().to_string();
+    let install_root = root.join("managed-skills").display().to_string();
+
+    let initial =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_string.clone()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Policy {
+                command: crate::skills_cli::SkillsPolicyCommands::Get,
+            },
+        })
+        .expect("policy get should succeed");
+    assert_eq!(initial.outcome.payload["persisted"], true);
+    assert_eq!(initial.outcome.payload["policy"]["enabled"], false);
+    assert_eq!(
+        initial.outcome.payload["policy"]["require_download_approval"],
+        true
+    );
+    assert_eq!(
+        initial.outcome.payload["policy"]["allowed_domains"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        initial.outcome.payload["policy"]["blocked_domains"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        initial.outcome.payload["policy"]["install_root"],
+        install_root
+    );
+
+    let set = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+        config: Some(config_string.clone()),
+        json: false,
+        command: crate::skills_cli::SkillsCommands::Policy {
+            command: crate::skills_cli::SkillsPolicyCommands::Set {
+                enabled: Some(true),
+                require_download_approval: Some(false),
+                allowed_domains: vec![
+                    " Skills.SH ".to_owned(),
+                    "clawhub.io".to_owned(),
+                    "skills.sh".to_owned(),
+                ],
+                clear_allowed_domains: false,
+                blocked_domains: vec!["*.EVIL.example".to_owned(), "*.evil.example".to_owned()],
+                clear_blocked_domains: false,
+                approve_policy_update: true,
+            },
+        },
+    })
+    .expect("policy set should succeed");
+    assert_eq!(set.outcome.payload["persisted"], true);
+    assert_eq!(set.outcome.payload["config_updated"], true);
+    assert_eq!(set.outcome.payload["policy"]["enabled"], true);
+    assert_eq!(
+        set.outcome.payload["policy"]["require_download_approval"],
+        false
+    );
+    assert_eq!(
+        set.outcome.payload["policy"]["allowed_domains"],
+        serde_json::json!(["clawhub.io", "skills.sh"])
+    );
+    assert_eq!(
+        set.outcome.payload["policy"]["blocked_domains"],
+        serde_json::json!(["*.evil.example"])
+    );
+
+    let (_, reloaded) =
+        mvp::config::load(Some(config_string.as_str())).expect("reload updated config");
+    assert!(reloaded.external_skills.enabled);
+    assert!(!reloaded.external_skills.require_download_approval);
+    assert_eq!(
+        reloaded.external_skills.allowed_domains,
+        vec!["clawhub.io".to_owned(), "skills.sh".to_owned()]
+    );
+    assert_eq!(
+        reloaded.external_skills.blocked_domains,
+        vec!["*.evil.example".to_owned()]
+    );
+    assert_eq!(
+        reloaded.external_skills.install_root.as_deref(),
+        Some(install_root.as_str())
+    );
+    assert!(reloaded.external_skills.auto_expose_installed);
+
+    let reset =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_string.clone()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Policy {
+                command: crate::skills_cli::SkillsPolicyCommands::Reset {
+                    approve_policy_update: true,
+                },
+            },
+        })
+        .expect("policy reset should succeed");
+    assert_eq!(reset.outcome.payload["persisted"], true);
+    assert_eq!(reset.outcome.payload["config_updated"], true);
+    assert_eq!(reset.outcome.payload["policy"]["enabled"], false);
+    assert_eq!(
+        reset.outcome.payload["policy"]["require_download_approval"],
+        true
+    );
+    assert_eq!(
+        reset.outcome.payload["policy"]["allowed_domains"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        reset.outcome.payload["policy"]["blocked_domains"],
+        serde_json::json!([])
+    );
+
+    let final_get =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_string),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Policy {
+                command: crate::skills_cli::SkillsPolicyCommands::Get,
+            },
+        })
+        .expect("policy get after reset should succeed");
+    assert_eq!(final_get.outcome.payload["policy"]["enabled"], false);
+    assert_eq!(
+        final_get.outcome.payload["policy"]["require_download_approval"],
+        true
+    );
+    assert_eq!(
+        final_get.outcome.payload["policy"]["allowed_domains"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        final_get.outcome.payload["policy"]["blocked_domains"],
+        serde_json::json!([])
+    );
+
+    let (_, reloaded_after_reset) = mvp::config::load(Some(config_path.to_string_lossy().as_ref()))
+        .expect("reload reset config");
+    assert!(!reloaded_after_reset.external_skills.enabled);
+    assert!(
+        reloaded_after_reset
+            .external_skills
+            .require_download_approval
+    );
+    assert!(
+        reloaded_after_reset
+            .external_skills
+            .allowed_domains
+            .is_empty()
+    );
+    assert!(
+        reloaded_after_reset
+            .external_skills
+            .blocked_domains
+            .is_empty()
+    );
+    assert_eq!(
+        reloaded_after_reset.external_skills.install_root.as_deref(),
+        Some(install_root.as_str())
+    );
+    assert!(reloaded_after_reset.external_skills.auto_expose_installed);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn execute_skills_command_policy_set_requires_explicit_approval() {
+    let root = unique_temp_dir("loongclaw-skills-cli-policy-approval");
+    let config_path = write_external_skills_config(&root, false);
+    let config_string = config_path.display().to_string();
+
+    let error =
+        crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+            config: Some(config_string.as_str().to_owned()),
+            json: false,
+            command: crate::skills_cli::SkillsCommands::Policy {
+                command: crate::skills_cli::SkillsPolicyCommands::Set {
+                    enabled: Some(true),
+                    require_download_approval: None,
+                    allowed_domains: Vec::new(),
+                    clear_allowed_domains: false,
+                    blocked_domains: Vec::new(),
+                    clear_blocked_domains: false,
+                    approve_policy_update: false,
+                },
+            },
+        })
+        .expect_err("policy set should require explicit approval");
+    assert!(
+        error.contains("--approve-policy-update"),
+        "approval error should direct operators to the explicit authorization flag: {error}"
+    );
+
+    let (_, reloaded) =
+        mvp::config::load(Some(config_string.as_str())).expect("reload unchanged config");
+    assert!(!reloaded.external_skills.enabled);
+    assert!(reloaded.external_skills.require_download_approval);
+    assert!(reloaded.external_skills.allowed_domains.is_empty());
+    assert!(reloaded.external_skills.blocked_domains.is_empty());
+
+    fs::remove_dir_all(&root).ok();
+}


### PR DESCRIPTION
## Summary

- Follow up on #164 by resolving external skills across deterministic `managed > user > project` scopes instead of treating managed installs as the only invocable surface.
- Surface resolved scope metadata and shadowed duplicates in core tools, capability snapshots, README docs, and `loongclaw skills list/info` operator output.
- Align daemon CLI policy writes with runtime domain-rule validation and harden tests against ambient `HOME` pollution and poisoned test locks.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:
- Managed installs remain strict and symlink-rejecting, while user/project discovery follows symlinked directories so common local skill layouts remain usable.
- Discovery precedence is explicit and deterministic, and lower-priority duplicates are surfaced as `shadowed_skills` instead of being silently hidden.
- `loongclaw skills policy set` now rejects malformed allow/block domain rules before persisting config, keeping daemon behavior aligned with the core external-skills runtime matcher.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional scenario checks:
- `cargo test -p loongclaw-app external_skills -- --nocapture`
- `cargo test -p loongclaw-daemon skills_cli -- --nocapture`

Config/runtime behavior notes:
- Before: `external_skills.list` / `inspect` / `invoke` and `loongclaw skills list` / `info` only surfaced managed installs, ambient user skills could leak into tests, and CLI policy writes could persist malformed domain rules.
- After: resolved skills now combine managed, user, and project discovery with deterministic precedence and duplicate reporting, capability snapshots expose each resolved skill once, and CLI policy persistence rejects malformed domain rules while preserving unrelated external-skills config.
- Regression coverage: `discovery_resolves_managed_user_and_project_scopes_with_shadowed_duplicates`, `discovery_follows_symlinked_user_skill_directories`, `capability_snapshot_lists_resolved_project_and_user_external_skills_once`, `execute_skills_command_list_reports_scopes_and_shadowed_skills`, `execute_skills_command_policy_set_rejects_invalid_domain_rules`.

## Linked Issues

Refs #159

Remaining #159 work stays open for per-skill metadata gating, migration/install bridges, and registry/update/sync workflows.
