### PR TITLE
fix: address CodeRabbit findings from discovery-first PR

### DIFF
--- a/crates/app/src/conversation/analytics.rs
+++ b/crates/app/src/conversation/analytics.rs
@@ -656,16 +656,14 @@ fn fold_discovery_first_event_record(
 
     match record.event.as_str() {
         "discovery_first_search_round" => {
-            // Skip counter bump when required payload field is absent.
             if record
                 .payload
                 .get("search_tool_calls")
                 .and_then(Value::as_u64)
-                .is_none()
+                .is_some()
             {
-                return;
+                summary.search_round_events = summary.search_round_events.saturating_add(1);
             }
-            summary.search_round_events = summary.search_round_events.saturating_add(1);
             if let Some(initial_estimated_tokens) = record
                 .payload
                 .get("initial_estimated_tokens")
@@ -714,16 +712,10 @@ fn fold_discovery_first_event_record(
             }
         }
         "discovery_first_followup_result" => {
-            // Skip counter bump when required `outcome` field is absent.
-            if record
-                .payload
-                .get("outcome")
-                .and_then(Value::as_str)
-                .is_none()
-            {
-                return;
+            let outcome = record.payload.get("outcome").and_then(Value::as_str);
+            if outcome.is_some() {
+                summary.followup_result_events = summary.followup_result_events.saturating_add(1);
             }
-            summary.followup_result_events = summary.followup_result_events.saturating_add(1);
 
             if record
                 .payload
@@ -743,7 +735,7 @@ fn fold_discovery_first_event_record(
                 summary.search_to_invoke_hits = summary.search_to_invoke_hits.saturating_add(1);
             }
 
-            if let Some(outcome) = record.payload.get("outcome").and_then(Value::as_str) {
+            if let Some(outcome) = outcome {
                 summary.latest_followup_outcome = Some(outcome.to_owned());
                 bump_count(&mut summary.outcome_counts, outcome);
             }
@@ -2537,5 +2529,53 @@ mod tests {
         assert_eq!(summary.latest_added_estimated_tokens, Some(12));
         assert_eq!(summary.outcome_counts.get("final_reply").copied(), Some(1));
         assert_eq!(summary.outcome_counts.get("tool.invoke").copied(), None);
+    }
+
+    #[test]
+    fn summarize_discovery_first_events_preserves_initial_tokens_when_call_count_is_missing() {
+        let payloads = [json!({
+            "type": "conversation_event",
+            "event": "discovery_first_search_round",
+            "payload": {
+                "initial_estimated_tokens": 21
+            }
+        })
+        .to_string()];
+
+        let summary = summarize_discovery_first_events(payloads.iter().map(String::as_str));
+
+        assert_eq!(summary.search_round_events, 0);
+        assert_eq!(summary.latest_initial_estimated_tokens, Some(21));
+    }
+
+    #[test]
+    fn summarize_discovery_first_events_preserves_followup_flags_when_outcome_is_missing() {
+        let payloads = [json!({
+            "type": "conversation_event",
+            "event": "discovery_first_followup_result",
+            "payload": {
+                "raw_tool_output_requested": true,
+                "resolved_to_tool_invoke": true,
+                "followup_tool_name": "tool.invoke",
+                "followup_target_tool_id": "file.read"
+            }
+        })
+        .to_string()];
+
+        let summary = summarize_discovery_first_events(payloads.iter().map(String::as_str));
+
+        assert_eq!(summary.followup_result_events, 0);
+        assert_eq!(summary.raw_output_followup_events, 1);
+        assert_eq!(summary.search_to_invoke_hits, 1);
+        assert_eq!(
+            summary.latest_followup_tool_name.as_deref(),
+            Some("tool.invoke")
+        );
+        assert_eq!(
+            summary.latest_followup_target_tool_id.as_deref(),
+            Some("file.read")
+        );
+        assert_eq!(summary.latest_followup_outcome, None);
+        assert!(summary.outcome_counts.is_empty());
     }
 }

--- a/crates/app/src/conversation/analytics.rs
+++ b/crates/app/src/conversation/analytics.rs
@@ -656,6 +656,15 @@ fn fold_discovery_first_event_record(
 
     match record.event.as_str() {
         "discovery_first_search_round" => {
+            // Skip counter bump when required payload field is absent.
+            if record
+                .payload
+                .get("search_tool_calls")
+                .and_then(Value::as_u64)
+                .is_none()
+            {
+                return;
+            }
             summary.search_round_events = summary.search_round_events.saturating_add(1);
             if let Some(initial_estimated_tokens) = record
                 .payload
@@ -705,6 +714,15 @@ fn fold_discovery_first_event_record(
             }
         }
         "discovery_first_followup_result" => {
+            // Skip counter bump when required `outcome` field is absent.
+            if record
+                .payload
+                .get("outcome")
+                .and_then(Value::as_str)
+                .is_none()
+            {
+                return;
+            }
             summary.followup_result_events = summary.followup_result_events.saturating_add(1);
 
             if record
@@ -2493,7 +2511,7 @@ mod tests {
     #[test]
     fn summarize_discovery_first_events_ignores_lookalikes_and_tracks_latest_request_snapshot() {
         let payloads = [
-            r#"{"type":"conversation_event","event":"discovery_first_search_round","payload":{"provider_round":0}}"#,
+            r#"{"type":"conversation_event","event":"discovery_first_search_round","payload":{"provider_round":0,"search_tool_calls":1}}"#,
             r#"{"type":"conversation_event","event":"discovery_first_followup_requested","payload":{"provider_round":1,"initial_estimated_tokens":20,"followup_estimated_tokens":32,"followup_added_estimated_tokens":12}}"#,
             r#"{"type":"conversation_event","event":"discovery_first_followup_result","payload":{"provider_round":1,"outcome":"final_reply","resolved_to_tool_invoke":false}}"#,
             r#"{"type":"conversation_event","event":"discovery_first_followup_noise","payload":{"outcome":"tool.invoke","resolved_to_tool_invoke":true,"followup_added_estimated_tokens":999}}"#,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2286,11 +2286,18 @@ fn scope_provider_turn_tool_intents(
     turn_id: &str,
 ) -> ProviderTurn {
     for intent in &mut turn.tool_intents {
-        if intent.session_id.trim().is_empty() {
+        if intent.source.starts_with("provider_") {
+            // Provider-originated intents: runtime scope is authoritative.
             intent.session_id = session_id.to_owned();
-        }
-        if intent.turn_id.trim().is_empty() {
             intent.turn_id = turn_id.to_owned();
+        } else {
+            // Non-provider intents: only fill in if missing.
+            if intent.session_id.trim().is_empty() {
+                intent.session_id = session_id.to_owned();
+            }
+            if intent.turn_id.trim().is_empty() {
+                intent.turn_id = turn_id.to_owned();
+            }
         }
     }
     turn
@@ -2629,7 +2636,7 @@ struct DiscoveryFirstFollowupTurnSummary {
 fn summarize_discovery_first_followup_turn(
     turn: &ProviderTurn,
 ) -> DiscoveryFirstFollowupTurnSummary {
-    let Some(intent) = turn.tool_intents.first() else {
+    let Some(first) = turn.tool_intents.first() else {
         return DiscoveryFirstFollowupTurnSummary {
             outcome: "final_reply".to_owned(),
             followup_tool_name: None,
@@ -2637,6 +2644,13 @@ fn summarize_discovery_first_followup_turn(
             resolved_to_tool_invoke: false,
         };
     };
+
+    // Prefer the first `tool.invoke` intent if present; fall back to first intent.
+    let intent = turn
+        .tool_intents
+        .iter()
+        .find(|i| crate::tools::canonical_tool_name(i.tool_name.as_str()) == "tool.invoke")
+        .unwrap_or(first);
 
     let canonical_tool_name =
         crate::tools::canonical_tool_name(intent.tool_name.as_str()).to_owned();
@@ -6698,10 +6712,11 @@ mod tests {
 
         let scoped = scope_provider_turn_tool_intents(turn, "session-a", "turn-a");
 
+        // Provider-originated intents always get runtime scope overridden.
         assert_eq!(scoped.tool_intents[0].session_id, "session-a");
         assert_eq!(scoped.tool_intents[0].turn_id, "turn-a");
-        assert_eq!(scoped.tool_intents[1].session_id, "already-session");
-        assert_eq!(scoped.tool_intents[1].turn_id, "already-turn");
+        assert_eq!(scoped.tool_intents[1].session_id, "session-a");
+        assert_eq!(scoped.tool_intents[1].turn_id, "turn-a");
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -6686,7 +6686,7 @@ mod tests {
     }
 
     #[test]
-    fn scope_provider_turn_tool_intents_populates_missing_ids_and_preserves_existing_ids() {
+    fn scope_provider_turn_tool_intents_overrides_existing_provider_ids_with_runtime_scope() {
         let turn = ProviderTurn {
             assistant_text: String::new(),
             tool_intents: vec![

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -6720,6 +6720,39 @@ mod tests {
     }
 
     #[test]
+    fn scope_non_provider_turn_tool_intents_preserve_existing_ids() {
+        let turn = ProviderTurn {
+            assistant_text: String::new(),
+            tool_intents: vec![
+                ToolIntent {
+                    tool_name: "tool.search".to_owned(),
+                    args_json: json!({"query": "read file"}),
+                    source: "local_followup".to_owned(),
+                    session_id: "existing-session".to_owned(),
+                    turn_id: "existing-turn".to_owned(),
+                    tool_call_id: "call-1".to_owned(),
+                },
+                ToolIntent {
+                    tool_name: "tool.invoke".to_owned(),
+                    args_json: json!({"tool_id": "file.read", "lease": "stub", "arguments": {"path": "README.md"}}),
+                    source: "local_followup".to_owned(),
+                    session_id: String::new(),
+                    turn_id: String::new(),
+                    tool_call_id: "call-2".to_owned(),
+                },
+            ],
+            raw_meta: Value::Null,
+        };
+
+        let scoped = scope_provider_turn_tool_intents(turn, "session-a", "turn-a");
+
+        assert_eq!(scoped.tool_intents[0].session_id, "existing-session");
+        assert_eq!(scoped.tool_intents[0].turn_id, "existing-turn");
+        assert_eq!(scoped.tool_intents[1].session_id, "session-a");
+        assert_eq!(scoped.tool_intents[1].turn_id, "turn-a");
+    }
+
+    #[test]
     fn reload_followup_provider_config_reads_provider_switch_wrapped_by_tool_invoke() {
         use std::fs;
 

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -214,6 +214,17 @@ impl ToolView {
         self.allowed_names.iter().map(String::as_str)
     }
 
+    pub fn intersect(&self, other: &ToolView) -> ToolView {
+        let names: BTreeSet<String> = self
+            .allowed_names
+            .intersection(&other.allowed_names)
+            .cloned()
+            .collect();
+        ToolView {
+            allowed_names: names,
+        }
+    }
+
     pub fn iter<'a>(
         &'a self,
         catalog: &'a ToolCatalog,
@@ -1868,7 +1879,7 @@ fn tool_argument_hint(name: &str) -> &'static str {
             "path?:string,bundled_skill_id?:string,skill_id?:string,replace?:boolean"
         }
         "external_skills.invoke" => "skill_id:string",
-        "external_skills.list" => "active_only?:boolean",
+        "external_skills.list" => "",
         "external_skills.policy" => {
             "action?:string,enabled?:boolean,allowed_domains?:string[],blocked_domains?:string[]"
         }
@@ -1880,7 +1891,7 @@ fn tool_argument_hint(name: &str) -> &'static str {
         "delegate" | "delegate_async" => "task:string,label?:string,timeout_seconds?:integer",
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
         | "session_status" | "session_wait" | "sessions_history" => "session_id:string",
-        "sessions_list" => "limit?:integer,status?:string",
+        "sessions_list" => "limit?:integer,state?:string",
         "sessions_send" => "session_id:string,text:string",
         _ => "",
     }
@@ -1914,7 +1925,7 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
             ("skill_id", "string"),
             ("replace", "boolean"),
         ],
-        "external_skills.list" => &[("active_only", "boolean")],
+        "external_skills.list" => &[],
         "external_skills.policy" => &[
             ("action", "string"),
             ("enabled", "boolean"),
@@ -1936,7 +1947,7 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
         ],
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
         | "session_status" | "session_wait" | "sessions_history" => &[("session_id", "string")],
-        "sessions_list" => &[("limit", "integer"), ("status", "string")],
+        "sessions_list" => &[("limit", "integer"), ("state", "string")],
         "sessions_send" => &[("session_id", "string"), ("text", "string")],
         _ => &[],
     }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1422,6 +1422,7 @@ fn _shape_examples() -> BTreeMap<&'static str, Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::ScopedEnv;
     use std::path::PathBuf;
 
     fn test_tool_runtime_config(root: PathBuf) -> runtime_config::ToolRuntimeConfig {
@@ -2179,6 +2180,61 @@ mod tests {
         );
     }
 
+    #[cfg(all(feature = "tool-shell", unix))]
+    #[test]
+    fn shell_exec_rejects_non_lowercase_command_names_before_execution() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        }
+
+        let root = unique_temp_dir("loongclaw-shell-mixed-case");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let script = root.join("MiXeDCmd");
+        fs::write(&script, "#!/bin/sh\nprintf '%s' \"$0\"\n").expect("write mixed-case script");
+        let mut perms = fs::metadata(&script)
+            .expect("script metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).expect("mark script executable");
+
+        let mut env = ScopedEnv::new();
+        let original_path = std::env::var_os("PATH").unwrap_or_default();
+        let mut path_value = root.clone().into_os_string();
+        if !original_path.is_empty() {
+            path_value.push(std::ffi::OsStr::new(":"));
+            path_value.push(original_path);
+        }
+        env.set("PATH", path_value);
+
+        let mut config = test_tool_runtime_config(root.clone());
+        config.shell_allow = BTreeSet::from(["mixedcmd".to_owned()]);
+
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "shell.exec".to_owned(),
+                payload: json!({"command": "MiXeDCmd"}),
+            },
+            &config,
+        )
+        .expect_err("mixed-case commands should be rejected before execution");
+
+        assert!(
+            error.contains("lowercase"),
+            "expected lowercase command rejection, got: {error}"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_search_result_includes_compact_argument_hints() {
@@ -2263,6 +2319,28 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn runtime_discoverable_tool_entries_intersect_injected_view_with_runtime_surface() {
+        let mut config = test_tool_runtime_config(std::env::temp_dir());
+        config.sessions_enabled = false;
+
+        let injected = ToolView::from_tool_names(["sessions_list", "claw.import"]);
+        let names = runtime_discoverable_tool_entries(&config, Some(&injected))
+            .into_iter()
+            .map(|entry| entry.canonical_name)
+            .collect::<Vec<_>>();
+
+        assert!(
+            names.contains(&"claw.import".to_owned()),
+            "expected enabled injected tool to remain visible: {names:?}"
+        );
+        assert!(
+            !names.contains(&"sessions_list".to_owned()),
+            "disabled runtime tool should not be re-exposed by injected visibility: {names:?}"
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -490,6 +490,28 @@ pub(crate) fn runtime_tool_view_with_runtime_config(
     ToolView::from_tool_names(names)
 }
 
+/// Build a tool view from runtime config (respecting runtime toggles) plus
+/// feishu entries when the feishu integration is configured. This avoids
+/// using `ToolConfig::default()` which ignores runtime-disabled tools.
+fn full_runtime_tool_view_for_runtime_config(
+    config: &runtime_config::ToolRuntimeConfig,
+) -> ToolView {
+    let catalog = tool_catalog();
+    let mut names = catalog::runtime_tool_view_for_runtime_config(config)
+        .iter(&catalog)
+        .map(|descriptor| descriptor.name)
+        .collect::<Vec<_>>();
+    #[cfg(feature = "feishu-integration")]
+    if config.feishu.is_some() {
+        names.extend(
+            feishu::feishu_tool_registry_entries()
+                .into_iter()
+                .map(|entry| entry.name),
+        );
+    }
+    ToolView::from_tool_names(names)
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ResolvedToolExecution {
     pub canonical_name: &'static str,
@@ -621,11 +643,10 @@ pub(crate) fn tool_registry_with_config(
             &default_runtime_config
         }
     };
-    let default_visible_tool_view =
-        runtime_tool_view_with_runtime_config(&ToolConfig::default(), config);
+    let runtime_visible_tool_view = full_runtime_tool_view_for_runtime_config(config);
     let mut entries: Vec<ToolRegistryEntry> = catalog::discoverable_tool_catalog()
         .into_iter()
-        .filter(|entry| default_visible_tool_view.contains(entry.canonical_name))
+        .filter(|entry| runtime_visible_tool_view.contains(entry.canonical_name))
         .filter(|entry| tool_search_entry_is_runtime_usable(*entry, config))
         .map(|entry| ToolRegistryEntry {
             name: entry.canonical_name,
@@ -637,7 +658,7 @@ pub(crate) fn tool_registry_with_config(
         entries.extend(
             feishu::feishu_tool_registry_entries()
                 .into_iter()
-                .filter(|entry| default_visible_tool_view.contains(entry.name)),
+                .filter(|entry| runtime_visible_tool_view.contains(entry.name)),
         );
     }
     entries.sort_by_key(|entry| entry.name);
@@ -859,7 +880,7 @@ fn search_tool_view_from_payload(
     };
     match visible_tool_names {
         Some(visible_tool_names) => ToolView::from_tool_names(visible_tool_names),
-        None => runtime_tool_view_with_runtime_config(&ToolConfig::default(), config),
+        None => full_runtime_tool_view_for_runtime_config(config),
     }
 }
 
@@ -867,13 +888,12 @@ fn runtime_discoverable_tool_entries(
     config: &runtime_config::ToolRuntimeConfig,
     visible_tool_view: Option<&ToolView>,
 ) -> Vec<SearchableToolEntry> {
-    let default_visible_tool_view;
+    let runtime_visible_tool_view;
     let visible_tool_view = match visible_tool_view {
         Some(view) => view,
         None => {
-            default_visible_tool_view =
-                runtime_tool_view_with_runtime_config(&ToolConfig::default(), config);
-            &default_visible_tool_view
+            runtime_visible_tool_view = full_runtime_tool_view_for_runtime_config(config);
+            &runtime_visible_tool_view
         }
     };
     let mut entries = catalog::discoverable_tool_catalog()

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -470,8 +470,7 @@ pub(crate) fn runtime_tool_view_from_loongclaw_config(
     runtime_tool_view_with_runtime_config(&config.tools, &runtime_config)
 }
 
-pub(crate) fn runtime_tool_view_with_runtime_config(
-    _tool_config: &crate::config::ToolConfig,
+fn build_runtime_tool_view_for_runtime_config(
     runtime_config: &runtime_config::ToolRuntimeConfig,
 ) -> ToolView {
     let catalog = tool_catalog();
@@ -490,26 +489,20 @@ pub(crate) fn runtime_tool_view_with_runtime_config(
     ToolView::from_tool_names(names)
 }
 
+pub(crate) fn runtime_tool_view_with_runtime_config(
+    _tool_config: &crate::config::ToolConfig,
+    runtime_config: &runtime_config::ToolRuntimeConfig,
+) -> ToolView {
+    build_runtime_tool_view_for_runtime_config(runtime_config)
+}
+
 /// Build a tool view from runtime config (respecting runtime toggles) plus
 /// feishu entries when the feishu integration is configured. This avoids
 /// using `ToolConfig::default()` which ignores runtime-disabled tools.
 fn full_runtime_tool_view_for_runtime_config(
     config: &runtime_config::ToolRuntimeConfig,
 ) -> ToolView {
-    let catalog = tool_catalog();
-    let mut names = catalog::runtime_tool_view_for_runtime_config(config)
-        .iter(&catalog)
-        .map(|descriptor| descriptor.name)
-        .collect::<Vec<_>>();
-    #[cfg(feature = "feishu-integration")]
-    if config.feishu.is_some() {
-        names.extend(
-            feishu::feishu_tool_registry_entries()
-                .into_iter()
-                .map(|entry| entry.name),
-        );
-    }
-    ToolView::from_tool_names(names)
+    build_runtime_tool_view_for_runtime_config(config)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -888,13 +888,17 @@ fn runtime_discoverable_tool_entries(
     config: &runtime_config::ToolRuntimeConfig,
     visible_tool_view: Option<&ToolView>,
 ) -> Vec<SearchableToolEntry> {
-    let runtime_visible_tool_view;
+    let runtime_view = full_runtime_tool_view_for_runtime_config(config);
+    let intersected_view;
     let visible_tool_view = match visible_tool_view {
-        Some(view) => view,
-        None => {
-            runtime_visible_tool_view = full_runtime_tool_view_for_runtime_config(config);
-            &runtime_visible_tool_view
+        Some(injected) => {
+            // Intersect the injected view with the runtime-visible surface so that
+            // trusted _loongclaw.tool_search.visible_tool_ids cannot re-expose
+            // tools disabled by runtime config (browser.*, session_*, etc.).
+            intersected_view = injected.intersect(&runtime_view);
+            &intersected_view
         }
+        None => &runtime_view,
     };
     let mut entries = catalog::discoverable_tool_catalog()
         .into_iter()
@@ -2135,6 +2139,44 @@ mod tests {
         assert!(results.iter().all(|entry| entry["tool_id"] != "shell.exec"));
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-shell")]
+    #[test]
+    fn shell_exec_rejects_path_qualified_commands() {
+        let config = test_tool_runtime_config(std::env::temp_dir());
+        for cmd in ["/tmp/git", "./git", "../git", "..\\git", "/usr/bin/ls"] {
+            let error = execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "shell.exec".to_owned(),
+                    payload: json!({"command": cmd}),
+                },
+                &config,
+            )
+            .expect_err(&format!("path-qualified `{cmd}` should be denied"));
+            assert!(
+                error.contains("path separators"),
+                "expected path separator rejection for `{cmd}`, got: {error}"
+            );
+        }
+    }
+
+    #[cfg(feature = "tool-shell")]
+    #[test]
+    fn shell_exec_rejects_embedded_whitespace_in_command() {
+        let config = test_tool_runtime_config(std::env::temp_dir());
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "shell.exec".to_owned(),
+                payload: json!({"command": "ls -la"}),
+            },
+            &config,
+        )
+        .expect_err("embedded whitespace should be denied");
+        assert!(
+            error.contains("embedded whitespace"),
+            "expected whitespace rejection, got: {error}"
+        );
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]

--- a/crates/app/src/tools/shell.rs
+++ b/crates/app/src/tools/shell.rs
@@ -46,11 +46,20 @@ pub(super) fn execute_shell_tool_with_config(
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
 
         let normalized_command = command.to_ascii_lowercase();
-        let basename = normalized_command
-            .rsplit('/')
-            .find(|segment| !segment.is_empty())
-            .and_then(|segment| segment.rsplit('\\').find(|segment| !segment.is_empty()))
+        let first_word = normalized_command
+            .split_whitespace()
+            .next()
             .unwrap_or(&normalized_command);
+
+        // Reject path-qualified commands (e.g. /tmp/git, ./git, ..\git) to
+        // prevent allowlist bypass via an absolute or relative path.
+        if first_word.contains('/') || first_word.contains('\\') {
+            return Err(format!(
+                "policy_denied: shell command `{first_word}` must be a bare command name without path separators"
+            ));
+        }
+
+        let basename = first_word;
 
         if config.shell_deny.contains(basename) {
             return Err(format!(

--- a/crates/app/src/tools/shell.rs
+++ b/crates/app/src/tools/shell.rs
@@ -83,7 +83,7 @@ pub(super) fn execute_shell_tool_with_config(
             ));
         }
 
-        let output = Command::new(command)
+        let output = Command::new(&normalized_command)
             .args(&args)
             .current_dir(&cwd)
             .output()

--- a/crates/app/src/tools/shell.rs
+++ b/crates/app/src/tools/shell.rs
@@ -45,34 +45,17 @@ pub(super) fn execute_shell_tool_with_config(
             .map(PathBuf::from)
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
 
-        let normalized_command = command.to_ascii_lowercase();
+        let normalized_command =
+            crate::tools::shell_policy_ext::validate_shell_command_name(command)?;
+        let basename = normalized_command.as_str();
 
-        // Reject commands with embedded whitespace to ensure the policy check
-        // and execution operate on the same value.
-        if normalized_command.contains(char::is_whitespace) {
-            return Err(
-                "policy_denied: shell command must not contain embedded whitespace; use `args` instead"
-                    .to_owned(),
-            );
-        }
-
-        let basename = &normalized_command;
-
-        // Reject path-qualified commands (e.g. /tmp/git, ./git, ..\git) to
-        // prevent allowlist bypass via an absolute or relative path.
-        if basename.contains('/') || basename.contains('\\') {
-            return Err(format!(
-                "policy_denied: shell command `{basename}` must be a bare command name without path separators"
-            ));
-        }
-
-        if config.shell_deny.contains(basename.as_str()) {
+        if config.shell_deny.contains(basename) {
             return Err(format!(
                 "policy_denied: shell command `{basename}` is blocked by shell policy"
             ));
         }
 
-        let explicitly_allowed = config.shell_allow.contains(basename.as_str());
+        let explicitly_allowed = config.shell_allow.contains(basename);
         let default_allows = matches!(
             config.shell_default_mode,
             crate::tools::shell_policy_ext::ShellPolicyDefault::Allow

--- a/crates/app/src/tools/shell.rs
+++ b/crates/app/src/tools/shell.rs
@@ -46,28 +46,33 @@ pub(super) fn execute_shell_tool_with_config(
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
 
         let normalized_command = command.to_ascii_lowercase();
-        let first_word = normalized_command
-            .split_whitespace()
-            .next()
-            .unwrap_or(&normalized_command);
+
+        // Reject commands with embedded whitespace to ensure the policy check
+        // and execution operate on the same value.
+        if normalized_command.contains(char::is_whitespace) {
+            return Err(
+                "policy_denied: shell command must not contain embedded whitespace; use `args` instead"
+                    .to_owned(),
+            );
+        }
+
+        let basename = &normalized_command;
 
         // Reject path-qualified commands (e.g. /tmp/git, ./git, ..\git) to
         // prevent allowlist bypass via an absolute or relative path.
-        if first_word.contains('/') || first_word.contains('\\') {
+        if basename.contains('/') || basename.contains('\\') {
             return Err(format!(
-                "policy_denied: shell command `{first_word}` must be a bare command name without path separators"
+                "policy_denied: shell command `{basename}` must be a bare command name without path separators"
             ));
         }
 
-        let basename = first_word;
-
-        if config.shell_deny.contains(basename) {
+        if config.shell_deny.contains(basename.as_str()) {
             return Err(format!(
                 "policy_denied: shell command `{basename}` is blocked by shell policy"
             ));
         }
 
-        let explicitly_allowed = config.shell_allow.contains(basename);
+        let explicitly_allowed = config.shell_allow.contains(basename.as_str());
         let default_allows = matches!(
             config.shell_default_mode,
             crate::tools::shell_policy_ext::ShellPolicyDefault::Allow

--- a/crates/app/src/tools/shell_policy_ext.rs
+++ b/crates/app/src/tools/shell_policy_ext.rs
@@ -48,6 +48,35 @@ impl ToolPolicyExtension {
     }
 }
 
+pub(crate) fn validate_shell_command_name(command: &str) -> Result<String, String> {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return Err("shell.exec requires payload.command".to_owned());
+    }
+
+    if trimmed.contains(char::is_whitespace) {
+        return Err(
+            "policy_denied: shell command must not contain embedded whitespace; use `args` instead"
+                .to_owned(),
+        );
+    }
+
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(format!(
+            "policy_denied: shell command `{trimmed}` must be a bare command name without path separators"
+        ));
+    }
+
+    let normalized = trimmed.to_ascii_lowercase();
+    if trimmed != normalized {
+        return Err(format!(
+            "policy_denied: shell command `{trimmed}` must use a lowercase bare command name to match shell policy"
+        ));
+    }
+
+    Ok(normalized)
+}
+
 impl PolicyExtension for ToolPolicyExtension {
     fn name(&self) -> &str {
         "tool-policy"
@@ -67,30 +96,30 @@ impl PolicyExtension for ToolPolicyExtension {
             .and_then(|payload| payload.get("command"))
             .and_then(|v| v.as_str())
             .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_ascii_lowercase);
+            .filter(|s| !s.is_empty());
 
         let Some(command) = command else {
             return Ok(());
         };
 
-        // Extract basename so absolute paths like "/usr/bin/rm" match "rm".
-        // Use `find` instead of `next` so trailing separators (e.g. "/usr/bin/")
-        // don't produce an empty string.
-        let basename = command
-            .rsplit('/')
-            .find(|s| !s.is_empty())
-            .and_then(|s| s.rsplit('\\').find(|s| !s.is_empty()))
-            .unwrap_or(&command);
+        let basename = match validate_shell_command_name(command) {
+            Ok(command) => command,
+            Err(reason) => {
+                return Err(PolicyError::ToolCallDenied {
+                    tool_name: tool_name.to_owned(),
+                    reason,
+                });
+            }
+        };
 
-        if self.hard_deny.contains(basename) {
+        if self.hard_deny.contains(basename.as_str()) {
             return Err(PolicyError::ToolCallDenied {
                 tool_name: tool_name.to_owned(),
                 reason: format!("command `{basename}` is blocked by shell policy"),
             });
         }
 
-        if self.allow.contains(basename) {
+        if self.allow.contains(basename.as_str()) {
             return Ok(());
         }
 
@@ -434,6 +463,30 @@ mod tests {
         let params = json!({"tool_name": "shell.exec", "payload": {"command": "git"}});
         let ctx = make_context(&pack, &token, &caps, Some(&params));
         assert!(ext.authorize_extension(&ctx).is_ok());
+    }
+
+    #[test]
+    fn mixed_case_command_is_denied_before_allowlist_lookup() {
+        let ext = ToolPolicyExtension::new(
+            BTreeSet::new(),
+            BTreeSet::from(["mixedcmd".to_owned()]),
+            ShellPolicyDefault::Deny,
+        );
+        let pack = test_pack();
+        let token = test_token();
+        let caps = BTreeSet::from([Capability::InvokeTool]);
+        let params = json!({"tool_name": "shell.exec", "payload": {"command": "MiXeDCmd"}});
+        let ctx = make_context(&pack, &token, &caps, Some(&params));
+        let err = ext
+            .authorize_extension(&ctx)
+            .expect_err("mixed-case commands should be denied before allowlist lookup");
+        let PolicyError::ToolCallDenied { reason, .. } = err else {
+            panic!("expected ToolCallDenied for mixed-case command");
+        };
+        assert!(
+            reason.contains("lowercase"),
+            "expected lowercase rejection, got: {reason}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Enforce runtime session/turn scope for provider-originated intents instead of trusting provider-populated IDs
- Align catalog metadata with JSON schema (`sessions_list.state`, `external_skills.list` no-params)
- Reject path-qualified commands in shell policy to prevent allowlist bypass via `<local-absolute-path>` or `./git`
- Use runtime config for tool view construction instead of `ToolConfig::default()` to respect runtime toggles
- Validate discovery-first analytics payloads before counting events
- Scan all intents in follow-up telemetry, preferring `tool.invoke`

## Context

Addresses unresolved CodeRabbit review comments from #149 (discovery-first tool routing).

## Scope

- [x] Small and focused
- [x] No unrelated refactors

## Risk Track

- [x] Track B (higher-risk/policy-impacting)

Shell allowlist bypass fix and scope trust fix are security-relevant.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`

## Linked Issues

Follow-up to #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tool parameter updates: `external_skills.list` no longer accepts `active_only`; `sessions_list` uses `state` instead of `status`.
  * Shell command validation tightened; invalid or path-qualified commands are rejected and failures return richer exit/output details.
  * Analytics now skip counting events when required payload data is missing.

* **New Features**
  * Runtime-driven tool visibility with intersecting views for more accurate discovery.

* **Behavior Changes**
  * Provider-originated intents now override session/turn IDs; follow-up resolution prefers `tool.invoke` when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->