### PR TITLE
fix(test): isolate TELEGRAM_BOT_TOKEN in channel inventory tests

### DIFF
--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -2170,6 +2170,9 @@ mod tests {
 
     #[test]
     fn channel_inventory_exposes_grouped_channel_surfaces() {
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.remove("TELEGRAM_BOT_TOKEN");
+
         let config = LoongClawConfig::default();
         let inventory = channel_inventory(&config);
 

--- a/crates/daemon/tests/integration.rs
+++ b/crates/daemon/tests/integration.rs
@@ -6,13 +6,17 @@
     clippy::unwrap_used,
     unused_imports,
     dead_code,
-    unsafe_code
+    unsafe_code,
+    clippy::disallowed_methods,
+    clippy::undocumented_unsafe_blocks
 )]
 use std::time::Duration;
 use std::{
     collections::{BTreeMap, BTreeSet},
+    ffi::OsString,
     fs,
     path::Path,
+    sync::MutexGuard,
 };
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
@@ -27,27 +31,32 @@ use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use tokio::time::sleep;
 
-struct ScopedEnv {
-    saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+pub struct MigrationEnvironmentGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: Vec<(String, Option<OsString>)>,
 }
 
-impl ScopedEnv {
-    fn new() -> Self {
-        Self { saved: Vec::new() }
-    }
-
-    fn remove(&mut self, key: &'static str) {
-        self.saved.push((key, std::env::var_os(key)));
-        unsafe { std::env::remove_var(key) };
-    }
-}
-
-impl Drop for ScopedEnv {
-    fn drop(&mut self) {
-        for (key, value) in self.saved.drain(..).rev() {
+impl MigrationEnvironmentGuard {
+    pub fn set(pairs: &[(&str, Option<&str>)]) -> Self {
+        let lock = lock_daemon_test_environment();
+        let mut saved = Vec::new();
+        for (key, value) in pairs {
+            saved.push(((*key).to_owned(), std::env::var_os(key)));
             match value {
                 Some(value) => unsafe { std::env::set_var(key, value) },
                 None => unsafe { std::env::remove_var(key) },
+            }
+        }
+        Self { _lock: lock, saved }
+    }
+}
+
+impl Drop for MigrationEnvironmentGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..).rev() {
+            match value {
+                Some(value) => unsafe { std::env::set_var(&key, value) },
+                None => unsafe { std::env::remove_var(&key) },
             }
         }
     }

--- a/crates/daemon/tests/integration.rs
+++ b/crates/daemon/tests/integration.rs
@@ -5,7 +5,8 @@
     clippy::panic,
     clippy::unwrap_used,
     unused_imports,
-    dead_code
+    dead_code,
+    unsafe_code
 )]
 use std::time::Duration;
 use std::{
@@ -25,6 +26,32 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use tokio::time::sleep;
+
+struct ScopedEnv {
+    saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl ScopedEnv {
+    fn new() -> Self {
+        Self { saved: Vec::new() }
+    }
+
+    fn remove(&mut self, key: &'static str) {
+        self.saved.push((key, std::env::var_os(key)));
+        unsafe { std::env::remove_var(key) };
+    }
+}
+
+impl Drop for ScopedEnv {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..).rev() {
+            match value {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+    }
+}
 
 #[path = "integration/mod.rs"]
 mod integration;

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -6,9 +6,7 @@
 )]
 
 use super::*;
-use std::ffi::OsString;
 use std::path::PathBuf;
-use std::sync::MutexGuard;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -23,45 +21,6 @@ fn unique_temp_dir(label: &str) -> PathBuf {
         "loongclaw-migration-{label}-{}-{nanos}-{counter}",
         std::process::id(),
     ))
