### PR TITLE
fix(daemon): shell-quote handoff config paths

### DIFF
--- a/crates/daemon/src/browser_preview.rs
+++ b/crates/daemon/src/browser_preview.rs
@@ -76,30 +76,18 @@ pub(crate) fn inspect_browser_preview_state_with_path_env(
 }
 
 pub(crate) fn browser_preview_enable_command(config_path: &str) -> String {
-    let config_path = shell_quote_argument(config_path);
-    format!(
-        "{} skills enable-browser-preview --config {}",
-        mvp::config::CLI_COMMAND_NAME,
-        config_path
-    )
+    crate::cli_handoff::format_subcommand_with_config("skills enable-browser-preview", config_path)
 }
 
 pub(crate) fn browser_preview_unblock_command(config_path: &str) -> String {
-    let config_path = shell_quote_argument(config_path);
     format!(
         "edit {} and remove `agent-browser` from [tools].shell_deny",
-        config_path
+        crate::cli_handoff::shell_quote_argument(config_path)
     )
 }
 
 pub(crate) fn browser_preview_ready_command(config_path: &str) -> String {
-    let config_path = shell_quote_argument(config_path);
-    format!(
-        "{} ask --config {} --message \"{}\"",
-        mvp::config::CLI_COMMAND_NAME,
-        config_path,
-        DEFAULT_BROWSER_PREVIEW_ASK_MESSAGE
-    )
+    crate::cli_handoff::format_ask_with_config(config_path, DEFAULT_BROWSER_PREVIEW_ASK_MESSAGE)
 }
 
 pub(crate) fn ensure_browser_preview_config(config: &mut mvp::config::LoongClawConfig) -> bool {
@@ -265,10 +253,6 @@ fn command_candidates(command: &str) -> Vec<String> {
     {
         vec![command.to_owned()]
     }
-}
-
-fn shell_quote_argument(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
 #[cfg(unix)]

--- a/crates/daemon/src/cli_handoff.rs
+++ b/crates/daemon/src/cli_handoff.rs
@@ -1,0 +1,52 @@
+use loongclaw_app as mvp;
+
+pub(crate) fn shell_quote_argument(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+pub(crate) fn format_subcommand_with_config(subcommand: &str, config_path: &str) -> String {
+    format!(
+        "{} {} --config {}",
+        mvp::config::CLI_COMMAND_NAME,
+        subcommand,
+        shell_quote_argument(config_path)
+    )
+}
+
+pub(crate) fn format_ask_with_config(config_path: &str, message: &str) -> String {
+    format!(
+        "{} ask --config {} --message \"{}\"",
+        mvp::config::CLI_COMMAND_NAME,
+        shell_quote_argument(config_path),
+        message
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_ask_with_config, format_subcommand_with_config, shell_quote_argument};
+
+    #[test]
+    fn shell_quote_argument_escapes_single_quotes() {
+        assert_eq!(
+            shell_quote_argument("/tmp/loongclaw's config.toml"),
+            "'/tmp/loongclaw'\"'\"'s config.toml'"
+        );
+    }
+
+    #[test]
+    fn format_subcommand_with_config_shell_quotes_the_config_path() {
+        assert_eq!(
+            format_subcommand_with_config("doctor", "/tmp/loongclaw's config.toml"),
+            "loongclaw doctor --config '/tmp/loongclaw'\"'\"'s config.toml'"
+        );
+    }
+
+    #[test]
+    fn format_ask_with_config_shell_quotes_the_config_path() {
+        assert_eq!(
+            format_ask_with_config("/tmp/loongclaw's config.toml", "say it's ready"),
+            "loongclaw ask --config '/tmp/loongclaw'\"'\"'s config.toml' --message \"say it's ready\""
+        );
+    }
+}

--- a/crates/daemon/src/cli_handoff.rs
+++ b/crates/daemon/src/cli_handoff.rs
@@ -15,10 +15,10 @@ pub(crate) fn format_subcommand_with_config(subcommand: &str, config_path: &str)
 
 pub(crate) fn format_ask_with_config(config_path: &str, message: &str) -> String {
     format!(
-        "{} ask --config {} --message \"{}\"",
+        "{} ask --config {} --message {}",
         mvp::config::CLI_COMMAND_NAME,
         shell_quote_argument(config_path),
-        message
+        shell_quote_argument(message)
     )
 }
 
@@ -46,7 +46,15 @@ mod tests {
     fn format_ask_with_config_shell_quotes_the_config_path() {
         assert_eq!(
             format_ask_with_config("/tmp/loongclaw's config.toml", "say it's ready"),
-            "loongclaw ask --config '/tmp/loongclaw'\"'\"'s config.toml' --message \"say it's ready\""
+            "loongclaw ask --config '/tmp/loongclaw'\"'\"'s config.toml' --message 'say it'\"'\"'s ready'"
+        );
+    }
+
+    #[test]
+    fn format_ask_with_config_shell_quotes_message_content() {
+        assert_eq!(
+            format_ask_with_config("/tmp/loongclaw.toml", "say \"hi\" and print $HOME"),
+            "loongclaw ask --config '/tmp/loongclaw.toml' --message 'say \"hi\" and print $HOME'"
         );
     }
 }

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -2080,7 +2080,7 @@ mod tests {
 
         assert!(
             next_steps.iter().any(|step| {
-                step == "Try a one-shot task: loongclaw ask --config '/tmp/loongclaw.toml' --message \"Summarize this repository and suggest the best next step.\""
+                step == "Try a one-shot task: loongclaw ask --config '/tmp/loongclaw.toml' --message 'Summarize this repository and suggest the best next step.'"
             }),
             "green doctor runs should hand the user into ask immediately: {next_steps:#?}"
         );

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1109,11 +1109,8 @@ fn build_doctor_next_steps_with_path_env(
 ) -> Vec<String> {
     let mut steps = Vec::new();
     let config_path_display = config_path.display().to_string();
-    let rerun_command = format!(
-        "{} doctor --config '{}'",
-        mvp::config::CLI_COMMAND_NAME,
-        config_path_display
-    );
+    let rerun_command =
+        crate::cli_handoff::format_subcommand_with_config("doctor", &config_path_display);
     let browser_preview =
         crate::browser_preview::inspect_browser_preview_state_with_path_env(config, path_env);
 
@@ -2029,6 +2026,34 @@ mod tests {
             next_steps.iter().any(|step| step
                 == "Re-run diagnostics: loongclaw doctor --config '/tmp/loongclaw.toml'"),
             "doctor should tell the operator how to confirm the repair path: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_shell_quotes_config_paths_with_single_quotes() {
+        let checks = vec![DoctorCheck {
+            name: "memory path".to_owned(),
+            level: DoctorCheckLevel::Fail,
+            detail: "/tmp/loongclaw-memory is missing".to_owned(),
+        }];
+        let next_steps = build_doctor_next_steps(
+            &checks,
+            Path::new("/tmp/loongclaw's config.toml"),
+            &mvp::config::LoongClawConfig::default(),
+            false,
+        );
+
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Apply safe local repairs: loongclaw doctor --config '/tmp/loongclaw'\"'\"'s config.toml' --fix"
+            }),
+            "doctor should shell-quote config paths with single quotes in fix commands: {next_steps:#?}"
+        );
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Re-run diagnostics: loongclaw doctor --config '/tmp/loongclaw'\"'\"'s config.toml'"
+            }),
+            "doctor should shell-quote config paths with single quotes in rerun commands: {next_steps:#?}"
         );
     }
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -36,6 +36,7 @@ pub use kernel;
 pub use sha2;
 
 pub mod browser_preview;
