### PR TITLE
fix: restore alpha-test onboarding personality and memory profile flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ cargo install --path crates/daemon
    loongclaw onboard
    ```
 
+   Guided onboarding now walks through provider setup, native prompt
+   personality, optional prompt addendum, and memory profile selection. Use
+   `--system-prompt` only when you want to replace the native prompt pack with a
+   full inline override.
+
 2. Set your provider credential in the env that onboarding selected:
 
    ```bash
@@ -292,7 +297,9 @@ tone, initiative, confirmation style, and response density.
 - `autonomous_executor`: decisive, high-initiative, and execution-oriented
 
 Interactive onboarding now defaults to personality selection, while advanced
-operators can still pass `--system-prompt` for a full inline override.
+operators can still pass `--system-prompt` for a full inline override. The same
+flow also keeps an optional native prompt addendum for lightweight operator
+tuning without abandoning the built-in prompt pack.
 
 ## Memory Profiles
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -135,6 +135,10 @@ cargo install --path crates/daemon
    loongclaw onboard
    ```
 
+   当前引导流程会依次带你完成 provider、原生 prompt personality、可选 prompt
+   addendum，以及 memory profile 的选择。只有在你明确想放弃原生 prompt pack
+   时，才建议改用 `--system-prompt` 做完整的 inline override。
+
 2. 按 onboarding 选中的环境变量名设置 provider 凭据：
 
    ```bash
@@ -167,6 +171,32 @@ cargo install --path crates/daemon
 ```bash
 cargo test --workspace --all-features
 ```