-}
-
-struct MigrationEnvironmentGuard {
-    _lock: MutexGuard<'static, ()>,
-    saved: Vec<(String, Option<OsString>)>,
-}
-
-impl MigrationEnvironmentGuard {
-    fn set(pairs: &[(&str, Option<&str>)]) -> Self {
-        let lock = super::lock_daemon_test_environment();
-        let mut saved = Vec::new();
-        for (key, value) in pairs {
-            saved.push(((*key).to_owned(), std::env::var_os(key)));
-            match value {
-                Some(value) => unsafe {
-                    std::env::set_var(key, value);
-                },
-                None => unsafe {
-                    std::env::remove_var(key);
-                },
-            }
-        }
-        Self { _lock: lock, saved }
-    }
-}
-
-impl Drop for MigrationEnvironmentGuard {
-    fn drop(&mut self) {
-        for (key, value) in self.saved.drain(..).rev() {
-            match value {
-                Some(value) => unsafe {
-                    std::env::set_var(&key, value);
-                },
-                None => unsafe {
-                    std::env::remove_var(&key);
-                },
-            }
-        }
-    }
 }
 
 #[test]

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -1408,7 +1408,10 @@ fn migration_compose_recommended_candidate_supplements_channel_fields_across_sou
 
 #[test]
 fn migration_compose_recommended_candidate_preserves_current_custom_provider_endpoint() {
-    let _env = MigrationEnvironmentGuard::set(&[("TELEGRAM_BOT_TOKEN", None)]);
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("TELEGRAM_BOT_TOKEN", None),
+        ("OPENROUTER_API_KEY", None),
+    ]);
 
     let mut existing = mvp::config::LoongClawConfig::default();
     existing.provider.kind = mvp::config::ProviderKind::Openrouter;

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -693,6 +693,8 @@ fn channel_preview_order_follows_shared_service_channel_catalog_order() {
 
 #[test]
 fn resolve_channel_import_readiness_reports_partial_channel_credentials() {
+    let _env = MigrationEnvironmentGuard::set(&[("TELEGRAM_BOT_TOKEN", None)]);
+
     let mut config = mvp::config::LoongClawConfig::default();
     config.feishu.app_id = Some("cli_a1b2c3".to_owned());
 
@@ -1198,6 +1200,8 @@ fn migration_render_preview_summarizes_multi_source_inputs() {
 #[test]
 fn migration_compose_recommended_candidate_supplements_channels_without_overwriting_ready_provider()
 {
+    let _env = MigrationEnvironmentGuard::set(&[("TELEGRAM_BOT_TOKEN", None)]);
+
     let mut existing = mvp::config::LoongClawConfig::default();
     existing.provider.api_key = Some("openai-secret".to_owned());
     existing.provider.model = "openai/gpt-5.1-codex".to_owned();
@@ -1404,6 +1408,8 @@ fn migration_compose_recommended_candidate_supplements_channel_fields_across_sou
 
 #[test]
 fn migration_compose_recommended_candidate_preserves_current_custom_provider_endpoint() {
+    let _env = MigrationEnvironmentGuard::set(&[("TELEGRAM_BOT_TOKEN", None)]);
+
     let mut existing = mvp::config::LoongClawConfig::default();
     existing.provider.kind = mvp::config::ProviderKind::Openrouter;
     existing.provider.model = "openrouter/openai/gpt-5.1".to_owned();
@@ -1566,6 +1572,8 @@ fn migration_compose_recommended_candidate_supplements_provider_transport_tuning
 
 #[test]
 fn migration_compose_recommended_candidate_avoids_provider_auto_pick_on_cross_source_conflict() {
+    let _env = MigrationEnvironmentGuard::set(&[("TELEGRAM_BOT_TOKEN", None)]);
+
     let mut codex = mvp::config::LoongClawConfig::default();
     codex.provider.model = "openai/gpt-5.1-codex".to_owned();
     codex.provider.api_key = Some("openai-secret".to_owned());

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -703,8 +703,7 @@ fn build_channels_cli_json_payload_includes_full_channel_catalog() {
 
 #[test]
 fn build_channels_cli_json_payload_includes_grouped_channel_surfaces() {
-    let mut env = super::ScopedEnv::new();
-    env.remove("TELEGRAM_BOT_TOKEN");
+    let _env = super::MigrationEnvironmentGuard::set(&[("TELEGRAM_BOT_TOKEN", None)]);
 
     let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -703,6 +703,9 @@ fn build_channels_cli_json_payload_includes_full_channel_catalog() {
 
 #[test]
 fn build_channels_cli_json_payload_includes_grouped_channel_surfaces() {
+    let mut env = super::ScopedEnv::new();
+    env.remove("TELEGRAM_BOT_TOKEN");
+
     let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
     let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);


### PR DESCRIPTION
## Summary
- Add TELEGRAM_BOT_TOKEN environment variable isolation in tests using LoongClawConfig::default(), using ScopedEnv / MigrationEnvironmentGuard to clear the environment variable
- Fix tests failing when user has TELEGRAM_BOT_TOKEN set in their shell
## Scope
- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors
## Risk Track
- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)
## Validation
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo test --workspace --all-features (all affected tests pass; 1 pre-existing test failure unrelated to this fi)
- [ ] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized
  - ScopedEnv and MigrationEnvironmentGuard save original environment variable values at test start and automatically restore them on drop
## Linked Issues
Closes #198 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to isolate and manage environment variables during integration tests.
  * Added utilities to temporarily apply and restore environment changes for test scenarios.
  * Adjusted several integration tests to explicitly simulate missing Telegram credentials to ensure payloads handle absent tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->