### PR TITLE
feat(browser): add companion readiness foundation

### DIFF
--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -53,12 +53,13 @@ pub(crate) use runtime::{normalize_dispatch_account_id, normalize_dispatch_chann
 pub use shared::{CLI_COMMAND_NAME, expand_path};
 #[allow(unused_imports)]
 pub use tools::{
-    BrowserToolConfig, DEFAULT_BROWSER_MAX_LINKS, DEFAULT_BROWSER_MAX_SESSIONS,
-    DEFAULT_BROWSER_MAX_TEXT_CHARS, DEFAULT_SHELL_ALLOW, DEFAULT_WEB_FETCH_MAX_BYTES,
-    DEFAULT_WEB_FETCH_MAX_REDIRECTS, DEFAULT_WEB_FETCH_TIMEOUT_SECONDS, ExternalSkillsConfig,
-    GovernedToolApprovalConfig, GovernedToolApprovalMode, MAX_BROWSER_MAX_LINKS,
-    MAX_BROWSER_MAX_SESSIONS, MAX_BROWSER_MAX_TEXT_CHARS, MAX_WEB_FETCH_MAX_BYTES,
-    SessionVisibility, ToolConfig, WebToolConfig,
+    BrowserCompanionToolConfig, BrowserToolConfig, DEFAULT_BROWSER_MAX_LINKS,
+    DEFAULT_BROWSER_MAX_SESSIONS, DEFAULT_BROWSER_MAX_TEXT_CHARS, DEFAULT_SHELL_ALLOW,
+    DEFAULT_WEB_FETCH_MAX_BYTES, DEFAULT_WEB_FETCH_MAX_REDIRECTS,
+    DEFAULT_WEB_FETCH_TIMEOUT_SECONDS, ExternalSkillsConfig, GovernedToolApprovalConfig,
+    GovernedToolApprovalMode, MAX_BROWSER_MAX_LINKS, MAX_BROWSER_MAX_SESSIONS,
+    MAX_BROWSER_MAX_TEXT_CHARS, MAX_WEB_FETCH_MAX_BYTES, SessionVisibility, ToolConfig,
+    WebToolConfig,
 };
 
 #[cfg(test)]

--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -47,6 +47,8 @@ pub struct ToolConfig {
     #[serde(default)]
     pub browser: BrowserToolConfig,
     #[serde(default)]
+    pub browser_companion: BrowserCompanionToolConfig,
+    #[serde(default)]
     pub web: WebToolConfig,
 }
 
@@ -122,6 +124,16 @@ pub struct BrowserToolConfig {
     pub max_text_chars: usize,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct BrowserCompanionToolConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub expected_version: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WebToolConfig {
     #[serde(default = "default_enabled")]
@@ -192,6 +204,7 @@ impl Default for ToolConfig {
             messages: MessageToolConfig::default(),
             delegate: DelegateToolConfig::default(),
             browser: BrowserToolConfig::default(),
+            browser_companion: BrowserCompanionToolConfig::default(),
             web: WebToolConfig::default(),
         }
     }
@@ -451,6 +464,9 @@ mod tests {
         assert_eq!(config.browser.max_sessions, 8);
         assert_eq!(config.browser.max_links, 40);
         assert_eq!(config.browser.max_text_chars, 6000);
+        assert!(!config.browser_companion.enabled);
+        assert!(config.browser_companion.command.is_none());
+        assert!(config.browser_companion.expected_version.is_none());
         assert!(config.web.enabled);
         assert!(!config.web.allow_private_hosts);
         assert!(config.web.allowed_domains.is_empty());
@@ -561,6 +577,29 @@ max_text_chars = 2048
         assert_eq!(parsed.tools.browser.max_sessions, 4);
         assert_eq!(parsed.tools.browser.max_links, 12);
         assert_eq!(parsed.tools.browser.max_text_chars, 2048);
+    }
+
+    #[cfg(feature = "config-toml")]
+    #[test]
+    fn tool_config_parses_browser_companion_controls_from_toml() {
+        let raw = r#"
+[tools.browser_companion]
+enabled = true
+command = "loongclaw-browser-companion"
+expected_version = "1.2.3"
+"#;
+        let parsed =
+            toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
+
+        assert!(parsed.tools.browser_companion.enabled);
+        assert_eq!(
+            parsed.tools.browser_companion.command.as_deref(),
+            Some("loongclaw-browser-companion")
+        );
+        assert_eq!(
+            parsed.tools.browser_companion.expected_version.as_deref(),
+            Some("1.2.3")
+        );
     }
 
     /// When `shell_deny` is absent, it must default to empty — users start

--- a/crates/app/src/runtime_env.rs
+++ b/crates/app/src/runtime_env.rs
@@ -81,11 +81,11 @@ pub fn initialize_runtime_environment(
         "LOONGCLAW_BROWSER_COMPANION_ENABLED",
         bool_env(config.tools.browser_companion.enabled),
     );
-    match config.tools.browser_companion.command.as_deref() {
+    match normalized_optional_str(config.tools.browser_companion.command.as_deref()) {
         Some(command) => set_env_var("LOONGCLAW_BROWSER_COMPANION_COMMAND", command),
         None => remove_env_var("LOONGCLAW_BROWSER_COMPANION_COMMAND"),
     }
-    match config.tools.browser_companion.expected_version.as_deref() {
+    match normalized_optional_str(config.tools.browser_companion.expected_version.as_deref()) {
         Some(expected_version) => set_env_var(
             "LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION",
             expected_version,
@@ -167,6 +167,10 @@ pub fn initialize_runtime_environment(
 
 fn bool_env(value: bool) -> &'static str {
     if value { "true" } else { "false" }
+}
+
+fn normalized_optional_str(raw: Option<&str>) -> Option<&str> {
+    raw.map(str::trim).filter(|value| !value.is_empty())
 }
 
 fn set_env_var(key: &str, value: impl AsRef<std::ffi::OsStr>) {
@@ -366,6 +370,27 @@ mod tests {
                 .ok()
                 .as_deref(),
             Some("1")
+        );
+    }
+
+    #[test]
+    fn initialize_runtime_environment_drops_blank_browser_companion_metadata() {
+        let mut env = ScopedEnv::new();
+        clear_runtime_environment_exports(&mut env);
+        let mut config = LoongClawConfig::default();
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some("   ".to_owned());
+        config.tools.browser_companion.expected_version = Some("\n\t".to_owned());
+
+        initialize_runtime_environment(&config, None);
+
+        assert_eq!(
+            std::env::var("LOONGCLAW_BROWSER_COMPANION_COMMAND").ok(),
+            None
+        );
+        assert_eq!(
+            std::env::var("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION").ok(),
+            None
         );
     }
 }

--- a/crates/app/src/runtime_env.rs
+++ b/crates/app/src/runtime_env.rs
@@ -182,17 +182,52 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::config::{LoongClawConfig, MemoryProfile};
+    use crate::test_support::ScopedEnv;
 
     use super::*;
 
-    fn env_lock() -> &'static std::sync::Mutex<()> {
-        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    fn clear_runtime_environment_exports(env: &mut ScopedEnv) {
+        for key in [
+            "LOONGCLAW_CONFIG_PATH",
+            "LOONGCLAW_MEMORY_BACKEND",
+            "LOONGCLAW_MEMORY_PROFILE",
+            "LOONGCLAW_SQLITE_PATH",
+            "LOONGCLAW_SLIDING_WINDOW",
+            "LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS",
+            "LOONGCLAW_MEMORY_PROFILE_NOTE",
+            "LOONGCLAW_SHELL_ALLOWLIST",
+            "LOONGCLAW_SHELL_DENY",
+            "LOONGCLAW_SHELL_DEFAULT_MODE",
+            "LOONGCLAW_FILE_ROOT",
+            "LOONGCLAW_EXTERNAL_SKILLS_ENABLED",
+            "LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL",
+            "LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS",
+            "LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS",
+            "LOONGCLAW_EXTERNAL_SKILLS_INSTALL_ROOT",
+            "LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED",
+            "LOONGCLAW_BROWSER_ENABLED",
+            "LOONGCLAW_BROWSER_MAX_SESSIONS",
+            "LOONGCLAW_BROWSER_MAX_LINKS",
+            "LOONGCLAW_BROWSER_MAX_TEXT_CHARS",
+            "LOONGCLAW_BROWSER_COMPANION_ENABLED",
+            "LOONGCLAW_BROWSER_COMPANION_COMMAND",
+            "LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION",
+            "LOONGCLAW_WEB_FETCH_ENABLED",
+            "LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS",
+            "LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS",
+            "LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS",
+            "LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS",
+            "LOONGCLAW_WEB_FETCH_MAX_BYTES",
+            "LOONGCLAW_WEB_FETCH_MAX_REDIRECTS",
+        ] {
+            env.remove(key);
+        }
     }
 
     #[test]
     fn initialize_runtime_environment_exports_core_env_vars() {
-        let _guard = env_lock().lock().expect("env lock");
+        let mut env = ScopedEnv::new();
+        clear_runtime_environment_exports(&mut env);
         let mut config = LoongClawConfig::default();
         config.memory.profile = MemoryProfile::WindowPlusSummary;
         config.memory.summary_max_chars = 900;
@@ -332,37 +367,5 @@ mod tests {
                 .as_deref(),
             Some("1")
         );
-
-        crate::process_env::remove_var("LOONGCLAW_CONFIG_PATH");
-        crate::process_env::remove_var("LOONGCLAW_MEMORY_BACKEND");
-        crate::process_env::remove_var("LOONGCLAW_MEMORY_PROFILE");
-        crate::process_env::remove_var("LOONGCLAW_SQLITE_PATH");
-        crate::process_env::remove_var("LOONGCLAW_SLIDING_WINDOW");
-        crate::process_env::remove_var("LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS");
-        crate::process_env::remove_var("LOONGCLAW_MEMORY_PROFILE_NOTE");
-        crate::process_env::remove_var("LOONGCLAW_SHELL_ALLOWLIST");
-        crate::process_env::remove_var("LOONGCLAW_SHELL_DENY");
-        crate::process_env::remove_var("LOONGCLAW_SHELL_DEFAULT_MODE");
-        crate::process_env::remove_var("LOONGCLAW_FILE_ROOT");
-        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_ENABLED");
-        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL");
-        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS");
-        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS");
-        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_INSTALL_ROOT");
-        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_ENABLED");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_MAX_SESSIONS");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_MAX_LINKS");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_MAX_TEXT_CHARS");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_ENABLED");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_COMMAND");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ENABLED");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_MAX_BYTES");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_MAX_REDIRECTS");
     }
 }

