### PR TITLE
fix: normalize chat diagnostics runtime binding seams

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -220,15 +220,6 @@ pub async fn run_cli_chat(
             continue;
         }
         if is_turn_checkpoint_repair_command(input)? {
-            #[cfg(feature = "memory-sqlite")]
-            print_turn_checkpoint_repair(
-                &runtime.turn_coordinator,
-                &runtime.config,
-                &runtime.session_id,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-            )
-            .await?;
-            #[cfg(not(feature = "memory-sqlite"))]
             print_turn_checkpoint_repair(
                 &runtime.turn_coordinator,
                 &runtime.config,
@@ -572,6 +563,12 @@ async fn load_history_lines(
             .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
             .await
             .map_err(|error| format!("load history via kernel failed: {error}"))?;
+        if outcome.status != "ok" {
+            return Err(format!(
+                "load history via kernel returned non-ok status: {}",
+                outcome.status
+            ));
+        }
         let turns = memory::decode_window_turns(&outcome.payload);
         return Ok(format_window_history_lines(&turns));
     }
@@ -1438,6 +1435,7 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     struct SharedTestMemoryAdapter {
         invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
+        status: String,
         window_turns: Value,
     }
 
@@ -1464,7 +1462,7 @@ mod tests {
                 .expect("invocations lock")
                 .push(request);
             Ok(MemoryCoreOutcome {
-                status: "ok".to_owned(),
+                status: self.status.clone(),
                 payload,
             })
         }
@@ -1472,6 +1470,14 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     fn build_kernel_context_with_window_turns(
+        window_turns: Value,
+    ) -> (crate::KernelContext, Arc<Mutex<Vec<MemoryCoreRequest>>>) {
+        build_kernel_context_with_window_outcome("ok", window_turns)
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn build_kernel_context_with_window_outcome(
+        status: &str,
         window_turns: Value,
     ) -> (crate::KernelContext, Arc<Mutex<Vec<MemoryCoreRequest>>>) {
         let audit = Arc::new(InMemoryAuditSink::default());
@@ -1495,6 +1501,7 @@ mod tests {
         let invocations = Arc::new(Mutex::new(Vec::new()));
         kernel.register_core_memory_adapter(SharedTestMemoryAdapter {
             invocations: invocations.clone(),
+            status: status.to_owned(),
             window_turns,
         });
         kernel
@@ -1700,6 +1707,54 @@ mod tests {
         assert_eq!(
             captured[0].payload["session_id"],
             "chat-binding-history-kernel"
+        );
+        assert_eq!(captured[0].payload["limit"], json!(16));
+
+        let _ = std::fs::remove_file(sqlite_path);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn print_history_rejects_non_ok_kernel_memory_outcome() {
+        let sqlite_path = unique_chat_sqlite_path("diagnostics-non-ok");
+        let _ = std::fs::remove_file(&sqlite_path);
+
+        let mut config = LoongClawConfig::default();
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        crate::memory::ensure_memory_db_ready(
+            Some(config.memory.resolved_sqlite_path()),
+            &memory_config,
+        )
+        .expect("initialize sqlite memory");
+
+        let (kernel_ctx, invocations) = build_kernel_context_with_window_outcome(
+            "error",
+            json!([
+                {
+                    "role": "user",
+                    "content": "kernel hello",
+                    "ts": 7
+                }
+            ]),
+        );
+        let error = load_history_lines(
+            "chat-binding-history-kernel-non-ok",
+            16,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+            &memory_config,
+        )
+        .await
+        .expect_err("non-ok kernel memory outcome should fail closed");
+        assert!(error.contains("non-ok status"), "unexpected error: {error}");
+        assert!(error.contains("error"), "unexpected error: {error}");
+
+        let captured = invocations.lock().expect("invocations lock");
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
+        assert_eq!(
+            captured[0].payload["session_id"],
+            "chat-binding-history-kernel-non-ok"
         );
         assert_eq!(captured[0].payload["limit"], json!(16));
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -1433,6 +1433,30 @@ mod tests {
     }
 
     #[cfg(feature = "memory-sqlite")]
+    fn cleanup_chat_test_memory(sqlite_path: &Path) {
+        let _ = std::fs::remove_file(sqlite_path);
+        let _ = std::fs::remove_file(format!("{}-wal", sqlite_path.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", sqlite_path.display()));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn init_chat_test_memory(label: &str) -> (LoongClawConfig, MemoryRuntimeConfig, PathBuf) {
+        let sqlite_path = unique_chat_sqlite_path(label);
+        cleanup_chat_test_memory(&sqlite_path);
+
+        let mut config = LoongClawConfig::default();
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        crate::memory::ensure_memory_db_ready(
+            Some(config.memory.resolved_sqlite_path()),
+            &memory_config,
+        )
+        .expect("initialize sqlite memory");
+
+        (config, memory_config, sqlite_path)
+    }
+
+    #[cfg(feature = "memory-sqlite")]
     struct SharedTestMemoryAdapter {
         invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
         status: String,
@@ -1642,17 +1666,7 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     #[tokio::test]
     async fn print_history_accepts_explicit_runtime_binding() {
-        let sqlite_path = unique_chat_sqlite_path("diagnostics");
-        let _ = std::fs::remove_file(&sqlite_path);
-
-        let mut config = LoongClawConfig::default();
-        config.memory.sqlite_path = sqlite_path.display().to_string();
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-        crate::memory::ensure_memory_db_ready(
-            Some(config.memory.resolved_sqlite_path()),
-            &memory_config,
-        )
-        .expect("initialize sqlite memory");
+        let (config, memory_config, sqlite_path) = init_chat_test_memory("diagnostics");
 
         let session_id = "chat-binding-history-direct";
         crate::memory::append_turn_direct(session_id, "user", "hello", &memory_config)
@@ -1710,23 +1724,13 @@ mod tests {
         );
         assert_eq!(captured[0].payload["limit"], json!(16));
 
-        let _ = std::fs::remove_file(sqlite_path);
+        cleanup_chat_test_memory(&sqlite_path);
     }
 
     #[cfg(feature = "memory-sqlite")]
     #[tokio::test]
     async fn print_history_rejects_non_ok_kernel_memory_outcome() {
-        let sqlite_path = unique_chat_sqlite_path("diagnostics-non-ok");
-        let _ = std::fs::remove_file(&sqlite_path);
-
-        let mut config = LoongClawConfig::default();
-        config.memory.sqlite_path = sqlite_path.display().to_string();
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-        crate::memory::ensure_memory_db_ready(
-            Some(config.memory.resolved_sqlite_path()),
-            &memory_config,
-        )
-        .expect("initialize sqlite memory");
+        let (_config, memory_config, sqlite_path) = init_chat_test_memory("diagnostics-non-ok");
 
         let (kernel_ctx, invocations) = build_kernel_context_with_window_outcome(
             "error",
@@ -1758,23 +1762,13 @@ mod tests {
         );
         assert_eq!(captured[0].payload["limit"], json!(16));
 
-        let _ = std::fs::remove_file(sqlite_path);
+        cleanup_chat_test_memory(&sqlite_path);
     }
 
     #[cfg(feature = "memory-sqlite")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn safe_lane_summary_output_accepts_explicit_runtime_binding() {
-        let sqlite_path = unique_chat_sqlite_path("safe-lane-output");
-        let _ = std::fs::remove_file(&sqlite_path);
-
-        let mut config = LoongClawConfig::default();
-        config.memory.sqlite_path = sqlite_path.display().to_string();
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-        crate::memory::ensure_memory_db_ready(
-            Some(config.memory.resolved_sqlite_path()),
-            &memory_config,
-        )
-        .expect("initialize sqlite memory");
+        let (config, memory_config, sqlite_path) = init_chat_test_memory("safe-lane-output");
 
         let direct_payloads = safe_lane_event_payloads();
         append_assistant_payloads(
@@ -1829,23 +1823,13 @@ mod tests {
         assert_eq!(captured[0].payload["limit"], json!(80));
         assert_eq!(captured[0].payload["allow_extended_limit"], json!(true));
 
-        let _ = std::fs::remove_file(sqlite_path);
+        cleanup_chat_test_memory(&sqlite_path);
     }
 
     #[cfg(feature = "memory-sqlite")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn turn_checkpoint_summary_output_accepts_explicit_runtime_binding() {
-        let sqlite_path = unique_chat_sqlite_path("turn-checkpoint-output");
-        let _ = std::fs::remove_file(&sqlite_path);
-
-        let mut config = LoongClawConfig::default();
-        config.memory.sqlite_path = sqlite_path.display().to_string();
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-        crate::memory::ensure_memory_db_ready(
-            Some(config.memory.resolved_sqlite_path()),
-            &memory_config,
-        )
-        .expect("initialize sqlite memory");
+        let (config, memory_config, sqlite_path) = init_chat_test_memory("turn-checkpoint-output");
 
         let direct_payloads = turn_checkpoint_event_payloads();
         append_assistant_payloads(
@@ -1895,7 +1879,7 @@ mod tests {
         assert_eq!(captured[0].payload["limit"], json!(112));
         assert_eq!(captured[0].payload["allow_extended_limit"], json!(true));
 
-        let _ = std::fs::remove_file(sqlite_path);
+        cleanup_chat_test_memory(&sqlite_path);
     }
 
     #[test]

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -17,8 +17,8 @@ use super::config::{self, ConversationConfig, LoongClawConfig};
 #[cfg(feature = "memory-sqlite")]
 use super::conversation::load_safe_lane_event_summary;
 use super::conversation::{
-    ConversationSessionAddress, ConversationTurnCoordinator, ProviderErrorMode,
-    resolve_context_engine_selection,
+    ConversationRuntimeBinding, ConversationSessionAddress, ConversationTurnCoordinator,
+    ProviderErrorMode, resolve_context_engine_selection,
 };
 #[cfg(any(test, feature = "memory-sqlite"))]
 use super::conversation::{SafeLaneEventSummary, SafeLaneFinalStatus};
@@ -160,7 +160,7 @@ pub async fn run_cli_chat(
             print_history(
                 &runtime.session_id,
                 runtime.config.memory.sliding_window,
-                Some(&runtime.kernel_ctx),
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
                 &runtime.memory_config,
             )
             .await?;
@@ -168,7 +168,7 @@ pub async fn run_cli_chat(
             print_history(
                 &runtime.session_id,
                 runtime.config.memory.sliding_window,
-                Some(&runtime.kernel_ctx),
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
             )
             .await?;
             continue;
@@ -181,7 +181,7 @@ pub async fn run_cli_chat(
                 &runtime.session_id,
                 limit,
                 &runtime.config.conversation,
-                Some(&runtime.kernel_ctx),
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
                 &runtime.memory_config,
             )
             .await?;
@@ -190,7 +190,7 @@ pub async fn run_cli_chat(
                 &runtime.session_id,
                 limit,
                 &runtime.config.conversation,
-                Some(&runtime.kernel_ctx),
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
             )
             .await?;
             continue;
@@ -204,7 +204,7 @@ pub async fn run_cli_chat(
                 &runtime.config,
                 &runtime.session_id,
                 limit,
-                Some(&runtime.kernel_ctx),
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
                 &runtime.memory_config,
             )
             .await?;
@@ -214,7 +214,7 @@ pub async fn run_cli_chat(
                 &runtime.config,
                 &runtime.session_id,
                 limit,
-                Some(&runtime.kernel_ctx),
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
             )
             .await?;
             continue;
@@ -225,7 +225,7 @@ pub async fn run_cli_chat(
                 &runtime.turn_coordinator,
                 &runtime.config,
                 &runtime.session_id,
-                Some(&runtime.kernel_ctx),
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
             )
             .await?;
             #[cfg(not(feature = "memory-sqlite"))]
@@ -233,7 +233,7 @@ pub async fn run_cli_chat(
                 &runtime.turn_coordinator,
                 &runtime.config,
                 &runtime.session_id,
-                Some(&runtime.kernel_ctx),
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
             )
             .await?;
             continue;
@@ -494,12 +494,12 @@ fn print_help() {
 async fn print_history(
     session_id: &str,
     limit: usize,
-    kernel_ctx: Option<&crate::KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
-        if let Some(ctx) = kernel_ctx {
+        if let Some(ctx) = binding.kernel_context() {
             let request = memory::build_window_request(session_id, limit);
             let caps = BTreeSet::from([Capability::MemoryRead]);
             let outcome = ctx
@@ -549,7 +549,7 @@ async fn print_history(
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = (session_id, limit, kernel_ctx);
+        let _ = (session_id, limit, binding);
         println!("history unavailable: memory-sqlite feature disabled");
         Ok(())
     }
@@ -636,20 +636,13 @@ async fn print_safe_lane_summary(
     session_id: &str,
     limit: usize,
     conversation_config: &ConversationConfig,
-    kernel_ctx: Option<&crate::KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
-        let summary = load_safe_lane_event_summary(
-            session_id,
-            limit,
-            crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
-                kernel_ctx,
-            ),
-            memory_config,
-        )
-        .await?;
+        let summary =
+            load_safe_lane_event_summary(session_id, limit, binding, memory_config).await?;
         println!(
             "{}",
             format_safe_lane_summary(session_id, limit, conversation_config, &summary)
@@ -659,7 +652,7 @@ async fn print_safe_lane_summary(
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = (session_id, limit, conversation_config, kernel_ctx);
+        let _ = (session_id, limit, conversation_config, binding);
         println!("safe-lane summary unavailable: memory-sqlite feature disabled");
         Ok(())
     }
@@ -671,20 +664,13 @@ async fn print_turn_checkpoint_summary(
     config: &LoongClawConfig,
     session_id: &str,
     limit: usize,
-    kernel_ctx: Option<&crate::KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     #[cfg(feature = "memory-sqlite")] _memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
         let diagnostics = turn_coordinator
-            .load_turn_checkpoint_diagnostics_with_limit(
-                config,
-                session_id,
-                limit,
-                crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
-                    kernel_ctx,
-                ),
-            )
+            .load_turn_checkpoint_diagnostics_with_limit(config, session_id, limit, binding)
             .await?;
         println!(
             "{}",
@@ -695,7 +681,7 @@ async fn print_turn_checkpoint_summary(
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = (turn_coordinator, config, session_id, limit, kernel_ctx);
+        let _ = (turn_coordinator, config, session_id, limit, binding);
         println!("turn checkpoint summary unavailable: memory-sqlite feature disabled");
         Ok(())
     }
@@ -706,18 +692,12 @@ async fn print_turn_checkpoint_repair(
     turn_coordinator: &ConversationTurnCoordinator,
     config: &LoongClawConfig,
     session_id: &str,
-    kernel_ctx: Option<&crate::KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
         let outcome = turn_coordinator
-            .repair_turn_checkpoint_tail(
-                config,
-                session_id,
-                crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
-                    kernel_ctx,
-                ),
-            )
+            .repair_turn_checkpoint_tail(config, session_id, binding)
             .await?;
         println!("{}", format_turn_checkpoint_repair(session_id, &outcome));
         Ok(())
@@ -725,7 +705,7 @@ async fn print_turn_checkpoint_repair(
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = (turn_coordinator, config, session_id, kernel_ctx);
+        let _ = (turn_coordinator, config, session_id, binding);
         println!("turn checkpoint repair unavailable: memory-sqlite feature disabled");
         Ok(())
     }
@@ -1308,6 +1288,7 @@ fn format_milli_ratio(value: Option<u32>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::conversation::ConversationRuntimeBinding;
     use std::path::PathBuf;
 
     #[test]
@@ -1342,6 +1323,17 @@ mod tests {
         assert!(!CliChatOptions::default().requests_explicit_acp());
     }
 
+    #[cfg(feature = "memory-sqlite")]
+    fn unique_chat_sqlite_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "loongclaw-chat-binding-{label}-{}.sqlite3",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ))
+    }
+
     #[tokio::test]
     async fn run_cli_ask_rejects_empty_message() {
         let error = run_cli_ask(None, None, "   ", &CliChatOptions::default())
@@ -1349,6 +1341,67 @@ mod tests {
             .expect_err("empty one-shot message should fail");
 
         assert!(error.contains("ask message must not be empty"));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn print_history_accepts_explicit_runtime_binding() {
+        let sqlite_path = unique_chat_sqlite_path("diagnostics");
+        let _ = std::fs::remove_file(&sqlite_path);
+
+        let mut config = LoongClawConfig::default();
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        crate::memory::ensure_memory_db_ready(
+            Some(config.memory.resolved_sqlite_path()),
+            &memory_config,
+        )
+        .expect("initialize sqlite memory");
+
+        let session_id = "chat-binding-session";
+        crate::memory::append_turn_direct(session_id, "user", "hello", &memory_config)
+            .expect("persist user turn");
+        crate::memory::append_turn_direct(session_id, "assistant", "world", &memory_config)
+            .expect("persist assistant turn");
+
+        let coordinator = ConversationTurnCoordinator::new();
+        print_history(
+            session_id,
+            config.memory.sliding_window,
+            ConversationRuntimeBinding::direct(),
+            &memory_config,
+        )
+        .await
+        .expect("print history with explicit direct binding");
+        print_safe_lane_summary(
+            session_id,
+            config.memory.sliding_window,
+            &config.conversation,
+            ConversationRuntimeBinding::direct(),
+            &memory_config,
+        )
+        .await
+        .expect("print safe lane summary with explicit direct binding");
+        print_turn_checkpoint_summary(
+            &coordinator,
+            &config,
+            session_id,
+            config.memory.sliding_window,
+            ConversationRuntimeBinding::direct(),
+            &memory_config,
+        )
+        .await
+        .expect("print turn checkpoint summary with explicit direct binding");
+        print_turn_checkpoint_repair(
+            &coordinator,
+            &config,
+            session_id,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("print turn checkpoint repair with explicit direct binding");
+
+        let _ = std::fs::remove_file(sqlite_path);
     }
 
     #[test]

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -29,7 +29,7 @@ use super::conversation::{
     TurnCheckpointSessionState, TurnCheckpointStage, TurnCheckpointTailRepairOutcome,
     TurnCheckpointTailRepairReason, TurnCheckpointTailRepairRuntimeProbe,
 };
-#[cfg(feature = "memory-sqlite")]
+#[cfg(any(test, feature = "memory-sqlite"))]
 use super::memory;
 #[cfg(feature = "memory-sqlite")]
 use super::memory::runtime_config::MemoryRuntimeConfig;
@@ -499,50 +499,8 @@ async fn print_history(
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
-        if let Some(ctx) = binding.kernel_context() {
-            let request = memory::build_window_request(session_id, limit);
-            let caps = BTreeSet::from([Capability::MemoryRead]);
-            let outcome = ctx
-                .kernel
-                .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
-                .await
-                .map_err(|error| format!("load history via kernel failed: {error}"))?;
-            let turns = memory::decode_window_turns(&outcome.payload);
-            if turns.is_empty() {
-                println!("(no history yet)");
-                return Ok(());
-            }
-            for turn in turns {
-                println!(
-                    "[{}] {}: {}",
-                    turn.ts.unwrap_or_default(),
-                    turn.role,
-                    turn.content
-                );
-            }
-            return Ok(());
-        }
-
-        let entries = memory::load_prompt_context(session_id, memory_config)
-            .map_err(|error| format!("load history failed: {error}"))?;
-        if entries.is_empty() {
-            println!("(no history yet)");
-            return Ok(());
-        }
-        for entry in entries {
-            match entry.kind {
-                memory::MemoryContextKind::Profile => {
-                    println!("[profile]");
-                    println!("{}", entry.content);
-                }
-                memory::MemoryContextKind::Summary => {
-                    println!("[summary]");
-                    println!("{}", entry.content);
-                }
-                memory::MemoryContextKind::Turn => {
-                    println!("{}: {}", entry.role, entry.content);
-                }
-            }
+        for line in load_history_lines(session_id, limit, binding, memory_config).await? {
+            println!("{line}");
         }
         Ok(())
     }
@@ -553,6 +511,74 @@ async fn print_history(
         println!("history unavailable: memory-sqlite feature disabled");
         Ok(())
     }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_window_history_lines(turns: &[memory::WindowTurn]) -> Vec<String> {
+    if turns.is_empty() {
+        return vec!["(no history yet)".to_owned()];
+    }
+
+    turns
+        .iter()
+        .map(|turn| {
+            format!(
+                "[{}] {}: {}",
+                turn.ts.unwrap_or_default(),
+                turn.role,
+                turn.content
+            )
+        })
+        .collect()
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_prompt_context_history_lines(entries: &[memory::MemoryContextEntry]) -> Vec<String> {
+    if entries.is_empty() {
+        return vec!["(no history yet)".to_owned()];
+    }
+
+    let mut lines = Vec::new();
+    for entry in entries {
+        match entry.kind {
+            memory::MemoryContextKind::Profile => {
+                lines.push("[profile]".to_owned());
+                lines.push(entry.content.clone());
+            }
+            memory::MemoryContextKind::Summary => {
+                lines.push("[summary]".to_owned());
+                lines.push(entry.content.clone());
+            }
+            memory::MemoryContextKind::Turn => {
+                lines.push(format!("{}: {}", entry.role, entry.content));
+            }
+        }
+    }
+    lines
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn load_history_lines(
+    session_id: &str,
+    limit: usize,
+    binding: ConversationRuntimeBinding<'_>,
+    memory_config: &MemoryRuntimeConfig,
+) -> CliResult<Vec<String>> {
+    if let Some(ctx) = binding.kernel_context() {
+        let request = memory::build_window_request(session_id, limit);
+        let caps = BTreeSet::from([Capability::MemoryRead]);
+        let outcome = ctx
+            .kernel
+            .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
+            .await
+            .map_err(|error| format!("load history via kernel failed: {error}"))?;
+        let turns = memory::decode_window_turns(&outcome.payload);
+        return Ok(format_window_history_lines(&turns));
+    }
+
+    let entries = memory::load_prompt_context(session_id, memory_config)
+        .map_err(|error| format!("load history failed: {error}"))?;
+    Ok(format_prompt_context_history_lines(&entries))
 }
 
 fn parse_safe_lane_summary_limit(input: &str, default_window: usize) -> CliResult<Option<usize>> {
@@ -641,11 +667,16 @@ async fn print_safe_lane_summary(
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
-        let summary =
-            load_safe_lane_event_summary(session_id, limit, binding, memory_config).await?;
         println!(
             "{}",
-            format_safe_lane_summary(session_id, limit, conversation_config, &summary)
+            load_safe_lane_summary_output(
+                session_id,
+                limit,
+                conversation_config,
+                binding,
+                memory_config,
+            )
+            .await?
         );
         Ok(())
     }
@@ -656,6 +687,23 @@ async fn print_safe_lane_summary(
         println!("safe-lane summary unavailable: memory-sqlite feature disabled");
         Ok(())
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn load_safe_lane_summary_output(
+    session_id: &str,
+    limit: usize,
+    conversation_config: &ConversationConfig,
+    binding: ConversationRuntimeBinding<'_>,
+    memory_config: &MemoryRuntimeConfig,
+) -> CliResult<String> {
+    let summary = load_safe_lane_event_summary(session_id, limit, binding, memory_config).await?;
+    Ok(format_safe_lane_summary(
+        session_id,
+        limit,
+        conversation_config,
+        &summary,
+    ))
 }
 
 #[allow(clippy::print_stdout)] // CLI output
@@ -669,12 +717,16 @@ async fn print_turn_checkpoint_summary(
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
-        let diagnostics = turn_coordinator
-            .load_turn_checkpoint_diagnostics_with_limit(config, session_id, limit, binding)
-            .await?;
         println!(
             "{}",
-            format_turn_checkpoint_summary_output(session_id, limit, &diagnostics)
+            load_turn_checkpoint_summary_output(
+                turn_coordinator,
+                config,
+                session_id,
+                limit,
+                binding,
+            )
+            .await?
         );
         Ok(())
     }
@@ -687,6 +739,24 @@ async fn print_turn_checkpoint_summary(
     }
 }
 
+#[cfg(feature = "memory-sqlite")]
+async fn load_turn_checkpoint_summary_output(
+    turn_coordinator: &ConversationTurnCoordinator,
+    config: &LoongClawConfig,
+    session_id: &str,
+    limit: usize,
+    binding: ConversationRuntimeBinding<'_>,
+) -> CliResult<String> {
+    let diagnostics = turn_coordinator
+        .load_turn_checkpoint_diagnostics_with_limit(config, session_id, limit, binding)
+        .await?;
+    Ok(format_turn_checkpoint_summary_output(
+        session_id,
+        limit,
+        &diagnostics,
+    ))
+}
+
 #[allow(clippy::print_stdout)] // CLI output
 async fn print_turn_checkpoint_repair(
     turn_coordinator: &ConversationTurnCoordinator,
@@ -696,10 +766,11 @@ async fn print_turn_checkpoint_repair(
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
-        let outcome = turn_coordinator
-            .repair_turn_checkpoint_tail(config, session_id, binding)
-            .await?;
-        println!("{}", format_turn_checkpoint_repair(session_id, &outcome));
+        println!(
+            "{}",
+            load_turn_checkpoint_repair_output(turn_coordinator, config, session_id, binding)
+                .await?
+        );
         Ok(())
     }
 
@@ -709,6 +780,19 @@ async fn print_turn_checkpoint_repair(
         println!("turn checkpoint repair unavailable: memory-sqlite feature disabled");
         Ok(())
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn load_turn_checkpoint_repair_output(
+    turn_coordinator: &ConversationTurnCoordinator,
+    config: &LoongClawConfig,
+    session_id: &str,
+    binding: ConversationRuntimeBinding<'_>,
+) -> CliResult<String> {
+    let outcome = turn_coordinator
+        .repair_turn_checkpoint_tail(config, session_id, binding)
+        .await?;
+    Ok(format_turn_checkpoint_repair(session_id, &outcome))
 }
 
 #[cfg(any(test, feature = "memory-sqlite"))]
@@ -1290,6 +1374,23 @@ mod tests {
     use super::*;
     use crate::conversation::ConversationRuntimeBinding;
     use std::path::PathBuf;
+    #[cfg(feature = "memory-sqlite")]
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::{Arc, Mutex},
+    };
+
+    #[cfg(feature = "memory-sqlite")]
+    use async_trait::async_trait;
+    #[cfg(feature = "memory-sqlite")]
+    use loongclaw_contracts::{Capability, ExecutionRoute, HarnessKind, MemoryPlaneError};
+    #[cfg(feature = "memory-sqlite")]
+    use loongclaw_kernel::{
+        CoreMemoryAdapter, FixedClock, InMemoryAuditSink, LoongClawKernel, MemoryCoreOutcome,
+        MemoryCoreRequest, StaticPolicyEngine, VerticalPackManifest,
+    };
+    #[cfg(feature = "memory-sqlite")]
+    use serde_json::{Value, json};
 
     #[test]
     fn cli_chat_options_detect_explicit_acp_requests() {
@@ -1334,6 +1435,194 @@ mod tests {
         ))
     }
 
+    #[cfg(feature = "memory-sqlite")]
+    struct SharedTestMemoryAdapter {
+        invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
+        window_turns: Value,
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[async_trait]
+    impl CoreMemoryAdapter for SharedTestMemoryAdapter {
+        fn name(&self) -> &str {
+            "chat-binding-memory-shared"
+        }
+
+        async fn execute_core_memory(
+            &self,
+            request: MemoryCoreRequest,
+        ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
+            let payload = if request.operation == crate::memory::MEMORY_OP_WINDOW {
+                json!({
+                    "turns": self.window_turns.clone()
+                })
+            } else {
+                json!({})
+            };
+            self.invocations
+                .lock()
+                .expect("invocations lock")
+                .push(request);
+            Ok(MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload,
+            })
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn build_kernel_context_with_window_turns(
+        window_turns: Value,
+    ) -> (crate::KernelContext, Arc<Mutex<Vec<MemoryCoreRequest>>>) {
+        let audit = Arc::new(InMemoryAuditSink::default());
+        let clock = Arc::new(FixedClock::new(1_700_000_000));
+        let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+        let pack = VerticalPackManifest {
+            pack_id: "chat-test-pack".to_owned(),
+            domain: "testing".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: None,
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::from([Capability::MemoryRead, Capability::MemoryWrite]),
+            metadata: BTreeMap::new(),
+        };
+        kernel.register_pack(pack).expect("register pack");
+
+        let invocations = Arc::new(Mutex::new(Vec::new()));
+        kernel.register_core_memory_adapter(SharedTestMemoryAdapter {
+            invocations: invocations.clone(),
+            window_turns,
+        });
+        kernel
+            .set_default_core_memory_adapter("chat-binding-memory-shared")
+            .expect("set default memory adapter");
+
+        let token = kernel
+            .issue_token("chat-test-pack", "chat-test-agent", 3600)
+            .expect("issue token");
+
+        let ctx = crate::KernelContext {
+            kernel: Arc::new(kernel),
+            token,
+        };
+        (ctx, invocations)
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn append_assistant_payloads(
+        session_id: &str,
+        payloads: &[String],
+        memory_config: &MemoryRuntimeConfig,
+    ) {
+        for payload in payloads {
+            crate::memory::append_turn_direct(session_id, "assistant", payload, memory_config)
+                .expect("persist assistant payload");
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn assistant_window_turns(payloads: &[String]) -> Value {
+        json!(
+            payloads
+                .iter()
+                .enumerate()
+                .map(|(index, payload)| json!({
+                    "role": "assistant",
+                    "content": payload,
+                    "ts": index as i64 + 1
+                }))
+                .collect::<Vec<_>>()
+        )
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn safe_lane_event_payloads() -> Vec<String> {
+        vec![
+            json!({
+                "type": "conversation_event",
+                "event": "plan_round_started",
+                "payload": {
+                    "round": 0
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "verify_failed",
+                "payload": {
+                    "failure_code": "safe_lane_plan_verify_failed"
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "final_status",
+                "payload": {
+                    "status": "failed",
+                    "failure_code": "safe_lane_plan_verify_failed",
+                    "route_decision": "terminal"
+                }
+            })
+            .to_string(),
+        ]
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn turn_checkpoint_event_payloads() -> Vec<String> {
+        vec![
+            json!({
+                "type": "conversation_event",
+                "event": "turn_checkpoint",
+                "payload": {
+                    "schema_version": 1,
+                    "stage": "post_persist",
+                    "checkpoint": {
+                        "lane": {
+                            "lane": "safe",
+                            "result_kind": "tool_call"
+                        },
+                        "finalization": {
+                            "persistence_mode": "success"
+                        }
+                    },
+                    "finalization_progress": {
+                        "after_turn": "pending",
+                        "compaction": "pending"
+                    },
+                    "failure": null
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "turn_checkpoint",
+                "payload": {
+                    "schema_version": 1,
+                    "stage": "finalized",
+                    "checkpoint": {
+                        "lane": {
+                            "lane": "safe",
+                            "result_kind": "tool_call"
+                        },
+                        "finalization": {
+                            "persistence_mode": "success"
+                        }
+                    },
+                    "finalization_progress": {
+                        "after_turn": "completed",
+                        "compaction": "skipped"
+                    },
+                    "failure": null
+                }
+            })
+            .to_string(),
+        ]
+    }
+
     #[tokio::test]
     async fn run_cli_ask_rejects_empty_message() {
         let error = run_cli_ask(None, None, "   ", &CliChatOptions::default())
@@ -1358,48 +1647,198 @@ mod tests {
         )
         .expect("initialize sqlite memory");
 
-        let session_id = "chat-binding-session";
+        let session_id = "chat-binding-history-direct";
         crate::memory::append_turn_direct(session_id, "user", "hello", &memory_config)
             .expect("persist user turn");
         crate::memory::append_turn_direct(session_id, "assistant", "world", &memory_config)
             .expect("persist assistant turn");
 
-        let coordinator = ConversationTurnCoordinator::new();
-        print_history(
+        let direct_lines = load_history_lines(
             session_id,
             config.memory.sliding_window,
             ConversationRuntimeBinding::direct(),
             &memory_config,
         )
         .await
-        .expect("print history with explicit direct binding");
-        print_safe_lane_summary(
-            session_id,
-            config.memory.sliding_window,
+        .expect("load history lines with explicit direct binding");
+        assert_eq!(
+            direct_lines,
+            vec!["user: hello".to_owned(), "assistant: world".to_owned()]
+        );
+
+        let (kernel_ctx, invocations) = build_kernel_context_with_window_turns(json!([
+            {
+                "role": "user",
+                "content": "kernel hello",
+                "ts": 7
+            },
+            {
+                "role": "assistant",
+                "content": "kernel world",
+                "ts": 8
+            }
+        ]));
+        let kernel_lines = load_history_lines(
+            "chat-binding-history-kernel",
+            16,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+            &memory_config,
+        )
+        .await
+        .expect("load history lines with explicit kernel binding");
+        assert_eq!(
+            kernel_lines,
+            vec![
+                "[7] user: kernel hello".to_owned(),
+                "[8] assistant: kernel world".to_owned()
+            ]
+        );
+
+        let captured = invocations.lock().expect("invocations lock");
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
+        assert_eq!(
+            captured[0].payload["session_id"],
+            "chat-binding-history-kernel"
+        );
+        assert_eq!(captured[0].payload["limit"], json!(16));
+
+        let _ = std::fs::remove_file(sqlite_path);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn safe_lane_summary_output_accepts_explicit_runtime_binding() {
+        let sqlite_path = unique_chat_sqlite_path("safe-lane-output");
+        let _ = std::fs::remove_file(&sqlite_path);
+
+        let mut config = LoongClawConfig::default();
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        crate::memory::ensure_memory_db_ready(
+            Some(config.memory.resolved_sqlite_path()),
+            &memory_config,
+        )
+        .expect("initialize sqlite memory");
+
+        let direct_payloads = safe_lane_event_payloads();
+        append_assistant_payloads(
+            "chat-binding-safe-lane-direct",
+            &direct_payloads,
+            &memory_config,
+        );
+        let direct_output = load_safe_lane_summary_output(
+            "chat-binding-safe-lane-direct",
+            64,
             &config.conversation,
             ConversationRuntimeBinding::direct(),
             &memory_config,
         )
         .await
-        .expect("print safe lane summary with explicit direct binding");
-        print_turn_checkpoint_summary(
-            &coordinator,
-            &config,
-            session_id,
-            config.memory.sliding_window,
-            ConversationRuntimeBinding::direct(),
+        .expect("load safe lane summary via direct binding");
+        assert!(
+            direct_output
+                .contains("safe_lane_summary session=chat-binding-safe-lane-direct limit=64")
+        );
+        assert!(direct_output.contains("round_started=1"));
+        assert!(direct_output.contains("verify_failed=1"));
+        assert!(direct_output.contains("failure_code=safe_lane_plan_verify_failed"));
+
+        let kernel_payloads = safe_lane_event_payloads();
+        let (kernel_ctx, invocations) =
+            build_kernel_context_with_window_turns(assistant_window_turns(&kernel_payloads));
+        let kernel_output = load_safe_lane_summary_output(
+            "chat-binding-safe-lane-kernel",
+            80,
+            &config.conversation,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
             &memory_config,
         )
         .await
-        .expect("print turn checkpoint summary with explicit direct binding");
-        print_turn_checkpoint_repair(
+        .expect("load safe lane summary via kernel binding");
+        assert!(
+            kernel_output
+                .contains("safe_lane_summary session=chat-binding-safe-lane-kernel limit=80")
+        );
+        assert!(kernel_output.contains("round_started=1"));
+        assert!(kernel_output.contains("verify_failed=1"));
+        assert!(kernel_output.contains("failure_code=safe_lane_plan_verify_failed"));
+
+        let captured = invocations.lock().expect("invocations lock");
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
+        assert_eq!(
+            captured[0].payload["session_id"],
+            "chat-binding-safe-lane-kernel"
+        );
+        assert_eq!(captured[0].payload["limit"], json!(80));
+        assert_eq!(captured[0].payload["allow_extended_limit"], json!(true));
+
+        let _ = std::fs::remove_file(sqlite_path);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn turn_checkpoint_summary_output_accepts_explicit_runtime_binding() {
+        let sqlite_path = unique_chat_sqlite_path("turn-checkpoint-output");
+        let _ = std::fs::remove_file(&sqlite_path);
+
+        let mut config = LoongClawConfig::default();
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        crate::memory::ensure_memory_db_ready(
+            Some(config.memory.resolved_sqlite_path()),
+            &memory_config,
+        )
+        .expect("initialize sqlite memory");
+
+        let direct_payloads = turn_checkpoint_event_payloads();
+        append_assistant_payloads(
+            "chat-binding-turn-checkpoint-direct",
+            &direct_payloads,
+            &memory_config,
+        );
+        let coordinator = ConversationTurnCoordinator::new();
+        let direct_output = load_turn_checkpoint_summary_output(
             &coordinator,
             &config,
-            session_id,
+            "chat-binding-turn-checkpoint-direct",
+            96,
             ConversationRuntimeBinding::direct(),
         )
         .await
-        .expect("print turn checkpoint repair with explicit direct binding");
+        .expect("load turn checkpoint summary via direct binding");
+        assert!(direct_output.contains("turn_checkpoint_summary session=chat-binding-turn-checkpoint-direct limit=96 checkpoints=2"));
+        assert!(direct_output.contains("state=finalized"));
+        assert!(direct_output.contains("after_turn=completed"));
+        assert!(direct_output.contains("compaction=skipped"));
+
+        let kernel_payloads = turn_checkpoint_event_payloads();
+        let (kernel_ctx, invocations) =
+            build_kernel_context_with_window_turns(assistant_window_turns(&kernel_payloads));
+        let kernel_output = load_turn_checkpoint_summary_output(
+            &coordinator,
+            &config,
+            "chat-binding-turn-checkpoint-kernel",
+            112,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("load turn checkpoint summary via kernel binding");
+        assert!(kernel_output.contains("turn_checkpoint_summary session=chat-binding-turn-checkpoint-kernel limit=112 checkpoints=2"));
+        assert!(kernel_output.contains("state=finalized"));
+        assert!(kernel_output.contains("after_turn=completed"));
+        assert!(kernel_output.contains("compaction=skipped"));
+
+        let captured = invocations.lock().expect("invocations lock");
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
+        assert_eq!(
+            captured[0].payload["session_id"],
+            "chat-binding-turn-checkpoint-kernel"
+        );
+        assert_eq!(captured[0].payload["limit"], json!(112));
+        assert_eq!(captured[0].payload["allow_extended_limit"], json!(true));
 
         let _ = std::fs::remove_file(sqlite_path);
     }

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -7,6 +7,7 @@ use loongclaw_contracts::{Capability, MemoryCoreRequest};
 use serde_json::{Value, json};
 
 use crate::CliResult;
+use crate::KernelContext;
 #[cfg(feature = "memory-sqlite")]
 use crate::memory;
 #[cfg(feature = "memory-sqlite")]
@@ -182,6 +183,25 @@ pub async fn load_safe_lane_event_summary(
 }
 
 pub async fn load_discovery_first_event_summary(
+    session_id: &str,
+    limit: usize,
+    kernel_ctx: Option<&KernelContext>,
+    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+) -> CliResult<DiscoveryFirstEventSummary> {
+    load_discovery_first_event_summary_with_binding(
+        session_id,
+        limit,
+        kernel_ctx.map_or_else(
+            ConversationRuntimeBinding::direct,
+            ConversationRuntimeBinding::kernel,
+        ),
+        #[cfg(feature = "memory-sqlite")]
+        memory_config,
+    )
+    .await
+}
+
+pub(crate) async fn load_discovery_first_event_summary_with_binding(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -184,15 +184,11 @@ pub async fn load_safe_lane_event_summary(
 pub async fn load_discovery_first_event_summary(
     session_id: &str,
     limit: usize,
-    kernel_ctx: Option<&crate::KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<DiscoveryFirstEventSummary> {
     #[cfg(feature = "memory-sqlite")]
     {
-        let binding =
-            super::runtime_binding::ConversationRuntimeBinding::from_optional_kernel_context(
-                kernel_ctx,
-            );
         let assistant_contents =
             load_assistant_contents_from_session_window(session_id, limit, binding, memory_config)
                 .await?;
@@ -203,7 +199,7 @@ pub async fn load_discovery_first_event_summary(
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = (session_id, limit, kernel_ctx);
+        let _ = (session_id, limit, binding);
         Err("discovery-first summary unavailable: memory-sqlite feature disabled".to_owned())
     }
 }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8517,6 +8517,45 @@ fn build_kernel_context_with_raw_window_payload(
     (ctx, invocations)
 }
 
+#[cfg(feature = "memory-sqlite")]
+fn prepare_discovery_first_summary_test(
+    db_scope: &str,
+    direct_session_id: &str,
+    payloads: &[String],
+) -> (PathBuf, MemoryRuntimeConfig) {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id(db_scope, "binding")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    for payload in payloads {
+        crate::memory::append_turn_direct(direct_session_id, "assistant", payload, &mem_config)
+            .expect("persist discovery-first payload");
+    }
+
+    (db_path, mem_config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn discovery_first_window_turns(payloads: &[String]) -> Value {
+    json!(
+        payloads
+            .iter()
+            .enumerate()
+            .map(|(index, payload)| json!({
+                "role": "assistant",
+                "content": payload,
+                "ts": index + 1
+            }))
+            .collect::<Vec<_>>()
+    )
+}
+
 struct SharedTestMemoryAdapter {
     invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
     window_turns: Value,
@@ -9018,25 +9057,11 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
         .to_string(),
     ];
 
-    let db_path = std::env::temp_dir().join(format!(
-        "{}.sqlite3",
-        unique_acp_test_id("conversation-discovery-first", "binding")
-    ));
-    let _ = std::fs::remove_file(&db_path);
-
-    let mut config = test_config();
-    config.memory.sqlite_path = db_path.display().to_string();
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-
-    for payload in &payloads {
-        crate::memory::append_turn_direct(
-            "session-discovery-first-direct",
-            "assistant",
-            payload,
-            &mem_config,
-        )
-        .expect("persist discovery-first payload");
-    }
+    let (db_path, mem_config) = prepare_discovery_first_summary_test(
+        "conversation-discovery-first",
+        "session-discovery-first-direct",
+        &payloads,
+    );
 
     let direct_summary = super::session_history::load_discovery_first_event_summary_with_binding(
         "session-discovery-first-direct",
@@ -9054,19 +9079,9 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
         Some("file.read")
     );
 
-    let kernel_turns = json!(
-        payloads
-            .iter()
-            .enumerate()
-            .map(|(index, payload)| json!({
-                "role": "assistant",
-                "content": payload,
-                "ts": index + 1
-            }))
-            .collect::<Vec<_>>()
-    );
     let audit = Arc::new(InMemoryAuditSink::default());
-    let (kernel_ctx, invocations) = build_kernel_context_with_window_turns(audit, kernel_turns);
+    let (kernel_ctx, invocations) =
+        build_kernel_context_with_window_turns(audit, discovery_first_window_turns(&payloads));
 
     let kernel_summary = super::session_history::load_discovery_first_event_summary_with_binding(
         "session-discovery-first-kernel",
@@ -9126,25 +9141,11 @@ async fn load_discovery_first_event_summary_preserves_public_kernel_context_sign
         .to_string(),
     ];
 
-    let db_path = std::env::temp_dir().join(format!(
-        "{}.sqlite3",
-        unique_acp_test_id("conversation-discovery-first-compat", "binding")
-    ));
-    let _ = std::fs::remove_file(&db_path);
-
-    let mut config = test_config();
-    config.memory.sqlite_path = db_path.display().to_string();
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-
-    for payload in &payloads {
-        crate::memory::append_turn_direct(
-            "session-discovery-first-compat-direct",
-            "assistant",
-            payload,
-            &mem_config,
-        )
-        .expect("persist discovery-first payload");
-    }
+    let (db_path, mem_config) = prepare_discovery_first_summary_test(
+        "conversation-discovery-first-compat",
+        "session-discovery-first-compat-direct",
+        &payloads,
+    );
 
     let direct_summary = load_discovery_first_event_summary(
         "session-discovery-first-compat-direct",
@@ -9161,19 +9162,9 @@ async fn load_discovery_first_event_summary_preserves_public_kernel_context_sign
         Some("file.read")
     );
 
-    let kernel_turns = json!(
-        payloads
-            .iter()
-            .enumerate()
-            .map(|(index, payload)| json!({
-                "role": "assistant",
-                "content": payload,
-                "ts": index + 1
-            }))
-            .collect::<Vec<_>>()
-    );
     let audit = Arc::new(InMemoryAuditSink::default());
-    let (kernel_ctx, invocations) = build_kernel_context_with_window_turns(audit, kernel_turns);
+    let (kernel_ctx, invocations) =
+        build_kernel_context_with_window_turns(audit, discovery_first_window_turns(&payloads));
 
     let kernel_summary = load_discovery_first_event_summary(
         "session-discovery-first-compat-kernel",

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8977,6 +8977,126 @@ async fn load_turn_checkpoint_event_summary_direct_read_failure_uses_neutral_err
     let _ = std::fs::remove_dir_all(&sqlite_dir);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
+    let payloads = [
+        json!({
+            "type": "conversation_event",
+            "event": "discovery_first_search_round",
+            "payload": {
+                "provider_round": 0,
+                "search_tool_calls": 1,
+                "raw_tool_output_requested": false,
+                "initial_estimated_tokens": 12
+            }
+        })
+        .to_string(),
+        json!({
+            "type": "conversation_event",
+            "event": "discovery_first_followup_requested",
+            "payload": {
+                "provider_round": 1,
+                "raw_tool_output_requested": true,
+                "initial_estimated_tokens": 12,
+                "followup_estimated_tokens": 21,
+                "followup_added_estimated_tokens": 9
+            }
+        })
+        .to_string(),
+        json!({
+            "type": "conversation_event",
+            "event": "discovery_first_followup_result",
+            "payload": {
+                "provider_round": 1,
+                "outcome": "tool.invoke",
+                "followup_tool_name": "tool.invoke",
+                "followup_target_tool_id": "file.read",
+                "resolved_to_tool_invoke": true,
+                "raw_tool_output_requested": true
+            }
+        })
+        .to_string(),
+    ];
+
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-discovery-first", "binding")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    for payload in &payloads {
+        crate::memory::append_turn_direct(
+            "session-discovery-first-direct",
+            "assistant",
+            payload,
+            &mem_config,
+        )
+        .expect("persist discovery-first payload");
+    }
+
+    let direct_summary = load_discovery_first_event_summary(
+        "session-discovery-first-direct",
+        32,
+        ConversationRuntimeBinding::direct(),
+        &mem_config,
+    )
+    .await
+    .expect("load discovery-first summary via direct binding");
+    assert_eq!(direct_summary.search_round_events, 1);
+    assert_eq!(direct_summary.followup_requested_events, 1);
+    assert_eq!(direct_summary.followup_result_events, 1);
+    assert_eq!(
+        direct_summary.latest_followup_target_tool_id.as_deref(),
+        Some("file.read")
+    );
+
+    let kernel_turns = json!(
+        payloads
+            .iter()
+            .enumerate()
+            .map(|(index, payload)| json!({
+                "role": "assistant",
+                "content": payload,
+                "ts": index + 1
+            }))
+            .collect::<Vec<_>>()
+    );
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (kernel_ctx, invocations) = build_kernel_context_with_window_turns(audit, kernel_turns);
+
+    let kernel_summary = load_discovery_first_event_summary(
+        "session-discovery-first-kernel",
+        48,
+        ConversationRuntimeBinding::kernel(&kernel_ctx),
+        &mem_config,
+    )
+    .await
+    .expect("load discovery-first summary via kernel binding");
+    assert_eq!(kernel_summary.search_round_events, 1);
+    assert_eq!(kernel_summary.followup_requested_events, 1);
+    assert_eq!(kernel_summary.followup_result_events, 1);
+    assert_eq!(
+        kernel_summary.latest_followup_target_tool_id.as_deref(),
+        Some("file.read")
+    );
+
+    let captured = invocations.lock().expect("invocations lock");
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
+    assert_eq!(
+        captured[0].payload["session_id"],
+        "session-discovery-first-kernel"
+    );
+    assert_eq!(captured[0].payload["limit"], json!(48));
+    assert_eq!(captured[0].payload["allow_extended_limit"], json!(true));
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
 #[cfg(not(feature = "memory-sqlite"))]
 #[tokio::test]
 async fn persist_turn_without_memory_sqlite_is_noop_with_kernel_context() {

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -9038,7 +9038,7 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
         .expect("persist discovery-first payload");
     }
 
-    let direct_summary = load_discovery_first_event_summary(
+    let direct_summary = super::session_history::load_discovery_first_event_summary_with_binding(
         "session-discovery-first-direct",
         32,
         ConversationRuntimeBinding::direct(),
@@ -9068,7 +9068,7 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
     let audit = Arc::new(InMemoryAuditSink::default());
     let (kernel_ctx, invocations) = build_kernel_context_with_window_turns(audit, kernel_turns);
 
-    let kernel_summary = load_discovery_first_event_summary(
+    let kernel_summary = super::session_history::load_discovery_first_event_summary_with_binding(
         "session-discovery-first-kernel",
         48,
         ConversationRuntimeBinding::kernel(&kernel_ctx),
@@ -9092,6 +9092,112 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
         "session-discovery-first-kernel"
     );
     assert_eq!(captured[0].payload["limit"], json!(48));
+    assert_eq!(captured[0].payload["allow_extended_limit"], json!(true));
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_discovery_first_event_summary_preserves_public_kernel_context_signature() {
+    let payloads = [
+        json!({
+            "type": "conversation_event",
+            "event": "discovery_first_search_round",
+            "payload": {
+                "provider_round": 0,
+                "search_tool_calls": 2,
+                "raw_tool_output_requested": false,
+                "initial_estimated_tokens": 8
+            }
+        })
+        .to_string(),
+        json!({
+            "type": "conversation_event",
+            "event": "discovery_first_followup_result",
+            "payload": {
+                "provider_round": 0,
+                "outcome": "tool.invoke",
+                "followup_tool_name": "tool.invoke",
+                "followup_target_tool_id": "file.read",
+                "resolved_to_tool_invoke": true,
+                "raw_tool_output_requested": false
+            }
+        })
+        .to_string(),
+    ];
+
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-discovery-first-compat", "binding")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    for payload in &payloads {
+        crate::memory::append_turn_direct(
+            "session-discovery-first-compat-direct",
+            "assistant",
+            payload,
+            &mem_config,
+        )
+        .expect("persist discovery-first payload");
+    }
+
+    let direct_summary = load_discovery_first_event_summary(
+        "session-discovery-first-compat-direct",
+        16,
+        None,
+        &mem_config,
+    )
+    .await
+    .expect("load discovery-first summary via legacy direct signature");
+    assert_eq!(direct_summary.search_round_events, 1);
+    assert_eq!(direct_summary.followup_result_events, 1);
+    assert_eq!(
+        direct_summary.latest_followup_target_tool_id.as_deref(),
+        Some("file.read")
+    );
+
+    let kernel_turns = json!(
+        payloads
+            .iter()
+            .enumerate()
+            .map(|(index, payload)| json!({
+                "role": "assistant",
+                "content": payload,
+                "ts": index + 1
+            }))
+            .collect::<Vec<_>>()
+    );
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (kernel_ctx, invocations) = build_kernel_context_with_window_turns(audit, kernel_turns);
+
+    let kernel_summary = load_discovery_first_event_summary(
+        "session-discovery-first-compat-kernel",
+        24,
+        Some(&kernel_ctx),
+        &mem_config,
+    )
+    .await
+    .expect("load discovery-first summary via legacy kernel signature");
+    assert_eq!(kernel_summary.search_round_events, 1);
+    assert_eq!(kernel_summary.followup_result_events, 1);
+    assert_eq!(
+        kernel_summary.latest_followup_target_tool_id.as_deref(),
+        Some("file.read")
+    );
+
+    let captured = invocations.lock().expect("invocations lock");
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
+    assert_eq!(
+        captured[0].payload["session_id"],
+        "session-discovery-first-compat-kernel"
+    );
+    assert_eq!(captured[0].payload["limit"], json!(24));
     assert_eq!(captured[0].payload["allow_extended_limit"], json!(true));
 
     let _ = std::fs::remove_file(&db_path);

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -39,6 +39,7 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 - Detached async delegate spawns carry an owned kernel context forward when the parent binding is kernel-bound. Direct-mode parents keep direct-mode children.
 - Kernel-bound history helpers no longer reuse direct sqlite fallback behind the caller's back. Higher-level orchestration may still choose how to handle the surfaced error.
 - Safe-lane governor diagnostics now surface history load status and normalized error codes instead of silently collapsing kernel history failures into an undifferentiated "no history" state.
+- User-facing chat diagnostics and the discovery-first session-history summary now preserve explicit `ConversationRuntimeBinding` semantics instead of reconstructing execution mode from optional kernel context.
 
 **Provider runtime binding note:**
 - The provider binding makes provider governance explicit without importing conversation-layer semantics into provider code. `Kernel` means failover/audit behavior may emit kernel-backed audit events; `Direct` means provider execution is intentionally running without that authority while still recording in-process failover metrics.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -39,7 +39,7 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 - Detached async delegate spawns carry an owned kernel context forward when the parent binding is kernel-bound. Direct-mode parents keep direct-mode children.
 - Kernel-bound history helpers no longer reuse direct sqlite fallback behind the caller's back. Higher-level orchestration may still choose how to handle the surfaced error.
 - Safe-lane governor diagnostics now surface history load status and normalized error codes instead of silently collapsing kernel history failures into an undifferentiated "no history" state.
-- User-facing chat diagnostics and the discovery-first session-history summary now preserve explicit `ConversationRuntimeBinding` semantics instead of reconstructing execution mode from optional kernel context.
+- User-facing chat diagnostics now preserve explicit `ConversationRuntimeBinding` semantics end-to-end. The discovery-first session-history path uses the same binding-first implementation internally. The public `Option<&KernelContext>` entrypoint remains an explicit compatibility wrapper instead of carrying shadow authority semantics deeper into the runtime.
 
 **Provider runtime binding note:**
 - The provider binding makes provider governance explicit without importing conversation-layer semantics into provider code. `Kernel` means failover/audit behavior may emit kernel-backed audit events; `Direct` means provider execution is intentionally running without that authority while still recording in-process failover metrics.

--- a/docs/plans/2026-03-16-chat-diagnostics-binding-normalization-design.md
+++ b/docs/plans/2026-03-16-chat-diagnostics-binding-normalization-design.md
@@ -1,0 +1,105 @@
+# Chat Diagnostics Binding Normalization Design
+
+Date: 2026-03-16
+Scope: follow-up for issue #191 on `alpha-test`
+
+## Problem
+
+`ConversationRuntimeBinding` already exists to make conversation execution mode
+explicit, but the CLI chat diagnostics layer still leaks back to raw
+`Option<&KernelContext>`.
+
+The remaining drift is concentrated in:
+
+1. `crates/app/src/chat.rs`
+   - `print_history(...)`
+   - `print_safe_lane_summary(...)`
+   - `print_turn_checkpoint_summary(...)`
+   - `print_turn_checkpoint_repair(...)`
+2. `crates/app/src/conversation/session_history.rs`
+   - `load_discovery_first_event_summary(...)`
+
+These helpers either:
+
+1. accept `Option<&KernelContext>` even when the caller already knows the
+   runtime mode, or
+2. immediately convert that optional kernel context back into
+   `ConversationRuntimeBinding`.
+
+That does not create a new exploit on its own, but it weakens the type-level
+contract around governed versus direct execution and makes future drift easier.
+
+## Goals
+
+1. Keep chat diagnostics on explicit `ConversationRuntimeBinding<'_>`.
+2. Keep the session-history discovery-first summary helper on the same explicit
+   binding contract as the neighboring history helpers.
+3. Preserve current behavior:
+   - kernel-bound callers still use kernel memory windows
+   - direct callers still use direct/sqlite history paths
+   - user-facing command output remains unchanged
+4. Keep the slice small enough for a standalone issue and PR.
+
+## Non-goals
+
+1. Do not normalize the remaining provider-layer `Option<&KernelContext>` seams.
+2. Do not widen this slice into turn-loop or ACP work.
+3. Do not redesign history summary rendering or CLI output formats.
+
+## Alternatives Considered
+
+### A. Leave chat diagnostics alone because they are "just CLI helpers"
+
+Rejected. These helpers are user-facing orchestration boundaries. Leaving them
+optional-context-based keeps the conversation runtime story weaker exactly where
+operator tooling is supposed to be truthful.
+
+### B. Resume the broad conversation binding normalization refactor
+
+Rejected for this branch. The broader 2026-03-15 plan spans multiple files and
+surfaces. This follow-up should land a tighter, lower-risk slice that directly
+matches issue #191.
+
+### C. Normalize only the chat diagnostics and discovery-first helper
+
+Recommended. It removes the most obvious optional-context leftovers at the CLI
+diagnostic boundary without dragging in unrelated conversation internals.
+
+## Proposed Design
+
+Use `ConversationRuntimeBinding<'_>` directly in the remaining chat diagnostic
+helpers and in `load_discovery_first_event_summary(...)`.
+
+Concrete changes:
+
+1. `chat.rs`
+   - command dispatch sites pass `ConversationRuntimeBinding::kernel(&runtime.kernel_ctx)`
+   - helper signatures accept `ConversationRuntimeBinding<'_>`
+   - `print_history(...)` calls `binding.kernel_context()` only at the leaf that
+     branches between kernel-backed memory windows and direct history loading
+2. `session_history.rs`
+   - `load_discovery_first_event_summary(...)` accepts binding directly
+   - it reuses the same `load_assistant_contents_from_session_window(...)`
+     contract as adjacent helpers without re-deriving binding from an option
+
+## Expected Outcome
+
+After this slice:
+
+1. chat diagnostics no longer encode execution mode as `Some/None`
+2. the conversation history helper surface becomes more internally consistent
+3. the governed/runtime narrative becomes slightly more truthful without
+   changing runtime behavior
+
+## Test Strategy
+
+Add focused regression coverage that proves:
+
+1. chat diagnostic helpers compile and run when called with explicit
+   `ConversationRuntimeBinding::direct()`
+2. the discovery-first history helper compiles and runs with explicit direct and
+   kernel bindings
+3. existing summary/checkpoint behavior stays unchanged
+
+The tests do not need to prove new behavior. They need to prove that the
+binding contract has become explicit at these remaining seams.

--- a/docs/plans/2026-03-16-chat-diagnostics-binding-normalization-design.md
+++ b/docs/plans/2026-03-16-chat-diagnostics-binding-normalization-design.md
@@ -32,8 +32,9 @@ contract around governed versus direct execution and makes future drift easier.
 ## Goals
 
 1. Keep chat diagnostics on explicit `ConversationRuntimeBinding<'_>`.
-2. Keep the session-history discovery-first summary helper on the same explicit
-   binding contract as the neighboring history helpers.
+2. Keep the session-history discovery-first summary implementation on the same
+   explicit binding contract as the neighboring history helpers without
+   breaking the existing public `Option<&KernelContext>` wrapper.
 3. Preserve current behavior:
    - kernel-bound callers still use kernel memory windows
    - direct callers still use direct/sqlite history paths
@@ -75,19 +76,22 @@ Concrete changes:
 1. `chat.rs`
    - command dispatch sites pass `ConversationRuntimeBinding::kernel(&runtime.kernel_ctx)`
    - helper signatures accept `ConversationRuntimeBinding<'_>`
-   - `print_history(...)` calls `binding.kernel_context()` only at the leaf that
-     branches between kernel-backed memory windows and direct history loading
+   - `print_*` remains a thin CLI shell around binding-aware output builders so
+     routing and rendered output can be asserted directly in tests
 2. `session_history.rs`
-   - `load_discovery_first_event_summary(...)` accepts binding directly
-   - it reuses the same `load_assistant_contents_from_session_window(...)`
-     contract as adjacent helpers without re-deriving binding from an option
+   - keep `load_discovery_first_event_summary(...)` as the compatibility wrapper
+     that still accepts `Option<&KernelContext>`
+   - move the normalized binding-first implementation into an internal helper so
+     adjacent history helpers share the same explicit runtime contract without a
+     public API break
 
 ## Expected Outcome
 
 After this slice:
 
 1. chat diagnostics no longer encode execution mode as `Some/None`
-2. the conversation history helper surface becomes more internally consistent
+2. the conversation history implementation becomes more internally consistent
+   while preserving the current public discovery-first helper signature
 3. the governed/runtime narrative becomes slightly more truthful without
    changing runtime behavior
 
@@ -95,11 +99,14 @@ After this slice:
 
 Add focused regression coverage that proves:
 
-1. chat diagnostic helpers compile and run when called with explicit
-   `ConversationRuntimeBinding::direct()`
-2. the discovery-first history helper compiles and runs with explicit direct and
+1. chat diagnostic output builders produce the expected `/history`,
+   `/safe_lane_summary`, and `/turn_checkpoint_summary` output for both direct
+   and kernel bindings
+2. the normalized internal discovery-first helper runs with explicit direct and
    kernel bindings
-3. existing summary/checkpoint behavior stays unchanged
+3. the public discovery-first wrapper still accepts `None` and `Some(&ctx)`
+   without compile-time or runtime regressions
 
 The tests do not need to prove new behavior. They need to prove that the
-binding contract has become explicit at these remaining seams.
+binding contract has become explicit at these remaining seams while the public
+compatibility boundary remains stable.

--- a/docs/plans/2026-03-16-chat-diagnostics-binding-normalization-implementation-plan.md
+++ b/docs/plans/2026-03-16-chat-diagnostics-binding-normalization-implementation-plan.md
@@ -20,20 +20,27 @@
 
 Add:
 
-1. a `chat.rs` async test that calls the chat diagnostic helpers with
-   `ConversationRuntimeBinding::direct()`
-2. a `conversation/tests.rs` async test that calls
-   `load_discovery_first_event_summary(...)` with explicit
-   `ConversationRuntimeBinding::direct()` and `ConversationRuntimeBinding::kernel(...)`
+1. `chat.rs` async tests that assert real `/history`,
+   `/safe_lane_summary`, and `/turn_checkpoint_summary` output for explicit
+   direct and kernel bindings
+2. a `conversation/tests.rs` async test that calls the normalized
+   discovery-first helper with explicit `ConversationRuntimeBinding::direct()`
+   and `ConversationRuntimeBinding::kernel(...)`
+3. a `conversation/tests.rs` async compatibility test that still calls
+   `load_discovery_first_event_summary(...)` with `None` and `Some(&ctx)`
 
 **Step 2: Run test to verify it fails**
 
 Run:
 
-- `cargo test -p loongclaw-app print_history_accepts_explicit_runtime_binding -- --exact --nocapture`
-- `cargo test -p loongclaw-app load_discovery_first_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app chat::tests::print_history_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app chat::tests::safe_lane_summary_output_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app chat::tests::turn_checkpoint_summary_output_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app conversation::tests::load_discovery_first_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app conversation::tests::load_discovery_first_event_summary_preserves_public_kernel_context_signature -- --exact --nocapture`
 
-Expected: FAIL because the helper signatures still require `Option<&KernelContext>`.
+Expected: FAIL because the output builders and compatibility-preserving helper
+split do not exist yet.
 
 ### Task 2: Normalize helper signatures and leaf conversions
 
@@ -46,16 +53,22 @@ Expected: FAIL because the helper signatures still require `Option<&KernelContex
 1. Change the remaining chat diagnostic helper signatures to accept
    `ConversationRuntimeBinding<'_>`
 2. Update command dispatch call sites to pass explicit binding values
-3. Change `load_discovery_first_event_summary(...)` to accept binding directly
-4. Use `binding.kernel_context()` only at the leaf where a lower-level branch
+3. Introduce binding-aware output builders underneath the `print_*` shells so
+   tests can assert routing and formatted output directly
+4. Keep `load_discovery_first_event_summary(...)` as the public compatibility
+   wrapper while moving the binding-first implementation into an internal helper
+5. Use `binding.kernel_context()` only at the leaf where a lower-level branch
    still truly needs optional kernel context
 
 **Step 2: Run targeted tests to verify they pass**
 
 Run:
 
-- `cargo test -p loongclaw-app print_history_accepts_explicit_runtime_binding -- --exact --nocapture`
-- `cargo test -p loongclaw-app load_discovery_first_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app chat::tests::print_history_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app chat::tests::safe_lane_summary_output_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app chat::tests::turn_checkpoint_summary_output_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app conversation::tests::load_discovery_first_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app conversation::tests::load_discovery_first_event_summary_preserves_public_kernel_context_signature -- --exact --nocapture`
 
 Expected: PASS
 
@@ -69,14 +82,18 @@ Expected: PASS
 **Step 1: Update docs**
 
 Record that the chat diagnostic boundary now preserves explicit runtime binding
-semantics and note any remaining follow-up seams outside this slice.
+semantics, that the public discovery-first helper remains a compatibility
+wrapper, and note any remaining follow-up seams outside this slice.
 
 **Step 2: Run focused verification**
 
 Run:
 
-- `cargo test -p loongclaw-app print_history_accepts_explicit_runtime_binding -- --exact --nocapture`
-- `cargo test -p loongclaw-app load_discovery_first_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app chat::tests::print_history_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app chat::tests::safe_lane_summary_output_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app chat::tests::turn_checkpoint_summary_output_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app conversation::tests::load_discovery_first_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app conversation::tests::load_discovery_first_event_summary_preserves_public_kernel_context_signature -- --exact --nocapture`
 - `cargo test -p loongclaw-app load_turn_checkpoint_event_summary -- --test-threads=1`
 
 Expected: PASS

--- a/docs/plans/2026-03-16-chat-diagnostics-binding-normalization-implementation-plan.md
+++ b/docs/plans/2026-03-16-chat-diagnostics-binding-normalization-implementation-plan.md
@@ -1,0 +1,104 @@
+# Chat Diagnostics Binding Normalization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Normalize the remaining chat diagnostic and discovery-first session-history helpers onto `ConversationRuntimeBinding<'_>`.
+
+**Architecture:** Keep the slice narrow. Update only the user-facing chat diagnostic helpers and the discovery-first summary helper so they stop accepting raw optional kernel context and instead preserve explicit runtime binding semantics through their surface.
+
+**Tech Stack:** Rust, Tokio tests, GitHub issue-first workflow
+
+---
+
+### Task 1: Add failing tests for explicit binding-based helper calls
+
+**Files:**
+- Modify: `crates/app/src/chat.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Add:
+
+1. a `chat.rs` async test that calls the chat diagnostic helpers with
+   `ConversationRuntimeBinding::direct()`
+2. a `conversation/tests.rs` async test that calls
+   `load_discovery_first_event_summary(...)` with explicit
+   `ConversationRuntimeBinding::direct()` and `ConversationRuntimeBinding::kernel(...)`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+- `cargo test -p loongclaw-app print_history_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app load_discovery_first_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
+
+Expected: FAIL because the helper signatures still require `Option<&KernelContext>`.
+
+### Task 2: Normalize helper signatures and leaf conversions
+
+**Files:**
+- Modify: `crates/app/src/chat.rs`
+- Modify: `crates/app/src/conversation/session_history.rs`
+
+**Step 1: Write minimal implementation**
+
+1. Change the remaining chat diagnostic helper signatures to accept
+   `ConversationRuntimeBinding<'_>`
+2. Update command dispatch call sites to pass explicit binding values
+3. Change `load_discovery_first_event_summary(...)` to accept binding directly
+4. Use `binding.kernel_context()` only at the leaf where a lower-level branch
+   still truly needs optional kernel context
+
+**Step 2: Run targeted tests to verify they pass**
+
+Run:
+
+- `cargo test -p loongclaw-app print_history_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app load_discovery_first_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
+
+Expected: PASS
+
+### Task 3: Refresh docs and full verification
+
+**Files:**
+- Modify: `docs/SECURITY.md`
+- Modify: `docs/plans/2026-03-16-chat-diagnostics-binding-normalization-design.md`
+- Modify: `docs/plans/2026-03-16-chat-diagnostics-binding-normalization-implementation-plan.md`
+
+**Step 1: Update docs**
+
+Record that the chat diagnostic boundary now preserves explicit runtime binding
+semantics and note any remaining follow-up seams outside this slice.
+
+**Step 2: Run focused verification**
+
+Run:
+
+- `cargo test -p loongclaw-app print_history_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app load_discovery_first_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app load_turn_checkpoint_event_summary -- --test-threads=1`
+
+Expected: PASS
+
+**Step 3: Run full verification**
+
+Run:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features`
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-03-16-chat-diagnostics-binding-normalization-design.md \
+        docs/plans/2026-03-16-chat-diagnostics-binding-normalization-implementation-plan.md \
+        docs/SECURITY.md \
+        crates/app/src/chat.rs \
+        crates/app/src/conversation/session_history.rs \
+        crates/app/src/conversation/tests.rs
+git commit -m "refactor: normalize chat diagnostics runtime binding"
+```


### PR DESCRIPTION
## Summary

- Normalize the remaining chat diagnostic helpers onto explicit `ConversationRuntimeBinding` output builders instead of reconstructing runtime mode inside `print_*` paths.
- Preserve the public `load_discovery_first_event_summary(...)` `Option<&KernelContext>` entrypoint as a compatibility wrapper while moving the binding-first implementation behind an internal helper.
- Strengthen regression coverage and docs so direct/kernel routing, user-facing diagnostics output, and targeted verification commands all match the actual code paths.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

- The slice remains intentionally narrow: `chat.rs`, `conversation/session_history.rs`, focused tests, and binding-contract docs.
- Runtime behavior stays the same for direct and kernel-bound callers; the follow-up preserves public compatibility for the discovery-first summary while keeping the internal runtime contract binding-first.
- The new tests now cover direct and kernel-bound `/history`, `/safe_lane_summary`, and `/turn_checkpoint_summary` output, plus both the internal binding-first discovery-first helper and the public compatibility wrapper.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Before/after behavior:
- Before: chat diagnostics and the discovery-first summary seam mixed public `Option<&KernelContext>` inputs with internal binding reconstruction; the focused test commands in the implementation plan could also false-green under `--exact` because they were not module-qualified.
- After: chat diagnostics preserve explicit binding through testable output builders, the public discovery-first helper keeps its `Option<&KernelContext>` compatibility surface while delegating to a binding-first implementation, and the focused verification commands use module-qualified exact test names that execute the intended regressions.
- Regression coverage: `chat::tests::print_history_accepts_explicit_runtime_binding`, `chat::tests::safe_lane_summary_output_accepts_explicit_runtime_binding`, `chat::tests::turn_checkpoint_summary_output_accepts_explicit_runtime_binding`, `conversation::tests::load_discovery_first_event_summary_accepts_explicit_runtime_binding`, `conversation::tests::load_discovery_first_event_summary_preserves_public_kernel_context_signature`, and existing `load_turn_checkpoint_event_summary*` history-summary tests.

Additional scenario checks:
- `cargo test -p loongclaw-app chat::tests::print_history_accepts_explicit_runtime_binding -- --exact --nocapture`
- `cargo test -p loongclaw-app chat::tests::safe_lane_summary_output_accepts_explicit_runtime_binding -- --exact --nocapture`
- `cargo test -p loongclaw-app chat::tests::turn_checkpoint_summary_output_accepts_explicit_runtime_binding -- --exact --nocapture`
- `cargo test -p loongclaw-app conversation::tests::load_discovery_first_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
- `cargo test -p loongclaw-app conversation::tests::load_discovery_first_event_summary_preserves_public_kernel_context_signature -- --exact --nocapture`
- `cargo test -p loongclaw-app load_turn_checkpoint_event_summary -- --test-threads=1`

## Linked Issues

Closes #191


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Normalized chat diagnostics to use an explicit runtime binding across history, summary, checkpoint, and repair flows; introduced internal binding-aware helpers for loading and formatting conversation output and updated CLI paths while preserving public compatibility wrappers.

* **Tests**
  * Added tests, scaffolding, and mock bindings (including memory-backed scenarios) to validate binding-based diagnostic paths for both direct and kernel-backed runtimes.

* **Documentation**
  * Updated security notes and added design and implementation plans describing the binding-first approach and verification strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->