+mod cli_handoff;
 pub mod doctor_cli;
 pub mod feishu_cli;
 pub mod feishu_support;

--- a/crates/daemon/src/migration/channels/mod.rs
+++ b/crates/daemon/src/migration/channels/mod.rs
@@ -184,11 +184,9 @@ pub fn collect_channel_next_actions(
                     .map(|subcommand| ChannelNextAction {
                         id: adapter.id,
                         label: descriptor.label,
-                        command: format!(
-                            "{} {} --config '{}'",
-                            mvp::config::CLI_COMMAND_NAME,
+                        command: crate::cli_handoff::format_subcommand_with_config(
                             subcommand,
-                            config_path
+                            config_path,
                         ),
                     })
             })

--- a/crates/daemon/src/next_actions.rs
+++ b/crates/daemon/src/next_actions.rs
@@ -50,22 +50,16 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
             kind: SetupNextActionKind::Ask,
             browser_preview_phase: None,
             label: "ask example".to_owned(),
-            command: format!(
-                "{} ask --config '{}' --message \"{}\"",
-                mvp::config::CLI_COMMAND_NAME,
+            command: crate::cli_handoff::format_ask_with_config(
                 config_path,
-                DEFAULT_FIRST_ASK_MESSAGE
+                DEFAULT_FIRST_ASK_MESSAGE,
             ),
         });
         actions.push(SetupNextAction {
             kind: SetupNextActionKind::Chat,
             browser_preview_phase: None,
             label: "chat".to_owned(),
-            command: format!(
-                "{} chat --config '{}'",
-                mvp::config::CLI_COMMAND_NAME,
-                config_path
-            ),
+            command: crate::cli_handoff::format_subcommand_with_config("chat", config_path),
         });
     }
     actions.extend(
@@ -119,11 +113,7 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
             kind: SetupNextActionKind::Doctor,
             browser_preview_phase: None,
             label: "doctor".to_owned(),
-            command: format!(
-                "{} doctor --config {}",
-                mvp::config::CLI_COMMAND_NAME,
-                config_path
-            ),
+            command: crate::cli_handoff::format_subcommand_with_config("doctor", config_path),
         });
     }
     actions

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -633,15 +633,21 @@ fn import_cli_apply_summary_shell_quotes_config_paths_with_single_quotes() {
 
     assert!(
         rendered.contains(
-            "next step: loongclaw ask --config '/tmp/loongclaw'\"'\"'s config.toml' --message"
+            "next step: loongclaw ask --config '/tmp/loongclaw'\"'\"'s config.toml' --message 'Summarize this repository and suggest the best next step.'"
         ),
-        "apply summary should shell-quote single quotes in the primary ask command: {lines:#?}"
+        "apply summary should shell-quote single quotes in the primary ask command and keep the suggested message shell-safe: {lines:#?}"
     );
     assert!(
         rendered.contains(
             "also available: chat · loongclaw chat --config '/tmp/loongclaw'\"'\"'s config.toml'"
         ),
         "apply summary should shell-quote single quotes in the secondary chat command: {lines:#?}"
+    );
+    assert!(
+        rendered.contains(
+            "also available: telegram · loongclaw telegram-serve --config '/tmp/loongclaw'\"'\"'s config.toml'"
+        ),
+        "apply summary should shell-quote single quotes in channel handoff commands: {lines:#?}"
     );
 }
 

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -619,6 +619,33 @@ fn import_cli_apply_summary_includes_registry_channel_actions() {
 }
 
 #[test]
