### PR TITLE
Establish alpha-test GitHub collaboration baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug Report
-description: Report a reproducible bug.
+description: Report a reproducible defect in LoongClaw's active alpha-test runtime.
+title: "[Bug]: "
 labels:
   - bug
   - triage
@@ -7,46 +8,155 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting. Please provide a minimal reproducible case.
+        Thanks for filing a bug report.
+        Please keep the report evidence-based, redact secrets, and provide the shortest reproducible path you can.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which surface looks most affected?
+      options:
+        - Kernel / policy / approvals
+        - Contracts
+        - Protocol
+        - Spec / architecture boundaries
+        - Daemon / CLI / install
+        - Providers / routing
+        - Tools
+        - Browser automation
+        - Channels / integrations
+        - ACP control plane
+        - Conversation / session runtime
+        - Memory / context assembly
+        - Config
+        - Migration / onboarding
+        - Docs / contributor workflow
+        - CI / release / workflows
+        - Unknown / needs triage
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: What is the practical impact?
+      options:
+        - S0 - security risk / data loss
+        - S1 - workflow blocked
+        - S2 - degraded behavior
+        - S3 - minor issue
+    validations:
+      required: true
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Regression?
+      options:
+        - Unknown
+        - Yes, this worked before
+        - No, this is a first-time setup or newly exercised path
+    validations:
+      required: true
+
   - type: textarea
     id: summary
     attributes:
       label: Summary
       description: What happened?
-      placeholder: Clear description of the bug.
+      placeholder: After updating provider profiles, LoongClaw selects the wrong active provider for a channel turn.
     validations:
       required: true
+
   - type: textarea
     id: expected
     attributes:
       label: Expected behavior
-      placeholder: What did you expect instead?
+      description: What should have happened instead?
+      placeholder: The runtime should preserve the explicitly selected provider profile and route the request through it.
     validations:
       required: true
+
   - type: textarea
     id: repro
     attributes:
       label: Reproduction steps
+      description: Provide exact commands, config edits, or request flow.
       placeholder: |
-        1. ...
-        2. ...
-        3. ...
+        1. Configure provider profile A and provider profile B.
+        2. Set profile B as the active profile.
+        3. Run `loongclaw ask --message "ping"`.
+        4. Observe the request executes through profile A.
+      render: bash
     validations:
       required: true
+
   - type: input
     id: version
     attributes:
       label: Version / commit
-      placeholder: e.g. main@<sha> or release tag
+      description: Release tag or exact branch/commit tested.
+      placeholder: alpha-test@ec9ee5f or v0.3.2
     validations:
       required: true
-  - type: dropdown
-    id: track
+
+  - type: input
+    id: os
     attributes:
-      label: Contribution track impact
-      description: Which track is most likely affected?
-      options:
-        - Track A (routine/low-risk)
-        - Track B (higher-risk/policy-impacting)
+      label: Operating system
+      placeholder: macOS 15.4 / Ubuntu 24.04 / Windows 11
     validations:
       required: true
+
+  - type: input
+    id: runtime_context
+    attributes:
+      label: Runtime context
+      description: Optional but recommended. Include the relevant provider / model / tool / channel / browser / ACP context. Redact secrets.
+      placeholder: provider=openrouter, model=claude-sonnet, channel=telegram, tool=browser.open, acp=disabled
+
+  - type: textarea
+    id: config_context
+    attributes:
+      label: Config / environment context
+      description: Relevant config keys, env overrides, and feature flags. Redact secrets and private endpoints.
+      placeholder: |
+        [provider]
+        active_profile = "work"
+
+        [tools.browser]
+        enabled = true
+
+        Env overrides:
+        LOONGCLAW_CONTEXT_ENGINE=legacy
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots / evidence
+      description: Paste the shortest logs or screenshots that prove the defect. Redact tokens, credentials, and private data.
+      render: text
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who is affected, how often this happens, and what practical damage it causes.
+      placeholder: |
+        Affected users: contributors testing multi-provider configs
+        Frequency: always
+        Consequence: wrong provider routing and misleading operator output
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I reproduced this on the latest `alpha-test` branch tip or the latest published release.
+          required: true
+        - label: I redacted secrets, tokens, and private endpoints from everything I attached.
+          required: true
+        - label: I searched existing issues and did not find the same report already tracked.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,15 @@ contact_links:
   - name: Security vulnerability report
     url: https://github.com/loongclaw-ai/loongclaw/security/advisories/new
     about: Report security issues privately.