--- a/crates/app/src/runtime_env.rs
+++ b/crates/app/src/runtime_env.rs
@@ -78,6 +78,21 @@ pub fn initialize_runtime_environment(
         config.tools.browser.max_text_chars.to_string(),
     );
     set_env_var(
+        "LOONGCLAW_BROWSER_COMPANION_ENABLED",
+        bool_env(config.tools.browser_companion.enabled),
+    );
+    match config.tools.browser_companion.command.as_deref() {
+        Some(command) => set_env_var("LOONGCLAW_BROWSER_COMPANION_COMMAND", command),
+        None => remove_env_var("LOONGCLAW_BROWSER_COMPANION_COMMAND"),
+    }
+    match config.tools.browser_companion.expected_version.as_deref() {
+        Some(expected_version) => set_env_var(
+            "LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION",
+            expected_version,
+        ),
+        None => remove_env_var("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION"),
+    }
+    set_env_var(
         "LOONGCLAW_WEB_FETCH_ENABLED",
         bool_env(config.tools.web.enabled),
     );
@@ -187,6 +202,9 @@ mod tests {
         config.tools.browser.max_sessions = 4;
         config.tools.browser.max_links = 12;
         config.tools.browser.max_text_chars = 2048;
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some("loongclaw-browser-companion".to_owned());
+        config.tools.browser_companion.expected_version = Some("1.2.3".to_owned());
         config.tools.web.enabled = false;
         config.tools.web.allow_private_hosts = true;
         config.tools.web.allowed_domains = vec!["docs.example.com".to_owned()];
@@ -257,6 +275,24 @@ mod tests {
             Some("2048")
         );
         assert_eq!(
+            std::env::var("LOONGCLAW_BROWSER_COMPANION_ENABLED")
+                .ok()
+                .as_deref(),
+            Some("true")
+        );
+        assert_eq!(
+            std::env::var("LOONGCLAW_BROWSER_COMPANION_COMMAND")
+                .ok()
+                .as_deref(),
+            Some("loongclaw-browser-companion")
+        );
+        assert_eq!(
+            std::env::var("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION")
+                .ok()
+                .as_deref(),
+            Some("1.2.3")
+        );
+        assert_eq!(
             std::env::var("LOONGCLAW_WEB_FETCH_ENABLED").ok().as_deref(),
             Some("false")
         );
@@ -318,6 +354,9 @@ mod tests {
         crate::process_env::remove_var("LOONGCLAW_BROWSER_MAX_SESSIONS");
         crate::process_env::remove_var("LOONGCLAW_BROWSER_MAX_LINKS");
         crate::process_env::remove_var("LOONGCLAW_BROWSER_MAX_TEXT_CHARS");
+        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_ENABLED");
+        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_COMMAND");
+        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION");
         crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ENABLED");
         crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS");
         crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS");

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -104,6 +104,18 @@ pub enum ToolExposureClass {
     Discoverable,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum ToolVisibilityGate {
+    Always,
+    Sessions,
+    Messages,
+    Delegate,
+    Browser,
+    BrowserCompanion,
+    ExternalSkills,
+    WebFetch,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ToolDescriptor {
     pub name: &'static str,
@@ -113,6 +125,7 @@ pub struct ToolDescriptor {
     pub execution_kind: ToolExecutionKind,
     pub availability: ToolAvailability,
     pub exposure: ToolExposureClass,
+    pub visibility_gate: ToolVisibilityGate,
     provider_definition_builder: fn(&ToolDescriptor) -> Value,
 }
 
@@ -271,6 +284,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::ProviderCore,
+            visibility_gate: ToolVisibilityGate::Always,
             provider_definition_builder: tool_search_definition,
         },
         ToolDescriptor {
@@ -281,6 +295,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::ProviderCore,
+            visibility_gate: ToolVisibilityGate::Always,
             provider_definition_builder: tool_invoke_definition,
         },
         ToolDescriptor {
@@ -291,6 +306,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Always,
             provider_definition_builder: claw_import_definition,
         },
         ToolDescriptor {
@@ -301,6 +317,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::ExternalSkills,
             provider_definition_builder: external_skills_fetch_definition,
         },
         ToolDescriptor {
@@ -311,6 +328,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::ExternalSkills,
             provider_definition_builder: external_skills_inspect_definition,
         },
         ToolDescriptor {
@@ -321,6 +339,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::ExternalSkills,
             provider_definition_builder: external_skills_install_definition,
         },
         ToolDescriptor {
@@ -331,6 +350,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::ExternalSkills,
             provider_definition_builder: external_skills_invoke_definition,
         },
         ToolDescriptor {
@@ -341,6 +361,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::ExternalSkills,
             provider_definition_builder: external_skills_list_definition,
         },
         ToolDescriptor {
@@ -351,6 +372,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Always,
             provider_definition_builder: external_skills_policy_definition,
         },
         ToolDescriptor {
@@ -361,6 +383,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::ExternalSkills,
             provider_definition_builder: external_skills_remove_definition,
         },
         ToolDescriptor {
@@ -371,6 +394,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Always,
             provider_definition_builder: provider_switch_definition,
         },
         ToolDescriptor {
@@ -381,6 +405,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
             provider_definition_builder: approval_request_resolve_definition,
         },
         ToolDescriptor {
@@ -391,6 +416,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
             provider_definition_builder: approval_request_status_definition,
         },
         ToolDescriptor {
@@ -401,6 +427,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
             provider_definition_builder: approval_requests_list_definition,
         },
         ToolDescriptor {
@@ -411,6 +438,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Delegate,
             provider_definition_builder: delegate_definition,
         },
         ToolDescriptor {
@@ -421,6 +449,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Delegate,
             provider_definition_builder: delegate_async_definition,
         },
         ToolDescriptor {
@@ -431,6 +460,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
             provider_definition_builder: session_archive_definition,
         },
         ToolDescriptor {
@@ -441,6 +471,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
             provider_definition_builder: session_cancel_definition,
         },
         ToolDescriptor {
@@ -451,6 +482,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
             provider_definition_builder: session_events_definition,
         },
         ToolDescriptor {
@@ -461,6 +493,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
             provider_definition_builder: session_recover_definition,
         },
         ToolDescriptor {
@@ -471,6 +504,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
             provider_definition_builder: session_status_definition,
         },
         ToolDescriptor {
@@ -481,6 +515,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
             provider_definition_builder: session_wait_definition,
         },
         ToolDescriptor {
@@ -491,6 +526,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
             provider_definition_builder: sessions_history_definition,
         },
         ToolDescriptor {
@@ -501,6 +537,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
             provider_definition_builder: sessions_list_definition,
         },
         ToolDescriptor {
@@ -511,6 +548,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_messaging_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Messages,
             provider_definition_builder: sessions_send_definition,
         },
     ];
@@ -525,6 +563,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Always,
             provider_definition_builder: file_read_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -535,6 +574,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Always,
             provider_definition_builder: file_write_definition,
         });
     }
