### PR TITLE
feat(browser): ship browser companion preview flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,8 +401,8 @@ Agent-facing tools:
   - Saves artifact under `<tools.file_root>/external-skills-downloads/`.
   - Enforces allowlist/blocklist before network download.
 - `external_skills_install`
-  - Requires local `path`.
-  - Accepts a directory containing `SKILL.md` or a local `.tgz` / `.tar.gz` archive.
+  - Requires either a local `path` or a first-party `bundled_skill_id`.
+  - Accepts a directory containing `SKILL.md`, a local `.tgz` / `.tar.gz` archive, or a first-party `bundled_skill_id`.
   - Installs the skill under `<tools.file_root>/external-skills-installed/` by default.
 - `external_skills_list`
   - Lists resolved external skills across `managed`, `user`, and `project` scopes.
@@ -424,6 +424,10 @@ Operator-facing CLI:
   - Includes any lower-priority duplicates that were shadowed by the selected skill.
 - `loongclaw skills install <path> [--skill-id ID] [--replace] [--config PATH] [--json]`
   - Installs a local skill directory or `.tgz` / `.tar.gz` archive through the same managed runtime path as `external_skills.install`.
+- `loongclaw skills install-bundled <skill-id> [--replace] [--config PATH] [--json]`
+  - Installs a first-party bundled skill such as `browser-companion-preview` without requiring a local archive path.
+- `loongclaw skills enable-browser-preview [--replace] [--config PATH] [--json]`
+  - Globally enables the external-skills runtime for this config, turns on installed-skill auto exposure, allows `agent-browser` through shell policy when needed, and installs the bundled `browser-companion-preview` skill.
 - `loongclaw skills remove <skill-id> [--config PATH] [--json]`
   - Removes one managed installed skill from the local index.
 - `loongclaw skills policy get|set|reset [--config PATH] [--json]`
@@ -443,6 +447,26 @@ Recommended runtime flow:
    - User and project discovery follow directory symlinks inside those skill roots; managed installs still reject symlinked sources
 4. Inspect with `external_skills.inspect` or `loongclaw skills info`
 5. Load instructions with `external_skills.invoke`
+
+Browser preview fast path:
+
+```bash
+loongclaw skills enable-browser-preview --config ~/.loongclaw/config.toml
+agent-browser --help
+loongclaw doctor --config ~/.loongclaw/config.toml
+```
+
+This preview keeps the shipped safe browser lane (`browser.open`,
+`browser.extract`, `browser.click`) as the default. It adds a first-party
+managed helper skill that can route richer multi-step page work through
+`agent-browser` when the runtime, shell policy, and local binary are all ready.
+It does not install or manage the `agent-browser` runtime for you; bring that
+binary yourself, then use `doctor` to confirm it is available on `PATH`.
+
+Today this preview is still a managed `external_skills.invoke` lane that uses
+`shell.exec` against `agent-browser`. It does not yet provide the same bounded,
+profile-isolated browser safety model as the built-in `browser.open`,
+`browser.extract`, and `browser.click` tools.
 
 ## Key Features
 
@@ -561,7 +585,7 @@ cargo build -p loongclaw-daemon --no-default-features --features "channel-cli,pr
 | [Reliability](docs/RELIABILITY.md) | Build and kernel invariants |
 | [Examples](examples/README.md) | Spec files, plugin samples, benchmarks |
 | [Product Specs](docs/product-specs/index.md) | User-facing requirements for onboarding, ask, doctor, channels, and WebChat expectations |
-| [Skills](skills/) | Agent skills (`update-harness.skill`) |
+| [Skills](skills/) | Agent skills (`update-harness.skill`, `browser-companion-preview/`) |
 | [Changelog](CHANGELOG.md) | Release history |
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Operator-facing CLI:
   - Installs a first-party bundled skill such as `browser-companion-preview` without requiring a local archive path.
 - `loongclaw skills enable-browser-preview [--replace] [--config PATH] [--json]`
   - Globally enables the external-skills runtime for this config, turns on installed-skill auto exposure, allows `agent-browser` through shell policy when needed, and installs the bundled `browser-companion-preview` skill.
+  - Refuses explicit `[tools].shell_deny` conflicts for `agent-browser`; remove that entry or adjust policy before running the command.
 - `loongclaw skills remove <skill-id> [--config PATH] [--json]`
   - Removes one managed installed skill from the local index.
 - `loongclaw skills policy get|set|reset [--config PATH] [--json]`
@@ -450,23 +451,24 @@ Recommended runtime flow:
 
 Browser preview fast path:
 
+This preview keeps the shipped safe browser lane (`browser.open`,
+`browser.extract`, `browser.click`) as the default. Today it is still a managed
+`external_skills.invoke` lane that uses `shell.exec` against `agent-browser`, so
+it does not yet provide the same bounded, profile-isolated browser safety model
+as the built-in browser tools.
+
 ```bash
 loongclaw skills enable-browser-preview --config ~/.loongclaw/config.toml
 agent-browser --help
 loongclaw doctor --config ~/.loongclaw/config.toml
 ```
 
-This preview keeps the shipped safe browser lane (`browser.open`,
-`browser.extract`, `browser.click`) as the default. It adds a first-party
-managed helper skill that can route richer multi-step page work through
-`agent-browser` when the runtime, shell policy, and local binary are all ready.
-It does not install or manage the `agent-browser` runtime for you; bring that
-binary yourself, then use `doctor` to confirm it is available on `PATH`.
-
-Today this preview is still a managed `external_skills.invoke` lane that uses
-`shell.exec` against `agent-browser`. It does not yet provide the same bounded,
-profile-isolated browser safety model as the built-in `browser.open`,
-`browser.extract`, and `browser.click` tools.
+It adds a first-party managed helper skill that can route richer multi-step page
+work through `agent-browser` when the runtime, shell policy, and local binary
+are all ready. It does not install or manage the `agent-browser` runtime for
+you; bring that binary yourself, then use `doctor` to confirm it is available
+on `PATH`. A healthy `doctor` run should report `agent-browser` as available and
+avoid browser preview follow-up errors.
 
 ## Key Features
 

--- a/crates/app/src/tools/bundled_skills.rs
+++ b/crates/app/src/tools/bundled_skills.rs
@@ -1,0 +1,25 @@
+pub(crate) const BROWSER_COMPANION_PREVIEW_SKILL_ID: &str = "browser-companion-preview";
+pub(crate) const BROWSER_COMPANION_PREVIEW_SOURCE_PATH: &str =
+    "bundled://browser-companion-preview";
+pub(crate) const BROWSER_COMPANION_COMMAND: &str = "agent-browser";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BundledExternalSkill {
+    pub(crate) skill_id: &'static str,
+    pub(crate) source_path: &'static str,
+    pub(crate) instructions: &'static str,
+}
+
+const BROWSER_COMPANION_PREVIEW_INSTRUCTIONS: &str =
+    include_str!("../../../../skills/browser-companion-preview/SKILL.md");
+
+pub(crate) fn bundled_external_skill(skill_id: &str) -> Option<BundledExternalSkill> {
+    match skill_id.trim() {
+        BROWSER_COMPANION_PREVIEW_SKILL_ID => Some(BundledExternalSkill {
+            skill_id: BROWSER_COMPANION_PREVIEW_SKILL_ID,
+            source_path: BROWSER_COMPANION_PREVIEW_SOURCE_PATH,
+            instructions: BROWSER_COMPANION_PREVIEW_INSTRUCTIONS,
+        }),
+        _ => None,
+    }
+}

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1920,7 +1920,8 @@ fn tool_required_fields(name: &str) -> &'static [&'static str] {
         "external_skills.inspect" | "external_skills.invoke" | "external_skills.remove" => {
             &["skill_id"]
         }
-        "external_skills.install" => &["path", "bundled_skill_id"],
+        // Grouped requirements are the source of truth for this tool's anyOf shape.
+        "external_skills.install" => &[],
         "file.read" => &["path"],
         "file.write" => &["path", "content"],
         "shell.exec" => &["command"],

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1160,13 +1160,17 @@ fn external_skills_install_definition(descriptor: &ToolDescriptor) -> Value {
         "type": "function",
         "function": {
             "name": descriptor.provider_name,
-            "description": "Install a managed external skill from a local directory or local .tgz/.tar.gz archive under the configured file root.",
+            "description": "Install a managed external skill from a local directory, local .tgz/.tar.gz archive, or a first-party bundled skill id.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "path": {
                         "type": "string",
                         "description": "Path to a local directory containing SKILL.md or a local .tgz/.tar.gz archive."
+                    },
+                    "bundled_skill_id": {
+                        "type": "string",
+                        "description": "Optional first-party bundled skill identifier, for example `browser-companion-preview`."
                     },
                     "skill_id": {
                         "type": "string",
@@ -1177,7 +1181,10 @@ fn external_skills_install_definition(descriptor: &ToolDescriptor) -> Value {
                         "description": "Replace an existing installed skill with the same id. Defaults to false."
                     }
                 },
-                "required": ["path"],
+                "anyOf": [
+                    { "required": ["path"] },
+                    { "required": ["bundled_skill_id"] }
+                ],
                 "additionalProperties": false
             }
         }
@@ -1823,7 +1830,9 @@ fn tool_argument_hint(name: &str) -> &'static str {
             "url:string,approval_granted?:boolean,save_as?:string,max_bytes?:integer"
         }
         "external_skills.inspect" => "skill_id:string",
-        "external_skills.install" => "path:string",
+        "external_skills.install" => {
+            "path?:string,bundled_skill_id?:string,skill_id?:string,replace?:boolean"
+        }
         "external_skills.invoke" => "skill_id:string",
         "external_skills.list" => "active_only?:boolean",
         "external_skills.policy" => {
@@ -1865,7 +1874,12 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
         "external_skills.inspect" | "external_skills.invoke" | "external_skills.remove" => {
             &[("skill_id", "string")]
         }
-        "external_skills.install" => &[("path", "string")],
+        "external_skills.install" => &[
+            ("path", "string"),
+            ("bundled_skill_id", "string"),
+            ("skill_id", "string"),
+            ("replace", "boolean"),
+        ],
         "external_skills.list" => &[("active_only", "boolean")],
         "external_skills.policy" => &[
             ("action", "string"),
@@ -1894,6 +1908,10 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
     }
 }
 