+  - name: Questions and troubleshooting
+    url: https://github.com/loongclaw-ai/loongclaw/discussions
+    about: Use Discussions for Q&A, setup questions, and general troubleshooting.
+  - name: Community chat
+    url: https://discord.gg/7kSTX9mca
+    about: Join Discord for community help and operator discussion.
+  - name: Contribution guide
+    url: https://github.com/loongclaw-ai/loongclaw/blob/alpha-test/CONTRIBUTING.md
+    about: Read the active alpha-test contribution workflow before opening a PR.
+  - name: GitHub collaboration reference
+    url: https://github.com/loongclaw-ai/loongclaw/blob/alpha-test/docs/references/github-collaboration.md
+    about: See labels, branch model, and intake/review rules for the active collaboration baseline.

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -1,0 +1,91 @@
+name: Documentation Improvement
+description: Report missing, incorrect, or confusing docs and contributor guidance.
+title: "[Docs]: "
+labels:
+  - documentation
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for documentation drift, missing guidance, broken workflows, or confusing contributor instructions.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which documentation surface is most affected?
+      options:
+        - Docs / contributor workflow
+        - CI / release / workflows
+        - Daemon / CLI / install
+        - Providers / routing
+        - Tools
+        - Browser automation
+        - Channels / integrations
+        - ACP control plane
+        - Conversation / session runtime
+        - Memory / context assembly
+        - Config
+        - Migration / onboarding
+        - Kernel / policy / approvals
+        - Contracts
+        - Protocol
+        - Spec / architecture boundaries
+        - Unknown / needs triage
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is wrong or missing?
+      placeholder: CONTRIBUTING.md tells contributors to branch from main even though alpha-test is the actual integration branch.
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_gap
+    attributes:
+      label: Current gap
+      description: Describe the incorrect, missing, or confusing documentation in detail.
+      placeholder: The docs do not explain which branch external contributors should target, and issue intake links do not reflect the current review flow.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_fix
+    attributes:
+      label: Proposed improvement
+      description: What should the documentation say instead?
+      placeholder: Add an explicit branch model section, issue intake guidance, and label automation reference.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / links
+      description: Link the relevant files, PRs, workflows, or screenshots if available.
+      placeholder: |
+        - CONTRIBUTING.md
+        - .github/workflows/enforce-alpha-test-to-main.yml
+        - recent PRs targeting alpha-test
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who is confused or blocked, and what practical consequence follows from the current docs?
+      placeholder: New contributors follow the wrong branch model and open PRs with the wrong base branch.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues and did not find the same documentation gap already tracked.
+          required: true
+        - label: I used concrete file or workflow references where possible.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,35 +1,118 @@
 name: Feature Request
-description: Propose a new feature or enhancement.
+description: Propose a new capability or meaningful product/runtime improvement.
+title: "[Feature]: "
 labels:
   - enhancement
   - triage
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion.
+        Please focus on the user or operator problem, concrete constraints, and what "done" should mean.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which surface would this request primarily affect?
+      options:
+        - Kernel / policy / approvals
+        - Contracts
+        - Protocol
+        - Spec / architecture boundaries
+        - Daemon / CLI / install
+        - Providers / routing
+        - Tools
+        - Browser automation
+        - Channels / integrations
+        - ACP control plane
+        - Conversation / session runtime
+        - Memory / context assembly
+        - Config
+        - Migration / onboarding
+        - Docs / contributor workflow
+        - CI / release / workflows
+        - Unknown / needs triage
+    validations:
+      required: true
+
   - type: textarea
     id: problem
     attributes:
       label: Problem statement
-      description: What user/system problem are you trying to solve?
-      placeholder: Describe the problem and constraints.
+      description: What user or system problem are you trying to solve?
+      placeholder: Contributors cannot tell which branch or issue intake path is authoritative, so review and triage context arrives fragmented.
     validations:
       required: true
+
   - type: textarea
     id: proposal
     attributes:
       label: Proposed solution