@@ -549,6 +589,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Always,
             provider_definition_builder: shell_exec_definition,
         });
     }
@@ -563,6 +604,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Browser,
             provider_definition_builder: browser_click_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -573,6 +615,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Browser,
             provider_definition_builder: browser_extract_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -584,6 +627,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Browser,
             provider_definition_builder: browser_open_definition,
         });
     }
@@ -598,6 +642,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::WebFetch,
             provider_definition_builder: web_fetch_definition,
         });
     }
@@ -625,7 +670,11 @@ pub fn runtime_tool_view_for_config_with_external_skills(
             .iter()
             .filter(|descriptor| descriptor.availability == ToolAvailability::Runtime)
             .filter(|descriptor| {
-                tool_is_enabled_for_runtime_view(descriptor.name, config, external_skills_enabled)
+                tool_visibility_gate_enabled_for_runtime_view(
+                    descriptor.visibility_gate,
+                    config,
+                    external_skills_enabled,
+                )
             })
             .map(|descriptor| descriptor.name),
     )
@@ -638,7 +687,9 @@ pub fn runtime_tool_view_for_runtime_config(config: &ToolRuntimeConfig) -> ToolV
             .descriptors()
             .iter()
             .filter(|descriptor| descriptor.availability == ToolAvailability::Runtime)
