### PR TITLE
fix: harden provider active selection semantics

### DIFF
--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -1204,6 +1204,7 @@ fn validate_channel_account_integrity<'a, I>(
         );
         extra_message_variables.insert("raw_account_labels".to_owned(), labels.join(", "));
         issues.push(ConfigValidationIssue {
+            severity: super::shared::ConfigValidationSeverity::Error,
             code: ConfigValidationCode::DuplicateChannelAccountId,
             field_path: format!("{channel_key}.accounts"),
             inline_field_path: format!("{channel_key}.accounts.{normalized_account_id}"),
@@ -1242,6 +1243,7 @@ fn validate_channel_account_integrity<'a, I>(
             .join(", "),
     );
     issues.push(ConfigValidationIssue {
+        severity: super::shared::ConfigValidationSeverity::Error,
         code: ConfigValidationCode::UnknownChannelDefaultAccount,
         field_path: format!("{channel_key}.default_account"),
         inline_field_path: format!("{channel_key}.accounts"),

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -15,8 +15,8 @@ use super::{
     feishu_integration::FeishuIntegrationConfig,
     provider::{ProviderConfig, ProviderKind, ProviderProfileConfig},
     shared::{
-        ConfigValidationIssue, ConfigValidationLocale, DEFAULT_CONFIG_FILE,
-        default_loongclaw_home as shared_default_loongclaw_home, expand_path,
+        ConfigValidationIssue, ConfigValidationLocale, ConfigValidationSeverity,
+        DEFAULT_CONFIG_FILE, default_loongclaw_home as shared_default_loongclaw_home, expand_path,
         format_config_validation_issues,
     },
     tools_memory::{ExternalSkillsConfig, MemoryConfig, ToolConfig},
@@ -24,6 +24,7 @@ use super::{
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ConfigValidationDiagnostic {
+    pub severity: String,
     pub code: String,
     pub problem_type: String,
     pub title_key: String,
@@ -42,6 +43,7 @@ impl ConfigValidationDiagnostic {
     fn from_issue(issue: &ConfigValidationIssue, locale: ConfigValidationLocale) -> Self {
         let message_variables = issue.message_variables();
         Self {
+            severity: issue.severity_str().to_owned(),
             code: issue.code.as_str().to_owned(),
             problem_type: issue.code.problem_type_uri().to_owned(),
             title_key: issue.title_key().to_owned(),
@@ -515,6 +517,116 @@ fn normalize_provider_profile_id(raw: &str) -> Option<String> {
     normalize_dispatch_channel_id(raw)
 }
 
+#[derive(Debug, Clone, Default)]
+struct RawProviderSelectionIntent {
+    legacy_provider_explicit: bool,
+    active_provider_explicit: bool,
+    raw_active_provider: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActiveProviderSelectionBasis {
+    ExplicitActiveProvider,
+    ExplicitLegacyProvider,
+    FirstSavedProfile,
+    LegacyOnly,
+}
+
+impl ActiveProviderSelectionBasis {
+    const fn diagnostic_summary(self) -> &'static str {
+        match self {
+            Self::ExplicitActiveProvider => "the explicit active_provider value",
+            Self::ExplicitLegacyProvider => "the explicit legacy [provider] table",
+            Self::FirstSavedProfile => "the first saved provider profile in sorted order",
+            Self::LegacyOnly => "the legacy [provider] table",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct ProviderSelectionNormalizationReport {
+    legacy_provider_explicit: bool,
+    active_provider_explicit: bool,
+    requested_active_provider: Option<String>,
+    selected_active_provider: Option<String>,
+    configured_profile_ids: Vec<String>,
+    selection_basis: Option<ActiveProviderSelectionBasis>,
+    warn_implicit_active_provider: bool,
+    warn_unknown_active_provider: bool,
+    recovered_legacy_profile_id: Option<String>,
+    legacy_profile_inserted: bool,
+    legacy_provider_validation_issues: Vec<ConfigValidationIssue>,
+}
+
+impl ProviderSelectionNormalizationReport {
+    fn validation_issues(&self) -> Vec<ConfigValidationIssue> {
+        let mut issues = self.legacy_provider_validation_issues.clone();
+        let configured_profile_ids = self.configured_profile_ids.join(", ");
+        let selected_profile_id = self
+            .selected_active_provider
+            .as_deref()
+            .unwrap_or("unknown")
+            .to_owned();
+        let selection_basis = self
+            .selection_basis
+            .map(ActiveProviderSelectionBasis::diagnostic_summary)
+            .unwrap_or("provider profile normalization")
+            .to_owned();
+
+        if self.warn_implicit_active_provider {
+            let mut extra_message_variables = BTreeMap::new();
+            extra_message_variables.insert("selected_profile_id".to_owned(), selected_profile_id);
+            extra_message_variables.insert("selection_basis".to_owned(), selection_basis.clone());
+            extra_message_variables.insert(
+                "configured_profile_ids".to_owned(),
+                configured_profile_ids.clone(),
+            );
+            issues.push(ConfigValidationIssue {
+                severity: ConfigValidationSeverity::Warn,
+                code: super::shared::ConfigValidationCode::ImplicitActiveProvider,
+                field_path: "active_provider".to_owned(),
+                inline_field_path: "providers".to_owned(),
+                example_env_name: String::new(),
+                suggested_env_name: self.selected_active_provider.clone(),
+                extra_message_variables,
+            });
+        }
+
+        if self.warn_unknown_active_provider {
+            let mut extra_message_variables = BTreeMap::new();
+            extra_message_variables.insert(
+                "requested_profile_id".to_owned(),
+                self.requested_active_provider
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or("(blank)")
+                    .to_owned(),
+            );
+            extra_message_variables.insert(
+                "selected_profile_id".to_owned(),
+                self.selected_active_provider
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_owned()),
+            );
+            extra_message_variables.insert("selection_basis".to_owned(), selection_basis);
+            extra_message_variables
+                .insert("configured_profile_ids".to_owned(), configured_profile_ids);
+            issues.push(ConfigValidationIssue {
+                severity: ConfigValidationSeverity::Warn,
+                code: super::shared::ConfigValidationCode::UnknownActiveProvider,
+                field_path: "active_provider".to_owned(),
+                inline_field_path: "providers".to_owned(),
+                example_env_name: String::new(),
+                suggested_env_name: self.selected_active_provider.clone(),
+                extra_message_variables,
+            });
+        }
+
+        issues
+    }
+}
+
 pub const PROVIDER_SELECTOR_PLACEHOLDER: &str = "<profile|model|kind>";
 pub const PROVIDER_SELECTOR_HUMAN_SUMMARY: &str =
     "profile id, unique model name or suffix, or provider kind";
@@ -938,18 +1050,31 @@ pub(crate) fn normalize_dispatch_account_id(raw: &str) -> Option<String> {
 }
 
 impl LoongClawConfig {
-    fn collect_validation_issues(&self) -> Vec<ConfigValidationIssue> {
+    fn collect_validation_issues_with_report(
+        &self,
+        selection_report: Option<&ProviderSelectionNormalizationReport>,
+    ) -> Vec<ConfigValidationIssue> {
         let mut issues = Vec::new();
         if self.providers.is_empty() {
             issues.extend(self.provider.validate());
         } else {
             for (profile_id, profile) in &self.providers {
+                if selection_report.is_some_and(|report| {
+                    report.legacy_profile_inserted
+                        && report.recovered_legacy_profile_id.as_deref()
+                            == Some(profile_id.as_str())
+                }) {
+                    continue;
+                }
                 issues.extend(
                     profile
                         .provider
                         .validate_with_field_prefix(format!("providers.{profile_id}").as_str()),
                 );
             }
+        }
+        if let Some(report) = selection_report {
+            issues.extend(report.validation_issues());
         }
         issues.extend(super::channels::collect_channel_validation_issues(self));
         issues.extend(self.feishu_integration.validate());
@@ -959,11 +1084,22 @@ impl LoongClawConfig {
     }
 
     pub fn validate(&self) -> CliResult<()> {
-        let issues = self.collect_validation_issues();
-        if issues.is_empty() {
+        self.validate_with_report(None)
+    }
+
+    fn validate_with_report(
+        &self,
+        selection_report: Option<&ProviderSelectionNormalizationReport>,
+    ) -> CliResult<()> {
+        let issues = self.collect_validation_issues_with_report(selection_report);
+        let errors = issues
+            .into_iter()
+            .filter(ConfigValidationIssue::is_error)
+            .collect::<Vec<_>>();
+        if errors.is_empty() {
             return Ok(());
         }
-        Err(format_config_validation_issues(&issues))
+        Err(format_config_validation_issues(&errors))
     }
 
     pub fn validation_diagnostics(&self) -> Vec<ConfigValidationDiagnostic> {
@@ -974,7 +1110,15 @@ impl LoongClawConfig {
         &self,
         locale: ConfigValidationLocale,
     ) -> Vec<ConfigValidationDiagnostic> {
-        self.collect_validation_issues()
+        self.validation_diagnostics_with_locale_and_report(locale, None)
+    }
+
+    fn validation_diagnostics_with_locale_and_report(
+        &self,
+        locale: ConfigValidationLocale,
+        selection_report: Option<&ProviderSelectionNormalizationReport>,
+    ) -> Vec<ConfigValidationDiagnostic> {
+        self.collect_validation_issues_with_report(selection_report)
             .iter()
             .map(|issue| ConfigValidationDiagnostic::from_issue(issue, locale))
             .collect()
@@ -1106,10 +1250,26 @@ impl LoongClawConfig {
     }
 
     fn normalize_provider_profiles(&mut self) {
+        let _ = self.normalize_provider_profiles_with_intent(None);
+    }
+
+    fn normalize_provider_profiles_with_intent(
+        &mut self,
+        intent: Option<&RawProviderSelectionIntent>,
+    ) -> ProviderSelectionNormalizationReport {
         let normalized_last_provider = self
             .last_provider
             .as_deref()
             .and_then(normalize_provider_profile_id);
+        let mut report = ProviderSelectionNormalizationReport {
+            legacy_provider_explicit: intent
+                .is_some_and(|selection| selection.legacy_provider_explicit),
+            active_provider_explicit: intent
+                .is_some_and(|selection| selection.active_provider_explicit),
+            requested_active_provider: intent
+                .and_then(|selection| selection.raw_active_provider.clone()),
+            ..ProviderSelectionNormalizationReport::default()
+        };
 
         if self.providers.is_empty() {
             let active_provider = self
@@ -1123,7 +1283,10 @@ impl LoongClawConfig {
                 .insert(active_provider.clone(), active_profile);
             self.active_provider = Some(active_provider);
             self.last_provider = normalized_last_provider;
-            return;
+            report.selected_active_provider = self.active_provider.clone();
+            report.configured_profile_ids = self.providers.keys().cloned().collect();
+            report.selection_basis = Some(ActiveProviderSelectionBasis::LegacyOnly);
+            return report;
         }
 
         let mut normalized_profiles = BTreeMap::new();
@@ -1133,21 +1296,41 @@ impl LoongClawConfig {
             normalized_profiles.insert(normalized_profile_id, profile.clone());
         }
         self.providers = normalized_profiles;
+        report.configured_profile_ids = self.providers.keys().cloned().collect();
 
-        let Some(active_provider) = self
+        let explicit_active_provider = self
             .active_provider
             .as_deref()
             .and_then(normalize_provider_profile_id)
             .filter(|profile_id| self.providers.contains_key(profile_id))
+            .inspect(|_| {
+                report.selection_basis = Some(ActiveProviderSelectionBasis::ExplicitActiveProvider);
+            });
+        if report.active_provider_explicit && explicit_active_provider.is_none() {
+            report.warn_unknown_active_provider = true;
+        }
+        let active_provider = explicit_active_provider
             .or_else(|| {
-                let legacy_profile_id = self.provider.inferred_profile_id();
-                self.providers
-                    .contains_key(&legacy_profile_id)
-                    .then_some(legacy_profile_id)
+                if !report.legacy_provider_explicit {
+                    return None;
+                }
+                let (legacy_profile_id, inserted) =
+                    recover_active_provider_from_legacy_config(&self.provider, &mut self.providers);
+                report.configured_profile_ids = self.providers.keys().cloned().collect();
+                report.selection_basis = Some(ActiveProviderSelectionBasis::ExplicitLegacyProvider);
+                report.recovered_legacy_profile_id = Some(legacy_profile_id.clone());
+                report.legacy_profile_inserted = inserted;
+                Some(legacy_profile_id)
             })
-            .or_else(|| self.providers.keys().next().cloned())
-        else {
-            return;
+            .or_else(|| {
+                let first_profile_id = self.providers.keys().next().cloned();
+                if first_profile_id.is_some() {
+                    report.selection_basis = Some(ActiveProviderSelectionBasis::FirstSavedProfile);
+                }
+                first_profile_id
+            });
+        let Some(active_provider) = active_provider else {
+            return report;
         };
         self.active_provider = Some(active_provider.clone());
         self.last_provider =
@@ -1155,6 +1338,10 @@ impl LoongClawConfig {
         if let Some(active_profile) = self.providers.get(&active_provider) {
             self.provider = active_profile.provider.clone();
         }
+        report.selected_active_provider = Some(active_provider);
+        report.warn_implicit_active_provider =
+            !report.active_provider_explicit && report.configured_profile_ids.len() > 1;
+        report
     }
 
     fn resolve_provider_switch_target_from_normalized(&self, selector: &str) -> CliResult<String> {
@@ -1238,6 +1425,110 @@ impl LoongClawConfig {
     }
 }
 
+fn normalized_inferred_profile_id(provider: &ProviderConfig) -> String {
+    normalize_provider_profile_id(provider.inferred_profile_id().as_str())
+        .unwrap_or_else(|| provider.inferred_profile_id())
+}
+
+fn matching_legacy_provider_profile_id(
+    providers: &BTreeMap<String, ProviderProfileConfig>,
+    legacy_provider: &ProviderConfig,
+) -> Option<String> {
+    let inferred_profile_id = normalized_inferred_profile_id(legacy_provider);
+    if providers
+        .get(&inferred_profile_id)
+        .is_some_and(|profile| profile.provider == *legacy_provider)
+    {
+        return Some(inferred_profile_id);
+    }
+
+    let exact_matches = providers
+        .iter()
+        .filter(|(_profile_id, profile)| profile.provider == *legacy_provider)
+        .map(|(profile_id, _profile)| profile_id.clone())
+        .collect::<Vec<_>>();
+    if exact_matches.len() == 1 {
+        return exact_matches.into_iter().next();
+    }
+    exact_matches.into_iter().next()
+}
+
+fn next_available_provider_profile_id(
+    providers: &BTreeMap<String, ProviderProfileConfig>,
+    base_profile_id: &str,
+) -> String {
+    if !providers.contains_key(base_profile_id) {
+        return base_profile_id.to_owned();
+    }
+    for suffix in 2.. {
+        let candidate = format!("{base_profile_id}-{suffix}");
+        if !providers.contains_key(&candidate) {
+            return candidate;
+        }
+    }
+    unreachable!("provider profile id suffix search should always terminate")
+}
+
+fn recover_active_provider_from_legacy_config(
+    legacy_provider: &ProviderConfig,
+    providers: &mut BTreeMap<String, ProviderProfileConfig>,
+) -> (String, bool) {
+    if let Some(profile_id) = matching_legacy_provider_profile_id(providers, legacy_provider) {
+        return (profile_id, false);
+    }
+
+    let profile_id = next_available_provider_profile_id(
+        providers,
+        normalized_inferred_profile_id(legacy_provider).as_str(),
+    );
+    let mut recovered_profile = ProviderProfileConfig::from_provider(legacy_provider.clone());
+    recovered_profile.default_for_kind = !providers
+        .values()
+        .any(|profile| profile.provider.kind == recovered_profile.provider.kind);
+    providers.insert(profile_id.clone(), recovered_profile);
+    (profile_id, true)
+}
+
+#[cfg(feature = "config-toml")]
+fn inspect_raw_provider_selection_intent(raw: &str) -> CliResult<RawProviderSelectionIntent> {
+    let value = toml::from_str::<toml::Value>(raw)
+        .map_err(|error| format!("failed to parse TOML config: {error}"))?;
+    let table = value.as_table();
+    Ok(RawProviderSelectionIntent {
+        legacy_provider_explicit: table.is_some_and(|root| root.contains_key("provider")),
+        active_provider_explicit: table.is_some_and(|root| root.contains_key("active_provider")),
+        raw_active_provider: table
+            .and_then(|root| root.get("active_provider"))
+            .and_then(toml::Value::as_str)
+            .map(str::to_owned),
+    })
+}
+
+#[cfg(feature = "config-toml")]
+fn parse_toml_config_components(
+    raw: &str,
+) -> CliResult<(LoongClawConfig, ProviderSelectionNormalizationReport)> {
+    let mut config = toml::from_str::<LoongClawConfig>(raw)
+        .map_err(|error| format!("failed to parse TOML config: {error}"))?;
+    let selection_intent = inspect_raw_provider_selection_intent(raw)?;
+    let had_saved_provider_profiles = !config.providers.is_empty();
+    let legacy_provider_before_normalization = config.provider.clone();
+    let mut selection_report =
+        config.normalize_provider_profiles_with_intent(Some(&selection_intent));
+    if selection_intent.legacy_provider_explicit && had_saved_provider_profiles {
+        selection_report.legacy_provider_validation_issues =
+            legacy_provider_before_normalization.validate();
+    }
+    Ok((config, selection_report))
+}
+
+#[cfg(not(feature = "config-toml"))]
+fn parse_toml_config_components(
+    _raw: &str,
+) -> CliResult<(LoongClawConfig, ProviderSelectionNormalizationReport)> {
+    Err("config-toml feature is disabled for this build".to_owned())
+}
+
 pub fn load(path: Option<&str>) -> CliResult<(PathBuf, LoongClawConfig)> {
     let config_path = path.map(expand_path).unwrap_or_else(default_config_path);
     let raw = fs::read_to_string(&config_path).map_err(|error| {
@@ -1274,11 +1565,11 @@ pub fn validate_file_with_locale(
             config_path.display()
         )
     })?;
-    let config = parse_toml_config_without_validation(&raw)?;
+    let (config, selection_report) = parse_toml_config_components(&raw)?;
     let locale = ConfigValidationLocale::from_tag(locale_tag);
     Ok((
         config_path,
-        config.validation_diagnostics_with_locale(locale),
+        config.validation_diagnostics_with_locale_and_report(locale, Some(&selection_report)),
     ))
 }
 
@@ -1352,17 +1643,14 @@ pub fn default_loongclaw_home() -> PathBuf {
 
 #[cfg(feature = "config-toml")]
 fn parse_toml_config(raw: &str) -> CliResult<LoongClawConfig> {
-    let config = parse_toml_config_without_validation(raw)?;
-    config.validate()?;
+    let (config, selection_report) = parse_toml_config_components(raw)?;
+    config.validate_with_report(Some(&selection_report))?;
     Ok(config)
 }
 
 #[cfg(feature = "config-toml")]
 fn parse_toml_config_without_validation(raw: &str) -> CliResult<LoongClawConfig> {
-    let mut config = toml::from_str::<LoongClawConfig>(raw)
-        .map_err(|error| format!("failed to parse TOML config: {error}"))?;
-    config.normalize_provider_profiles();
-    Ok(config)
+    parse_toml_config_components(raw).map(|(config, _selection_report)| config)
 }
 
 #[cfg(not(feature = "config-toml"))]
@@ -1527,6 +1815,7 @@ api_key_env = "$OPENAI_API_KEY"
         let (_, diagnostics) = validate_file(Some(config_path.to_string_lossy().as_ref()))
             .expect("validate_file should parse and return diagnostics");
         assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, "error");
         assert_eq!(diagnostics[0].code, "config.env_pointer.dollar_prefix");
         assert_eq!(
             diagnostics[0].problem_type,
@@ -1580,6 +1869,7 @@ bot_token_env = "WORK_TELEGRAM_TOKEN_DUP"
         let (_, diagnostics) = validate_file(Some(config_path.to_string_lossy().as_ref()))
             .expect("validate_file should parse and return diagnostics");
         assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, "error");
         assert_eq!(diagnostics[0].code, "config.channel_account.duplicate_id");
         assert_eq!(
             diagnostics[0].problem_type,
@@ -1802,6 +2092,227 @@ api_key = "${DEEPSEEK_API_KEY}"
         assert_eq!(loaded.provider.kind, ProviderKind::Deepseek);
 
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn mixed_legacy_and_profile_config_preserves_explicit_legacy_provider_when_active_provider_missing()
+     {
+        let raw = r#"
+[provider]
+kind = "volcengine_coding"
+model = "ark-code-latest"
+base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"
+wire_api = "chat_completions"
+chat_completions_path = "/chat/completions"
+
+[providers.openrouter]
+default_for_kind = true
+kind = "openrouter"
+model = "z-ai/glm-4.5-air:free"
+base_url = "https://openrouter.ai"
+wire_api = "chat_completions"
+chat_completions_path = "/api/v1/chat/completions"
+"#;
+
+        let config = parse_toml_config_without_validation(raw).expect("config should parse");
+
+        assert_eq!(config.active_provider_id(), Some("volcengine_coding"));
+        assert_eq!(config.provider.kind, ProviderKind::VolcengineCoding);
+        assert_eq!(config.provider.model, "ark-code-latest");
+        assert!(
+            config.providers.contains_key("volcengine_coding"),
+            "legacy provider intent should be preserved as a normalized saved profile: {config:#?}"
+        );
+        assert!(
+            config.providers.contains_key("openrouter"),
+            "existing saved profiles should be retained during normalization: {config:#?}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn validate_file_reports_warning_for_implicit_active_provider_recovery_in_mixed_config() {
+        let path = unique_config_path("loongclaw-config-provider-selection-warning");
+        let raw = r#"
+[provider]
+kind = "volcengine_coding"
+model = "ark-code-latest"
+base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"
+wire_api = "chat_completions"
+chat_completions_path = "/chat/completions"
+
+[providers.openrouter]
+default_for_kind = true
+kind = "openrouter"
+model = "z-ai/glm-4.5-air:free"
+base_url = "https://openrouter.ai"
+wire_api = "chat_completions"
+chat_completions_path = "/api/v1/chat/completions"
+"#;
+        fs::write(&path, raw).expect("write mixed provider config");
+
+        let (_, diagnostics) = validate_file(Some(path.to_string_lossy().as_ref()))
+            .expect("validate_file should parse and return diagnostics");
+
+        assert!(
+            diagnostics.iter().any(|diagnostic| diagnostic.code
+                == "config.provider_selection.implicit_active"
+                && diagnostic.severity == "warn"
+                && diagnostic.field_path == "active_provider"),
+            "mixed configs without an explicit active_provider should surface a warning-level provider-selection diagnostic: {diagnostics:#?}"
+        );
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn mixed_config_recovers_invalid_explicit_active_provider_from_legacy_provider() {
+        let raw = r#"
+active_provider = "missing-profile"
+
+[provider]
+kind = "volcengine_coding"
+model = "ark-code-latest"
+base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"
+wire_api = "chat_completions"
+chat_completions_path = "/chat/completions"
+
+[providers.openrouter]
+default_for_kind = true
+kind = "openrouter"
+model = "z-ai/glm-4.5-air:free"
+base_url = "https://openrouter.ai"
+wire_api = "chat_completions"
+chat_completions_path = "/api/v1/chat/completions"
+"#;
+
+        let config = parse_toml_config_without_validation(raw).expect("config should parse");
+
+        assert_eq!(config.active_provider_id(), Some("volcengine_coding"));
+        assert_eq!(config.provider.kind, ProviderKind::VolcengineCoding);
+        assert_eq!(config.provider.model, "ark-code-latest");
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn validate_file_reports_warning_for_unknown_active_provider_recovery_in_mixed_config() {
+        let path = unique_config_path("loongclaw-config-provider-selection-unknown-active");
+        let raw = r#"
+active_provider = "missing-profile"
+
+[provider]
+kind = "volcengine_coding"
+model = "ark-code-latest"
+base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"
+wire_api = "chat_completions"
+chat_completions_path = "/chat/completions"
+
+[providers.openrouter]
+default_for_kind = true
+kind = "openrouter"
+model = "z-ai/glm-4.5-air:free"
+base_url = "https://openrouter.ai"
+wire_api = "chat_completions"
+chat_completions_path = "/api/v1/chat/completions"
+"#;
+        fs::write(&path, raw).expect("write mixed provider config");
+
+        let (_, diagnostics) = validate_file(Some(path.to_string_lossy().as_ref()))
+            .expect("validate_file should parse and return diagnostics");
+
+        assert!(
+            diagnostics.iter().any(|diagnostic| diagnostic.code
+                == "config.provider_selection.unknown_active"
+                && diagnostic.severity == "warn"
+                && diagnostic.field_path == "active_provider"),
+            "mixed configs with an invalid explicit active_provider should surface a warning-level recovery diagnostic: {diagnostics:#?}"
+        );
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn validate_file_reports_legacy_provider_field_errors_even_when_provider_profiles_exist() {
+        let path = unique_config_path("loongclaw-config-legacy-provider-validation");
+        let raw = r#"
+active_provider = "openrouter"
+
+[provider]
+kind = "volcengine_coding"
+model = "ark-code-latest"
+api_key_env = "$VOLCENGINE_CODING_API_KEY"
+base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"
+wire_api = "chat_completions"
+chat_completions_path = "/chat/completions"
+
+[providers.openrouter]
+default_for_kind = true
+kind = "openrouter"
+model = "z-ai/glm-4.5-air:free"
+base_url = "https://openrouter.ai"
+wire_api = "chat_completions"
+chat_completions_path = "/api/v1/chat/completions"
+"#;
+        fs::write(&path, raw).expect("write mixed provider config");
+
+        let (_, diagnostics) = validate_file(Some(path.to_string_lossy().as_ref()))
+            .expect("validate_file should parse and return diagnostics");
+
+        assert!(
+            diagnostics.iter().any(|diagnostic| {
+                diagnostic.code == "config.env_pointer.dollar_prefix"
+                    && diagnostic.field_path == "provider.api_key_env"
+                    && diagnostic.severity == "error"
+            }),
+            "explicit legacy provider fields should still be validated when saved provider profiles also exist: {diagnostics:#?}"
+        );
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn mixed_config_recovers_explicit_legacy_provider_without_overwriting_conflicting_profile_id() {
+        let raw = r#"
+[provider]
+kind = "openrouter"
+model = "z-ai/glm-4.5-air:free"
+base_url = "https://openrouter.ai"
+wire_api = "chat_completions"
+chat_completions_path = "/api/v1/chat/completions"
+
+[providers.openrouter]
+default_for_kind = true
+kind = "openai"
+model = "gpt-5"
+"#;
+
+        let config = parse_toml_config_without_validation(raw).expect("config should parse");
+
+        assert_eq!(config.provider.kind, ProviderKind::Openrouter);
+        assert_eq!(config.provider.model, "z-ai/glm-4.5-air:free");
+        assert_eq!(config.active_provider_id(), Some("openrouter-2"));
+        assert_eq!(
+            config
+                .providers
+                .get("openrouter")
+                .expect("conflicting saved profile should be retained")
+                .provider
+                .kind,
+            ProviderKind::Openai
+        );
+        assert_eq!(
+            config
+                .providers
+                .get("openrouter-2")
+                .expect("legacy provider should be recovered into a fresh profile id")
+                .provider
+                .kind,
+            ProviderKind::Openrouter
+        );
     }
 
     #[test]

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -1460,13 +1460,14 @@ fn next_available_provider_profile_id(
     if !providers.contains_key(base_profile_id) {
         return base_profile_id.to_owned();
     }
-    for suffix in 2.. {
+    let max_suffix = providers.len().saturating_add(2);
+    for suffix in 2..=max_suffix {
         let candidate = format!("{base_profile_id}-{suffix}");
         if !providers.contains_key(&candidate) {
             return candidate;
         }
     }
-    unreachable!("provider profile id suffix search should always terminate")
+    format!("{base_profile_id}-{max_suffix}")
 }
 
 fn recover_active_provider_from_legacy_config(

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -20,6 +20,25 @@ pub(super) enum ConfigValidationLocale {
     En,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ConfigValidationSeverity {
+    Error,
+    Warn,
+}
+
+impl ConfigValidationSeverity {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warn => "warn",
+        }
+    }
+
+    pub const fn is_error(self) -> bool {
+        matches!(self, Self::Error)
+    }
+}
+
 impl ConfigValidationLocale {
     pub fn from_tag(raw: &str) -> Self {
         let normalized = raw.trim().to_ascii_lowercase();
@@ -51,6 +70,8 @@ pub(super) enum ConfigValidationCode {
     NumericRange,
     DuplicateChannelAccountId,
     UnknownChannelDefaultAccount,
+    ImplicitActiveProvider,
+    UnknownActiveProvider,
 }
 
 impl ConfigValidationCode {
@@ -67,6 +88,12 @@ impl ConfigValidationCode {
             }
             ConfigValidationCode::UnknownChannelDefaultAccount => {
                 "config.channel_account.unknown_default"
+            }
+            ConfigValidationCode::ImplicitActiveProvider => {
+                "config.provider_selection.implicit_active"
+            }
+            ConfigValidationCode::UnknownActiveProvider => {
+                "config.provider_selection.unknown_active"
             }
         }
     }
@@ -95,6 +122,12 @@ impl ConfigValidationCode {
             ConfigValidationCode::UnknownChannelDefaultAccount => {
                 "urn:loongclaw:problem:config.channel_account.unknown_default"
             }
+            ConfigValidationCode::ImplicitActiveProvider => {
+                "urn:loongclaw:problem:config.provider_selection.implicit_active"
+            }
+            ConfigValidationCode::UnknownActiveProvider => {
+                "urn:loongclaw:problem:config.provider_selection.unknown_active"
+            }
         }
     }
 
@@ -111,6 +144,12 @@ impl ConfigValidationCode {
             }
             ConfigValidationCode::UnknownChannelDefaultAccount => {
                 "config.channel_account.unknown_default.title"
+            }
+            ConfigValidationCode::ImplicitActiveProvider => {
+                "config.provider_selection.implicit_active.title"
+            }
+            ConfigValidationCode::UnknownActiveProvider => {
+                "config.provider_selection.unknown_active.title"
             }
         }
     }
@@ -137,6 +176,8 @@ impl ConfigValidationCode {
                 "Duplicate Normalized Channel Account ID"
             }
             ConfigValidationCode::UnknownChannelDefaultAccount => "Unknown Channel Default Account",
+            ConfigValidationCode::ImplicitActiveProvider => "Implicit Active Provider Selection",
+            ConfigValidationCode::UnknownActiveProvider => "Unknown Active Provider Selection",
         }
     }
 
@@ -166,12 +207,19 @@ impl ConfigValidationCode {
             ConfigValidationCode::UnknownChannelDefaultAccount => {
                 "[{code}] {field_path} points to `{requested_account_id}`, but configured accounts are: {configured_account_ids}. set `{field_path}` to one of the configured account ids"
             }
+            ConfigValidationCode::ImplicitActiveProvider => {
+                "[{code}] {field_path} is not set explicitly. LoongClaw selected `{selected_profile_id}` using {selection_basis}. set `{field_path} = \"{selected_profile_id}\"` to make the active provider explicit"
+            }
+            ConfigValidationCode::UnknownActiveProvider => {
+                "[{code}] {field_path} points to `{requested_profile_id}`, but configured provider profiles are: {configured_profile_ids}. LoongClaw recovered to `{selected_profile_id}` using {selection_basis}. update `{field_path}` to an available profile id"
+            }
         }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ConfigValidationIssue {
+    pub severity: ConfigValidationSeverity,
     pub code: ConfigValidationCode,
     pub field_path: String,
     pub inline_field_path: String,
@@ -189,12 +237,21 @@ impl ConfigValidationIssue {
         self.code.title_key()
     }
 
+    pub(super) const fn severity_str(&self) -> &'static str {
+        self.severity.as_str()
+    }
+
+    pub(super) const fn is_error(&self) -> bool {
+        self.severity.is_error()
+    }
+
     pub(super) fn title(&self, locale: ConfigValidationLocale) -> String {
         self.code.localized_title(locale).to_owned()
     }
 
     pub(super) fn message_variables(&self) -> BTreeMap<String, String> {
         let mut variables = BTreeMap::new();
+        variables.insert("severity".to_owned(), self.severity.as_str().to_owned());
         variables.insert("code".to_owned(), self.code.as_str().to_owned());
         variables.insert("field_path".to_owned(), self.field_path.clone());
         variables.insert(
@@ -269,6 +326,14 @@ const EN_VALIDATION_MESSAGE_CATALOG: &[ConfigValidationCatalogEntry] = &[
         "Unknown Channel Default Account",
     ),
     ConfigValidationCatalogEntry::new(
+        "config.provider_selection.implicit_active.title",
+        "Implicit Active Provider Selection",
+    ),
+    ConfigValidationCatalogEntry::new(
+        "config.provider_selection.unknown_active.title",
+        "Unknown Active Provider Selection",
+    ),
+    ConfigValidationCatalogEntry::new(
         "config.env_pointer.assignment",
         "[{code}] {field_path} expects an environment variable name, not `KEY=VALUE`. use `{field_path} = \"{suggested_env_name}\"` and place the secret value in that env var",
     ),
@@ -299,6 +364,14 @@ const EN_VALIDATION_MESSAGE_CATALOG: &[ConfigValidationCatalogEntry] = &[
     ConfigValidationCatalogEntry::new(
         "config.channel_account.unknown_default",
         "[{code}] {field_path} points to `{requested_account_id}`, but configured accounts are: {configured_account_ids}. set `{field_path}` to one of the configured account ids",
+    ),
+    ConfigValidationCatalogEntry::new(
+        "config.provider_selection.implicit_active",
+        "[{code}] {field_path} is not set explicitly. LoongClaw selected `{selected_profile_id}` using {selection_basis}. set `{field_path} = \"{selected_profile_id}\"` to make the active provider explicit",
+    ),
+    ConfigValidationCatalogEntry::new(
+        "config.provider_selection.unknown_active",
+        "[{code}] {field_path} points to `{requested_profile_id}`, but configured provider profiles are: {configured_profile_ids}. LoongClaw recovered to `{selected_profile_id}` using {selection_basis}. update `{field_path}` to an available profile id",
     ),
 ];
 
@@ -392,6 +465,7 @@ pub(super) fn validate_env_pointer_field(
 
     if let Some((name, _value)) = parse_env_assignment(trimmed) {
         return Err(Box::new(ConfigValidationIssue {
+            severity: ConfigValidationSeverity::Error,
             code: ConfigValidationCode::Assignment,
             field_path: field_path.to_owned(),
             inline_field_path: hint.inline_field_path.to_owned(),
@@ -404,6 +478,7 @@ pub(super) fn validate_env_pointer_field(
     if let Some(raw_name) = trimmed.strip_prefix('$') {
         let suggested = normalize_dollar_prefixed_env_name(raw_name, hint.example_env_name);
         return Err(Box::new(ConfigValidationIssue {
+            severity: ConfigValidationSeverity::Error,
             code: ConfigValidationCode::DollarPrefix,
             field_path: field_path.to_owned(),
             inline_field_path: hint.inline_field_path.to_owned(),
@@ -420,6 +495,7 @@ pub(super) fn validate_env_pointer_field(
             raw_name.to_owned()
         };
         return Err(Box::new(ConfigValidationIssue {
+            severity: ConfigValidationSeverity::Error,
             code: ConfigValidationCode::PercentWrapped,
             field_path: field_path.to_owned(),
             inline_field_path: hint.inline_field_path.to_owned(),
@@ -431,6 +507,7 @@ pub(super) fn validate_env_pointer_field(
 
     if looks_like_secret_literal(trimmed, hint.detect_telegram_token_shape) {
         return Err(Box::new(ConfigValidationIssue {
+            severity: ConfigValidationSeverity::Error,
             code: ConfigValidationCode::SecretLiteral,
             field_path: field_path.to_owned(),
             inline_field_path: hint.inline_field_path.to_owned(),
@@ -442,6 +519,7 @@ pub(super) fn validate_env_pointer_field(
 
     if !looks_like_compatible_env_name(trimmed) {
         return Err(Box::new(ConfigValidationIssue {
+            severity: ConfigValidationSeverity::Error,
             code: ConfigValidationCode::InvalidName,
             field_path: field_path.to_owned(),
             inline_field_path: hint.inline_field_path.to_owned(),
@@ -470,6 +548,7 @@ pub(super) fn validate_numeric_range(
     extra_message_variables.insert("max".to_owned(), max.to_string());
 
     Err(Box::new(ConfigValidationIssue {
+        severity: ConfigValidationSeverity::Error,
         code: ConfigValidationCode::NumericRange,
         field_path: field_path.to_owned(),
         inline_field_path: field_path.to_owned(),
@@ -685,6 +764,7 @@ mod tests {
     #[test]
     fn env_pointer_issue_render_uses_catalog_title_and_template() {
         let issue = ConfigValidationIssue {
+            severity: ConfigValidationSeverity::Error,
             code: ConfigValidationCode::DollarPrefix,
             field_path: "provider.api_key_env".to_owned(),
             inline_field_path: "provider.api_key".to_owned(),

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -52,28 +52,10 @@ pub(crate) async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<(
     config_mutated |= maybe_apply_channel_env_fix(&mut config, options.fix, &mut fixes);
 
     let has_provider_credentials = mvp::provider::provider_auth_ready(&config).await;
-    if has_provider_credentials {
-        checks.push(DoctorCheck {
-            name: "provider credentials".to_owned(),
-            level: DoctorCheckLevel::Pass,
-            detail: "provider credentials are available".to_owned(),
-        });
-    } else {
-        let hints = crate::onboard_cli::provider_credential_env_hints(&config.provider);
-        let detail = if hints.is_empty() {
-            "provider credentials are missing".to_owned()
-        } else {
-            format!(
-                "provider credentials are missing (try env: {})",
-                hints.join(", ")
-            )
-        };
-        checks.push(DoctorCheck {
-            name: "provider credentials".to_owned(),
-            level: DoctorCheckLevel::Warn,
-            detail,
-        });
-    }
+    checks.push(provider_credentials_doctor_check(
+        &config,
+        has_provider_credentials,
+    ));
 
     checks.push(provider_transport_doctor_check(&config.provider));
 
@@ -96,11 +78,7 @@ pub(crate) async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<(
                 level: DoctorCheckLevel::Pass,
                 detail: format!("{} model(s) available", models.len()),
             }),
-            Err(error) => checks.push(DoctorCheck {
-                name: "provider model probe".to_owned(),
-                level: DoctorCheckLevel::Fail,
-                detail: error,
-            }),
+            Err(error) => checks.push(provider_model_probe_failure_check(&config, error)),
         }
     }
 
@@ -962,6 +940,60 @@ fn provider_transport_doctor_check(provider: &mvp::config::ProviderConfig) -> Do
     }
 }
 
+fn provider_credentials_doctor_check(
+    config: &mvp::config::LoongClawConfig,
+    has_provider_credentials: bool,
+) -> DoctorCheck {
+    let provider_label = crate::provider_presentation::active_provider_detail_label(config);
+    if has_provider_credentials {
+        return DoctorCheck {
+            name: "provider credentials".to_owned(),
+            level: DoctorCheckLevel::Pass,
+            detail: format!("{provider_label}: provider credentials are available"),
+        };
+    }
+
+    let hints = crate::onboard_cli::provider_credential_env_hints(&config.provider);
+    let detail = if hints.is_empty() {
+        "provider credentials are missing".to_owned()
+    } else {
+        format!(
+            "provider credentials are missing (try env: {})",
+            hints.join(", ")
+        )
+    };
+    DoctorCheck {
+        name: "provider credentials".to_owned(),
+        level: DoctorCheckLevel::Warn,
+        detail: format!("{provider_label}: {detail}"),
+    }
+}
+
+fn provider_model_probe_failure_check(
+    config: &mvp::config::LoongClawConfig,
+    error: String,
+) -> DoctorCheck {
+    if let Some(model) = config.provider.explicit_model() {
+        return DoctorCheck {
+            name: "provider model probe".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: format!(
+                "{}: model catalog probe failed ({error}); chat may still work because model `{model}` is explicitly configured",
+                crate::provider_presentation::active_provider_detail_label(config)
+            ),
+        };
+    }
+
+    DoctorCheck {
+        name: "provider model probe".to_owned(),
+        level: DoctorCheckLevel::Fail,
+        detail: format!(
+            "{}: {error}",
+            crate::provider_presentation::active_provider_detail_label(config)
+        ),
+    }
+}
+
 #[cfg(test)]
 fn collect_channel_doctor_checks(config: &mvp::config::LoongClawConfig) -> Vec<DoctorCheck> {
     crate::migration::channels::collect_channel_doctor_checks(config)
@@ -1203,6 +1235,42 @@ mod tests {
                 .detail
                 .contains("retry chat_completions automatically"),
             "doctor should surface the automatic transport fallback in review mode: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_warns_for_explicit_model() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.model = "openai/gpt-5.1-codex".to_owned();
+
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider rejected the model list".to_owned(),
+        );
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, DoctorCheckLevel::Warn);
+        assert!(
+            check.detail.contains("explicitly configured"),
+            "doctor should explain that explicit-model runtime may still work when catalog probing fails: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_fails_for_auto_model() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.model = "auto".to_owned();
+
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider rejected the model list".to_owned(),
+        );
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, DoctorCheckLevel::Fail);
+        assert!(
+            check.detail.contains("OpenAI [openai]"),
+            "doctor failures should still identify the active provider context: {check:#?}"
         );
     }
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1105,6 +1105,7 @@ fn run_validate_config_cli(
     let (resolved_path, diagnostics) =
         mvp::config::validate_file_with_locale(config_path, &normalized_locale)?;
     let diagnostics_count = diagnostics.len();
+    let diagnostics_summary = summarize_validation_diagnostics(&diagnostics);
 
     match output {
         ValidateConfigOutput::Text => {
@@ -1112,9 +1113,12 @@ fn run_validate_config_cli(
                 println!("config={} valid=true", resolved_path.display());
             } else {
                 println!(
-                    "config={} valid=false diagnostics={}",
+                    "config={} valid={} diagnostics={} errors={} warnings={}",
                     resolved_path.display(),
-                    diagnostics_count
+                    diagnostics_summary.valid,
+                    diagnostics_count,
+                    diagnostics_summary.error_count,
+                    diagnostics_summary.warning_count,
                 );
                 for diagnostic in &diagnostics {
                     println!("{}", diagnostic.message);
@@ -1125,7 +1129,9 @@ fn run_validate_config_cli(
             let payload = json!({
                 "diagnostics_schema_version": 1,
                 "config": resolved_path.display().to_string(),
-                "valid": diagnostics.is_empty(),
+                "valid": diagnostics_summary.valid,
+                "error_count": diagnostics_summary.error_count,
+                "warning_count": diagnostics_summary.warning_count,
                 "locale": normalized_locale,
                 "supported_locales": supported_locales.clone(),
                 "diagnostics": diagnostics,
@@ -1141,6 +1147,9 @@ fn run_validate_config_cli(
                     "title": "Configuration Valid",
                     "detail": "No configuration diagnostics were reported.",
                     "instance": resolved_path.display().to_string(),
+                    "valid": true,
+                    "error_count": 0,
+                    "warning_count": 0,
                     "locale": normalized_locale,
                     "supported_locales": supported_locales.clone(),
                     "diagnostics_schema_version": 1,
@@ -1148,10 +1157,21 @@ fn run_validate_config_cli(
                 })
             } else {
                 json!({
-                    "type": "urn:loongclaw:problem:config.validation_failed",
-                    "title": "Configuration Validation Failed",
+                    "type": if diagnostics_summary.valid {
+                        "urn:loongclaw:problem:config.validation_warning"
+                    } else {
+                        "urn:loongclaw:problem:config.validation_failed"
+                    },
+                    "title": if diagnostics_summary.valid {
+                        "Configuration Warnings Reported"
+                    } else {
+                        "Configuration Validation Failed"
+                    },
                     "detail": format!("{} configuration diagnostic(s) were reported.", diagnostics_count),
                     "instance": resolved_path.display().to_string(),
+                    "valid": diagnostics_summary.valid,
+                    "error_count": diagnostics_summary.error_count,
+                    "warning_count": diagnostics_summary.warning_count,
                     "locale": normalized_locale,
                     "supported_locales": supported_locales.clone(),
                     "diagnostics_schema_version": 1,
@@ -1172,6 +1192,31 @@ fn run_validate_config_cli(
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ValidationDiagnosticSummary {
+    valid: bool,
+    error_count: usize,
+    warning_count: usize,
+}
+
+fn summarize_validation_diagnostics(
+    diagnostics: &[mvp::config::ConfigValidationDiagnostic],
+) -> ValidationDiagnosticSummary {
+    let error_count = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == "error")
+        .count();
+    let warning_count = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == "warn")
+        .count();
+    ValidationDiagnosticSummary {
+        valid: error_count == 0,
+        error_count,
+        warning_count,
+    }
 }
 
 fn resolve_validate_output(

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -145,6 +145,7 @@ pub(crate) enum OnboardNonInteractiveWarningPolicy {
     #[default]
     Block,
     AcceptedBySkipModelProbe,
+    AcceptedByExplicitModel,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -1074,12 +1075,7 @@ async fn run_preflight_checks(
                 detail: format!("{} model(s) available", models.len()),
                 non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
             }),
-            Err(error) => checks.push(OnboardCheck {
-                name: "provider model probe",
-                level: OnboardCheckLevel::Fail,
-                detail: error,
-                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
-            }),
+            Err(error) => checks.push(provider_model_probe_failure_check(config, error)),
         }
     }
 
@@ -1095,8 +1091,38 @@ async fn run_preflight_checks(
     checks
 }
 
+fn provider_check_detail_prefix(config: &mvp::config::LoongClawConfig) -> String {
+    crate::provider_presentation::active_provider_detail_label(config)
+}
+
+fn provider_model_probe_failure_check(
+    config: &mvp::config::LoongClawConfig,
+    error: String,
+) -> OnboardCheck {
+    if let Some(model) = config.provider.explicit_model() {
+        return OnboardCheck {
+            name: "provider model probe",
+            level: OnboardCheckLevel::Warn,
+            detail: format!(
+                "{}: model catalog probe failed ({error}); chat may still work because model `{model}` is explicitly configured",
+                provider_check_detail_prefix(config)
+            ),
+            non_interactive_warning_policy:
+                OnboardNonInteractiveWarningPolicy::AcceptedByExplicitModel,
+        };
+    }
+
+    OnboardCheck {
+        name: "provider model probe",
+        level: OnboardCheckLevel::Fail,
+        detail: format!("{}: {error}", provider_check_detail_prefix(config)),
+        non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+    }
+}
+
 pub(crate) fn provider_credential_check(config: &mvp::config::LoongClawConfig) -> OnboardCheck {
     let provider = &config.provider;
+    let provider_prefix = provider_check_detail_prefix(config);
     let inline_oauth = provider
         .oauth_access_token
         .as_deref()
@@ -1106,7 +1132,7 @@ pub(crate) fn provider_credential_check(config: &mvp::config::LoongClawConfig) -
         return OnboardCheck {
             name: "provider credentials",
             level: OnboardCheckLevel::Pass,
-            detail: "inline oauth access token configured".to_owned(),
+            detail: format!("{provider_prefix}: inline oauth access token configured"),
             non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
         };
     }
@@ -1120,7 +1146,7 @@ pub(crate) fn provider_credential_check(config: &mvp::config::LoongClawConfig) -
         return OnboardCheck {
             name: "provider credentials",
             level: OnboardCheckLevel::Pass,
-            detail: "inline api key configured".to_owned(),
+            detail: format!("{provider_prefix}: inline api key configured"),
             non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
         };
     }
@@ -1132,7 +1158,7 @@ pub(crate) fn provider_credential_check(config: &mvp::config::LoongClawConfig) -
         return OnboardCheck {
             name: "provider credentials",
             level: OnboardCheckLevel::Pass,
-            detail,
+            detail: format!("{provider_prefix}: {detail}"),
             non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
         };
     }
@@ -1143,7 +1169,7 @@ pub(crate) fn provider_credential_check(config: &mvp::config::LoongClawConfig) -
     OnboardCheck {
         name: "provider credentials",
         level: OnboardCheckLevel::Warn,
-        detail,
+        detail: format!("{provider_prefix}: {detail}"),
         non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
     }
 }
@@ -1166,10 +1192,14 @@ fn is_explicitly_accepted_non_interactive_warning(
     check: &OnboardCheck,
     options: &OnboardCommandOptions,
 ) -> bool {
-    options.skip_model_probe
+    (options.skip_model_probe
         && matches!(
             check.non_interactive_warning_policy,
             OnboardNonInteractiveWarningPolicy::AcceptedBySkipModelProbe
+        ))
+        || matches!(
+            check.non_interactive_warning_policy,
+            OnboardNonInteractiveWarningPolicy::AcceptedByExplicitModel
         )
 }
 
@@ -4547,6 +4577,68 @@ mod tests {
                         .contains("retry chat_completions automatically")
             }),
             "preflight should surface transport review before writing a Responses-compatible config: {checks:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_warns_for_explicit_model() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.model = "openai/gpt-5.1-codex".to_owned();
+
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider rejected the model list".to_owned(),
+        );
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, OnboardCheckLevel::Warn);
+        assert!(
+            check.detail.contains("explicitly configured"),
+            "explicit-model probe failures should explain that catalog discovery is advisory: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_fails_for_auto_model() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.model = "auto".to_owned();
+
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider rejected the model list".to_owned(),
+        );
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, OnboardCheckLevel::Fail);
+        assert!(
+            check.detail.contains("OpenAI [openai]"),
+            "onboard failures should still identify the active provider context: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn explicit_model_probe_warning_is_accepted_non_interactively() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.model = "openai/gpt-5.1-codex".to_owned();
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider rejected the model list".to_owned(),
+        );
+        let options = OnboardCommandOptions {
+            output: None,
+            force: false,
+            non_interactive: true,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            system_prompt: None,
+            skip_model_probe: false,
+        };
+
+        assert!(
+            is_explicitly_accepted_non_interactive_warning(&check, &options),
+            "explicit-model probe warnings should not block non-interactive onboarding because model discovery is advisory: {check:#?}"
         );
     }
 

--- a/crates/daemon/src/provider_presentation.rs
+++ b/crates/daemon/src/provider_presentation.rs
@@ -20,6 +20,18 @@ pub(crate) fn active_provider_label(config: &mvp::config::LoongClawConfig) -> St
         .unwrap_or_else(|| guided_provider_label(config.provider.kind).to_owned())
 }
 
+pub(crate) fn active_provider_detail_label(config: &mvp::config::LoongClawConfig) -> String {
+    let profile_id = config
+        .active_provider_id()
+        .unwrap_or(config.provider.kind.profile().id);
+    let kind = config
+        .providers
+        .get(profile_id)
+        .map(|profile| profile.provider.kind)
+        .unwrap_or(config.provider.kind);
+    format!("{} [{profile_id}]", guided_provider_label(kind))
+}
+
 pub(crate) fn saved_provider_profile_ids(config: &mvp::config::LoongClawConfig) -> Vec<String> {
     if config.providers.is_empty() {
         return vec![

--- a/crates/daemon/src/tests/mod.rs
+++ b/crates/daemon/src/tests/mod.rs
@@ -43,6 +43,27 @@ fn channel_supported_target_kinds(raw: &str) -> Vec<&'static str> {
         .collect()
 }
 
+fn validation_diagnostic_with_severity(
+    severity: &str,
+    code: &str,
+) -> mvp::config::ConfigValidationDiagnostic {
+    mvp::config::ConfigValidationDiagnostic {
+        severity: severity.to_owned(),
+        code: code.to_owned(),
+        problem_type: format!("urn:loongclaw:problem:{code}"),
+        title_key: format!("{code}.title"),
+        title: code.to_owned(),
+        message_key: code.to_owned(),
+        message_locale: "en".to_owned(),
+        message_variables: BTreeMap::new(),
+        field_path: "active_provider".to_owned(),
+        inline_field_path: "providers".to_owned(),
+        example_env_name: String::new(),
+        suggested_env_name: None,
+        message: code.to_owned(),
+    }
+}
+
 fn approval_test_operation(tool_name: &str, payload: Value) -> OperationSpec {
     OperationSpec::ToolCore {
         tool_name: tool_name.to_owned(),
@@ -184,6 +205,30 @@ fn resolve_validate_output_rejects_conflicting_json_and_output_flags() {
     let error = resolve_validate_output(true, Some(ValidateConfigOutput::Json))
         .expect_err("conflicting flags should fail");
     assert!(error.contains("conflicts"));
+}
+
+#[test]
+fn validation_summary_treats_warning_only_diagnostics_as_valid() {
+    let summary = summarize_validation_diagnostics(&[validation_diagnostic_with_severity(
+        "warn",
+        "config.provider_selection.implicit_active",
+    )]);
+
+    assert!(summary.valid);
+    assert_eq!(summary.error_count, 0);
+    assert_eq!(summary.warning_count, 1);
+}
+
+#[test]
+fn validation_summary_counts_error_and_warning_diagnostics_separately() {
+    let summary = summarize_validation_diagnostics(&[
+        validation_diagnostic_with_severity("error", "config.env_pointer.dollar_prefix"),
+        validation_diagnostic_with_severity("warn", "config.provider_selection.implicit_active"),
+    ]);
+
+    assert!(!summary.valid);
+    assert_eq!(summary.error_count, 1);
+    assert_eq!(summary.warning_count, 1);
 }
 
 #[test]

--- a/crates/daemon/src/tests/onboard_cli.rs
+++ b/crates/daemon/src/tests/onboard_cli.rs
@@ -245,8 +245,22 @@ fn extract_success_section_lines(transcript: &[String]) -> Vec<String> {
 fn start_local_model_probe_server(
     expected_requests: usize,
 ) -> (SocketAddr, std::thread::JoinHandle<Vec<String>>) {
+    start_local_model_probe_server_with_models_response(
+        expected_requests,
+        "HTTP/1.1 200 OK",
+        r#"{"data":[{"id":"openai/gpt-5.1-codex"}]}"#,
+    )
+}
+
+fn start_local_model_probe_server_with_models_response(
+    expected_requests: usize,
+    models_status_line: &str,
+    models_body: &str,
+) -> (SocketAddr, std::thread::JoinHandle<Vec<String>>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider test listener");
     let addr = listener.local_addr().expect("local addr");
+    let models_status_line = models_status_line.to_owned();
+    let models_body = models_body.to_owned();
     let server = std::thread::spawn(move || {
         let mut requests = Vec::new();
         for _ in 0..expected_requests {
@@ -257,10 +271,7 @@ fn start_local_model_probe_server(
             requests.push(request.clone());
 
             let (status_line, body) = if request.starts_with("GET /v1/models ") {
-                (
-                    "HTTP/1.1 200 OK",
-                    r#"{"data":[{"id":"openai/gpt-5.1-codex"}]}"#.to_owned(),
-                )
+                (models_status_line.as_str(), models_body.clone())
             } else {
                 (
                     "HTTP/1.1 404 Not Found",
@@ -449,7 +460,6 @@ async fn non_interactive_onboard_rejects_unresolved_preflight_warnings() {
 
     let mut options = default_non_interactive_onboard_options(&output);
     options.system_prompt = Some("force a pending write".to_owned());
-
     let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
     let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
     let error = crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
@@ -563,6 +573,47 @@ async fn non_interactive_onboard_allows_explicit_skip_model_probe_warning() {
         config.provider.api_key(),
         Some("test-openai-key".to_owned()),
         "loaded config should still resolve the canonical env reference at runtime"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_onboard_allows_explicit_model_probe_warning() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("non-interactive-explicit-model-warning-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+
+    let (addr, server) = start_local_model_probe_server_with_models_response(
+        1,
+        "HTTP/1.1 401 Unauthorized",
+        r#"{"error":{"message":"No cookie auth credentials found"}}"#,
+    );
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.base_url = format!("http://{addr}");
+    config.provider.model = "openai/gpt-5.1-codex".to_owned();
+    config.provider.api_key = Some("test-openai-key".to_owned());
+    mvp::config::write(Some(output.to_string_lossy().as_ref()), &config, true)
+        .expect("write existing config");
+
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.system_prompt = Some("force a pending write".to_owned());
+    options.force = true;
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect("explicit-model probe warnings should not block non-interactive onboarding");
+
+    let requests = server.join().expect("join local provider server");
+    assert!(
+        requests.iter().any(|request| {
+            let normalized = request.to_ascii_lowercase();
+            request.starts_with("GET /v1/models ")
+                && normalized.contains("authorization: bearer test-openai-key")
+        }),
+        "explicit-model warning path should still perform the model probe with resolved auth before allowing onboarding to continue: {requests:#?}"
     );
 }
 
@@ -1018,6 +1069,44 @@ fn provider_credential_check_accepts_inline_api_key() {
     assert!(
         check.detail.contains("inline api key"),
         "inline provider credentials should pass preflight without forcing an env var: {check:#?}"
+    );
+}
+
+#[test]
+fn provider_credential_check_mentions_active_profile_id_when_saved_profiles_exist() {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.set_active_provider_profile(
+        "volcengine-coding",
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::VolcengineCoding,
+                model: "ark-code-latest".to_owned(),
+                api_key: Some("inline-secret".to_owned()),
+                base_url: "https://ark.cn-beijing.volces.com/api/coding/v3".to_owned(),
+                wire_api: mvp::config::ProviderWireApi::ChatCompletions,
+                chat_completions_path: "/chat/completions".to_owned(),
+                ..mvp::config::ProviderConfig::default()
+            },
+        },
+    );
+    config.providers.insert(
+        "openrouter".to_owned(),
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Openrouter,
+                model: "z-ai/glm-4.5-air:free".to_owned(),
+                ..mvp::config::ProviderConfig::default()
+            },
+        },
+    );
+
+    let check = crate::onboard_cli::provider_credential_check(&config);
+
+    assert!(
+        check.detail.contains("volcengine-coding"),
+        "provider credential diagnostics should identify the active saved profile, not just the provider kind: {check:#?}"
     );
 }
 

--- a/docs/plans/2026-03-16-provider-active-selection-safety-design.md
+++ b/docs/plans/2026-03-16-provider-active-selection-safety-design.md
@@ -1,0 +1,227 @@
+# Provider Active Selection Safety Design
+
+Date: 2026-03-16
+Status: Approved for implementation
+
+## Goal
+
+Fix provider-selection drift in `alpha-test` so mixed legacy `[provider]` and
+profile-based `[providers.*]` configurations preserve the user's intended
+runtime provider, surface the risk through config diagnostics, and stop
+misleading `doctor` / `onboard` output when model discovery is only advisory.
+
+This design addresses the class of failures where chat traffic, provider auth
+checks, and runtime diagnostics silently target a different provider than the
+one the user explicitly configured.
+
+## Problem Statement
+
+The current config/runtime flow has three coupled hazards:
+
+1. Mixed legacy/profile configs can silently change the active provider.
+2. `validate-config` does not explain that risk.
+3. `doctor` and `onboard` overstate model-probe failures even when an explicit
+   `model` means runtime chat does not depend on `/models`.
+
+The drift is global, not provider-specific. OpenRouter, Volcengine Coding, and
+any other provider profile can be affected because the current fallback depends
+on normalized profile storage rather than explicit selection intent.
+
+## Root Cause
+
+### Active-provider fallback is inferred from storage order
+
+`LoongClawConfig::normalize_provider_profiles()` currently normalizes profile
+storage and then resolves the active provider using this priority:
+
+1. explicit `active_provider`
+2. inferred legacy profile id from `config.provider`
+3. `providers.keys().next()`
+
+That final fallback is effectively lexicographic because `providers` is a
+`BTreeMap`. Once `providers` is non-empty and `active_provider` is absent or
+invalid, the runtime may silently switch to the alphabetically first profile.
+
+### Deserialization loses config intent
+
+After `toml::from_str::<LoongClawConfig>()`, the code cannot tell whether the
+top-level `provider` table was explicitly present or whether `provider` just
+contains default OpenAI values. That makes it impossible to distinguish:
+
+- a user who explicitly chose a legacy provider and has not yet migrated
+- a profile-only config with no legacy provider intent
+
+### Validation only checks one branch of config shape
+
+`collect_validation_issues()` validates:
+
+- the top-level `provider` only when `providers` is empty
+- saved `providers.<id>` only when `providers` is non-empty
+
+That means mixed configs do not receive any diagnostic explaining that the
+top-level provider and saved profiles disagree or that the active provider is
+being inferred implicitly.
+
+### Doctor / onboard do not separate runtime viability from catalog viability
+
+`doctor` and `onboard` currently treat `fetch_available_models()` failure as a
+hard failure whenever credentials exist. But explicit model mode already allows
+runtime chat to proceed without catalog discovery because the request path can
+use the configured model directly.
+
+## Design Principles
+
+### Principle 1: Explicit user selection wins over container order
+
+Runtime provider selection must never depend on `BTreeMap` ordering when the
+user gave an explicit legacy or profile selection signal.
+
+### Principle 2: Compatibility must remain readable, but not silent
+
+Legacy `[provider]` stays supported. Mixed legacy/profile states are allowed to
+load for compatibility, but risky states must be surfaced as diagnostics.
+
+### Principle 3: Diagnostics need severity
+
+The system needs warning-level diagnostics for dangerous-but-loadable config
+states. Fatal parse/validation errors remain possible, but not every issue is a
+hard stop.
+
+### Principle 4: Runtime checks must describe what they actually prove
+
+`/models` probing proves catalog availability. It does not always prove whether
+chat will fail. Diagnostics must distinguish those two facts.
+
+## Target Behavior
+
+### Config loading and normalization
+
+When a config mixes legacy `[provider]` and saved `[providers.*]`:
+
+- if `active_provider` is explicit and valid, use it
+- if `active_provider` is explicit but missing in `providers`, keep loading but
+  emit a warning and recover deterministically
+- if `active_provider` is absent and legacy `[provider]` was explicitly set,
+  preserve that legacy runtime choice instead of falling back to the first map
+  entry
+- if necessary, synthesize or match a provider profile that corresponds to the
+  explicit legacy provider and mark it active
+- only use a stable fallback when there is genuinely no explicit selection
+  intent anywhere
+
+### Validation output
+
+`validate-config` should emit diagnostics with severity, at minimum:
+
+- `error` for invalid env pointer / numeric / unknown account diagnostics that
+  already fail semantic validation today
+- `warn` for dangerous mixed provider-selection states that remain loadable
+
+Important warning scenarios:
+
+- mixed legacy `[provider]` plus `[providers.*]` with no explicit
+  `active_provider`
+- explicit `active_provider` that does not resolve to any saved profile and
+  forced recovery occurs
+- active provider being reconstructed from legacy intent because profile-based
+  selection is incomplete
+
+The CLI should keep `valid=true` when there are no error diagnostics and report
+warning/error counts separately. Severity exists to distinguish warnings from
+hard errors and to let callers reason about policy without hiding problems.
+
+### Doctor and onboard behavior
+
+Provider-oriented diagnostics must clearly identify the active selection being
+checked, ideally including both:
+
+- active provider profile id
+- provider kind / model strategy summary
+
+Model-probe semantics should change:
+
+- auto-discovery mode: model probe failure remains `FAIL`
+- explicit-model mode: model probe failure becomes `WARN`, with detail that
+  catalog discovery failed but chat may still work because the model is
+  explicitly configured
+
+## Implementation Strategy
+
+### 1. Preserve raw config intent during parse
+
+Extend `LoongClawConfig` with internal, non-serialized flags such as:
+
+- `legacy_provider_explicit`
+- `active_provider_explicit`
+
+Populate them by first parsing the raw TOML into `toml::Value`, then
+deserializing the config struct. This is the smallest change that preserves user
+intent without rewriting the entire config loader.
+
+### 2. Centralize deterministic active-provider recovery
+
+Refactor provider normalization to:
+
+- normalize profile ids first
+- resolve active selection from explicit profile intent when possible
+- otherwise recover from explicit legacy provider intent by finding or creating
+  the matching profile
+- avoid implicit lexicographic fallback when a stronger signal exists
+
+### 3. Add diagnostic severity
+
+Introduce a severity field on config diagnostics so text, JSON, and
+`application/problem+json` can all distinguish warnings from errors. Existing
+validation helpers stay reusable, but diagnostics become richer and future-safe.
+
+### 4. Align doctor / onboard with provider selection and model strategy
+
+Use the normalized active profile information in presentation and model-probe
+detail strings. Explicit-model mode should produce a warning-level probe result
+instead of a false hard failure.
+
+## Non-Goals
+
+- changing provider auth schemes or provider-specific request adapters
+- redesigning runtime request execution beyond the model-probe classification
+- removing legacy `[provider]` compatibility
+- changing normal chat failover semantics
+
+## Risks And Mitigations
+
+### Risk: new severity plumbing expands validation surface
+
+Mitigation:
+
+- keep the initial severity model minimal: `Error` and `Warn`
+- default existing diagnostics to `Error`
+- add targeted tests for text, JSON, and problem-json outputs
+
+### Risk: normalization changes can alter persisted config state
+
+Mitigation:
+
+- write regression tests for legacy-only, profile-only, and mixed configs
+- ensure writes stay canonical and stable after reload
+
+### Risk: doctor/onboard wording drifts from actual runtime guarantees
+
+Mitigation:
+
+- keep probe messages explicit about what failed: catalog lookup, not the chat
+  request itself
+- add tests for both explicit-model and auto-discovery paths
+
+## Verification Plan
+
+Add regression coverage for:
+
+- mixed legacy/profile configs missing `active_provider`
+- invalid explicit `active_provider` recovery
+- warning diagnostics for provider-selection drift hazards
+- `doctor` explicit-model probe downgrade to warning
+- `onboard` explicit-model probe downgrade to warning
+- text / JSON / problem-json validation output carrying severity
+
+Then run focused package tests plus broader package regressions before commit and
+PR.

--- a/docs/plans/2026-03-16-provider-active-selection-safety-implementation-plan.md
+++ b/docs/plans/2026-03-16-provider-active-selection-safety-implementation-plan.md
@@ -1,0 +1,317 @@
+# Provider Active Selection Safety Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent silent provider-selection drift across mixed legacy/profile configs, add severity-aware config diagnostics, and make `doctor` / `onboard` treat explicit-model probe failures as advisory warnings rather than hard failures.
+
+**Architecture:** Preserve raw TOML intent during config parsing, then normalize provider profiles with deterministic active-provider recovery that prefers explicit user choice over container order. Extend validation diagnostics with severity, and finally align `doctor` / `onboard` to the normalized active provider plus the provider's model-selection strategy.
+
+**Tech Stack:** Rust, serde, toml, existing `loongclaw-app` config/provider runtime, daemon CLI diagnostics, cargo test, cargo fmt.
+
+---
+
+### Task 1: Add failing config regression tests for selection drift
+
+**Files:**
+- Modify: `crates/app/src/config/runtime.rs`
+- Test: `crates/app/src/config/runtime.rs`
+
+**Step 1: Write the failing test**
+
+Add tests covering:
+
+```rust
+#[test]
+fn load_mixed_legacy_and_profile_config_preserves_explicit_legacy_provider_when_active_provider_missing() {
+    let config = parse_toml_config_without_validation(raw).expect("config should parse");
+    assert_eq!(config.active_provider_id(), Some("volcengine-coding"));
+}
+
+#[test]
+fn load_mixed_config_recovers_missing_active_provider_from_explicit_legacy_provider() {
+    let config = parse_toml_config_without_validation(raw).expect("config should parse");
+    assert_eq!(config.provider.kind, ProviderKind::VolcengineCoding);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app mixed_legacy_and_profile_config -- --nocapture`
+Expected: FAIL because normalization currently falls back to the first
+`providers` map entry.
+
+**Step 3: Write minimal implementation**
+
+- add raw-intent tracking fields to `LoongClawConfig`
+- parse raw TOML for explicit `provider` / `active_provider` presence
+- update normalization to recover active selection from explicit legacy intent
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app mixed_legacy_and_profile_config -- --nocapture`
+Expected: PASS.
+
+### Task 2: Add failing validation-diagnostic severity tests
+
+**Files:**
+- Modify: `crates/app/src/config/shared.rs`
+- Modify: `crates/app/src/config/runtime.rs`
+- Test: `crates/app/src/config/runtime.rs`
+
+**Step 1: Write the failing test**
+
+Add tests covering:
+
+```rust
+#[test]
+fn validate_file_reports_warning_for_mixed_provider_selection_without_explicit_active_provider() {
+    let (_, diagnostics) = validate_file(Some(path)).expect("validate_file should parse");
+    assert_eq!(diagnostics[0].severity, "warn");
+}
+
+#[test]
+fn validate_file_keeps_existing_env_pointer_diagnostics_as_errors() {
+    let (_, diagnostics) = validate_file(Some(path)).expect("validate_file should parse");
+    assert_eq!(diagnostics[0].severity, "error");
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app validate_file_reports_warning_for_mixed_provider_selection_without_explicit_active_provider -- --nocapture`
+Expected: FAIL because diagnostics do not yet expose severity or emit the new
+provider-selection warning.
+
+**Step 3: Write minimal implementation**
+
+- introduce config validation severity enum and serialization
+- default existing diagnostics to `Error`
+- add warning diagnostics for risky mixed provider-selection states
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app validate_file_reports_warning_for_mixed_provider_selection_without_explicit_active_provider -- --nocapture`
+Expected: PASS.
+
+### Task 3: Add failing validate-config CLI output tests
+
+**Files:**
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/daemon/src/tests/mod.rs`
+- Test: `crates/daemon/src/tests/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add tests covering:
+
+```rust
+#[test]
+fn validate_config_json_includes_diagnostic_severity() {
+    let payload = run_validate_config_json(...);
+    assert_eq!(payload["diagnostics"][0]["severity"], "warn");
+}
+
+#[test]
+fn validate_config_problem_json_preserves_warning_diagnostics() {
+    let payload = run_validate_config_problem_json(...);
+    assert_eq!(payload["errors"][0]["severity"], "warn");
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon validate_config_json_includes_diagnostic_severity -- --nocapture`
+Expected: FAIL because the serialized diagnostics do not yet include severity.
+
+**Step 3: Write minimal implementation**
+
+- thread diagnostic severity through text / JSON / problem-json output
+- keep `fail_on_diagnostics` semantics unchanged for now
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon validate_config_json_includes_diagnostic_severity -- --nocapture`
+Expected: PASS.
+
+### Task 4: Add failing doctor/onboard tests for explicit-model probe downgrade
+
+**Files:**
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `crates/daemon/src/tests/onboard_cli.rs`
+- Modify: `crates/daemon/src/tests/mod.rs`
+- Test: `crates/daemon/src/tests/onboard_cli.rs`
+- Test: `crates/daemon/src/doctor_cli.rs`
+
+**Step 1: Write the failing test**
+
+Add tests covering:
+
+```rust
+#[tokio::test]
+async fn explicit_model_probe_failure_warns_during_onboard_preflight() {
+    let checks = run_preflight_checks(&config_with_explicit_model(), false).await;
+    assert_eq!(model_probe.level, OnboardCheckLevel::Warn);
+}
+
+#[tokio::test]
+async fn explicit_model_probe_failure_warns_during_doctor() {
+    let checks = collect_doctor_checks_for_config(config_with_explicit_model()).await;
+    assert_eq!(model_probe.level, DoctorCheckLevel::Warn);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon explicit_model_probe_failure_warns -- --nocapture`
+Expected: FAIL because probe failures are currently classified as `Fail`.
+
+**Step 3: Write minimal implementation**
+
+- classify model-probe failures using `provider.explicit_model()`
+- keep auto-discovery failures as `Fail`
+- include detail that explicit-model chat may still work without catalog
+  discovery
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon explicit_model_probe_failure_warns -- --nocapture`
+Expected: PASS.
+
+### Task 5: Add active-provider context to doctor/onboard detail
+
+**Files:**
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `crates/daemon/src/provider_presentation.rs`
+- Modify: `crates/daemon/src/tests/onboard_cli.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+
+**Step 1: Write the failing test**
+
+Add tests covering:
+
+```rust
+#[test]
+fn provider_credential_check_mentions_active_provider_profile() {
+    let check = provider_credential_check(&config_with_active_profile("openrouter"));
+    assert!(check.detail.contains("openrouter"));
+}
+
+#[test]
+fn provider_model_probe_warning_mentions_explicit_model_mode() {
+    let check = classify_probe_failure(...);
+    assert!(check.detail.contains("explicitly configured"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon provider_credential_check_mentions_active_provider_profile -- --nocapture`
+Expected: FAIL because current details describe only the normalized provider
+config, not the selected saved profile.
+
+**Step 3: Write minimal implementation**
+
+- add helper(s) that render active provider context from normalized config
+- reuse them in doctor/onboard detail text
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon provider_credential_check_mentions_active_provider_profile -- --nocapture`
+Expected: PASS.
+
+### Task 6: Run focused suites and broader regressions
+
+**Files:**
+- Modify: `crates/app/src/config/runtime.rs`
+- Modify: `crates/app/src/config/shared.rs`
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Test: `crates/daemon/src/tests/mod.rs`
+- Test: `crates/daemon/src/tests/onboard_cli.rs`
+
+**Step 1: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app mixed_legacy_and_profile_config -- --nocapture
+cargo test -p loongclaw-app validate_file_reports_warning_for_mixed_provider_selection_without_explicit_active_provider -- --nocapture
+cargo test -p loongclaw-daemon explicit_model_probe_failure_warns -- --nocapture
+```
+
+Expected: PASS.
+
+**Step 2: Run broader package regressions**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app -- --test-threads=1
+cargo test -p loongclaw-daemon -- --test-threads=1
+```
+
+Expected: PASS.
+
+**Step 3: Run formatting verification**
+
+Run:
+
+```bash
+cargo fmt --all --check
+```
+
+Expected: PASS.
+
+### Task 7: Prepare delivery artifacts
+
+**Files:**
+- Modify: `docs/plans/2026-03-16-provider-active-selection-safety-design.md`
+- Modify: `docs/plans/2026-03-16-provider-active-selection-safety-implementation-plan.md`
+- Modify: `crates/app/src/config/runtime.rs`
+- Modify: `crates/app/src/config/shared.rs`
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+
+**Step 1: Inspect scope before commit**
+
+Run:
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```
+
+Expected: only provider-selection safety files are present.
+
+**Step 2: Commit**
+
+Run:
+
+```bash
+git add docs/plans/2026-03-16-provider-active-selection-safety-design.md \
+  docs/plans/2026-03-16-provider-active-selection-safety-implementation-plan.md \
+  crates/app/src/config/runtime.rs \
+  crates/app/src/config/shared.rs \
+  crates/daemon/src/main.rs \
+  crates/daemon/src/doctor_cli.rs \
+  crates/daemon/src/onboard_cli.rs \
+  crates/daemon/src/tests/mod.rs \
+  crates/daemon/src/tests/onboard_cli.rs
+git commit -m "fix: harden provider active selection semantics"
+```
+
+**Step 3: Push and open PR**
+
+Run:
+
+```bash
+git push fork-chumyin fix/provider-active-selection
+gh pr create --repo loongclaw-ai/loongclaw --base alpha-test --head chumyin:fix/provider-active-selection
+```
+
+PR body must include: `Closes #175`


### PR DESCRIPTION
## Summary

- preserve explicit legacy `[provider]` intent during TOML parsing and normalization so mixed configs no longer drift to the first saved profile when `active_provider` is missing or invalid
- add severity-aware config diagnostics and `validate-config` summaries so warning-only provider-selection recovery is visible without being treated as a hard config failure
- downgrade explicit-model catalog probe failures in `doctor` and `onboard` to warnings and include active profile context in provider diagnostics

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

- Changes provider-selection fallback for mixed legacy/profile configs by preserving raw TOML selection intent before normalization.
- Warning-only validation is now reported as `valid=true` with separate `error_count` and `warning_count`; hard errors still fail semantic validation.
- Added regression coverage for the explicit legacy path, invalid or implicit selection recovery, conflicting recovered profile IDs, and explicit-model `/models` probe failures.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Before/after behavior and regression coverage:

- Before: mixed `[provider]` plus `[providers.*]` configs could silently activate the first normalized profile, and invalid or missing `active_provider` recovery was effectively ordered-map dependent.
- After: valid explicit `active_provider` still wins; otherwise explicit legacy `[provider]` intent is matched or recovered deterministically, warning diagnostics are emitted for implicit or unknown active-provider recovery, and explicit-model catalog probe failures stay advisory in `doctor` and `onboard`.
- Fresh verification run:
  - `cargo test -p loongclaw-app -- --test-threads=1`
  - `cargo test -p loongclaw-daemon -- --test-threads=1`
- Targeted regression coverage added for:
  - mixed configs preserving explicit legacy provider when `active_provider` is absent
  - warning diagnostics for implicit or unknown active-provider recovery
  - legacy-provider field validation even when saved profiles exist
  - conflicting recovered profile IDs
  - explicit-model probe warnings in `doctor` and `onboard`
  - warning-only `validate-config` summaries and active-profile-aware credential or probe details
- Process-global env mutations in onboarding tests are serialized and restored with `DetectedEnvironmentGuard`.
- Follow-up commit `688c0a0` removed the `clippy::unreachable` violation in provider-profile recovery; the rerun CI for this PR head is fully green.

## Linked Issues

Closes #175