+fn import_cli_apply_summary_shell_quotes_config_paths_with_single_quotes() {
+    let candidate = sample_import_candidate();
+    let lines = loongclaw_daemon::import_cli::render_import_apply_summary_lines_for_width(
+        std::path::Path::new("/tmp/loongclaw's config.toml"),
+        &candidate,
+        &[loongclaw_daemon::migration::types::SetupDomainKind::Channels],
+        &candidate.config,
+        false,
+        160,
+    );
+    let rendered = lines.join(" ");
+
+    assert!(
+        rendered.contains(
+            "next step: loongclaw ask --config '/tmp/loongclaw'\"'\"'s config.toml' --message"
+        ),
+        "apply summary should shell-quote single quotes in the primary ask command: {lines:#?}"
+    );
+    assert!(
+        rendered.contains(
+            "also available: chat · loongclaw chat --config '/tmp/loongclaw'\"'\"'s config.toml'"
+        ),
+        "apply summary should shell-quote single quotes in the secondary chat command: {lines:#?}"
+    );
+}
+
+#[test]
 fn import_cli_apply_summary_uses_channel_handoff_when_cli_is_disabled() {
     let mut candidate = sample_import_candidate();
     candidate.config.cli.enabled = false;

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -5754,6 +5754,30 @@ fn onboarding_success_summary_includes_brand_header() {
 }
 
 #[test]
+fn onboarding_success_summary_shell_quotes_config_paths_with_single_quotes() {
+    let path = PathBuf::from("/tmp/loongclaw's config.toml");
+    let summary = loongclaw_daemon::onboard_cli::build_onboarding_success_summary(
+        &path,
+        &mvp::config::LoongClawConfig::default(),
+        None,
+    );
+    let lines =
+        loongclaw_daemon::onboard_cli::render_onboarding_success_summary_with_width(&summary, 160);
+    let rendered = lines.join(" ");
+
+    assert!(
+        rendered.contains(
+            "start here: loongclaw ask --config '/tmp/loongclaw'\"'\"'s config.toml' --message"
+        ),
+        "success summary should shell-quote single quotes in the primary ask handoff: {lines:#?}"
+    );
+    assert!(
+        rendered.contains("- chat: loongclaw chat --config '/tmp/loongclaw'\"'\"'s config.toml'"),
+        "success summary should shell-quote single quotes in the secondary chat handoff: {lines:#?}"
+    );
+}
+
+#[test]
 fn onboarding_success_summary_prefers_oauth_env_over_api_key_env_when_both_are_configured() {
     let path = PathBuf::from("/tmp/loongclaw-config.toml");
     let mut config = mvp::config::LoongClawConfig::default();

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -5659,8 +5659,8 @@ fn render_onboarding_success_summary_compacts_for_narrow_width() {
                 .any(|line| line == "  '/tmp/loongclaw-config.toml' --message")
             && lines
                 .iter()
-                .any(|line| line == "  \"Summarize this repository and suggest the")
-            && lines.iter().any(|line| line == "  best next step.\""),
+                .any(|line| line == "  'Summarize this repository and suggest the")
+            && lines.iter().any(|line| line == "  best next step.'"),
         "narrow renderer should keep the primary ask example readable even when the command wraps: {lines:#?}"
     );
     assert!(


### PR DESCRIPTION
## Summary

- extract a small daemon-local handoff formatter so browser preview, onboarding, import, doctor, and channel next actions all use the same shell-safe config-path quoting
- fix the remaining first-run and recovery commands that still broke when the generated config path contained a single quote
- add focused regression coverage for doctor next steps plus onboarding/import handoff summaries with quoted config paths

- Why this change is needed?
  `alpha-test` already handled this case correctly in browser preview, but the surrounding onboarding / doctor / migration handoff surfaces were still assembling `--config` commands by hand. That left copy-paste guidance broken for valid config paths like `<local-absolute-path>'s config.toml`.

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional validation performed:
- `cargo test -p loongclaw-daemon build_doctor_next_steps_shell_quotes_config_paths_with_single_quotes -- --nocapture`
- `cargo test -p loongclaw-daemon import_cli_apply_summary_shell_quotes_config_paths_with_single_quotes -- --nocapture`
- `cargo test -p loongclaw-daemon onboarding_success_summary_shell_quotes_config_paths_with_single_quotes -- --nocapture`
- `cargo test -p loongclaw-daemon 'cli_handoff::tests::' -- --nocapture`
- `cargo test -p loongclaw-daemon browser_preview_commands_shell_escape_config_paths -- --nocapture`
- `cargo test --workspace`

## Linked Issues

Closes #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized CLI command formatting and quoting into shared utilities to ensure consistent, safe shell-quoting for config paths (including single quotes) across the daemon.

* **Tests**
  * Added and updated tests verifying shell-quoting and command formatting in onboarding, import/apply summaries, doctor, browser preview, and channel handoffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->