-      placeholder: Describe your proposed approach.
+      description: Describe the preferred behavior, UX, API, or workflow.
+      placeholder: Add area-aware issue intake, lightweight path label automation, and explicit alpha-test contribution guidance.
     validations:
       required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals / out of scope
+      description: What should not be included in the first iteration?
+      placeholder: Do not add aggressive auto-close bots or a 300-label taxonomy in the first pass.
+
   - type: textarea
     id: alternatives
     attributes:
       label: Alternatives considered
-      placeholder: What alternatives did you consider and why not use them?
-  - type: dropdown
-    id: risk
+      description: What alternatives did you consider and why not use them?
+      placeholder: Keep manual triage, add only docs, or copy OpenClaw's full automation without adaptation.
+
+  - type: textarea
+    id: acceptance
     attributes:
-      label: Estimated risk track
+      label: Acceptance criteria
+      description: What concrete outcomes would make this request complete?
+      placeholder: |
+        - PRs get stable area labels automatically
+        - Bug reports capture runtime evidence consistently
+        - Contributor docs point external PRs at alpha-test
+
+  - type: dropdown
+    id: sensitivity
+    attributes:
+      label: Policy / security / breaking sensitivity
       options:
-        - Track A (routine/low-risk)
-        - Track B (higher-risk/policy-impacting)
+        - No, this looks routine
+        - Yes, this touches policy, security, or potentially breaking behavior
+        - Not sure
     validations:
       required: true
+
+  - type: textarea
+    id: rollout
+    attributes:
+      label: Rollout / rollback notes
+      description: Optional. How should this land safely, and how could it be backed out quickly if needed?
+      placeholder: Start with documentation + labeler only, then add stronger automation later if triage quality improves.
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who benefits, how often this matters, and what the practical consequence is if it does not land.
+      placeholder: |
+        Affected users: external contributors and maintainers
+        Frequency: every issue / PR intake
+        Consequence if missing: more manual triage and weaker review context
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues and did not find the same request already tracked.
+          required: true
+        - label: I used project-scoped wording and removed secrets or private data from examples.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,30 +1,76 @@
 ## Summary
 
-- What changed?
-- Why this change is needed?
+- Problem:
+- Why it matters:
+- What changed:
+- What did not change (scope boundary):
 
-## Scope
+## Linked Issues
 
-- [ ] Small and focused
-- [ ] Includes docs updates (if needed)
-- [ ] No unrelated refactors
+- Closes #
+- Related #
+
+## Change Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Security hardening
+- [ ] CI / workflow / release
+
+## Touched Areas
+
+- [ ] Kernel / policy / approvals
+- [ ] Contracts / protocol / spec
+- [ ] Daemon / CLI / install
+- [ ] Providers / routing
+- [ ] Tools
+- [ ] Browser automation
+- [ ] Channels / integrations
+- [ ] ACP / conversation / session runtime
+- [ ] Memory / context assembly
+- [ ] Config / migration / onboarding
+- [ ] Docs / contributor workflow
+- [ ] CI / release / workflows
 
 ## Risk Track
 
-- [ ] Track A (routine/low-risk)
-- [ ] Track B (higher-risk/policy-impacting)
+- [ ] Track A (routine / low-risk)
+- [ ] Track B (higher-risk / policy-impacting)
 
