### PR TITLE
fix: close the release-first install contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Shell syntax checks
         run: |
+          bash -n scripts/install.sh
           bash -n scripts/architecture_budget_lib.sh
           bash -n scripts/check_architecture_boundaries.sh
           bash -n scripts/check_architecture_drift_freshness.sh
@@ -35,6 +36,7 @@ jobs:
           bash -n scripts/test_architecture_budget_scripts.sh
           bash -n scripts/test_check_architecture_drift_freshness.sh
           bash -n scripts/test_generate_architecture_drift_report.sh
+          bash -n scripts/test_install_sh.sh
           bash -n scripts/release_artifact_lib.sh
           bash -n scripts/bootstrap_release_local_artifacts.sh
           bash -n scripts/test_release_artifact_lib.sh
@@ -49,6 +51,7 @@ jobs:
           bash scripts/test_architecture_budget_scripts.sh
           bash scripts/test_check_architecture_drift_freshness.sh
           bash scripts/test_generate_architecture_drift_report.sh
+          bash scripts/test_install_sh.sh
           bash scripts/test_release_artifact_lib.sh
           bash scripts/test_bootstrap_release_local_artifacts.sh
           bash scripts/test_stress_daemon_tests.sh

--- a/README.md
+++ b/README.md
@@ -176,8 +176,15 @@ The bootstrap installer is fetched directly from the repository. It prefers the 
 Release binary, verifies its SHA256 checksum, installs `loongclaw`, and can immediately hand you
 into guided onboarding.
 
-If the repository has not published its first release yet, the installer exits with a clear message.
-Use the source install path below in that case.
+If the repository has not published a public release yet, the installer exits with an explicit
+source-install fallback instead of constructing a broken download URL. Until the first public
+release is shipped, expect the source path below to be the fast path:
+
+```bash
+git clone https://github.com/loongclaw-ai/loongclaw.git
+cd loongclaw
+bash scripts/install.sh --source --onboard
+```
 
 <details>
 <summary>Linux / macOS</summary>