+const EMPTY_REQUIRED_FIELD_GROUPS: &[&[&str]] = &[];
+const EXTERNAL_SKILLS_INSTALL_REQUIRED_FIELD_GROUPS: &[&[&str]] =
+    &[&["path"], &["bundled_skill_id"]];
+
 fn tool_required_fields(name: &str) -> &'static [&'static str] {
     match name {
         "tool.search" => &["query"],
@@ -1902,7 +1920,7 @@ fn tool_required_fields(name: &str) -> &'static [&'static str] {
         "external_skills.inspect" | "external_skills.invoke" | "external_skills.remove" => {
             &["skill_id"]
         }
-        "external_skills.install" => &["path"],
+        "external_skills.install" => &["path", "bundled_skill_id"],
         "file.read" => &["path"],
         "file.write" => &["path", "content"],
         "shell.exec" => &["command"],
@@ -1911,6 +1929,13 @@ fn tool_required_fields(name: &str) -> &'static [&'static str] {
         | "session_status" | "session_wait" | "sessions_history" => &["session_id"],
         "sessions_send" => &["session_id", "text"],
         _ => &[],
+    }
+}
+
+pub(crate) fn tool_required_field_groups(name: &str) -> &'static [&'static [&'static str]] {
+    match name {
+        "external_skills.install" => EXTERNAL_SKILLS_INSTALL_REQUIRED_FIELD_GROUPS,
+        _ => EMPTY_REQUIRED_FIELD_GROUPS,
     }
 }
 

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -524,7 +524,9 @@ pub(super) fn execute_external_skills_install_tool_with_config(
                 .and_then(|value| (!value.is_empty()).then_some(value))
                 .map(normalize_skill_id)
                 .transpose()?
-                .unwrap_or_else(|| derive_skill_id_from_markdown(&skill_root, skill_markdown.as_str()));
+                .unwrap_or_else(|| {
+                    derive_skill_id_from_markdown(&skill_root, skill_markdown.as_str())
+                });
             let display_name =
                 derive_skill_display_name(skill_markdown.as_str(), skill_id.as_str());
             let summary = derive_skill_summary(skill_markdown.as_str());

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -391,8 +391,12 @@ pub(super) fn execute_external_skills_install_tool_with_config(
         .get("path")
         .and_then(Value::as_str)
         .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| "external_skills.install requires payload.path".to_owned())?;
+        .filter(|value| !value.is_empty());
+    let bundled_skill_id = payload
+        .get("bundled_skill_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
     let replace = payload
         .get("replace")
         .and_then(Value::as_bool)
@@ -402,9 +406,20 @@ pub(super) fn execute_external_skills_install_tool_with_config(
         .and_then(Value::as_str)
         .map(str::trim);
 
+    if raw_path.is_some() && bundled_skill_id.is_some() {
+        return Err(
+            "external_skills.install accepts either payload.path or payload.bundled_skill_id, not both"
+                .to_owned(),
+        );
+    }
+    if raw_path.is_none() && bundled_skill_id.is_none() {
+        return Err(
+            "external_skills.install requires payload.path or payload.bundled_skill_id".to_owned(),
+        );
+    }
+
     require_enabled_runtime_policy(config)?;
 
-    let source_path = super::file::resolve_safe_file_path_with_config(raw_path, config)?;
     let install_root = resolve_install_root(config);
     fs::create_dir_all(&install_root).map_err(|error| {
         format!(
@@ -412,49 +427,141 @@ pub(super) fn execute_external_skills_install_tool_with_config(
             install_root.display()
         )
     })?;
+    let (skill_id, display_name, summary, source_kind, source_path, incoming_root, digest) =
+        if let Some(bundled_skill_id) = bundled_skill_id {
+            if explicit_skill_id
+                .and_then(|value| (!value.is_empty()).then_some(value))
+                .is_some()
+            {
+                return Err(
+                    "external_skills.install cannot override payload.skill_id when payload.bundled_skill_id is used"
+                        .to_owned(),
+                );
+            }
+            let bundled = super::bundled_skills::bundled_external_skill(bundled_skill_id)
+                .ok_or_else(|| {
+                    format!(
+                        "external_skills.install does not recognize bundled skill `{bundled_skill_id}`"
+                    )
+                })?;
+            let skill_id = normalize_skill_id(bundled.skill_id)?;
+            let display_name = derive_skill_display_name(bundled.instructions, bundled.skill_id);
+            let summary = derive_skill_summary(bundled.instructions);
+            let incoming_root = unique_managed_install_transition_path(
+                &install_root,
+                skill_id.as_str(),
+                "incoming",
+            )?;
+            let mut incoming_cleanup = ScopedDirCleanup::new(Some(incoming_root.clone()));
+            fs::create_dir_all(&incoming_root).map_err(|error| {
+                format!(
+                    "failed to create bundled external skill staging directory {}: {error}",
+                    incoming_root.display()
+                )
+            })?;
+            let installed_skill_md_path = incoming_root.join(DEFAULT_SKILL_FILENAME);
+            fs::write(&installed_skill_md_path, bundled.instructions).map_err(|error| {
+                format!(
+                    "failed to write bundled external skill source {}: {error}",
+                    installed_skill_md_path.display()
+                )
+            })?;
+            let digest = format!("{:x}", Sha256::digest(bundled.instructions.as_bytes()));
+            incoming_cleanup.disarm();
+            (
+                skill_id,
+                display_name,
+                summary,
+                "bundled".to_owned(),
+                bundled.source_path.to_owned(),
+                incoming_root,
+                digest,
+            )
+        } else {
+            let Some(raw_path) = raw_path else {
+                return Err(
+                    "external_skills.install internal error: missing path after payload validation"
+                        .to_owned(),
+                );
+            };
+            let source_path = super::file::resolve_safe_file_path_with_config(raw_path, config)?;
+            let source_metadata = fs::symlink_metadata(&source_path).map_err(|error| {
+                format!(
+                    "failed to inspect external skill source {}: {error}",
+                    source_path.display()
+                )
+            })?;
+            let source_file_type = source_metadata.file_type();
+            if source_file_type.is_symlink() {
+                return Err(format!(
+                    "external skill source {} cannot be a symlink",
+                    source_path.display()
+                ));
+            }
 
-    let source_metadata = fs::symlink_metadata(&source_path).map_err(|error| {
-        format!(
-            "failed to inspect external skill source {}: {error}",
-            source_path.display()
-        )
-    })?;
-    let source_file_type = source_metadata.file_type();
-    if source_file_type.is_symlink() {
-        return Err(format!(
-            "external skill source {} cannot be a symlink",
-            source_path.display()
-        ));
-    }
-
-    let (skill_root, source_kind, cleanup_root) = if source_file_type.is_dir() {
-        let skill_root = resolve_skill_root(&source_path)?;
-        (skill_root, "directory", None)
-    } else if source_file_type.is_file() {
-        let (staging_root, skill_root) = extract_archive_to_staging(&source_path, &install_root)?;
-        (skill_root, "archive", Some(staging_root))
-    } else {
-        return Err(format!(
-            "external skill source {} must be a directory or a regular file",
-            source_path.display()
-        ));
-    };
-    let _cleanup_root = ScopedDirCleanup::new(cleanup_root);
-
-    let skill_md_path = skill_root.join(DEFAULT_SKILL_FILENAME);
-    let skill_markdown = fs::read_to_string(&skill_md_path).map_err(|error| {
-        format!(
-            "failed to read installed skill source {}: {error}",
-            skill_md_path.display()
-        )
-    })?;
-    let skill_id = explicit_skill_id
-        .and_then(|value| (!value.is_empty()).then_some(value))
-        .map(normalize_skill_id)
-        .transpose()?
-        .unwrap_or_else(|| derive_skill_id_from_markdown(&skill_root, skill_markdown.as_str()));
-    let display_name = derive_skill_display_name(skill_markdown.as_str(), skill_id.as_str());
-    let summary = derive_skill_summary(skill_markdown.as_str());
+            let (skill_root, source_kind, cleanup_root) = if source_file_type.is_dir() {
+                let skill_root = resolve_skill_root(&source_path)?;
+                (skill_root, "directory", None)
+            } else if source_file_type.is_file() {
+                let (staging_root, skill_root) =
+                    extract_archive_to_staging(&source_path, &install_root)?;
+                (skill_root, "archive", Some(staging_root))
+            } else {
+                return Err(format!(
+                    "external skill source {} must be a directory or a regular file",
+                    source_path.display()
+                ));
+            };
+            let _cleanup_root = ScopedDirCleanup::new(cleanup_root);
+            let skill_md_path = skill_root.join(DEFAULT_SKILL_FILENAME);
+            let skill_markdown = fs::read_to_string(&skill_md_path).map_err(|error| {
+                format!(
+                    "failed to read installed skill source {}: {error}",
+                    skill_md_path.display()
+                )
+            })?;
+            let skill_id = explicit_skill_id
+                .and_then(|value| (!value.is_empty()).then_some(value))
+                .map(normalize_skill_id)
+                .transpose()?
+                .unwrap_or_else(|| derive_skill_id_from_markdown(&skill_root, skill_markdown.as_str()));
+            let display_name =
+                derive_skill_display_name(skill_markdown.as_str(), skill_id.as_str());
+            let summary = derive_skill_summary(skill_markdown.as_str());
+            let incoming_root = unique_managed_install_transition_path(
+                &install_root,
+                skill_id.as_str(),
+                "incoming",
+            )?;
+            let mut incoming_cleanup = ScopedDirCleanup::new(Some(incoming_root.clone()));
+            fs::create_dir_all(&incoming_root).map_err(|error| {
+                format!(
+                    "failed to create external skill destination {}: {error}",
+                    incoming_root.display()
+                )
+            })?;
+            copy_dir_recursive(&skill_root, &incoming_root)?;
+            let installed_skill_md_path = incoming_root.join(DEFAULT_SKILL_FILENAME);
+            let installed_skill_markdown =
+                fs::read_to_string(&installed_skill_md_path).map_err(|error| {
+                    format!(
+                        "failed to verify installed skill {}: {error}",
+                        installed_skill_md_path.display()
+                    )
+                })?;
+            let digest = format!("{:x}", Sha256::digest(installed_skill_markdown.as_bytes()));
+            incoming_cleanup.disarm();
+            (
+                skill_id,
+                display_name,
+                summary,
+                source_kind.to_owned(),
+                source_path.display().to_string(),
+                incoming_root,
+                digest,
+            )
+        };
+    let _incoming_cleanup = ScopedDirCleanup::new(Some(incoming_root.clone()));
 
     let mut index = load_installed_skill_index(&install_root)?;
     let previous_index = index.clone();
@@ -465,20 +572,6 @@ pub(super) fn execute_external_skills_install_tool_with_config(
     }
 
     let destination_root = managed_skill_install_path(&install_root, skill_id.as_str())?;
-    let incoming_root =
-        unique_managed_install_transition_path(&install_root, skill_id.as_str(), "incoming")?;
-    let _incoming_cleanup = ScopedDirCleanup::new(Some(incoming_root.clone()));
-    copy_dir_recursive(&skill_root, &incoming_root)?;
-
-    let installed_skill_md_path = incoming_root.join(DEFAULT_SKILL_FILENAME);
-    let installed_skill_markdown =
-        fs::read_to_string(&installed_skill_md_path).map_err(|error| {
-            format!(
-                "failed to verify installed skill {}: {error}",
-                installed_skill_md_path.display()
-            )
-        })?;
-    let digest = format!("{:x}", Sha256::digest(installed_skill_markdown.as_bytes()));
     let installed_at_unix = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_secs())
@@ -489,8 +582,8 @@ pub(super) fn execute_external_skills_install_tool_with_config(
         skill_id: skill_id.clone(),
         display_name: display_name.clone(),
         summary: summary.clone(),
-        source_kind: source_kind.to_owned(),
-        source_path: source_path.display().to_string(),
+        source_kind: source_kind.clone(),
+        source_path: source_path.clone(),
         install_path: destination_root.display().to_string(),
         skill_md_path: destination_root
             .join(DEFAULT_SKILL_FILENAME)
@@ -583,7 +676,7 @@ pub(super) fn execute_external_skills_install_tool_with_config(
             "display_name": display_name,
             "summary": summary,
             "source_kind": source_kind,
-            "source_path": source_path.display().to_string(),
+            "source_path": source_path,
             "install_path": destination_root.display().to_string(),
             "skill_md_path": destination_root.join(DEFAULT_SKILL_FILENAME).display().to_string(),
             "sha256": digest,
@@ -805,6 +898,10 @@ impl ExternalSkillsPolicyOverride {
 impl ScopedDirCleanup {
     fn new(path: Option<PathBuf>) -> Self {
         Self(path)
+    }
+
+    fn disarm(&mut self) {
+        self.0 = None;
     }
 }
 
@@ -2360,6 +2457,80 @@ mod tests {
                     .exists(),
                 "managed external skill copy should exist"
             );
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn install_from_bundled_skill_id_writes_managed_index_and_copy() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-install-bundled");
+            fs::create_dir_all(&root).expect("create fixture root");
+            let config = managed_runtime_config(&root);
+
+            let outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload: json!({
+                        "bundled_skill_id": "browser-companion-preview"
+                    }),
+                },
+                &config,
+            )
+            .expect("bundled install should succeed");
+
+            assert_eq!(outcome.status, "ok");
+            assert_eq!(outcome.payload["skill_id"], "browser-companion-preview");
+            assert_eq!(outcome.payload["source_kind"], "bundled");
+            assert_eq!(
+                outcome.payload["source_path"],
+                "bundled://browser-companion-preview"
+            );
+            let installed_skill = root
+                .join("external-skills-installed")
+                .join("browser-companion-preview")
+                .join("SKILL.md");
+            assert!(
+                installed_skill.exists(),
+                "bundled managed skill should exist"
+            );
+            let installed_skill_body =
+                fs::read_to_string(&installed_skill).expect("read bundled managed skill");
+            assert!(
+                installed_skill_body.contains("agent-browser"),
+                "bundled preview instructions should preserve the packaged browser companion guidance"
+            );
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn install_rejects_path_and_bundled_skill_id_together() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-install-bundled-conflict");
+            fs::create_dir_all(&root).expect("create fixture root");
+            write_file(
+                &root,
+                "source/demo-skill/SKILL.md",
+                "# Demo Skill\n\nConflicting payload should fail.\n",
+            );
+            let config = managed_runtime_config(&root);
+
+            let error = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload: json!({
+                        "path": "source/demo-skill",
+                        "bundled_skill_id": "browser-companion-preview"
+                    }),
+                },
+                &config,
+            )
+            .expect_err("mixed path and bundled skill id should fail");
+
+            assert!(error.contains("either payload.path or payload.bundled_skill_id"));
 
             fs::remove_dir_all(&root).ok();
         });

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -708,12 +708,8 @@ fn search_argument_hint_from_provider_definition(parameters: &Value) -> String {
     let Some(properties) = parameters.get("properties").and_then(Value::as_object) else {
         return String::new();
     };
-    let required = parameters
-        .get("required")
-        .and_then(Value::as_array)
+    let required = schema_required_fields(parameters)
         .into_iter()
-        .flatten()
-        .filter_map(Value::as_str)
         .collect::<BTreeSet<_>>();
     let mut fields = properties
         .iter()
@@ -734,13 +730,60 @@ fn search_argument_hint_from_provider_definition(parameters: &Value) -> String {
     fields.join(",")
 }
 
+fn schema_required_fields(parameters: &Value) -> Vec<String> {
+    parameters
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn schema_required_field_groups(parameters: &Value) -> Vec<Vec<String>> {
+    ["anyOf", "oneOf"]
+        .into_iter()
+        .filter_map(|key| parameters.get(key).and_then(Value::as_array))
+        .flatten()
+        .filter_map(|schema| {
+            let required = schema
+                .get("required")
+                .and_then(Value::as_array)?
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_owned)
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            if required.is_empty() {
+                None
+            } else {
+                Some(required)
+            }
+        })
+        .collect()
+}
+
+fn default_required_field_groups(
+    required_fields: &[String],
+    mut required_field_groups: Vec<Vec<String>>,
+) -> Vec<Vec<String>> {
+    if required_field_groups.is_empty() && !required_fields.is_empty() {
+        required_field_groups.push(required_fields.to_vec());
+    }
+    required_field_groups
+}
+
 fn searchable_entry_from_catalog(entry: catalog::ToolCatalogEntry) -> SearchableToolEntry {
     let required_fields = entry
         .required_fields
         .iter()
         .map(|field| (*field).to_owned())
         .collect::<Vec<_>>();
-    let mut required_field_groups = catalog::tool_required_field_groups(entry.canonical_name)
+    let required_field_groups = catalog::tool_required_field_groups(entry.canonical_name)
         .iter()
         .map(|group| {
             group
@@ -749,9 +792,8 @@ fn searchable_entry_from_catalog(entry: catalog::ToolCatalogEntry) -> Searchable
                 .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
-    if required_field_groups.is_empty() && !required_fields.is_empty() {
-        required_field_groups.push(required_fields.clone());
-    }
+    let required_field_groups =
+        default_required_field_groups(&required_fields, required_field_groups);
 
     SearchableToolEntry {
         canonical_name: entry.canonical_name.to_owned(),
@@ -774,14 +816,11 @@ fn feishu_searchable_entries() -> Vec<SearchableToolEntry> {
                 .get("parameters")
                 .cloned()
                 .unwrap_or_else(|| json!({}));
-            let required_fields = parameters
-                .get("required")
-                .and_then(Value::as_array)
-                .into_iter()
-                .flatten()
-                .filter_map(Value::as_str)
-                .map(str::to_owned)
-                .collect::<Vec<_>>();
+            let required_fields = schema_required_fields(&parameters);
+            let required_field_groups = default_required_field_groups(
+                &required_fields,
+                schema_required_field_groups(&parameters),
+            );
             Some(SearchableToolEntry {
                 canonical_name: canonical_tool_name(provider_name).to_owned(),
                 summary: function
@@ -790,11 +829,7 @@ fn feishu_searchable_entries() -> Vec<SearchableToolEntry> {
                     .unwrap_or_default()
                     .to_owned(),
                 argument_hint: search_argument_hint_from_provider_definition(&parameters),
-                required_field_groups: if required_fields.is_empty() {
-                    Vec::new()
-                } else {
-                    vec![required_fields.clone()]
-                },
+                required_field_groups,
                 required_fields,
                 tags: vec!["feishu".to_owned()],
             })
@@ -2096,11 +2131,19 @@ mod tests {
     fn tool_search_reports_alternative_required_fields_for_bundled_skill_install() {
         let entry = catalog::find_tool_catalog_entry("external_skills.install")
             .expect("external_skills.install should exist in the catalog");
+        let searchable = searchable_entry_from_catalog(entry);
 
-        assert_eq!(entry.required_fields, &["path", "bundled_skill_id"]);
+        assert!(
+            entry.required_fields.is_empty(),
+            "catalog required_fields should only list unconditional requirements"
+        );
+        assert!(
+            searchable.required_fields.is_empty(),
+            "search should not flatten grouped alternatives into required_fields"
+        );
         assert_eq!(
-            catalog::tool_required_field_groups("external_skills.install"),
-            &[&["path"][..], &["bundled_skill_id"][..]]
+            searchable.required_field_groups,
+            vec![vec!["path".to_owned()], vec!["bundled_skill_id".to_owned()]]
         );
     }
 
@@ -2210,6 +2253,21 @@ mod tests {
                 .iter()
                 .any(|entry| entry["tool_id"] == "feishu.messages.send"),
             "feishu send should be discoverable through tool.search: {results:?}"
+        );
+    }
+
+    #[cfg(feature = "feishu-integration")]
+    #[test]
+    fn feishu_searchable_entries_report_anyof_required_groups() {
+        let entry = feishu_searchable_entries()
+            .into_iter()
+            .find(|entry| entry.canonical_name == "feishu.doc.append")
+            .expect("feishu.doc.append should be discoverable");
+
+        assert_eq!(entry.required_fields, vec!["url".to_owned()]);
+        assert_eq!(
+            entry.required_field_groups,
+            vec![vec!["content".to_owned()], vec!["content_path".to_owned()]]
         );
     }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -22,6 +22,7 @@ use crate::memory::runtime_config::MemoryRuntimeConfig;
 pub(crate) mod approval;
 #[cfg(feature = "tool-browser")]
 mod browser;
+mod bundled_skills;
 mod catalog;
 mod claw_import;
 pub(crate) mod delegate;
@@ -54,6 +55,9 @@ pub(crate) use feishu::{DeferredFeishuCardUpdate, drain_deferred_feishu_card_upd
 pub use kernel_adapter::MvpToolAdapter;
 
 pub(crate) const BROWSER_SESSION_SCOPE_FIELD: &str = "__loongclaw_browser_scope";
+pub const BROWSER_COMPANION_PREVIEW_SKILL_ID: &str =
+    bundled_skills::BROWSER_COMPANION_PREVIEW_SKILL_ID;
+pub const BROWSER_COMPANION_COMMAND: &str = bundled_skills::BROWSER_COMPANION_COMMAND;
 
 pub(crate) const LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY: &str = "_loongclaw";
 const LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY: &str = "tool_search";
@@ -597,6 +601,7 @@ struct SearchableToolEntry {
     summary: String,
     argument_hint: String,
     required_fields: Vec<String>,
+    required_field_groups: Vec<Vec<String>>,
     tags: Vec<String>,
 }
 
@@ -730,15 +735,30 @@ fn search_argument_hint_from_provider_definition(parameters: &Value) -> String {
 }
 
 fn searchable_entry_from_catalog(entry: catalog::ToolCatalogEntry) -> SearchableToolEntry {
+    let required_fields = entry
+        .required_fields
+        .iter()
+        .map(|field| (*field).to_owned())
+        .collect::<Vec<_>>();
+    let mut required_field_groups = catalog::tool_required_field_groups(entry.canonical_name)
+        .iter()
+        .map(|group| {
+            group
+                .iter()
+                .map(|field| (*field).to_owned())
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    if required_field_groups.is_empty() && !required_fields.is_empty() {
+        required_field_groups.push(required_fields.clone());
+    }
+
     SearchableToolEntry {
         canonical_name: entry.canonical_name.to_owned(),
         summary: entry.summary.to_owned(),
         argument_hint: entry.argument_hint.to_owned(),
-        required_fields: entry
-            .required_fields
-            .iter()
-            .map(|field| (*field).to_owned())
-            .collect(),
+        required_fields,
+        required_field_groups,
         tags: entry.tags.iter().map(|tag| (*tag).to_owned()).collect(),
     }
 }
@@ -754,6 +774,14 @@ fn feishu_searchable_entries() -> Vec<SearchableToolEntry> {
                 .get("parameters")
                 .cloned()
                 .unwrap_or_else(|| json!({}));
+            let required_fields = parameters
+                .get("required")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .map(str::to_owned)
+                .collect::<Vec<_>>();
             Some(SearchableToolEntry {
                 canonical_name: canonical_tool_name(provider_name).to_owned(),
                 summary: function
@@ -762,14 +790,12 @@ fn feishu_searchable_entries() -> Vec<SearchableToolEntry> {
                     .unwrap_or_default()
                     .to_owned(),
                 argument_hint: search_argument_hint_from_provider_definition(&parameters),
-                required_fields: parameters
-                    .get("required")
-                    .and_then(Value::as_array)
-                    .into_iter()
-                    .flatten()
-                    .filter_map(Value::as_str)
-                    .map(str::to_owned)
-                    .collect(),
+                required_field_groups: if required_fields.is_empty() {
+                    Vec::new()
+                } else {
+                    vec![required_fields.clone()]
+                },
+                required_fields,
                 tags: vec!["feishu".to_owned()],
             })
         })
@@ -918,6 +944,7 @@ fn execute_tool_search_tool_with_config(
                 "summary": entry.summary,
                 "argument_hint": entry.argument_hint,
                 "required_fields": entry.required_fields,
+                "required_field_groups": entry.required_field_groups,
                 "tags": entry.tags,
                 "why": why,
                 "lease": issue_tool_lease(entry.canonical_name.as_str(), payload),
@@ -2062,6 +2089,19 @@ mod tests {
         }));
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
+    #[test]
+    fn tool_search_reports_alternative_required_fields_for_bundled_skill_install() {
+        let entry = catalog::find_tool_catalog_entry("external_skills.install")
+            .expect("external_skills.install should exist in the catalog");
+
+        assert_eq!(entry.required_fields, &["path", "bundled_skill_id"]);
+        assert_eq!(
+            catalog::tool_required_field_groups("external_skills.install"),
+            &[&["path"][..], &["bundled_skill_id"][..]]
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/daemon/src/browser_preview.rs
+++ b/crates/daemon/src/browser_preview.rs
@@ -76,23 +76,26 @@ pub(crate) fn inspect_browser_preview_state_with_path_env(
 }
 
 pub(crate) fn browser_preview_enable_command(config_path: &str) -> String {
+    let config_path = shell_quote_argument(config_path);
     format!(
-        "{} skills enable-browser-preview --config '{}'",
+        "{} skills enable-browser-preview --config {}",
         mvp::config::CLI_COMMAND_NAME,
         config_path
     )
 }
 
 pub(crate) fn browser_preview_unblock_command(config_path: &str) -> String {
+    let config_path = shell_quote_argument(config_path);
     format!(
-        "edit '{}' and remove `agent-browser` from [tools].shell_deny",
+        "edit {} and remove `agent-browser` from [tools].shell_deny",
         config_path
     )
 }
 
 pub(crate) fn browser_preview_ready_command(config_path: &str) -> String {
+    let config_path = shell_quote_argument(config_path);
     format!(
-        "{} ask --config '{}' --message \"{}\"",
+        "{} ask --config {} --message \"{}\"",
         mvp::config::CLI_COMMAND_NAME,
         config_path,
         DEFAULT_BROWSER_PREVIEW_ASK_MESSAGE
@@ -146,6 +149,7 @@ pub(crate) fn ensure_browser_preview_config(config: &mut mvp::config::LoongClawC
 
     updated
 }
+
 pub(crate) fn bundled_skill_install_path(config: &mvp::config::LoongClawConfig) -> PathBuf {
     let install_root = config
         .external_skills
@@ -241,26 +245,30 @@ fn command_on_path(command: &str, path_env: Option<&OsStr>) -> bool {
     env::split_paths(path_env).any(|dir| {
         command_candidates(command)
             .into_iter()
-            .map(|candidate| dir.join(candidate))
+            .map(|candidate| dir.join(&candidate))
             .any(|candidate| command_candidate_is_available(&candidate))
     })
 }
 
-fn command_candidates(command: &str) -> Vec<&str> {
+fn command_candidates(command: &str) -> Vec<String> {
     #[cfg(windows)]
     {
         vec![
-            command,
-            "agent-browser.exe",
-            "agent-browser.cmd",
-            "agent-browser.bat",
-            "agent-browser.com",
+            command.to_owned(),
+            format!("{command}.exe"),
+            format!("{command}.cmd"),
+            format!("{command}.bat"),
+            format!("{command}.com"),
         ]
     }
     #[cfg(not(windows))]
     {
-        vec![command]
+        vec![command.to_owned()]
     }
+}
+
+fn shell_quote_argument(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
 #[cfg(unix)]
@@ -275,4 +283,32 @@ fn command_candidate_is_available(path: &std::path::Path) -> bool {
 #[cfg(windows)]
 fn command_candidate_is_available(path: &std::path::Path) -> bool {
     path.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        browser_preview_enable_command, browser_preview_ready_command,
+        browser_preview_unblock_command,
+    };
+
+    #[test]
+    fn browser_preview_commands_shell_escape_config_paths() {
+        let config_path = "/tmp/loongclaw's config.toml";
+
+        assert_eq!(
+            browser_preview_enable_command(config_path),
+            "loongclaw skills enable-browser-preview --config '/tmp/loongclaw'\"'\"'s config.toml'"
+        );
+        assert_eq!(
+            browser_preview_unblock_command(config_path),
+            "edit '/tmp/loongclaw'\"'\"'s config.toml' and remove `agent-browser` from [tools].shell_deny"
+        );
+        assert!(
+            browser_preview_ready_command(config_path).starts_with(
+                "loongclaw ask --config '/tmp/loongclaw'\"'\"'s config.toml' --message "
+            ),
+            "ready command should quote the config path for copy-paste safety"
+        );
+    }
 }

--- a/crates/daemon/src/browser_preview.rs
+++ b/crates/daemon/src/browser_preview.rs
@@ -1,0 +1,278 @@
+use std::{env, ffi::OsStr, path::PathBuf};
+
+use loongclaw_app as mvp;
+
+pub(crate) const BROWSER_PREVIEW_SKILL_ID: &str = mvp::tools::BROWSER_COMPANION_PREVIEW_SKILL_ID;
+pub(crate) const BROWSER_PREVIEW_ENABLE_LABEL: &str = "enable browser preview";
+pub(crate) const BROWSER_PREVIEW_UNBLOCK_LABEL: &str = "allow agent-browser";
+pub(crate) const BROWSER_PREVIEW_READY_LABEL: &str = "browser companion preview";
+const DEFAULT_BROWSER_PREVIEW_ASK_MESSAGE: &str = "Use external_skills.invoke to load browser-companion-preview, then use the browser companion preview to inspect https://example.com and summarize the result.";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BrowserPreviewState {
+    pub(crate) runtime_enabled: bool,
+    pub(crate) auto_expose_installed: bool,
+    pub(crate) skill_installed: bool,
+    pub(crate) shell_allowed: bool,
+    pub(crate) explicit_shell_deny: bool,
+    pub(crate) runtime_available: bool,
+}
+
+impl BrowserPreviewState {
+    pub(crate) fn ready(&self) -> bool {
+        self.runtime_enabled
+            && self.auto_expose_installed
+            && self.skill_installed
+            && self.shell_allowed
+            && self.runtime_available
+    }
+
+    pub(crate) fn needs_enable_command(&self) -> bool {
+        !self.explicit_shell_deny
+            && (!self.runtime_enabled
+                || !self.auto_expose_installed
+                || !self.skill_installed
+                || !self.shell_allowed)
+    }
+
+    pub(crate) fn needs_shell_unblock(&self) -> bool {
+        self.explicit_shell_deny
+    }
+
+    pub(crate) fn needs_runtime_install(&self) -> bool {
+        !self.runtime_available
+    }
+
+    fn has_preview_intent(&self) -> bool {
+        self.runtime_enabled
+            || self.auto_expose_installed
+            || self.skill_installed
+            || self.shell_allowed
+    }
+}
+
+pub(crate) fn inspect_browser_preview_state(
+    config: &mvp::config::LoongClawConfig,
+) -> BrowserPreviewState {
+    let path_env = env::var_os("PATH");
+    inspect_browser_preview_state_with_path_env(config, path_env.as_deref())
+}
+
+pub(crate) fn inspect_browser_preview_state_with_path_env(
+    config: &mvp::config::LoongClawConfig,
+    path_env: Option<&OsStr>,
+) -> BrowserPreviewState {
+    BrowserPreviewState {
+        runtime_enabled: config.external_skills.enabled,
+        auto_expose_installed: config.external_skills.auto_expose_installed,
+        skill_installed: bundled_skill_install_path(config).is_file(),
+        shell_allowed: shell_policy_allows_command(config, mvp::tools::BROWSER_COMPANION_COMMAND),
+        explicit_shell_deny: shell_policy_explicitly_denies_command(
+            config,
+            mvp::tools::BROWSER_COMPANION_COMMAND,
+        ),
+        runtime_available: command_on_path(mvp::tools::BROWSER_COMPANION_COMMAND, path_env),
+    }
+}
+
+pub(crate) fn browser_preview_enable_command(config_path: &str) -> String {
+    format!(
+        "{} skills enable-browser-preview --config '{}'",
+        mvp::config::CLI_COMMAND_NAME,
+        config_path
+    )
+}
+
+pub(crate) fn browser_preview_unblock_command(config_path: &str) -> String {
+    format!(
+        "edit '{}' and remove `agent-browser` from [tools].shell_deny",
+        config_path
+    )
+}
+
+pub(crate) fn browser_preview_ready_command(config_path: &str) -> String {
+    format!(
+        "{} ask --config '{}' --message \"{}\"",
+        mvp::config::CLI_COMMAND_NAME,
+        config_path,
+        DEFAULT_BROWSER_PREVIEW_ASK_MESSAGE
+    )
+}
+
+pub(crate) fn ensure_browser_preview_config(config: &mut mvp::config::LoongClawConfig) -> bool {
+    let mut updated = false;
+
+    if config
+        .tools
+        .file_root
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("")
+        .is_empty()
+    {
+        config.tools.file_root = Some(
+            mvp::config::default_loongclaw_home()
+                .join("workspace")
+                .display()
+                .to_string(),
+        );
+        updated = true;
+    }
+
+    if !config.external_skills.enabled {
+        config.external_skills.enabled = true;
+        updated = true;
+    }
+    if !config.external_skills.auto_expose_installed {
+        config.external_skills.auto_expose_installed = true;
+        updated = true;
+    }
+
+    let command = mvp::tools::BROWSER_COMPANION_COMMAND;
+    let shell_denied = shell_policy_explicitly_denies_command(config, command);
+    let shell_default_allow = config
+        .tools
+        .shell_default_mode
+        .eq_ignore_ascii_case("allow");
+    let shell_allowed = config
+        .tools
+        .shell_allow
+        .iter()
+        .any(|entry| entry.eq_ignore_ascii_case(command));
+    if !shell_denied && !shell_default_allow && !shell_allowed {
+        config.tools.shell_allow.push(command.to_owned());
+        updated = true;
+    }
+
+    updated
+}
+pub(crate) fn bundled_skill_install_path(config: &mvp::config::LoongClawConfig) -> PathBuf {
+    let install_root = config
+        .external_skills
+        .resolved_install_root()
+        .unwrap_or_else(|| {
+            config
+                .tools
+                .resolved_file_root()
+                .join("external-skills-installed")
+        });
+    install_root.join(BROWSER_PREVIEW_SKILL_ID).join("SKILL.md")
+}
+
+pub(crate) fn shell_policy_allows_command(
+    config: &mvp::config::LoongClawConfig,
+    command: &str,
+) -> bool {
+    if shell_policy_explicitly_denies_command(config, command) {
+        return false;
+    }
+    if config
+        .tools
+        .shell_allow
+        .iter()
+        .any(|entry| entry.eq_ignore_ascii_case(command))
+    {
+        return true;
+    }
+    config
+        .tools
+        .shell_default_mode
+        .eq_ignore_ascii_case("allow")
+}
+
+pub(crate) fn shell_policy_explicitly_denies_command(
+    config: &mvp::config::LoongClawConfig,
+    command: &str,
+) -> bool {
+    config
+        .tools
+        .shell_deny
+        .iter()
+        .any(|entry| entry.eq_ignore_ascii_case(command))
+}
+
+pub(crate) fn browser_preview_check(
+    config: &mvp::config::LoongClawConfig,
+    path_env: Option<&OsStr>,
+) -> Option<crate::doctor_cli::DoctorCheck> {
+    let state = inspect_browser_preview_state_with_path_env(config, path_env);
+    if !state.has_preview_intent() {
+        return None;
+    }
+
+    if state.ready() {
+        return Some(crate::doctor_cli::DoctorCheck {
+            name: "browser companion preview".to_owned(),
+            level: crate::doctor_cli::DoctorCheckLevel::Pass,
+            detail: "managed preview is ready".to_owned(),
+        });
+    }
+
+    let mut missing = Vec::new();
+    if !state.runtime_enabled {
+        missing.push("external skills runtime is disabled");
+    }
+    if !state.auto_expose_installed {
+        missing.push("installed skills are not auto-exposed");
+    }
+    if !state.skill_installed {
+        missing.push("helper skill is not installed");
+    }
+    if state.explicit_shell_deny {
+        missing.push("shell policy hard-denies `agent-browser`");
+    } else if !state.shell_allowed {
+        missing.push("shell policy does not allow `agent-browser`");
+    }
+    if !state.runtime_available {
+        missing.push("`agent-browser` is not on PATH");
+    }
+
+    Some(crate::doctor_cli::DoctorCheck {
+        name: "browser companion preview".to_owned(),
+        level: crate::doctor_cli::DoctorCheckLevel::Warn,
+        detail: format!("not ready ({})", missing.join("; ")),
+    })
+}
+
+fn command_on_path(command: &str, path_env: Option<&OsStr>) -> bool {
+    let Some(path_env) = path_env else {
+        return false;
+    };
+    env::split_paths(path_env).any(|dir| {
+        command_candidates(command)
+            .into_iter()
+            .map(|candidate| dir.join(candidate))
+            .any(|candidate| command_candidate_is_available(&candidate))
+    })
+}
+
+fn command_candidates(command: &str) -> Vec<&str> {
+    #[cfg(windows)]
+    {
+        vec![
+            command,
+            "agent-browser.exe",
+            "agent-browser.cmd",
+            "agent-browser.bat",
+            "agent-browser.com",
+        ]
+    }
+    #[cfg(not(windows))]
+    {
+        vec![command]
+    }
+}
+
+#[cfg(unix)]
+fn command_candidate_is_available(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::metadata(path)
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(windows)]
+fn command_candidate_is_available(path: &std::path::Path) -> bool {
+    path.is_file()
+}

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::env;
+use std::ffi::OsStr;
 use std::fs;
 use std::path::Path;
 
@@ -132,6 +133,11 @@ pub async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
 
     checks.extend(check_feishu_integration(&config, options.fix, &mut fixes));
     checks.extend(check_channel_surfaces(&config));
+    let path_env = env::var_os("PATH");
+    checks.extend(crate::browser_preview::browser_preview_check(
+        &config,
+        path_env.as_deref(),
+    ));
 
     if options.fix && config_mutated {
         let path = config_path
@@ -1084,6 +1090,23 @@ fn build_doctor_next_steps(
     config: &mvp::config::LoongClawConfig,
     fix_requested: bool,
 ) -> Vec<String> {
+    let path_env = env::var_os("PATH");
+    build_doctor_next_steps_with_path_env(
+        checks,
+        config_path,
+        config,
+        fix_requested,
+        path_env.as_deref(),
+    )
+}
+
+fn build_doctor_next_steps_with_path_env(
+    checks: &[DoctorCheck],
+    config_path: &Path,
+    config: &mvp::config::LoongClawConfig,
+    fix_requested: bool,
+    path_env: Option<&OsStr>,
+) -> Vec<String> {
     let mut steps = Vec::new();
     let config_path_display = config_path.display().to_string();
     let rerun_command = format!(
@@ -1091,6 +1114,8 @@ fn build_doctor_next_steps(
         mvp::config::CLI_COMMAND_NAME,
         config_path_display
     );
+    let browser_preview =
+        crate::browser_preview::inspect_browser_preview_state_with_path_env(config, path_env);
 
     if !fix_requested
         && checks.iter().any(|check| {
@@ -1156,17 +1181,43 @@ fn build_doctor_next_steps(
     }
 
     if doctor_ready_for_first_turn(checks) {
-        for action in crate::next_actions::collect_setup_next_actions(config, &config_path_display)
-            .into_iter()
-            .take(2)
-        {
+        for action in select_doctor_first_turn_actions(
+            crate::next_actions::collect_setup_next_actions_with_path_env(
+                config,
+                &config_path_display,
+                path_env,
+            ),
+        ) {
             let prefix = match action.kind {
                 crate::next_actions::SetupNextActionKind::Ask => "Try a one-shot task",
                 crate::next_actions::SetupNextActionKind::Chat => "Open interactive chat",
                 crate::next_actions::SetupNextActionKind::Channel => "Open a channel",
+                crate::next_actions::SetupNextActionKind::BrowserPreview => {
+                    match action.browser_preview_phase {
+                        Some(crate::next_actions::BrowserPreviewActionPhase::Enable) => {
+                            "Optional browser preview"
+                        }
+                        Some(crate::next_actions::BrowserPreviewActionPhase::Unblock) => {
+                            "Unblock browser preview"
+                        }
+                        Some(crate::next_actions::BrowserPreviewActionPhase::InstallRuntime) => {
+                            "Verify `agent-browser` is available"
+                        }
+                        Some(crate::next_actions::BrowserPreviewActionPhase::Ready) | None => {
+                            "Try browser companion preview"
+                        }
+                    }
+                }
                 crate::next_actions::SetupNextActionKind::Doctor => "Run diagnostics",
             };
             push_unique_step(&mut steps, format!("{prefix}: {}", action.command));
+        }
+        if !browser_preview.runtime_available {
+            push_unique_step(
+                &mut steps,
+                "Install `agent-browser` and verify the CLI is available on PATH: agent-browser --help"
+                    .to_owned(),
+            );
         }
     }
 
@@ -1188,6 +1239,62 @@ fn doctor_ready_for_first_turn(checks: &[DoctorCheck]) -> bool {
         && checks.iter().any(|check| {
             check.name == "provider credentials" && check.level == DoctorCheckLevel::Pass
         })
+}
+
+fn select_doctor_first_turn_actions(
+    actions: Vec<crate::next_actions::SetupNextAction>,
+) -> Vec<crate::next_actions::SetupNextAction> {
+    let mut prioritized = Vec::new();
+
+    push_first_matching_action(&mut prioritized, &actions, |action| {
+        action.kind == crate::next_actions::SetupNextActionKind::Ask
+    });
+    push_first_matching_action(&mut prioritized, &actions, |action| {
+        action.kind == crate::next_actions::SetupNextActionKind::Chat
+    });
+    push_first_matching_action(&mut prioritized, &actions, |action| {
+        action.kind == crate::next_actions::SetupNextActionKind::BrowserPreview
+            && matches!(
+                action.browser_preview_phase,
+                Some(crate::next_actions::BrowserPreviewActionPhase::Ready)
+                    | Some(crate::next_actions::BrowserPreviewActionPhase::Unblock)
+                    | Some(crate::next_actions::BrowserPreviewActionPhase::Enable)
+            )
+    });
+
+    for action in actions {
+        push_unique_action(&mut prioritized, action);
+        if prioritized.len() == 3 {
+            break;
+        }
+    }
+
+    prioritized.truncate(3);
+    prioritized
+}
+
+fn push_first_matching_action<F>(
+    prioritized: &mut Vec<crate::next_actions::SetupNextAction>,
+    actions: &[crate::next_actions::SetupNextAction],
+    predicate: F,
+) where
+    F: Fn(&crate::next_actions::SetupNextAction) -> bool,
+{
+    if let Some(action) = actions.iter().find(|action| predicate(action)) {
+        push_unique_action(prioritized, action.clone());
+    }
+}
+
+fn push_unique_action(
+    prioritized: &mut Vec<crate::next_actions::SetupNextAction>,
+    action: crate::next_actions::SetupNextAction,
+) {
+    if prioritized
+        .iter()
+        .all(|existing| existing.command != action.command)
+    {
+        prioritized.push(action);
+    }
 }
 
 fn push_unique_step(steps: &mut Vec<String>, step: String) {
@@ -1957,6 +2064,69 @@ mod tests {
                 step == "Open interactive chat: loongclaw chat --config '/tmp/loongclaw.toml'"
             }),
             "green doctor runs should still advertise chat as the follow-up path: {next_steps:#?}"
+        );
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Optional browser preview: loongclaw skills enable-browser-preview --config '/tmp/loongclaw.toml'"
+            }),
+            "green doctor runs should surface the optional browser preview with a single concrete command: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_guides_browser_companion_preview_setup() {
+        let checks = vec![DoctorCheck {
+            name: "provider credentials".to_owned(),
+            level: DoctorCheckLevel::Pass,
+            detail: "provider credentials are available".to_owned(),
+        }];
+        let config = mvp::config::LoongClawConfig::default();
+
+        let next_steps = build_doctor_next_steps_with_path_env(
+            &checks,
+            Path::new("/tmp/loongclaw.toml"),
+            &config,
+            false,
+            Some(std::ffi::OsStr::new("")),
+        );
+
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Optional browser preview: loongclaw skills enable-browser-preview --config '/tmp/loongclaw.toml'"
+            }),
+            "doctor should collapse preview setup into one operator-facing enable step by default: {next_steps:#?}"
+        );
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Install `agent-browser` and verify the CLI is available on PATH: agent-browser --help"
+            }),
+            "doctor should still point to the missing agent-browser runtime dependency: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_keeps_browser_preview_visible_when_channels_are_enabled() {
+        let checks = vec![DoctorCheck {
+            name: "provider credentials".to_owned(),
+            level: DoctorCheckLevel::Pass,
+            detail: "provider credentials are available".to_owned(),
+        }];
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.telegram.enabled = true;
+
+        let next_steps = build_doctor_next_steps_with_path_env(
+            &checks,
+            Path::new("/tmp/loongclaw.toml"),
+            &config,
+            false,
+            Some(std::ffi::OsStr::new("")),
+        );
+
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Optional browser preview: loongclaw skills enable-browser-preview --config '/tmp/loongclaw.toml'"
+            }),
+            "doctor should keep a browser preview action visible even when channel actions are available: {next_steps:#?}"
         );
     }
 }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -35,6 +35,7 @@ pub use base64;
 pub use kernel;
 pub use sha2;
 
+pub mod browser_preview;
 pub mod doctor_cli;
 pub mod feishu_cli;
 pub mod feishu_support;

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -378,7 +378,6 @@ async fn main() {
         Commands::Feishu { command } => feishu_cli::run_feishu_command(command).await,
     };
     if let Err(error) = result {
-        // startup error reporting
         #[allow(clippy::print_stderr)]
         {
             eprintln!("error: {error}");

--- a/crates/daemon/src/next_actions.rs
+++ b/crates/daemon/src/next_actions.rs
@@ -104,8 +104,8 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
             Some(SetupNextAction {
                 kind: SetupNextActionKind::BrowserPreview,
                 browser_preview_phase: Some(BrowserPreviewActionPhase::InstallRuntime),
-                label: "agent-browser check".to_owned(),
-                command: "agent-browser --help".to_owned(),
+                label: format!("{} check", mvp::tools::BROWSER_COMPANION_COMMAND),
+                command: format!("{} --help", mvp::tools::BROWSER_COMPANION_COMMAND),
             })
         } else {
             None
@@ -268,6 +268,34 @@ mod tests {
         fs::remove_dir_all(&root).ok();
     }
 
+    #[test]
+    fn collect_setup_next_actions_guides_browser_preview_enable_when_not_configured() {
+        let root = unique_temp_dir("loongclaw-next-actions-browser-companion-enable");
+        let bin_dir = root.join("bin");
+        write_fake_agent_browser(&bin_dir);
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.file_root = Some(root.display().to_string());
+
+        let actions = collect_setup_next_actions_with_path_env(
+            &config,
+            "/tmp/loongclaw.toml",
+            Some(bin_dir.as_os_str()),
+        );
+
+        assert_eq!(actions[2].kind, SetupNextActionKind::BrowserPreview);
+        assert_eq!(
+            actions[2].browser_preview_phase,
+            Some(BrowserPreviewActionPhase::Enable)
+        );
+        assert!(
+            actions[2].command.contains("enable-browser-preview"),
+            "browser preview enable action should point operators at the preview bootstrap command: {actions:#?}"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
     #[cfg(unix)]
     #[test]
     fn collect_setup_next_actions_requires_an_executable_agent_browser_binary() {
@@ -299,8 +327,14 @@ mod tests {
             actions[2].browser_preview_phase,
             Some(BrowserPreviewActionPhase::InstallRuntime)
         );
-        assert_eq!(actions[2].label, "agent-browser check");
-        assert_eq!(actions[2].command, "agent-browser --help");
+        assert_eq!(
+            actions[2].label,
+            format!("{} check", mvp::tools::BROWSER_COMPANION_COMMAND)
+        );
+        assert_eq!(
+            actions[2].command,
+            format!("{} --help", mvp::tools::BROWSER_COMPANION_COMMAND)
+        );
 
         fs::remove_dir_all(&root).ok();
     }

--- a/crates/daemon/src/next_actions.rs
+++ b/crates/daemon/src/next_actions.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsStr;
+
 use loongclaw_app as mvp;
 
 pub use mvp::chat::DEFAULT_FIRST_PROMPT as DEFAULT_FIRST_ASK_MESSAGE;
@@ -7,12 +9,22 @@ pub enum SetupNextActionKind {
     Ask,
     Chat,
     Channel,
+    BrowserPreview,
     Doctor,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BrowserPreviewActionPhase {
+    Ready,
+    Unblock,
+    Enable,
+    InstallRuntime,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetupNextAction {
     pub kind: SetupNextActionKind,
+    pub browser_preview_phase: Option<BrowserPreviewActionPhase>,
     pub label: String,
     pub command: String,
 }
@@ -21,10 +33,22 @@ pub fn collect_setup_next_actions(
     config: &mvp::config::LoongClawConfig,
     config_path: &str,
 ) -> Vec<SetupNextAction> {
+    let path_env = std::env::var_os("PATH");
+    collect_setup_next_actions_with_path_env(config, config_path, path_env.as_deref())
+}
+
+pub(crate) fn collect_setup_next_actions_with_path_env(
+    config: &mvp::config::LoongClawConfig,
+    config_path: &str,
+    path_env: Option<&OsStr>,
+) -> Vec<SetupNextAction> {
     let mut actions = Vec::new();
+    let browser_preview =
+        crate::browser_preview::inspect_browser_preview_state_with_path_env(config, path_env);
     if config.cli.enabled {
         actions.push(SetupNextAction {
             kind: SetupNextActionKind::Ask,
+            browser_preview_phase: None,
             label: "ask example".to_owned(),
             command: format!(
                 "{} ask --config '{}' --message \"{}\"",
@@ -35,6 +59,7 @@ pub fn collect_setup_next_actions(
         });
         actions.push(SetupNextAction {
             kind: SetupNextActionKind::Chat,
+            browser_preview_phase: None,
             label: "chat".to_owned(),
             command: format!(
                 "{} chat --config '{}'",
@@ -48,13 +73,51 @@ pub fn collect_setup_next_actions(
             .into_iter()
             .map(|action| SetupNextAction {
                 kind: SetupNextActionKind::Channel,
+                browser_preview_phase: None,
                 label: action.label.to_owned(),
                 command: action.command,
             }),
     );
+    if config.cli.enabled {
+        let preview_action = if browser_preview.ready() {
+            Some(SetupNextAction {
+                kind: SetupNextActionKind::BrowserPreview,
+                browser_preview_phase: Some(BrowserPreviewActionPhase::Ready),
+                label: crate::browser_preview::BROWSER_PREVIEW_READY_LABEL.to_owned(),
+                command: crate::browser_preview::browser_preview_ready_command(config_path),
+            })
+        } else if browser_preview.needs_shell_unblock() {
+            Some(SetupNextAction {
+                kind: SetupNextActionKind::BrowserPreview,
+                browser_preview_phase: Some(BrowserPreviewActionPhase::Unblock),
+                label: crate::browser_preview::BROWSER_PREVIEW_UNBLOCK_LABEL.to_owned(),
+                command: crate::browser_preview::browser_preview_unblock_command(config_path),
+            })
+        } else if browser_preview.needs_enable_command() {
+            Some(SetupNextAction {
+                kind: SetupNextActionKind::BrowserPreview,
+                browser_preview_phase: Some(BrowserPreviewActionPhase::Enable),
+                label: crate::browser_preview::BROWSER_PREVIEW_ENABLE_LABEL.to_owned(),
+                command: crate::browser_preview::browser_preview_enable_command(config_path),
+            })
+        } else if browser_preview.needs_runtime_install() {
+            Some(SetupNextAction {
+                kind: SetupNextActionKind::BrowserPreview,
+                browser_preview_phase: Some(BrowserPreviewActionPhase::InstallRuntime),
+                label: "agent-browser check".to_owned(),
+                command: "agent-browser --help".to_owned(),
+            })
+        } else {
+            None
+        };
+        if let Some(action) = preview_action {
+            actions.push(action);
+        }
+    }
     if actions.is_empty() {
         actions.push(SetupNextAction {
             kind: SetupNextActionKind::Doctor,
+            browser_preview_phase: None,
             label: "doctor".to_owned(),
             command: format!(
                 "{} doctor --config {}",
@@ -64,4 +127,181 @@ pub fn collect_setup_next_actions(
         });
     }
     actions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    fn write_file(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent directory");
+        }
+        fs::write(path, content).expect("write fixture");
+    }
+
+    #[cfg(unix)]
+    fn write_fake_agent_browser(bin_dir: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = bin_dir.join("agent-browser");
+        fs::create_dir_all(bin_dir).expect("create bin dir");
+        fs::write(&path, "#!/bin/sh\nexit 0\n").expect("write fake agent-browser");
+        let mut permissions = fs::metadata(&path).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).expect("set executable bit");
+    }
+
+    #[cfg(windows)]
+    fn write_fake_agent_browser(bin_dir: &Path) {
+        fs::create_dir_all(bin_dir).expect("create bin dir");
+        fs::write(bin_dir.join("agent-browser.exe"), b"").expect("write fake agent-browser");
+    }
+
+    #[cfg(unix)]
+    fn write_non_executable_agent_browser(bin_dir: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = bin_dir.join("agent-browser");
+        fs::create_dir_all(bin_dir).expect("create bin dir");
+        fs::write(&path, "#!/bin/sh\nexit 0\n").expect("write fake agent-browser");
+        let mut permissions = fs::metadata(&path).expect("metadata").permissions();
+        permissions.set_mode(0o644);
+        fs::set_permissions(&path, permissions).expect("clear executable bit");
+    }
+
+    #[test]
+    fn collect_setup_next_actions_promotes_browser_companion_preview_when_ready() {
+        let root = unique_temp_dir("loongclaw-next-actions-browser-companion");
+        let install_root = root.join("managed-skills");
+        write_file(
+            &install_root,
+            "browser-companion-preview/SKILL.md",
+            "# Browser Companion Preview\n\nUse agent-browser through shell.exec.\n",
+        );
+        let bin_dir = root.join("bin");
+        write_fake_agent_browser(&bin_dir);
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.file_root = Some(root.display().to_string());
+        config.tools.shell_allow.push("agent-browser".to_owned());
+        config.external_skills.enabled = true;
+        config.external_skills.auto_expose_installed = true;
+        config.external_skills.install_root = Some(install_root.display().to_string());
+
+        let actions = collect_setup_next_actions_with_path_env(
+            &config,
+            "/tmp/loongclaw.toml",
+            Some(bin_dir.as_os_str()),
+        );
+
+        assert_eq!(actions[0].kind, SetupNextActionKind::Ask);
+        assert_eq!(actions[1].kind, SetupNextActionKind::Chat);
+        assert_eq!(actions[2].kind, SetupNextActionKind::BrowserPreview);
+        assert_eq!(
+            actions[2].browser_preview_phase,
+            Some(BrowserPreviewActionPhase::Ready)
+        );
+        assert_eq!(actions[2].label, "browser companion preview");
+        assert!(
+            actions[2]
+                .command
+                .contains("Use external_skills.invoke to load browser-companion-preview"),
+            "ready preview action should hand users into a truthful one-shot ask flow: {actions:#?}"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn collect_setup_next_actions_guides_browser_preview_shell_unblock_when_hard_denied() {
+        let root = unique_temp_dir("loongclaw-next-actions-browser-companion-shell-deny");
+        let install_root = root.join("managed-skills");
+        write_file(
+            &install_root,
+            "browser-companion-preview/SKILL.md",
+            "# Browser Companion Preview\n\nUse agent-browser through shell.exec.\n",
+        );
+        let bin_dir = root.join("bin");
+        write_fake_agent_browser(&bin_dir);
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.file_root = Some(root.display().to_string());
+        config.tools.shell_deny.push("agent-browser".to_owned());
+        config.external_skills.enabled = true;
+        config.external_skills.auto_expose_installed = true;
+        config.external_skills.install_root = Some(install_root.display().to_string());
+
+        let actions = collect_setup_next_actions_with_path_env(
+            &config,
+            "/tmp/loongclaw.toml",
+            Some(bin_dir.as_os_str()),
+        );
+
+        assert_eq!(actions[2].kind, SetupNextActionKind::BrowserPreview);
+        assert_eq!(
+            actions[2].browser_preview_phase,
+            Some(BrowserPreviewActionPhase::Unblock)
+        );
+        assert_eq!(actions[2].label, "allow agent-browser");
+        assert!(
+            actions[2]
+                .command
+                .contains("remove `agent-browser` from [tools].shell_deny"),
+            "shell hard-deny should produce an unblock step instead of looping back to enable-browser-preview: {actions:#?}"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_setup_next_actions_requires_an_executable_agent_browser_binary() {
+        let root = unique_temp_dir("loongclaw-next-actions-browser-companion-nonexec");
+        let install_root = root.join("managed-skills");
+        write_file(
+            &install_root,
+            "browser-companion-preview/SKILL.md",
+            "# Browser Companion Preview\n\nUse agent-browser through shell.exec.\n",
+        );
+        let bin_dir = root.join("bin");
+        write_non_executable_agent_browser(&bin_dir);
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.file_root = Some(root.display().to_string());
+        config.tools.shell_allow.push("agent-browser".to_owned());
+        config.external_skills.enabled = true;
+        config.external_skills.auto_expose_installed = true;
+        config.external_skills.install_root = Some(install_root.display().to_string());
+
+        let actions = collect_setup_next_actions_with_path_env(
+            &config,
+            "/tmp/loongclaw.toml",
+            Some(bin_dir.as_os_str()),
+        );
+
+        assert_eq!(actions[2].kind, SetupNextActionKind::BrowserPreview);
+        assert_eq!(
+            actions[2].browser_preview_phase,
+            Some(BrowserPreviewActionPhase::InstallRuntime)
+        );
+        assert_eq!(actions[2].label, "agent-browser check");
+        assert_eq!(actions[2].command, "agent-browser --help");
+
+        fs::remove_dir_all(&root).ok();
+    }
 }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -418,6 +418,7 @@ pub enum OnboardingActionKind {
     Ask,
     Chat,
     Channel,
+    BrowserPreview,
     Doctor,
 }
 
@@ -2476,6 +2477,9 @@ fn build_onboarding_success_summary_with_memory(
                 crate::next_actions::SetupNextActionKind::Ask => OnboardingActionKind::Ask,
                 crate::next_actions::SetupNextActionKind::Chat => OnboardingActionKind::Chat,
                 crate::next_actions::SetupNextActionKind::Channel => OnboardingActionKind::Channel,
+                crate::next_actions::SetupNextActionKind::BrowserPreview => {
+                    OnboardingActionKind::BrowserPreview
+                }
                 crate::next_actions::SetupNextActionKind::Doctor => OnboardingActionKind::Doctor,
             },
             label: action.label,

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -359,18 +359,28 @@ fn execute_enable_browser_preview_command(
         );
     }
 
-    let mut outcome = execute_install_bundled_skill_command(
+    if config_updated {
+        persist_config_update(resolved_path, &updated_config)?;
+    }
+    let install_result = execute_install_bundled_skill_command(
         resolved_path,
         &updated_config,
         crate::browser_preview::BROWSER_PREVIEW_SKILL_ID,
         replace
             || crate::browser_preview::inspect_browser_preview_state(&updated_config)
                 .skill_installed,
-    )?;
-
-    if config_updated {
-        persist_config_update(resolved_path, &updated_config)?;
-    }
+    );
+    let mut outcome = match install_result {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            if config_updated {
+                persist_config_update(resolved_path, config).map_err(|rollback_error| {
+                    format!("{error}; browser preview config rollback failed: {rollback_error}")
+                })?;
+            }
+            return Err(error);
+        }
+    };
     *config = updated_config;
 
     if let Some(payload) = outcome.payload.as_object_mut() {

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -20,6 +20,17 @@ pub enum SkillsCommands {
         #[arg(long, default_value_t = false)]
         replace: bool,
     },
+    /// Install a first-party bundled managed external skill
+    InstallBundled {
+        skill_id: String,
+        #[arg(long, default_value_t = false)]
+        replace: bool,
+    },
+    /// Enable the managed browser preview flow and install its bundled helper skill
+    EnableBrowserPreview {
+        #[arg(long, default_value_t = false)]
+        replace: bool,
+    },
     /// Remove an installed managed external skill
     Remove { skill_id: String },
     /// Inspect or update persisted runtime policy for external skills
@@ -40,6 +51,8 @@ pub enum SkillsPolicyCommands {
         enabled: Option<bool>,
         #[arg(long)]
         require_download_approval: Option<bool>,
+        #[arg(long)]
+        auto_expose_installed: Option<bool>,
         #[arg(long = "allow-domain")]
         allowed_domains: Vec<String>,
         #[arg(long, default_value_t = false)]
@@ -91,23 +104,48 @@ pub fn execute_skills_command(options: SkillsCommandOptions) -> CliResult<Skills
         SkillsCommands::Policy { command } => {
             execute_policy_command(&resolved_path, &mut config, command)?
         }
+        SkillsCommands::EnableBrowserPreview { replace } => {
+            execute_enable_browser_preview_command(&resolved_path, &mut config, replace)?
+        }
         command @ (SkillsCommands::List
         | SkillsCommands::Info { .. }
         | SkillsCommands::Install { .. }
+        | SkillsCommands::InstallBundled { .. }
         | SkillsCommands::Remove { .. }) => {
-            let tool_runtime_config =
-                mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
-                    &config,
-                    Some(&resolved_path),
-                );
-            let request = build_skills_tool_request(command)?;
-            mvp::tools::execute_tool_core_with_config(request, &tool_runtime_config)?
+            execute_non_policy_skills_command(&resolved_path, &config, command)?
         }
     };
     Ok(SkillsCommandExecution {
         resolved_config_path: resolved_path.display().to_string(),
         outcome,
     })
+}
+
+fn execute_non_policy_skills_command(
+    resolved_path: &Path,
+    config: &mvp::config::LoongClawConfig,
+    command: SkillsCommands,
+) -> CliResult<ToolCoreOutcome> {
+    match command {
+        SkillsCommands::InstallBundled { skill_id, replace } => {
+            execute_install_bundled_skill_command(resolved_path, config, &skill_id, replace)
+        }
+        command @ (SkillsCommands::List
+        | SkillsCommands::Info { .. }
+        | SkillsCommands::Install { .. }
+        | SkillsCommands::Remove { .. }) => {
+            let tool_runtime_config =
+                mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+                    config,
+                    Some(resolved_path),
+                );
+            let request = build_skills_tool_request(command)?;
+            mvp::tools::execute_tool_core_with_config(request, &tool_runtime_config)
+        }
+        SkillsCommands::Policy { .. } | SkillsCommands::EnableBrowserPreview { .. } => {
+            Err("unexpected skills CLI command routed through non-policy execution path".to_owned())
+        }
+    }
 }
 
 fn build_skills_tool_request(command: SkillsCommands) -> CliResult<ToolCoreRequest> {
@@ -137,6 +175,9 @@ fn build_skills_tool_request(command: SkillsCommands) -> CliResult<ToolCoreReque
                 tool_name: "external_skills.install".to_owned(),
                 payload: Value::Object(payload),
             })
+        }
+        SkillsCommands::InstallBundled { .. } | SkillsCommands::EnableBrowserPreview { .. } => {
+            Err("bundled skills install requests are handled directly by the daemon CLI".to_owned())
         }
         SkillsCommands::Remove { skill_id } => Ok(ToolCoreRequest {
             tool_name: "external_skills.remove".to_owned(),
@@ -175,6 +216,7 @@ fn execute_policy_command(
             config.external_skills.require_download_approval = defaults.require_download_approval;
             config.external_skills.allowed_domains = defaults.allowed_domains;
             config.external_skills.blocked_domains = defaults.blocked_domains;
+            config.external_skills.auto_expose_installed = defaults.auto_expose_installed;
             persist_config_update(resolved_path, config)?;
             Ok(ToolCoreOutcome {
                 status: "ok".to_owned(),
@@ -191,6 +233,7 @@ fn execute_policy_command(
         SkillsPolicyCommands::Set {
             enabled,
             require_download_approval,
+            auto_expose_installed,
             allowed_domains,
             clear_allowed_domains,
             blocked_domains,
@@ -212,6 +255,7 @@ fn execute_policy_command(
 
             let has_mutation = enabled.is_some()
                 || require_download_approval.is_some()
+                || auto_expose_installed.is_some()
                 || clear_allowed_domains
                 || !allowed_domains.is_empty()
                 || clear_blocked_domains
@@ -226,6 +270,9 @@ fn execute_policy_command(
             }
             if let Some(require_download_approval) = require_download_approval {
                 config.external_skills.require_download_approval = require_download_approval;
+            }
+            if let Some(auto_expose_installed) = auto_expose_installed {
+                config.external_skills.auto_expose_installed = auto_expose_installed;
             }
             if clear_allowed_domains {
                 config.external_skills.allowed_domains.clear();
@@ -273,6 +320,73 @@ fn persist_config_update(
 ) -> CliResult<()> {
     let path = resolved_path.to_string_lossy();
     mvp::config::write(Some(path.as_ref()), config, true).map(|_| ())
+}
+
+fn execute_install_bundled_skill_command(
+    resolved_path: &Path,
+    config: &mvp::config::LoongClawConfig,
+    skill_id: &str,
+    replace: bool,
+) -> CliResult<ToolCoreOutcome> {
+    let tool_runtime_config = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+        config,
+        Some(resolved_path),
+    );
+    let request = ToolCoreRequest {
+        tool_name: "external_skills.install".to_owned(),
+        payload: json!({
+            "bundled_skill_id": skill_id,
+            "replace": replace,
+        }),
+    };
+    mvp::tools::execute_tool_core_with_config(request, &tool_runtime_config)
+}
+
+fn execute_enable_browser_preview_command(
+    resolved_path: &Path,
+    config: &mut mvp::config::LoongClawConfig,
+    replace: bool,
+) -> CliResult<ToolCoreOutcome> {
+    let mut updated_config = config.clone();
+    let config_updated = crate::browser_preview::ensure_browser_preview_config(&mut updated_config);
+    if crate::browser_preview::shell_policy_explicitly_denies_command(
+        &updated_config,
+        mvp::tools::BROWSER_COMPANION_COMMAND,
+    ) {
+        return Err(
+            "browser preview cannot be enabled while [tools].shell_deny blocks `agent-browser`; remove that entry and retry"
+                .to_owned(),
+        );
+    }
+
+    let mut outcome = execute_install_bundled_skill_command(
+        resolved_path,
+        &updated_config,
+        crate::browser_preview::BROWSER_PREVIEW_SKILL_ID,
+        replace
+            || crate::browser_preview::inspect_browser_preview_state(&updated_config)
+                .skill_installed,
+    )?;
+
+    if config_updated {
+        persist_config_update(resolved_path, &updated_config)?;
+    }
+    *config = updated_config;
+
+    if let Some(payload) = outcome.payload.as_object_mut() {
+        payload.insert(
+            "tool_name".to_owned(),
+            json!("skills.enable-browser-preview"),
+        );
+        payload.insert("config_updated".to_owned(), json!(config_updated));
+        payload.insert("browser_preview_enabled".to_owned(), json!(true));
+        payload.insert(
+            "runtime_binary_available".to_owned(),
+            json!(crate::browser_preview::inspect_browser_preview_state(config).runtime_available),
+        );
+    }
+
+    Ok(outcome)
 }
 
 fn persistent_policy_payload(config: &mvp::config::LoongClawConfig) -> Value {
@@ -408,7 +522,7 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                 }
             }
         }
-        "external_skills.install" => {
+        "external_skills.install" | "skills.enable-browser-preview" => {
             lines.push(format!(
                 "installed skill_id={}",
                 payload
@@ -444,6 +558,22 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                     .and_then(Value::as_bool)
                     .unwrap_or(false)
             ));
+            if tool_name == "skills.enable-browser-preview" {
+                lines.push(format!(
+                    "config_updated={}",
+                    payload
+                        .get("config_updated")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false)
+                ));
+                lines.push(format!(
+                    "runtime_binary_available={}",
+                    payload
+                        .get("runtime_binary_available")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false)
+                ));
+            }
         }
         "external_skills.remove" => {
             lines.push(format!(

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -4155,10 +4155,11 @@ fn onboarding_success_summary_advertises_browser_preview_enable_action() {
     );
     assert!(
         lines.iter().any(|line| {
-            line == "- enable browser preview: loongclaw skills enable-browser-preview --config"
+            line.contains("enable browser preview")
+                && line.contains("loongclaw skills enable-browser-preview --config")
         }) && lines
             .iter()
-            .any(|line| line == "  '/tmp/loongclaw-config.toml'"),
+            .any(|line| line.contains("/tmp/loongclaw-config.toml")),
         "success summary should render the browser preview enable action in the follow-up section: {lines:#?}"
     );
 }

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -4123,10 +4123,44 @@ fn onboarding_success_summary_derives_structured_actions() {
         summary.next_actions[3].kind,
         loongclaw_daemon::onboard_cli::OnboardingActionKind::Channel
     );
+    assert_eq!(
+        summary.next_actions[4].kind,
+        crate::onboard_cli::OnboardingActionKind::BrowserPreview
+    );
     assert_eq!(summary.next_actions[0].label, "ask example");
     assert_eq!(summary.next_actions[1].label, "chat");
     assert_eq!(summary.next_actions[2].label, "telegram");
     assert_eq!(summary.next_actions[3].label, "feishu");
+    assert_eq!(summary.next_actions[4].label, "enable browser preview");
+}
+
+#[test]
+fn onboarding_success_summary_advertises_browser_preview_enable_action() {
+    let path = PathBuf::from("/tmp/loongclaw-config.toml");
+    let summary = crate::onboard_cli::build_onboarding_success_summary(
+        &path,
+        &mvp::config::LoongClawConfig::default(),
+        None,
+    );
+    let lines = crate::onboard_cli::render_onboarding_success_summary_with_width(&summary, 80);
+
+    assert!(
+        summary.next_actions.iter().any(|action| {
+            action.kind == crate::onboard_cli::OnboardingActionKind::BrowserPreview
+                && action.label == "enable browser preview"
+                && action.command
+                    == "loongclaw skills enable-browser-preview --config '/tmp/loongclaw-config.toml'"
+        }),
+        "onboarding should surface a concrete browser preview enable step for operators: {summary:#?}"
+    );
+    assert!(
+        lines.iter().any(|line| {
+            line == "- enable browser preview: loongclaw skills enable-browser-preview --config"
+        }) && lines
+            .iter()
+            .any(|line| line == "  '/tmp/loongclaw-config.toml'"),
+        "success summary should render the browser preview enable action in the follow-up section: {lines:#?}"
+    );
 }
 
 #[test]

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -140,7 +140,9 @@ fn skills_install_cli_parses_global_flags_after_subcommand() {
                 other @ loongclaw_daemon::skills_cli::SkillsCommands::List
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled { .. }
-                | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                    ..
+                }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Remove { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Policy { .. } => {
                     panic!("unexpected skills subcommand parsed: {other:?}")
@@ -184,7 +186,9 @@ fn skills_install_bundled_cli_parses_global_flags_after_subcommand() {
                 other @ loongclaw_daemon::skills_cli::SkillsCommands::List
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
-                | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                    ..
+                }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Remove { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Policy { .. } => {
                     panic!("unexpected skills subcommand parsed: {other:?}")
@@ -218,9 +222,7 @@ fn skills_enable_browser_preview_cli_parses_global_flags_after_subcommand() {
             assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
             assert!(json);
             match command {
-                loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
-                    replace,
-                } => {
+                loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview { replace } => {
                     assert!(replace);
                 }
                 other @ loongclaw_daemon::skills_cli::SkillsCommands::List
@@ -292,7 +294,9 @@ fn skills_policy_set_cli_parses_domain_and_approval_flags() {
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled { .. }
-            | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview { .. }
+            | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                ..
+            }
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::Remove { .. } => {
                 panic!("unexpected skills subcommand parsed: {other:?}")
             }
@@ -348,10 +352,10 @@ fn execute_skills_command_enable_browser_preview_persists_runtime_and_installs_h
 
     let list = loongclaw_daemon::skills_cli::execute_skills_command(
         loongclaw_daemon::skills_cli::SkillsCommandOptions {
-        config: Some(config_path.display().to_string()),
-        json: false,
-        command: loongclaw_daemon::skills_cli::SkillsCommands::List,
-    },
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::List,
+        },
     )
     .expect("skills list should succeed after browser preview enable");
     assert!(
@@ -373,12 +377,12 @@ fn execute_skills_command_enable_browser_preview_is_idempotent_after_first_insta
 
     loongclaw_daemon::skills_cli::execute_skills_command(
         loongclaw_daemon::skills_cli::SkillsCommandOptions {
-        config: Some(config_path.display().to_string()),
-        json: false,
-        command: loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
-            replace: false,
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                replace: false,
+            },
         },
-    },
     )
     .expect("initial enable browser preview should succeed");
 
@@ -655,23 +659,23 @@ fn execute_skills_command_list_reports_scopes_and_shadowed_skills() {
 
     loongclaw_daemon::skills_cli::execute_skills_command(
         loongclaw_daemon::skills_cli::SkillsCommandOptions {
-        config: Some(config_path.display().to_string()),
-        json: false,
-        command: loongclaw_daemon::skills_cli::SkillsCommands::Install {
-            path: "source/demo-skill".to_owned(),
-            skill_id: None,
-            replace: false,
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Install {
+                path: "source/demo-skill".to_owned(),
+                skill_id: None,
+                replace: false,
+            },
         },
-    },
     )
     .expect("skills install should succeed");
 
     let list = loongclaw_daemon::skills_cli::execute_skills_command(
         loongclaw_daemon::skills_cli::SkillsCommandOptions {
-        config: Some(config_path.display().to_string()),
-        json: false,
-        command: loongclaw_daemon::skills_cli::SkillsCommands::List,
-    },
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::List,
+        },
     )
     .expect("skills list should succeed");
     assert_eq!(list.outcome.payload["skills"][0]["skill_id"], "demo-skill");
@@ -727,10 +731,10 @@ fn execute_skills_command_list_anchors_project_scope_to_config_directory_when_fi
 
     let list = loongclaw_daemon::skills_cli::execute_skills_command(
         loongclaw_daemon::skills_cli::SkillsCommandOptions {
-        config: Some(config_path.display().to_string()),
-        json: false,
-        command: loongclaw_daemon::skills_cli::SkillsCommands::List,
-    },
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::List,
+        },
     )
     .expect("skills list should succeed");
     let skills = list.outcome.payload["skills"]
@@ -785,10 +789,10 @@ fn execute_skills_command_list_prefers_nearest_project_ancestor_for_duplicate_sk
 
     let list = loongclaw_daemon::skills_cli::execute_skills_command(
         loongclaw_daemon::skills_cli::SkillsCommandOptions {
-        config: Some(config_path.display().to_string()),
-        json: false,
-        command: loongclaw_daemon::skills_cli::SkillsCommands::List,
-    },
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::List,
+        },
     )
     .expect("skills list should succeed");
     assert_eq!(list.outcome.payload["skills"][0]["skill_id"], "demo-skill");
@@ -854,12 +858,12 @@ fn execute_skills_command_installs_bundled_browser_companion_preview() {
 
     let info = loongclaw_daemon::skills_cli::execute_skills_command(
         loongclaw_daemon::skills_cli::SkillsCommandOptions {
-        config: Some(config_path.display().to_string()),
-        json: false,
-        command: loongclaw_daemon::skills_cli::SkillsCommands::Info {
-            skill_id: "browser-companion-preview".to_owned(),
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Info {
+                skill_id: "browser-companion-preview".to_owned(),
+            },
         },
-    },
     )
     .expect("bundled skills info should succeed");
     assert!(

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -523,6 +523,54 @@ fn execute_skills_command_enable_browser_preview_rolls_back_config_on_install_fa
     fs::remove_dir_all(&root).ok();
 }
 
+#[cfg(unix)]
+#[test]
+fn execute_skills_command_enable_browser_preview_rolls_back_skill_on_config_persist_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = unique_temp_dir("loongclaw-skills-cli-browser-preview-config-failure");
+    let install_root = root.join("managed-skills");
+    let config_path = root.join("loongclaw.toml");
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.tools.file_root = Some(root.display().to_string());
+    config.external_skills.install_root = Some(install_root.display().to_string());
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write config fixture");
+
+    let mut permissions = fs::metadata(&config_path)
+        .expect("read config file metadata")
+        .permissions();
+    permissions.set_mode(0o444);
+    fs::set_permissions(&config_path, permissions).expect("lock config file");
+
+    let error = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                replace: false,
+            },
+        },
+    )
+    .expect_err("enable browser preview should fail when config persistence fails");
+
+    assert!(
+        error.contains("Permission denied") || error.contains("permission denied"),
+        "error should surface the config write failure: {error}"
+    );
+    assert!(
+        !install_root.join("browser-companion-preview").exists(),
+        "failed config persistence should not leave the helper skill installed"
+    );
+
+    let mut cleanup_permissions = fs::metadata(&config_path)
+        .expect("read config file metadata for cleanup")
+        .permissions();
+    cleanup_permissions.set_mode(0o644);
+    fs::set_permissions(&config_path, cleanup_permissions).expect("unlock config file");
+    fs::remove_dir_all(&root).ok();
+}
+
 #[test]
 fn execute_skills_command_installs_lists_inspects_and_removes_skill() {
     let root = unique_temp_dir("loongclaw-skills-cli-install");

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -139,6 +139,8 @@ fn skills_install_cli_parses_global_flags_after_subcommand() {
                 }
                 other @ loongclaw_daemon::skills_cli::SkillsCommands::List
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Remove { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Policy { .. } => {
                     panic!("unexpected skills subcommand parsed: {other:?}")
@@ -146,6 +148,93 @@ fn skills_install_cli_parses_global_flags_after_subcommand() {
             }
         }
         other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn skills_install_bundled_cli_parses_global_flags_after_subcommand() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "skills",
+        "install-bundled",
+        "browser-companion-preview",
+        "--replace",
+        "--json",
+        "--config",
+        "/tmp/loongclaw.toml",
+    ])
+    .expect("skills install-bundled CLI should parse");
+
+    match cli.command {
+        Some(Commands::Skills {
+            config,
+            json,
+            command,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(json);
+            match command {
+                loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled {
+                    skill_id,
+                    replace,
+                } => {
+                    assert_eq!(skill_id, "browser-companion-preview");
+                    assert!(replace);
+                }
+                other @ loongclaw_daemon::skills_cli::SkillsCommands::List
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Remove { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Policy { .. } => {
+                    panic!("unexpected skills subcommand parsed: {other:?}")
+                }
+            }
+        }
+        Some(other) => panic!("unexpected command parsed: {other:?}"),
+        None => panic!("expected skills command to parse"),
+    }
+}
+
+#[test]
+fn skills_enable_browser_preview_cli_parses_global_flags_after_subcommand() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "skills",
+        "enable-browser-preview",
+        "--replace",
+        "--json",
+        "--config",
+        "/tmp/loongclaw.toml",
+    ])
+    .expect("skills enable-browser-preview CLI should parse");
+
+    match cli.command {
+        Some(Commands::Skills {
+            config,
+            json,
+            command,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(json);
+            match command {
+                loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                    replace,
+                } => {
+                    assert!(replace);
+                }
+                other @ loongclaw_daemon::skills_cli::SkillsCommands::List
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Remove { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Policy { .. } => {
+                    panic!("unexpected skills subcommand parsed: {other:?}")
+                }
+            }
+        }
+        Some(other) => panic!("unexpected command parsed: {other:?}"),
+        None => panic!("expected skills command to parse"),
     }
 }
 
@@ -160,6 +249,8 @@ fn skills_policy_set_cli_parses_domain_and_approval_flags() {
         "true",
         "--require-download-approval",
         "false",
+        "--auto-expose-installed",
+        "true",
         "--allow-domain",
         "skills.sh",
         "--allow-domain",
@@ -176,6 +267,7 @@ fn skills_policy_set_cli_parses_domain_and_approval_flags() {
                 loongclaw_daemon::skills_cli::SkillsPolicyCommands::Set {
                     enabled,
                     require_download_approval,
+                    auto_expose_installed,
                     allowed_domains,
                     blocked_domains,
                     approve_policy_update,
@@ -184,6 +276,7 @@ fn skills_policy_set_cli_parses_domain_and_approval_flags() {
                 } => {
                     assert_eq!(enabled, Some(true));
                     assert_eq!(require_download_approval, Some(false));
+                    assert_eq!(auto_expose_installed, Some(true));
                     assert_eq!(allowed_domains, vec!["skills.sh", "clawhub.io"]);
                     assert_eq!(blocked_domains, vec!["*.evil.example"]);
                     assert!(approve_policy_update);
@@ -198,12 +291,232 @@ fn skills_policy_set_cli_parses_domain_and_approval_flags() {
             other @ loongclaw_daemon::skills_cli::SkillsCommands::List
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
+            | other @ loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled { .. }
+            | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview { .. }
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::Remove { .. } => {
                 panic!("unexpected skills subcommand parsed: {other:?}")
             }
         },
         other => panic!("unexpected command parsed: {other:?}"),
     }
+}
+
+#[test]
+fn execute_skills_command_enable_browser_preview_persists_runtime_and_installs_helper_skill() {
+    let root = unique_temp_dir("loongclaw-skills-cli-browser-preview");
+    let config_path = write_external_skills_config(&root, false);
+
+    let enable = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                replace: false,
+            },
+        },
+    )
+    .expect("enable browser preview should succeed");
+
+    assert_eq!(
+        enable.outcome.payload["skill_id"],
+        "browser-companion-preview"
+    );
+    assert_eq!(
+        enable.outcome.payload["display_name"],
+        "Browser Companion Preview"
+    );
+
+    let reloaded = mvp::config::load(Some(config_path.to_string_lossy().as_ref()))
+        .expect("reload config")
+        .1;
+    assert!(
+        reloaded.external_skills.enabled,
+        "enable-browser-preview should persist external skills enablement"
+    );
+    assert!(
+        reloaded.external_skills.auto_expose_installed,
+        "enable-browser-preview should persist installed-skill auto exposure"
+    );
+    assert!(
+        reloaded
+            .tools
+            .shell_allow
+            .iter()
+            .any(|command| command == "agent-browser"),
+        "enable-browser-preview should allow the browser companion command through shell policy"
+    );
+
+    let list = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+        config: Some(config_path.display().to_string()),
+        json: false,
+        command: loongclaw_daemon::skills_cli::SkillsCommands::List,
+    },
+    )
+    .expect("skills list should succeed after browser preview enable");
+    assert!(
+        list.outcome.payload["skills"]
+            .as_array()
+            .expect("skills payload should be an array")
+            .iter()
+            .any(|skill| skill["skill_id"] == "browser-companion-preview"),
+        "browser preview helper skill should be installed into the managed skills runtime"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn execute_skills_command_enable_browser_preview_is_idempotent_after_first_install() {
+    let root = unique_temp_dir("loongclaw-skills-cli-browser-preview-idempotent");
+    let config_path = write_external_skills_config(&root, false);
+
+    loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+        config: Some(config_path.display().to_string()),
+        json: false,
+        command: loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+            replace: false,
+        },
+    },
+    )
+    .expect("initial enable browser preview should succeed");
+
+    let second = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                replace: false,
+            },
+        },
+    )
+    .expect("second enable browser preview should stay idempotent");
+
+    assert_eq!(
+        second.outcome.payload["skill_id"],
+        "browser-companion-preview"
+    );
+    assert_eq!(second.outcome.payload["replaced"], true);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn execute_skills_command_enable_browser_preview_rejects_explicit_shell_deny_without_mutation() {
+    let root = unique_temp_dir("loongclaw-skills-cli-browser-preview-shell-deny");
+    let config_path = write_external_skills_config(&root, false);
+    let config_string = config_path.display().to_string();
+    let (resolved_path, mut config) =
+        mvp::config::load(Some(config_string.as_str())).expect("load config");
+    config.tools.shell_deny.push("agent-browser".to_owned());
+    mvp::config::write(
+        Some(resolved_path.to_string_lossy().as_ref()),
+        &config,
+        true,
+    )
+    .expect("persist hard-deny fixture");
+
+    let error = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_string.clone()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                replace: false,
+            },
+        },
+    )
+    .expect_err("enable browser preview should reject an explicit shell deny");
+
+    assert!(
+        error.contains("shell_deny"),
+        "error should identify the blocking shell deny entry: {error}"
+    );
+
+    let (_, reloaded) =
+        mvp::config::load(Some(config_string.as_str())).expect("reload unchanged config");
+    assert!(
+        !reloaded.external_skills.enabled,
+        "failed enable should not flip external skills on"
+    );
+    assert!(
+        !reloaded.external_skills.auto_expose_installed,
+        "failed enable should not turn on installed-skill auto exposure"
+    );
+    assert!(
+        !reloaded
+            .tools
+            .shell_allow
+            .iter()
+            .any(|command| command == "agent-browser"),
+        "failed enable should not add agent-browser to shell allow"
+    );
+    assert!(
+        reloaded
+            .tools
+            .shell_deny
+            .iter()
+            .any(|command| command == "agent-browser"),
+        "explicit hard deny should be preserved for the operator to remove intentionally"
+    );
+    assert!(
+        !root
+            .join("managed-skills")
+            .join("browser-companion-preview")
+            .exists(),
+        "failed enable should not install the helper skill"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn execute_skills_command_enable_browser_preview_rolls_back_config_on_install_failure() {
+    let root = unique_temp_dir("loongclaw-skills-cli-browser-preview-install-failure");
+    let config_path = write_external_skills_config(&root, false);
+    let config_string = config_path.display().to_string();
+    fs::write(
+        root.join("managed-skills"),
+        "block install root with a file",
+    )
+    .expect("create install-root blocker");
+
+    let error = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_string.clone()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                replace: false,
+            },
+        },
+    )
+    .expect_err("enable browser preview should fail when the install root cannot be prepared");
+
+    assert!(
+        error.contains("failed to create external skills install root"),
+        "error should explain that the install root setup failed: {error}"
+    );
+
+    let (_, reloaded) =
+        mvp::config::load(Some(config_string.as_str())).expect("reload unchanged config");
+    assert!(
+        !reloaded.external_skills.enabled,
+        "failed enable should not persist external skills enablement"
+    );
+    assert!(
+        !reloaded.external_skills.auto_expose_installed,
+        "failed enable should not persist installed-skill auto exposure"
+    );
+    assert!(
+        !reloaded
+            .tools
+            .shell_allow
+            .iter()
+            .any(|command| command == "agent-browser"),
+        "failed enable should not persist agent-browser on the shell allow list"
+    );
+
+    fs::remove_dir_all(&root).ok();
 }
 
 #[test]
@@ -340,22 +653,26 @@ fn execute_skills_command_list_reports_scopes_and_shadowed_skills() {
     );
     let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
 
-    crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+    loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
         config: Some(config_path.display().to_string()),
         json: false,
-        command: crate::skills_cli::SkillsCommands::Install {
+        command: loongclaw_daemon::skills_cli::SkillsCommands::Install {
             path: "source/demo-skill".to_owned(),
             skill_id: None,
             replace: false,
         },
-    })
+    },
+    )
     .expect("skills install should succeed");
 
-    let list = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+    let list = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
         config: Some(config_path.display().to_string()),
         json: false,
-        command: crate::skills_cli::SkillsCommands::List,
-    })
+        command: loongclaw_daemon::skills_cli::SkillsCommands::List,
+    },
+    )
     .expect("skills list should succeed");
     assert_eq!(list.outcome.payload["skills"][0]["skill_id"], "demo-skill");
     assert_eq!(list.outcome.payload["skills"][0]["scope"], "managed");
@@ -363,8 +680,8 @@ fn execute_skills_command_list_reports_scopes_and_shadowed_skills() {
         list.outcome.payload["shadowed_skills"][0]["scope"],
         "project"
     );
-    let rendered =
-        crate::skills_cli::render_skills_cli_text(&list).expect("text rendering should succeed");
+    let rendered = loongclaw_daemon::skills_cli::render_skills_cli_text(&list)
+        .expect("text rendering should succeed");
     assert!(
         rendered.contains("scope=managed"),
         "CLI text should show resolved scope: {rendered}"
@@ -408,11 +725,13 @@ fn execute_skills_command_list_anchors_project_scope_to_config_directory_when_fi
     let env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
     let _cwd = SkillsCliCurrentDirGuard::set(&env, &outside);
 
-    let list = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+    let list = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
         config: Some(config_path.display().to_string()),
         json: false,
-        command: crate::skills_cli::SkillsCommands::List,
-    })
+        command: loongclaw_daemon::skills_cli::SkillsCommands::List,
+    },
+    )
     .expect("skills list should succeed");
     let skills = list.outcome.payload["skills"]
         .as_array()
@@ -464,11 +783,13 @@ fn execute_skills_command_list_prefers_nearest_project_ancestor_for_duplicate_sk
     let env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
     let _cwd = SkillsCliCurrentDirGuard::set(&env, &root.join("workspace/subdir"));
 
-    let list = crate::skills_cli::execute_skills_command(crate::skills_cli::SkillsCommandOptions {
+    let list = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
         config: Some(config_path.display().to_string()),
         json: false,
-        command: crate::skills_cli::SkillsCommands::List,
-    })
+        command: loongclaw_daemon::skills_cli::SkillsCommands::List,
+    },
+    )
     .expect("skills list should succeed");
     assert_eq!(list.outcome.payload["skills"][0]["skill_id"], "demo-skill");
     assert_eq!(list.outcome.payload["skills"][0]["scope"], "project");
@@ -499,6 +820,57 @@ fn execute_skills_command_list_prefers_nearest_project_ancestor_for_duplicate_sk
 
     fs::remove_dir_all(&root).ok();
     fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn execute_skills_command_installs_bundled_browser_companion_preview() {
+    let root = unique_temp_dir("loongclaw-skills-cli-bundled-install");
+    let config_path = write_external_skills_config(&root, true);
+
+    let install = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled {
+                skill_id: "browser-companion-preview".to_owned(),
+                replace: false,
+            },
+        },
+    )
+    .expect("bundled skills install should succeed");
+    assert_eq!(
+        install.outcome.payload["skill_id"],
+        "browser-companion-preview"
+    );
+    assert_eq!(
+        install.outcome.payload["display_name"],
+        "Browser Companion Preview"
+    );
+    assert_eq!(install.outcome.payload["source_kind"], "bundled");
+    assert_eq!(
+        install.outcome.payload["source_path"],
+        "bundled://browser-companion-preview"
+    );
+
+    let info = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+        config: Some(config_path.display().to_string()),
+        json: false,
+        command: loongclaw_daemon::skills_cli::SkillsCommands::Info {
+            skill_id: "browser-companion-preview".to_owned(),
+        },
+    },
+    )
+    .expect("bundled skills info should succeed");
+    assert!(
+        info.outcome.payload["instructions_preview"]
+            .as_str()
+            .expect("instructions preview should be text")
+            .contains("agent-browser"),
+        "bundled browser companion preview should teach the managed agent-browser flow"
+    );
+
+    fs::remove_dir_all(&root).ok();
 }
 
 #[test]