+
+## Prompt 与 Personality
+
+LoongClaw 内置了一个原生 prompt pack，并提供三个默认 personality。它们共享同一
+套安全优先边界，只会调整语气、主动性、确认阈值和回答密度：
+
+- `calm_engineering`：严谨、直接、技术导向
+- `friendly_collab`：更友好、更协作，在有帮助时会多解释一点
+- `autonomous_executor`：更果断、主动性更高、偏执行导向
+
+交互式 onboarding 默认会先走 personality 选择；如果你确实需要完全改写 system
+prompt，可以显式传 `--system-prompt` 进入 inline override 路径。保留原生 prompt
+pack 时，还可以在 onboarding 里填写一个可选的 prompt addendum，做轻量定制而不
+必放弃内置 prompt。
+
+## Memory Profiles
+
+LoongClaw 把记忆行为和存储后端解耦。当前后端仍然是 SQLite，但 operator 已经可以
+在 onboarding 中选择三种 context injection 模式：
+
+- `window_only`：只加载最近的 sliding window
+- `window_plus_summary`：在最近窗口前加入更早轮次的摘要块
+- `profile_plus_window`：在最近窗口前注入 durable `profile_note`
+
+`profile_note` 是当前 alpha-test 中最适合迁移旧 claw 身份、长期偏好和稳定操作习惯
+的持久记忆通道，不需要再把所有长期设定都硬塞进 system prompt。
 
 ## 记忆配置与记忆系统
 

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -718,7 +718,6 @@ mod tests {
         clear_tool_runtime_env(&mut env);
         #[cfg(feature = "feishu-integration")]
         clear_feishu_runtime_env(&mut env);
-
         env.set("LOONGCLAW_TOOL_SESSIONS_ENABLED", "false");
         env.set("LOONGCLAW_TOOL_MESSAGES_ENABLED", "true");
         env.set("LOONGCLAW_TOOL_DELEGATE_ENABLED", "false");
@@ -947,6 +946,10 @@ mod tests {
     #[cfg(feature = "feishu-integration")]
     #[test]
     fn from_loongclaw_config_ignores_disabled_feishu_accounts_when_detecting_runtime() {
+        let mut env = ScopedEnv::new();
+        env.set("FEISHU_APP_ID", "cli_env_a1b2c3");
+        env.set("FEISHU_APP_SECRET", "env-secret");
+
         let config = crate::config::LoongClawConfig {
             feishu: crate::config::FeishuChannelConfig {
                 enabled: true,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -279,6 +279,12 @@ pub enum Commands {
         /// Provider credential environment variable name, for example OPENAI_API_KEY
         #[arg(long = "api-key", alias = "api-key-env")]
         api_key_env: Option<String>,
+        /// Select a native prompt personality in non-interactive mode
+        #[arg(long)]
+        personality: Option<String>,
+        /// Select a memory profile in non-interactive mode
+        #[arg(long)]
+        memory_profile: Option<String>,
         /// Preseed the CLI system prompt instead of editing it interactively
         #[arg(long)]
         system_prompt: Option<String>,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -109,6 +109,8 @@ async fn main() {
             provider,
             model,
             api_key_env,
+            personality,
+            memory_profile,
             system_prompt,
             skip_model_probe,
         } => {
@@ -120,6 +122,8 @@ async fn main() {
                 provider,
                 model,
                 api_key_env,
+                personality,
+                memory_profile,
                 system_prompt,
                 skip_model_probe,
             })

--- a/crates/daemon/src/migration/discovery.rs
+++ b/crates/daemon/src/migration/discovery.rs
@@ -50,11 +50,16 @@ pub fn classify_current_setup(output_path: &Path) -> CurrentSetupState {
 
     let default_config = mvp::config::LoongClawConfig::default();
     let has_only_provider_selection_changes = config.provider.has_only_selection_changes()
+        && config.cli.enabled == default_config.cli.enabled
         && config.cli.system_prompt == default_config.cli.system_prompt
+        && config.cli.prompt_pack_id == default_config.cli.prompt_pack_id
+        && config.cli.personality == default_config.cli.personality
+        && config.cli.system_prompt_addendum == default_config.cli.system_prompt_addendum
         && config.cli.exit_commands == default_config.cli.exit_commands
         && channels::registered_enabled_channel_ids(&config).is_empty()
         && config.tools.shell_allow == default_config.tools.shell_allow
         && config.tools.file_root == default_config.tools.file_root
+        && config.memory.profile == default_config.memory.profile
         && config.memory.sqlite_path == default_config.memory.sqlite_path
         && config.memory.sliding_window == default_config.memory.sliding_window;
 
@@ -342,7 +347,8 @@ fn collect_domain_previews(
     }
 
     let default_memory = mvp::config::MemoryConfig::default();
-    if config.memory.sqlite_path != default_memory.sqlite_path
+    if config.memory.profile != default_memory.profile
+        || config.memory.sqlite_path != default_memory.sqlite_path
         || config.memory.sliding_window != default_memory.sliding_window
     {
         domains.push(DomainPreview {
@@ -350,11 +356,7 @@ fn collect_domain_previews(
             status: PreviewStatus::Ready,
             decision: source_kind.default_domain_decision(),
             source: source.to_owned(),
-            summary: format!(
-                "{} · window {}",
-                config.memory.resolved_sqlite_path().display(),
-                config.memory.sliding_window
-            ),
+            summary: memory_behavior_summary(&config.memory),
         });
     }
 
@@ -592,6 +594,9 @@ fn cli_import_surface(config: &mvp::config::LoongClawConfig) -> Option<ImportSur
     let default_cli = mvp::config::CliChannelConfig::default();
     if config.cli.enabled == default_cli.enabled
         && config.cli.system_prompt == default_cli.system_prompt
+        && config.cli.prompt_pack_id == default_cli.prompt_pack_id
+        && config.cli.personality == default_cli.personality
+        && config.cli.system_prompt_addendum == default_cli.system_prompt_addendum
         && config.cli.exit_commands == default_cli.exit_commands
     {
         return None;
@@ -600,6 +605,65 @@ fn cli_import_surface(config: &mvp::config::LoongClawConfig) -> Option<ImportSur
         name: "cli channel",
         domain: SetupDomainKind::Cli,
         level: ImportSurfaceLevel::Ready,
-        detail: "custom CLI behavior detected".to_owned(),
+        detail: cli_behavior_summary(&config.cli),
     })
+}
+
+fn cli_behavior_summary(config: &mvp::config::CliChannelConfig) -> String {
+    let default_cli = mvp::config::CliChannelConfig::default();
+    let mut parts = Vec::new();
+    if config.uses_native_prompt_pack() {
+        parts.push("native prompt pack".to_owned());
+        parts.push(format!(
+            "personality {}",
+            crate::onboard_cli::prompt_personality_id(config.resolved_personality())
+        ));
+        if config
+            .system_prompt_addendum
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty())
+        {
+            parts.push("prompt addendum configured".to_owned());
+        }
+    } else if !config.system_prompt.trim().is_empty() {
+        parts.push("inline system prompt override".to_owned());
+    }
+    if config.exit_commands != default_cli.exit_commands {
+        parts.push(format!("exit commands {}", config.exit_commands.join(", ")));
+    }
+    if parts.is_empty() {
+        "custom CLI behavior detected".to_owned()
+    } else {
+        parts.join(" · ")
+    }
+}
+
+fn memory_behavior_summary(config: &mvp::config::MemoryConfig) -> String {
+    format!(
+        "profile {} · {} · window {}",
+        config.profile.as_str(),
+        config.resolved_sqlite_path().display(),
+        config.sliding_window
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_import_surface_detects_prompt_pack_metadata_changes() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.cli.personality = Some(mvp::prompt::PromptPersonality::FriendlyCollab);
+
+        let surfaces = collect_import_surfaces(&config);
+
+        assert!(
+            surfaces
+                .iter()
+                .any(|surface| surface.domain == SetupDomainKind::Cli),
+            "changing prompt-pack personality metadata should mark the CLI domain as imported: {surfaces:#?}"
+        );
+    }
 }

--- a/crates/daemon/src/migration/discovery.rs
+++ b/crates/daemon/src/migration/discovery.rs
@@ -348,7 +348,7 @@ fn collect_domain_previews(
 
     let default_memory = mvp::config::MemoryConfig::default();
     if config.memory.profile != default_memory.profile
-        || config.memory.sqlite_path != default_memory.sqlite_path
+        || !memory_sqlite_path_looks_default(&config.memory.sqlite_path, &default_memory)
         || config.memory.sliding_window != default_memory.sliding_window
     {
         domains.push(DomainPreview {
@@ -407,6 +407,23 @@ fn collect_domain_previews(
     }
 
     domains
+}
+
+fn memory_sqlite_path_looks_default(
+    sqlite_path: &str,
+    default_memory: &mvp::config::MemoryConfig,
+) -> bool {
+    if sqlite_path == default_memory.sqlite_path {
+        return true;
+    }
+
+    let current_default_path = Path::new(default_memory.sqlite_path.as_str());
+    let candidate_path = Path::new(sqlite_path);
+    candidate_path.file_name() == current_default_path.file_name()
+        && candidate_path
+            .parent()
+            .and_then(Path::file_name)
+            .is_some_and(|component| component == ".loongclaw")
 }
 
 fn map_surface_level(level: ImportSurfaceLevel) -> PreviewStatus {

--- a/crates/daemon/src/migration/discovery.rs
+++ b/crates/daemon/src/migration/discovery.rs
@@ -60,7 +60,7 @@ pub fn classify_current_setup(output_path: &Path) -> CurrentSetupState {
         && config.tools.shell_allow == default_config.tools.shell_allow
         && config.tools.file_root == default_config.tools.file_root
         && config.memory.profile == default_config.memory.profile
-        && config.memory.sqlite_path == default_config.memory.sqlite_path
+        && memory_sqlite_path_looks_default(&config.memory.sqlite_path, &default_config.memory)
         && config.memory.sliding_window == default_config.memory.sliding_window;
 
     if has_only_provider_selection_changes && !has_provider_auth {

--- a/crates/daemon/src/migration/planner.rs
+++ b/crates/daemon/src/migration/planner.rs
@@ -473,10 +473,22 @@ fn supplement_cli_config(
         target.enabled = true;
         changed = true;
     }
-    if target.system_prompt == default.system_prompt
-        && source.system_prompt != default.system_prompt
-    {
+    let target_prompt_defaults = target.prompt_pack_id == default.prompt_pack_id
+        && target.personality == default.personality
+        && target.system_prompt_addendum == default.system_prompt_addendum
+        && target.system_prompt == default.system_prompt;
+    let source_prompt_changed = source.prompt_pack_id != default.prompt_pack_id
+        || source.personality != default.personality
+        || source.system_prompt_addendum != default.system_prompt_addendum
+        || source.system_prompt != default.system_prompt;
+    if target_prompt_defaults && source_prompt_changed {
+        target.prompt_pack_id = source.prompt_pack_id.clone();
+        target.personality = source.personality;
+        target.system_prompt_addendum = source.system_prompt_addendum.clone();
         target.system_prompt = source.system_prompt.clone();
+        if target.uses_native_prompt_pack() {
+            target.refresh_native_system_prompt();
+        }
         changed = true;
     }
     for command in &source.exit_commands {
@@ -494,6 +506,10 @@ fn supplement_memory_config(
 ) -> bool {
     let default = mvp::config::MemoryConfig::default();
     let mut changed = false;
+    if target.profile == default.profile && source.profile != default.profile {
+        target.profile = source.profile;
+        changed = true;
+    }
     if target.sqlite_path == default.sqlite_path && source.sqlite_path != default.sqlite_path {
         target.sqlite_path = source.sqlite_path.clone();
         changed = true;
@@ -525,8 +541,33 @@ fn supplement_tool_config(
     changed
 }
 
-fn cli_summary(_config: &mvp::config::CliChannelConfig, supplemented_from: &[String]) -> String {
-    let mut summary = "custom CLI behavior detected".to_owned();
+fn cli_summary(config: &mvp::config::CliChannelConfig, supplemented_from: &[String]) -> String {
+    let mut parts = Vec::new();
+    if config.uses_native_prompt_pack() {
+        parts.push("native prompt pack".to_owned());
+        parts.push(format!(
+            "personality {}",
+            crate::onboard_cli::prompt_personality_id(config.resolved_personality())
+        ));
+        if config
+            .system_prompt_addendum
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty())
+        {
+            parts.push("prompt addendum configured".to_owned());
+        }
+    } else if !config.system_prompt.trim().is_empty() {
+        parts.push("inline system prompt override".to_owned());
+    }
+    if config.exit_commands != mvp::config::CliChannelConfig::default().exit_commands {
+        parts.push(format!("exit commands {}", config.exit_commands.join(", ")));
+    }
+    let mut summary = if parts.is_empty() {
+        "custom CLI behavior detected".to_owned()
+    } else {
+        parts.join(" · ")
+    };
     if !supplemented_from.is_empty() {
         summary.push_str(" · supplemented from ");
         summary.push_str(&supplemented_from.join(", "));
@@ -536,7 +577,8 @@ fn cli_summary(_config: &mvp::config::CliChannelConfig, supplemented_from: &[Str
 
 fn memory_summary(config: &mvp::config::MemoryConfig, supplemented_from: &[String]) -> String {
     let mut summary = format!(
-        "{} · window {}",
+        "profile {} · {} · window {}",
+        config.profile.as_str(),
         config.resolved_sqlite_path().display(),
         config.sliding_window
     );

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -22,6 +22,8 @@ pub struct OnboardCommandOptions {
     pub provider: Option<String>,
     pub model: Option<String>,
     pub api_key_env: Option<String>,
+    pub personality: Option<String>,
+    pub memory_profile: Option<String>,
     pub system_prompt: Option<String>,
     pub skip_model_probe: bool,
 }
@@ -132,6 +134,25 @@ fn is_explicit_onboard_clear_input(raw: &str) -> bool {
     raw.trim().eq_ignore_ascii_case(ONBOARD_CLEAR_INPUT_TOKEN)
 }
 
+fn prompt_optional(
+    ui: &mut impl OnboardUi,
+    label: &str,
+    current: Option<&str>,
+) -> CliResult<Option<String>> {
+    let value = ui.prompt_required(label)?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(current
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned));
+    }
+    if trimmed == "-" {
+        return Ok(None);
+    }
+    Ok(Some(trimmed.to_owned()))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OnboardCheckLevel {
     Pass,
@@ -210,58 +231,84 @@ enum OnboardHeaderStyle {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GuidedPromptPath {
+    NativePromptPack,
+    InlineOverride,
+}
+
+impl GuidedPromptPath {
+    const fn total_steps(self) -> usize {
+        match self {
+            GuidedPromptPath::NativePromptPack => 7,
+            GuidedPromptPath::InlineOverride => 6,
+        }
+    }
+
+    const fn index(self, step: GuidedOnboardStep) -> usize {
+        match (self, step) {
+            (_, GuidedOnboardStep::Provider) => 1,
+            (_, GuidedOnboardStep::Model) => 2,
+            (_, GuidedOnboardStep::CredentialEnv) => 3,
+            (GuidedPromptPath::NativePromptPack, GuidedOnboardStep::Personality) => 4,
+            (GuidedPromptPath::NativePromptPack, GuidedOnboardStep::PromptCustomization) => 5,
+            (GuidedPromptPath::NativePromptPack, GuidedOnboardStep::MemoryProfile) => 6,
+            (GuidedPromptPath::NativePromptPack, GuidedOnboardStep::Review) => 7,
+            (GuidedPromptPath::InlineOverride, GuidedOnboardStep::PromptCustomization) => 4,
+            (GuidedPromptPath::InlineOverride, GuidedOnboardStep::MemoryProfile) => 5,
+            (GuidedPromptPath::InlineOverride, GuidedOnboardStep::Review) => 6,
+            (GuidedPromptPath::InlineOverride, GuidedOnboardStep::Personality) => 4,
+        }
+    }
+
+    const fn label(self, step: GuidedOnboardStep) -> &'static str {
+        match step {
+            GuidedOnboardStep::Provider => "provider",
+            GuidedOnboardStep::Model => "model",
+            GuidedOnboardStep::CredentialEnv => "credential source",
+            GuidedOnboardStep::Personality => "personality",
+            GuidedOnboardStep::PromptCustomization => match self {
+                GuidedPromptPath::NativePromptPack => "prompt addendum",
+                GuidedPromptPath::InlineOverride => "system prompt",
+            },
+            GuidedOnboardStep::MemoryProfile => "memory profile",
+            GuidedOnboardStep::Review => "review",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GuidedOnboardStep {
     Provider,
     Model,
     CredentialEnv,
-    SystemPrompt,
+    Personality,
+    PromptCustomization,
+    MemoryProfile,
     Review,
 }
 
 impl GuidedOnboardStep {
-    const TOTAL: usize = 5;
-
-    const fn index(self) -> usize {
-        match self {
-            GuidedOnboardStep::Provider => 1,
-            GuidedOnboardStep::Model => 2,
-            GuidedOnboardStep::CredentialEnv => 3,
-            GuidedOnboardStep::SystemPrompt => 4,
-            GuidedOnboardStep::Review => 5,
-        }
-    }
-
-    const fn label(self) -> &'static str {
-        match self {
-            GuidedOnboardStep::Provider => "provider",
-            GuidedOnboardStep::Model => "model",
-            GuidedOnboardStep::CredentialEnv => "credential source",
-            GuidedOnboardStep::SystemPrompt => "system prompt",
-            GuidedOnboardStep::Review => "review",
-        }
-    }
-
-    fn progress_line(self) -> String {
+    fn progress_line(self, path: GuidedPromptPath) -> String {
         format!(
             "step {} of {} · {}",
-            self.index(),
-            Self::TOTAL,
-            self.label()
+            path.index(self),
+            path.total_steps(),
+            path.label(self)
         )
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReviewFlowStyle {
-    Guided,
+    Guided(GuidedPromptPath),
     QuickCurrentSetup,
     QuickDetectedSetup,
 }
 
 impl ReviewFlowStyle {
-    const fn presentation_kind(self) -> crate::onboard_presentation::ReviewFlowKind {
+    const fn review_kind(self) -> crate::onboard_presentation::ReviewFlowKind {
         match self {
-            ReviewFlowStyle::Guided => crate::onboard_presentation::ReviewFlowKind::Guided,
+            ReviewFlowStyle::Guided(_) => crate::onboard_presentation::ReviewFlowKind::Guided,
             ReviewFlowStyle::QuickCurrentSetup => {
                 crate::onboard_presentation::ReviewFlowKind::QuickCurrentSetup
             }
@@ -273,9 +320,11 @@ impl ReviewFlowStyle {
 
     fn progress_line(self) -> String {
         match self {
-            ReviewFlowStyle::Guided => GuidedOnboardStep::Review.progress_line(),
+            ReviewFlowStyle::Guided(prompt_path) => {
+                GuidedOnboardStep::Review.progress_line(prompt_path)
+            }
             ReviewFlowStyle::QuickCurrentSetup | ReviewFlowStyle::QuickDetectedSetup => {
-                crate::onboard_presentation::review_flow_copy(self.presentation_kind())
+                crate::onboard_presentation::review_flow_copy(self.review_kind())
                     .progress_line
                     .to_owned()
             }
@@ -283,7 +332,7 @@ impl ReviewFlowStyle {
     }
 
     const fn header_subtitle(self) -> &'static str {
-        crate::onboard_presentation::review_flow_copy(self.presentation_kind()).header_subtitle
+        crate::onboard_presentation::review_flow_copy(self.review_kind()).header_subtitle
     }
 }
 
@@ -395,6 +444,10 @@ pub struct OnboardingSuccessSummary {
     pub model: String,
     pub transport: String,
     pub credential: Option<OnboardingCredentialSummary>,
+    pub prompt_mode: String,
+    pub personality: Option<String>,
+    pub prompt_addendum: Option<String>,
+    pub memory_profile: String,
     pub memory_path: Option<String>,
     pub channels: Vec<String>,
     pub domain_outcomes: Vec<OnboardingDomainOutcome>,
@@ -485,32 +538,71 @@ pub async fn run_onboard_cli_with_ui(
     let review_flow_style = if skip_detailed_setup {
         shortcut_kind
             .map(OnboardShortcutKind::review_flow_style)
-            .unwrap_or(ReviewFlowStyle::Guided)
+            .unwrap_or(ReviewFlowStyle::Guided(GuidedPromptPath::NativePromptPack))
     } else {
-        ReviewFlowStyle::Guided
+        ReviewFlowStyle::Guided(resolve_guided_prompt_path(&options, &config))
     };
 
     if !skip_detailed_setup {
+        let guided_prompt_path = resolve_guided_prompt_path(&options, &config);
         let selected_provider = resolve_provider_selection(
             &options,
             &config,
             &starting_selection.provider_selection,
+            guided_prompt_path,
             ui,
             context,
         )?;
         config.provider = selected_provider;
 
-        let selected_model = resolve_model_selection(&options, &config, ui, context)?;
+        let selected_model =
+            resolve_model_selection(&options, &config, guided_prompt_path, ui, context)?;
         config.provider.model = selected_model;
 
         let default_api_key_env = preferred_api_key_env_default(&config);
-        let selected_api_key_env =
-            resolve_api_key_env_selection(&options, &config, default_api_key_env, ui, context)?;
+        let selected_api_key_env = resolve_api_key_env_selection(
+            &options,
+            &config,
+            default_api_key_env,
+            guided_prompt_path,
+            ui,
+            context,
+        )?;
         apply_selected_api_key_env(&mut config.provider, selected_api_key_env);
 
-        let system_prompt_selection =
-            resolve_system_prompt_selection(&options, &config, ui, context)?;
-        apply_selected_system_prompt(&mut config, system_prompt_selection);
+        match guided_prompt_path {
+            GuidedPromptPath::NativePromptPack => {
+                let personality = resolve_personality_selection(&options, &config, ui, context)?;
+                config.cli.prompt_pack_id = Some(mvp::prompt::DEFAULT_PROMPT_PACK_ID.to_owned());
+                config.cli.personality = Some(personality);
+                config.cli.system_prompt_addendum =
+                    resolve_prompt_addendum_selection(&options, &config, ui, context)?;
+                config.cli.refresh_native_system_prompt();
+            }
+            GuidedPromptPath::InlineOverride => {
+                let system_prompt_selection =
+                    resolve_system_prompt_selection(&options, &config, ui, context)?;
+                match system_prompt_selection {
+                    SystemPromptSelection::KeepCurrent => {}
+                    SystemPromptSelection::RestoreBuiltIn => {
+                        config.cli.prompt_pack_id =
+                            Some(mvp::prompt::DEFAULT_PROMPT_PACK_ID.to_owned());
+                        config.cli.personality = Some(mvp::prompt::PromptPersonality::default());
+                        config.cli.system_prompt_addendum = None;
+                        config.cli.refresh_native_system_prompt();
+                    }
+                    SystemPromptSelection::Set(system_prompt) => {
+                        config.cli.prompt_pack_id = Some(String::new());
+                        config.cli.personality = None;
+                        config.cli.system_prompt_addendum = None;
+                        config.cli.system_prompt = system_prompt;
+                    }
+                }
+            }
+        }
+
+        config.memory.profile =
+            resolve_memory_profile_selection(&options, &config, guided_prompt_path, ui, context)?;
     }
 
     let workspace_guidance = context
@@ -681,6 +773,43 @@ pub async fn run_onboard_cli_with_ui(
     Ok(())
 }
 
+fn resolve_guided_prompt_path(
+    options: &OnboardCommandOptions,
+    config: &mvp::config::LoongClawConfig,
+) -> GuidedPromptPath {
+    if options
+        .system_prompt
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        return GuidedPromptPath::InlineOverride;
+    }
+    if options
+        .personality
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        return GuidedPromptPath::NativePromptPack;
+    }
+    if config.cli.uses_native_prompt_pack() {
+        return GuidedPromptPath::NativePromptPack;
+    }
+    if !config.cli.system_prompt.trim().is_empty() {
+        return GuidedPromptPath::InlineOverride;
+    }
+    GuidedPromptPath::NativePromptPack
+}
+
+pub fn resolve_guided_prompt_path_label_for_test(
+    options: &OnboardCommandOptions,
+    config: &mvp::config::LoongClawConfig,
+) -> &'static str {
+    match resolve_guided_prompt_path(options, config) {
+        GuidedPromptPath::NativePromptPack => "native",
+        GuidedPromptPath::InlineOverride => "inline",
+    }
+}
+
 pub fn build_channel_onboarding_follow_up_lines(
     config: &mvp::config::LoongClawConfig,
 ) -> Vec<String> {
@@ -719,6 +848,7 @@ fn resolve_provider_selection(
     options: &OnboardCommandOptions,
     config: &mvp::config::LoongClawConfig,
     provider_selection: &crate::migration::ProviderSelectionPlan,
+    guided_prompt_path: GuidedPromptPath,
     ui: &mut impl OnboardUi,
     context: &OnboardRuntimeContext,
 ) -> CliResult<mvp::config::ProviderConfig> {
@@ -762,6 +892,7 @@ fn resolve_provider_selection(
         ui,
         render_provider_selection_screen_lines_with_style(
             provider_selection,
+            guided_prompt_path,
             context.render_width,
             true,
         ),
@@ -882,6 +1013,7 @@ pub fn resolve_provider_config_from_selection(
 fn resolve_model_selection(
     options: &OnboardCommandOptions,
     config: &mvp::config::LoongClawConfig,
+    guided_prompt_path: GuidedPromptPath,
     ui: &mut impl OnboardUi,
     context: &OnboardRuntimeContext,
 ) -> CliResult<String> {
@@ -907,6 +1039,7 @@ fn resolve_model_selection(
         render_model_selection_screen_lines_with_style(
             config,
             default_model,
+            guided_prompt_path,
             context.render_width,
             true,
         ),
@@ -923,6 +1056,7 @@ fn resolve_api_key_env_selection(
     options: &OnboardCommandOptions,
     config: &mvp::config::LoongClawConfig,
     default_api_key_env: String,
+    guided_prompt_path: GuidedPromptPath,
     ui: &mut impl OnboardUi,
     context: &OnboardRuntimeContext,
 ) -> CliResult<String> {
@@ -950,6 +1084,7 @@ fn resolve_api_key_env_selection(
             config,
             default_api_key_env.as_str(),
             initial,
+            guided_prompt_path,
             context.render_width,
             true,
         ),
@@ -996,6 +1131,78 @@ fn apply_selected_system_prompt(
     }
 }
 
+fn resolve_personality_selection(
+    options: &OnboardCommandOptions,
+    config: &mvp::config::LoongClawConfig,
+    ui: &mut impl OnboardUi,
+    context: &OnboardRuntimeContext,
+) -> CliResult<mvp::prompt::PromptPersonality> {
+    if options.non_interactive {
+        if let Some(personality_raw) = options.personality.as_deref() {
+            return parse_prompt_personality(personality_raw).ok_or_else(|| {
+                format!(
+                    "unsupported --personality value \"{personality_raw}\". supported: {}",
+                    supported_personality_list()
+                )
+            });
+        }
+        return Ok(config.cli.resolved_personality());
+    }
+
+    let default_personality = options
+        .personality
+        .as_deref()
+        .and_then(parse_prompt_personality)
+        .unwrap_or_else(|| config.cli.resolved_personality());
+    print_lines(
+        ui,
+        render_personality_selection_screen_lines_with_style(
+            config,
+            default_personality,
+            context.render_width,
+            true,
+        ),
+    )?;
+    loop {
+        let input =
+            ui.prompt_with_default("Personality", prompt_personality_id(default_personality))?;
+        if let Some(personality) = parse_prompt_personality(&input) {
+            return Ok(personality);
+        }
+        print_message(
+            ui,
+            format!(
+                "Unsupported personality: {input}. Use one of: {}",
+                supported_personality_list()
+            ),
+        )?;
+    }
+}
+
+fn resolve_prompt_addendum_selection(
+    options: &OnboardCommandOptions,
+    config: &mvp::config::LoongClawConfig,
+    ui: &mut impl OnboardUi,
+    context: &OnboardRuntimeContext,
+) -> CliResult<Option<String>> {
+    if options.non_interactive {
+        return Ok(config.cli.system_prompt_addendum.clone());
+    }
+    print_lines(
+        ui,
+        render_prompt_addendum_selection_screen_lines_with_style(
+            config,
+            context.render_width,
+            true,
+        ),
+    )?;
+    prompt_optional(
+        ui,
+        "Prompt addendum (blank keeps current, '-' clears)",
+        config.cli.system_prompt_addendum.as_deref(),
+    )
+}
+
 fn resolve_system_prompt_selection(
     options: &OnboardCommandOptions,
     config: &mvp::config::LoongClawConfig,
@@ -1025,6 +1232,7 @@ fn resolve_system_prompt_selection(
         render_system_prompt_selection_screen_lines_with_style(
             config,
             initial,
+            GuidedPromptPath::InlineOverride,
             context.render_width,
             true,
         ),
@@ -1038,6 +1246,55 @@ fn resolve_system_prompt_selection(
         return Ok(SystemPromptSelection::KeepCurrent);
     }
     Ok(SystemPromptSelection::Set(trimmed.to_owned()))
+}
+
+fn resolve_memory_profile_selection(
+    options: &OnboardCommandOptions,
+    config: &mvp::config::LoongClawConfig,
+    guided_prompt_path: GuidedPromptPath,
+    ui: &mut impl OnboardUi,
+    context: &OnboardRuntimeContext,
+) -> CliResult<mvp::config::MemoryProfile> {
+    if options.non_interactive {
+        if let Some(profile_raw) = options.memory_profile.as_deref() {
+            return parse_memory_profile(profile_raw).ok_or_else(|| {
+                format!(
+                    "unsupported --memory-profile value \"{profile_raw}\". supported: {}",
+                    supported_memory_profile_list()
+                )
+            });
+        }
+        return Ok(config.memory.profile);
+    }
+
+    let default_profile = options
+        .memory_profile
+        .as_deref()
+        .and_then(parse_memory_profile)
+        .unwrap_or(config.memory.profile);
+    print_lines(
+        ui,
+        render_memory_profile_selection_screen_lines_with_style(
+            config,
+            default_profile,
+            guided_prompt_path,
+            context.render_width,
+            true,
+        ),
+    )?;
+    loop {
+        let input = ui.prompt_with_default("Memory profile", memory_profile_id(default_profile))?;
+        if let Some(profile) = parse_memory_profile(&input) {
+            return Ok(profile);
+        }
+        print_message(
+            ui,
+            format!(
+                "Unsupported memory profile: {input}. Use one of: {}",
+                supported_memory_profile_list()
+            ),
+        )?;
+    }
 }
 
 async fn run_preflight_checks(
@@ -2258,7 +2515,7 @@ pub fn render_onboard_review_lines_with_guidance(
         workspace_guidance,
         None,
         width,
-        ReviewFlowStyle::Guided,
+        ReviewFlowStyle::Guided(GuidedPromptPath::NativePromptPack),
         false,
     )
 }
@@ -2492,11 +2749,36 @@ fn build_onboarding_success_summary_with_memory(
         model: config.provider.model.clone(),
         transport: config.provider.transport_readiness().summary,
         credential: summarize_provider_credential(&config.provider),
+        prompt_mode: summarize_prompt_mode(config),
+        personality: config
+            .cli
+            .uses_native_prompt_pack()
+            .then(|| prompt_personality_id(config.cli.resolved_personality()).to_owned()),
+        prompt_addendum: summarize_prompt_addendum(config),
+        memory_profile: memory_profile_id(config.memory.profile).to_owned(),
         memory_path: memory_path.map(str::to_owned),
         channels: enabled_channel_ids(config),
         domain_outcomes: collect_onboarding_domain_outcomes(review_candidate),
         next_actions,
     }
+}
+
+fn summarize_prompt_mode(config: &mvp::config::LoongClawConfig) -> String {
+    if config.cli.uses_native_prompt_pack() {
+        "native prompt pack".to_owned()
+    } else {
+        "inline system prompt override".to_owned()
+    }
+}
+
+fn summarize_prompt_addendum(config: &mvp::config::LoongClawConfig) -> Option<String> {
+    config
+        .cli
+        .system_prompt_addendum
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
 }
 
 fn render_onboarding_domain_outcome_lines(
@@ -2592,6 +2874,30 @@ fn render_onboarding_success_summary_with_width_and_style(
             width,
         ));
     }
+    lines.extend(mvp::presentation::render_wrapped_text_line(
+        "- prompt mode: ",
+        &summary.prompt_mode,
+        width,
+    ));
+    if let Some(personality) = summary.personality.as_deref() {
+        lines.extend(mvp::presentation::render_wrapped_text_line(
+            "- personality: ",
+            personality,
+            width,
+        ));
+    }
+    if let Some(prompt_addendum) = summary.prompt_addendum.as_deref() {
+        lines.extend(mvp::presentation::render_wrapped_text_line(
+            "- prompt addendum: ",
+            prompt_addendum,
+            width,
+        ));
+    }
+    lines.extend(mvp::presentation::render_wrapped_text_line(
+        "- memory profile: ",
+        &summary.memory_profile,
+        width,
+    ));
     if let Some(memory_path) = summary.memory_path.as_deref() {
         lines.extend(mvp::presentation::render_wrapped_text_line(
             "- sqlite memory: ",
@@ -2831,7 +3137,7 @@ fn render_onboard_choice_screen(
     width: usize,
     subtitle: &str,
     title: &str,
-    step: Option<GuidedOnboardStep>,
+    step: Option<(GuidedOnboardStep, GuidedPromptPath)>,
     intro_lines: Vec<String>,
     options: Vec<OnboardScreenOption>,
     footer_lines: Vec<String>,
@@ -2840,9 +3146,9 @@ fn render_onboard_choice_screen(
     let mut lines = render_onboard_header(header_style, width, subtitle, color_enabled);
     lines.push(String::new());
     lines.extend(render_onboard_wrapped_display_lines([title], width));
-    if let Some(step) = step {
+    if let Some((step, guided_prompt_path)) = step {
         lines.extend(render_onboard_wrapped_display_lines(
-            [step.progress_line()],
+            [step.progress_line(guided_prompt_path)],
             width,
         ));
     }
@@ -2862,6 +3168,7 @@ fn render_onboard_input_screen(
     width: usize,
     title: &str,
     step: GuidedOnboardStep,
+    guided_prompt_path: GuidedPromptPath,
     context_lines: Vec<String>,
     hint_lines: Vec<String>,
     color_enabled: bool,
@@ -2870,7 +3177,7 @@ fn render_onboard_input_screen(
     lines.push(String::new());
     lines.extend(render_onboard_wrapped_display_lines([title], width));
     lines.extend(render_onboard_wrapped_display_lines(
-        [step.progress_line()],
+        [step.progress_line(guided_prompt_path)],
         width,
     ));
     lines.extend(render_onboard_wrapped_display_lines(context_lines, width));
@@ -3001,8 +3308,16 @@ fn render_onboarding_risk_screen_lines_with_style(
     )
 }
 
-pub fn render_preflight_summary_screen_lines(checks: &[OnboardCheck], width: usize) -> Vec<String> {
-    render_preflight_summary_screen_lines_with_style(checks, width, ReviewFlowStyle::Guided, false)
+pub fn render_preflight_summary_screen_lines(
+    checks: &[OnboardCheck],
+    width: usize,
+) -> Vec<String> {
+    render_preflight_summary_screen_lines_with_style(
+        checks,
+        width,
+        ReviewFlowStyle::Guided(GuidedPromptPath::NativePromptPack),
+        false,
+    )
 }
 
 pub fn render_current_setup_preflight_summary_screen_lines(
@@ -3112,7 +3427,7 @@ pub fn render_write_confirmation_screen_lines(
         config_path,
         warnings_kept,
         width,
-        ReviewFlowStyle::Guided,
+        ReviewFlowStyle::Guided(GuidedPromptPath::NativePromptPack),
         false,
     )
 }
@@ -3538,11 +3853,17 @@ pub fn render_provider_selection_screen_lines(
     plan: &crate::migration::ProviderSelectionPlan,
     width: usize,
 ) -> Vec<String> {
-    render_provider_selection_screen_lines_with_style(plan, width, false)
+    render_provider_selection_screen_lines_with_style(
+        plan,
+        GuidedPromptPath::NativePromptPack,
+        width,
+        false,
+    )
 }
 
 fn render_provider_selection_screen_lines_with_style(
     plan: &crate::migration::ProviderSelectionPlan,
+    guided_prompt_path: GuidedPromptPath,
     width: usize,
     color_enabled: bool,
 ) -> Vec<String> {
@@ -3586,7 +3907,7 @@ fn render_provider_selection_screen_lines_with_style(
         width,
         "choose the current provider",
         "choose active provider",
-        Some(GuidedOnboardStep::Provider),
+        Some((GuidedOnboardStep::Provider, guided_prompt_path)),
         intro,
         options,
         with_default_choice_footer(
@@ -3623,6 +3944,7 @@ pub fn render_model_selection_screen_lines(
     render_model_selection_screen_lines_with_style(
         config,
         config.provider.model.as_str(),
+        GuidedPromptPath::NativePromptPack,
         width,
         false,
     )
@@ -3633,12 +3955,19 @@ pub fn render_model_selection_screen_lines_with_default(
     prompt_default: &str,
     width: usize,
 ) -> Vec<String> {
-    render_model_selection_screen_lines_with_style(config, prompt_default, width, false)
+    render_model_selection_screen_lines_with_style(
+        config,
+        prompt_default,
+        GuidedPromptPath::NativePromptPack,
+        width,
+        false,
+    )
 }
 
 fn render_model_selection_screen_lines_with_style(
     config: &mvp::config::LoongClawConfig,
     prompt_default: &str,
+    guided_prompt_path: GuidedPromptPath,
     width: usize,
     color_enabled: bool,
 ) -> Vec<String> {
@@ -3662,6 +3991,7 @@ fn render_model_selection_screen_lines_with_style(
         width,
         "choose model",
         GuidedOnboardStep::Model,
+        guided_prompt_path,
         context_lines,
         vec![
             render_model_selection_default_hint_line(config, prompt_default),
@@ -3680,6 +4010,7 @@ pub fn render_api_key_env_selection_screen_lines(
         config,
         default_api_key_env,
         default_api_key_env,
+        GuidedPromptPath::NativePromptPack,
         width,
         false,
     )
@@ -3695,6 +4026,7 @@ pub fn render_api_key_env_selection_screen_lines_with_default(
         config,
         default_api_key_env,
         prompt_default,
+        GuidedPromptPath::NativePromptPack,
         width,
         false,
     )
@@ -3704,6 +4036,7 @@ fn render_api_key_env_selection_screen_lines_with_style(
     config: &mvp::config::LoongClawConfig,
     default_api_key_env: &str,
     prompt_default: &str,
+    guided_prompt_path: GuidedPromptPath,
     width: usize,
     color_enabled: bool,
 ) -> Vec<String> {
@@ -3744,6 +4077,7 @@ fn render_api_key_env_selection_screen_lines_with_style(
         width,
         "choose credential source",
         GuidedOnboardStep::CredentialEnv,
+        guided_prompt_path,
         context_lines,
         hint_lines,
         color_enabled,
@@ -3757,6 +4091,7 @@ pub fn render_system_prompt_selection_screen_lines(
     render_system_prompt_selection_screen_lines_with_style(
         config,
         config.cli.system_prompt.as_str(),
+        GuidedPromptPath::InlineOverride,
         width,
         false,
     )
@@ -3767,12 +4102,19 @@ pub fn render_system_prompt_selection_screen_lines_with_default(
     prompt_default: &str,
     width: usize,
 ) -> Vec<String> {
-    render_system_prompt_selection_screen_lines_with_style(config, prompt_default, width, false)
+    render_system_prompt_selection_screen_lines_with_style(
+        config,
+        prompt_default,
+        GuidedPromptPath::InlineOverride,
+        width,
+        false,
+    )
 }
 
 fn render_system_prompt_selection_screen_lines_with_style(
     config: &mvp::config::LoongClawConfig,
     prompt_default: &str,
+    guided_prompt_path: GuidedPromptPath,
     width: usize,
     color_enabled: bool,
 ) -> Vec<String> {
@@ -3786,7 +4128,8 @@ fn render_system_prompt_selection_screen_lines_with_style(
     render_onboard_input_screen(
         width,
         "adjust cli behavior",
-        GuidedOnboardStep::SystemPrompt,
+        GuidedOnboardStep::PromptCustomization,
+        guided_prompt_path,
         vec![format!("- current prompt: {current_prompt_display}")],
         vec![
             render_system_prompt_selection_default_hint_line(config, prompt_default),
@@ -3800,7 +4143,181 @@ fn render_system_prompt_selection_screen_lines_with_style(
     )
 }
 
-pub fn render_existing_config_write_screen_lines(config_path: &str, width: usize) -> Vec<String> {
+pub fn render_personality_selection_screen_lines(
+    config: &mvp::config::LoongClawConfig,
+    width: usize,
+) -> Vec<String> {
+    render_personality_selection_screen_lines_with_style(
+        config,
+        config.cli.resolved_personality(),
+        width,
+        false,
+    )
+}
+
+fn render_personality_selection_screen_lines_with_style(
+    config: &mvp::config::LoongClawConfig,
+    default_personality: mvp::prompt::PromptPersonality,
+    width: usize,
+    color_enabled: bool,
+) -> Vec<String> {
+    let options = [
+        (
+            mvp::prompt::PromptPersonality::CalmEngineering,
+            "calm engineering",
+            "rigorous, direct, and technically grounded",
+        ),
+        (
+            mvp::prompt::PromptPersonality::FriendlyCollab,
+            "friendly collab",
+            "warm, cooperative, and explanatory when helpful",
+        ),
+        (
+            mvp::prompt::PromptPersonality::AutonomousExecutor,
+            "autonomous executor",
+            "decisive, high-initiative, and execution-oriented",
+        ),
+    ]
+    .into_iter()
+    .map(|(personality, label, detail)| OnboardScreenOption {
+        key: prompt_personality_id(personality).to_owned(),
+        label: label.to_owned(),
+        detail_lines: vec![detail.to_owned()],
+        recommended: personality == default_personality,
+    })
+    .collect::<Vec<_>>();
+
+    render_onboard_choice_screen(
+        OnboardHeaderStyle::Brand,
+        width,
+        "choose how LoongClaw should speak and take initiative",
+        "choose personality",
+        Some((
+            GuidedOnboardStep::Personality,
+            GuidedPromptPath::NativePromptPack,
+        )),
+        vec![format!(
+            "- current personality: {}",
+            prompt_personality_id(config.cli.resolved_personality())
+        )],
+        options,
+        vec![render_default_choice_footer_line(
+            prompt_personality_id(default_personality),
+            "the current personality",
+        )],
+        color_enabled,
+    )
+}
+
+pub fn render_prompt_addendum_selection_screen_lines(
+    config: &mvp::config::LoongClawConfig,
+    width: usize,
+) -> Vec<String> {
+    render_prompt_addendum_selection_screen_lines_with_style(config, width, false)
+}
+
+fn render_prompt_addendum_selection_screen_lines_with_style(
+    config: &mvp::config::LoongClawConfig,
+    width: usize,
+    color_enabled: bool,
+) -> Vec<String> {
+    let current_addendum = config
+        .cli
+        .system_prompt_addendum
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("none");
+
+    render_onboard_input_screen(
+        width,
+        "adjust prompt addendum",
+        GuidedOnboardStep::PromptCustomization,
+        GuidedPromptPath::NativePromptPack,
+        vec![
+            format!(
+                "- personality: {}",
+                prompt_personality_id(config.cli.resolved_personality())
+            ),
+            format!("- current addendum: {current_addendum}"),
+        ],
+        vec![
+            "- blank keeps the current addendum".to_owned(),
+            "- type '-' to clear it".to_owned(),
+        ],
+        color_enabled,
+    )
+}
+
+pub fn render_memory_profile_selection_screen_lines(
+    config: &mvp::config::LoongClawConfig,
+    width: usize,
+) -> Vec<String> {
+    render_memory_profile_selection_screen_lines_with_style(
+        config,
+        config.memory.profile,
+        GuidedPromptPath::NativePromptPack,
+        width,
+        false,
+    )
+}
+
+fn render_memory_profile_selection_screen_lines_with_style(
+    config: &mvp::config::LoongClawConfig,
+    default_profile: mvp::config::MemoryProfile,
+    guided_prompt_path: GuidedPromptPath,
+    width: usize,
+    color_enabled: bool,
+) -> Vec<String> {
+    let options = [
+        (
+            mvp::config::MemoryProfile::WindowOnly,
+            "recent turns only",
+            "load only the active sliding window",
+        ),
+        (
+            mvp::config::MemoryProfile::WindowPlusSummary,
+            "window plus summary",
+            "add a summary block before the recent window",
+        ),
+        (
+            mvp::config::MemoryProfile::ProfilePlusWindow,
+            "profile plus window",
+            "inject durable profile notes before the recent window",
+        ),
+    ]
+    .into_iter()
+    .map(|(profile, label, detail)| OnboardScreenOption {
+        key: memory_profile_id(profile).to_owned(),
+        label: label.to_owned(),
+        detail_lines: vec![detail.to_owned()],
+        recommended: profile == default_profile,
+    })
+    .collect::<Vec<_>>();
+
+    render_onboard_choice_screen(
+        OnboardHeaderStyle::Brand,
+        width,
+        "choose how much memory context LoongClaw should inject",
+        "choose memory profile",
+        Some((GuidedOnboardStep::MemoryProfile, guided_prompt_path)),
+        vec![format!(
+            "- current profile: {}",
+            memory_profile_id(config.memory.profile)
+        )],
+        options,
+        vec![render_default_choice_footer_line(
+            memory_profile_id(default_profile),
+            "the current memory profile",
+        )],
+        color_enabled,
+    )
+}
+
+pub fn render_existing_config_write_screen_lines(
+    config_path: &str,
+    width: usize,
+) -> Vec<String> {
     render_existing_config_write_screen_lines_with_style(config_path, width, false)
 }
 
@@ -3871,6 +4388,30 @@ fn render_onboard_review_digest_lines(
     if let Some(credential_line) = render_onboard_review_credential_line(&config.provider) {
         lines.push(credential_line);
     }
+    lines.extend(mvp::presentation::render_wrapped_text_line(
+        "- prompt mode: ",
+        &summarize_prompt_mode(config),
+        width,
+    ));
+    if config.cli.uses_native_prompt_pack() {
+        lines.extend(mvp::presentation::render_wrapped_text_line(
+            "- personality: ",
+            prompt_personality_id(config.cli.resolved_personality()),
+            width,
+        ));
+        if let Some(prompt_addendum) = summarize_prompt_addendum(config) {
+            lines.extend(mvp::presentation::render_wrapped_text_line(
+                "- prompt addendum: ",
+                &prompt_addendum,
+                width,
+            ));
+        }
+    }
+    lines.extend(mvp::presentation::render_wrapped_text_line(
+        "- memory profile: ",
+        memory_profile_id(config.memory.profile),
+        width,
+    ));
 
     let enabled_channels = enabled_channel_ids(config)
         .into_iter()
@@ -4184,6 +4725,14 @@ fn onboard_has_explicit_overrides(options: &OnboardCommandOptions) -> bool {
             .as_deref()
             .is_some_and(|value| !value.trim().is_empty())
         || options
+            .personality
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+        || options
+            .memory_profile
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+        || options
             .system_prompt
             .as_deref()
             .is_some_and(|value| !value.trim().is_empty())
@@ -4208,6 +4757,33 @@ pub fn parse_provider_kind(raw: &str) -> Option<mvp::config::ProviderKind> {
 }
 
 pub fn provider_default_api_key_env(kind: mvp::config::ProviderKind) -> Option<&'static str> {
+pub fn parse_prompt_personality(raw: &str) -> Option<mvp::prompt::PromptPersonality> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "calm_engineering" | "engineering" | "calm" => {
+            Some(mvp::prompt::PromptPersonality::CalmEngineering)
+        }
+        "friendly_collab" | "friendly" | "collab" => {
+            Some(mvp::prompt::PromptPersonality::FriendlyCollab)
+        }
+        "autonomous_executor" | "autonomous" | "executor" => {
+            Some(mvp::prompt::PromptPersonality::AutonomousExecutor)
+        }
+        _ => None,
+    }
+}
+
+pub fn parse_memory_profile(raw: &str) -> Option<mvp::config::MemoryProfile> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "window_only" | "window" => Some(mvp::config::MemoryProfile::WindowOnly),
+        "window_plus_summary" | "summary" | "summary_window" => {
+            Some(mvp::config::MemoryProfile::WindowPlusSummary)
+        }
+        "profile_plus_window" | "profile" | "profile_window" => {
+            Some(mvp::config::MemoryProfile::ProfilePlusWindow)
+        }
+        _ => None,
+    }
+}
     kind.default_api_key_env()
 }
 
@@ -4220,11 +4796,34 @@ pub fn provider_kind_display_name(kind: mvp::config::ProviderKind) -> &'static s
 }
 
 pub fn supported_provider_list() -> String {
+pub fn prompt_personality_id(personality: mvp::prompt::PromptPersonality) -> &'static str {
+    match personality {
+        mvp::prompt::PromptPersonality::CalmEngineering => "calm_engineering",
+        mvp::prompt::PromptPersonality::FriendlyCollab => "friendly_collab",
+        mvp::prompt::PromptPersonality::AutonomousExecutor => "autonomous_executor",
+    }
+}
+
+pub fn memory_profile_id(profile: mvp::config::MemoryProfile) -> &'static str {
+    match profile {
+        mvp::config::MemoryProfile::WindowOnly => "window_only",
+        mvp::config::MemoryProfile::WindowPlusSummary => "window_plus_summary",
+        mvp::config::MemoryProfile::ProfilePlusWindow => "profile_plus_window",
+    }
+}
     mvp::config::ProviderKind::all_sorted()
         .iter()
         .map(|kind| kind.as_str())
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+pub fn supported_personality_list() -> &'static str {
+    "calm_engineering, friendly_collab, autonomous_executor"
+}
+
+pub fn supported_memory_profile_list() -> &'static str {
+    "window_only, window_plus_summary, profile_plus_window"
 }
 
 fn resolve_write_plan(
@@ -4618,11 +5217,14 @@ mod tests {
                 provider: None,
                 model: None,
                 api_key_env: None,
+                personality: None,
+                memory_profile: None,
                 system_prompt: None,
                 skip_model_probe: false,
             },
             &config,
             "OPENAI_API_KEY".to_owned(),
+            GuidedPromptPath::NativePromptPack,
             &mut ui,
             &context,
         )
@@ -4650,6 +5252,8 @@ mod tests {
                 provider: None,
                 model: None,
                 api_key_env: None,
+                personality: None,
+                memory_profile: None,
                 system_prompt: None,
                 skip_model_probe: false,
             },
@@ -4682,6 +5286,8 @@ mod tests {
                 provider: None,
                 model: None,
                 api_key_env: None,
+                personality: None,
+                memory_profile: None,
                 system_prompt: None,
                 skip_model_probe: false,
             },
@@ -4714,6 +5320,8 @@ mod tests {
                 provider: None,
                 model: None,
                 api_key_env: None,
+                personality: None,
+                memory_profile: None,
                 system_prompt: Some("prefer concise code reviews".to_owned()),
                 skip_model_probe: false,
             },
@@ -4762,6 +5370,8 @@ mod tests {
             provider: None,
             model: None,
             api_key_env: None,
+            personality: None,
+            memory_profile: None,
             system_prompt: None,
             skip_model_probe: true,
         };

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1114,6 +1114,7 @@ fn apply_selected_api_key_env(
     provider.set_api_key_env(Some(selected_api_key_env.to_owned()));
 }
 
+#[cfg(test)]
 fn apply_selected_system_prompt(
     config: &mut mvp::config::LoongClawConfig,
     selection: SystemPromptSelection,

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -3311,10 +3311,7 @@ fn render_onboarding_risk_screen_lines_with_style(
     )
 }
 
-pub fn render_preflight_summary_screen_lines(
-    checks: &[OnboardCheck],
-    width: usize,
-) -> Vec<String> {
+pub fn render_preflight_summary_screen_lines(checks: &[OnboardCheck], width: usize) -> Vec<String> {
     render_preflight_summary_screen_lines_with_style(
         checks,
         width,
@@ -4317,10 +4314,7 @@ fn render_memory_profile_selection_screen_lines_with_style(
     )
 }
 
-pub fn render_existing_config_write_screen_lines(
-    config_path: &str,
-    width: usize,
-) -> Vec<String> {
+pub fn render_existing_config_write_screen_lines(config_path: &str, width: usize) -> Vec<String> {
     render_existing_config_write_screen_lines_with_style(config_path, width, false)
 }
 
@@ -4759,7 +4753,6 @@ pub fn parse_provider_kind(raw: &str) -> Option<mvp::config::ProviderKind> {
     mvp::config::ProviderKind::parse(raw)
 }
 
-pub fn provider_default_api_key_env(kind: mvp::config::ProviderKind) -> Option<&'static str> {
 pub fn parse_prompt_personality(raw: &str) -> Option<mvp::prompt::PromptPersonality> {
     match raw.trim().to_ascii_lowercase().as_str() {
         "calm_engineering" | "engineering" | "calm" => {
@@ -4787,6 +4780,8 @@ pub fn parse_memory_profile(raw: &str) -> Option<mvp::config::MemoryProfile> {
         _ => None,
     }
 }
+
+pub fn provider_default_api_key_env(kind: mvp::config::ProviderKind) -> Option<&'static str> {
     kind.default_api_key_env()
 }
 
@@ -4798,7 +4793,6 @@ pub fn provider_kind_display_name(kind: mvp::config::ProviderKind) -> &'static s
     kind.display_name()
 }
 
-pub fn supported_provider_list() -> String {
 pub fn prompt_personality_id(personality: mvp::prompt::PromptPersonality) -> &'static str {
     match personality {
         mvp::prompt::PromptPersonality::CalmEngineering => "calm_engineering",
@@ -4814,6 +4808,8 @@ pub fn memory_profile_id(profile: mvp::config::MemoryProfile) -> &'static str {
         mvp::config::MemoryProfile::ProfilePlusWindow => "profile_plus_window",
     }
 }
+
+pub fn supported_provider_list() -> String {
     mvp::config::ProviderKind::all_sorted()
         .iter()
         .map(|kind| kind.as_str())

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -791,11 +791,13 @@ fn resolve_guided_prompt_path(
     {
         return GuidedPromptPath::NativePromptPack;
     }
-    if config.cli.uses_native_prompt_pack() {
-        return GuidedPromptPath::NativePromptPack;
-    }
-    if !config.cli.system_prompt.trim().is_empty() {
-        return GuidedPromptPath::InlineOverride;
+    if options.non_interactive {
+        if config.cli.uses_native_prompt_pack() {
+            return GuidedPromptPath::NativePromptPack;
+        }
+        if !config.cli.system_prompt.trim().is_empty() {
+            return GuidedPromptPath::InlineOverride;
+        }
     }
     GuidedPromptPath::NativePromptPack
 }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -5193,6 +5193,8 @@ mod tests {
             provider: None,
             model: None,
             api_key_env: None,
+            personality: None,
+            memory_profile: None,
             system_prompt: None,
             skip_model_probe: false,
         };

--- a/crates/daemon/src/onboard_presentation.rs
+++ b/crates/daemon/src/onboard_presentation.rs
@@ -16,7 +16,7 @@ pub struct ReviewFlowCopy {
 pub const fn review_flow_copy(kind: ReviewFlowKind) -> ReviewFlowCopy {
     match kind {
         ReviewFlowKind::Guided => ReviewFlowCopy {
-            progress_line: "step 5 of 5 · review",
+            progress_line: "step 7 of 7 · review",
             header_subtitle: "review setup",
         },
         ReviewFlowKind::QuickCurrentSetup => ReviewFlowCopy {
@@ -183,7 +183,7 @@ pub const fn shortcut_continue_detail() -> &'static str {
 }
 
 pub const fn shortcut_adjust_detail() -> &'static str {
-    "review provider, model, credentials, and cli behavior"
+    "review provider, model, credentials, prompt behavior, and memory"
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -92,6 +92,46 @@ fn onboard_cli_keeps_legacy_api_key_env_alias() {
 }
 
 #[test]
+fn onboard_cli_accepts_personality_flag() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "onboard",
+        "--non-interactive",
+        "--accept-risk",
+        "--personality",
+        "friendly_collab",
+    ])
+    .expect("`--personality` should parse");
+
+    match cli.command {
+        Some(Commands::Onboard { personality, .. }) => {
+            assert_eq!(personality.as_deref(), Some("friendly_collab"));
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn onboard_cli_accepts_memory_profile_flag() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "onboard",
+        "--non-interactive",
+        "--accept-risk",
+        "--memory-profile",
+        "profile_plus_window",
+    ])
+    .expect("`--memory-profile` should parse");
+
+    match cli.command {
+        Some(Commands::Onboard { memory_profile, .. }) => {
+            assert_eq!(memory_profile.as_deref(), Some("profile_plus_window"));
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
 fn benchmark_memory_context_cli_parses_custom_knobs() {
     let cli = Cli::try_parse_from([
         "loongclaw",

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -1678,6 +1678,61 @@ fn migration_compose_recommended_candidate_avoids_provider_auto_pick_on_cross_so
 }
 
 #[test]
+fn migration_compose_recommended_candidate_ignores_home_drift_for_default_memory_path() {
+    let home_a = unique_temp_dir("home-drift-a");
+    let home_b = unique_temp_dir("home-drift-b");
+    std::fs::create_dir_all(&home_a).expect("create first home");
+    std::fs::create_dir_all(&home_b).expect("create second home");
+
+    let (codex, env) = {
+        let _guard =
+            MigrationEnvironmentGuard::set(&[("HOME", Some(home_a.to_string_lossy().as_ref()))]);
+
+        let mut codex = mvp::config::LoongClawConfig::default();
+        codex.provider.model = "openai/gpt-5.1-codex".to_owned();
+        codex.provider.api_key = Some("openai-secret".to_owned());
+
+        let mut env = mvp::config::LoongClawConfig::default();
+        env.provider.kind = mvp::config::ProviderKind::Deepseek;
+        let profile = env.provider.kind.profile();
+        env.provider.base_url = profile.base_url.to_owned();
+        env.provider.chat_completions_path = profile.chat_completions_path.to_owned();
+        env.provider.model = "deepseek-chat".to_owned();
+        env.provider.api_key = Some("deepseek-secret".to_owned());
+        (codex, env)
+    };
+
+    let _guard =
+        MigrationEnvironmentGuard::set(&[("HOME", Some(home_b.to_string_lossy().as_ref()))]);
+
+    let codex_candidate = crate::migration::discovery::build_import_candidate(
+        crate::migration::types::ImportSourceKind::CodexConfig,
+        "Codex config at ~/.codex/config.toml".to_owned(),
+        codex,
+        crate::migration::discovery::resolve_channel_import_readiness_from_config,
+        Vec::new(),
+    )
+    .expect("codex candidate");
+    let env_candidate = crate::migration::discovery::build_import_candidate(
+        crate::migration::types::ImportSourceKind::Environment,
+        "your current environment".to_owned(),
+        env,
+        crate::migration::discovery::resolve_channel_import_readiness_from_config,
+        Vec::new(),
+    )
+    .expect("env candidate");
+
+    let composed = crate::migration::planner::compose_recommended_import_candidate(&[
+        codex_candidate,
+        env_candidate,
+    ]);
+    assert!(
+        composed.is_none(),
+        "default memory sqlite paths should not create a fake recommended plan after HOME changes"
+    );
+}
+
+#[test]
 fn migration_compose_recommended_candidate_keeps_non_provider_domains_when_cross_source_provider_conflict_requires_manual_choice()
  {
     let mut codex = mvp::config::LoongClawConfig::default();

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -560,6 +560,29 @@ fn migration_classify_current_setup_treats_provider_tuning_changes_as_repairable
 }
 
 #[test]
+fn migration_classify_current_setup_treats_prompt_and_memory_metadata_as_repairable() {
+    let path = unique_temp_dir("prompt-memory-metadata").join("config.toml");
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.kind = mvp::config::ProviderKind::Ollama;
+    let profile = config.provider.kind.profile();
+    config.provider.base_url = profile.base_url.to_owned();
+    config.provider.chat_completions_path = profile.chat_completions_path.to_owned();
+    config.provider.api_key_env = None;
+    config.provider.oauth_access_token_env = None;
+    config.cli.personality = Some(mvp::prompt::PromptPersonality::FriendlyCollab);
+    config.cli.refresh_native_system_prompt();
+    config.memory.profile = mvp::config::MemoryProfile::ProfilePlusWindow;
+    mvp::config::write(Some(path.to_string_lossy().as_ref()), &config, true)
+        .expect("write config with prompt and memory metadata");
+
+    assert_eq!(
+        crate::migration::discovery::classify_current_setup(&path),
+        crate::migration::types::CurrentSetupState::Repairable,
+        "prompt-pack or memory-profile metadata changes should not be collapsed into the legacy selection-only bucket"
+    );
+}
+
+#[test]
 fn migration_build_import_candidate_detects_provider_env_pointer_only_changes() {
     let mut config = mvp::config::LoongClawConfig::default();
     config.provider.api_key_env = Some("LOONGCLAW_CUSTOM_OPENAI_KEY".to_owned());
@@ -580,6 +603,56 @@ fn migration_build_import_candidate_detects_provider_env_pointer_only_changes() 
             .any(|domain| domain.kind
                 == loongclaw_daemon::migration::types::SetupDomainKind::Provider),
         "provider env-pointer-only changes should still surface as a provider import domain: {candidate:#?}"
+    );
+}
+
+#[test]
+fn migration_recommended_plan_supplements_cli_prompt_metadata_and_memory_profile() {
+    let mut current_config = mvp::config::LoongClawConfig::default();
+    current_config.provider.api_key_env = Some("OPENAI_API_KEY".to_owned());
+    let current = crate::migration::discovery::build_import_candidate(
+        crate::migration::types::ImportSourceKind::ExistingLoongClawConfig,
+        "existing config at ~/.config/loongclaw/config.toml".to_owned(),
+        current_config,
+        crate::migration::discovery::resolve_channel_import_readiness_from_config,
+        Vec::new(),
+    )
+    .expect("current config candidate");
+
+    let mut detected_config = mvp::config::LoongClawConfig::default();
+    detected_config.cli.personality = Some(mvp::prompt::PromptPersonality::FriendlyCollab);
+    detected_config.cli.system_prompt_addendum = Some("Keep answers direct.".to_owned());
+    detected_config.cli.refresh_native_system_prompt();
+    detected_config.memory.profile = mvp::config::MemoryProfile::ProfilePlusWindow;
+
+    let detected = crate::migration::discovery::build_import_candidate(
+        crate::migration::types::ImportSourceKind::Environment,
+        "your current environment".to_owned(),
+        detected_config,
+        crate::migration::discovery::resolve_channel_import_readiness_from_config,
+        Vec::new(),
+    )
+    .expect("detected prompt and memory metadata should build as a candidate");
+
+    let recommended =
+        crate::migration::planner::compose_recommended_import_candidate(&[current, detected])
+            .expect("recommended import plan");
+
+    assert_eq!(
+        recommended.config.cli.personality,
+        Some(mvp::prompt::PromptPersonality::FriendlyCollab)
+    );
+    assert_eq!(
+        recommended.config.cli.system_prompt_addendum.as_deref(),
+        Some("Keep answers direct.")
+    );
+    assert!(
+        recommended.config.cli.uses_native_prompt_pack(),
+        "supplemented CLI config should stay on the native prompt-pack path"
+    );
+    assert_eq!(
+        recommended.config.memory.profile,
+        mvp::config::MemoryProfile::ProfilePlusWindow
     );
 }
 

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -583,6 +583,39 @@ fn migration_classify_current_setup_treats_prompt_and_memory_metadata_as_repaira
 }
 
 #[test]
+fn migration_classify_current_setup_ignores_home_drift_for_default_memory_path() {
+    let home_a = unique_temp_dir("classify-home-drift-a");
+    let home_b = unique_temp_dir("classify-home-drift-b");
+    std::fs::create_dir_all(&home_a).expect("create first classify home");
+    std::fs::create_dir_all(&home_b).expect("create second classify home");
+
+    let path = unique_temp_dir("classify-home-drift").join("config.toml");
+    {
+        let _guard =
+            MigrationEnvironmentGuard::set(&[("HOME", Some(home_a.to_string_lossy().as_ref()))]);
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Ollama;
+        let profile = config.provider.kind.profile();
+        config.provider.base_url = profile.base_url.to_owned();
+        config.provider.chat_completions_path = profile.chat_completions_path.to_owned();
+        config.provider.api_key_env = None;
+        config.provider.oauth_access_token_env = None;
+        mvp::config::write(Some(path.to_string_lossy().as_ref()), &config, true)
+            .expect("write legacy-style config under first home");
+    }
+
+    let _guard =
+        MigrationEnvironmentGuard::set(&[("HOME", Some(home_b.to_string_lossy().as_ref()))]);
+
+    assert_eq!(
+        crate::migration::discovery::classify_current_setup(&path),
+        crate::migration::types::CurrentSetupState::LegacyOrIncomplete,
+        "default memory sqlite path drift from HOME changes should not force a legacy selection-only config into the repairable bucket"
+    );
+}
+
+#[test]
 fn migration_build_import_candidate_detects_provider_env_pointer_only_changes() {
     let mut config = mvp::config::LoongClawConfig::default();
     config.provider.api_key_env = Some("LOONGCLAW_CUSTOM_OPENAI_KEY".to_owned());

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -313,6 +313,8 @@ fn default_non_interactive_onboard_options(
         provider: None,
         model: None,
         api_key_env: None,
+        personality: None,
+        memory_profile: None,
         system_prompt: None,
         skip_model_probe: false,
     }
@@ -449,6 +451,43 @@ fn provider_kind_id_mapping_includes_kimi_coding() {
 }
 
 #[test]
+fn parse_prompt_personality_accepts_supported_ids() {
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("calm_engineering"),
+        Some(mvp::prompt::PromptPersonality::CalmEngineering)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("friendly_collab"),
+        Some(mvp::prompt::PromptPersonality::FriendlyCollab)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("autonomous_executor"),
+        Some(mvp::prompt::PromptPersonality::AutonomousExecutor)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("unknown"),
+        None
+    );
+}
+
+#[test]
+fn parse_memory_profile_accepts_supported_ids() {
+    assert_eq!(
+        crate::onboard_cli::parse_memory_profile("window_only"),
+        Some(mvp::config::MemoryProfile::WindowOnly)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_memory_profile("window_plus_summary"),
+        Some(mvp::config::MemoryProfile::WindowPlusSummary)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_memory_profile("profile_plus_window"),
+        Some(mvp::config::MemoryProfile::ProfilePlusWindow)
+    );
+    assert_eq!(crate::onboard_cli::parse_memory_profile("unknown"), None);
+}
+
+#[test]
 fn supported_provider_list_matches_canonical_provider_catalog() {
     let expected = mvp::config::ProviderKind::all_sorted()
         .iter()
@@ -472,6 +511,104 @@ fn non_interactive_requires_explicit_risk_acknowledgement() {
         .expect("risk gate should pass after acknowledgement");
     loongclaw_daemon::onboard_cli::validate_non_interactive_risk_gate(false, false)
         .expect("interactive mode should not require explicit flag");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_personality_and_memory_profile_are_persisted() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", "openai-test-token");
+    }
+
+    let output_path = unique_temp_path("non-interactive-personality-memory-config.toml");
+    let transcript = run_scripted_onboard_flow(
+        crate::onboard_cli::OnboardCommandOptions {
+            output: output_path.to_str().map(str::to_owned),
+            force: false,
+            non_interactive: true,
+            accept_risk: true,
+            provider: Some("openai".to_owned()),
+            model: Some("openai/gpt-5.1".to_owned()),
+            api_key_env: Some("OPENAI_API_KEY".to_owned()),
+            personality: Some("friendly_collab".to_owned()),
+            memory_profile: Some("profile_plus_window".to_owned()),
+            system_prompt: None,
+            skip_model_probe: true,
+        },
+        std::iter::empty::<String>(),
+        None,
+        None,
+    )
+    .await
+    .expect("run non-interactive onboarding with personality and memory profile");
+
+    assert!(
+        transcript
+            .iter()
+            .any(|line| line.contains("onboarding complete")),
+        "non-interactive personality/memory path should still complete successfully: {transcript:#?}"
+    );
+
+    let (_, config) = mvp::config::load(output_path.to_str())
+        .expect("load non-interactive personality/memory config");
+    assert_eq!(
+        config.cli.personality,
+        Some(mvp::prompt::PromptPersonality::FriendlyCollab)
+    );
+    assert_eq!(
+        config.memory.profile,
+        mvp::config::MemoryProfile::ProfilePlusWindow
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_system_prompt_override_disables_prompt_pack() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", "openai-test-token");
+    }
+
+    let output_path = unique_temp_path("non-interactive-inline-prompt-config.toml");
+    let transcript = run_scripted_onboard_flow(
+        crate::onboard_cli::OnboardCommandOptions {
+            output: output_path.to_str().map(str::to_owned),
+            force: false,
+            non_interactive: true,
+            accept_risk: true,
+            provider: Some("openai".to_owned()),
+            model: Some("openai/gpt-5.1".to_owned()),
+            api_key_env: Some("OPENAI_API_KEY".to_owned()),
+            personality: None,
+            memory_profile: None,
+            system_prompt: Some("Stay concise and technical.".to_owned()),
+            skip_model_probe: true,
+        },
+        std::iter::empty::<String>(),
+        None,
+        None,
+    )
+    .await
+    .expect("run non-interactive onboarding with an inline system prompt override");
+
+    assert!(
+        transcript
+            .iter()
+            .any(|line| line.contains("onboarding complete")),
+        "non-interactive inline override path should still complete successfully: {transcript:#?}"
+    );
+
+    let (_, config) =
+        mvp::config::load(output_path.to_str()).expect("load inline override config");
+
+    assert!(
+        !config.cli.uses_native_prompt_pack(),
+        "explicit inline prompt override should disable the native prompt pack metadata"
+    );
+    assert_eq!(
+        config.cli.system_prompt_addendum, None,
+        "inline override should not keep a native prompt addendum behind"
+    );
+    assert_eq!(config.cli.system_prompt, "Stay concise and technical.");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -848,6 +985,8 @@ async fn interactive_onboard_clear_token_keeps_inline_provider_credential() {
             provider: None,
             model: None,
             api_key_env: None,
+            personality: None,
+            memory_profile: None,
             system_prompt: None,
             skip_model_probe: true,
         },
@@ -893,6 +1032,8 @@ async fn interactive_onboard_clear_token_restores_builtin_system_prompt() {
             provider: None,
             model: None,
             api_key_env: None,
+            personality: None,
+            memory_profile: None,
             system_prompt: None,
             skip_model_probe: true,
         },
@@ -977,6 +1118,8 @@ requires_openai_auth = true
             provider: None,
             model: None,
             api_key_env: None,
+            personality: None,
+            memory_profile: None,
             system_prompt: None,
             skip_model_probe: false,
         },
@@ -1016,6 +1159,8 @@ requires_openai_auth = true
             provider: None,
             model: None,
             api_key_env: None,
+            personality: None,
+            memory_profile: None,
             system_prompt: None,
             skip_model_probe: false,
         },
@@ -1747,7 +1892,7 @@ fn onboard_presentation_review_and_shortcut_copy_stays_canonical() {
     let guided = loongclaw_daemon::onboard_presentation::review_flow_copy(
         loongclaw_daemon::onboard_presentation::ReviewFlowKind::Guided,
     );
-    assert_eq!(guided.progress_line, "step 5 of 5 · review");
+    assert_eq!(guided.progress_line, "step 7 of 7 · review");
     assert_eq!(guided.header_subtitle, "review setup");
 
     let quick_current = loongclaw_daemon::onboard_presentation::review_flow_copy(
@@ -2474,7 +2619,7 @@ fn onboard_provider_selection_screen_includes_focus_title_and_choices() {
         "provider choice screen should use a focused decision title: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line == "step 1 of 5 · provider"),
+        lines.iter().any(|line| line == "step 1 of 7 · provider"),
         "provider choice screen should keep the guided-flow progress context inside the screen: {lines:#?}"
     );
     assert!(
@@ -2903,6 +3048,8 @@ fn onboard_current_setup_shortcut_is_limited_to_healthy_interactive_keep_flow() 
         provider: None,
         model: None,
         api_key_env: None,
+        personality: None,
+        memory_profile: None,
         system_prompt: None,
         skip_model_probe: false,
     };
@@ -3022,6 +3169,8 @@ fn onboard_detected_setup_shortcut_is_limited_to_interactive_import_flow_with_de
         provider: None,
         model: None,
         api_key_env: None,
+        personality: None,
+        memory_profile: None,
         system_prompt: None,
         skip_model_probe: false,
     };
@@ -3701,7 +3850,7 @@ fn onboard_model_selection_screen_keeps_provider_context() {
         "model screen should use a focused title: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line == "step 2 of 5 · model"),
+        lines.iter().any(|line| line == "step 2 of 7 · model"),
         "model screen should include guided progress context without relying on an external step header: {lines:#?}"
     );
     assert!(
@@ -3779,7 +3928,7 @@ fn onboard_model_selection_screen_wraps_compact_header_and_progress_on_narrow_wi
         "narrow model screen should split the compact header instead of forcing brand and version onto one line: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line == "step 2 of 5 · model"),
+        lines.iter().any(|line| line == "step 2 of 7 · model"),
         "narrow model screen should still keep the step context visible: {lines:#?}"
     );
 }
@@ -3808,7 +3957,7 @@ fn onboard_api_key_env_screen_explains_suggested_env_and_blank_behavior() {
     assert!(
         lines
             .iter()
-            .any(|line| line == "step 3 of 5 · credential source"),
+            .any(|line| line == "step 3 of 7 · credential source"),
         "credential-env screen should include guided progress context inside the screen: {lines:#?}"
     );
     assert!(
@@ -3903,7 +4052,7 @@ fn onboard_api_key_env_screen_wraps_progress_line_on_narrow_width() {
         "credential-env screen should keep the progress line within narrow terminal widths: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line == "step 3 of 5 ·"),
+        lines.iter().any(|line| line == "step 3 of 7 ·"),
         "narrow credential-env screen should keep the step label on the first wrapped line: {lines:#?}"
     );
     assert!(
@@ -3931,7 +4080,7 @@ fn onboard_system_prompt_screen_explains_blank_behavior() {
     assert!(
         lines
             .iter()
-            .any(|line| line == "step 4 of 5 · system prompt"),
+            .any(|line| line == "step 4 of 6 · system prompt"),
         "system-prompt screen should include guided progress context inside the screen: {lines:#?}"
     );
     assert!(
@@ -4000,6 +4149,83 @@ fn onboard_system_prompt_screen_wraps_long_current_prompt() {
             .iter()
             .any(|line| line == "  code-focused when reviewing repo state"),
         "system-prompt screen should continue wrapped prompt text on an indented line: {lines:#?}"
+    );
+}
+
+#[test]
+fn onboard_personality_selection_screen_shows_native_personality_choices() {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.cli.personality = Some(mvp::prompt::PromptPersonality::FriendlyCollab);
+
+    let lines = crate::onboard_cli::render_personality_selection_screen_lines(&config, 80);
+
+    assert!(
+        lines.iter().any(|line| line == "choose personality"),
+        "personality screen should use a focused title: {lines:#?}"
+    );
+    assert!(
+        lines.iter().any(|line| line == "step 4 of 7 · personality"),
+        "personality screen should surface the native prompt-pack progress step: {lines:#?}"
+    );
+    assert!(
+        lines.iter().any(|line| line.contains("[friendly_collab]")),
+        "personality screen should show the canonical friendly_collab selector: {lines:#?}"
+    );
+}
+
+#[test]
+fn onboard_prompt_addendum_screen_explains_keep_and_clear_behavior() {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.cli.system_prompt_addendum = Some("Keep answers direct.".to_owned());
+
+    let lines = crate::onboard_cli::render_prompt_addendum_selection_screen_lines(&config, 80);
+
+    assert!(
+        lines.iter().any(|line| line == "adjust prompt addendum"),
+        "prompt-addendum screen should use a focused title: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "step 5 of 7 · prompt addendum"),
+        "prompt-addendum screen should surface the native prompt-pack progress step: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("blank keeps the current addendum")),
+        "prompt-addendum screen should explain how to preserve the current addendum: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("type '-' to clear it")),
+        "prompt-addendum screen should explain how to clear the current addendum: {lines:#?}"
+    );
+}
+
+#[test]
+fn onboard_memory_profile_screen_shows_supported_profiles() {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.memory.profile = mvp::config::MemoryProfile::ProfilePlusWindow;
+
+    let lines = crate::onboard_cli::render_memory_profile_selection_screen_lines(&config, 80);
+
+    assert!(
+        lines.iter().any(|line| line == "choose memory profile"),
+        "memory-profile screen should use a focused title: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "step 6 of 7 · memory profile"),
+        "memory-profile screen should surface the native prompt-pack progress step: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("[profile_plus_window]")),
+        "memory-profile screen should show the canonical profile_plus_window selector: {lines:#?}"
     );
 }
 
@@ -4211,7 +4437,7 @@ fn onboard_preflight_screen_summarizes_status_counts_and_guidance() {
         "preflight screen should use a focused title: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line == "step 5 of 5 · review"),
+        lines.iter().any(|line| line == "step 7 of 7 · review"),
         "preflight screen should stay anchored to the review step: {lines:#?}"
     );
     assert!(
@@ -4328,7 +4554,7 @@ fn current_setup_preflight_screen_uses_quick_review_progress_copy() {
         "current-setup preflight should use quick-review progress copy: {lines:#?}"
     );
     assert!(
-        lines.iter().all(|line| line != "step 5 of 5 · review"),
+        lines.iter().all(|line| line != "step 7 of 7 · review"),
         "current-setup preflight should not reuse the guided step progress copy: {lines:#?}"
     );
 }
@@ -4354,7 +4580,7 @@ fn detected_setup_preflight_screen_uses_quick_review_progress_copy() {
         "detected-setup preflight should use quick-review progress copy: {lines:#?}"
     );
     assert!(
-        lines.iter().all(|line| line != "step 5 of 5 · review"),
+        lines.iter().all(|line| line != "step 7 of 7 · review"),
         "detected-setup preflight should not reuse the guided step progress copy: {lines:#?}"
     );
 }
@@ -4444,7 +4670,7 @@ fn current_setup_write_confirmation_screen_uses_quick_review_progress_copy() {
         "current-setup write-confirm should use quick-review progress copy: {lines:#?}"
     );
     assert!(
-        lines.iter().all(|line| line != "step 5 of 5 · review"),
+        lines.iter().all(|line| line != "step 7 of 7 · review"),
         "current-setup write-confirm should not reuse the guided step progress copy: {lines:#?}"
     );
 }
@@ -4465,7 +4691,7 @@ fn detected_setup_write_confirmation_screen_uses_quick_review_progress_copy() {
         "detected-setup write-confirm should use quick-review progress copy: {lines:#?}"
     );
     assert!(
-        lines.iter().all(|line| line != "step 5 of 5 · review"),
+        lines.iter().all(|line| line != "step 7 of 7 · review"),
         "detected-setup write-confirm should not reuse the guided step progress copy: {lines:#?}"
     );
 }
@@ -4494,6 +4720,8 @@ async fn onboard_current_setup_shortcut_flow_skips_detailed_edit_screens() {
             provider: None,
             model: None,
             api_key_env: None,
+            personality: None,
+            memory_profile: None,
             system_prompt: None,
             skip_model_probe: true,
         },
@@ -4574,6 +4802,8 @@ requires_openai_auth = true
             provider: None,
             model: None,
             api_key_env: None,
+            personality: None,
+            memory_profile: None,
             system_prompt: None,
             skip_model_probe: true,
         },
@@ -4669,6 +4899,8 @@ requires_openai_auth = true
             provider: None,
             model: None,
             api_key_env: None,
+            personality: None,
+            memory_profile: None,
             system_prompt: None,
             skip_model_probe: true,
         },
@@ -4722,6 +4954,8 @@ requires_openai_auth = true
             provider: None,
             model: None,
             api_key_env: None,
+            personality: None,
+            memory_profile: None,
             system_prompt: None,
             skip_model_probe: true,
         },
@@ -4772,6 +5006,8 @@ async fn onboard_current_setup_adjustments_preserve_unchanged_domain_actions_in_
             provider: None,
             model: None,
             api_key_env: None,
+            personality: None,
+            memory_profile: None,
             system_prompt: None,
             skip_model_probe: true,
         },
@@ -4792,7 +5028,7 @@ async fn onboard_current_setup_adjustments_preserve_unchanged_domain_actions_in_
     .await
     .expect("run scripted current-setup onboarding with adjustments");
 
-    let review_lines = extract_review_section_lines(&transcript, "step 5 of 5 · review");
+    let review_lines = extract_review_section_lines(&transcript, "step 7 of 7 · review");
     let has_domain_action = |domain_label: &str, action_label: &str| {
         review_lines.iter().enumerate().any(|(index, line)| {
             line.contains(&format!("- {domain_label} ["))
@@ -4845,6 +5081,110 @@ async fn onboard_current_setup_adjustments_preserve_unchanged_domain_actions_in_
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn onboard_current_setup_adjustments_capture_personality_and_memory_profile() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let workspace_root = unique_temp_path("current-adjusted-personality-memory-workspace");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    std::fs::write(workspace_root.join("AGENTS.md"), "# local guidance\n")
+        .expect("write workspace guidance");
+
+    let output_path = unique_temp_path("current-adjusted-personality-memory-config.toml");
+    let mut existing = mvp::config::LoongClawConfig::default();
+    existing.provider.model = "gpt-4.1".to_owned();
+    existing.provider.api_key = Some("inline-secret".to_owned());
+    mvp::config::write(output_path.to_str(), &existing, true).expect("write existing config");
+
+    let transcript = run_scripted_onboard_flow(
+        crate::onboard_cli::OnboardCommandOptions {
+            output: output_path.to_str().map(str::to_owned),
+            force: false,
+            non_interactive: false,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            personality: None,
+            memory_profile: None,
+            system_prompt: None,
+            skip_model_probe: true,
+        },
+        [
+            "1",
+            "2",
+            "openai",
+            "gpt-4.1",
+            "OPENAI_API_KEY",
+            "friendly_collab",
+            "",
+            "profile_plus_window",
+            "y",
+            "y",
+            "o",
+        ],
+        Some(workspace_root),
+        None,
+    )
+    .await
+    .expect("run scripted current-setup onboarding with personality and memory profile changes");
+
+    let joined = transcript.join("\n");
+    assert!(
+        joined.contains("step 4 of 7 · personality"),
+        "guided current-setup adjustments should expose a dedicated personality step: {transcript:#?}"
+    );
+    assert!(
+        joined.contains("step 5 of 7 · prompt addendum"),
+        "guided current-setup adjustments should expose a dedicated prompt-addendum step: {transcript:#?}"
+    );
+    assert!(
+        joined.contains("step 6 of 7 · memory profile"),
+        "guided current-setup adjustments should expose a dedicated memory-profile step: {transcript:#?}"
+    );
+
+    let (_, config) = mvp::config::load(output_path.to_str())
+        .expect("load current-setup personality/memory config");
+    assert_eq!(
+        config.cli.personality,
+        Some(mvp::prompt::PromptPersonality::FriendlyCollab)
+    );
+    assert_eq!(
+        config.memory.profile,
+        mvp::config::MemoryProfile::ProfilePlusWindow
+    );
+}
+
+#[test]
+fn onboard_interactive_flow_defaults_back_to_native_prompt_pack_even_from_inline_override() {
+    let mut existing = mvp::config::LoongClawConfig::default();
+    existing.cli.prompt_pack_id = Some(String::new());
+    existing.cli.personality = None;
+    existing.cli.system_prompt_addendum = None;
+    existing.cli.system_prompt = "Stay terse and imperative.".to_owned();
+
+    let path = crate::onboard_cli::resolve_guided_prompt_path_label_for_test(
+        &crate::onboard_cli::OnboardCommandOptions {
+            output: None,
+            force: false,
+            non_interactive: false,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            personality: None,
+            memory_profile: None,
+            system_prompt: None,
+            skip_model_probe: true,
+        },
+        &existing,
+    );
+
+    assert_eq!(
+        path, "native",
+        "interactive onboarding should default back to the native prompt-pack path even when the current config uses an inline override"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn onboard_detected_setup_adjustments_preserve_unchanged_detected_actions_in_review() {
     let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let workspace_root = unique_temp_path("detected-adjusted-review-workspace");
@@ -4876,6 +5216,8 @@ requires_openai_auth = true
             provider: None,
             model: None,
             api_key_env: None,
+            personality: None,
+            memory_profile: None,
             system_prompt: None,
             skip_model_probe: true,
         },
@@ -4896,7 +5238,7 @@ requires_openai_auth = true
     .await
     .expect("run scripted detected-setup onboarding with adjustments");
 
-    let review_lines = extract_review_section_lines(&transcript, "step 5 of 5 · review");
+    let review_lines = extract_review_section_lines(&transcript, "step 7 of 7 · review");
     let has_domain_action = |domain_label: &str, action_label: &str| {
         review_lines.iter().enumerate().any(|(index, line)| {
             line.contains(&format!("- {domain_label} ["))
@@ -4998,7 +5340,7 @@ fn onboard_review_lines_include_brand_header() {
         "review screen should retain a clear review heading under the brand block: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line == "step 5 of 5 · review"),
+        lines.iter().any(|line| line == "step 7 of 7 · review"),
         "review screen should include guided progress context inside the screen: {lines:#?}"
     );
 }
@@ -5025,6 +5367,24 @@ fn onboard_review_lines_include_core_setup_summary_for_fresh_setup() {
             .iter()
             .any(|line| line.contains("- credential source: ${OPENAI_API_KEY}")),
         "review should keep the suggested credential env visible for fresh setup flows: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("- prompt mode: native prompt pack")),
+        "review should surface the active prompt mode for fresh setup flows: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("- personality: calm_engineering")),
+        "review should surface the active native personality during onboarding: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("- memory profile: window_only")),
+        "review should surface the selected memory profile during onboarding: {lines:#?}"
     );
 }
 
@@ -5111,7 +5471,7 @@ fn current_setup_review_lines_use_quick_review_progress_copy() {
         "current-setup review should use quick-review progress copy: {lines:#?}"
     );
     assert!(
-        lines.iter().all(|line| line != "step 5 of 5 · review"),
+        lines.iter().all(|line| line != "step 7 of 7 · review"),
         "current-setup review should not reuse the guided step progress copy: {lines:#?}"
     );
 }
@@ -5132,7 +5492,7 @@ fn detected_setup_review_lines_use_quick_review_progress_copy() {
         "detected-setup review should use quick-review progress copy: {lines:#?}"
     );
     assert!(
-        lines.iter().all(|line| line != "step 5 of 5 · review"),
+        lines.iter().all(|line| line != "step 7 of 7 · review"),
         "detected-setup review should not reuse the guided step progress copy: {lines:#?}"
     );
 }
@@ -5306,8 +5666,6 @@ fn onboarding_success_summary_includes_brand_header() {
 
     let lines =
         loongclaw_daemon::onboard_cli::render_onboarding_success_summary_with_width(&summary, 80);
-    let rendered = lines.join(" ");
-
     assert!(
         lines[0].starts_with("██╗"),
         "success summary should start with the shared LOONGCLAW brand block: {lines:#?}"
@@ -5321,10 +5679,30 @@ fn onboarding_success_summary_includes_brand_header() {
         "success summary should retain a clear completion heading: {lines:#?}"
     );
     assert!(
-        rendered
+        lines.join(" ")
             .contains("start here: loongclaw ask --config '/tmp/loongclaw-config.toml' --message")
-            && rendered.contains("Summarize this repository and suggest the best next step."),
+            && lines
+                .join(" ")
+                .contains("Summarize this repository and suggest the best next step."),
         "success summary should elevate ask as the primary handoff command even when wrapping is needed: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("- prompt mode: native prompt pack")),
+        "success summary should include the prompt mode that onboarding persisted: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("- personality: calm_engineering")),
+        "success summary should include the selected native personality: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("- memory profile: window_only")),
+        "success summary should include the selected memory profile: {lines:#?}"
     );
 }
 
@@ -5367,6 +5745,10 @@ fn onboarding_success_summary_reports_existing_config_kept() {
             label: "credential source",
             value: "${OPENAI_API_KEY}".to_owned(),
         }),
+        prompt_mode: "native prompt pack".to_owned(),
+        personality: Some("calm_engineering".to_owned()),
+        prompt_addendum: None,
+        memory_profile: "window_only".to_owned(),
         memory_path: None,
         channels: vec!["cli".to_owned()],
         domain_outcomes: Vec::new(),
@@ -5440,6 +5822,10 @@ fn onboarding_success_summary_groups_domain_outcomes_by_decision() {
             label: "credential source",
             value: "${OPENAI_API_KEY}".to_owned(),
         }),
+        prompt_mode: "native prompt pack".to_owned(),
+        personality: Some("friendly_collab".to_owned()),
+        prompt_addendum: Some("Keep answers direct.".to_owned()),
+        memory_profile: "profile_plus_window".to_owned(),
         memory_path: None,
         channels: vec!["cli".to_owned()],
         domain_outcomes: vec![
@@ -5500,6 +5886,10 @@ fn onboarding_success_summary_wraps_domain_outcomes_for_narrow_width() {
             label: "credential source",
             value: "${OPENAI_API_KEY}".to_owned(),
         }),
+        prompt_mode: "native prompt pack".to_owned(),
+        personality: Some("friendly_collab".to_owned()),
+        prompt_addendum: Some("Keep answers direct.".to_owned()),
+        memory_profile: "profile_plus_window".to_owned(),
         memory_path: None,
         channels: vec!["cli".to_owned()],
         domain_outcomes: vec![

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -176,7 +176,11 @@ impl loongclaw_daemon::onboard_cli::OnboardUi for ScriptedOnboardUi {
         default: &str,
     ) -> loongclaw_daemon::CliResult<String> {
         self.outputs.push(format!("PROMPT {label} [{default}]"));
-        self.next_input(label)
+        let value = self.next_input(label)?;
+        if value.trim().is_empty() {
+            return Ok(default.to_owned());
+        }
+        Ok(value)
     }
 
     fn prompt_required(&mut self, label: &str) -> loongclaw_daemon::CliResult<String> {
@@ -597,8 +601,7 @@ async fn non_interactive_system_prompt_override_disables_prompt_pack() {
         "non-interactive inline override path should still complete successfully: {transcript:#?}"
     );
 
-    let (_, config) =
-        mvp::config::load(output_path.to_str()).expect("load inline override config");
+    let (_, config) = mvp::config::load(output_path.to_str()).expect("load inline override config");
 
     assert!(
         !config.cli.uses_native_prompt_pack(),
@@ -990,7 +993,9 @@ async fn interactive_onboard_clear_token_keeps_inline_provider_credential() {
             system_prompt: None,
             skip_model_probe: true,
         },
-        ["1", "2", "openai", "gpt-4.1", ":clear", "", "y", "y", "o"],
+        [
+            "1", "2", "openai", "gpt-4.1", ":clear", "", "", "", "y", "y", "o",
+        ],
         None,
         None,
     )
@@ -1034,10 +1039,12 @@ async fn interactive_onboard_clear_token_restores_builtin_system_prompt() {
             api_key_env: None,
             personality: None,
             memory_profile: None,
-            system_prompt: None,
+            system_prompt: Some(existing.cli.system_prompt.clone()),
             skip_model_probe: true,
         },
-        ["1", "2", "openai", "gpt-4.1", "", ":clear", "y", "y", "o"],
+        [
+            "1", "2", "openai", "gpt-4.1", "", ":clear", "", "y", "y", "o",
+        ],
         None,
         None,
     )
@@ -5017,7 +5024,9 @@ async fn onboard_current_setup_adjustments_preserve_unchanged_domain_actions_in_
             "openai",
             "gpt-4.1",
             "OPENAI_API_KEY",
+            "",
             "custom review prompt",
+            "",
             "y",
             "y",
             "o",
@@ -5185,37 +5194,6 @@ fn onboard_interactive_flow_defaults_back_to_native_prompt_pack_even_from_inline
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn onboard_interactive_flow_defaults_back_to_native_prompt_pack_even_from_inline_override() {
-    let mut existing = mvp::config::LoongClawConfig::default();
-    existing.cli.prompt_pack_id = Some(String::new());
-    existing.cli.personality = None;
-    existing.cli.system_prompt_addendum = None;
-    existing.cli.system_prompt = "Stay terse and imperative.".to_owned();
-
-    let path = crate::onboard_cli::resolve_guided_prompt_path_label_for_test(
-        &crate::onboard_cli::OnboardCommandOptions {
-            output: None,
-            force: false,
-            non_interactive: false,
-            accept_risk: true,
-            provider: None,
-            model: None,
-            api_key_env: None,
-            personality: None,
-            memory_profile: None,
-            system_prompt: None,
-            skip_model_probe: true,
-        },
-        &existing,
-    );
-
-    assert_eq!(
-        path, "native",
-        "interactive onboarding should default back to the native prompt-pack path even when the current config currently uses an inline override"
-    );
-}
-
-#[tokio::test(flavor = "current_thread")]
 async fn onboard_detected_setup_adjustments_preserve_unchanged_detected_actions_in_review() {
     let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let workspace_root = unique_temp_path("detected-adjusted-review-workspace");
@@ -5259,6 +5237,8 @@ requires_openai_auth = true
             "openai",
             "openai/gpt-5.1-codex-preview",
             "OPENAI_API_KEY",
+            "",
+            "",
             "",
             "y",
             "y",
@@ -5710,7 +5690,8 @@ fn onboarding_success_summary_includes_brand_header() {
         "success summary should retain a clear completion heading: {lines:#?}"
     );
     assert!(
-        lines.join(" ")
+        lines
+            .join(" ")
             .contains("start here: loongclaw ask --config '/tmp/loongclaw-config.toml' --message")
             && lines
                 .join(" ")

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -5185,6 +5185,37 @@ fn onboard_interactive_flow_defaults_back_to_native_prompt_pack_even_from_inline
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn onboard_interactive_flow_defaults_back_to_native_prompt_pack_even_from_inline_override() {
+    let mut existing = mvp::config::LoongClawConfig::default();
+    existing.cli.prompt_pack_id = Some(String::new());
+    existing.cli.personality = None;
+    existing.cli.system_prompt_addendum = None;
+    existing.cli.system_prompt = "Stay terse and imperative.".to_owned();
+
+    let path = crate::onboard_cli::resolve_guided_prompt_path_label_for_test(
+        &crate::onboard_cli::OnboardCommandOptions {
+            output: None,
+            force: false,
+            non_interactive: false,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            personality: None,
+            memory_profile: None,
+            system_prompt: None,
+            skip_model_probe: true,
+        },
+        &existing,
+    );
+
+    assert_eq!(
+        path, "native",
+        "interactive onboarding should default back to the native prompt-pack path even when the current config currently uses an inline override"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn onboard_detected_setup_adjustments_preserve_unchanged_detected_actions_in_review() {
     let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let workspace_root = unique_temp_path("detected-adjusted-review-workspace");

--- a/docs/plans/2026-03-15-alpha-test-onboard-personality-selection-repair-design.md
+++ b/docs/plans/2026-03-15-alpha-test-onboard-personality-selection-repair-design.md
@@ -1,0 +1,208 @@
+# Alpha-Test Onboard Personality Selection Repair Design
+
+## Context
+
+`alpha-test` currently exposes three conflicting product surfaces for onboarding:
+
+- English docs describe personality selection and memory-profile selection as
+  first-class onboarding capabilities.
+- Product specs still define those capabilities as acceptance criteria.
+- The current onboarding implementation only exposes provider, model,
+  credential-env, and `system_prompt` editing.
+
+This drift is not only a docs problem. The current onboarding flow also writes
+`cli.system_prompt` without disabling the native prompt pack, which means the
+visible "system prompt" customization path can diverge from the runtime prompt
+that the provider layer actually uses.
+
+## Problem Statement
+
+The current branch regressed from an earlier implementation that supported:
+
+- interactive personality selection
+- non-interactive `--personality`
+- interactive memory profile selection
+- non-interactive `--memory-profile`
+- explicit inline prompt override semantics that disabled the native prompt pack
+
+That behavior disappeared during the 2026-03-14 onboarding/import unification
+refactor. The regression was not caught because new onboarding tests focused on
+review and shortcut UX, not on prompt-pack behavior or onboarding surface
+parity.
+
+## Goals
+
+- Restore interactive personality selection in `loongclaw onboard`.
+- Restore non-interactive `--personality`.
+- Restore interactive memory profile selection.
+- Restore non-interactive `--memory-profile`.
+- Make inline system prompt override semantics truthful again by disabling the
+  native prompt pack when onboarding captures an explicit inline prompt.
+- Keep the unified onboarding/import flow and current review UX intact.
+- Align English and Chinese README wording with the actual repaired behavior.
+- Add regression tests that fail before the fix and pass after it.
+
+## Non-Goals
+
+- Reworking the import architecture beyond the minimum needed to preserve CLI
+  prompt semantics.
+- Adding arbitrary user-defined personalities.
+- Changing runtime prompt composition outside of onboarding/import regression
+  repair.
+- Broad wording cleanup outside of the affected onboarding/docs surfaces.
+
+## Constraints
+
+- The fix must preserve the current `alpha-test` guided onboarding structure
+  unless a behavior change is necessary for correctness.
+- `cli.prompt_pack_id`, `cli.personality`, `cli.system_prompt_addendum`, and
+  `memory.profile` must remain compatible with existing config loading.
+- Migration/import logic must not silently overwrite user-owned CLI identity
+  metadata in ways that conflict with the restored onboarding semantics.
+
+## Options Considered
+
+### Option 1: Docs-only rollback
+
+Remove personality/memory claims from docs and leave onboarding as-is.
+
+Rejected:
+
+- The runtime already has native prompt-pack metadata and memory profiles.
+- The current `system_prompt` onboarding path is likely misleading at runtime.
+- This would normalize a regression instead of fixing it.
+
+### Option 2: Restore the old onboarding logic wholesale
+
+Revert large parts of the pre-unification onboarding implementation.
+
+Rejected:
+
+- It would discard useful review, shortcut, and starting-point UX added by the
+  later refactor.
+- It creates a larger merge surface than needed.
+
+### Option 3: Repair the unified flow in place
+
+Keep the current onboarding/import architecture, but reintroduce explicit
+personality and memory-profile handling and restore correct inline prompt
+override semantics.
+
+Recommended:
+
+- Smallest change that fixes the regression at the product seam.
+- Preserves the newer onboarding/import review model.
+- Lets tests pin the intended behavior in the current architecture.
+
+## Proposed Design
+
+### Onboarding Surface
+
+Extend `OnboardCommandOptions` and the clap `Onboard` command with:
+
+- `--personality`
+- `--memory-profile`
+
+Restore guided onboarding steps so the detailed flow becomes:
+
+1. provider
+2. model
+3. credential source
+4. personality
+5. prompt addendum or inline override
+6. memory profile
+7. review
+
+The exact wording should follow the current polished onboarding copy style.
+
+### Prompt Semantics
+
+Split onboarding CLI behavior into two explicit paths:
+
+- Native prompt-pack path:
+  - keep `prompt_pack_id`
+  - set `personality`
+  - set or clear `system_prompt_addendum`
+  - call `refresh_native_system_prompt()`
+- Inline override path:
+  - clear `prompt_pack_id`
+  - clear `personality`
+  - clear `system_prompt_addendum`
+  - store the explicit inline `system_prompt`
+
+Interactive onboarding should default to native prompt-pack selection. Advanced
+operators can still pass `--system-prompt` to switch into full inline override
+mode.
+
+### Memory Profile Semantics
+
+Restore onboarding support for:
+
+- `window_only`
+- `window_plus_summary`
+- `profile_plus_window`
+
+Interactive onboarding should surface the current/default memory profile.
+Non-interactive onboarding should accept and validate `--memory-profile`.
+
+### Import And CLI Domain Consistency
+
+The current migration discovery/planner code still treats the CLI domain mostly
+as `system_prompt + exit_commands`. That is too narrow for the repaired
+onboarding model.
+
+The minimal repair is:
+
+- include prompt-pack metadata and addendum in CLI-diff detection
+- preserve inline override vs native-pack semantics when supplementing CLI
+  config
+- avoid treating a personality-only or addendum-only change as "default CLI"
+
+This keeps import/review output consistent with the runtime and avoids future
+drift.
+
+### Docs Alignment
+
+- English README: keep the personality and memory-profile sections, but make
+  the wording truthful to the restored behavior.
+- Chinese README: add matching onboarding personality/memory-profile content so
+  both READMEs describe the same surface.
+- Product specs remain acceptance criteria docs; do not mark them complete in
+  prose, but ensure README wording does not outrun the repaired implementation.
+
+## Testing Strategy
+
+Add failing tests first for:
+
+- clap parsing of `--personality` and `--memory-profile`
+- non-interactive personality/memory-profile application
+- interactive detailed flow transcript showing personality and memory profile
+  steps
+- inline `--system-prompt` path clearing prompt-pack metadata
+- current unified-flow import/discovery CLI-domain comparisons correctly
+  respecting prompt-pack metadata
+
+Validation after implementation:
+
+- targeted daemon/app tests for the new regression coverage
+- broader `cargo test` scope for daemon/app if build queue permits
+- formatting and clippy before PR
+
+## Risks
+
+- Reintroducing the old behavior too literally could conflict with the current
+  onboarding review model.
+- Import/migration logic may have hidden assumptions that only compare
+  `system_prompt`.
+- README updates could accidentally claim more than the restored runtime
+  actually guarantees.
+
+## Success Criteria
+
+The fix is complete when:
+
+- `loongclaw onboard --help` exposes `--personality` and `--memory-profile`
+- interactive onboarding visibly offers personality and memory-profile choices
+- inline prompt override semantics are honored by runtime prompt resolution
+- docs in both languages match the shipped behavior
+- regression tests fail before the change and pass after it

--- a/docs/plans/2026-03-15-alpha-test-onboard-personality-selection-repair-implementation-plan.md
+++ b/docs/plans/2026-03-15-alpha-test-onboard-personality-selection-repair-implementation-plan.md
@@ -1,0 +1,204 @@
+# Alpha-Test Onboard Personality Selection Repair Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Repair `alpha-test` onboarding so personality selection, memory-profile selection, and inline prompt override semantics are correct again across runtime, tests, and docs.
+
+**Architecture:** Keep the current unified onboarding/import flow, but reintroduce personality and memory-profile handling as first-class onboarding fields. Align CLI-domain diff/planning logic with prompt-pack metadata so review/import behavior matches runtime semantics instead of only comparing `system_prompt`.
+
+**Tech Stack:** Rust, clap, existing `loongclaw-app` config/prompt/runtime modules, daemon onboarding/import flow, Markdown docs, `cargo test`, `cargo fmt`, `cargo clippy`.
+
+---
+
+### Task 1: Add failing CLI parser coverage for the missing flags
+
+**Files:**
+- Modify: `crates/daemon/src/main.rs`
+
+**Step 1: Write the failing test**
+
+Add parser tests that expect `loongclaw onboard --personality friendly_collab`
+and `loongclaw onboard --memory-profile profile_plus_window` to parse into the
+`Onboard` command.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon onboard_cli_accepts_personality_flag -- --exact`
+Expected: FAIL because the current clap command has no `personality` field.
+
+**Step 3: Write minimal implementation**
+
+Add the clap fields and thread them into `OnboardCommandOptions`.
+
+**Step 4: Run test to verify it passes**
+
+Run the same targeted test and the matching memory-profile parser test.
+
+**Step 5: Commit**
+
+Commit message: `test: restore onboard parser coverage for personality and memory profile`
+
+### Task 2: Add failing onboarding behavior tests for detailed guided flow
+
+**Files:**
+- Modify: `crates/daemon/src/tests/onboard_cli.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `crates/daemon/src/onboard_presentation.rs`
+
+**Step 1: Write the failing test**
+
+Add transcript-level tests that assert the guided flow includes personality and
+memory-profile steps, and that the resulting config uses the selected values.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon onboard_guided_flow_captures_personality_and_memory_profile -- --exact`
+Expected: FAIL because the current guided flow only has `system prompt`.
+
+**Step 3: Write minimal implementation**
+
+Reintroduce guided personality and memory-profile selection inside the unified
+flow without removing current review/shortcut behavior.
+
+**Step 4: Run test to verify it passes**
+
+Run the targeted guided-flow test and nearby onboarding transcript tests.
+
+**Step 5: Commit**
+
+Commit message: `feat: restore guided onboard personality and memory profile selection`
+
+### Task 3: Add failing regression tests for inline prompt override semantics
+
+**Files:**
+- Modify: `crates/daemon/src/tests/onboard_cli.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `crates/app/src/provider/request_message_runtime.rs`
+
+**Step 1: Write the failing test**
+
+Add onboarding tests that prove explicit inline `system_prompt` selection clears
+`prompt_pack_id`, `personality`, and `system_prompt_addendum`, and that the
+resolved runtime system message starts with the inline prompt.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon non_interactive_system_prompt_override_disables_prompt_pack -- --exact`
+Expected: FAIL because onboarding currently only mutates `cli.system_prompt`.
+
+**Step 3: Write minimal implementation**
+
+Update onboarding selection logic so full inline override explicitly disables
+native prompt-pack metadata.
+
+**Step 4: Run test to verify it passes**
+
+Run the targeted onboarding test and the relevant app/provider prompt test.
+
+**Step 5: Commit**
+
+Commit message: `fix: restore truthful onboard inline prompt override semantics`
+
+### Task 4: Add failing CLI-domain migration tests for prompt metadata
+
+**Files:**
+- Modify: `crates/daemon/src/migration/discovery.rs`
+- Modify: `crates/daemon/src/migration/planner.rs`
+- Modify: `crates/daemon/src/tests/onboard_cli.rs`
+
+**Step 1: Write the failing test**
+
+Add tests showing that prompt-pack metadata and addendum differences are
+detected as CLI-domain differences and preserved by supplementation logic.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon cli_import_surface_detects_prompt_pack_metadata_changes -- --exact`
+Expected: FAIL because current discovery/planner code only compares
+`system_prompt` and `exit_commands`.
+
+**Step 3: Write minimal implementation**
+
+Expand CLI-domain comparison and supplementation logic to account for prompt
+pack id, personality, and addendum semantics.
+
+**Step 4: Run test to verify it passes**
+
+Run the new targeted tests plus nearby discovery/planner tests.
+
+**Step 5: Commit**
+
+Commit message: `fix: align onboard migration cli domain with prompt metadata`
+
+### Task 5: Add docs coverage and README parity
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+- Modify: `docs/plans/2026-03-15-alpha-test-onboard-personality-selection-repair-design.md`
+
+**Step 1: Write the failing check**
+
+Use the repaired behavior as the source of truth and identify any README claims
+that remain out of sync after code changes.
+
+**Step 2: Verify the mismatch exists**
+
+Run targeted text inspection with `rg`/`sed`.
+Expected: current Chinese README lacks personality onboarding content.
+
+**Step 3: Write minimal implementation**
+
+Update both READMEs so they describe the same restored onboarding behavior and
+do not overclaim beyond the implemented flow.
+
+**Step 4: Verify the docs match**
+
+Re-read the affected sections and confirm terminology parity.
+
+**Step 5: Commit**
+
+Commit message: `docs: align onboard personality and memory profile docs`
+
+### Task 6: Full validation and GitHub delivery
+
+**Files:**
+- Modify: `.github/PULL_REQUEST_TEMPLATE.md` only if repository policy requires template updates
+- Add or update: GitHub issue and PR artifacts
+
+**Step 1: Run focused validation**
+
+Run targeted `cargo test` commands for each repaired regression cluster.
+
+**Step 2: Run repository validation**
+
+Run:
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features`
+
+If the shared cargo queue blocks progress, wait and rerun instead of claiming
+success without evidence.
+
+**Step 3: Review git isolation**
+
+Run:
+- `git status --short`
+- `git diff --cached --name-only`
+- `git diff --cached`
+
+Ensure only task-scoped changes are included.
+
+**Step 4: Publish branch and GitHub artifacts**
+
+- Open or update the issue using the repository bug template fields.
+- Push the branch to `origin`.
+- Open a PR against `upstream/alpha-test` using the PR template and `Closes #<id>`.
+
+**Step 5: Final verification**
+
+Re-check local validation output, PR body, linked issue, and branch status.
+
+**Step 6: Commit**
+
+Commit message: `fix: restore onboard personality and memory profile flows`


### PR DESCRIPTION
## Summary

- What changed?
  - Restored `loongclaw onboard` personality selection and memory profile selection on `alpha-test`, including the native prompt-pack guided flow.
  - Preserved inline `--system-prompt` overrides while making interactive onboarding fall back to the native prompt-pack flow again instead of sticking to an existing inline override.
  - Extended migration/onboarding metadata handling for `cli.prompt_pack_id`, `cli.personality`, `cli.system_prompt_addendum`, and `memory.profile`.
  - Aligned both `README.md` and `README.zh-CN.md` with the actual onboarding flow.
  - Stabilized migration import planning so a process-level `HOME` drift does not misclassify the default memory sqlite path as custom and fabricate a recommended import candidate.
  - Aligned the scripted onboarding test harness with terminal default-value behavior and completed the remaining onboard option coverage after rebasing onto the latest `alpha-test`.
- Why this change is needed?
  - `alpha-test` documentation promised onboarding personality selection, but the actual onboarding flow no longer exposed it.
  - Existing inline prompt override configs also caused interactive onboarding to skip the intended native prompt-pack selection flow.
  - Workspace-level tests were flaky because migration candidate composition could change when process-global `HOME` changed between config construction and candidate building.
  - The rebased branch still needed final test-harness cleanup so the regression suite matched the shipped terminal behavior exactly.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Validation details:

- `cargo fmt --all -- --check`
- `REAL_CARGO=$(rustup which cargo) && CARGO_TARGET_DIR=<local-absolute-path> "$REAL_CARGO" test -p loongclaw-daemon onboard_cli`
- `REAL_CARGO=$(rustup which cargo) && CARGO_TARGET_DIR=<local-absolute-path> "$REAL_CARGO" test -p loongclaw-app runtime_config`
- Re-ran `REAL_CARGO=$(rustup which cargo) && CARGO_TARGET_DIR=<local-absolute-path> "$REAL_CARGO" test -p loongclaw-app runtime_config` 5 consecutive times after the first green run to confirm the env-isolation flake no longer reproduced.
- `REAL_CARGO=$(rustup which cargo) && CARGO_TARGET_DIR=<local-absolute-path> "$REAL_CARGO" clippy --workspace --all-targets --all-features -- -D warnings`
- `REAL_CARGO=$(rustup which cargo) && CARGO_TARGET_DIR=<local-absolute-path> "$REAL_CARGO" test --workspace --all-features`
- After rebasing onto the latest `upstream/alpha-test`, reran `cargo fmt --all -- --check`, `REAL_CARGO=$(rustup which cargo) && CARGO_TARGET_DIR=<local-absolute-path> "$REAL_CARGO" clippy --workspace --all-targets --all-features -- -D warnings`, and `REAL_CARGO=$(rustup which cargo) && CARGO_TARGET_DIR=<local-absolute-path> "$REAL_CARGO" test --workspace --all-features` on the rebased head.
- Added `migration_compose_recommended_candidate_ignores_home_drift_for_default_memory_path` to lock the HOME-drift regression down.
- Env-mutating runtime tests now restore state through `crate::test_support::ScopedEnv` and the migration HOME-drift regression restores `HOME` through `MigrationEnvironmentGuard`.

## Linked Issues

Closes #171


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--personality` and `--memory-profile` CLI flags for non-interactive onboarding configuration.
  * Enhanced guided onboarding flow with explicit personality and memory profile selection steps.
  * Improved distinction between native prompt pack and inline prompt override paths during setup.

* **Documentation**
  * Expanded README with comprehensive onboarding guidance covering personality selection, memory profiles, and prompt override semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->