### PR TITLE
refactor: split tools_memory.rs into tools.rs and memory.rs

### DIFF
--- a/crates/app/src/config/memory.rs
+++ b/crates/app/src/config/memory.rs
@@ -1,0 +1,343 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+use super::shared::{
+    ConfigValidationIssue, DEFAULT_SQLITE_FILE, default_loongclaw_home, expand_path,
+    validate_numeric_range,
+};
+
+pub(crate) const MIN_MEMORY_SLIDING_WINDOW: usize = 1;
+pub(crate) const MAX_MEMORY_SLIDING_WINDOW: usize = 128;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemoryConfig {
+    #[serde(default)]
+    pub backend: MemoryBackendKind,
+    #[serde(default)]
+    pub profile: MemoryProfile,
+    #[serde(default)]
+    pub system: MemorySystemKind,
+    #[serde(default = "default_true")]
+    pub fail_open: bool,
+    #[serde(default)]
+    pub ingest_mode: MemoryIngestMode,
+    #[serde(default = "default_sqlite_path")]
+    pub sqlite_path: String,
+    #[serde(default = "default_sliding_window")]
+    pub sliding_window: usize,
+    #[serde(default = "default_summary_max_chars")]
+    pub summary_max_chars: usize,
+    #[serde(default)]
+    pub profile_note: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryBackendKind {
+    #[default]
+    Sqlite,
+}
+
+impl MemoryBackendKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Sqlite => "sqlite",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "sqlite" => Some(Self::Sqlite),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryProfile {
+    #[default]
+    WindowOnly,
+    WindowPlusSummary,
+    ProfilePlusWindow,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MemorySystemKind {
+    #[default]
+    Builtin,
+}
+
+impl MemorySystemKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Builtin => "builtin",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "builtin" => Some(Self::Builtin),
+            _ => None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for MemorySystemKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse_id(&raw).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "unsupported memory.system `{}` (available: builtin)",
+                raw.trim()
+            ))
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryIngestMode {
+    #[default]
+    SyncMinimal,
+    AsyncBackground,
+}
+
+impl MemoryIngestMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SyncMinimal => "sync_minimal",
+            Self::AsyncBackground => "async_background",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "sync_minimal" => Some(Self::SyncMinimal),
+            "async_background" => Some(Self::AsyncBackground),
+            _ => None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for MemoryIngestMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse_id(&raw).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "unsupported memory.ingest_mode `{}` (available: sync_minimal, async_background)",
+                raw.trim()
+            ))
+        })
+    }
+}
+
+impl MemoryProfile {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::WindowOnly => "window_only",
+            Self::WindowPlusSummary => "window_plus_summary",
+            Self::ProfilePlusWindow => "profile_plus_window",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "window_only" => Some(Self::WindowOnly),
+            "window_plus_summary" => Some(Self::WindowPlusSummary),
+            "profile_plus_window" => Some(Self::ProfilePlusWindow),
+            _ => None,
+        }
+    }
+
+    pub const fn mode(self) -> MemoryMode {
+        match self {
+            Self::WindowOnly => MemoryMode::WindowOnly,
+            Self::WindowPlusSummary => MemoryMode::WindowPlusSummary,
+            Self::ProfilePlusWindow => MemoryMode::ProfilePlusWindow,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MemoryMode {
+    #[default]
+    WindowOnly,
+    WindowPlusSummary,
+    ProfilePlusWindow,
+}
+
+impl MemoryMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::WindowOnly => "window_only",
+            Self::WindowPlusSummary => "window_plus_summary",
+            Self::ProfilePlusWindow => "profile_plus_window",
+        }
+    }
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            backend: MemoryBackendKind::default(),
+            profile: MemoryProfile::default(),
+            system: MemorySystemKind::default(),
+            fail_open: default_true(),
+            ingest_mode: MemoryIngestMode::default(),
+            sqlite_path: default_sqlite_path(),
+            sliding_window: default_sliding_window(),
+            summary_max_chars: default_summary_max_chars(),
+            profile_note: None,
+        }
+    }
+}
+
+impl MemoryConfig {
+    pub fn resolved_sqlite_path(&self) -> PathBuf {
+        expand_path(&self.sqlite_path)
+    }
+
+    pub(super) fn validate(&self) -> Vec<ConfigValidationIssue> {
+        let mut issues = Vec::new();
+        if let Err(issue) = validate_numeric_range(
+            "memory.sliding_window",
+            self.sliding_window,
+            MIN_MEMORY_SLIDING_WINDOW,
+            MAX_MEMORY_SLIDING_WINDOW,
+        ) {
+            issues.push(*issue);
+        }
+        issues
+    }
+
+    pub const fn resolved_backend(&self) -> MemoryBackendKind {
+        self.backend
+    }
+
+    pub const fn resolved_profile(&self) -> MemoryProfile {
+        self.profile
+    }
+
+    pub const fn resolved_system(&self) -> MemorySystemKind {
+        self.system
+    }
+
+    pub const fn resolved_mode(&self) -> MemoryMode {
+        self.profile.mode()
+    }
+
+    pub const fn strict_mode_requested(&self) -> bool {
+        !self.fail_open
+    }
+
+    pub const fn strict_mode_active(&self) -> bool {
+        false
+    }
+
+    pub const fn effective_fail_open(&self) -> bool {
+        !self.strict_mode_active()
+    }
+
+    pub fn summary_char_budget(&self) -> usize {
+        self.summary_max_chars.max(256)
+    }
+
+    pub fn trimmed_profile_note(&self) -> Option<String> {
+        self.profile_note
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    }
+}
+
+fn default_sqlite_path() -> String {
+    default_loongclaw_home()
+        .join(DEFAULT_SQLITE_FILE)
+        .display()
+        .to_string()
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+const fn default_sliding_window() -> usize {
+    12
+}
+
+const fn default_summary_max_chars() -> usize {
+    1200
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::DEFAULT_MEMORY_SYSTEM_ID;
+
+    #[test]
+    fn memory_profile_defaults_to_window_only() {
+        let config = MemoryConfig::default();
+        assert_eq!(config.backend, MemoryBackendKind::Sqlite);
+        assert_eq!(config.profile, MemoryProfile::WindowOnly);
+        assert_eq!(config.resolved_mode(), MemoryMode::WindowOnly);
+    }
+
+    #[test]
+    fn memory_system_defaults_to_builtin() {
+        let config = MemoryConfig::default();
+        assert_eq!(config.system, MemorySystemKind::Builtin);
+        assert_eq!(config.resolved_system(), MemorySystemKind::Builtin);
+        assert_eq!(config.resolved_system().as_str(), DEFAULT_MEMORY_SYSTEM_ID);
+    }
+
+    #[test]
+    fn memory_system_rejects_unimplemented_future_variant_ids() {
+        assert_eq!(MemorySystemKind::parse_id("lucid"), None);
+    }
+
+    #[test]
+    fn hydrated_memory_policy_defaults_are_fail_open_and_sync_minimal() {
+        let config = MemoryConfig::default();
+        assert!(config.fail_open);
+        assert!(config.effective_fail_open());
+        assert!(!config.strict_mode_requested());
+        assert!(!config.strict_mode_active());
+        assert_eq!(config.ingest_mode, MemoryIngestMode::SyncMinimal);
+    }
+
+    #[test]
+    fn strict_mode_request_remains_reserved_and_disabled_by_default() {
+        let config = MemoryConfig {
+            fail_open: false,
+            ..MemoryConfig::default()
+        };
+
+        assert!(config.strict_mode_requested());
+        assert!(!config.strict_mode_active());
+        assert!(config.effective_fail_open());
+    }
+
+    #[test]
+    fn profile_plus_window_keeps_trimmed_profile_note() {
+        let config = MemoryConfig {
+            profile: MemoryProfile::ProfilePlusWindow,
+            profile_note: Some("  imported preferences  ".to_owned()),
+            ..MemoryConfig::default()
+        };
+
+        assert_eq!(
+            config.trimmed_profile_note().as_deref(),
+            Some("imported preferences")
+        );
+    }
+}

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -1,10 +1,11 @@
 mod channels;
 mod conversation;
 mod feishu_integration;
+mod memory;
 mod provider;
 mod runtime;
 mod shared;
-mod tools_memory;
+mod tools;
 
 #[allow(unused_imports)]
 pub use channels::{
@@ -22,6 +23,10 @@ pub(crate) use channels::{
 #[allow(unused_imports)]
 pub use conversation::{ConversationConfig, ConversationTurnLoopConfig};
 pub use feishu_integration::FeishuIntegrationConfig;
+#[allow(unused_imports)]
+pub use memory::{
+    MemoryBackendKind, MemoryConfig, MemoryIngestMode, MemoryMode, MemoryProfile, MemorySystemKind,
+};
 #[allow(unused_imports)]
 pub use provider::{
     ProviderAuthScheme, ProviderConfig, ProviderFeatureFamily, ProviderKind, ProviderProfileConfig,
@@ -47,13 +52,12 @@ pub(crate) use runtime::{normalize_dispatch_account_id, normalize_dispatch_chann
 #[allow(unused_imports)]
 pub use shared::{CLI_COMMAND_NAME, expand_path};
 #[allow(unused_imports)]
-pub use tools_memory::{
+pub use tools::{
     BrowserToolConfig, DEFAULT_BROWSER_MAX_LINKS, DEFAULT_BROWSER_MAX_SESSIONS,
     DEFAULT_BROWSER_MAX_TEXT_CHARS, DEFAULT_SHELL_ALLOW, DEFAULT_WEB_FETCH_MAX_BYTES,
     DEFAULT_WEB_FETCH_MAX_REDIRECTS, DEFAULT_WEB_FETCH_TIMEOUT_SECONDS, ExternalSkillsConfig,
     GovernedToolApprovalConfig, GovernedToolApprovalMode, MAX_BROWSER_MAX_LINKS,
     MAX_BROWSER_MAX_SESSIONS, MAX_BROWSER_MAX_TEXT_CHARS, MAX_WEB_FETCH_MAX_BYTES,
-    MemoryBackendKind, MemoryConfig, MemoryIngestMode, MemoryMode, MemoryProfile, MemorySystemKind,
     SessionVisibility, ToolConfig, WebToolConfig,
 };
 

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -13,13 +13,14 @@ use super::{
     channels::{CliChannelConfig, FeishuChannelConfig, TelegramChannelConfig},
     conversation::ConversationConfig,
     feishu_integration::FeishuIntegrationConfig,
+    memory::MemoryConfig,
     provider::{ProviderConfig, ProviderKind, ProviderProfileConfig},
     shared::{
         ConfigValidationIssue, ConfigValidationLocale, DEFAULT_CONFIG_FILE,
         default_loongclaw_home as shared_default_loongclaw_home, expand_path,
         format_config_validation_issues,
     },
-    tools_memory::{ExternalSkillsConfig, MemoryConfig, ToolConfig},
+    tools::{ExternalSkillsConfig, ToolConfig},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2221,7 +2222,7 @@ api_key = "${DEEPSEEK_API_KEY}"
     #[cfg(feature = "config-toml")]
     fn tool_config_round_trips_session_and_delegate_settings() {
         let mut config = LoongClawConfig::default();
-        config.tools.sessions.visibility = crate::config::tools_memory::SessionVisibility::SelfOnly;
+        config.tools.sessions.visibility = crate::config::tools::SessionVisibility::SelfOnly;
         config.tools.sessions.list_limit = 12;
         config.tools.sessions.history_limit = 34;
         config.tools.messages.enabled = true;

--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -1,14 +1,9 @@
 use std::{collections::BTreeSet, path::PathBuf};
 
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
-use super::shared::{
-    ConfigValidationIssue, DEFAULT_SQLITE_FILE, default_loongclaw_home, expand_path,
-    validate_numeric_range,
-};
+use super::shared::{ConfigValidationIssue, expand_path, validate_numeric_range};
 
-pub(crate) const MIN_MEMORY_SLIDING_WINDOW: usize = 1;
-pub(crate) const MAX_MEMORY_SLIDING_WINDOW: usize = 128;
 pub const DEFAULT_WEB_FETCH_MAX_BYTES: usize = 1024 * 1024;
 pub const DEFAULT_WEB_FETCH_TIMEOUT_SECONDS: u64 = 15;
 pub const DEFAULT_WEB_FETCH_MAX_REDIRECTS: usize = 3;
@@ -185,181 +180,6 @@ pub struct ExternalSkillsConfig {
     pub auto_expose_installed: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct MemoryConfig {
-    #[serde(default)]
-    pub backend: MemoryBackendKind,
-    #[serde(default)]
-    pub profile: MemoryProfile,
-    #[serde(default)]
-    pub system: MemorySystemKind,
-    #[serde(default = "default_true")]
-    pub fail_open: bool,
-    #[serde(default)]
-    pub ingest_mode: MemoryIngestMode,
-    #[serde(default = "default_sqlite_path")]
-    pub sqlite_path: String,
-    #[serde(default = "default_sliding_window")]
-    pub sliding_window: usize,
-    #[serde(default = "default_summary_max_chars")]
-    pub summary_max_chars: usize,
-    #[serde(default)]
-    pub profile_note: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum MemoryBackendKind {
-    #[default]
-    Sqlite,
-}
-
-impl MemoryBackendKind {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Sqlite => "sqlite",
-        }
-    }
-
-    pub fn parse_id(raw: &str) -> Option<Self> {
-        match raw.trim().to_ascii_lowercase().as_str() {
-            "sqlite" => Some(Self::Sqlite),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum MemoryProfile {
-    #[default]
-    WindowOnly,
-    WindowPlusSummary,
-    ProfilePlusWindow,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum MemorySystemKind {
-    #[default]
-    Builtin,
-}
-
-impl MemorySystemKind {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Builtin => "builtin",
-        }
-    }
-
-    pub fn parse_id(raw: &str) -> Option<Self> {
-        match raw.trim().to_ascii_lowercase().as_str() {
-            "builtin" => Some(Self::Builtin),
-            _ => None,
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for MemorySystemKind {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let raw = String::deserialize(deserializer)?;
-        Self::parse_id(&raw).ok_or_else(|| {
-            serde::de::Error::custom(format!(
-                "unsupported memory.system `{}` (available: builtin)",
-                raw.trim()
-            ))
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum MemoryIngestMode {
-    #[default]
-    SyncMinimal,
-    AsyncBackground,
-}
-
-impl MemoryIngestMode {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::SyncMinimal => "sync_minimal",
-            Self::AsyncBackground => "async_background",
-        }
-    }
-
-    pub fn parse_id(raw: &str) -> Option<Self> {
-        match raw.trim().to_ascii_lowercase().as_str() {
-            "sync_minimal" => Some(Self::SyncMinimal),
-            "async_background" => Some(Self::AsyncBackground),
-            _ => None,
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for MemoryIngestMode {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let raw = String::deserialize(deserializer)?;
-        Self::parse_id(&raw).ok_or_else(|| {
-            serde::de::Error::custom(format!(
-                "unsupported memory.ingest_mode `{}` (available: sync_minimal, async_background)",
-                raw.trim()
-            ))
-        })
-    }
-}
-
-impl MemoryProfile {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::WindowOnly => "window_only",
-            Self::WindowPlusSummary => "window_plus_summary",
-            Self::ProfilePlusWindow => "profile_plus_window",
-        }
-    }
-
-    pub fn parse_id(raw: &str) -> Option<Self> {
-        match raw.trim().to_ascii_lowercase().as_str() {
-            "window_only" => Some(Self::WindowOnly),
-            "window_plus_summary" => Some(Self::WindowPlusSummary),
-            "profile_plus_window" => Some(Self::ProfilePlusWindow),
-            _ => None,
-        }
-    }
-
-    pub const fn mode(self) -> MemoryMode {
-        match self {
-            Self::WindowOnly => MemoryMode::WindowOnly,
-            Self::WindowPlusSummary => MemoryMode::WindowPlusSummary,
-            Self::ProfilePlusWindow => MemoryMode::ProfilePlusWindow,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum MemoryMode {
-    #[default]
-    WindowOnly,
-    WindowPlusSummary,
-    ProfilePlusWindow,
-}
-
-impl MemoryMode {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::WindowOnly => "window_only",
-            Self::WindowPlusSummary => "window_plus_summary",
-            Self::ProfilePlusWindow => "profile_plus_window",
-        }
-    }
-}
-
 impl Default for ToolConfig {
     fn default() -> Self {
         Self {
@@ -534,88 +354,6 @@ impl WebToolConfig {
     }
 }
 
-impl Default for MemoryConfig {
-    fn default() -> Self {
-        Self {
-            backend: MemoryBackendKind::default(),
-            profile: MemoryProfile::default(),
-            system: MemorySystemKind::default(),
-            fail_open: default_true(),
-            ingest_mode: MemoryIngestMode::default(),
-            sqlite_path: default_sqlite_path(),
-            sliding_window: default_sliding_window(),
-            summary_max_chars: default_summary_max_chars(),
-            profile_note: None,
-        }
-    }
-}
-
-impl MemoryConfig {
-    pub fn resolved_sqlite_path(&self) -> PathBuf {
-        expand_path(&self.sqlite_path)
-    }
-
-    pub(super) fn validate(&self) -> Vec<ConfigValidationIssue> {
-        let mut issues = Vec::new();
-        if let Err(issue) = validate_numeric_range(
-            "memory.sliding_window",
-            self.sliding_window,
-            MIN_MEMORY_SLIDING_WINDOW,
-            MAX_MEMORY_SLIDING_WINDOW,
-        ) {
-            issues.push(*issue);
-        }
-        issues
-    }
-
-    pub const fn resolved_backend(&self) -> MemoryBackendKind {
-        self.backend
-    }
-
-    pub const fn resolved_profile(&self) -> MemoryProfile {
-        self.profile
-    }
-
-    pub const fn resolved_system(&self) -> MemorySystemKind {
-        self.system
-    }
-
-    pub const fn resolved_mode(&self) -> MemoryMode {
-        self.profile.mode()
-    }
-
-    pub const fn strict_mode_requested(&self) -> bool {
-        !self.fail_open
-    }
-
-    pub const fn strict_mode_active(&self) -> bool {
-        false
-    }
-
-    pub const fn effective_fail_open(&self) -> bool {
-        !self.strict_mode_active()
-    }
-
-    pub fn summary_char_budget(&self) -> usize {
-        self.summary_max_chars.max(256)
-    }
-
-    pub fn trimmed_profile_note(&self) -> Option<String> {
-        self.profile_note
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned)
-    }
-}
-
-fn default_sqlite_path() -> String {
-    default_loongclaw_home()
-        .join(DEFAULT_SQLITE_FILE)
-        .display()
-        .to_string()
-}
-
 const fn default_enabled() -> bool {
     true
 }
@@ -668,10 +406,6 @@ const fn default_require_download_approval() -> bool {
     true
 }
 
-const fn default_true() -> bool {
-    true
-}
-
 const fn default_auto_expose_installed() -> bool {
     true
 }
@@ -686,18 +420,10 @@ fn normalize_domain_entries(entries: &[String]) -> Vec<String> {
     }
     normalized.into_iter().collect()
 }
-const fn default_sliding_window() -> usize {
-    12
-}
-
-const fn default_summary_max_chars() -> usize {
-    1200
-}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::memory::DEFAULT_MEMORY_SYSTEM_ID;
 
     #[test]
     fn tool_config_defaults_expose_session_runtime_policy() {
@@ -835,63 +561,6 @@ max_text_chars = 2048
         assert_eq!(parsed.tools.browser.max_sessions, 4);
         assert_eq!(parsed.tools.browser.max_links, 12);
         assert_eq!(parsed.tools.browser.max_text_chars, 2048);
-    }
-
-    #[test]
-    fn memory_profile_defaults_to_window_only() {
-        let config = MemoryConfig::default();
-        assert_eq!(config.backend, MemoryBackendKind::Sqlite);
-        assert_eq!(config.profile, MemoryProfile::WindowOnly);
-        assert_eq!(config.resolved_mode(), MemoryMode::WindowOnly);
-    }
-
-    #[test]
-    fn memory_system_defaults_to_builtin() {
-        let config = MemoryConfig::default();
-        assert_eq!(config.system, MemorySystemKind::Builtin);
-        assert_eq!(config.resolved_system(), MemorySystemKind::Builtin);
-        assert_eq!(config.resolved_system().as_str(), DEFAULT_MEMORY_SYSTEM_ID);
-    }
-
-    #[test]
-    fn memory_system_rejects_unimplemented_future_variant_ids() {
-        assert_eq!(MemorySystemKind::parse_id("lucid"), None);
-    }
-
-    #[test]
-    fn hydrated_memory_policy_defaults_are_fail_open_and_sync_minimal() {
-        let config = MemoryConfig::default();
-        assert!(config.fail_open);
-        assert!(config.effective_fail_open());
-        assert!(!config.strict_mode_requested());
-        assert!(!config.strict_mode_active());
-        assert_eq!(config.ingest_mode, MemoryIngestMode::SyncMinimal);
-    }
-
-    #[test]
-    fn strict_mode_request_remains_reserved_and_disabled_by_default() {
-        let config = MemoryConfig {
-            fail_open: false,
-            ..MemoryConfig::default()
-        };
-
-        assert!(config.strict_mode_requested());
-        assert!(!config.strict_mode_active());
-        assert!(config.effective_fail_open());
-    }
-
-    #[test]
-    fn profile_plus_window_keeps_trimmed_profile_note() {
-        let config = MemoryConfig {
-            profile: MemoryProfile::ProfilePlusWindow,
-            profile_note: Some("  imported preferences  ".to_owned()),
-            ..MemoryConfig::default()
-        };
-
-        assert_eq!(
-            config.trimmed_profile_note().as_deref(),
-            Some("imported preferences")
-        );
     }
 
     /// When `shell_deny` is absent, it must default to empty — users start


### PR DESCRIPTION
## Summary

- Split `crates/app/src/config/tools_memory.rs` into two focused modules: `tools.rs` and `memory.rs`
- Tool types (ToolConfig, GovernedToolApprovalConfig, SessionToolConfig, etc.) and memory types (MemoryConfig, MemoryBackendKind, MemoryProfile, etc.) had zero cross-references — independent domains sharing one file
- Updates `mod.rs` re-exports and `runtime.rs` internal imports

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [ ] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

## Linked Issues

Closes #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive memory configuration system with selectable backends, profiles, ingest modes, and sensible defaults.
  * Runtime validation of memory settings and automatic path expansion for storage locations.
  * Profile notes trimmed and character-budgeting for summaries enforced.

* **Refactor**
  * Memory configuration reorganized into its own module for clearer organization and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->