-If Track B, include design/risk notes:
+If Track B, fill these in:
+
+- Risk notes:
+- Rollout / guardrails:
+- Rollback path:
 
 ## Validation
 
 - [ ] `cargo fmt --all -- --check`
 - [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
-- [ ] `cargo test --workspace --all-features`
-- [ ] Additional scenario/benchmark checks (if applicable)
+- [ ] `cargo test --workspace --locked`
+- [ ] `cargo test --workspace --all-features --locked`
+- [ ] Relevant architecture / dep-graph / docs checks for touched areas
+- [ ] Additional scenario, benchmark, or manual checks when behavior changed
 - [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
 - [ ] If tests mutate process-global env: document how state is restored or serialized
 
-## Linked Issues
+Commands and evidence:
 
-Closes #
+```text
+Paste the exact commands you ran and summarize the result.
+```
+
+## User-visible / Operator-visible Changes
+
+- None, or describe the exact change:
+
+## Failure Recovery
+
+- Fast rollback or disable path:
+- Observable failure symptoms reviewers should watch for:
+
+## Reviewer Focus
+
+- Point reviewers at the files, edge cases, or risk seams that deserve the most attention.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,134 @@
+"area: kernel":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/kernel/**"
+
+"area: contracts":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/contracts/**"
+
+"area: protocol":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/protocol/**"
+
+"area: spec":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/spec/**"
+          - "docs/design-docs/**"
+          - "docs/product-specs/**"
+
+"area: daemon":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/daemon/**"
+          - "scripts/install.sh"
+          - "scripts/install.ps1"
+
+"area: providers":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/app/src/provider/**"
+          - "crates/app/src/config/provider.rs"
+
+"area: tools":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/app/src/tools/**"
+
+"area: browser":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/app/src/tools/browser.rs"
+
+"area: channels":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/app/src/channel/**"
+          - "crates/app/src/feishu/**"
+
+"area: memory":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/app/src/memory/**"
+          - "crates/app/src/config/memory.rs"
+
+"area: conversation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/app/src/conversation/**"
+          - "crates/app/src/prompt/**"
+          - "crates/app/src/session/**"
+          - "crates/app/src/config/conversation.rs"
+
+"area: config":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/app/src/config/**"
+          - "crates/spec/config/**"
+
+"area: acp":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/app/src/acp/**"
+
+"area: migration":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/app/src/migration/**"
+
+"area: docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "README.md"
+          - "README.zh-CN.md"
+          - "CONTRIBUTING.md"
+          - "SECURITY.md"
+          - "CODE_OF_CONDUCT.md"
+          - ".github/ISSUE_TEMPLATE/**"
+          - ".github/PULL_REQUEST_TEMPLATE.md"
+
+"area: ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/dependabot.yml"
+          - ".github/labeler.yml"
+          - "Taskfile.yml"
+          - "scripts/architecture_budget_lib.sh"
+          - "scripts/bootstrap_release_local_artifacts.sh"
+          - "scripts/check*.sh"
+          - "scripts/generate_architecture_drift_report.sh"
+          - "scripts/lint_*.sh"
+          - "scripts/release_artifact_lib.sh"
+          - "scripts/test_*.sh"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - ".github/ISSUE_TEMPLATE/**"
+          - ".github/PULL_REQUEST_TEMPLATE.md"
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
+rust:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.rs"
+          - "Cargo.toml"
+          - "Cargo.lock"
+          - "crates/**/Cargo.toml"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Cargo.lock"
+          - "Cargo.toml"
+          - "crates/**/Cargo.toml"

--- a/.github/workflows/enforce-alpha-test-to-main.yml
+++ b/.github/workflows/enforce-alpha-test-to-main.yml
@@ -1,4 +1,4 @@
-name: enforce-dev-to-main
+name: enforce-alpha-test-to-main
 
 on:
   pull_request_target:
@@ -11,24 +11,24 @@ on:
       - edited
 
 jobs:
-  block-non-dev-source:
-    if: ${{ github.event.pull_request.head.ref != 'dev' }}
+  block-non-alpha-test-source:
+    if: ${{ github.event.pull_request.head.ref != 'alpha-test' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       issues: write
       contents: read
     steps:
-      - name: Close PR when source branch is not dev
+      - name: Close PR when source branch is not alpha-test
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const pr = context.payload.pull_request;
             const body = [
-              "Only `dev` can merge into `main` in this repository.",
+              "Only `alpha-test` can merge into `main` in this repository.",
               "",
               `Current source branch: \`${pr.head.ref}\``,
-              "Please merge your changes into `dev` first, then open a PR from `dev` to `main`."
+              "Please land your changes on `alpha-test` first, then open the promotion PR from `alpha-test` to `main`."
             ].join("\\n");
 
             await github.rest.issues.createComment({
@@ -45,4 +45,4 @@ jobs:
               state: "closed"
             });
 
-            core.setFailed("Blocked: only dev can merge into main.");
+            core.setFailed("Blocked: only alpha-test can merge into main.");

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,235 @@
+name: labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - edited
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  workflow_dispatch:
+
+concurrency:
+  group: labeler-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  sync-managed-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Ensure managed labels exist
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const managedLabels = [
+              { name: "triage", color: "ededed", description: "Needs maintainer routing or follow-up." },
+              { name: "area: kernel", color: "0052cc", description: "Kernel policy, approvals, and audit surfaces." },
+              { name: "area: contracts", color: "0052cc", description: "Shared contract and type surfaces." },
+              { name: "area: protocol", color: "0052cc", description: "Protocol crate and wire-level behavior." },
+              { name: "area: spec", color: "0052cc", description: "Architecture boundaries, product specs, and design docs." },
+              { name: "area: daemon", color: "0052cc", description: "Daemon binary, CLI entrypoints, and install flow." },
+              { name: "area: providers", color: "0052cc", description: "Provider routing, selection, and transport behavior." },
+              { name: "area: tools", color: "0052cc", description: "Tool runtime, policy adapters, and tool catalog behavior." },
+              { name: "area: browser", color: "0052cc", description: "Browser automation surfaces and related tooling." },
+              { name: "area: channels", color: "0052cc", description: "Channel adapters and external integration surfaces." },
+              { name: "area: memory", color: "0052cc", description: "Memory system, context assembly, and persistence flow." },
+              { name: "area: conversation", color: "0052cc", description: "Conversation runtime, session flow, and prompt assembly." },
+              { name: "area: config", color: "0052cc", description: "Runtime config parsing, schema, and defaults." },
+              { name: "area: acp", color: "0052cc", description: "ACP manager, binding, routing, and control plane surfaces." },
+              { name: "area: migration", color: "0052cc", description: "Onboarding, legacy import, and migration flow." },
+              { name: "area: docs", color: "0052cc", description: "Contributor docs, references, and issue/PR guidance." },
+              { name: "area: ci", color: "0052cc", description: "CI, workflows, release automation, and repo governance scripts." },
+              { name: "documentation", color: "0075ca", description: "Improvements or additions to documentation." },
+              { name: "dependencies", color: "0366d6", description: "Pull requests that update dependency files." },
+              { name: "github_actions", color: "000000", description: "Pull requests that update GitHub Actions code." },
+              { name: "rust", color: "000000", description: "Pull requests that update Rust code." },
+              { name: "size: XS", color: "c2e0c6", description: "Tiny pull request: 0-50 changed lines." },
+              { name: "size: S", color: "bfd4f2", description: "Small pull request: 51-200 changed lines." },
+              { name: "size: M", color: "fbca04", description: "Medium pull request: 201-500 changed lines." },
+              { name: "size: L", color: "f9d0c4", description: "Large pull request: 501-1000 changed lines." },
+              { name: "size: XL", color: "d93f0b", description: "Very large pull request: more than 1000 changed lines." }
+            ];
+
+            for (const label of managedLabels) {
+              try {
+                const { data: current } = await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name
+                });
+
+                const currentDescription = current.description || "";
+                if (
+                  current.color.toLowerCase() !== label.color.toLowerCase() ||
+                  currentDescription !== label.description
+                ) {
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    new_name: label.name,
+                    color: label.color,
+                    description: label.description
+                  });
+                  core.info(`Updated label ${label.name}`);
+                }
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                });
+                core.info(`Created label ${label.name}`);
+              }
+            }
+
+            core.notice(`Managed ${managedLabels.length} labels.`);
+
+  label-pull-request:
+    if: ${{ github.event_name == 'pull_request_target' }}
+    needs: sync-managed-labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout base repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Apply path labels
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true
+
+      - name: Apply size label
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const issueNumber = context.payload.pull_request.number;
+            const sizeLabels = ["size: XS", "size: S", "size: M", "size: L", "size: XL"];
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: issueNumber,
+              per_page: 100
+            });
+
+            const changedLines = files.reduce((total, file) => total + file.additions + file.deletions, 0);
+
+            let sizeLabel = "size: XL";
+            if (changedLines <= 50) {
+              sizeLabel = "size: XS";
+            } else if (changedLines <= 200) {
+              sizeLabel = "size: S";
+            } else if (changedLines <= 500) {
+              sizeLabel = "size: M";
+            } else if (changedLines <= 1000) {
+              sizeLabel = "size: L";
+            }
+
+            const { data: existingLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+
+            const mergedLabels = [
+              ...existingLabels
+                .map((label) => label.name)
+                .filter((name) => !sizeLabels.includes(name)),
+              sizeLabel
+            ];
+
+            await github.rest.issues.setLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: mergedLabels
+            });
+
+            core.notice(`Applied ${sizeLabel} from ${changedLines} changed lines.`);
+
+  label-issue-area:
+    if: ${{ github.event_name == 'issues' }}
+    needs: sync-managed-labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Sync issue area label from form
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const areaLabelMap = {
+              "Kernel / policy / approvals": "area: kernel",
+              "Contracts": "area: contracts",
+              "Protocol": "area: protocol",
+              "Spec / architecture boundaries": "area: spec",
+              "Daemon / CLI / install": "area: daemon",
+              "Providers / routing": "area: providers",
+              "Tools": "area: tools",
+              "Browser automation": "area: browser",
+              "Channels / integrations": "area: channels",
+              "ACP control plane": "area: acp",
+              "Conversation / session runtime": "area: conversation",
+              "Memory / context assembly": "area: memory",
+              "Config": "area: config",
+              "Migration / onboarding": "area: migration",
+              "Docs / contributor workflow": "area: docs",
+              "CI / release / workflows": "area: ci",
+              "Unknown / needs triage": null
+            };
+
+            const managedAreaLabels = Object.values(areaLabelMap).filter(Boolean);
+            const body = (issue.body || "").replace(/\r\n/g, "\n");
+            const match = body.match(/^### Area\s*\n+([^\n]+)/m);
+            const selectedArea = match ? match[1].trim() : null;
+            const nextAreaLabel = selectedArea ? areaLabelMap[selectedArea] : null;
+
+            const { data: existingLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number
+            });
+
+            const mergedLabels = existingLabels
+              .map((label) => label.name)
+              .filter((name) => !managedAreaLabels.includes(name));
+
+            if (nextAreaLabel) {
+              mergedLabels.push(nextAreaLabel);
+            }
+
+            await github.rest.issues.setLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: mergedLabels
+            });
+
+            if (selectedArea) {
+              core.notice(`Resolved issue area "${selectedArea}" to ${nextAreaLabel ?? "no managed area label"}.`);
+            } else {
+              core.notice("No Area section found in issue body; left managed area labels cleared.");
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,12 @@ Track B flow:
 
 If you are unsure which track applies, open an issue and ask maintainers for triage.
 
+## Branch Model
+
+- `alpha-test` is the active integration branch for normal OSS work.
+- `main` is the promotion branch and should only receive reviewed changes from `alpha-test`.
+- The repository default branch setting does not yet fully reflect this flow. Until that changes, treat the docs and workflow files on `alpha-test` as the authoritative contributor baseline.
+
 ## Where Do I Start?
 
 Use [Core Beliefs](docs/design-docs/core-beliefs.md) and [Layered Kernel Design](docs/design-docs/layered-kernel-design.md) for architecture principles and dependency boundaries.
@@ -127,11 +133,21 @@ cargo test --workspace --all-features
 ## Standard Workflow
 
 1. Fork the repository.
-2. Create a branch from `main`.
+2. Create a branch from `alpha-test`.
 3. Make focused commits.
 4. Run required checks.
-5. Open a pull request using the PR template.
+5. Open a pull request against `alpha-test` using the PR template unless a maintainer explicitly asks for a promotion PR into `main`.
 6. Address review feedback and keep PR scope focused.
+
+## Issue Intake
+
+- Use the bug report form for reproducible runtime or workflow defects.
+- Use the feature request form for new capabilities, behavior changes, or meaningful product/runtime improvements.
+- Use the documentation improvement form for contributor guide drift, missing references, or confusing review workflow docs.
+- Use GitHub Discussions for setup questions and general troubleshooting.
+- Use the private security advisory flow for vulnerabilities instead of public issues.
+
+See [docs/references/github-collaboration.md](docs/references/github-collaboration.md) for the current label baseline, issue routing, and the default-branch visibility caveat for issue forms.
 
 ## Commit and PR Expectations
 

--- a/README.md
+++ b/README.md
@@ -666,8 +666,8 @@ loongclaw validate-config --config ~/.loongclaw/config.toml --json
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow,
-including contribution workflows (routine vs. higher-risk changes) and recipes for adding
-providers, tools, and channels.
+including the active `alpha-test` contribution branch, issue intake routes, validation
+expectations, and recipes for adding providers, tools, and channels.
 
 - [Contributing Guide](CONTRIBUTING.md)
 - [Code of Conduct](CODE_OF_CONDUCT.md)

--- a/docs/references/github-collaboration.md
+++ b/docs/references/github-collaboration.md
@@ -1,0 +1,98 @@
+# GitHub Collaboration Reference
+
+This document defines the active GitHub collaboration baseline for the `alpha-test` branch.
+
+## Active Branch Model
+
+- `alpha-test` is the active integration branch for day-to-day OSS work.
+- Contributors should branch from `alpha-test` and target `alpha-test` with normal pull requests.
+- `main` is the promotion branch. Only reviewed `alpha-test` changes should move into `main`.
+- The current default branch setting still lags this collaboration model. Until the default branch changes, or the same `.github/ISSUE_TEMPLATE` content is mirrored into `dev`, treat the docs and templates on `alpha-test` as the review source of truth.
+
+## Intake Routes
+
+| Need | Route | Why |
+| --- | --- | --- |
+| Reproducible runtime defect | Bug report form | Captures severity, regression status, repro, runtime context, and evidence. |
+| New capability or behavior change | Feature request form | Captures problem statement, acceptance criteria, rollout notes, and scope boundaries. |
+| Missing, wrong, or confusing docs | Documentation improvement form | Captures branch-model drift, workflow gaps, and concrete doc references. |
+| Setup question or general troubleshooting | GitHub Discussions / Discord | Keeps support traffic out of the issue queue. |
+| Security vulnerability | Private security advisory | Avoids publishing sensitive details in public issues. |
+
+## Managed Labels
+
+### Area Labels
+
+These labels intentionally stay lightweight. They provide routing value without copying the oversized taxonomies used by much larger projects.
+
+| Label | Meaning |
+| --- | --- |
+| `area: kernel` | Kernel policy, approvals, and audit surfaces |
+| `area: contracts` | Shared contract and type surfaces |
+| `area: protocol` | Protocol crate and wire-level behavior |
+| `area: spec` | Architecture boundaries, specs, and design docs |
+| `area: daemon` | Daemon binary, CLI entrypoints, and install flow |
+| `area: providers` | Provider routing, profile selection, and transport behavior |
+| `area: tools` | Tool runtime, policy adapters, and tool catalog behavior |
+| `area: browser` | Browser automation surfaces |
+| `area: channels` | Channel adapters and integrations |
+| `area: memory` | Memory system, context assembly, and persistence flow |
+| `area: conversation` | Conversation runtime, session flow, and prompt assembly |
+| `area: config` | Runtime config parsing, schema, and defaults |
+| `area: acp` | ACP manager, binding, routing, and control plane surfaces |
+| `area: migration` | Onboarding, legacy import, and migration flow |
+| `area: docs` | Contributor docs, references, and collaboration guidance |
+| `area: ci` | CI, workflows, release automation, and governance scripts |
+
+### Size Labels
+
+| Label | Threshold |
+| --- | --- |
+| `size: XS` | 0-50 changed lines |
+| `size: S` | 51-200 changed lines |
+| `size: M` | 201-500 changed lines |
+| `size: L` | 501-1000 changed lines |
+| `size: XL` | More than 1000 changed lines |
+
+### Existing General Labels
+
+The collaboration baseline continues to use the existing general labels for issue type and common routing:
+
+- `bug`
+- `enhancement`
+- `documentation`
+- `question`
+- `help wanted`
+- `good first issue`
+- `duplicate`
+- `invalid`
+- `wontfix`
+- `triage`
+- `dependencies`
+- `github_actions`
+- `rust`
+
+## Automation Rules
+
+- The `labeler` workflow ensures the managed `area:*` and `size:*` labels exist.
+- Pull requests receive path-based labels from `.github/labeler.yml`.
+- Pull requests also receive a single `size:*` label based on total added plus removed lines.
+- Issue forms with an `Area` dropdown sync to one managed `area:*` label.
+- Choosing `Unknown / needs triage` keeps the issue in `triage` without forcing an `area:*` label.
+- Maintainers can run `workflow_dispatch` on `labeler` to backfill labels after merging the workflow.
+
+## Pull Request Expectations
+
+- Link the tracking issue in the PR body and include an explicit closing clause when the PR is meant to resolve it.
+- Keep the PR scoped to one logical change stream.
+- Fill in the PR template with changed areas, risk track, validation commands, and reviewer focus.
+- If the change is Track B, include rollout and rollback notes directly in the PR body.
+
+## Current Limitation
+
+GitHub serves public issue forms from the default branch. At the moment, the repository default branch is not aligned with the active `alpha-test` contribution flow. That means the improved forms in `alpha-test` will not become public until one of these happens:
+
+1. The repository default branch is changed to `alpha-test`.
+2. The `.github/ISSUE_TEMPLATE` changes are mirrored into `dev`.
+
+Until then, this document and [CONTRIBUTING.md](../../CONTRIBUTING.md) are the authoritative guidance for contributors and maintainers reviewing `alpha-test`.


### PR DESCRIPTION
## Summary

- Problem:
  The active `alpha-test` contribution flow had richer maintainer expectations than the repository's public GitHub intake surface. Issue forms were too light, PR expectations were underspecified, label automation was missing, and `CONTRIBUTING.md` still told contributors to branch from `main`.
- Why it matters:
  This left maintainers doing too much manual triage and caused drift between the real review path (`alpha-test`) and the documented one.
- What changed:
  - Expanded bug and feature forms and added a dedicated documentation improvement form.
  - Added richer issue contact links plus a collaboration reference doc.
  - Introduced a lightweight `area:*` + `size:*` label baseline with repo-managed sync, PR path labeling, PR size labeling, and issue-area label syncing.
  - Renamed the branch-protection workflow to enforce `alpha-test -> main`.
  - Aligned `CONTRIBUTING.md` and README wording with the current branch model.
- What did not change (scope boundary):
  - Did not switch the repository default branch.
  - Did not add aggressive stale or auto-close bots.
  - Did not introduce a large label taxonomy.

## Linked Issues

- Closes #192
- Related # none

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [x] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
python3 - <<'PY'
import pathlib
import yaml
for path in [
    pathlib.Path('.github/ISSUE_TEMPLATE/bug_report.yml'),
    pathlib.Path('.github/ISSUE_TEMPLATE/feature_request.yml'),
    pathlib.Path('.github/ISSUE_TEMPLATE/docs_improvement.yml'),
    pathlib.Path('.github/ISSUE_TEMPLATE/config.yml'),
    pathlib.Path('.github/labeler.yml'),
    pathlib.Path('.github/workflows/labeler.yml'),
    pathlib.Path('.github/workflows/enforce-alpha-test-to-main.yml'),
]:
    yaml.safe_load(path.read_text())
PY

go run github.com/rhysd/actionlint/cmd/actionlint@latest
git diff --check
scripts/check-docs.sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked

Result:
- YAML parsing passed for the new forms, config, and workflows
- actionlint passed
- git diff --check passed
- check-docs passed (warn-only release trace gaps were pre-existing)
- cargo fmt / clippy / default tests / all-features tests all passed
```

## User-visible / Operator-visible Changes

- New issues can capture area, severity, regression state, runtime context, and documentation-specific drift more consistently once the forms are available from the default branch.
- Maintainers get a documented `alpha-test` collaboration baseline and a lightweight label automation path after merge.

## Failure Recovery

- Fast rollback or disable path:
  Revert the `labeler` workflow and `.github/labeler.yml` if the new label automation proves noisy, or revert the form/template docs changes independently.
- Observable failure symptoms reviewers should watch for:
  Unexpected PR label churn, issue area labels not matching the selected form value, or contributors still following the wrong branch model because the default branch remains `dev`.

## Reviewer Focus

- Check that the new issue forms ask for the right amount of runtime context without becoming too heavy.
- Check that the `labeler` workflow stays intentionally small and does not drift into an oversized taxonomy.
- Check the default-branch caveat in the new docs so contributors are not misled about issue form visibility.
