### PR TITLE
fix: harden governed runtime delegate and history paths

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,7 +98,7 @@ policy-aware but business-logic-light.
 These are the core principles for anyone working in this codebase. They are enforced
 mechanically where possible.
 
-1. **Kernel-first** -- all execution paths route through the kernel's capability, policy, and audit system. No shadow paths.
+1. **Kernel-first** -- kernel-governed execution routes through the kernel's capability, policy, and audit system. Remaining direct compatibility paths must be explicit and are follow-up work, not implicit shadow routing.
 2. **No breaking changes** -- new features are additive only. Existing public API signatures stay unchanged.
 3. **Capability-gated by default** -- every tool call, memory operation, and connector invocation requires a valid `CapabilityToken`.
 4. **Audit everything security-critical** -- policy denials, token lifecycle events, and module invocations all emit structured audit events.

--- a/crates/app/src/context.rs
+++ b/crates/app/src/context.rs
@@ -20,6 +20,7 @@ pub(crate) const DEFAULT_TOKEN_TTL_S: u64 = 86400;
 ///
 /// `pack_id` and `agent_id` are accessed via the embedded `CapabilityToken`
 /// to avoid data divergence.
+#[derive(Clone)]
 pub struct KernelContext {
     pub kernel: Arc<LoongClawKernel<StaticPolicyEngine>>,
     pub token: CapabilityToken,

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -70,13 +70,14 @@ fn normalize_session_id(session_id: String) -> String {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct AsyncDelegateSpawnRequest {
     pub child_session_id: String,
     pub parent_session_id: String,
     pub task: String,
     pub label: Option<String>,
     pub timeout_seconds: u64,
+    pub kernel_context: Option<KernelContext>,
 }
 
 #[async_trait]
@@ -137,7 +138,9 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
             request.label,
             &request.task,
             request.timeout_seconds,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::from_optional_kernel_context(
+                request.kernel_context.as_ref(),
+            ),
         )
         .await;
         Ok(())

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -314,16 +314,19 @@ fn collect_assistant_contents_from_memory_window_payload(
     let turns = turns_payload.and_then(Value::as_array).ok_or_else(|| {
         AssistantHistoryLoadError::kernel_malformed_payload("missing or non-array turns")
     })?;
-    Ok(turns
-        .iter()
-        .filter_map(|turn| {
-            (turn.get("role").and_then(Value::as_str) == Some("assistant"))
-                .then(|| {
-                    turn.get("content")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default()
-                })
-                .map(ToOwned::to_owned)
-        })
-        .collect())
+    let mut assistant_contents = Vec::new();
+    for (index, turn) in turns.iter().enumerate() {
+        if turn.get("role").and_then(Value::as_str) != Some("assistant") {
+            continue;
+        }
+
+        let content = turn.get("content").and_then(Value::as_str).ok_or_else(|| {
+            AssistantHistoryLoadError::kernel_malformed_payload(format!(
+                "assistant turn at index {index} missing or non-string content"
+            ))
+        })?;
+        assistant_contents.push(content.to_owned());
+    }
+
+    Ok(assistant_contents)
 }

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -188,14 +188,19 @@ pub(crate) async fn load_assistant_contents_from_session_window(
         let outcome = ctx
             .kernel
             .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
-            .await;
-        if let Ok(outcome) = outcome
-            && outcome.status == "ok"
-        {
-            return Ok(collect_assistant_contents_from_memory_window_payload(
-                outcome.payload.get("turns"),
+            .await
+            .map_err(|error| format!("load assistant history via kernel failed: {error}"))?;
+
+        if outcome.status != "ok" {
+            return Err(format!(
+                "load assistant history via kernel returned non-ok status: {}",
+                outcome.status
             ));
         }
+
+        return Ok(collect_assistant_contents_from_memory_window_payload(
+            outcome.payload.get("turns"),
+        ));
     }
 
     let turns = memory::window_direct(session_id, limit, memory_config)

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -19,6 +19,68 @@ use super::analytics::{
 };
 use super::runtime_binding::ConversationRuntimeBinding;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AssistantHistoryLoadErrorCode {
+    DirectReadFailed,
+    KernelRequestFailed,
+    KernelNonOkStatus,
+}
+
+impl AssistantHistoryLoadErrorCode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::DirectReadFailed => "direct_read_failed",
+            Self::KernelRequestFailed => "kernel_request_failed",
+            Self::KernelNonOkStatus => "kernel_non_ok_status",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AssistantHistoryLoadError {
+    code: AssistantHistoryLoadErrorCode,
+    message: String,
+}
+
+impl AssistantHistoryLoadError {
+    #[cfg(feature = "memory-sqlite")]
+    fn direct_read_failed(error: impl std::fmt::Display) -> Self {
+        Self {
+            code: AssistantHistoryLoadErrorCode::DirectReadFailed,
+            message: format!("load turn checkpoint summary failed: {error}"),
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn kernel_request_failed(error: impl std::fmt::Display) -> Self {
+        Self {
+            code: AssistantHistoryLoadErrorCode::KernelRequestFailed,
+            message: format!("load assistant history via kernel failed: {error}"),
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn kernel_non_ok_status(status: impl AsRef<str>) -> Self {
+        Self {
+            code: AssistantHistoryLoadErrorCode::KernelNonOkStatus,
+            message: format!(
+                "load assistant history via kernel returned non-ok status: {}",
+                status.as_ref()
+            ),
+        }
+    }
+
+    pub(crate) fn code(&self) -> AssistantHistoryLoadErrorCode {
+        self.code
+    }
+}
+
+impl std::fmt::Display for AssistantHistoryLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TurnCheckpointLatestEntry {
     pub summary: TurnCheckpointEventSummary,
@@ -175,6 +237,18 @@ pub(crate) async fn load_assistant_contents_from_session_window(
     binding: ConversationRuntimeBinding<'_>,
     memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<Vec<String>> {
+    load_assistant_contents_from_session_window_detailed(session_id, limit, binding, memory_config)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) async fn load_assistant_contents_from_session_window_detailed(
+    session_id: &str,
+    limit: usize,
+    binding: ConversationRuntimeBinding<'_>,
+    memory_config: &MemoryRuntimeConfig,
+) -> Result<Vec<String>, AssistantHistoryLoadError> {
     if let Some(ctx) = binding.kernel_context() {
         let request = MemoryCoreRequest {
             operation: memory::MEMORY_OP_WINDOW.to_owned(),
@@ -189,12 +263,11 @@ pub(crate) async fn load_assistant_contents_from_session_window(
             .kernel
             .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
             .await
-            .map_err(|error| format!("load assistant history via kernel failed: {error}"))?;
+            .map_err(AssistantHistoryLoadError::kernel_request_failed)?;
 
         if outcome.status != "ok" {
-            return Err(format!(
-                "load assistant history via kernel returned non-ok status: {}",
-                outcome.status
+            return Err(AssistantHistoryLoadError::kernel_non_ok_status(
+                &outcome.status,
             ));
         }
 
@@ -204,7 +277,7 @@ pub(crate) async fn load_assistant_contents_from_session_window(
     }
 
     let turns = memory::window_direct(session_id, limit, memory_config)
-        .map_err(|error| format!("load turn checkpoint summary failed: {error}"))?;
+        .map_err(AssistantHistoryLoadError::direct_read_failed)?;
     Ok(turns
         .iter()
         .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.clone()))

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -24,6 +24,7 @@ pub(crate) enum AssistantHistoryLoadErrorCode {
     DirectReadFailed,
     KernelRequestFailed,
     KernelNonOkStatus,
+    KernelMalformedPayload,
 }
 
 impl AssistantHistoryLoadErrorCode {
@@ -32,6 +33,7 @@ impl AssistantHistoryLoadErrorCode {
             Self::DirectReadFailed => "direct_read_failed",
             Self::KernelRequestFailed => "kernel_request_failed",
             Self::KernelNonOkStatus => "kernel_non_ok_status",
+            Self::KernelMalformedPayload => "kernel_malformed_payload",
         }
     }
 }
@@ -66,6 +68,17 @@ impl AssistantHistoryLoadError {
             message: format!(
                 "load assistant history via kernel returned non-ok status: {}",
                 status.as_ref()
+            ),
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn kernel_malformed_payload(reason: impl AsRef<str>) -> Self {
+        Self {
+            code: AssistantHistoryLoadErrorCode::KernelMalformedPayload,
+            message: format!(
+                "load assistant history via kernel returned malformed payload: {}",
+                reason.as_ref()
             ),
         }
     }
@@ -271,9 +284,7 @@ pub(crate) async fn load_assistant_contents_from_session_window_detailed(
             ));
         }
 
-        return Ok(collect_assistant_contents_from_memory_window_payload(
-            outcome.payload.get("turns"),
-        ));
+        return collect_assistant_contents_from_memory_window_payload(outcome.payload.get("turns"));
     }
 
     let turns = memory::window_direct(session_id, limit, memory_config)
@@ -299,22 +310,20 @@ fn build_turn_checkpoint_history_snapshot(
 #[cfg(feature = "memory-sqlite")]
 fn collect_assistant_contents_from_memory_window_payload(
     turns_payload: Option<&Value>,
-) -> Vec<String> {
-    turns_payload
-        .and_then(Value::as_array)
-        .map(|turns| {
-            turns
-                .iter()
-                .filter_map(|turn| {
-                    (turn.get("role").and_then(Value::as_str) == Some("assistant"))
-                        .then(|| {
-                            turn.get("content")
-                                .and_then(Value::as_str)
-                                .unwrap_or_default()
-                        })
-                        .map(ToOwned::to_owned)
+) -> Result<Vec<String>, AssistantHistoryLoadError> {
+    let turns = turns_payload.and_then(Value::as_array).ok_or_else(|| {
+        AssistantHistoryLoadError::kernel_malformed_payload("missing or non-array turns")
+    })?;
+    Ok(turns
+        .iter()
+        .filter_map(|turn| {
+            (turn.get("role").and_then(Value::as_str) == Some("assistant"))
+                .then(|| {
+                    turn.get("content")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
                 })
-                .collect()
+                .map(ToOwned::to_owned)
         })
-        .unwrap_or_default()
+        .collect())
 }

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -47,7 +47,7 @@ impl AssistantHistoryLoadError {
     fn direct_read_failed(error: impl std::fmt::Display) -> Self {
         Self {
             code: AssistantHistoryLoadErrorCode::DirectReadFailed,
-            message: format!("load turn checkpoint summary failed: {error}"),
+            message: format!("direct read failed: {error}"),
         }
     }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -6225,6 +6225,33 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_requests_extended_h
     );
     assert_eq!(window_request.payload["limit"], 200);
     assert_eq!(window_request.payload["allow_extended_limit"], true);
+
+    let persisted = runtime.persisted.lock().expect("persisted lock");
+    let lane_selected_payload = persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != "conversation_event" {
+                return None;
+            }
+            if parsed.get("event")?.as_str()? != "lane_selected" {
+                return None;
+            }
+            parsed.get("payload").cloned()
+        })
+        .next_back()
+        .expect("lane_selected payload");
+    assert_eq!(
+        lane_selected_payload["session_governor"]["history_load_status"],
+        "loaded"
+    );
+    assert_eq!(
+        lane_selected_payload["session_governor"]["history_load_error"],
+        Value::Null
+    );
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -6418,6 +6445,17 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_does_not_reuse_sqli
     assert_eq!(
         lane_selected_payload["session_governor"]["failed_threshold_triggered"],
         false
+    );
+    assert_eq!(
+        lane_selected_payload["session_governor"]["history_load_status"],
+        "unavailable"
+    );
+    assert!(
+        lane_selected_payload["session_governor"]["history_load_error"]
+            .as_str()
+            .expect("history load error text")
+            .contains("non-ok status"),
+        "expected surfaced governor history load error: {lane_selected_payload:?}"
     );
 
     let _ = std::fs::remove_file(&db_path);

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8475,6 +8475,48 @@ fn build_kernel_context_with_window_error(
     (ctx, invocations)
 }
 
+fn build_kernel_context_with_raw_window_payload(
+    audit: Arc<InMemoryAuditSink>,
+    payload: Value,
+) -> (KernelContext, Arc<Mutex<Vec<MemoryCoreRequest>>>) {
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::MemoryWrite, Capability::MemoryRead]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+
+    let invocations = Arc::new(Mutex::new(Vec::new()));
+    kernel.register_core_memory_adapter(RawWindowPayloadMemoryAdapter {
+        invocations: invocations.clone(),
+        payload,
+    });
+    kernel
+        .set_default_core_memory_adapter("test-memory-raw-window-payload")
+        .expect("set default memory adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    (ctx, invocations)
+}
+
 struct SharedTestMemoryAdapter {
     invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
     window_turns: Value,
@@ -8566,6 +8608,38 @@ impl CoreMemoryAdapter for FailingWindowMemoryAdapter {
             .push(request.clone());
         if request.operation == crate::memory::MEMORY_OP_WINDOW {
             return Err(MemoryPlaneError::Execution(self.error.clone()));
+        }
+        Ok(MemoryCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({}),
+        })
+    }
+}
+
+struct RawWindowPayloadMemoryAdapter {
+    invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
+    payload: Value,
+}
+
+#[async_trait]
+impl CoreMemoryAdapter for RawWindowPayloadMemoryAdapter {
+    fn name(&self) -> &str {
+        "test-memory-raw-window-payload"
+    }
+
+    async fn execute_core_memory(
+        &self,
+        request: MemoryCoreRequest,
+    ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
+        self.invocations
+            .lock()
+            .expect("invocations lock")
+            .push(request.clone());
+        if request.operation == crate::memory::MEMORY_OP_WINDOW {
+            return Ok(MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload: self.payload.clone(),
+            });
         }
         Ok(MemoryCoreOutcome {
             status: "ok".to_owned(),
@@ -8805,6 +8879,30 @@ async fn load_turn_checkpoint_event_summary_fails_closed_when_kernel_window_erro
     assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
 
     let _ = std::fs::remove_file(&db_path);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_turn_checkpoint_event_summary_fails_closed_when_kernel_window_payload_is_malformed() {
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (ctx, invocations) =
+        build_kernel_context_with_raw_window_payload(audit, json!({"unexpected": "shape"}));
+    let config = test_config();
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    let error = load_turn_checkpoint_event_summary(
+        "session-kernel-window-malformed",
+        8,
+        ConversationRuntimeBinding::kernel(&ctx),
+        &mem_config,
+    )
+    .await
+    .expect_err("kernel-bound history should fail closed on malformed payload");
+
+    assert!(error.contains("malformed"), "unexpected error: {error}");
+
+    let captured = invocations.lock().expect("invocations lock");
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -6450,12 +6450,9 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_does_not_reuse_sqli
         lane_selected_payload["session_governor"]["history_load_status"],
         "unavailable"
     );
-    assert!(
-        lane_selected_payload["session_governor"]["history_load_error"]
-            .as_str()
-            .expect("history load error text")
-            .contains("non-ok status"),
-        "expected surfaced governor history load error: {lane_selected_payload:?}"
+    assert_eq!(
+        lane_selected_payload["session_governor"]["history_load_error"], "kernel_non_ok_status",
+        "expected normalized governor history load error code: {lane_selected_payload:?}"
     );
 
     let _ = std::fs::remove_file(&db_path);

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -199,7 +199,9 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
             request.label,
             &request.task,
             request.timeout_seconds,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::from_optional_kernel_context(
+                request.kernel_context.as_ref(),
+            ),
         )
         .await;
         Ok(())
@@ -6227,7 +6229,7 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_requests_extended_h
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_safe_lane_session_governor_falls_back_to_configured_sqlite_history_when_kernel_window_is_non_ok()
+async fn handle_turn_with_runtime_safe_lane_session_governor_does_not_reuse_sqlite_history_when_kernel_window_is_non_ok()
  {
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
     use loongclaw_kernel::{CoreMemoryAdapter, CoreToolAdapter};
@@ -6386,12 +6388,12 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_falls_back_to_confi
             ConversationRuntimeBinding::kernel(&ctx),
         )
         .await
-        .expect("safe lane should use sqlite governor fallback history");
+        .expect("safe lane turn should continue without governed history fallback");
 
     let calls = *call_counter.lock().expect("call counter lock");
-    assert_eq!(
-        calls, 1,
-        "governor should suppress replans when configured sqlite history shows chronic failure"
+    assert!(
+        calls > 1,
+        "governor should no longer suppress replans from configured sqlite history when kernel history is unavailable"
     );
 
     let persisted = runtime.persisted.lock().expect("persisted lock");
@@ -6412,10 +6414,10 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_falls_back_to_confi
         })
         .next_back()
         .expect("lane_selected payload");
-    assert_eq!(lane_selected_payload["session_governor"]["engaged"], true);
+    assert_eq!(lane_selected_payload["session_governor"]["engaged"], false);
     assert_eq!(
         lane_selected_payload["session_governor"]["failed_threshold_triggered"],
-        true
+        false
     );
 
     let _ = std::fs::remove_file(&db_path);
@@ -8396,6 +8398,48 @@ fn build_kernel_context_with_window_turn_sequence(
     (ctx, invocations)
 }
 
+fn build_kernel_context_with_window_error(
+    audit: Arc<InMemoryAuditSink>,
+    error: &str,
+) -> (KernelContext, Arc<Mutex<Vec<MemoryCoreRequest>>>) {
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::MemoryWrite, Capability::MemoryRead]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+
+    let invocations = Arc::new(Mutex::new(Vec::new()));
+    kernel.register_core_memory_adapter(FailingWindowMemoryAdapter {
+        invocations: invocations.clone(),
+        error: error.to_owned(),
+    });
+    kernel
+        .set_default_core_memory_adapter("test-memory-failing-window")
+        .expect("set default memory adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    (ctx, invocations)
+}
+
 struct SharedTestMemoryAdapter {
     invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
     window_turns: Value,
@@ -8462,6 +8506,35 @@ impl CoreMemoryAdapter for SequencedTestMemoryAdapter {
         Ok(MemoryCoreOutcome {
             status: "ok".to_owned(),
             payload,
+        })
+    }
+}
+
+struct FailingWindowMemoryAdapter {
+    invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
+    error: String,
+}
+
+#[async_trait]
+impl CoreMemoryAdapter for FailingWindowMemoryAdapter {
+    fn name(&self) -> &str {
+        "test-memory-failing-window"
+    }
+
+    async fn execute_core_memory(
+        &self,
+        request: MemoryCoreRequest,
+    ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
+        self.invocations
+            .lock()
+            .expect("invocations lock")
+            .push(request.clone());
+        if request.operation == crate::memory::MEMORY_OP_WINDOW {
+            return Err(MemoryPlaneError::Execution(self.error.clone()));
+        }
+        Ok(MemoryCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({}),
         })
     }
 }
@@ -8651,6 +8724,52 @@ async fn load_turn_checkpoint_event_summary_prefers_kernel_memory_window_when_co
     );
     assert_eq!(captured[0].payload["limit"], json!(96));
     assert_eq!(captured[0].payload["allow_extended_limit"], json!(true));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_turn_checkpoint_event_summary_fails_closed_when_kernel_window_errors() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "kernel-window-error")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 8;
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(
+        "session-kernel-window-error",
+        "assistant",
+        r#"{"type":"conversation_event","event":"turn_checkpoint","payload":{"schema_version":1,"stage":"finalized","checkpoint":{"lane":{"lane":"safe","result_kind":"tool_call"},"finalization":{"persistence_mode":"success"}},"finalization_progress":{"after_turn":"completed","compaction":"skipped"},"failure":null}}"#,
+        &mem_config,
+    )
+    .expect("seed sqlite fallback history");
+
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (ctx, invocations) =
+        build_kernel_context_with_window_error(audit, "forced kernel window failure");
+
+    let error = load_turn_checkpoint_event_summary(
+        "session-kernel-window-error",
+        8,
+        ConversationRuntimeBinding::kernel(&ctx),
+        &mem_config,
+    )
+    .await
+    .expect_err("kernel-bound history should fail closed");
+
+    assert!(
+        error.contains("load assistant history via kernel failed"),
+        "unexpected error: {error}"
+    );
+
+    let captured = invocations.lock().expect("invocations lock");
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
+
+    let _ = std::fs::remove_file(&db_path);
 }
 
 #[cfg(not(feature = "memory-sqlite"))]
@@ -11555,6 +11674,10 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
     assert_eq!(spawn_request.task, "child async task");
     assert_eq!(spawn_request.label.as_deref(), Some("async-child"));
     assert_eq!(spawn_request.timeout_seconds, 9);
+    assert!(
+        spawn_request.kernel_context.is_none(),
+        "direct parent turns should keep async delegate children in direct mode"
+    );
     assert_eq!(child.state, crate::session::repository::SessionState::Ready);
     assert_eq!(child.label.as_deref(), Some("async-child"));
 
@@ -11576,6 +11699,94 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
     assert_eq!(
         requested.state,
         crate::session::repository::SessionState::Ready
+    );
+
+    release_notify.notify_waiters();
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spawn_request() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-delegate-async", "kernel-binding")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let (gated_spawner, request_rx, release_notify) = GatedFakeAsyncDelegateSpawner::new();
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Delegating async.".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "delegate_async",
+                json!({
+                    "task": "child async task",
+                    "label": "async-child",
+                    "timeout_seconds": 9
+                }),
+                "root-session",
+                "turn-delegate-async-parent",
+                "call-delegate-async-parent",
+            )],
+            raw_meta: Value::Null,
+        })],
+        vec![],
+    )
+    .with_async_delegate_spawner(Arc::new(gated_spawner))
+    .with_durable_memory_config(memory_config.clone());
+
+    let (_audit, kernel_ctx) = {
+        let audit = Arc::new(InMemoryAuditSink::default());
+        let (kernel_ctx, _invocations) = build_kernel_context(audit.clone());
+        (audit, kernel_ctx)
+    };
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let queued_call = tokio::spawn(async move {
+        coordinator
+            .handle_turn_with_runtime(
+                &config,
+                "root-session",
+                "show raw json tool output",
+                ProviderErrorMode::Propagate,
+                &runtime,
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
+            )
+            .await
+    });
+
+    let spawn_request = tokio::time::timeout(std::time::Duration::from_millis(250), request_rx)
+        .await
+        .expect("delegate_async should dispatch spawn quickly")
+        .expect("gated async delegate spawn request");
+    let reply = tokio::time::timeout(std::time::Duration::from_millis(250), queued_call)
+        .await
+        .expect("delegate_async should return queued handle without waiting")
+        .expect("join queued delegate_async task")
+        .expect("delegate_async reply");
+
+    assert!(
+        reply.contains("\"tool\":\"delegate_async\""),
+        "expected raw delegate_async tool output, got: {reply}"
+    );
+    assert!(
+        spawn_request.kernel_context.is_some(),
+        "kernel-bound parent turns should preserve kernel context for async delegate children"
     );
 
     release_notify.notify_waiters();

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8807,6 +8807,42 @@ async fn load_turn_checkpoint_event_summary_fails_closed_when_kernel_window_erro
     let _ = std::fs::remove_file(&db_path);
 }
 
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn load_turn_checkpoint_event_summary_direct_read_failure_uses_neutral_error_message() {
+    let sqlite_dir = std::env::temp_dir().join(unique_acp_test_id(
+        "conversation-turn-checkpoint",
+        "direct-read-error",
+    ));
+    let _ = std::fs::remove_dir_all(&sqlite_dir);
+    std::fs::create_dir_all(&sqlite_dir).expect("create sqlite placeholder directory");
+
+    let mut config = test_config();
+    config.memory.sqlite_path = sqlite_dir.display().to_string();
+    config.memory.sliding_window = 8;
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    let error = load_turn_checkpoint_event_summary(
+        "session-direct-read-error",
+        8,
+        ConversationRuntimeBinding::direct(),
+        &mem_config,
+    )
+    .await
+    .expect_err("direct history load should fail when sqlite path is a directory");
+
+    assert!(
+        error.contains("direct read failed"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        !error.contains("load turn checkpoint summary failed"),
+        "error should use context-agnostic wording: {error}"
+    );
+
+    let _ = std::fs::remove_dir_all(&sqlite_dir);
+}
+
 #[cfg(not(feature = "memory-sqlite"))]
 #[tokio::test]
 async fn persist_turn_without_memory_sqlite_is_noop_with_kernel_context() {
@@ -11790,6 +11826,7 @@ async fn handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spa
         let (kernel_ctx, _invocations) = build_kernel_context(audit.clone());
         (audit, kernel_ctx)
     };
+    let expected_kernel_ctx = kernel_ctx.clone();
 
     let coordinator = ConversationTurnCoordinator::new();
     let queued_call = tokio::spawn(async move {
@@ -11822,6 +11859,15 @@ async fn handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spa
     assert!(
         spawn_request.kernel_context.is_some(),
         "kernel-bound parent turns should preserve kernel context for async delegate children"
+    );
+    let child_kernel_ctx = spawn_request
+        .kernel_context
+        .as_ref()
+        .expect("spawn request should carry kernel context");
+    assert_eq!(child_kernel_ctx.token, expected_kernel_ctx.token);
+    assert!(
+        Arc::ptr_eq(&child_kernel_ctx.kernel, &expected_kernel_ctx.kernel),
+        "spawned child should inherit the same kernel instance"
     );
 
     release_notify.notify_waiters();

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8905,6 +8905,42 @@ async fn load_turn_checkpoint_event_summary_fails_closed_when_kernel_window_payl
     assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_turn_checkpoint_event_summary_fails_closed_when_kernel_window_assistant_content_is_malformed()
+ {
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (ctx, invocations) = build_kernel_context_with_raw_window_payload(
+        audit,
+        json!({
+            "turns": [
+                {
+                    "role": "assistant",
+                    "content": {
+                        "unexpected": "shape"
+                    }
+                }
+            ]
+        }),
+    );
+    let config = test_config();
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    let error = load_turn_checkpoint_event_summary(
+        "session-kernel-window-malformed-assistant-content",
+        8,
+        ConversationRuntimeBinding::kernel(&ctx),
+        &mem_config,
+    )
+    .await
+    .expect_err("kernel-bound history should fail closed on malformed assistant content");
+
+    assert!(error.contains("malformed"), "unexpected error: {error}");
+
+    let captured = invocations.lock().expect("invocations lock");
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
+}
+
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
 async fn load_turn_checkpoint_event_summary_direct_read_failure_uses_neutral_error_message() {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3399,6 +3399,7 @@ where
                     self.runtime,
                     &session_context,
                     replay_request.payload,
+                    self.binding,
                 )
                 .await
             }
@@ -3709,6 +3710,7 @@ where
                     self.runtime,
                     session_context,
                     request.payload,
+                    binding,
                 )
                 .await
             }
@@ -3785,6 +3787,7 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
     runtime: &R,
     session_context: &SessionContext,
     payload: Value,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
     if !config.tools.delegate.enabled {
         return Err("app_tool_disabled: delegate is disabled by config".to_owned());
@@ -3839,6 +3842,7 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
             task: delegate_request.task,
             label: child_label,
             timeout_seconds: delegate_request.timeout_seconds,
+            kernel_context: binding.kernel_context().cloned(),
         },
     );
 
@@ -3866,6 +3870,7 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
     _runtime: &R,
     _session_context: &SessionContext,
     _payload: Value,
+    _binding: ConversationRuntimeBinding<'_>,
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
     Err("delegate_async requires sqlite memory support (enable feature `memory-sqlite`)".to_owned())
 }

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -65,8 +65,8 @@ use super::safe_lane_failure::{
 };
 #[cfg(feature = "memory-sqlite")]
 use super::session_history::{
-    load_assistant_contents_from_session_window, load_latest_turn_checkpoint_entry,
-    load_turn_checkpoint_history_snapshot,
+    AssistantHistoryLoadErrorCode, load_assistant_contents_from_session_window_detailed,
+    load_latest_turn_checkpoint_entry, load_turn_checkpoint_history_snapshot,
 };
 use super::turn_budget::{
     EscalatingAttemptBudget, SafeLaneBackpressureBudget, SafeLaneContinuationBudgetDecision,
@@ -522,7 +522,7 @@ struct SafeLaneSessionGovernorDecision {
     engaged: bool,
     history_window_turns: usize,
     history_load_status: SafeLaneGovernorHistoryLoadStatus,
-    history_load_error: Option<String>,
+    history_load_error: Option<AssistantHistoryLoadErrorCode>,
     failed_final_status_events: u32,
     failed_final_status_threshold: u32,
     failed_threshold_triggered: bool,
@@ -552,7 +552,7 @@ impl SafeLaneSessionGovernorDecision {
             "engaged": self.engaged,
             "history_window_turns": self.history_window_turns,
             "history_load_status": self.history_load_status.as_str(),
-            "history_load_error": self.history_load_error,
+            "history_load_error": self.history_load_error.map(|error| error.as_str()),
             "failed_final_status_events": self.failed_final_status_events,
             "failed_final_status_threshold": self.failed_final_status_threshold,
             "failed_threshold_triggered": self.failed_threshold_triggered,
@@ -581,7 +581,7 @@ impl SafeLaneSessionGovernorDecision {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct SafeLaneGovernorHistorySignals {
     history_load_status: SafeLaneGovernorHistoryLoadStatus,
-    history_load_error: Option<String>,
+    history_load_error: Option<AssistantHistoryLoadErrorCode>,
     summary: SafeLaneEventSummary,
     final_status_failed_samples: Vec<bool>,
     backpressure_failure_samples: Vec<bool>,
@@ -5305,7 +5305,7 @@ fn decide_safe_lane_session_governor(
         engaged,
         history_window_turns,
         history_load_status: history.history_load_status,
-        history_load_error: history.history_load_error.clone(),
+        history_load_error: history.history_load_error,
         failed_final_status_events,
         failed_final_status_threshold,
         failed_threshold_triggered,
@@ -5352,7 +5352,7 @@ async fn load_safe_lane_history_signals_for_governor(
     #[cfg(feature = "memory-sqlite")]
     {
         let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-        return match load_assistant_contents_from_session_window(
+        return match load_assistant_contents_from_session_window_detailed(
             session_id,
             window_turns,
             binding,
@@ -5365,7 +5365,7 @@ async fn load_safe_lane_history_signals_for_governor(
             }
             Err(error) => SafeLaneGovernorHistorySignals {
                 history_load_status: SafeLaneGovernorHistoryLoadStatus::Unavailable,
-                history_load_error: Some(error),
+                history_load_error: Some(error.code()),
                 ..SafeLaneGovernorHistorySignals::default()
             },
         };

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -499,10 +499,30 @@ impl SafeLaneRuntimeHealthSignal {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum SafeLaneGovernorHistoryLoadStatus {
+    #[default]
+    Disabled,
+    Loaded,
+    Unavailable,
+}
+
+impl SafeLaneGovernorHistoryLoadStatus {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Loaded => "loaded",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
 struct SafeLaneSessionGovernorDecision {
     engaged: bool,
     history_window_turns: usize,
+    history_load_status: SafeLaneGovernorHistoryLoadStatus,
+    history_load_error: Option<String>,
     failed_final_status_events: u32,
     failed_final_status_threshold: u32,
     failed_threshold_triggered: bool,
@@ -527,10 +547,12 @@ struct SafeLaneSessionGovernorDecision {
 }
 
 impl SafeLaneSessionGovernorDecision {
-    fn as_json(self) -> Value {
+    fn as_json(&self) -> Value {
         json!({
             "engaged": self.engaged,
             "history_window_turns": self.history_window_turns,
+            "history_load_status": self.history_load_status.as_str(),
+            "history_load_error": self.history_load_error,
             "failed_final_status_events": self.failed_final_status_events,
             "failed_final_status_threshold": self.failed_final_status_threshold,
             "failed_threshold_triggered": self.failed_threshold_triggered,
@@ -558,6 +580,8 @@ impl SafeLaneSessionGovernorDecision {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct SafeLaneGovernorHistorySignals {
+    history_load_status: SafeLaneGovernorHistoryLoadStatus,
+    history_load_error: Option<String>,
     summary: SafeLaneEventSummary,
     final_status_failed_samples: Vec<bool>,
     backpressure_failure_samples: Vec<bool>,
@@ -576,6 +600,7 @@ struct SafeLanePlanLoopState {
 
 impl SafeLanePlanLoopState {
     fn new(config: &LoongClawConfig, governor: SafeLaneSessionGovernorDecision) -> Self {
+        let force_no_replan = governor.force_no_replan;
         let mut tool_node_max_attempts = config.conversation.safe_lane_node_max_attempts.max(1);
         if let Some(forced_node_max_attempts) = governor.forced_node_max_attempts {
             tool_node_max_attempts = tool_node_max_attempts.min(forced_node_max_attempts.max(1));
@@ -590,7 +615,7 @@ impl SafeLanePlanLoopState {
 
         Self {
             governor,
-            replan_budget: SafeLaneReplanBudget::new(if governor.force_no_replan {
+            replan_budget: SafeLaneReplanBudget::new(if force_no_replan {
                 0
             } else {
                 config.conversation.safe_lane_replan_max_rounds
@@ -4526,7 +4551,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                     &verify_failure,
                     state.replan_budget,
                     state.metrics,
-                    state.governor,
+                    &state.governor,
                 );
                 emit_safe_lane_event(
                     config,
@@ -4638,7 +4663,7 @@ async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
                     &round_failure_meta,
                     state.replan_budget,
                     state.metrics,
-                    state.governor,
+                    &state.governor,
                 );
                 let failure_summary = summarize_plan_failure(&failure);
                 emit_safe_lane_event(
@@ -5279,6 +5304,8 @@ fn decide_safe_lane_session_governor(
     SafeLaneSessionGovernorDecision {
         engaged,
         history_window_turns,
+        history_load_status: history.history_load_status,
+        history_load_error: history.history_load_error.clone(),
         failed_final_status_events,
         failed_final_status_threshold,
         failed_threshold_triggered,
@@ -5325,7 +5352,7 @@ async fn load_safe_lane_history_signals_for_governor(
     #[cfg(feature = "memory-sqlite")]
     {
         let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-        if let Ok(assistant_contents) = load_assistant_contents_from_session_window(
+        return match load_assistant_contents_from_session_window(
             session_id,
             window_turns,
             binding,
@@ -5333,13 +5360,21 @@ async fn load_safe_lane_history_signals_for_governor(
         )
         .await
         {
-            return summarize_governor_history_signals(
-                assistant_contents.iter().map(String::as_str),
-            );
-        }
+            Ok(assistant_contents) => {
+                summarize_governor_history_signals(assistant_contents.iter().map(String::as_str))
+            }
+            Err(error) => SafeLaneGovernorHistorySignals {
+                history_load_status: SafeLaneGovernorHistoryLoadStatus::Unavailable,
+                history_load_error: Some(error),
+                ..SafeLaneGovernorHistorySignals::default()
+            },
+        };
     }
 
-    SafeLaneGovernorHistorySignals::default()
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        SafeLaneGovernorHistorySignals::default()
+    }
 }
 
 fn summarize_governor_history_signals<'a, I>(
@@ -5350,6 +5385,8 @@ where
 {
     let projection = summarize_safe_lane_history(assistant_contents);
     SafeLaneGovernorHistorySignals {
+        history_load_status: SafeLaneGovernorHistoryLoadStatus::Loaded,
+        history_load_error: None,
         summary: projection.summary,
         final_status_failed_samples: projection.final_status_failed_samples,
         backpressure_failure_samples: projection.backpressure_failure_samples,
@@ -5590,7 +5627,7 @@ impl SafeLaneFailureRoute {
         Self::terminal_with_source(reason, SafeLaneFailureRouteSource::BackpressureGuard)
     }
 
-    fn with_session_governor_override(self, governor: SafeLaneSessionGovernorDecision) -> Self {
+    fn with_session_governor_override(self, governor: &SafeLaneSessionGovernorDecision) -> Self {
         if governor.force_no_replan && self.is_base_round_budget_terminal() {
             return Self::terminal_with_source(
                 SafeLaneFailureRouteReason::SessionGovernorNoReplan,
@@ -5618,7 +5655,7 @@ fn decide_safe_lane_failure_route(
     failure: &TurnFailure,
     replan_budget: SafeLaneReplanBudget,
     metrics: SafeLaneExecutionMetrics,
-    governor: SafeLaneSessionGovernorDecision,
+    governor: &SafeLaneSessionGovernorDecision,
 ) -> SafeLaneFailureRoute {
     SafeLaneFailureRoute::from_failure(failure, replan_budget)
         .with_backpressure_guard(safe_lane_backpressure_budget(config), metrics)
@@ -7771,7 +7808,7 @@ mod tests {
                 total_attempts_used: 2,
                 ..SafeLaneExecutionMetrics::default()
             },
-            SafeLaneSessionGovernorDecision::default(),
+            &SafeLaneSessionGovernorDecision::default(),
         );
 
         assert_eq!(route.decision, SafeLaneFailureRouteDecision::Terminal);
@@ -7790,7 +7827,7 @@ mod tests {
             &TurnFailure::retryable("safe_lane_plan_node_retryable_error", "transient"),
             SafeLaneReplanBudget::new(1).after_replan(),
             SafeLaneExecutionMetrics::default(),
-            SafeLaneSessionGovernorDecision {
+            &SafeLaneSessionGovernorDecision {
                 force_no_replan: true,
                 ..SafeLaneSessionGovernorDecision::default()
             },
@@ -7947,6 +7984,8 @@ mod tests {
         let mut summary = SafeLaneEventSummary::default();
         summary.final_status_counts.insert("failed".to_owned(), 1);
         let history = SafeLaneGovernorHistorySignals {
+            history_load_status: SafeLaneGovernorHistoryLoadStatus::Loaded,
+            history_load_error: None,
             summary,
             final_status_failed_samples: vec![false, true, true, true],
             backpressure_failure_samples: vec![false, false, false, false],
@@ -7998,6 +8037,8 @@ mod tests {
         let mut summary = SafeLaneEventSummary::default();
         summary.final_status_counts.insert("failed".to_owned(), 1);
         let history = SafeLaneGovernorHistorySignals {
+            history_load_status: SafeLaneGovernorHistoryLoadStatus::Loaded,
+            history_load_error: None,
             summary,
             final_status_failed_samples: vec![true, false, false, false, false],
             backpressure_failure_samples: vec![true, false, false, false, false],
@@ -8022,7 +8063,7 @@ mod tests {
             force_no_replan: true,
             ..SafeLaneSessionGovernorDecision::default()
         };
-        let overridden = route.with_session_governor_override(governor);
+        let overridden = route.with_session_governor_override(&governor);
         assert_eq!(
             overridden.reason,
             SafeLaneFailureRouteReason::SessionGovernorNoReplan

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -27,8 +27,8 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 **Current coverage:**
 - `shell.exec` — Kernel-mediated tool execution with capability checks, shell policy extensions, and audit events
 - `file.read` / `file.write` — Kernel-mediated tool execution with filesystem capabilities, file policy extension checks, and audit events
-- Conversation tool turns — Fast-lane and safe-lane inner tool execution now flow through an explicit `ConversationRuntimeBinding` (`Kernel` or `Direct`); core tools require a bound `KernelContext`, and missing authority is rejected at the binding boundary as `no_kernel_context`
-- Memory/runtime/context orchestration — The conversation module now carries `ConversationRuntimeBinding` end-to-end across runtime, context, persistence, turn coordination, loop followup, history, and app-dispatch seams
+- Conversation tool turns — Fast-lane and safe-lane inner tool execution now flow through an explicit `ConversationRuntimeBinding` (`Kernel` or `Direct`); core tools require a bound `KernelContext`, missing authority is rejected at the binding boundary as `no_kernel_context`, and async delegate child turns now inherit parent kernel authority instead of forcing direct mode
+- Memory/runtime/context orchestration — The conversation module now carries `ConversationRuntimeBinding` end-to-end across runtime, context, persistence, turn coordination, loop followup, history, and app-dispatch seams. Kernel-bound history readers fail closed on kernel memory-window errors or non-`ok` statuses instead of silently downgrading to direct sqlite
 - Provider request/failover orchestration — Provider request entrypoints and failover telemetry now use an explicit `ProviderRuntimeBinding` (`Kernel` or `Direct`). Provider failover metrics record in both modes, while kernel-backed audit emission only occurs when provider execution is explicitly kernel-bound
 - Outer integration wrappers — Raw optional kernel context is now limited to explicit integration boundaries such as `channel::process_inbound_with_provider`, which immediately normalize into a binding-first runtime seam instead of carrying shadow authority semantics deeper into the runtime
 - Connector/ACP/runtime-only analytics — Not uniformly routed through the L1 policy chain yet
@@ -36,6 +36,8 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 **Conversation runtime binding note:**
 - The binding makes the high-level execution mode explicit: `Kernel` means the turn is allowed to call kernel-mediated core tools; `Direct` means conversation orchestration may continue, but kernel-only tool execution must fail closed.
 - This removes ambiguity from conversation traits and dispatcher seams where `None` previously overloaded multiple meanings such as "direct mode", "not wired yet", or "forgot to pass kernel authority".
+- Detached async delegate spawns carry an owned kernel context forward when the parent binding is kernel-bound. Direct-mode parents keep direct-mode children.
+- Kernel-bound history helpers no longer reuse direct sqlite fallback behind the caller's back. Higher-level orchestration may still choose how to handle the surfaced error.
 
 **Provider runtime binding note:**
 - The provider binding makes provider governance explicit without importing conversation-layer semantics into provider code. `Kernel` means failover/audit behavior may emit kernel-backed audit events; `Direct` means provider execution is intentionally running without that authority while still recording in-process failover metrics.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -38,6 +38,7 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 - This removes ambiguity from conversation traits and dispatcher seams where `None` previously overloaded multiple meanings such as "direct mode", "not wired yet", or "forgot to pass kernel authority".
 - Detached async delegate spawns carry an owned kernel context forward when the parent binding is kernel-bound. Direct-mode parents keep direct-mode children.
 - Kernel-bound history helpers no longer reuse direct sqlite fallback behind the caller's back. Higher-level orchestration may still choose how to handle the surfaced error.
+- Safe-lane governor diagnostics now surface history load status and error details instead of silently collapsing kernel history failures into an undifferentiated "no history" state.
 
 **Provider runtime binding note:**
 - The provider binding makes provider governance explicit without importing conversation-layer semantics into provider code. `Kernel` means failover/audit behavior may emit kernel-backed audit events; `Direct` means provider execution is intentionally running without that authority while still recording in-process failover metrics.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -38,7 +38,7 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 - This removes ambiguity from conversation traits and dispatcher seams where `None` previously overloaded multiple meanings such as "direct mode", "not wired yet", or "forgot to pass kernel authority".
 - Detached async delegate spawns carry an owned kernel context forward when the parent binding is kernel-bound. Direct-mode parents keep direct-mode children.
 - Kernel-bound history helpers no longer reuse direct sqlite fallback behind the caller's back. Higher-level orchestration may still choose how to handle the surfaced error.
-- Safe-lane governor diagnostics now surface history load status and error details instead of silently collapsing kernel history failures into an undifferentiated "no history" state.
+- Safe-lane governor diagnostics now surface history load status and normalized error codes instead of silently collapsing kernel history failures into an undifferentiated "no history" state.
 
 **Provider runtime binding note:**
 - The provider binding makes provider governance explicit without importing conversation-layer semantics into provider code. `Kernel` means failover/audit behavior may emit kernel-backed audit events; `Direct` means provider execution is intentionally running without that authority while still recording in-process failover metrics.

--- a/docs/plans/2026-03-16-governed-runtime-path-hardening-design.md
+++ b/docs/plans/2026-03-16-governed-runtime-path-hardening-design.md
@@ -146,7 +146,9 @@ Normalized error contract for persisted diagnostics:
 
 1. `kernel_request_failed` when the kernel memory-window request itself errors
 2. `kernel_non_ok_status` when the kernel responds with a non-`ok` status
-3. `direct_read_failed` when an intentional direct-mode sqlite read fails
+3. `kernel_malformed_payload` when the kernel responds with `ok` but omits a
+   usable `payload.turns` array
+4. `direct_read_failed` when an intentional direct-mode sqlite read fails
 
 Observability requirements in this slice:
 

--- a/docs/plans/2026-03-16-governed-runtime-path-hardening-design.md
+++ b/docs/plans/2026-03-16-governed-runtime-path-hardening-design.md
@@ -78,6 +78,19 @@ This keeps the semantics simple:
 
 The child runtime no longer invents a weaker execution mode than the parent.
 
+Implementation notes for this slice:
+
+1. `KernelContext` derives `Clone` so detached spawn requests can own inherited
+   authority without borrowing parent stack state.
+2. `AsyncDelegateSpawnRequest` carries `kernel_context: Option<KernelContext>`
+   instead of inferring runtime mode from an absent borrow.
+3. The async delegate spawner reconstructs `ConversationRuntimeBinding` via
+   `ConversationRuntimeBinding::from_optional_kernel_context(...)` before
+   entering child-turn execution.
+4. If inherited kernel execution later fails, the child returns an explicit
+   error through the existing spawn/future path rather than silently
+   downgrading to direct mode.
+
 ### 2. Kernel-bound history reads fail closed
 
 `load_assistant_contents_from_session_window(...)` currently treats
@@ -98,8 +111,50 @@ degrade silently.
 For higher-level consumers that intentionally fail open, the runtime should at
 least surface that distinction explicitly. In this slice the safe-lane session
 governor keeps fail-open planning behavior, but it records history load status
-and error details in runtime diagnostics instead of silently looking identical
-to "no historical signal".
+and a normalized error code in runtime diagnostics instead of silently looking
+identical to "no historical signal".
+
+#### Backward Compatibility And Migration
+
+This is an intentional contract change for kernel-bound history readers only.
+Direct-mode callers still read sqlite directly, but governed callers now get an
+explicit error instead of a shadow sqlite fallback.
+
+Affected consumers in this slice:
+
+1. safe-lane governor history loading in
+   `load_safe_lane_history_signals_for_governor(...)`
+2. checkpoint readers reached through
+   `load_turn_checkpoint_history_snapshot(...)`,
+   `load_turn_checkpoint_event_summary(...)`, and
+   `load_latest_turn_checkpoint_entry(...)`
+3. higher-level history summaries that opt into kernel-bound execution, such as
+   safe-lane and discovery-first summary helpers
+
+Migration approach for `alpha-test`:
+
+1. leave `ConversationRuntimeBinding::Direct` behavior unchanged so direct-mode
+   compatibility remains stable
+2. let kernel-bound callers see explicit failures and update fail-open
+   orchestration one consumer at a time instead of preserving an implicit shadow
+   path
+3. keep safe-lane governor fail-open at the planning layer for now, but persist
+   `history_load_status` plus a normalized `history_load_error` code so
+   operators can distinguish "no history" from "governed history unavailable"
+
+Normalized error contract for persisted diagnostics:
+
+1. `kernel_request_failed` when the kernel memory-window request itself errors
+2. `kernel_non_ok_status` when the kernel responds with a non-`ok` status
+3. `direct_read_failed` when an intentional direct-mode sqlite read fails
+
+Observability requirements in this slice:
+
+1. persisted safe-lane governor events keep `history_load_status`
+2. persisted safe-lane governor events record only normalized
+   `history_load_error` codes
+3. full underlying error strings stay in process-local error returns rather than
+   durable session events
 
 ### 3. Truthful docs for the remaining architecture state
 
@@ -130,6 +185,7 @@ Add focused regression coverage for:
 3. kernel-bound history readers fail when the memory window kernel request
    fails
 4. direct-mode history readers still use sqlite successfully
+5. safe-lane governor diagnostics persist normalized history load error codes
 
 ## Why This Slice Matters
 

--- a/docs/plans/2026-03-16-governed-runtime-path-hardening-design.md
+++ b/docs/plans/2026-03-16-governed-runtime-path-hardening-design.md
@@ -147,7 +147,7 @@ Normalized error contract for persisted diagnostics:
 1. `kernel_request_failed` when the kernel memory-window request itself errors
 2. `kernel_non_ok_status` when the kernel responds with a non-`ok` status
 3. `kernel_malformed_payload` when the kernel responds with `ok` but omits a
-   usable `payload.turns` array
+   usable `payload.turns` array or includes malformed assistant turn content
 4. `direct_read_failed` when an intentional direct-mode sqlite read fails
 
 Observability requirements in this slice:
@@ -186,8 +186,10 @@ Add focused regression coverage for:
 2. local child-runtime spawn preserves kernel binding in tests
 3. kernel-bound history readers fail when the memory window kernel request
    fails
-4. direct-mode history readers still use sqlite successfully
-5. safe-lane governor diagnostics persist normalized history load error codes
+4. kernel-bound history readers fail when the memory window payload is
+   structurally malformed, including malformed assistant turn content
+5. direct-mode history readers still use sqlite successfully
+6. safe-lane governor diagnostics persist normalized history load error codes
 
 ## Why This Slice Matters
 

--- a/docs/plans/2026-03-16-governed-runtime-path-hardening-design.md
+++ b/docs/plans/2026-03-16-governed-runtime-path-hardening-design.md
@@ -1,0 +1,134 @@
+# Governed Runtime Path Hardening Design
+
+Date: 2026-03-16
+Branch: `fix/alpha-test-governed-runtime-path-hardening-20260316`
+Scope: close the highest-value conversation-runtime governed/direct drift in `alpha-test`
+
+## Problem
+
+`alpha-test` now carries an explicit `ConversationRuntimeBinding`, but two hot
+paths still contradict the kernel-first story in production behavior:
+
+1. async delegate child execution inherits a parent session lineage yet drops
+   into `ConversationRuntimeBinding::Direct`
+2. kernel-bound session-history reads silently downgrade to direct sqlite when
+   the kernel memory-window request fails or returns a non-`ok` outcome
+
+Those paths are not harmless implementation details. They weaken the meaning of
+"kernel-bound" from an execution contract into caller discipline.
+
+## Goals
+
+1. Preserve parent conversation binding when launching async delegate child
+   turns.
+2. Make kernel-bound session-history reads fail closed instead of silently
+   downgrading to direct sqlite.
+3. Update architecture/security docs so they describe the real runtime contract
+   after this slice, including the remaining intentional direct paths.
+4. Keep the patch reviewable and local to conversation/runtime/documentation
+   seams.
+
+## Non-goals
+
+1. Do not kernelize every direct path in `app`, `channel`, or `acp`.
+2. Do not redesign tool approval, channel delivery, or provider failover.
+3. Do not introduce the persistent audit sink in this slice.
+
+## Alternatives Considered
+
+### A. Full repository-wide kernelization
+
+Rejected. It would mix channel, provider, session, and conversation concerns
+into one high-risk patch and make failures hard to attribute.
+
+### B. Add more audit around the drift but keep behavior
+
+Rejected. That would improve observability but still leave the architecture
+contract weaker than the documentation.
+
+### C. Close the highest-value governed/direct gaps first
+
+Recommended. It delivers a concrete architecture-truth improvement with bounded
+blast radius and regression tests.
+
+## Decision
+
+Implement option C in one reviewable slice:
+
+1. carry conversation runtime binding through async delegate spawn
+2. fail closed when a kernel-bound history request cannot be satisfied by the
+   kernel
+3. document the current state precisely, including remaining intentional direct
+   seams
+
+## Proposed Design
+
+### 1. Async delegate children inherit runtime binding
+
+`AsyncDelegateSpawnRequest` should carry owned inherited kernel authority for
+detached child execution. In practice that means threading an owned
+`Option<KernelContext>` through the spawn request, then reconstructing
+`ConversationRuntimeBinding` inside the async delegate spawner before calling
+`run_started_delegate_child_turn_with_runtime(...)`.
+
+This keeps the semantics simple:
+
+1. direct parent -> direct child remains allowed
+2. kernel-bound parent -> kernel-bound child remains governed
+
+The child runtime no longer invents a weaker execution mode than the parent.
+
+### 2. Kernel-bound history reads fail closed
+
+`load_assistant_contents_from_session_window(...)` currently treats
+"kernel returned an error" and "turn intentionally runs direct" as the same
+outcome. Those are different states.
+
+The helper should instead behave as follows:
+
+1. `ConversationRuntimeBinding::Direct` -> read from sqlite directly
+2. `ConversationRuntimeBinding::Kernel(_)` and kernel returns `ok` -> use kernel
+   payload
+3. `ConversationRuntimeBinding::Kernel(_)` and kernel errors or returns
+   non-`ok` -> return an explicit error to the caller
+
+That preserves direct compatibility paths without allowing governed reads to
+degrade silently.
+
+### 3. Truthful docs for the remaining architecture state
+
+`ARCHITECTURE.md` and `docs/SECURITY.md` should stop claiming that all execution
+paths already route through the kernel with no shadow paths. After this slice,
+the more accurate statement is:
+
+1. kernel-governed core execution is the architectural direction
+2. conversation runtime now distinguishes explicit `Kernel` versus `Direct`
+   modes
+3. some outer integration and app-only paths still remain intentionally direct
+   and are follow-up work
+
+## Expected Behavioral Outcome
+
+1. async delegate children launched from governed parents keep kernel authority
+2. kernel-bound history-summary and checkpoint readers report governed failure
+   instead of silently reading sqlite
+3. direct-mode history helpers still work as before
+4. repository docs no longer overclaim full kernel closure
+
+## Test Strategy
+
+Add focused regression coverage for:
+
+1. async delegate spawn request carries the original binding
+2. local child-runtime spawn preserves kernel binding in tests
+3. kernel-bound history readers fail when the memory window kernel request
+   fails
+4. direct-mode history readers still use sqlite successfully
+
+## Why This Slice Matters
+
+The strongest immediate architecture risk in `alpha-test` is not missing
+abstractions. It is contract drift between what the code claims and what it
+actually guarantees. Closing these two paths moves the runtime toward a more
+defensible kernel-first model without pretending the entire repository is
+already there.

--- a/docs/plans/2026-03-16-governed-runtime-path-hardening-design.md
+++ b/docs/plans/2026-03-16-governed-runtime-path-hardening-design.md
@@ -95,6 +95,12 @@ The helper should instead behave as follows:
 That preserves direct compatibility paths without allowing governed reads to
 degrade silently.
 
+For higher-level consumers that intentionally fail open, the runtime should at
+least surface that distinction explicitly. In this slice the safe-lane session
+governor keeps fail-open planning behavior, but it records history load status
+and error details in runtime diagnostics instead of silently looking identical
+to "no historical signal".
+
 ### 3. Truthful docs for the remaining architecture state
 
 `ARCHITECTURE.md` and `docs/SECURITY.md` should stop claiming that all execution

--- a/docs/plans/2026-03-16-governed-runtime-path-hardening-implementation-plan.md
+++ b/docs/plans/2026-03-16-governed-runtime-path-hardening-implementation-plan.md
@@ -12,7 +12,7 @@ as the authority boundary instead of implicit downgrade behavior.
 
 ---
 
-### Task 1: Lock the scope in docs and GitHub issue text
+## Task 1: Lock the scope in docs and GitHub issue text
 
 **Files:**
 - Create: `docs/plans/2026-03-16-governed-runtime-path-hardening-design.md`
@@ -36,7 +36,7 @@ Open a GitHub bug issue describing:
 
 Expected: issue exists before PR creation and uses the repository template.
 
-### Task 2: Add RED tests for the hardening slice
+## Task 2: Add RED tests for the hardening slice
 
 **Files:**
 - Modify: `crates/app/src/conversation/tests.rs`
@@ -63,7 +63,7 @@ Run:
 Expected: FAIL before implementation because binding is still dropped and
 kernel-bound history still falls back.
 
-### Task 3: Preserve binding through async delegate spawn
+## Task 3: Preserve binding through async delegate spawn
 
 **Files:**
 - Modify: `crates/app/src/conversation/runtime.rs`
@@ -85,7 +85,7 @@ and then into `run_started_delegate_child_turn_with_runtime(...)`.
 
 Adjust fake/local async delegate spawners to preserve and/or record the binding.
 
-### Task 4: Fail closed for kernel-bound history reads
+## Task 4: Fail closed for kernel-bound history reads
 
 **Files:**
 - Modify: `crates/app/src/conversation/session_history.rs`
@@ -108,10 +108,10 @@ Retain the direct sqlite path only for `ConversationRuntimeBinding::Direct`.
 **Step 4: Preserve observability in fail-open consumers**
 
 Where higher-level orchestration still chooses to proceed without governor
-history, surface explicit history load status/error diagnostics instead of
+history, surface explicit history load status/error-code diagnostics instead of
 collapsing the failure into a silent default.
 
-### Task 5: Refresh architecture/security docs
+## Task 5: Refresh architecture/security docs
 
 **Files:**
 - Modify: `ARCHITECTURE.md`
@@ -127,7 +127,7 @@ language that matches the current governed-versus-direct split.
 Document that conversation runtime now uses explicit binding semantics, while
 some outer app/channel paths still remain direct follow-up work.
 
-### Task 6: Verify, commit, and deliver
+## Task 6: Verify, commit, and deliver
 
 **Files:**
 - Modify only the files in this scoped slice

--- a/docs/plans/2026-03-16-governed-runtime-path-hardening-implementation-plan.md
+++ b/docs/plans/2026-03-16-governed-runtime-path-hardening-implementation-plan.md
@@ -105,6 +105,12 @@ history load error instead of hitting sqlite fallback.
 
 Retain the direct sqlite path only for `ConversationRuntimeBinding::Direct`.
 
+**Step 4: Preserve observability in fail-open consumers**
+
+Where higher-level orchestration still chooses to proceed without governor
+history, surface explicit history load status/error diagnostics instead of
+collapsing the failure into a silent default.
+
 ### Task 5: Refresh architecture/security docs
 
 **Files:**

--- a/docs/plans/2026-03-16-governed-runtime-path-hardening-implementation-plan.md
+++ b/docs/plans/2026-03-16-governed-runtime-path-hardening-implementation-plan.md
@@ -1,0 +1,154 @@
+# Governed Runtime Path Hardening Implementation Plan
+
+**Goal:** Close the highest-value conversation runtime governed/direct drift by
+preserving async delegate child binding, failing closed for kernel-bound history
+reads, and updating docs to match the real architecture state.
+
+**Architecture:** Keep the patch local to conversation runtime spawn/history
+helpers and architecture/security docs. Use explicit `ConversationRuntimeBinding`
+as the authority boundary instead of implicit downgrade behavior.
+
+**Tech Stack:** Rust, Tokio tests, `loongclaw-app`, GitHub issue-first workflow
+
+---
+
+### Task 1: Lock the scope in docs and GitHub issue text
+
+**Files:**
+- Create: `docs/plans/2026-03-16-governed-runtime-path-hardening-design.md`
+- Create: `docs/plans/2026-03-16-governed-runtime-path-hardening-implementation-plan.md`
+
+**Step 1: Confirm the target seams**
+
+Run:
+- `rg -n "ConversationRuntimeBinding::direct\\(\\)" crates/app/src/conversation/runtime.rs crates/app/src/conversation/tests.rs`
+- `rg -n "load_assistant_contents_from_session_window" crates/app/src/conversation/session_history.rs`
+
+Expected: the delegate-child direct override and the session-history fallback
+site are both enumerated.
+
+**Step 2: Draft the delivery issue**
+
+Open a GitHub bug issue describing:
+- async delegate child binding drift
+- kernel-bound history fallback drift
+- the scoped plan to harden those paths first
+
+Expected: issue exists before PR creation and uses the repository template.
+
+### Task 2: Add RED tests for the hardening slice
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Add delegate-child binding regression tests**
+
+Cover both:
+- async delegate spawn request records the inherited binding
+- local child runtime spawn forwards the same binding into
+  `run_started_delegate_child_turn_with_runtime(...)`
+
+**Step 2: Add kernel-bound history fail-closed regression**
+
+Add a test that binds a kernel context whose memory adapter fails the window
+request and assert `load_turn_checkpoint_event_summary(...)` returns an error
+instead of silently reading sqlite.
+
+**Step 3: Run targeted tests to confirm RED**
+
+Run:
+- `cargo test -p loongclaw-app delegate_async -- --test-threads=1`
+- `cargo test -p loongclaw-app load_turn_checkpoint_event_summary -- --test-threads=1`
+
+Expected: FAIL before implementation because binding is still dropped and
+kernel-bound history still falls back.
+
+### Task 3: Preserve binding through async delegate spawn
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Extend the spawn request**
+
+Add owned inherited kernel authority to `AsyncDelegateSpawnRequest` so detached
+spawns can reconstruct `ConversationRuntimeBinding` without borrowing parent
+stack state.
+
+**Step 2: Forward the inherited binding**
+
+Pass the current binding from async delegate scheduling into the spawn request
+and then into `run_started_delegate_child_turn_with_runtime(...)`.
+
+**Step 3: Update tests and fakes**
+
+Adjust fake/local async delegate spawners to preserve and/or record the binding.
+
+### Task 4: Fail closed for kernel-bound history reads
+
+**Files:**
+- Modify: `crates/app/src/conversation/session_history.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Separate direct mode from kernel failure**
+
+Make `load_assistant_contents_from_session_window(...)` branch on
+`ConversationRuntimeBinding` directly.
+
+**Step 2: Return explicit errors for governed failures**
+
+If the kernel memory-window call errors or returns non-`ok`, return a clear
+history load error instead of hitting sqlite fallback.
+
+**Step 3: Keep direct mode stable**
+
+Retain the direct sqlite path only for `ConversationRuntimeBinding::Direct`.
+
+### Task 5: Refresh architecture/security docs
+
+**Files:**
+- Modify: `ARCHITECTURE.md`
+- Modify: `docs/SECURITY.md`
+
+**Step 1: Remove overclaiming**
+
+Replace "all execution paths route through the kernel" / "no shadow paths" with
+language that matches the current governed-versus-direct split.
+
+**Step 2: Describe the current enforcement boundary**
+
+Document that conversation runtime now uses explicit binding semantics, while
+some outer app/channel paths still remain direct follow-up work.
+
+### Task 6: Verify, commit, and deliver
+
+**Files:**
+- Modify only the files in this scoped slice
+
+**Step 1: Run targeted verification**
+
+Run:
+- `cargo test -p loongclaw-app delegate_async -- --test-threads=1`
+- `cargo test -p loongclaw-app load_turn_checkpoint_event_summary -- --test-threads=1`
+
+Expected: PASS
+
+**Step 2: Run full package verification**
+
+Run:
+- `cargo fmt --all`
+- `cargo fmt --all -- --check`
+- `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
+- `cargo test -p loongclaw-app --all-features -- --test-threads=1`
+
+Expected: PASS
+
+**Step 3: Review the scoped diff and commit**
+
+Run:
+- `git status --short`
+- `git diff --cached --name-only`
+- `git diff --cached`
+
+Expected: only the governed-runtime hardening slice is staged before commit.


### PR DESCRIPTION
## Summary

- Preserve inherited kernel authority across detached `delegate_async` child execution by carrying owned kernel context through the async spawn request.
- Fail closed for kernel-bound conversation history readers instead of silently downgrading to direct sqlite when the kernel memory window fails.
- Surface `history_load_status` and `history_load_error` in safe-lane governor diagnostics so fail-open planning no longer looks identical to “no history”.
- Refresh architecture/security docs and regression tests so the repository narrative matches the runtime contract.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

- Detached async delegate children now preserve parent kernel authority instead of forcing direct mode.
- Kernel-bound history helpers no longer reuse sqlite as a shadow governed path.
- Safe-lane governor intentionally remains fail-open at the planning layer, but runtime diagnostics now distinguish loaded history from unavailable governed history and surface the underlying load error.
- Safe-lane governor coverage was updated to reflect the new contract across both successful governed reads and non-`ok` kernel window responses.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional scenario checks:
- `target/debug/deps/loongclaw_app-6eebd4cd4bb67776 conversation::tests::handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spawn_request --exact --nocapture`
- `target/debug/deps/loongclaw_app-6eebd4cd4bb67776 conversation::tests::load_turn_checkpoint_event_summary_fails_closed_when_kernel_window_errors --exact --nocapture`
- `target/debug/deps/loongclaw_app-6eebd4cd4bb67776 conversation::tests::handle_turn_with_runtime_safe_lane_session_governor_requests_extended_history_window --exact --nocapture`
- `target/debug/deps/loongclaw_app-6eebd4cd4bb67776 conversation::tests::handle_turn_with_runtime_safe_lane_session_governor_does_not_reuse_sqlite_history_when_kernel_window_is_non_ok --exact --nocapture`

## Linked Issues

Closes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async delegate child turns inherit parent kernel authority; kernel-bound delegates carry context into spawned tasks.
  * Assistant-history loading now fails closed on kernel memory errors and surfaces structured load-status and normalized error codes/msgs.
  * Governor diagnostics report history load status (disabled/loaded/unavailable) and associated error codes.

* **Documentation**
  * Architecture and security docs updated; new design/implementation plans for governed runtime-path hardening.

* **Tests**
  * Added/updated tests for kernel-memory failures and kernel-context propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->