### PR TITLE
fix(onboard): surface non-release trace metadata and compact guard headers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,8 @@ jobs:
         uses: Swatinem/rust-cache@c676846f29d98ff6b0106d3608c7ffd4048af17b
 
       - name: Build release binary
+        env:
+          LOONGCLAW_RELEASE_BUILD: "1"
         run: cargo build --release --locked -p loongclaw-daemon --bin ${{ env.BIN_NAME }} --target ${{ matrix.target }}
 
       - name: Package archive (Unix)

--- a/crates/app/build.rs
+++ b/crates/app/build.rs
@@ -1,0 +1,88 @@
+#[path = "build_support/version_metadata.rs"]
+mod version_metadata;
+
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=LOONGCLAW_RELEASE_BUILD");
+    println!("cargo:rerun-if-env-changed=LOONGCLAW_BUILD_CHANNEL");
+    println!("cargo:rerun-if-env-changed=LOONGCLAW_GIT_SHA");
+
+    let repo_root = repo_root();
+    emit_git_rerun_hints(&repo_root);
+
+    let release_build_env = env::var("LOONGCLAW_RELEASE_BUILD").ok();
+    let channel_env = env::var("LOONGCLAW_BUILD_CHANNEL").ok();
+    let sha_env = env::var("LOONGCLAW_GIT_SHA").ok();
+    let git_branch = git_output(&repo_root, &["branch", "--show-current"]);
+    let git_sha = git_output(&repo_root, &["rev-parse", "--short=7", "HEAD"]);
+
+    let metadata = version_metadata::resolve_build_metadata(
+        release_build_env.as_deref(),
+        channel_env.as_deref(),
+        sha_env.as_deref(),
+        git_branch.as_deref(),
+        git_sha.as_deref(),
+    );
+
+    emit_rustc_env(
+        "LOONGCLAW_RELEASE_BUILD",
+        if metadata.release_build { "1" } else { "" },
+    );
+    emit_rustc_env(
+        "LOONGCLAW_BUILD_CHANNEL",
+        metadata.channel.as_deref().unwrap_or(""),
+    );
+    emit_rustc_env(
+        "LOONGCLAW_GIT_SHA",
+        metadata.short_sha.as_deref().unwrap_or(""),
+    );
+}
+
+fn repo_root() -> PathBuf {
+    let manifest_dir = env::var_os("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .or_else(|| env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."));
+    manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .unwrap_or(manifest_dir)
+}
+
+fn emit_git_rerun_hints(repo_root: &Path) {
+    let symbolic_head_ref = git_output(repo_root, &["rev-parse", "--symbolic-full-name", "HEAD"])
+        .filter(|head_ref| head_ref != "HEAD");
+
+    for target in version_metadata::git_rerun_hint_targets(symbolic_head_ref.as_deref()) {
+        if let Some(path) = git_output(repo_root, &["rev-parse", "--git-path", target.as_str()]) {
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+}
+
+fn git_output(repo_root: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
+fn emit_rustc_env(key: &str, value: &str) {
+    println!("cargo:rustc-env={key}={value}");
+}

--- a/crates/app/build.rs
+++ b/crates/app/build.rs
@@ -59,7 +59,8 @@ fn emit_git_rerun_hints(repo_root: &Path) {
 
     for target in version_metadata::git_rerun_hint_targets(symbolic_head_ref.as_deref()) {
         if let Some(path) = git_output(repo_root, &["rev-parse", "--git-path", target.as_str()]) {
-            println!("cargo:rerun-if-changed={path}");
+            let rerun_path = version_metadata::resolve_git_rerun_hint_path(repo_root, &path);
+            println!("cargo:rerun-if-changed={}", rerun_path.display());
         }
     }
 }

--- a/crates/app/build_support/version_metadata.rs
+++ b/crates/app/build_support/version_metadata.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuildMetadata {
     pub release_build: bool,
@@ -41,6 +43,15 @@ pub fn git_rerun_hint_targets(symbolic_head_ref: Option<&str>) -> Vec<String> {
     }
     targets.push("packed-refs".to_owned());
     targets
+}
+
+pub fn resolve_git_rerun_hint_path(repo_root: &Path, git_path: impl AsRef<Path>) -> PathBuf {
+    let git_path = git_path.as_ref();
+    if git_path.is_absolute() {
+        git_path.to_path_buf()
+    } else {
+        repo_root.join(git_path)
+    }
 }
 
 fn normalize_metadata_value(raw: Option<&str>) -> Option<String> {

--- a/crates/app/build_support/version_metadata.rs
+++ b/crates/app/build_support/version_metadata.rs
@@ -1,0 +1,61 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildMetadata {
+    pub release_build: bool,
+    pub channel: Option<String>,
+    pub short_sha: Option<String>,
+}
+
+pub fn resolve_build_metadata(
+    release_build_env: Option<&str>,
+    explicit_channel_env: Option<&str>,
+    explicit_sha_env: Option<&str>,
+    git_branch: Option<&str>,
+    git_sha: Option<&str>,
+) -> BuildMetadata {
+    let release_build = release_build_env.is_some_and(is_truthy_env_value);
+    if release_build {
+        return BuildMetadata {
+            release_build: true,
+            channel: None,
+            short_sha: None,
+        };
+    }
+
+    let channel = normalize_metadata_value(explicit_channel_env)
+        .or_else(|| normalize_metadata_value(git_branch));
+    let short_sha = normalize_metadata_value(explicit_sha_env)
+        .or_else(|| normalize_metadata_value(git_sha))
+        .map(short_sha);
+
+    BuildMetadata {
+        release_build: false,
+        channel,
+        short_sha,
+    }
+}
+
+pub fn git_rerun_hint_targets(symbolic_head_ref: Option<&str>) -> Vec<String> {
+    let mut targets = vec!["HEAD".to_owned()];
+    if let Some(head_ref) = normalize_metadata_value(symbolic_head_ref) {
+        targets.push(head_ref);
+    }
+    targets.push("packed-refs".to_owned());
+    targets
+}
+
+fn normalize_metadata_value(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn short_sha(raw: String) -> String {
+    raw.chars().take(7).collect()
+}
+
+fn is_truthy_env_value(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes"
+    )
+}

--- a/crates/app/src/presentation.rs
+++ b/crates/app/src/presentation.rs
@@ -494,7 +494,7 @@ mod tests {
     }
 
     #[test]
-    fn presentation_current_build_embeds_git_trace_metadata_for_non_release_builds() {
+    fn presentation_current_build_surfaces_embedded_git_trace_metadata_when_available() {
         let release_build = option_env!("LOONGCLAW_RELEASE_BUILD")
             .map(str::trim)
             .is_some_and(is_truthy_env_value);
@@ -502,16 +502,17 @@ mod tests {
             return;
         }
 
-        let short_sha = option_env!("LOONGCLAW_GIT_SHA")
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .expect("non-release builds should embed a short git sha");
         let version_line = BuildVersionInfo::current().render_version_line();
 
-        assert!(
-            version_line.contains(short_sha),
-            "current build version line should expose the embedded short git sha: {version_line}"
-        );
+        if let Some(short_sha) = option_env!("LOONGCLAW_GIT_SHA")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            assert!(
+                version_line.contains(short_sha),
+                "current build version line should expose the embedded short git sha when build metadata provides it: {version_line}"
+            );
+        }
 
         if let Some(channel) = option_env!("LOONGCLAW_BUILD_CHANNEL")
             .map(str::trim)

--- a/crates/app/src/presentation.rs
+++ b/crates/app/src/presentation.rs
@@ -494,6 +494,37 @@ mod tests {
     }
 
     #[test]
+    fn presentation_current_build_embeds_git_trace_metadata_for_non_release_builds() {
+        let release_build = option_env!("LOONGCLAW_RELEASE_BUILD")
+            .map(str::trim)
+            .is_some_and(is_truthy_env_value);
+        if release_build {
+            return;
+        }
+
+        let short_sha = option_env!("LOONGCLAW_GIT_SHA")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .expect("non-release builds should embed a short git sha");
+        let version_line = BuildVersionInfo::current().render_version_line();
+
+        assert!(
+            version_line.contains(short_sha),
+            "current build version line should expose the embedded short git sha: {version_line}"
+        );
+
+        if let Some(channel) = option_env!("LOONGCLAW_BUILD_CHANNEL")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            assert!(
+                version_line.contains(channel),
+                "current build version line should surface the embedded build channel: {version_line}"
+            );
+        }
+    }
+
+    #[test]
     fn presentation_style_brand_lines_can_disable_color() {
         let lines = vec![
             BrandLine::new(BrandLineRole::Banner, "LOONGCLAW"),

--- a/crates/app/tests/build_metadata.rs
+++ b/crates/app/tests/build_metadata.rs
@@ -84,3 +84,17 @@ fn release_build_clears_non_release_trace_metadata() {
         }
     );
 }
+
+#[test]
+fn non_release_build_allows_missing_git_metadata_when_detection_is_unavailable() {
+    let metadata = version_metadata::resolve_build_metadata(None, None, None, None, None);
+
+    assert_eq!(
+        metadata,
+        BuildMetadata {
+            release_build: false,
+            channel: None,
+            short_sha: None,
+        }
+    );
+}

--- a/crates/app/tests/build_metadata.rs
+++ b/crates/app/tests/build_metadata.rs
@@ -1,6 +1,7 @@
 #[path = "../build_support/version_metadata.rs"]
 mod version_metadata;
 
+use std::path::{Path, PathBuf};
 use version_metadata::BuildMetadata;
 
 #[test]
@@ -96,5 +97,26 @@ fn non_release_build_allows_missing_git_metadata_when_detection_is_unavailable()
             channel: None,
             short_sha: None,
         }
+    );
+}
+
+#[test]
+fn git_rerun_hint_path_resolves_repo_relative_git_paths_against_repo_root() {
+    let repo_root = Path::new("/tmp/loongclaw");
+
+    assert_eq!(
+        version_metadata::resolve_git_rerun_hint_path(repo_root, ".git/HEAD"),
+        PathBuf::from("/tmp/loongclaw/.git/HEAD")
+    );
+}
+
+#[test]
+fn git_rerun_hint_path_preserves_absolute_git_paths() {
+    let repo_root = Path::new("/tmp/loongclaw");
+    let git_path = PathBuf::from("/tmp/git/worktrees/app/HEAD");
+
+    assert_eq!(
+        version_metadata::resolve_git_rerun_hint_path(repo_root, git_path.as_path()),
+        git_path
     );
 }

--- a/crates/app/tests/build_metadata.rs
+++ b/crates/app/tests/build_metadata.rs
@@ -1,0 +1,86 @@
+#[path = "../build_support/version_metadata.rs"]
+mod version_metadata;
+
+use version_metadata::BuildMetadata;
+
+#[test]
+fn non_release_build_prefers_git_branch_and_short_sha_when_not_overridden() {
+    let metadata = version_metadata::resolve_build_metadata(
+        None,
+        None,
+        None,
+        Some("alpha-test"),
+        Some("ec9ee5f0d57b9ef18110786407c3ccdb447bbcf7"),
+    );
+
+    assert_eq!(
+        metadata,
+        BuildMetadata {
+            release_build: false,
+            channel: Some("alpha-test".to_owned()),
+            short_sha: Some("ec9ee5f".to_owned()),
+        }
+    );
+}
+
+#[test]
+fn explicit_compile_overrides_win_over_git_detection() {
+    let metadata = version_metadata::resolve_build_metadata(
+        None,
+        Some("custom-preview"),
+        Some("1234567890abcdef"),
+        Some("alpha-test"),
+        Some("ec9ee5f0d57b9ef18110786407c3ccdb447bbcf7"),
+    );
+
+    assert_eq!(
+        metadata,
+        BuildMetadata {
+            release_build: false,
+            channel: Some("custom-preview".to_owned()),
+            short_sha: Some("1234567".to_owned()),
+        }
+    );
+}
+
+#[test]
+fn git_rerun_hint_targets_include_head_ref_and_packed_refs() {
+    assert_eq!(
+        version_metadata::git_rerun_hint_targets(Some(
+            "refs/heads/fix/onboard-pr187-followup-20260316"
+        )),
+        vec![
+            "HEAD".to_owned(),
+            "refs/heads/fix/onboard-pr187-followup-20260316".to_owned(),
+            "packed-refs".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn git_rerun_hint_targets_handle_detached_head() {
+    assert_eq!(
+        version_metadata::git_rerun_hint_targets(None),
+        vec!["HEAD".to_owned(), "packed-refs".to_owned(),]
+    );
+}
+
+#[test]
+fn release_build_clears_non_release_trace_metadata() {
+    let metadata = version_metadata::resolve_build_metadata(
+        Some("1"),
+        Some("alpha-test"),
+        Some("ec9ee5f0d57b9ef18110786407c3ccdb447bbcf7"),
+        Some("alpha-test"),
+        Some("ec9ee5f0d57b9ef18110786407c3ccdb447bbcf7"),
+    );
+
+    assert_eq!(
+        metadata,
+        BuildMetadata {
+            release_build: true,
+            channel: None,
+            short_sha: None,
+        }
+    );
+}

--- a/crates/app/tests/build_metadata.rs
+++ b/crates/app/tests/build_metadata.rs
@@ -1,7 +1,7 @@
 #[path = "../build_support/version_metadata.rs"]
 mod version_metadata;
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use version_metadata::BuildMetadata;
 
 #[test]
@@ -102,21 +102,25 @@ fn non_release_build_allows_missing_git_metadata_when_detection_is_unavailable()
 
 #[test]
 fn git_rerun_hint_path_resolves_repo_relative_git_paths_against_repo_root() {
-    let repo_root = Path::new("/tmp/loongclaw");
+    let repo_root = std::env::temp_dir().join("loongclaw");
 
     assert_eq!(
-        version_metadata::resolve_git_rerun_hint_path(repo_root, ".git/HEAD"),
-        PathBuf::from("/tmp/loongclaw/.git/HEAD")
+        version_metadata::resolve_git_rerun_hint_path(&repo_root, PathBuf::from(".git/HEAD")),
+        repo_root.join(".git").join("HEAD")
     );
 }
 
 #[test]
 fn git_rerun_hint_path_preserves_absolute_git_paths() {
-    let repo_root = Path::new("/tmp/loongclaw");
-    let git_path = PathBuf::from("/tmp/git/worktrees/app/HEAD");
+    let repo_root = std::env::temp_dir().join("loongclaw");
+    let git_path = std::env::temp_dir()
+        .join("git")
+        .join("worktrees")
+        .join("app")
+        .join("HEAD");
 
     assert_eq!(
-        version_metadata::resolve_git_rerun_hint_path(repo_root, git_path.as_path()),
+        version_metadata::resolve_git_rerun_hint_path(&repo_root, git_path.as_path()),
         git_path
     );
 }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -3279,7 +3279,7 @@ fn render_onboarding_risk_screen_lines_with_style(
 ) -> Vec<String> {
     let copy = crate::onboard_presentation::risk_screen_copy();
     render_onboard_choice_screen(
-        OnboardHeaderStyle::Brand,
+        OnboardHeaderStyle::Compact,
         width,
         copy.subtitle,
         copy.title,
@@ -4324,7 +4324,7 @@ fn render_existing_config_write_screen_lines_with_style(
     color_enabled: bool,
 ) -> Vec<String> {
     render_onboard_choice_screen(
-        OnboardHeaderStyle::Brand,
+        OnboardHeaderStyle::Compact,
         width,
         "decide how to write the config",
         "existing config found",

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -16,6 +16,23 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 static IMPORT_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn assert_compact_loongclaw_header(lines: &[String], context: &str) {
+    assert!(
+        lines
+            .first()
+            .is_some_and(|line| line.starts_with("LOONGCLAW")),
+        "{context} should start with the compact LOONGCLAW header: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .take_while(|line| !line.is_empty())
+            .any(|line| line.contains(concat!("v", env!("CARGO_PKG_VERSION")))),
+        "{context} should keep the current build version visible even when the branch name wraps: {lines:#?}"
+    );
+}
+
 fn unique_temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -517,10 +534,7 @@ fn import_cli_apply_summary_wraps_long_path_and_domains_for_narrow_width() {
         46,
     );
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW  v"),
-        "apply summary should use the compact LOONGCLAW header: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "apply summary");
     assert!(
         lines.iter().any(|line| line == "import applied"),
         "apply summary should keep a focused title: {lines:#?}"

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -17,6 +17,23 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 static TEMP_PATH_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn assert_compact_loongclaw_header(lines: &[String], context: &str) {
+    assert!(
+        lines
+            .first()
+            .is_some_and(|line| line.starts_with("LOONGCLAW")),
+        "{context} should start with the compact LOONGCLAW header: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .take_while(|line| !line.is_empty())
+            .any(|line| line.contains(concat!("v", env!("CARGO_PKG_VERSION")))),
+        "{context} should keep the current build version visible even when the branch name wraps: {lines:#?}"
+    );
+}
+
 fn unique_temp_path(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1382,12 +1399,13 @@ fn backup_existing_config_copies_without_removing_original() {
 }
 
 #[test]
-fn onboard_risk_screen_includes_brand_header_and_continue_cancel_options() {
+fn onboard_risk_screen_uses_compact_header_and_continue_cancel_options() {
     let lines = loongclaw_daemon::onboard_cli::render_onboarding_risk_screen_lines(80);
 
+    assert_compact_loongclaw_header(&lines, "risk screen");
     assert!(
-        lines[0].starts_with("██╗"),
-        "risk screen should start with the shared LOONGCLAW brand block: {lines:#?}"
+        !lines[0].starts_with("██╗"),
+        "risk screen should avoid the oversized block-logo banner on the guard screen: {lines:#?}"
     );
     assert!(
         lines.iter().any(|line| line == "security check"),
@@ -3848,10 +3866,7 @@ fn onboard_model_selection_screen_keeps_provider_context() {
 
     let lines = loongclaw_daemon::onboard_cli::render_model_selection_screen_lines(&config, 80);
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW  v"),
-        "model screen should start with the compact LOONGCLAW step header: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "model screen");
     assert!(
         lines.iter().any(|line| line == "choose model"),
         "model screen should use a focused title: {lines:#?}"
@@ -3953,10 +3968,7 @@ fn onboard_api_key_env_screen_explains_suggested_env_and_blank_behavior() {
         80,
     );
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW  v"),
-        "credential-env screen should start with the compact LOONGCLAW step header: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "credential-env screen");
     assert!(
         lines.iter().any(|line| line == "choose credential source"),
         "credential-env screen should use a focused title: {lines:#?}"
@@ -4076,10 +4088,7 @@ fn onboard_system_prompt_screen_explains_blank_behavior() {
     let lines =
         loongclaw_daemon::onboard_cli::render_system_prompt_selection_screen_lines(&config, 80);
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW  v"),
-        "system-prompt screen should start with the compact LOONGCLAW step header: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "system-prompt screen");
     assert!(
         lines.iter().any(|line| line == "adjust cli behavior"),
         "system-prompt screen should frame this as a behavior adjustment: {lines:#?}"
@@ -4145,6 +4154,7 @@ fn onboard_system_prompt_screen_wraps_long_current_prompt() {
     let lines =
         loongclaw_daemon::onboard_cli::render_system_prompt_selection_screen_lines(&config, 48);
 
+    assert_compact_loongclaw_header(&lines, "system-prompt screen");
     assert!(
         lines
             .iter()
@@ -4369,9 +4379,10 @@ fn onboard_existing_config_write_screen_offers_replace_backup_and_cancel() {
         80,
     );
 
+    assert_compact_loongclaw_header(&lines, "existing-config write screen");
     assert!(
-        lines[0].starts_with("██╗"),
-        "existing-config write screen should start with the shared LOONGCLAW brand block: {lines:#?}"
+        !lines[0].starts_with("██╗"),
+        "existing-config write screen should avoid the oversized block-logo banner on the write guard screen: {lines:#?}"
     );
     assert!(
         lines.iter().any(|line| line == "existing config found"),
@@ -4435,10 +4446,7 @@ fn onboard_preflight_screen_summarizes_status_counts_and_guidance() {
 
     let lines = loongclaw_daemon::onboard_cli::render_preflight_summary_screen_lines(&checks, 80);
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW  v"),
-        "preflight screen should use the compact LOONGCLAW step header after review to avoid banner repetition: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "preflight screen");
     assert!(
         lines.iter().any(|line| line == "preflight checks"),
         "preflight screen should use a focused title: {lines:#?}"
@@ -4600,10 +4608,7 @@ fn onboard_write_confirmation_screen_shows_target_path_and_write_choice() {
         80,
     );
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW  v"),
-        "write-confirm screen should use the compact branded header: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "write-confirm screen");
     assert!(
         lines.iter().any(|line| line == "ready to write config"),
         "write-confirm screen should use a focused title: {lines:#?}"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -87,9 +87,17 @@ function Install-FromSource {
 
     Write-Host "==> Building loongclaw from source (release)"
     Push-Location $repoRoot
+    $hadReleaseBuild = Test-Path Env:LOONGCLAW_RELEASE_BUILD
+    $previousReleaseBuild = $env:LOONGCLAW_RELEASE_BUILD
     try {
+        $env:LOONGCLAW_RELEASE_BUILD = "1"
         cargo build -p loongclaw-daemon --bin loongclaw --release --locked | Out-Host
     } finally {
+        if ($hadReleaseBuild) {
+            $env:LOONGCLAW_RELEASE_BUILD = $previousReleaseBuild
+        } elseif (Test-Path Env:LOONGCLAW_RELEASE_BUILD) {
+            Remove-Item Env:LOONGCLAW_RELEASE_BUILD
+        }
         Pop-Location
     }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -246,7 +246,8 @@ install_from_source() {
   printf '==> Building loongclaw from source (release)\n'
   (
     cd "${repo_root}"
-    cargo build -p loongclaw-daemon --bin "${bin_name}" --release --locked
+    LOONGCLAW_RELEASE_BUILD=1 \
+      cargo build -p loongclaw-daemon --bin "${bin_name}" --release --locked
   )
 
   source_binary="${repo_root}/target/release/${bin_name}"


### PR DESCRIPTION
## Summary

- auto-inject non-release build metadata from git so onboarding headers show branch and short commit without manual `LOONGCLAW_BUILD_CHANNEL` / `LOONGCLAW_GIT_SHA` wiring
- switch the `security check` and `existing config found` guard screens to the compact header so confirmation screens stop feeling top-heavy and keep the focus on the decision itself
- stabilize compact-header regression coverage for wrapped branch names and keep build-script rerun targets correct for symbolic refs, packed refs, detached HEAD, and git worktrees
- Why this change is needed?
  The main onboarding restoration landed via #180, but one residual follow-up remained on latest `alpha-test`: non-release builds could still collapse to a bare `v0.1.2` line, and the guard screens still reused the full block-logo banner even though the user task was a focused confirmation.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional validation performed:
- `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo fmt --all -- --check`
- `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test --workspace`
- `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test --workspace --all-features`
- `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test -p loongclaw-daemon -- --test-threads=1`
- Build-metadata coverage now exercises git fallback, explicit compile-time overrides, release masking, current build rendering, and rerun-target selection for symbolic refs, detached HEAD, packed refs, and git worktrees.
- Compact-header regression coverage now checks the affected guard screens and keeps compact-header assertions stable when long branch names wrap.
- The daemon spot check keeps env-sensitive coverage serialized under `--test-threads=1` for this run.

## Linked Issues

Closes #195


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App versions now embed and display build metadata (short git SHA and optional channel) for non-release builds when available.

* **Style**
  * Onboarding and configuration screens use a compact header presentation.

* **Tests**
  * Expanded tests covering build-metadata resolution, git-related behaviors, and updated header rendering.

* **Chores**
  * Build and release tooling now propagate build-time metadata into compiled artifacts; CI and installers set the release-build flag during packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->