-            .filter(|descriptor| tool_is_enabled_for_runtime_policy(descriptor.name, config))
+            .filter(|descriptor| {
+                tool_visibility_gate_enabled_for_runtime_policy(descriptor.visibility_gate, config)
+            })
             .map(|descriptor| descriptor.name),
     )
 }
@@ -757,61 +808,36 @@ fn descriptor_to_entry(descriptor: &ToolDescriptor) -> ToolCatalogEntry {
     }
 }
 
-fn tool_is_enabled_for_runtime_view(
-    tool_name: &str,
+fn tool_visibility_gate_enabled_for_runtime_view(
+    gate: ToolVisibilityGate,
     config: &ToolConfig,
     external_skills_enabled: bool,
 ) -> bool {
-    match tool_name {
-        "approval_request_resolve"
-        | "approval_request_status"
-        | "approval_requests_list"
-        | "sessions_list"
-        | "sessions_history"
-        | "session_status"
-        | "session_events"
-        | "session_archive"
-        | "session_cancel"
-        | "session_recover"
-        | "session_wait" => config.sessions.enabled,
-        "sessions_send" => config.messages.enabled,
-        "delegate" | "delegate_async" => config.delegate.enabled,
-        "browser.open" | "browser.extract" | "browser.click" => config.browser.enabled,
-        "external_skills.fetch"
-        | "external_skills.inspect"
-        | "external_skills.install"
-        | "external_skills.invoke"
-        | "external_skills.list"
-        | "external_skills.remove" => external_skills_enabled,
-        "web.fetch" => config.web.enabled,
-        _ => true,
+    match gate {
+        ToolVisibilityGate::Always => true,
+        ToolVisibilityGate::Sessions => config.sessions.enabled,
+        ToolVisibilityGate::Messages => config.messages.enabled,
+        ToolVisibilityGate::Delegate => config.delegate.enabled,
+        ToolVisibilityGate::Browser => config.browser.enabled,
+        ToolVisibilityGate::BrowserCompanion => false,
+        ToolVisibilityGate::ExternalSkills => external_skills_enabled,
+        ToolVisibilityGate::WebFetch => config.web.enabled,
     }
 }
 
-fn tool_is_enabled_for_runtime_policy(tool_name: &str, config: &ToolRuntimeConfig) -> bool {
-    match tool_name {
-        "approval_request_resolve"
-        | "approval_request_status"
-        | "approval_requests_list"
-        | "sessions_list"
-        | "sessions_history"
-        | "session_status"
-        | "session_events"
-        | "session_archive"
-        | "session_cancel"
-        | "session_recover"
-        | "session_wait" => config.sessions_enabled,
-        "sessions_send" => config.messages_enabled,
-        "delegate" | "delegate_async" => config.delegate_enabled,
-        "browser.open" | "browser.extract" | "browser.click" => config.browser.enabled,
-        "external_skills.fetch"
-        | "external_skills.inspect"
-        | "external_skills.install"
-        | "external_skills.invoke"
-        | "external_skills.list"
-        | "external_skills.remove" => config.external_skills.enabled,
-        "web.fetch" => config.web_fetch.enabled,
-        _ => true,
+fn tool_visibility_gate_enabled_for_runtime_policy(
+    gate: ToolVisibilityGate,
+    config: &ToolRuntimeConfig,
+) -> bool {
+    match gate {
+        ToolVisibilityGate::Always => true,
+        ToolVisibilityGate::Sessions => config.sessions_enabled,
+        ToolVisibilityGate::Messages => config.messages_enabled,
+        ToolVisibilityGate::Delegate => config.delegate_enabled,
+        ToolVisibilityGate::Browser => config.browser.enabled,
+        ToolVisibilityGate::BrowserCompanion => config.browser_companion.is_runtime_ready(),
+        ToolVisibilityGate::ExternalSkills => config.external_skills.enabled,
+        ToolVisibilityGate::WebFetch => config.web_fetch.enabled,
     }
 }
 
@@ -1937,5 +1963,54 @@ fn tool_tags(name: &str) -> &'static [&'static str] {
         }
         "sessions_send" => &["session", "message", "channel"],
         _ => &[],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_companion_visibility_gate_requires_runtime_readiness() {
+        let mut config = ToolRuntimeConfig::default();
+        config.browser_companion.enabled = true;
+        config.browser_companion.ready = false;
+
+        assert!(!tool_visibility_gate_enabled_for_runtime_policy(
+            ToolVisibilityGate::BrowserCompanion,
+            &config
+        ));
+
+        config.browser_companion.ready = true;
+
+        assert!(tool_visibility_gate_enabled_for_runtime_policy(
+            ToolVisibilityGate::BrowserCompanion,
+            &config
+        ));
+    }
+
+    #[test]
+    fn browser_companion_visibility_gate_stays_hidden_for_config_only_views() {
+        let mut config = ToolConfig::default();
+        config.browser_companion.enabled = true;
+
+        assert!(!tool_visibility_gate_enabled_for_runtime_view(
+            ToolVisibilityGate::BrowserCompanion,
+            &config,
+            false
+        ));
+    }
+
+    #[test]
+    fn browser_visibility_gate_is_independent_from_companion_settings() {
+        let mut config = ToolRuntimeConfig::default();
+        config.browser.enabled = true;
+        config.browser_companion.enabled = false;
+        config.browser_companion.ready = false;
+
+        assert!(tool_visibility_gate_enabled_for_runtime_policy(
+            ToolVisibilityGate::Browser,
+            &config
+        ));
     }
 }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -738,7 +738,15 @@ pub fn delegate_child_tool_view_for_config_with_delegate(
                     names.push(descriptor.name);
                 }
             }
-            name if allowlist.contains(name) => names.push(name),
+            name if allowlist.contains(name)
+                && tool_visibility_gate_enabled_for_runtime_view(
+                    descriptor.visibility_gate,
+                    config,
+                    false,
+                ) =>
+            {
+                names.push(name);
+            }
             _ => {}
         }
     }