--- a/docs/plans/2026-03-16-release-install-contract-design.md
+++ b/docs/plans/2026-03-16-release-install-contract-design.md
@@ -1,0 +1,129 @@
+# Release Install Contract Design
+
+## Goal
+
+Close the release-first install contract for LoongClaw so the shipped
+installers, product docs, and tests all describe the same real behavior when
+GitHub releases exist and when they do not.
+
+## Current State
+
+- `README.md` already exposes a release-first installer path and documents a
+  source fallback when no GitHub release is published yet.
+- `scripts/install.sh` and `scripts/install.ps1` already prefer GitHub Release
+  assets and fail closed when `releases/latest` is missing.
+- The Bash installer is not easily smoke-testable against local release
+  fixtures because the download base is hard-coded to GitHub.
+- There is no end-to-end smoke test for the actual `scripts/install.sh`
+  entrypoint.
+- Public GitHub release APIs currently report no published releases for
+  `loongclaw-ai/loongclaw`, so users still land on the fallback path today.
+- `docs/product-specs/installation.md` still looks like a draft because every
+  acceptance box is unchecked.
+
+## Problem
+
+The repository currently has the right release-first shape but not the full
+contract:
+
+1. the installers are hard to verify end-to-end without talking to GitHub
+2. the missing-release path is honest but not actionable enough
+3. the public install docs and spec do not clearly communicate today's real
+   first-run path
+4. release-first support therefore exists more as infrastructure than as a
+   reliably testable user contract
+
+That is a user-experience gap for MVP, because install is the first moment where
+the product either feels trustworthy or not.
+
+## Chosen Slice
+
+Implement a narrow install-contract slice instead of expanding into package
+managers or heavier release tooling:
+
+1. Add a local release-base override to both installers so they can be tested
+   against fixture assets.
+2. Add a real smoke test for `scripts/install.sh` that covers successful
+   install, checksum failure, and missing-release guidance.
+3. Improve missing-release guidance with exact next actions instead of a vague
+   fallback hint.
+4. Tighten README and installation spec wording so the quickstart stays honest
+   before the first public release exists.
+
+This gives the MVP a sturdier install story without introducing package-manager
+distribution, auto-update logic, or broader release orchestration.
+
+## Design
+
+### 1. Testable installer inputs
+
+Introduce a download-base override for installer fetches:
+
+- `scripts/install.sh` reads `LOONGCLAW_INSTALL_RELEASE_BASE_URL` before falling
+  back to `https://github.com/<repo>/releases`.
+- `scripts/install.ps1` mirrors that override through the same environment
+  variable.
+
+The override is intentionally narrow: it only changes the base URL used for the
+archive and checksum downloads, leaving release-tag resolution unchanged unless
+the caller also pins `--version`.
+
+### 2. Bash smoke coverage
+
+Add `scripts/test_install_sh.sh` as an end-to-end shell smoke test for the
+actual installer script:
+
+- install from a local release fixture through the override base URL
+- fail on a deliberately corrupted checksum file
+- fail with exact source-install guidance when `releases/latest` is absent
+
+This test operates entirely on temp directories and fixture assets, so it does
+not require a published GitHub release.
+
+### 3. Missing-release guidance
+
+When the latest-release lookup fails, both installers should print an
+immediately actionable next path:
+
+- clone the repository from GitHub
+- run the source installer from that checkout
+- optionally continue straight into onboarding
+
+The message should be copy-pastable and should not assume the user already knows
+what a “repository checkout” means.
+
+### 4. Product docs
+
+The public install docs should explicitly say:
+
+- the bootstrap installer is release-first when assets exist
+- no public release is published in the repository today
+- the supported immediate fallback is the source installer below
+- `--onboard` is the fastest path into a first useful answer
+
+This keeps the product honest without downgrading the release-first direction.
+
+## Non-Goals
+
+- Homebrew, winget, apt, or other package-manager distribution
+- Auto-update / self-update
+- Linux ARM64 packaging or broader target-matrix changes
+- Retrofitting release docs or CI governance into a larger release audit
+
+## Risks
+
+- The shell smoke test only covers the Bash entrypoint. Mitigation: mirror the
+  PowerShell behavior closely and document local verification limits if `pwsh`
+  is unavailable.
+- A new override could become user-facing surface area unintentionally.
+  Mitigation: keep it undocumented and scoped to testability, not product docs.
+
+## Acceptance Criteria
+
+- `scripts/test_install_sh.sh` fails before implementation and passes after.
+- `scripts/install.sh` supports a release-base override, installs successfully
+  from a local fixture, and fails closed on checksum drift.
+- Both installers print exact source-install next steps when no public release
+  exists.
+- `README.md` and `docs/product-specs/installation.md` match the shipped
+  release-first-with-source-fallback behavior.