@@ -545,6 +917,7 @@ fn execute_skills_command_policy_round_trips_persisted_config() {
                 command: loongclaw_daemon::skills_cli::SkillsPolicyCommands::Set {
                     enabled: Some(true),
                     require_download_approval: Some(false),
+                    auto_expose_installed: Some(true),
                     allowed_domains: vec![
                         " Skills.SH ".to_owned(),
                         "clawhub.io".to_owned(),
@@ -574,6 +947,7 @@ fn execute_skills_command_policy_round_trips_persisted_config() {
         set.outcome.payload["policy"]["blocked_domains"],
         serde_json::json!(["*.evil.example"])
     );
+    assert_eq!(set.outcome.payload["policy"]["auto_expose_installed"], true);
 
     let (_, reloaded) =
         mvp::config::load(Some(config_string.as_str())).expect("reload updated config");
@@ -591,7 +965,7 @@ fn execute_skills_command_policy_round_trips_persisted_config() {
         reloaded.external_skills.install_root.as_deref(),
         Some(install_root.as_str())
     );
-    assert!(!reloaded.external_skills.auto_expose_installed);
+    assert!(reloaded.external_skills.auto_expose_installed);
 
     let reset = loongclaw_daemon::skills_cli::execute_skills_command(
         loongclaw_daemon::skills_cli::SkillsCommandOptions {
@@ -688,6 +1062,7 @@ fn execute_skills_command_policy_set_normalizes_domain_rules_for_persistence() {
                 command: loongclaw_daemon::skills_cli::SkillsPolicyCommands::Set {
                     enabled: Some(true),
                     require_download_approval: None,
+                    auto_expose_installed: None,
                     allowed_domains: vec!["https://Skills.SH/catalog".to_owned()],
                     clear_allowed_domains: false,
                     blocked_domains: vec!["HTTPS://evil.example/download".to_owned()],
@@ -736,6 +1111,7 @@ fn execute_skills_command_policy_set_requires_explicit_approval() {
                 command: loongclaw_daemon::skills_cli::SkillsPolicyCommands::Set {
                     enabled: Some(true),
                     require_download_approval: None,
+                    auto_expose_installed: None,
                     allowed_domains: Vec::new(),
                     clear_allowed_domains: false,
                     blocked_domains: Vec::new(),
@@ -775,6 +1151,7 @@ fn execute_skills_command_policy_set_rejects_invalid_domain_rules() {
                 command: loongclaw_daemon::skills_cli::SkillsPolicyCommands::Set {
                     enabled: Some(true),
                     require_download_approval: None,
+                    auto_expose_installed: None,
                     allowed_domains: vec!["not-a-domain".to_owned()],
                     clear_allowed_domains: false,
                     blocked_domains: Vec::new(),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # LoongClaw Roadmap
 
-Last updated: 2026-03-14
+Last updated: 2026-03-16
 
 This roadmap is execution-focused. Every stage has:
 
@@ -302,8 +302,13 @@ Remaining deliverables:
 - beginner installation hardening:
   - sustain tagged release publishing across macOS/Linux/Windows
   - expand beyond installer scripts into package-manager distribution only after release adoption is stable
+- managed browser automation companion:
+  - keep `browser.open`, `browser.extract`, and `browser.click` as the shipped safe browser lane
+  - add an optional first-party managed browser companion for richer page actions
+  - wire install, `onboard`, and `doctor` into companion presence, version, and isolated profile health
+  - expose richer browser automation only through truthful runtime-visible tool advertising and governed tool contracts
 - browser-facing assistant surface:
-  - WebChat implementation
+  - WebChat implementation as a thin shell over existing ask/chat and browser semantics, not a separate assistant runtime
 
 Acceptance criteria:
 

--- a/docs/plans/2026-03-16-browser-automation-companion-design.md
+++ b/docs/plans/2026-03-16-browser-automation-companion-design.md
@@ -1,0 +1,383 @@
+# Browser Automation Companion Design
+
+## Problem
+
+LoongClaw now ships a truthful first-MVP browser surface through
+`browser.open`, `browser.extract`, and `browser.click`. That closes the gap
+between "no visible web capability" and "the assistant can safely inspect and
+follow public pages".
+
+It does not yet close the next user-perceived gap:
+
+- non-developer users still cannot see LoongClaw complete common browser tasks
+  such as login, navigation, form entry, or screenshots
+- the current browser surface is intentionally limited to bounded HTML/session
+  navigation and cannot become a task-execution browser without breaking its
+  safety and packaging goals
+- simply preinstalling an `agent-browser` skill would help power users, but it
+  would not make the capability truthful, supported, or reliably available for
+  normal users
+
+Compared with OpenClaw, the next meaningful browser gap is not "missing every
+browser feature they expose". It is that LoongClaw still lacks a governed,
+installable, non-terminal path from "inspect a page" to "complete a page
+workflow".
+
+## Goal
+
+Define the next browser automation phase as a LoongClaw-native product slice
+that:
+
+1. preserves the shipped lightweight browser tools as the default safe lane
+2. adds a managed browser automation companion for richer page tasks
+3. keeps installation friction controlled through optional packaging rather than
+   forcing every user to install a heavyweight browser stack
+4. exposes richer browser automation only when the companion runtime is healthy,
+   enabled, and policy-allowed
+5. prepares WebChat or future control surfaces to reuse the same assistant
+   semantics instead of inventing a separate runtime
+
+## Non-Goals
+
+- replacing the shipped lightweight browser tools with a heavyweight browser
+  dependency
+- making Chromium/Playwright-style automation mandatory in the default install
+- giving the model raw shell-level access to an unmanaged browser CLI as the
+  primary browser API
+- using browser automation as a shortcut to store or transmit user passwords
+- shipping WebChat, dashboard controls, cron, or broader trigger automation in
+  this slice
+
+## Constraints
+
+- LoongClaw must remain truthful about what is actually usable. Browser
+  automation tools must not be advertised before the companion runtime, profile,
+  and policy gates are ready.
+- The base install story must continue to optimize for low friction. Heavy
+  browser dependencies can only land as an optional pack or companion runtime,
+  not as a new universal requirement.
+- The browser companion must fit LoongClaw's existing security model:
+  capabilities, approval gates, auditability, deterministic failure messages,
+  and user-visible health checks.
+- Browser profile isolation is mandatory. The product must not default to
+  reusing a user's personal browser profile.
+
+## Approach Options
+
+### Option A: Preinstall only the `agent-browser` skill
+
+Ship a bundled or preinstalled skill that teaches the agent how to call an
+external `agent-browser` CLI.
+
+Pros:
+
+- lowest implementation cost
+- gives advanced users a fast path immediately
+- creates a reusable workflow template for future browser sessions
+
+Cons:
+
+- the runtime still depends on a separately installed browser CLI and browser
+  engine
+- the capability is not truthful for normal users unless onboarding/doctor also
+  manage installation state
+- model-facing execution would still tend to collapse into `shell.exec` instead
+  of a governed browser API
+- session lifecycle, profile health, approval semantics, and structured errors
+  remain outside LoongClaw's main product surface
+
+### Option B: Managed browser automation companion with an optional helper skill
+
+Keep the current lightweight browser tools, add a first-party managed companion
+runtime for richer automation, and optionally preinstall a helper skill on top
+of that runtime.
+
+Pros:
+
+- preserves the low-friction shipped browser lane for public web inspection
+- adds a believable "page task execution" lane without polluting the default
+  install or tool surface
+- lets `onboard`, `doctor`, install scripts, and future WebChat reuse the same
+  runtime truth about readiness
+- keeps LoongClaw in control of capability policy, approval, audit events, and
+  tool schemas
+
+Cons:
+
+- requires new install/health/profile management work
+- adds a second browser lane that must be explained clearly
+- still needs careful tool design to avoid exposing a raw automation substrate
+
+### Option C: Full browser runtime inside core LoongClaw
+
+Make heavy browser automation a built-in always-available core tool family.
+
+Pros:
+
+- strongest parity signal against browser-heavy assistant products
+- simplest mental model once fully shipped
+
+Cons:
+
+- directly conflicts with the current install-friction reduction goal
+- pulls browser runtime, system dependency, and profile-management complexity
+  into the default binary path
+- increases support and CI surface before the non-terminal product shell exists
+
+## Decision
+
+Choose Option B.
+
+LoongClaw should treat richer browser automation as an optional but
+product-grade companion lane:
+
+- the existing `browser.open` / `browser.extract` / `browser.click` tools remain
+  the default safe browser surface
+- a managed browser automation companion provides interactive page actions for
+  users who opt in
+- an `agent-browser`-style helper skill may be bundled as a convenience layer,
+  but it is not the source of truth for runtime capability
+
+This gives LoongClaw the best path to "assistant can complete browser tasks"
+without undoing the distribution and safety gains that the MVP just made.
+
+## Product Model
+
+### 1. Two browser lanes, one product story
+
+LoongClaw should explicitly present browser capabilities as two lanes:
+
+1. **Safe Browser Lane**
+   - shipped by default
+   - public pages only
+   - bounded HTML/session inspection
+   - tools: `browser.open`, `browser.extract`, `browser.click`
+2. **Automation Companion Lane**
+   - optional installation
+   - isolated managed browser profile
+   - richer actions such as typing, waiting, screenshots, and multi-step page
+     navigation
+   - advertised only when the companion runtime is healthy and enabled
+
+The user story becomes coherent:
+
+- out of the box, LoongClaw can safely inspect the web
+- with the companion enabled, LoongClaw can complete supported browser tasks
+
+### 2. Browser automation companion packaging
+
+The richer lane should be packaged as a first-party managed companion runtime.
+
+Implementation direction:
+
+- distribute the companion as a separately installable pack or release artifact
+  instead of a mandatory default dependency
+- keep the install path operator-friendly:
+  - install script flag or optional pack selection
+  - `onboard` prompt to enable enhanced browser automation
+  - `doctor` checks for runtime presence, version compatibility, and browser
+    profile health
+- support an embedded helper skill on top of the companion for user education,
+  examples, and task recipes
+
+This keeps the base LoongClaw binary lean while still making the richer browser
+lane feel first-party.
+
+### 3. Governed adapter instead of raw shell execution
+
+LoongClaw must not treat browser automation as "the model can call `shell.exec`
+with an external browser CLI".
+
+Instead, add a governed adapter layer that exposes stable LoongClaw-owned tool
+contracts, for example:
+
+- `browser.session.start`
+- `browser.navigate`
+- `browser.snapshot`
+- `browser.click`
+- `browser.type`
+- `browser.wait`
+- `browser.extract`
+- `browser.screenshot`
+- `browser.session.stop`
+
+These tool names are illustrative, but the important part is the contract:
+
+- session-scoped operations
+- typed payloads and typed failures
+- capability-aware authorization
+- audit events on reads, writes, and terminal actions
+- runtime visibility driven by actual companion readiness
+
+The companion runtime may be implemented using an upstream browser automation
+engine, but the public tool surface belongs to LoongClaw.
+
+### 4. Action classes and approval model
+
+The richer browser lane should distinguish between low-risk and high-risk
+actions:
+
+- **Read-oriented actions**
+  - navigate to public pages
+  - snapshot page structure
+  - extract text or links
+  - take screenshots
+- **Write-oriented actions**
+  - type into fields
+  - click submit buttons
+  - upload files
+  - trigger downloads
+  - confirm irreversible page actions
+
+Policy direction:
+
+- read-oriented actions may run under the normal browser capability lane
+- write-oriented actions should require stronger policy and, when appropriate,
+  explicit user approval
+- approval prompts should speak in page-task language, not raw technical
+  command language
+
+### 5. Profile and login model
+
+The product should default to an isolated LoongClaw-managed browser profile.
+
+Rules:
+
+- never default to the user's personal browser profile
+- store companion profile state under a LoongClaw-owned runtime directory
+- let users log in manually inside the isolated browser when required
+- let LoongClaw reuse that isolated profile for later automated sessions
+- do not make "give the agent my username and password" the default story
+
+This keeps the product explainable and avoids turning browser automation into a
+secret-handling shortcut.
+
+### 6. Tool visibility and UX
+
+The companion lane must integrate with the same truthfulness rules the MVP now
+uses for other tools.
+
+When the companion is unavailable, unhealthy, disabled, or policy-blocked:
+
+- companion tools are absent from capability snapshots
+- provider tool definitions omit them
+- `ask` and `chat` do not hint at them as available
+- `doctor` tells the user exactly what to do next
+
+When the companion is healthy:
+
+- `onboard` can recommend an enhanced browser automation example
+- `doctor` can confirm that richer browser automation is ready
+- future WebChat or Control UI work can reuse the same state instead of adding a
+  shadow browser runtime
+
+### 7. Role of a preinstalled helper skill
+
+Bundling or preinstalling a browser helper skill is still useful, but only as a
+secondary layer.
+
+It should provide:
+
+- natural-language browser task recipes
+- user-facing examples
+- safe defaults for common flows
+- troubleshooting guidance
+
+It should not be treated as:
+
+- the only browser automation integration
+- a substitute for install/doctor/runtime health plumbing
+- permission to advertise an unavailable capability
+
+## Rollout Plan
+
+### Phase 1: Companion-aware docs and health model
+
+- define the companion lane in product docs and roadmap
+- add onboarding and doctor expectations for optional enhanced browser
+  automation
+- optionally bundle a helper skill for advanced users, but keep it clearly
+  labeled as preview guidance
+
+### Phase 2: Managed companion runtime and health checks
+
+- add runtime configuration for companion enablement
+- add install/onboard/doctor checks for presence, version, and profile health
+- add truthful capability advertising rules for the companion lane
+
+### Phase 3: Governed browser automation adapter
+
+- add typed tool contracts for richer browser sessions
+- map those tools to the companion runtime
+- enforce read/write policy separation and approval semantics
+- emit structured audit events
+
+### Phase 4: Thin non-terminal surfaces
+
+- let WebChat or a future Control shell reuse the same browser automation lane
+- keep the shell thin and reuse `ask` / `chat` semantics instead of forking a
+  separate assistant runtime
+
+## Testing Strategy
+
+The implementation track should require evidence at four layers:
+
+1. **Packaging tests**
+   - companion install path selection
+   - version compatibility
+   - failure messaging for missing runtime pieces
+2. **Runtime truth tests**
+   - advertised tools match actual runtime readiness
+   - companion-disabled configs hide the richer browser tools
+3. **Policy tests**
+   - read and write actions take the correct approval path
+   - session and profile isolation remain scoped
+4. **Operator UX tests**
+   - `onboard` offers clear opt-in copy
+   - `doctor` explains missing companion prerequisites as next actions
+   - first-run examples only appear when the companion is truly usable
+
+## Risks And Mitigations
+
+### Risk: the helper skill is mistaken for the actual browser integration
+
+Mitigation:
+
+- make the skill optional or clearly marked as a helper layer
+- keep runtime health, tool visibility, and execution in the companion adapter
+  path
+
+### Risk: the companion drags too much weight into the base install
+
+Mitigation:
+
+- package it as an optional install pack
+- keep the safe browser lane intact for default installs
+
+### Risk: users trust the companion with secrets too early
+
+Mitigation:
+
+- use isolated profiles
+- default to manual login in the managed browser
+- gate write actions and irreversible page actions more strictly than reads
+
+### Risk: browser capability copy drifts from actual runtime readiness
+
+Mitigation:
+
+- derive all user-facing advertising from the same runtime health and tool
+  visibility path
+- add tests that compare capability snapshot output against actual companion
+  readiness
+
+## Acceptance Criteria
+
+- LoongClaw docs clearly distinguish the shipped safe browser lane from the
+  planned automation companion lane
+- the roadmap and product specs define browser automation companion work as the
+  next browser-capability step before WebChat
+- the implementation plan breaks the work into packaging, health, policy,
+  runtime, and UX slices
+- GitHub delivery artifacts can track this work without conflating it with the
+  already shipped minimal browser surface

--- a/docs/plans/2026-03-16-browser-automation-companion-implementation-plan.md
+++ b/docs/plans/2026-03-16-browser-automation-companion-implementation-plan.md
@@ -1,0 +1,286 @@
+# Browser Automation Companion Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a managed browser automation companion lane to LoongClaw without replacing the shipped lightweight browser tools or increasing default install friction.
+
+**Architecture:** Keep `browser.open` / `browser.extract` / `browser.click` as the default safe browser lane, then layer an optional managed browser automation companion behind a LoongClaw-owned governed adapter, truthful tool visibility, and install/onboard/doctor health integration.
+
+**Tech Stack:** Rust, existing tool/runtime policy infrastructure, install scripts, Markdown docs, optional companion packaging, GitHub release artifacts.
+
+---
+
+### Task 1: Land the design, spec, and roadmap contract
+
+**Files:**
+- Create: `docs/plans/2026-03-16-browser-automation-companion-design.md`
+- Create: `docs/plans/2026-03-16-browser-automation-companion-implementation-plan.md`
+- Create: `docs/product-specs/browser-automation-companion.md`
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/product-specs/browser-automation.md`
+- Modify: `docs/ROADMAP.md`
+
+**Step 1: Write the artifacts**
+
+- record the two-lane browser model: shipped safe browser lane plus optional
+  automation companion lane
+- keep the companion lane explicitly marked as planned or expectation-setting,
+  not already shipped
+- define the role of a helper skill as additive guidance, not the runtime
+  capability source of truth
+
+**Step 2: Verify the artifacts exist**
+
+Run: `test -f docs/plans/2026-03-16-browser-automation-companion-design.md && test -f docs/plans/2026-03-16-browser-automation-companion-implementation-plan.md && test -f docs/product-specs/browser-automation-companion.md`
+
+Expected: success
+
+### Task 2: Add companion runtime configuration and readiness model
+
+**Files:**
+- Modify: `crates/app/src/config/tools_memory.rs`
+- Modify: `crates/app/src/tools/runtime_config.rs`
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Test: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- a distinct browser companion config surface exists
+- companion tools remain hidden when the runtime is disabled or unhealthy
+- runtime-visible tool catalogs and provider definitions expose the same
+  companion-visible set
+- the shipped lightweight browser tools remain unaffected when the companion is
+  off
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app tool_visibility companion`
+
+Expected: FAIL because the runtime config and tool visibility model do not yet
+understand a companion lane.
+
+**Step 3: Write minimal implementation**
+
+- add companion enablement and readiness inputs to runtime config
+- extend tool descriptors with companion-lane visibility support
+- keep base browser tools and companion tools separately testable
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app tool_visibility companion`
+
+Expected: PASS
+
+### Task 3: Add doctor and onboarding companion health checks
+
+**Files:**
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `crates/daemon/src/tests/onboard_cli.rs`
+- Modify: `crates/daemon/src/tests/doctor_cli.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- `onboard` can present enhanced browser automation as an optional companion
+  choice
+- `doctor` reports missing companion runtime, version mismatch, or missing
+  isolated profile as next-action guidance
+- healthy companion state is rendered distinctly from the default safe browser
+  lane
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon onboard doctor companion`
+
+Expected: FAIL because onboarding and doctor do not yet understand the companion
+  readiness model.
+
+**Step 3: Write minimal implementation**
+
+- add companion-aware onboarding prompts and summaries
+- add doctor checks for runtime presence, version compatibility, and profile
+  health
+- render next-step actions instead of raw missing-state text
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon onboard doctor companion`
+
+Expected: PASS
+
+### Task 4: Add companion install and packaging hooks
+
+**Files:**
+- Modify: `scripts/install.sh`
+- Modify: `scripts/install.ps1`
+- Modify: `.github/workflows/release.yml`
+- Modify: `scripts/test_release_artifact_lib.sh`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- the install flow can optionally request the browser automation companion pack
+- unsupported platforms fail with a concrete next step
+- the release workflow publishes the companion artifact or manifest expected by
+  the installers
+
+**Step 2: Run test to verify it fails**
+
+Run: `bash scripts/test_release_artifact_lib.sh`
+
+Expected: FAIL because install and release artifacts do not yet expose a
+  companion pack contract.
+
+**Step 3: Write minimal implementation**
+
+- define artifact naming or manifest format for the companion lane
+- add install flags or onboarding-assisted install steps
+- publish the required release metadata
+
+**Step 4: Run test to verify it passes**
+
+Run: `bash scripts/test_release_artifact_lib.sh`
+
+Expected: PASS
+
+### Task 5: Add the governed browser automation adapter
+
+**Files:**
+- Create: `crates/app/src/tools/browser_companion.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Test: `crates/app/src/tools/browser_companion.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- companion sessions can be started only when the runtime is ready
+- navigation, click, type, wait, extract, screenshot, and session stop return
+  typed outcomes
+- read actions and write actions follow different policy or approval paths
+- session IDs remain scoped and auditable
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app browser_companion`
+
+Expected: FAIL because the governed adapter does not yet exist.
+
+**Step 3: Write minimal implementation**
+
+- implement the companion adapter boundary
+- map companion operations into LoongClaw-owned tool payloads and results
+- emit audit events and typed failures
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app browser_companion`
+
+Expected: PASS
+
+### Task 6: Add profile isolation and approval evidence
+
+**Files:**
+- Modify: `crates/app/src/tools/approval.rs`
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `crates/app/src/context.rs`
+- Test: `crates/app/src/tools/approval.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- companion profiles are isolated from unrelated LoongClaw sessions
+- write-oriented page actions request stronger authorization than read actions
+- profile lifecycle and approval decisions are traceable in audit evidence
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app approval companion profile`
+
+Expected: FAIL because profile isolation and approval evidence are not yet wired
+  for the companion lane.
+
+**Step 3: Write minimal implementation**
+
+- add isolated profile identifiers and runtime state plumbing
+- bind high-risk page actions to stronger approval handling
+- emit structured audit fields that explain what the browser session attempted
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app approval companion profile`
+
+Expected: PASS
+
+### Task 7: Add helper skill and example flows
+
+**Files:**
+- Create or Modify: packaged helper skill files under the selected first-party
+  skill location
+- Modify: `README.md`
+- Modify: `docs/product-specs/browser-automation-companion.md`
+
+**Step 1: Write the failing docs or packaging checks**
+
+- define how the helper skill is bundled, discovered, or recommended
+- make sure docs do not imply the helper skill alone provides the runtime
+
+**Step 2: Run the checks**
+
+Run: `rg -n "helper skill|companion|browser.session.start|browser.screenshot" README.md docs`
+
+Expected: matches only where the new product story is defined correctly.
+
+**Step 3: Write minimal implementation**
+
+- add first-party helper skill content with task recipes
+- keep examples aligned with actual companion availability rules
+
+**Step 4: Re-run the checks**
+
+Run: `rg -n "helper skill|companion|browser.session.start|browser.screenshot" README.md docs`
+
+Expected: PASS with consistent language.
+
+### Task 8: Full verification and delivery
+
+**Files:**
+- Modify only what the previous tasks require
+
+**Step 1: Run focused verification**
+
+Run: `bash scripts/test_release_artifact_lib.sh`
+Run: `cargo test -p loongclaw-daemon onboard doctor companion`
+Run: `cargo test -p loongclaw-app browser_companion tool_visibility approval`
+
+Expected: PASS
+
+**Step 2: Run broad verification**
+
+Run: `cargo fmt --all -- --check`
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+Run: `cargo test --workspace --all-features --locked`
+
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add docs/plans docs/product-specs docs/ROADMAP.md README.md scripts .github/workflows crates/app crates/daemon
+git commit -m "feat(browser): define managed automation companion lane"
+```
+
+**Step 4: Push and open PR**
+
+- push branch to the fork remote
+- open PR against `alpha-test`
+- link the tracking issue with an explicit closing clause

--- a/docs/plans/2026-03-16-browser-automation-companion-implementation-plan.md
+++ b/docs/plans/2026-03-16-browser-automation-companion-implementation-plan.md
@@ -1,6 +1,6 @@
 # Browser Automation Companion Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> Execution note: implement this plan task-by-task using the standard plan-execution workflow.
 
 **Goal:** Add a managed browser automation companion lane to LoongClaw without replacing the shipped lightweight browser tools or increasing default install friction.
 
@@ -9,6 +9,8 @@
 **Tech Stack:** Rust, existing tool/runtime policy infrastructure, install scripts, Markdown docs, optional companion packaging, GitHub release artifacts.
 
 ---
+
+## Execution Tasks
 
 ### Task 1: Land the design, spec, and roadmap contract
 

--- a/docs/product-specs/browser-automation-companion.md
+++ b/docs/product-specs/browser-automation-companion.md
@@ -1,0 +1,34 @@
+# Browser Automation Companion
+
+## User Story
+
+As a LoongClaw user, I want an optional managed browser automation companion so
+that the assistant can complete supported page tasks without turning the default
+runtime into a heavyweight browser platform.
+
+## Acceptance Criteria
+
+- [ ] Product docs clearly distinguish the shipped safe browser lane
+      (`browser.open`, `browser.extract`, `browser.click`) from the planned
+      browser automation companion lane.
+- [ ] The browser automation companion is treated as an optional enhanced
+      capability with its own install, onboarding, and doctor readiness flow,
+      not as a mandatory dependency for all LoongClaw users.
+- [ ] When the companion is unavailable, unhealthy, disabled, or policy-blocked,
+      its richer browser tools are not advertised in capability snapshots,
+      provider tool schemas, or product-facing first-run guidance.
+- [ ] When the companion does ship, it reuses LoongClaw's existing capability,
+      approval, policy, and audit model rather than exposing a raw shell-only
+      browser CLI.
+- [ ] The companion uses an isolated LoongClaw-managed browser profile by
+      default instead of assuming access to the user's personal browser profile.
+- [ ] Any bundled or preinstalled helper skill for browser automation is
+      documented as guidance on top of the companion runtime, not as the source
+      of truth for whether the capability is installed and supported.
+
+## Out of Scope
+
+- Replacing the shipped lightweight browser tools
+- Making heavy browser automation part of the default install path
+- WebChat, dashboard controls, or broader trigger automation
+- Arbitrary desktop automation outside the browser surface

--- a/docs/product-specs/browser-automation-companion.md
+++ b/docs/product-specs/browser-automation-companion.md
@@ -37,7 +37,7 @@ automation companion:
 - continued default shipping of only `browser.open`, `browser.extract`, and
   `browser.click` as built-in browser tools
 
-The full governed companion runtime, richer tool catalog, isolated browser
+The fully governed companion runtime, richer tool catalog, isolated browser
 profile lifecycle, and stronger approval/audit semantics remain planned work.
 
 ## Out of Scope

--- a/docs/product-specs/browser-automation-companion.md
+++ b/docs/product-specs/browser-automation-companion.md
@@ -26,6 +26,20 @@ runtime into a heavyweight browser platform.
       documented as guidance on top of the companion runtime, not as the source
       of truth for whether the capability is installed and supported.
 
+## Current Preview Scope
+
+The currently shipped preview scope is narrower than the final managed browser
+automation companion:
+
+- a first-party bundled `browser-companion-preview` managed skill
+- `loongclaw skills enable-browser-preview` as the operator-facing fast path
+- `onboard` and `doctor` next actions that surface the preview truthfully
+- continued default shipping of only `browser.open`, `browser.extract`, and
+  `browser.click` as built-in browser tools
+
+The full governed companion runtime, richer tool catalog, isolated browser
+profile lifecycle, and stronger approval/audit semantics remain planned work.
+
 ## Out of Scope
 
 - Replacing the shipped lightweight browser tools

--- a/docs/product-specs/browser-automation.md
+++ b/docs/product-specs/browser-automation.md
@@ -27,5 +27,7 @@ safe links without needing a full desktop browser runtime.
 ## Out of Scope
 
 - A full Chromium or Playwright runtime
+- A managed browser automation companion with richer login, typing, screenshot,
+  or form-completion actions
 - Arbitrary JavaScript execution or login automation
 - Form filling, uploads, or unrestricted browser macros

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -13,6 +13,7 @@ Product specs describe **what** the product does from the user's perspective, no
 - [One-Shot Ask](one-shot-ask.md)
 - [Doctor](doctor.md)
 - [Browser Automation](browser-automation.md)
+- [Browser Automation Companion](browser-automation-companion.md)
 - [Channel Setup](channel-setup.md)
 - [Tool Surface](tool-surface.md)
 - [WebChat](webchat.md)
@@ -22,7 +23,7 @@ Product specs describe **what** the product does from the user's perspective, no
 ## Notes
 
 - `Installation`, `Onboarding`, `One-Shot Ask`, `Doctor`, `Browser Automation`, `Tool Surface`, and `Channel Setup` define the shipped first-run and support journey for the current MVP.
-- `WebChat` is an expectation-setting spec for the next user-facing surface. It should not be documented as generally available before the implementation exists.
+- `Browser Automation Companion` and `WebChat` are expectation-setting specs for the next user-facing surfaces. They should not be documented as generally available before the implementation exists.
 
 Template for new specs:
 

--- a/skills/browser-companion-preview/SKILL.md
+++ b/skills/browser-companion-preview/SKILL.md
@@ -1,0 +1,57 @@
+# Browser Companion Preview
+
+Use this managed skill when a task needs richer browser automation through the
+`agent-browser` CLI than the built-in `browser.open`, `browser.extract`, and
+`browser.click` tools can reliably provide.
+
+This preview is loaded through `external_skills.invoke` and currently routes
+work through `shell.exec`. It does not yet provide the same bounded,
+profile-isolated safety model as the built-in browser tools.
+
+## Preconditions
+
+- This preview expects the `agent-browser` CLI to be installed and available on
+  `PATH`.
+- This preview uses `shell.exec` to call `agent-browser`, so shell policy must
+  allow the `agent-browser` command.
+- Enabling this preview usually means the operator has also enabled the
+  external-skills runtime with installed-skill auto exposure for the current
+  config.
+- If those prerequisites are missing, say so plainly and stop instead of
+  pretending the browser task completed.
+
+## Operating Rules
+
+1. Treat `agent-browser` as the execution adapter for multi-step page work.
+2. Keep the user informed with short progress updates before major browser
+   actions.
+3. Use the ref-based workflow:
+   - `agent-browser open <url>`
+   - `agent-browser snapshot -i`
+   - interact with `click`, `fill`, `select`, `press`, or `scroll`
+   - re-run `agent-browser snapshot -i` after navigation or DOM changes
+4. For extraction tasks, prefer:
+   - `agent-browser get text body`
+   - `agent-browser get text @eN`
+   - `agent-browser screenshot --full`
+5. If a task needs login, 2FA, arbitrary JavaScript execution, destructive form
+   submission, or unsupported browser state management, explain that this is a
+   limited preview and stop for operator approval instead of improvising.
+
+## Command Patterns
+
+```text
+agent-browser open https://example.com
+agent-browser snapshot -i
+agent-browser click @e3
+agent-browser wait --load networkidle
+agent-browser snapshot -i
+agent-browser get text body
+agent-browser screenshot --full
+```
+
+## Response Style
+
+- Summarize what page or step you are on.
+- Surface blockers immediately.
+- Do not dump raw browser output unless the user asks for it.


### PR DESCRIPTION
## Summary

- ship a first-party `browser-companion-preview` bundled skill plus operator-facing `loongclaw skills install-bundled` and `loongclaw skills enable-browser-preview` flows
- surface truthful browser preview readiness in `onboard`, `doctor`, and next actions, including explicit unblock guidance when `agent-browser` is denied or missing
- extend managed external skill install/search metadata for bundled skill ids and harden install cleanup/rollback so the preview enable path does not leave broken state behind

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

- This ships a preview lane, not a full managed browser runtime. The built-in bounded browser tools remain the default browser surface.
- The preview is explicitly BYO `agent-browser` and currently routes through `external_skills.invoke` plus `shell.exec`; it is not presented as equivalent to the built-in bounded browser safety model.
- `enable-browser-preview` refuses explicit `[tools].shell_deny` conflicts, persists config only after bundled-skill install succeeds, and reports runtime availability separately so the operator is not told the preview is ready when the binary is missing.
- `doctor` and onboarding now keep at least one browser-preview action visible in first-turn suggestions, instead of letting channel actions squeeze it out.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional validation details:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --target-dir target/codex-browser-preview-verify-clippy -- -D warnings`
- `cargo test --workspace --all-features --locked --target-dir target/codex-browser-preview-verify-test`
- red/green regression proof for doctor action selection:
  - `cargo test -p loongclaw-daemon build_doctor_next_steps_keeps_browser_preview_visible_when_channels_are_enabled --target-dir target/codex-browser-preview-red -- --nocapture` (failed before the fix)
  - `cargo test -p loongclaw-daemon build_doctor_next_steps_keeps_browser_preview_visible_when_channels_are_enabled --target-dir target/codex-browser-preview-green -- --nocapture` (passed after the fix)

Before/after behavior and regression notes:

- Before: users had only the built-in safe browser lane plus manual external-skill assembly; there was no first-party fast path for browser preview install, `doctor` could hide the preview behind channel actions, and bundled helper install was not part of the managed runtime contract.
- After: operators can enable the preview in one command, install the bundled helper without a local archive path, and see truthful preview/blocked/runtime-missing guidance in onboarding and doctor flows.
- `external_skills.install` now supports either `path` or `bundled_skill_id`, and tool search exposes those alternative required-field groups.
- Explicit `agent-browser` deny rules now block preview enablement without mutating config.
- Failed bundled install keeps config unchanged and now cleans staging directories instead of leaving `.incoming-*` debris behind.
- No new tests mutate process-global env. PATH-sensitive preview checks use helper functions that accept an injected path value, so tests stay isolated without mutating the global process environment.

## Linked Issues

Closes #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview: Optional Browser Automation Companion for richer, opt-in browser actions.
  * CLI: `loongclaw skills install-bundled` and `loongclaw skills enable-browser-preview` to install/enable the preview; skills management accepts bundled IDs or local paths.
  * UX: Onboarding and doctor flows now surface browser-preview enablement and runtime-install guidance; tool search exposes grouped required-field hints.

* **Documentation**
  * Added design, implementation plan, product specs, and companion usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->