@@ -2012,5 +2020,16 @@ mod tests {
             ToolVisibilityGate::Browser,
             &config
         ));
+    }
+
+    #[test]
+    fn delegate_child_tool_view_respects_visibility_gates() {
+        let mut config = ToolConfig::default();
+        config.web.enabled = false;
+        config.delegate.child_tool_allowlist = vec!["web.fetch".to_owned()];
+
+        let child_view = delegate_child_tool_view_for_config(&config);
+
+        assert!(!child_view.contains("web.fetch"));
     }
 }

--- a/crates/app/src/tools/claw_import.rs
+++ b/crates/app/src/tools/claw_import.rs
@@ -614,6 +614,7 @@ mod tests {
             messages_enabled: true,
             delegate_enabled: true,
             browser: Default::default(),
+            browser_companion: Default::default(),
             web_fetch: Default::default(),
             external_skills: Default::default(),
             #[cfg(feature = "feishu-integration")]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -467,11 +467,11 @@ pub(crate) fn runtime_tool_view_from_loongclaw_config(
 }
 
 pub(crate) fn runtime_tool_view_with_runtime_config(
-    tool_config: &crate::config::ToolConfig,
+    _tool_config: &crate::config::ToolConfig,
     runtime_config: &runtime_config::ToolRuntimeConfig,
 ) -> ToolView {
     let catalog = tool_catalog();
-    let mut names = runtime_tool_view_for_config(tool_config)
+    let mut names = runtime_tool_view_for_runtime_config(runtime_config)
         .iter(&catalog)
         .map(|descriptor| descriptor.name)
         .collect::<Vec<_>>();
@@ -1605,6 +1605,23 @@ mod tests {
         assert!(enabled_view.contains("external_skills.fetch"));
         assert!(enabled_view.contains("external_skills.invoke"));
         assert!(enabled_view.contains("external_skills.list"));
+    }
+
+    #[test]
+    fn runtime_tool_view_with_runtime_config_uses_runtime_external_skills_policy() {
+        let runtime_config = runtime_config::ToolRuntimeConfig {
+            external_skills: runtime_config::ExternalSkillsRuntimePolicy {
+                enabled: true,
+                ..runtime_config::ExternalSkillsRuntimePolicy::default()
+            },
+            ..runtime_config::ToolRuntimeConfig::default()
+        };
+
+        let view = runtime_tool_view_with_runtime_config(&ToolConfig::default(), &runtime_config);
+
+        assert!(view.contains("external_skills.fetch"));
+        assert!(view.contains("external_skills.invoke"));
+        assert!(view.contains("external_skills.list"));
     }
 
     #[test]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1349,6 +1349,7 @@ mod tests {
             messages_enabled: true,
             delegate_enabled: true,
             browser: Default::default(),
+            browser_companion: Default::default(),
             web_fetch: Default::default(),
             external_skills: runtime_config::ExternalSkillsRuntimePolicy {
                 enabled: true,
@@ -2016,6 +2017,7 @@ mod tests {
             messages_enabled: true,
             delegate_enabled: true,
             browser: Default::default(),
+            browser_companion: Default::default(),
             web_fetch: Default::default(),
             external_skills: runtime_config::ExternalSkillsRuntimePolicy::default(),
             #[cfg(feature = "feishu-integration")]

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -50,6 +50,21 @@ impl Default for BrowserRuntimePolicy {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BrowserCompanionRuntimePolicy {
+    pub enabled: bool,
+    pub ready: bool,
+    pub command: Option<String>,
+    pub expected_version: Option<String>,
+}
+
+impl BrowserCompanionRuntimePolicy {
+    #[must_use]
+    pub fn is_runtime_ready(&self) -> bool {
+        self.enabled && self.ready
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WebFetchRuntimePolicy {
     pub enabled: bool,
@@ -117,6 +132,7 @@ pub struct ToolRuntimeConfig {
     pub messages_enabled: bool,
     pub delegate_enabled: bool,
     pub browser: BrowserRuntimePolicy,
+    pub browser_companion: BrowserCompanionRuntimePolicy,
     pub web_fetch: WebFetchRuntimePolicy,
     pub external_skills: ExternalSkillsRuntimePolicy,
     #[cfg(feature = "feishu-integration")]
@@ -138,6 +154,7 @@ impl Default for ToolRuntimeConfig {
             messages_enabled: false,
             delegate_enabled: true,
             browser: BrowserRuntimePolicy::default(),
+            browser_companion: BrowserCompanionRuntimePolicy::default(),
             web_fetch: WebFetchRuntimePolicy::default(),
             external_skills: ExternalSkillsRuntimePolicy::default(),
             #[cfg(feature = "feishu-integration")]
@@ -172,6 +189,16 @@ impl ToolRuntimeConfig {
                 max_sessions: config.tools.browser.max_sessions,
                 max_links: config.tools.browser.max_links,
                 max_text_chars: config.tools.browser.max_text_chars,
+            },
+            browser_companion: BrowserCompanionRuntimePolicy {
+                enabled: config.tools.browser_companion.enabled,
+                ready: parse_env_bool("LOONGCLAW_BROWSER_COMPANION_READY").unwrap_or(false),
+                command: normalize_optional_string(
+                    config.tools.browser_companion.command.as_deref(),
+                ),
+                expected_version: normalize_optional_string(
+                    config.tools.browser_companion.expected_version.as_deref(),
+                ),
             },
             web_fetch: WebFetchRuntimePolicy {
                 enabled: config.tools.web.enabled,
@@ -232,6 +259,13 @@ impl ToolRuntimeConfig {
             .unwrap_or(crate::config::DEFAULT_BROWSER_MAX_LINKS);
         let browser_max_text_chars = parse_env_usize("LOONGCLAW_BROWSER_MAX_TEXT_CHARS")
             .unwrap_or(crate::config::DEFAULT_BROWSER_MAX_TEXT_CHARS);
+        let browser_companion_enabled =
+            parse_env_bool("LOONGCLAW_BROWSER_COMPANION_ENABLED").unwrap_or(false);
+        let browser_companion_ready =
+            parse_env_bool("LOONGCLAW_BROWSER_COMPANION_READY").unwrap_or(false);
+        let browser_companion_command = parse_env_string("LOONGCLAW_BROWSER_COMPANION_COMMAND");
+        let browser_companion_expected_version =
+            parse_env_string("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION");
         let web_fetch_enabled = parse_env_bool("LOONGCLAW_WEB_FETCH_ENABLED").unwrap_or(true);
         let web_fetch_allow_private_hosts =
             parse_env_bool("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS").unwrap_or(false);
@@ -267,6 +301,12 @@ impl ToolRuntimeConfig {
                 max_sessions: browser_max_sessions,
                 max_links: browser_max_links,
                 max_text_chars: browser_max_text_chars,
+            },
+            browser_companion: BrowserCompanionRuntimePolicy {
+                enabled: browser_companion_enabled,
+                ready: browser_companion_ready,
+                command: browser_companion_command,
+                expected_version: browser_companion_expected_version,
             },
             web_fetch: WebFetchRuntimePolicy {
                 enabled: web_fetch_enabled,
@@ -320,6 +360,16 @@ fn parse_env_usize(key: &str) -> Option<usize> {
     std::env::var(key)
         .ok()
         .and_then(|raw| raw.trim().parse::<usize>().ok())
+}
+
+fn normalize_optional_string(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn parse_env_string(key: &str) -> Option<String> {
+    normalize_optional_string(std::env::var(key).ok().as_deref())
 }
 
 fn parse_env_domain_list(key: &str) -> BTreeSet<String> {
@@ -432,6 +482,10 @@ mod tests {
         assert_eq!(config.browser.max_sessions, 8);
         assert_eq!(config.browser.max_links, 40);
         assert_eq!(config.browser.max_text_chars, 6000);
+        assert!(!config.browser_companion.enabled);
+        assert!(!config.browser_companion.ready);
+        assert!(config.browser_companion.command.is_none());
+        assert!(config.browser_companion.expected_version.is_none());
         assert!(config.web_fetch.enabled);
         assert!(!config.web_fetch.allow_private_hosts);
         assert!(config.web_fetch.allowed_domains.is_empty());
@@ -472,6 +526,12 @@ mod tests {
                 max_links: 12,
                 max_text_chars: 2_048,
             },
+            browser_companion: BrowserCompanionRuntimePolicy {
+                enabled: true,
+                ready: true,
+                command: Some("loongclaw-browser-companion".to_owned()),
+                expected_version: Some("1.2.3".to_owned()),
+            },
             web_fetch: WebFetchRuntimePolicy {
                 enabled: false,
                 allow_private_hosts: true,
@@ -506,6 +566,16 @@ mod tests {
         assert_eq!(config.browser.max_sessions, 4);
         assert_eq!(config.browser.max_links, 12);
         assert_eq!(config.browser.max_text_chars, 2_048);
+        assert!(config.browser_companion.enabled);
+        assert!(config.browser_companion.ready);
+        assert_eq!(
+            config.browser_companion.command.as_deref(),
+            Some("loongclaw-browser-companion")
+        );
+        assert_eq!(
+            config.browser_companion.expected_version.as_deref(),
+            Some("1.2.3")
+        );
         assert!(!config.web_fetch.enabled);
         assert!(config.web_fetch.allow_private_hosts);
         assert!(
@@ -548,6 +618,29 @@ mod tests {
         assert!(config.shell_allow.is_empty());
     }
 
+    #[test]
+    fn from_loongclaw_config_projects_browser_companion_policy() {
+        crate::process_env::set_var("LOONGCLAW_BROWSER_COMPANION_READY", "true");
+        let mut config = crate::config::LoongClawConfig::default();
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some("loongclaw-browser-companion".to_owned());
+        config.tools.browser_companion.expected_version = Some("1.2.3".to_owned());
+
+        let runtime = ToolRuntimeConfig::from_loongclaw_config(&config, None);
+        assert!(runtime.browser_companion.enabled);
+        assert!(runtime.browser_companion.ready);
+        assert_eq!(
+            runtime.browser_companion.command.as_deref(),
+            Some("loongclaw-browser-companion")
+        );
+        assert_eq!(
+            runtime.browser_companion.expected_version.as_deref(),
+            Some("1.2.3")
+        );
+
+        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_READY");
+    }
+
     #[cfg(feature = "tool-shell")]
     #[test]
     fn injected_config_overrides_global() {
@@ -583,6 +676,13 @@ mod tests {
         crate::process_env::set_var("LOONGCLAW_BROWSER_MAX_SESSIONS", "4");
         crate::process_env::set_var("LOONGCLAW_BROWSER_MAX_LINKS", "12");
         crate::process_env::set_var("LOONGCLAW_BROWSER_MAX_TEXT_CHARS", "2048");
+        crate::process_env::set_var("LOONGCLAW_BROWSER_COMPANION_ENABLED", "true");
+        crate::process_env::set_var("LOONGCLAW_BROWSER_COMPANION_READY", "true");
+        crate::process_env::set_var(
+            "LOONGCLAW_BROWSER_COMPANION_COMMAND",
+            "loongclaw-browser-companion",
+        );
+        crate::process_env::set_var("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION", "1.2.3");
         crate::process_env::set_var("LOONGCLAW_WEB_FETCH_ENABLED", "false");
         crate::process_env::set_var("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS", "true");
         crate::process_env::set_var(
@@ -620,6 +720,16 @@ mod tests {
         assert_eq!(config.browser.max_sessions, 4);
         assert_eq!(config.browser.max_links, 12);
         assert_eq!(config.browser.max_text_chars, 2_048);
+        assert!(config.browser_companion.enabled);
+        assert!(config.browser_companion.ready);
+        assert_eq!(
+            config.browser_companion.command.as_deref(),
+            Some("loongclaw-browser-companion")
+        );
+        assert_eq!(
+            config.browser_companion.expected_version.as_deref(),
+            Some("1.2.3")
+        );
         assert!(!config.web_fetch.enabled);
         assert!(config.web_fetch.allow_private_hosts);
         assert!(
@@ -666,6 +776,10 @@ mod tests {
         crate::process_env::remove_var("LOONGCLAW_BROWSER_MAX_SESSIONS");
         crate::process_env::remove_var("LOONGCLAW_BROWSER_MAX_LINKS");
         crate::process_env::remove_var("LOONGCLAW_BROWSER_MAX_TEXT_CHARS");
+        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_ENABLED");
+        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_READY");
+        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_COMMAND");
+        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION");
         crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ENABLED");
         crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS");
         crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS");
@@ -717,6 +831,24 @@ mod tests {
         assert_eq!(policy.max_sessions, 4);
         assert_eq!(policy.max_links, 12);
         assert_eq!(policy.max_text_chars, 2_048);
+    }
+
+    #[test]
+    fn browser_companion_policy_struct_construction() {
+        let policy = BrowserCompanionRuntimePolicy {
+            enabled: true,
+            ready: false,
+            command: Some("loongclaw-browser-companion".to_owned()),
+            expected_version: Some("1.2.3".to_owned()),
+        };
+
+        assert!(policy.enabled);
+        assert!(!policy.ready);
+        assert_eq!(
+            policy.command.as_deref(),
+            Some("loongclaw-browser-companion")
+        );
+        assert_eq!(policy.expected_version.as_deref(), Some("1.2.3"));
     }
 
     #[test]

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -467,8 +467,48 @@ pub fn get_tool_runtime_config() -> &'static ToolRuntimeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::ScopedEnv;
     #[cfg(feature = "feishu-integration")]
     use std::collections::BTreeMap;
+
+    fn clear_tool_runtime_env(env: &mut ScopedEnv) {
+        for key in [
+            "LOONGCLAW_CONFIG_PATH",
+            "LOONGCLAW_FILE_ROOT",
+            "LOONGCLAW_TOOL_SESSIONS_ENABLED",
+            "LOONGCLAW_TOOL_MESSAGES_ENABLED",
+            "LOONGCLAW_TOOL_DELEGATE_ENABLED",
+            "LOONGCLAW_BROWSER_ENABLED",
+            "LOONGCLAW_BROWSER_MAX_SESSIONS",
+            "LOONGCLAW_BROWSER_MAX_LINKS",
+            "LOONGCLAW_BROWSER_MAX_TEXT_CHARS",
+            "LOONGCLAW_BROWSER_COMPANION_ENABLED",
+            "LOONGCLAW_BROWSER_COMPANION_READY",
+            "LOONGCLAW_BROWSER_COMPANION_COMMAND",
+            "LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION",
+            "LOONGCLAW_WEB_FETCH_ENABLED",
+            "LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS",
+            "LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS",
+            "LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS",
+            "LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS",
+            "LOONGCLAW_WEB_FETCH_MAX_BYTES",
+            "LOONGCLAW_WEB_FETCH_MAX_REDIRECTS",
+            "LOONGCLAW_EXTERNAL_SKILLS_ENABLED",
+            "LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL",
+            "LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS",
+            "LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS",
+            "LOONGCLAW_EXTERNAL_SKILLS_INSTALL_ROOT",
+            "LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED",
+        ] {
+            env.remove(key);
+        }
+    }
+
+    #[cfg(feature = "feishu-integration")]
+    fn clear_feishu_runtime_env(env: &mut ScopedEnv) {
+        env.remove("FEISHU_APP_ID");
+        env.remove("FEISHU_APP_SECRET");
+    }
 
     #[test]
     fn tool_runtime_config_from_env_defaults() {
@@ -614,13 +654,20 @@ mod tests {
 
     #[test]
     fn from_env_defaults_to_empty_allowlist() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        #[cfg(feature = "feishu-integration")]
+        clear_feishu_runtime_env(&mut env);
+
         let config = ToolRuntimeConfig::from_env();
         assert!(config.shell_allow.is_empty());
     }
 
     #[test]
     fn from_loongclaw_config_projects_browser_companion_policy() {
-        crate::process_env::set_var("LOONGCLAW_BROWSER_COMPANION_READY", "true");
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        env.set("LOONGCLAW_BROWSER_COMPANION_READY", "true");
         let mut config = crate::config::LoongClawConfig::default();
         config.tools.browser_companion.enabled = true;
         config.tools.browser_companion.command = Some("loongclaw-browser-companion".to_owned());
@@ -637,8 +684,6 @@ mod tests {
             runtime.browser_companion.expected_version.as_deref(),
             Some("1.2.3")
         );
-
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_READY");
     }
 
     #[cfg(feature = "tool-shell")]
@@ -669,48 +714,53 @@ mod tests {
 
     #[test]
     fn from_env_parses_external_skills_policy() {
-        crate::process_env::set_var("LOONGCLAW_TOOL_SESSIONS_ENABLED", "false");
-        crate::process_env::set_var("LOONGCLAW_TOOL_MESSAGES_ENABLED", "true");
-        crate::process_env::set_var("LOONGCLAW_TOOL_DELEGATE_ENABLED", "false");
-        crate::process_env::set_var("LOONGCLAW_BROWSER_ENABLED", "false");
-        crate::process_env::set_var("LOONGCLAW_BROWSER_MAX_SESSIONS", "4");
-        crate::process_env::set_var("LOONGCLAW_BROWSER_MAX_LINKS", "12");
-        crate::process_env::set_var("LOONGCLAW_BROWSER_MAX_TEXT_CHARS", "2048");
-        crate::process_env::set_var("LOONGCLAW_BROWSER_COMPANION_ENABLED", "true");
-        crate::process_env::set_var("LOONGCLAW_BROWSER_COMPANION_READY", "true");
-        crate::process_env::set_var(
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        #[cfg(feature = "feishu-integration")]
+        clear_feishu_runtime_env(&mut env);
+
+        env.set("LOONGCLAW_TOOL_SESSIONS_ENABLED", "false");
+        env.set("LOONGCLAW_TOOL_MESSAGES_ENABLED", "true");
+        env.set("LOONGCLAW_TOOL_DELEGATE_ENABLED", "false");
+        env.set("LOONGCLAW_BROWSER_ENABLED", "false");
+        env.set("LOONGCLAW_BROWSER_MAX_SESSIONS", "4");
+        env.set("LOONGCLAW_BROWSER_MAX_LINKS", "12");
+        env.set("LOONGCLAW_BROWSER_MAX_TEXT_CHARS", "2048");
+        env.set("LOONGCLAW_BROWSER_COMPANION_ENABLED", "true");
+        env.set("LOONGCLAW_BROWSER_COMPANION_READY", "true");
+        env.set(
             "LOONGCLAW_BROWSER_COMPANION_COMMAND",
             "loongclaw-browser-companion",
         );
-        crate::process_env::set_var("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION", "1.2.3");
-        crate::process_env::set_var("LOONGCLAW_WEB_FETCH_ENABLED", "false");
-        crate::process_env::set_var("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS", "true");
-        crate::process_env::set_var(
+        env.set("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION", "1.2.3");
+        env.set("LOONGCLAW_WEB_FETCH_ENABLED", "false");
+        env.set("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS", "true");
+        env.set(
             "LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS",
             "docs.example.com,api.example.com",
         );
-        crate::process_env::set_var("LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS", "internal.example");
-        crate::process_env::set_var("LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS", "9");
-        crate::process_env::set_var("LOONGCLAW_WEB_FETCH_MAX_BYTES", "262144");
-        crate::process_env::set_var("LOONGCLAW_WEB_FETCH_MAX_REDIRECTS", "1");
-        crate::process_env::set_var("LOONGCLAW_EXTERNAL_SKILLS_ENABLED", "true");
-        crate::process_env::set_var(
+        env.set("LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS", "internal.example");
+        env.set("LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS", "9");
+        env.set("LOONGCLAW_WEB_FETCH_MAX_BYTES", "262144");
+        env.set("LOONGCLAW_WEB_FETCH_MAX_REDIRECTS", "1");
+        env.set("LOONGCLAW_EXTERNAL_SKILLS_ENABLED", "true");
+        env.set(
             "LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL",
             "false",
         );
-        crate::process_env::set_var(
+        env.set(
             "LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS",
             "skills.sh,clawhub.io",
         );
-        crate::process_env::set_var(
+        env.set(
             "LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS",
             "malicious.example",
         );
-        crate::process_env::set_var(
+        env.set(
             "LOONGCLAW_EXTERNAL_SKILLS_INSTALL_ROOT",
             "/tmp/managed-skills",
         );
-        crate::process_env::set_var("LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED", "false");
+        env.set("LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED", "false");
 
         let config = ToolRuntimeConfig::from_env();
         assert!(!config.sessions_enabled);
@@ -768,31 +818,6 @@ mod tests {
             Some(PathBuf::from("/tmp/managed-skills"))
         );
         assert!(!config.external_skills.auto_expose_installed);
-
-        crate::process_env::remove_var("LOONGCLAW_TOOL_SESSIONS_ENABLED");
-        crate::process_env::remove_var("LOONGCLAW_TOOL_MESSAGES_ENABLED");
-        crate::process_env::remove_var("LOONGCLAW_TOOL_DELEGATE_ENABLED");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_ENABLED");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_MAX_SESSIONS");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_MAX_LINKS");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_MAX_TEXT_CHARS");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_ENABLED");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_READY");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_COMMAND");
-        crate::process_env::remove_var("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ENABLED");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_MAX_BYTES");
-        crate::process_env::remove_var("LOONGCLAW_WEB_FETCH_MAX_REDIRECTS");
-        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_ENABLED");
-        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL");
-        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS");
-        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS");
-        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_INSTALL_ROOT");
-        crate::process_env::remove_var("LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED");
     }
 
     #[test]
@@ -875,8 +900,11 @@ mod tests {
     #[cfg(feature = "feishu-integration")]
     #[test]
     fn from_env_enables_feishu_runtime_when_credentials_exist() {
-        crate::process_env::set_var("FEISHU_APP_ID", "cli_env_a1b2c3");
-        crate::process_env::set_var("FEISHU_APP_SECRET", "env-secret");
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        clear_feishu_runtime_env(&mut env);
+        env.set("FEISHU_APP_ID", "cli_env_a1b2c3");
+        env.set("FEISHU_APP_SECRET", "env-secret");
 
         let config = ToolRuntimeConfig::from_env();
         let feishu = config
@@ -894,9 +922,6 @@ mod tests {
             feishu.integration.resolved_sqlite_path(),
             crate::config::default_loongclaw_home().join("feishu.sqlite3")
         );
-
-        crate::process_env::remove_var("FEISHU_APP_ID");
-        crate::process_env::remove_var("FEISHU_APP_SECRET");
     }
 
     #[cfg(feature = "feishu-integration")]

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -869,6 +869,7 @@ mod tests {
 
         assert!(policy.enabled);
         assert!(!policy.ready);
+        assert!(!policy.is_runtime_ready());
         assert_eq!(
             policy.command.as_deref(),
             Some("loongclaw-browser-companion")


### PR DESCRIPTION
## Summary

- add a distinct `tools.browser_companion` config surface and runtime policy projection for the managed browser companion lane
- export and read companion runtime metadata (`enabled`, `ready`, `command`, `expected_version`) without changing the shipped lightweight browser tool behavior
- move runtime tool exposure onto descriptor-level visibility gates so future companion-only tools can stay hidden until runtime readiness is truthful
- update tests and helper runtime configs for the new companion policy path

This is the implementation foundation for issue #188 and follows the product/docs direction in #183 / #185 without overlapping that docs-only branch.

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track B (higher-risk/policy-impacting)
- [ ] Track A (routine/low-risk)

If Track B, include design/risk notes:

- This keeps the existing safe browser lane unchanged and only introduces truthful readiness/config seams for the future managed companion lane.
- Companion-only visibility stays hidden in config-only views and requires explicit runtime readiness in runtime-policy views.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional validation notes:

- `cargo test -p loongclaw-app browser_companion`
- `cargo test -p loongclaw-app`
- Added regression coverage for TOML parsing, runtime env export/import, runtime policy projection, and visibility-gate behavior.
- Tests that mutate process-global env explicitly clean up the companion env vars they set.

## Linked Issues

Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser companion tool is now configurable (enable/disable, custom command, expected version) and participates in runtime readiness checks.
  * New visibility gating system controls which tools are available in different runtime views and policies, with special handling for browser companion readiness.
* **Tests**
  * Added coverage for browser companion defaults, parsing, gating, and runtime/environment integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->