--- a/docs/plans/2026-03-16-release-install-contract-implementation-plan.md
+++ b/docs/plans/2026-03-16-release-install-contract-implementation-plan.md
@@ -1,0 +1,126 @@
+# Release Install Contract Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close LoongClaw's release-first install contract with smoke coverage, actionable fallback guidance, and synced install docs.
+
+**Architecture:** Keep the existing release-first installers, but make them smoke-testable through a local release-base override, improve missing-release guidance, and sync the public install docs to the current no-public-release reality.
+
+**Tech Stack:** Bash, PowerShell, Markdown docs, existing shell test harnesses.
+
+---
+
+### Task 1: Update the design artifacts to the chosen slice
+
+**Files:**
+- Create: `docs/plans/2026-03-16-release-install-contract-design.md`
+- Create: `docs/plans/2026-03-16-release-install-contract-implementation-plan.md`
+- Delete: `docs/plans/2026-03-16-release-install-truthfulness-design.md`
+- Delete: `docs/plans/2026-03-16-release-install-truthfulness-implementation-plan.md`
+
+**Step 1: Rewrite the scope**
+
+- Replace the earlier truthfulness-only framing with the chosen install-contract
+  slice so the tracked design and implementation notes match the branch.
+
+### Task 2: Add and verify the failing Bash smoke test
+
+**Files:**
+- Create: `scripts/test_install_sh.sh`
+- Modify: `scripts/install.sh`
+
+**Step 1: Keep the failing shell smoke coverage**
+
+- Cover:
+  - release-fixture install through `LOONGCLAW_INSTALL_RELEASE_BASE_URL`
+  - checksum mismatch failure
+  - missing latest-release guidance text
+
+**Step 2: Run test to verify it fails**
+
+Run: `bash scripts/test_install_sh.sh`
+Expected: FAIL because `install.sh` does not yet honor the override or print the
+full next-step guidance.
+
+**Step 3: Implement minimal Bash installer changes**
+
+- Add `LOONGCLAW_INSTALL_RELEASE_BASE_URL` support.
+- Improve the no-release message with exact clone + source-install commands.
+- Keep the rest of the release-first flow unchanged.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bash scripts/test_install_sh.sh`
+Expected: PASS
+
+### Task 3: Mirror the behavior in PowerShell
+
+**Files:**
+- Modify: `scripts/install.ps1`
+
+**Step 1: Keep PowerShell behavior parallel**
+
+- Add the same `LOONGCLAW_INSTALL_RELEASE_BASE_URL` override.
+- Improve the missing-release guidance with exact next actions.
+- Preserve Windows-specific install behavior otherwise.
+
+**Step 2: Verify as far as the environment allows**
+
+Run: `command -v pwsh`
+Expected: if unavailable, document that PowerShell parity was verified by
+implementation review rather than local execution.
+
+### Task 4: Sync the public install docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/product-specs/installation.md`
+
+**Step 1: Update public install wording**
+
+- Keep the release-first installer quickstart.
+- Explicitly state that no public release is published yet.
+- Point users to the source installer as the supported immediate fallback.
+- Mark the installation spec acceptance criteria as shipped when the behavior is
+  now real.
+
+**Step 2: Re-run relevant checks**
+
+Run: `bash scripts/test_install_sh.sh`
+Expected: PASS
+
+### Task 5: Full verification and GitHub delivery
+
+**Files:**
+- Modify: issue `#201` and open one PR against `alpha-test`
+
+**Step 1: Format and validate**
+
+Run: `cargo fmt --all -- --check`
+Expected: PASS
+
+**Step 2: Run targeted installer and release checks**
+
+Run: `bash scripts/test_install_sh.sh`
+Expected: PASS
+
+Run: `bash scripts/test_release_artifact_lib.sh`
+Expected: PASS
+
+Run: `bash scripts/test_bootstrap_release_local_artifacts.sh`
+Expected: PASS
+
+**Step 3: Run Rust quality gates**
+
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+Expected: PASS
+
+Run: `cargo test --workspace --all-features --locked`
+Expected: PASS
+
+**Step 4: Publish the GitHub artifacts**
+
+- Update issue `#201` so its title/body match the install-contract scope.
+- Commit only the install-contract slice.
+- Push the branch to the operator fork.
+- Open a PR against `alpha-test` with `Closes #201` in the body.

--- a/docs/product-specs/installation.md
+++ b/docs/product-specs/installation.md
@@ -8,17 +8,17 @@ or `chat` without reverse-engineering release or source workflows.
 
 ## Acceptance Criteria
 
-- [ ] Product docs expose a bootstrap installer path for Linux/macOS and
+- [x] Product docs expose a bootstrap installer path for Linux/macOS and
       Windows.
-- [ ] The bootstrap installer prefers GitHub Release binaries, verifies their
+- [x] The bootstrap installer prefers GitHub Release binaries, verifies their
       SHA256 checksums, and installs the matching `loongclaw` binary when a
       release exists for the requested version.
-- [ ] If the repository has not published a matching release yet, the installer
+- [x] If the repository has not published a matching release yet, the installer
       fails with an explicit next action instead of constructing a misleading or
       broken download URL.
-- [ ] Product docs keep a source-install path for repository users and document
+- [x] Product docs keep a source-install path for repository users and document
       the explicit `--source` fallback from a local checkout.
-- [ ] The install path can hand users directly into `loongclaw onboard` after a
+- [x] The install path can hand users directly into `loongclaw onboard` after a
       successful install.
 
 ## Out of Scope

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -8,6 +8,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+$ReleaseBaseUrl = if ($env:LOONGCLAW_INSTALL_RELEASE_BASE_URL) { $env:LOONGCLAW_INSTALL_RELEASE_BASE_URL } else { "https://github.com/$Repository/releases" }
 
 function Write-Usage {
     @"
@@ -36,12 +37,24 @@ function Normalize-ReleaseTag([string]$Raw) {
     return "v$Raw"
 }
 
+function New-MissingReleaseGuidance([string]$Repo) {
+    $repoName = ($Repo -split "/")[-1]
+    return @"
+no GitHub release is published for $Repo yet.
+
+Install from a local checkout instead:
+  git clone https://github.com/$Repo.git
+  cd $repoName
+  pwsh ./scripts/install.ps1 -Source -Onboard
+"@
+}
+
 function Resolve-LatestReleaseTag([string]$Repo) {
     $headers = @{ "User-Agent" = "LoongClaw-Install" }
     try {
         $release = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/$Repo/releases/latest"
     } catch {
-        throw "no GitHub release is published for $Repo yet. Run this installer from a repository checkout with -Source, or install from source manually."
+        throw (New-MissingReleaseGuidance -Repo $Repo)
     }
     if (-not $release.tag_name) {
         throw "failed to resolve latest release tag for $Repo"
@@ -114,7 +127,7 @@ function Install-FromRelease {
     $packageName = "loongclaw"
     $archiveName = Get-ReleaseArchiveName -PackageName $packageName -Tag $releaseTag -Target $target
     $checksumName = Get-ReleaseChecksumName -PackageName $packageName -Tag $releaseTag -Target $target
-    $releaseBase = "https://github.com/$Repository/releases/download/$releaseTag"
+    $releaseBase = "$ReleaseBaseUrl/download/$releaseTag"
     $archiveUrl = "$releaseBase/$archiveName"
     $checksumUrl = "$releaseBase/$checksumName"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -107,7 +107,7 @@ run_onboard=0
 install_source=0
 release_version="${LOONGCLAW_INSTALL_VERSION:-latest}"
 release_repo="${LOONGCLAW_INSTALL_REPO:-loongclaw-ai/loongclaw}"
-release_base_url="https://github.com/${release_repo}/releases"
+release_base_url="${LOONGCLAW_INSTALL_RELEASE_BASE_URL:-https://github.com/${release_repo}/releases}"
 package_name="loongclaw"
 bin_name="loongclaw"
 
@@ -171,6 +171,17 @@ normalize_release_tag() {
   printf 'v%s\n' "$raw"
 }
 
+print_missing_release_guidance() {
+  cat >&2 <<EOF
+error: no GitHub release is published for ${release_repo} yet.
+
+Install from a local checkout instead:
+  git clone https://github.com/${release_repo}.git
+  cd $(basename "${release_repo}")
+  bash scripts/install.sh --source --onboard
+EOF
+}
+
 resolve_latest_release_tag() {
   local api_url response tag
   api_url="https://api.github.com/repos/${release_repo}/releases/latest"
@@ -180,7 +191,7 @@ resolve_latest_release_tag() {
       -H 'User-Agent: LoongClaw-Install' \
       "${api_url}"
   )"; then
-    echo "error: no GitHub release is published for ${release_repo} yet. Run this installer from a repository checkout with --source, or install from source manually." >&2
+    print_missing_release_guidance
     exit 1
   fi
 

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/install.sh"
+. "$REPO_ROOT/scripts/release_artifact_lib.sh"
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" "$file"; then
+    echo "expected to find '$needle' in $file" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+sha256_file() {
+  local file_path="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file_path" | awk '{print $1}'
+    return 0
+  fi
+  sha256sum "$file_path" | awk '{print $1}'
+}
+
+host_target() {
+  release_target_for_platform "$(uname -s)" "$(uname -m)"
+}
+
+make_release_fixture() {
+  local fixture tag target archive_name checksum_name binary_name archive_path checksum_path release_dir
+  fixture="$(mktemp -d)"
+  tag="${1:-v0.1.2}"
+  target="$(host_target)"
+  archive_name="$(release_archive_name "loongclaw" "$tag" "$target")"
+  checksum_name="$(release_archive_checksum_name "loongclaw" "$tag" "$target")"
+  binary_name="$(release_binary_name_for_target "loongclaw" "$target")"
+  release_dir="$fixture/releases/download/$tag"
+  mkdir -p "$release_dir" "$fixture/staging"
+
+  cat >"$fixture/staging/$binary_name" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "onboard" ]]; then
+  printf 'onboard\n' >> "${ONBOARD_MARKER:?}"
+fi
+printf 'fixture-binary\n'
+EOF
+  chmod +x "$fixture/staging/$binary_name"
+
+  archive_path="$release_dir/$archive_name"
+  case "$archive_name" in
+    *.tar.gz)
+      tar -C "$fixture/staging" -czf "$archive_path" "$binary_name"
+      ;;
+    *.zip)
+      (cd "$fixture/staging" && zip -q "$archive_path" "$binary_name")
+      ;;
+    *)
+      echo "unsupported archive format in fixture: $archive_name" >&2
+      exit 1
+      ;;
+  esac
+
+  checksum_path="$release_dir/$checksum_name"
+  printf '%s  %s\n' "$(sha256_file "$archive_path")" "$archive_name" >"$checksum_path"
+
+  printf '%s\n' "$fixture"
+}
+
+make_latest_release_stub_bin() {
+  local fixture="$1"
+  mkdir -p "$fixture/fake-bin"
+  cat >"$fixture/fake-bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${@: -1}"
+if [[ "$url" == "https://api.github.com/repos/loongclaw-ai/loongclaw/releases/latest" ]]; then
+  exit 22
+fi
+
+cat >&2 <<ERR
+unexpected curl request: $url
+ERR
+exit 1
+EOF
+  chmod +x "$fixture/fake-bin/curl"
+}
+
+run_release_override_install_and_onboard_test() {
+  local fixture install_dir output_file marker
+  fixture="$(make_release_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/install.out"
+  marker="$fixture/onboard.log"
+  : >"$marker"
+
+  (
+    cd "$REPO_ROOT"
+    ONBOARD_MARKER="$marker" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
+  )
+
+  [[ -x "$install_dir/loongclaw" ]]
+  assert_contains "$output_file" "Installed loongclaw"
+  assert_contains "$output_file" "Running guided onboarding"
+  assert_contains "$marker" "onboard"
+}
+
+run_checksum_mismatch_fails_test() {
+  local fixture install_dir output_file tag target checksum_name
+  fixture="$(make_release_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/checksum.out"
+  tag="v0.1.2"
+  target="$(host_target)"
+  checksum_name="$(release_archive_checksum_name "loongclaw" "$tag" "$target")"
+  printf 'deadbeef  wrong-archive\n' >"$fixture/releases/download/$tag/$checksum_name"
+
+  if (
+    cd "$REPO_ROOT"
+    LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version "$tag" --prefix "$install_dir" >"$output_file" 2>&1
+  ); then
+    echo "expected install.sh to fail on checksum mismatch" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+
+  assert_contains "$output_file" "checksum verification failed"
+}
+
+run_missing_release_guidance_test() {
+  local fixture output_file
+  fixture="$(mktemp -d)"
+  trap 'rm -rf "$fixture"' RETURN
+  output_file="$fixture/missing-release.out"
+  make_latest_release_stub_bin "$fixture"
+
+  if (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      bash "$SCRIPT_UNDER_TEST" --prefix "$fixture/install" >"$output_file" 2>&1
+  ); then
+    echo "expected install.sh to fail when no latest GitHub release exists" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+
+  assert_contains "$output_file" "no GitHub release is published for loongclaw-ai/loongclaw yet"
+  assert_contains "$output_file" "git clone https://github.com/loongclaw-ai/loongclaw.git"
+  assert_contains "$output_file" "bash scripts/install.sh --source --onboard"
+}
+
+run_release_override_install_and_onboard_test
+run_checksum_mismatch_fails_test
+run_missing_release_guidance_test
+
+echo "install.sh smoke checks passed"


### PR DESCRIPTION
## Summary

- Add a local release-base override to `install.sh` and `install.ps1`, and print exact source-install fallback steps when no public release exists.
- Add `scripts/test_install_sh.sh` smoke coverage and run it in CI governance checks.
- Sync README and the installation product spec with the release-first plus source-fallback contract, and record the slice design and implementation notes.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features --locked`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional checks:
- `bash scripts/test_install_sh.sh`
- `bash scripts/test_release_artifact_lib.sh`
- `bash scripts/test_bootstrap_release_local_artifacts.sh`
- `bash scripts/check-docs.sh`
- `cargo test --workspace --locked`
- `git diff --check`

Notes:
- `scripts/test_install_sh.sh` scopes env overrides to subshell invocations and cleans temp fixtures with `trap`.
- `pwsh` was not available in this local environment, so `install.ps1` was verified by parity with the Bash change rather than by direct execution.

## Linked Issues

Closes #201
