### PR TITLE
feat(daemon): add runtime snapshot CLI

### DIFF
--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -463,7 +463,7 @@ pub fn is_provider_exposed_tool_name(raw: &str) -> bool {
         .is_some_and(|entry| entry.is_provider_core())
 }
 
-pub(crate) fn runtime_tool_view_from_loongclaw_config(
+pub fn runtime_tool_view_from_loongclaw_config(
     config: &crate::config::LoongClawConfig,
 ) -> ToolView {
     let runtime_config = runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None);

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -20,6 +20,7 @@ use kernel::{
 };
 use serde::Serialize;
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 
 pub use loongclaw_app as mvp;
 pub use loongclaw_spec::spec_execution::*;
@@ -365,6 +366,13 @@ pub enum Commands {
     },
     /// Fetch and print currently available provider model list
     ListModels {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Print a unified runtime snapshot for experiment reproducibility and lineage capture
+    RuntimeSnapshot {
         #[arg(long)]
         config: Option<String>,
         #[arg(long, default_value_t = false)]
@@ -929,6 +937,398 @@ pub async fn run_list_models_cli(config_path: Option<&str>, as_json: bool) -> Cl
         println!("{model}");
     }
     Ok(())
+}
+
+pub const RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone)]
+pub struct RuntimeSnapshotCliState {
+    pub config: String,
+    pub provider: RuntimeSnapshotProviderState,
+    pub context_engine: mvp::conversation::ContextEngineRuntimeSnapshot,
+    pub memory_system: mvp::memory::MemorySystemRuntimeSnapshot,
+    pub acp: mvp::acp::AcpRuntimeSnapshot,
+    pub enabled_channel_ids: Vec<String>,
+    pub enabled_service_channel_ids: Vec<String>,
+    pub channels: mvp::channel::ChannelInventory,
+    pub tool_runtime: mvp::tools::runtime_config::ToolRuntimeConfig,
+    pub visible_tool_names: Vec<String>,
+    pub capability_snapshot: String,
+    pub capability_snapshot_sha256: String,
+    pub external_skills: RuntimeSnapshotExternalSkillsState,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeSnapshotProviderState {
+    pub active_profile_id: String,
+    pub active_label: String,
+    pub last_provider_id: Option<String>,
+    pub saved_profile_ids: Vec<String>,
+    pub profiles: Vec<RuntimeSnapshotProviderProfileState>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeSnapshotProviderProfileState {
+    pub profile_id: String,
+    pub is_active: bool,
+    pub default_for_kind: bool,
+    pub kind: mvp::config::ProviderKind,
+    pub model: String,
+    pub wire_api: mvp::config::ProviderWireApi,
+    pub base_url: String,
+    pub endpoint: String,
+    pub models_endpoint: String,
+    pub protocol_family: &'static str,
+    pub credential_resolved: bool,
+    pub auth_env: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub temperature: f64,
+    pub max_tokens: Option<u32>,
+    pub request_timeout_ms: u64,
+    pub retry_max_attempts: usize,
+    pub header_names: Vec<String>,
+    pub preferred_models: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeSnapshotInventoryStatus {
+    Ok,
+    Disabled,
+    Error,
+}
+
+impl RuntimeSnapshotInventoryStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Disabled => "disabled",
+            Self::Error => "error",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeSnapshotExternalSkillsState {
+    pub policy: mvp::tools::runtime_config::ExternalSkillsRuntimePolicy,
+    pub override_active: bool,
+    pub inventory_status: RuntimeSnapshotInventoryStatus,
+    pub inventory_error: Option<String>,
+    pub inventory: Value,
+    pub resolved_skill_count: usize,
+    pub shadowed_skill_count: usize,
+}
+
+pub fn run_runtime_snapshot_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
+    let snapshot = collect_runtime_snapshot_cli_state(config_path)?;
+
+    if as_json {
+        let payload = build_runtime_snapshot_cli_json_payload(&snapshot);
+        let pretty = serde_json::to_string_pretty(&payload)
+            .map_err(|error| format!("serialize runtime snapshot output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_snapshot_text(&snapshot));
+    Ok(())
+}
+
+pub fn collect_runtime_snapshot_cli_state(
+    config_path: Option<&str>,
+) -> CliResult<RuntimeSnapshotCliState> {
+    let (resolved_path, config) = mvp::config::load(config_path)?;
+    let config_display = resolved_path.display().to_string();
+    let provider = collect_runtime_snapshot_provider_state(&config);
+    let context_engine = mvp::conversation::collect_context_engine_runtime_snapshot(&config)?;
+    let memory_system = mvp::memory::collect_memory_system_runtime_snapshot(&config)?;
+    let acp = mvp::acp::collect_acp_runtime_snapshot(&config)?;
+    let enabled_channel_ids = config.enabled_channel_ids();
+    let enabled_service_channel_ids = config.enabled_service_channel_ids();
+    let channels = mvp::channel::channel_inventory(&config);
+    let tool_runtime = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+        &config,
+        Some(resolved_path.as_path()),
+    );
+    let tool_view = mvp::tools::runtime_tool_view_from_loongclaw_config(&config);
+    let visible_tool_names = tool_view
+        .tool_names()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let capability_snapshot = mvp::tools::capability_snapshot_with_config(&tool_runtime);
+    let capability_snapshot_sha256 =
+        runtime_snapshot_tool_digest(&visible_tool_names, &capability_snapshot)?;
+    let external_skills = collect_runtime_snapshot_external_skills_state(&tool_runtime);
+
+    Ok(RuntimeSnapshotCliState {
+        config: config_display,
+        provider,
+        context_engine,
+        memory_system,
+        acp,
+        enabled_channel_ids,
+        enabled_service_channel_ids,
+        channels,
+        tool_runtime,
+        visible_tool_names,
+        capability_snapshot,
+        capability_snapshot_sha256,
+        external_skills,
+    })
+}
+
+fn collect_runtime_snapshot_provider_state(
+    config: &mvp::config::LoongClawConfig,
+) -> RuntimeSnapshotProviderState {
+    let active_profile_id = config
+        .active_provider_id()
+        .unwrap_or(config.provider.kind.profile().id)
+        .to_owned();
+    let saved_profile_ids = provider_presentation::saved_provider_profile_ids(config);
+    let profiles = if config.providers.is_empty() {
+        vec![build_runtime_snapshot_provider_profile_state(
+            active_profile_id.as_str(),
+            &mvp::config::ProviderProfileConfig {
+                default_for_kind: true,
+                provider: config.provider.clone(),
+            },
+            true,
+        )]
+    } else {
+        saved_profile_ids
+            .iter()
+            .filter_map(|profile_id| {
+                config.providers.get(profile_id).map(|profile| {
+                    build_runtime_snapshot_provider_profile_state(
+                        profile_id,
+                        profile,
+                        profile_id == &active_profile_id,
+                    )
+                })
+            })
+            .collect::<Vec<_>>()
+    };
+
+    RuntimeSnapshotProviderState {
+        active_profile_id,
+        active_label: provider_presentation::active_provider_detail_label(config),
+        last_provider_id: config.last_provider_id().map(str::to_owned),
+        saved_profile_ids,
+        profiles,
+    }
+}
+
+fn build_runtime_snapshot_provider_profile_state(
+    profile_id: &str,
+    profile: &mvp::config::ProviderProfileConfig,
+    is_active: bool,
+) -> RuntimeSnapshotProviderProfileState {
+    let provider = &profile.provider;
+    let mut header_names = provider.headers.keys().cloned().collect::<Vec<_>>();
+    header_names.sort();
+
+    RuntimeSnapshotProviderProfileState {
+        profile_id: profile_id.to_owned(),
+        is_active,
+        default_for_kind: profile.default_for_kind,
+        kind: provider.kind,
+        model: provider.model.clone(),
+        wire_api: provider.wire_api,
+        base_url: provider.resolved_base_url(),
+        endpoint: provider.endpoint(),
+        models_endpoint: provider.models_endpoint(),
+        protocol_family: provider.kind.profile().protocol_family.as_str(),
+        credential_resolved: provider.authorization_header().is_some(),
+        auth_env: provider.resolved_auth_env_name(),
+        reasoning_effort: provider
+            .reasoning_effort
+            .map(|value| value.as_str().to_owned()),
+        temperature: provider.temperature,
+        max_tokens: provider.max_tokens,
+        request_timeout_ms: provider.request_timeout_ms,
+        retry_max_attempts: provider.retry_max_attempts,
+        header_names,
+        preferred_models: provider.preferred_models.clone(),
+    }
+}
+
+fn collect_runtime_snapshot_external_skills_state(
+    tool_runtime: &mvp::tools::runtime_config::ToolRuntimeConfig,
+) -> RuntimeSnapshotExternalSkillsState {
+    let empty_inventory = json!({
+        "skills": [],
+        "shadowed_skills": [],
+    });
+
+    let (effective_policy, override_active) =
+        match runtime_snapshot_effective_external_skills_policy(tool_runtime) {
+            Ok(policy_state) => policy_state,
+            Err(error) => {
+                return RuntimeSnapshotExternalSkillsState {
+                    policy: tool_runtime.external_skills.clone(),
+                    override_active: false,
+                    inventory_status: RuntimeSnapshotInventoryStatus::Error,
+                    inventory_error: Some(error.clone()),
+                    inventory: json!({
+                        "skills": [],
+                        "shadowed_skills": [],
+                        "error": error,
+                    }),
+                    resolved_skill_count: 0,
+                    shadowed_skill_count: 0,
+                };
+            }
+        };
+
+    if !effective_policy.enabled {
+        return RuntimeSnapshotExternalSkillsState {
+            policy: effective_policy,
+            override_active,
+            inventory_status: RuntimeSnapshotInventoryStatus::Disabled,
+            inventory_error: None,
+            inventory: empty_inventory,
+            resolved_skill_count: 0,
+            shadowed_skill_count: 0,
+        };
+    }
+
+    match mvp::tools::execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "external_skills.list".to_owned(),
+            payload: json!({}),
+        },
+        tool_runtime,
+    ) {
+        Ok(outcome) => RuntimeSnapshotExternalSkillsState {
+            policy: effective_policy,
+            override_active,
+            inventory_status: RuntimeSnapshotInventoryStatus::Ok,
+            inventory_error: None,
+            resolved_skill_count: json_array_len(&outcome.payload["skills"]),
+            shadowed_skill_count: json_array_len(&outcome.payload["shadowed_skills"]),
+            inventory: outcome.payload,
+        },
+        Err(error) => RuntimeSnapshotExternalSkillsState {
+            policy: effective_policy,
+            override_active,
+            inventory_status: RuntimeSnapshotInventoryStatus::Error,
+            inventory_error: Some(error.clone()),
+            inventory: json!({
+                "skills": [],
+                "shadowed_skills": [],
+                "error": error,
+            }),
+            resolved_skill_count: 0,
+            shadowed_skill_count: 0,
+        },
+    }
+}
+
+fn runtime_snapshot_effective_external_skills_policy(
+    tool_runtime: &mvp::tools::runtime_config::ToolRuntimeConfig,
+) -> Result<
+    (
+        mvp::tools::runtime_config::ExternalSkillsRuntimePolicy,
+        bool,
+    ),
+    String,
+> {
+    let outcome = mvp::tools::execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "external_skills.policy".to_owned(),
+            payload: json!({
+                "action": "get",
+            }),
+        },
+        tool_runtime,
+    )
+    .map_err(|error| format!("resolve effective external skills policy failed: {error}"))?;
+
+    let policy = runtime_snapshot_external_skills_policy_from_payload(&outcome.payload)?;
+    let override_active = outcome
+        .payload
+        .get("override_active")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    Ok((policy, override_active))
+}
+
+fn runtime_snapshot_external_skills_policy_from_payload(
+    payload: &Value,
+) -> Result<mvp::tools::runtime_config::ExternalSkillsRuntimePolicy, String> {
+    let policy = payload
+        .get("policy")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            "runtime snapshot external skills policy payload missing `policy`".to_owned()
+        })?;
+
+    Ok(mvp::tools::runtime_config::ExternalSkillsRuntimePolicy {
+        enabled: policy
+            .get("enabled")
+            .and_then(Value::as_bool)
+            .ok_or_else(|| {
+                "runtime snapshot external skills policy missing `enabled`".to_owned()
+            })?,
+        require_download_approval: policy
+            .get("require_download_approval")
+            .and_then(Value::as_bool)
+            .ok_or_else(|| {
+                "runtime snapshot external skills policy missing `require_download_approval`"
+                    .to_owned()
+            })?,
+        allowed_domains: json_string_array_to_set(
+            policy.get("allowed_domains"),
+            "runtime snapshot external skills policy.allowed_domains",
+        )?,
+        blocked_domains: json_string_array_to_set(
+            policy.get("blocked_domains"),
+            "runtime snapshot external skills policy.blocked_domains",
+        )?,
+        install_root: policy
+            .get("install_root")
+            .and_then(Value::as_str)
+            .map(Path::new)
+            .map(Path::to_path_buf),
+        auto_expose_installed: policy
+            .get("auto_expose_installed")
+            .and_then(Value::as_bool)
+            .ok_or_else(|| {
+                "runtime snapshot external skills policy missing `auto_expose_installed`".to_owned()
+            })?,
+    })
+}
+
+fn runtime_snapshot_tool_digest(
+    visible_tool_names: &[String],
+    capability_snapshot: &str,
+) -> CliResult<String> {
+    let serialized = serde_json::to_vec(&json!({
+        "visible_tool_names": visible_tool_names,
+        "capability_snapshot": capability_snapshot,
+    }))
+    .map_err(|error| format!("serialize runtime snapshot tool digest input failed: {error}"))?;
+    Ok(format!("{:x}", Sha256::digest(serialized)))
+}
+
+fn json_array_len(value: &Value) -> usize {
+    value.as_array().map_or(0, Vec::len)
+}
+
+fn json_string_array_to_set(
+    value: Option<&Value>,
+    context: &str,
+) -> Result<BTreeSet<String>, String> {
+    let items = value
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("{context} must be an array"))?;
+    items
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .map(str::to_owned)
+                .ok_or_else(|| format!("{context} must contain only strings"))
+        })
+        .collect()
 }
 
 pub fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
@@ -2195,6 +2595,467 @@ pub fn run_feishu_serve_cli_impl(args: ChannelServeCliArgs<'_>) -> ChannelCliCom
 
 pub fn parse_json_payload(raw: &str, context: &str) -> CliResult<Value> {
     serde_json::from_str(raw).map_err(|error| format!("invalid JSON for {context}: {error}"))
+}
+
+pub fn build_runtime_snapshot_cli_json_payload(snapshot: &RuntimeSnapshotCliState) -> Value {
+    json!({
+        "config": snapshot.config,
+        "schema": {
+            "version": RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION,
+            "surface": "runtime_snapshot",
+            "purpose": "experiment_reproducibility",
+        },
+        "provider": runtime_snapshot_provider_json(&snapshot.provider),
+        "context_engine": runtime_snapshot_context_engine_json(&snapshot.context_engine),
+        "memory_system": runtime_snapshot_memory_system_json(&snapshot.memory_system),
+        "acp": runtime_snapshot_acp_json(&snapshot.acp),
+        "channels": {
+            "enabled_channel_ids": snapshot.enabled_channel_ids,
+            "enabled_service_channel_ids": snapshot.enabled_service_channel_ids,
+            "inventory": build_channels_cli_json_payload(&snapshot.config, &snapshot.channels),
+        },
+        "tool_runtime": runtime_snapshot_tool_runtime_json(&snapshot.tool_runtime),
+        "tools": {
+            "visible_tool_count": snapshot.visible_tool_names.len(),
+            "visible_tool_names": snapshot.visible_tool_names,
+            "capability_snapshot_sha256": snapshot.capability_snapshot_sha256,
+            "capability_snapshot": snapshot.capability_snapshot,
+        },
+        "external_skills": runtime_snapshot_external_skills_json(&snapshot.external_skills),
+    })
+}
+
+pub fn render_runtime_snapshot_text(snapshot: &RuntimeSnapshotCliState) -> String {
+    let mut lines = vec![
+        format!("config={}", snapshot.config),
+        format!(
+            "provider active_profile={} active_label=\"{}\" last_provider={}",
+            snapshot.provider.active_profile_id,
+            snapshot.provider.active_label,
+            snapshot.provider.last_provider_id.as_deref().unwrap_or("-")
+        ),
+        format!(
+            "provider saved_profiles={}",
+            render_string_list(
+                snapshot
+                    .provider
+                    .saved_profile_ids
+                    .iter()
+                    .map(String::as_str)
+            )
+        ),
+    ];
+
+    for profile in &snapshot.provider.profiles {
+        lines.push(format!(
+            "  profile {} active={} default_for_kind={} kind={} model={} wire_api={} credential_resolved={} auth_env={} endpoint={} models_endpoint={} temperature={} max_tokens={} timeout_ms={} retries={} headers={} preferred_models={}",
+            profile.profile_id,
+            profile.is_active,
+            profile.default_for_kind,
+            profile.kind.as_str(),
+            profile.model,
+            profile.wire_api.as_str(),
+            profile.credential_resolved,
+            profile.auth_env.as_deref().unwrap_or("-"),
+            profile.endpoint,
+            profile.models_endpoint,
+            profile.temperature,
+            profile
+                .max_tokens
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_owned()),
+            profile.request_timeout_ms,
+            profile.retry_max_attempts,
+            render_string_list(profile.header_names.iter().map(String::as_str)),
+            render_string_list(profile.preferred_models.iter().map(String::as_str))
+        ));
+    }
+
+    lines.push(format!(
+        "context_engine selected={} source={} api_version={} capabilities={}",
+        snapshot.context_engine.selected_metadata.id,
+        snapshot.context_engine.selected.source.as_str(),
+        snapshot.context_engine.selected_metadata.api_version,
+        format_capability_names(&snapshot.context_engine.selected_metadata.capability_names())
+    ));
+    lines.push(format!(
+        "context_engine compaction=enabled:{} min_messages:{} trigger_estimated_tokens:{} fail_open:{}",
+        snapshot.context_engine.compaction.enabled,
+        snapshot
+            .context_engine
+            .compaction
+            .min_messages
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_owned()),
+        snapshot
+            .context_engine
+            .compaction
+            .trigger_estimated_tokens
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_owned()),
+        snapshot.context_engine.compaction.fail_open
+    ));
+    lines.push(format!(
+        "memory selected={} source={} api_version={} capabilities={} summary={}",
+        snapshot.memory_system.selected_metadata.id,
+        snapshot.memory_system.selected.source.as_str(),
+        snapshot.memory_system.selected_metadata.api_version,
+        format_capability_names(&snapshot.memory_system.selected_metadata.capability_names()),
+        snapshot.memory_system.selected_metadata.summary
+    ));
+    lines.push(format!(
+        "memory policy=backend:{} profile:{} mode:{} ingest_mode:{} fail_open:{} strict_mode_requested:{} strict_mode_active:{} effective_fail_open:{}",
+        snapshot.memory_system.policy.backend.as_str(),
+        snapshot.memory_system.policy.profile.as_str(),
+        snapshot.memory_system.policy.mode.as_str(),
+        snapshot.memory_system.policy.ingest_mode.as_str(),
+        snapshot.memory_system.policy.fail_open,
+        snapshot.memory_system.policy.strict_mode_requested,
+        snapshot.memory_system.policy.strict_mode_active,
+        snapshot.memory_system.policy.effective_fail_open
+    ));
+    lines.push(format!(
+        "acp enabled={} selected={} source={} api_version={} capabilities={} dispatch_enabled={} routing={} thread_routing={} default_agent={} allowed_agents={} allowed_channels={} allowed_account_ids={} bootstrap_mcp_servers={} working_directory={}",
+        snapshot.acp.control_plane.enabled,
+        snapshot.acp.selected_metadata.id,
+        snapshot.acp.selected.source.as_str(),
+        snapshot.acp.selected_metadata.api_version,
+        format_capability_names(&snapshot.acp.selected_metadata.capability_names()),
+        snapshot.acp.control_plane.dispatch_enabled,
+        snapshot.acp.control_plane.conversation_routing.as_str(),
+        snapshot.acp.control_plane.thread_routing.as_str(),
+        snapshot.acp.control_plane.default_agent,
+        render_string_list(snapshot.acp.control_plane.allowed_agents.iter().map(String::as_str)),
+        render_string_list(snapshot.acp.control_plane.allowed_channels.iter().map(String::as_str)),
+        render_string_list(
+            snapshot
+                .acp
+                .control_plane
+                .allowed_account_ids
+                .iter()
+                .map(String::as_str)
+        ),
+        render_string_list(
+            snapshot
+                .acp
+                .control_plane
+                .bootstrap_mcp_servers
+                .iter()
+                .map(String::as_str)
+        ),
+        snapshot
+            .acp
+            .control_plane
+            .working_directory
+            .as_deref()
+            .unwrap_or("-")
+    ));
+    lines.push(format!(
+        "channels enabled={} service_enabled={} configured_accounts={} surfaces={}",
+        render_string_list(snapshot.enabled_channel_ids.iter().map(String::as_str)),
+        render_string_list(
+            snapshot
+                .enabled_service_channel_ids
+                .iter()
+                .map(String::as_str)
+        ),
+        snapshot.channels.channels.len(),
+        snapshot.channels.channel_surfaces.len()
+    ));
+    for surface in &snapshot.channels.channel_surfaces {
+        lines.push(format!(
+            "  channel {} implementation_status={} configured_accounts={} default_configured_account={} aliases={}",
+            surface.catalog.id,
+            surface.catalog.implementation_status.as_str(),
+            surface.configured_accounts.len(),
+            surface
+                .default_configured_account_id
+                .as_deref()
+                .unwrap_or("-"),
+            render_string_list(surface.catalog.aliases.iter().copied())
+        ));
+    }
+    lines.push(format!(
+        "tool_runtime shell_default={} shell_allow={} shell_deny={} sessions_enabled={} messages_enabled={} delegate_enabled={}",
+        shell_policy_default_str(snapshot.tool_runtime.shell_default_mode),
+        render_string_list(snapshot.tool_runtime.shell_allow.iter().map(String::as_str)),
+        render_string_list(snapshot.tool_runtime.shell_deny.iter().map(String::as_str)),
+        snapshot.tool_runtime.sessions_enabled,
+        snapshot.tool_runtime.messages_enabled,
+        snapshot.tool_runtime.delegate_enabled
+    ));
+    lines.push(format!(
+        "tool_runtime browser enabled={} max_sessions={} max_links={} max_text_chars={}",
+        snapshot.tool_runtime.browser.enabled,
+        snapshot.tool_runtime.browser.max_sessions,
+        snapshot.tool_runtime.browser.max_links,
+        snapshot.tool_runtime.browser.max_text_chars
+    ));
+    lines.push(format!(
+        "tool_runtime browser_companion enabled={} ready={} command={} expected_version={}",
+        snapshot.tool_runtime.browser_companion.enabled,
+        snapshot.tool_runtime.browser_companion.ready,
+        snapshot
+            .tool_runtime
+            .browser_companion
+            .command
+            .as_deref()
+            .unwrap_or("-"),
+        snapshot
+            .tool_runtime
+            .browser_companion
+            .expected_version
+            .as_deref()
+            .unwrap_or("-")
+    ));
+    lines.push(format!(
+        "tool_runtime web_fetch enabled={} allow_private_hosts={} timeout_seconds={} max_bytes={} max_redirects={} allowed_domains={} blocked_domains={}",
+        snapshot.tool_runtime.web_fetch.enabled,
+        snapshot.tool_runtime.web_fetch.allow_private_hosts,
+        snapshot.tool_runtime.web_fetch.timeout_seconds,
+        snapshot.tool_runtime.web_fetch.max_bytes,
+        snapshot.tool_runtime.web_fetch.max_redirects,
+        render_string_list(snapshot.tool_runtime.web_fetch.allowed_domains.iter().map(String::as_str)),
+        render_string_list(snapshot.tool_runtime.web_fetch.blocked_domains.iter().map(String::as_str))
+    ));
+    lines.push(format!(
+        "tools visible_count={} capability_snapshot_sha256={} visible_names={}",
+        snapshot.visible_tool_names.len(),
+        snapshot.capability_snapshot_sha256,
+        render_string_list(snapshot.visible_tool_names.iter().map(String::as_str))
+    ));
+    lines.push(format!(
+        "external_skills inventory_status={} override_active={} enabled={} require_download_approval={} auto_expose_installed={} install_root={} resolved_skills={} shadowed_skills={} inventory_error={}",
+        snapshot.external_skills.inventory_status.as_str(),
+        snapshot.external_skills.override_active,
+        snapshot.external_skills.policy.enabled,
+        snapshot.external_skills.policy.require_download_approval,
+        snapshot.external_skills.policy.auto_expose_installed,
+        snapshot
+            .external_skills
+            .policy
+            .install_root
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "-".to_owned()),
+        snapshot.external_skills.resolved_skill_count,
+        snapshot.external_skills.shadowed_skill_count,
+        snapshot
+            .external_skills
+            .inventory_error
+            .as_deref()
+            .unwrap_or("-")
+    ));
+
+    if let Some(skills) = snapshot
+        .external_skills
+        .inventory
+        .get("skills")
+        .and_then(Value::as_array)
+    {
+        for skill in skills {
+            lines.push(format!(
+                "  external_skill {} scope={} active={} sha256={}",
+                json_string_field(skill, "skill_id"),
+                json_string_field(skill, "scope"),
+                skill
+                    .get("active")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                json_string_field(skill, "sha256")
+            ));
+        }
+    }
+
+    lines
+        .into_iter()
+        .chain([
+            "capability_snapshot:".to_owned(),
+            snapshot.capability_snapshot.clone(),
+        ])
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn runtime_snapshot_provider_json(snapshot: &RuntimeSnapshotProviderState) -> Value {
+    json!({
+        "active_profile_id": snapshot.active_profile_id,
+        "active_label": snapshot.active_label,
+        "last_provider_id": snapshot.last_provider_id,
+        "saved_profile_ids": snapshot.saved_profile_ids,
+        "profiles": snapshot
+            .profiles
+            .iter()
+            .map(runtime_snapshot_provider_profile_json)
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn runtime_snapshot_provider_profile_json(profile: &RuntimeSnapshotProviderProfileState) -> Value {
+    json!({
+        "profile_id": profile.profile_id,
+        "is_active": profile.is_active,
+        "default_for_kind": profile.default_for_kind,
+        "kind": profile.kind.as_str(),
+        "model": profile.model,
+        "wire_api": profile.wire_api.as_str(),
+        "base_url": profile.base_url,
+        "endpoint": profile.endpoint,
+        "models_endpoint": profile.models_endpoint,
+        "protocol_family": profile.protocol_family,
+        "credential_resolved": profile.credential_resolved,
+        "auth_env": profile.auth_env,
+        "reasoning_effort": profile.reasoning_effort,
+        "temperature": profile.temperature,
+        "max_tokens": profile.max_tokens,
+        "request_timeout_ms": profile.request_timeout_ms,
+        "retry_max_attempts": profile.retry_max_attempts,
+        "header_names": profile.header_names,
+        "preferred_models": profile.preferred_models,
+    })
+}
+
+fn runtime_snapshot_context_engine_json(
+    snapshot: &mvp::conversation::ContextEngineRuntimeSnapshot,
+) -> Value {
+    json!({
+        "selected": context_engine_metadata_json(
+            &snapshot.selected_metadata,
+            Some(snapshot.selected.source.as_str())
+        ),
+        "available": snapshot
+            .available
+            .iter()
+            .map(|metadata| context_engine_metadata_json(metadata, None))
+            .collect::<Vec<_>>(),
+        "compaction": {
+            "enabled": snapshot.compaction.enabled,
+            "min_messages": snapshot.compaction.min_messages,
+            "trigger_estimated_tokens": snapshot.compaction.trigger_estimated_tokens,
+            "fail_open": snapshot.compaction.fail_open,
+        },
+    })
+}
+
+fn runtime_snapshot_memory_system_json(
+    snapshot: &mvp::memory::MemorySystemRuntimeSnapshot,
+) -> Value {
+    json!({
+        "selected": memory_system_metadata_json(
+            &snapshot.selected_metadata,
+            Some(snapshot.selected.source.as_str())
+        ),
+        "available": snapshot
+            .available
+            .iter()
+            .map(|metadata| memory_system_metadata_json(metadata, None))
+            .collect::<Vec<_>>(),
+        "policy": memory_system_policy_json(&snapshot.policy),
+    })
+}
+
+fn runtime_snapshot_acp_json(snapshot: &mvp::acp::AcpRuntimeSnapshot) -> Value {
+    json!({
+        "enabled": snapshot.control_plane.enabled,
+        "selected": acp_backend_metadata_json(
+            &snapshot.selected_metadata,
+            Some(snapshot.selected.source.as_str())
+        ),
+        "available": snapshot
+            .available
+            .iter()
+            .map(|metadata| acp_backend_metadata_json(metadata, None))
+            .collect::<Vec<_>>(),
+        "control_plane": acp_control_plane_json(&snapshot.control_plane),
+    })
+}
+
+fn runtime_snapshot_tool_runtime_json(
+    runtime: &mvp::tools::runtime_config::ToolRuntimeConfig,
+) -> Value {
+    json!({
+        "file_root": runtime
+            .file_root
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        "shell": {
+            "default_mode": shell_policy_default_str(runtime.shell_default_mode),
+            "allow": runtime.shell_allow.iter().collect::<Vec<_>>(),
+            "deny": runtime.shell_deny.iter().collect::<Vec<_>>(),
+        },
+        "sessions_enabled": runtime.sessions_enabled,
+        "messages_enabled": runtime.messages_enabled,
+        "delegate_enabled": runtime.delegate_enabled,
+        "browser": {
+            "enabled": runtime.browser.enabled,
+            "max_sessions": runtime.browser.max_sessions,
+            "max_links": runtime.browser.max_links,
+            "max_text_chars": runtime.browser.max_text_chars,
+        },
+        "browser_companion": {
+            "enabled": runtime.browser_companion.enabled,
+            "ready": runtime.browser_companion.ready,
+            "command": runtime.browser_companion.command,
+            "expected_version": runtime.browser_companion.expected_version,
+        },
+        "web_fetch": {
+            "enabled": runtime.web_fetch.enabled,
+            "allow_private_hosts": runtime.web_fetch.allow_private_hosts,
+            "allowed_domains": runtime.web_fetch.allowed_domains.iter().collect::<Vec<_>>(),
+            "blocked_domains": runtime.web_fetch.blocked_domains.iter().collect::<Vec<_>>(),
+            "timeout_seconds": runtime.web_fetch.timeout_seconds,
+            "max_bytes": runtime.web_fetch.max_bytes,
+            "max_redirects": runtime.web_fetch.max_redirects,
+        },
+    })
+}
+
+fn runtime_snapshot_external_skills_json(snapshot: &RuntimeSnapshotExternalSkillsState) -> Value {
+    json!({
+        "policy": {
+            "enabled": snapshot.policy.enabled,
+            "require_download_approval": snapshot.policy.require_download_approval,
+            "allowed_domains": snapshot.policy.allowed_domains.iter().collect::<Vec<_>>(),
+            "blocked_domains": snapshot.policy.blocked_domains.iter().collect::<Vec<_>>(),
+            "install_root": snapshot
+                .policy
+                .install_root
+                .as_ref()
+                .map(|path| path.display().to_string()),
+            "auto_expose_installed": snapshot.policy.auto_expose_installed,
+        },
+        "override_active": snapshot.override_active,
+        "inventory_status": snapshot.inventory_status.as_str(),
+        "inventory_error": snapshot.inventory_error,
+        "resolved_skill_count": snapshot.resolved_skill_count,
+        "shadowed_skill_count": snapshot.shadowed_skill_count,
+        "inventory": snapshot.inventory,
+    })
+}
+
+fn shell_policy_default_str(
+    mode: mvp::tools::shell_policy_ext::ShellPolicyDefault,
+) -> &'static str {
+    match mode {
+        mvp::tools::shell_policy_ext::ShellPolicyDefault::Deny => "deny",
+        mvp::tools::shell_policy_ext::ShellPolicyDefault::Allow => "allow",
+    }
+}
+
+fn render_string_list<'a>(values: impl IntoIterator<Item = &'a str>) -> String {
+    let rendered = values
+        .into_iter()
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    if rendered.is_empty() {
+        "-".to_owned()
+    } else {
+        rendered.join(",")
+    }
+}
+
+fn json_string_field<'a>(value: &'a Value, key: &str) -> &'a str {
+    value.get(key).and_then(Value::as_str).unwrap_or("-")
 }
 
 pub fn context_engine_metadata_json(

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1069,7 +1069,7 @@ pub fn collect_runtime_snapshot_cli_state(
         enabled_channel_ids,
         enabled_service_channel_ids,
         channels,
-        tool_runtime,
+        tool_runtime: snapshot_tool_runtime,
         visible_tool_names,
         capability_snapshot,
         capability_snapshot_sha256,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1049,15 +1049,16 @@ pub fn collect_runtime_snapshot_cli_state(
         &config,
         Some(resolved_path.as_path()),
     );
-    let tool_view = mvp::tools::runtime_tool_view_from_loongclaw_config(&config);
+    let (external_skills, snapshot_tool_runtime) =
+        collect_runtime_snapshot_external_skills_state(&tool_runtime);
+    let tool_view = mvp::tools::runtime_tool_view_for_runtime_config(&snapshot_tool_runtime);
     let visible_tool_names = tool_view
         .tool_names()
         .map(str::to_owned)
         .collect::<Vec<_>>();
-    let capability_snapshot = mvp::tools::capability_snapshot_with_config(&tool_runtime);
+    let capability_snapshot = mvp::tools::capability_snapshot_with_config(&snapshot_tool_runtime);
     let capability_snapshot_sha256 =
         runtime_snapshot_tool_digest(&visible_tool_names, &capability_snapshot)?;
-    let external_skills = collect_runtime_snapshot_external_skills_state(&tool_runtime);
 
     Ok(RuntimeSnapshotCliState {
         config: config_display,
@@ -1137,7 +1138,7 @@ fn build_runtime_snapshot_provider_profile_state(
         endpoint: provider.endpoint(),
         models_endpoint: provider.models_endpoint(),
         protocol_family: provider.kind.profile().protocol_family.as_str(),
-        credential_resolved: provider.authorization_header().is_some(),
+        credential_resolved: runtime_snapshot_provider_credentials_resolved(provider),
         auth_env: provider.resolved_auth_env_name(),
         reasoning_effort: provider
             .reasoning_effort
@@ -1151,9 +1152,24 @@ fn build_runtime_snapshot_provider_profile_state(
     }
 }
 
+fn runtime_snapshot_provider_credentials_resolved(provider: &mvp::config::ProviderConfig) -> bool {
+    if provider.resolved_auth_secret().is_some() {
+        return true;
+    }
+
+    ["authorization", "x-api-key"].iter().any(|header_name| {
+        provider
+            .header_value(header_name)
+            .is_some_and(|value| !value.trim().is_empty())
+    })
+}
+
 fn collect_runtime_snapshot_external_skills_state(
     tool_runtime: &mvp::tools::runtime_config::ToolRuntimeConfig,
-) -> RuntimeSnapshotExternalSkillsState {
+) -> (
+    RuntimeSnapshotExternalSkillsState,
+    mvp::tools::runtime_config::ToolRuntimeConfig,
+) {
     let empty_inventory = json!({
         "skills": [],
         "shadowed_skills": [],
@@ -1163,32 +1179,41 @@ fn collect_runtime_snapshot_external_skills_state(
         match runtime_snapshot_effective_external_skills_policy(tool_runtime) {
             Ok(policy_state) => policy_state,
             Err(error) => {
-                return RuntimeSnapshotExternalSkillsState {
-                    policy: tool_runtime.external_skills.clone(),
-                    override_active: false,
-                    inventory_status: RuntimeSnapshotInventoryStatus::Error,
-                    inventory_error: Some(error.clone()),
-                    inventory: json!({
-                        "skills": [],
-                        "shadowed_skills": [],
-                        "error": error,
-                    }),
-                    resolved_skill_count: 0,
-                    shadowed_skill_count: 0,
-                };
+                return (
+                    RuntimeSnapshotExternalSkillsState {
+                        policy: tool_runtime.external_skills.clone(),
+                        override_active: false,
+                        inventory_status: RuntimeSnapshotInventoryStatus::Error,
+                        inventory_error: Some(error.clone()),
+                        inventory: json!({
+                            "skills": [],
+                            "shadowed_skills": [],
+                            "error": error,
+                        }),
+                        resolved_skill_count: 0,
+                        shadowed_skill_count: 0,
+                    },
+                    tool_runtime.clone(),
+                );
             }
         };
 
+    let mut effective_tool_runtime = tool_runtime.clone();
+    effective_tool_runtime.external_skills = effective_policy.clone();
+
     if !effective_policy.enabled {
-        return RuntimeSnapshotExternalSkillsState {
-            policy: effective_policy,
-            override_active,
-            inventory_status: RuntimeSnapshotInventoryStatus::Disabled,
-            inventory_error: None,
-            inventory: empty_inventory,
-            resolved_skill_count: 0,
-            shadowed_skill_count: 0,
-        };
+        return (
+            RuntimeSnapshotExternalSkillsState {
+                policy: effective_policy,
+                override_active,
+                inventory_status: RuntimeSnapshotInventoryStatus::Disabled,
+                inventory_error: None,
+                inventory: empty_inventory,
+                resolved_skill_count: 0,
+                shadowed_skill_count: 0,
+            },
+            effective_tool_runtime,
+        );
     }
 
     match mvp::tools::execute_tool_core_with_config(
@@ -1196,30 +1221,36 @@ fn collect_runtime_snapshot_external_skills_state(
             tool_name: "external_skills.list".to_owned(),
             payload: json!({}),
         },
-        tool_runtime,
+        &effective_tool_runtime,
     ) {
-        Ok(outcome) => RuntimeSnapshotExternalSkillsState {
-            policy: effective_policy,
-            override_active,
-            inventory_status: RuntimeSnapshotInventoryStatus::Ok,
-            inventory_error: None,
-            resolved_skill_count: json_array_len(&outcome.payload["skills"]),
-            shadowed_skill_count: json_array_len(&outcome.payload["shadowed_skills"]),
-            inventory: outcome.payload,
-        },
-        Err(error) => RuntimeSnapshotExternalSkillsState {
-            policy: effective_policy,
-            override_active,
-            inventory_status: RuntimeSnapshotInventoryStatus::Error,
-            inventory_error: Some(error.clone()),
-            inventory: json!({
-                "skills": [],
-                "shadowed_skills": [],
-                "error": error,
-            }),
-            resolved_skill_count: 0,
-            shadowed_skill_count: 0,
-        },
+        Ok(outcome) => (
+            RuntimeSnapshotExternalSkillsState {
+                policy: effective_policy,
+                override_active,
+                inventory_status: RuntimeSnapshotInventoryStatus::Ok,
+                inventory_error: None,
+                resolved_skill_count: json_array_len(outcome.payload.get("skills")),
+                shadowed_skill_count: json_array_len(outcome.payload.get("shadowed_skills")),
+                inventory: outcome.payload,
+            },
+            effective_tool_runtime,
+        ),
+        Err(error) => (
+            RuntimeSnapshotExternalSkillsState {
+                policy: effective_policy,
+                override_active,
+                inventory_status: RuntimeSnapshotInventoryStatus::Error,
+                inventory_error: Some(error.clone()),
+                inventory: json!({
+                    "skills": [],
+                    "shadowed_skills": [],
+                    "error": error,
+                }),
+                resolved_skill_count: 0,
+                shadowed_skill_count: 0,
+            },
+            effective_tool_runtime,
+        ),
     }
 }
 
@@ -1310,8 +1341,8 @@ fn runtime_snapshot_tool_digest(
     Ok(format!("{:x}", Sha256::digest(serialized)))
 }
 
-fn json_array_len(value: &Value) -> usize {
-    value.as_array().map_or(0, Vec::len)
+fn json_array_len(value: Option<&Value>) -> usize {
+    value.and_then(Value::as_array).map_or(0, Vec::len)
 }
 
 fn json_string_array_to_set(

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -180,6 +180,9 @@ async fn main() {
         }),
         Commands::Channels { config, json } => run_channels_cli(config.as_deref(), json),
         Commands::ListModels { config, json } => run_list_models_cli(config.as_deref(), json).await,
+        Commands::RuntimeSnapshot { config, json } => {
+            run_runtime_snapshot_cli(config.as_deref(), json)
+        }
         Commands::ListContextEngines { config, json } => {
             run_list_context_engines_cli(config.as_deref(), json)
         }

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -234,6 +234,26 @@ fn memory_systems_cli_parses() {
 }
 
 #[test]
+fn runtime_snapshot_cli_parses() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-snapshot",
+        "--config",
+        "/tmp/loongclaw.toml",
+        "--json",
+    ])
+    .expect("`runtime-snapshot` should parse");
+
+    match cli.command {
+        Some(Commands::RuntimeSnapshot { config, json }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(json);
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
 fn acp_event_summary_cli_rejects_zero_limit() {
     let error = run_acp_event_summary_cli(None, Some("session-a"), 0, false)
         .expect_err("zero limit must be rejected");

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -32,6 +32,7 @@ mod import_cli;
 mod migration;
 mod onboard_cli;
 mod programmatic;
+mod runtime_snapshot_cli;
 mod skills_cli;
 mod spec_runtime;
 mod spec_runtime_bridge;

--- a/crates/daemon/tests/integration/runtime_snapshot_cli.rs
+++ b/crates/daemon/tests/integration/runtime_snapshot_cli.rs
@@ -1,0 +1,323 @@
+#![allow(unsafe_code)]
+#![allow(
+    clippy::disallowed_methods,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::undocumented_unsafe_blocks
+)]
+
+use super::*;
+use serde_json::Value;
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+    sync::MutexGuard,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+}
+
+fn write_file(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent directory");
+    }
+    fs::write(path, content).expect("write fixture");
+}
+
+struct RuntimeSnapshotEnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: Vec<(String, Option<OsString>)>,
+}
+
+impl RuntimeSnapshotEnvGuard {
+    fn set(pairs: &[(&str, Option<&str>)]) -> Self {
+        let lock = super::lock_daemon_test_environment();
+        let mut saved = Vec::new();
+        for (key, value) in pairs {
+            saved.push(((*key).to_owned(), std::env::var_os(key)));
+            match value {
+                Some(value) => unsafe {
+                    std::env::set_var(key, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(key);
+                },
+            }
+        }
+        Self { _lock: lock, saved }
+    }
+}
+
+impl Drop for RuntimeSnapshotEnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..).rev() {
+            match value {
+                Some(value) => unsafe {
+                    std::env::set_var(&key, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(&key);
+                },
+            }
+        }
+    }
+}
+
+struct RuntimeSnapshotPolicyResetGuard {
+    runtime_config: mvp::tools::runtime_config::ToolRuntimeConfig,
+}
+
+impl RuntimeSnapshotPolicyResetGuard {
+    fn new(runtime_config: &mvp::tools::runtime_config::ToolRuntimeConfig) -> Self {
+        Self {
+            runtime_config: runtime_config.clone(),
+        }
+    }
+}
+
+impl Drop for RuntimeSnapshotPolicyResetGuard {
+    fn drop(&mut self) {
+        let _ = mvp::tools::execute_tool_core_with_config(
+            kernel::ToolCoreRequest {
+                tool_name: "external_skills.policy".to_owned(),
+                payload: serde_json::json!({
+                    "action": "reset",
+                    "policy_update_approved": true,
+                }),
+            },
+            &self.runtime_config,
+        );
+    }
+}
+
+fn write_runtime_snapshot_config(root: &Path) -> (PathBuf, mvp::config::LoongClawConfig) {
+    fs::create_dir_all(root).expect("create fixture root");
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.tools.file_root = Some(root.display().to_string());
+    config.tools.shell_allow = vec!["git".to_owned(), "cargo".to_owned()];
+    config.tools.browser.enabled = true;
+    config.tools.browser_companion.enabled = true;
+    config.tools.browser_companion.command = Some("browser-companion".to_owned());
+    config.tools.browser_companion.expected_version = Some("1.2.3".to_owned());
+    config.tools.web.enabled = true;
+    config.tools.web.allowed_domains = vec!["docs.example.com".to_owned()];
+    config.tools.web.blocked_domains = vec!["internal.example".to_owned()];
+    config.external_skills.enabled = true;
+    config.external_skills.require_download_approval = false;
+    config.external_skills.auto_expose_installed = true;
+    config.external_skills.allowed_domains = vec!["skills.sh".to_owned()];
+    config.external_skills.install_root = Some(root.join("managed-skills").display().to_string());
+    config.acp.enabled = true;
+    config.acp.dispatch.enabled = true;
+    config.acp.default_agent = Some("codex".to_owned());
+    config.acp.allowed_agents = vec!["codex".to_owned(), "planner".to_owned()];
+    config.active_provider = Some("deepseek-lab".to_owned());
+    config.providers.insert(
+        "openai-main".to_owned(),
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: false,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Openai,
+                model: "gpt-4.1-mini".to_owned(),
+                ..Default::default()
+            },
+        },
+    );
+    config.providers.insert(
+        "deepseek-lab".to_owned(),
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Deepseek,
+                model: "deepseek-chat".to_owned(),
+                api_key: Some("${RUNTIME_SNAPSHOT_DEEPSEEK_KEY}".to_owned()),
+                ..Default::default()
+            },
+        },
+    );
+
+    let config_path = root.join("loongclaw.toml");
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write config fixture");
+    (config_path, config)
+}
+
+fn install_demo_skill(root: &Path, config: &mvp::config::LoongClawConfig, config_path: &Path) {
+    write_file(
+        root,
+        "source/demo-skill/SKILL.md",
+        "# Demo Skill\n\nInstalled for runtime snapshot coverage.\n",
+    );
+
+    let runtime_config = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+        config,
+        Some(config_path),
+    );
+    mvp::tools::execute_tool_core_with_config(
+        kernel::ToolCoreRequest {
+            tool_name: "external_skills.install".to_owned(),
+            payload: serde_json::json!({
+                "path": "source/demo-skill"
+            }),
+        },
+        &runtime_config,
+    )
+    .expect("install demo skill");
+}
+
+fn array_contains_string(array: &Value, needle: &str) -> bool {
+    array.as_array().is_some_and(|items| {
+        items
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|value| value == needle)
+    })
+}
+
+fn array_contains_object_field(array: &Value, field: &str, needle: &str) -> bool {
+    array.as_array().is_some_and(|items| {
+        items.iter().any(|item| {
+            item.get(field)
+                .and_then(Value::as_str)
+                .is_some_and(|value| value == needle)
+        })
+    })
+}
+
+#[test]
+fn runtime_snapshot_json_payload_includes_provider_tool_and_external_skill_inventory() {
+    let root = unique_temp_dir("loongclaw-runtime-snapshot-json");
+    let _env = RuntimeSnapshotEnvGuard::set(&[
+        ("RUNTIME_SNAPSHOT_DEEPSEEK_KEY", Some("demo-token")),
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+    ]);
+    let (config_path, config) = write_runtime_snapshot_config(&root);
+    install_demo_skill(&root, &config, &config_path);
+
+    let snapshot = collect_runtime_snapshot_cli_state(Some(
+        config_path.to_str().expect("config path should be utf-8"),
+    ))
+    .expect("collect runtime snapshot");
+    let payload = build_runtime_snapshot_cli_json_payload(&snapshot);
+
+    assert_eq!(payload["schema"]["version"], 1);
+    assert_eq!(payload["provider"]["active_profile_id"], "deepseek-lab");
+    assert!(array_contains_string(
+        &payload["provider"]["saved_profile_ids"],
+        "deepseek-lab"
+    ));
+    assert_eq!(
+        payload["provider"]["profiles"][0]["credential_resolved"],
+        true
+    );
+    assert!(array_contains_string(
+        &payload["tools"]["visible_tool_names"],
+        "external_skills.list"
+    ));
+    assert_eq!(payload["external_skills"]["policy"]["enabled"], true);
+    assert!(array_contains_object_field(
+        &payload["external_skills"]["inventory"]["skills"],
+        "skill_id",
+        "demo-skill"
+    ));
+    assert!(
+        payload["tools"]["capability_snapshot_sha256"]
+            .as_str()
+            .is_some_and(|value: &str| !value.is_empty()),
+        "capability snapshot digest should be populated"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_snapshot_json_payload_reflects_effective_external_skills_policy_override() {
+    let root = unique_temp_dir("loongclaw-runtime-snapshot-policy-override");
+    let _env = RuntimeSnapshotEnvGuard::set(&[
+        ("RUNTIME_SNAPSHOT_DEEPSEEK_KEY", Some("demo-token")),
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+    ]);
+    let (config_path, config) = write_runtime_snapshot_config(&root);
+    install_demo_skill(&root, &config, &config_path);
+
+    let runtime_config = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+        &config,
+        Some(config_path.as_path()),
+    );
+    let _policy_reset = RuntimeSnapshotPolicyResetGuard::new(&runtime_config);
+    mvp::tools::execute_tool_core_with_config(
+        kernel::ToolCoreRequest {
+            tool_name: "external_skills.policy".to_owned(),
+            payload: serde_json::json!({
+                "action": "set",
+                "policy_update_approved": true,
+                "enabled": false,
+                "require_download_approval": true,
+                "allowed_domains": ["override.example"],
+                "blocked_domains": ["blocked.example"],
+            }),
+        },
+        &runtime_config,
+    )
+    .expect("override runtime external skills policy");
+
+    let snapshot = collect_runtime_snapshot_cli_state(Some(
+        config_path.to_str().expect("config path should be utf-8"),
+    ))
+    .expect("collect runtime snapshot");
+    let payload = build_runtime_snapshot_cli_json_payload(&snapshot);
+
+    assert_eq!(payload["external_skills"]["policy"]["enabled"], false);
+    assert_eq!(
+        payload["external_skills"]["policy"]["require_download_approval"],
+        true
+    );
+    assert!(array_contains_string(
+        &payload["external_skills"]["policy"]["allowed_domains"],
+        "override.example"
+    ));
+    assert!(array_contains_string(
+        &payload["external_skills"]["policy"]["blocked_domains"],
+        "blocked.example"
+    ));
+    assert_eq!(payload["external_skills"]["override_active"], true);
+    assert_eq!(payload["external_skills"]["inventory_status"], "disabled");
+    assert_eq!(payload["external_skills"]["resolved_skill_count"], 0);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_snapshot_text_highlights_experiment_relevant_sections() {
+    let root = unique_temp_dir("loongclaw-runtime-snapshot-text");
+    let _env = RuntimeSnapshotEnvGuard::set(&[
+        ("RUNTIME_SNAPSHOT_DEEPSEEK_KEY", Some("demo-token")),
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+    ]);
+    let (config_path, config) = write_runtime_snapshot_config(&root);
+    install_demo_skill(&root, &config, &config_path);
+
+    let snapshot = collect_runtime_snapshot_cli_state(Some(
+        config_path.to_str().expect("config path should be utf-8"),
+    ))
+    .expect("collect runtime snapshot");
+    let rendered = render_runtime_snapshot_text(&snapshot);
+
+    assert!(rendered.contains("provider active_profile=deepseek-lab"));
+    assert!(rendered.contains("context_engine selected="));
+    assert!(rendered.contains("memory selected="));
+    assert!(rendered.contains("acp enabled=true"));
+    assert!(rendered.contains("tools visible_count="));
+    assert!(rendered.contains("external_skills inventory_status=ok override_active=false"));
+    assert!(rendered.contains("demo-skill"));
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/crates/daemon/tests/integration/runtime_snapshot_cli.rs
+++ b/crates/daemon/tests/integration/runtime_snapshot_cli.rs
@@ -192,6 +192,18 @@ fn array_contains_object_field(array: &Value, field: &str, needle: &str) -> bool
     })
 }
 
+fn array_object_with_string_field<'a>(
+    array: &'a Value,
+    field: &str,
+    needle: &str,
+) -> Option<&'a Value> {
+    array.as_array()?.iter().find(|item| {
+        item.get(field)
+            .and_then(Value::as_str)
+            .is_some_and(|value| value == needle)
+    })
+}
+
 #[test]
 fn runtime_snapshot_json_payload_includes_provider_tool_and_external_skill_inventory() {
     let root = unique_temp_dir("loongclaw-runtime-snapshot-json");
@@ -214,10 +226,13 @@ fn runtime_snapshot_json_payload_includes_provider_tool_and_external_skill_inven
         &payload["provider"]["saved_profile_ids"],
         "deepseek-lab"
     ));
-    assert_eq!(
-        payload["provider"]["profiles"][0]["credential_resolved"],
-        true
-    );
+    let active_profile = array_object_with_string_field(
+        &payload["provider"]["profiles"],
+        "profile_id",
+        "deepseek-lab",
+    )
+    .expect("active provider profile should be present");
+    assert_eq!(active_profile["credential_resolved"], true);
     assert!(array_contains_string(
         &payload["tools"]["visible_tool_names"],
         "external_skills.list"
@@ -239,6 +254,50 @@ fn runtime_snapshot_json_payload_includes_provider_tool_and_external_skill_inven
 }
 
 #[test]
+fn runtime_snapshot_json_payload_marks_x_api_key_profiles_as_credential_resolved() {
+    let root = unique_temp_dir("loongclaw-runtime-snapshot-x-api-key");
+    let _env = RuntimeSnapshotEnvGuard::set(&[
+        ("RUNTIME_SNAPSHOT_DEEPSEEK_KEY", Some("demo-token")),
+        (
+            "RUNTIME_SNAPSHOT_ANTHROPIC_KEY",
+            Some("anthropic-demo-token"),
+        ),
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+    ]);
+    let (config_path, mut config) = write_runtime_snapshot_config(&root);
+    config.providers.insert(
+        "anthropic-lab".to_owned(),
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: false,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Anthropic,
+                model: "claude-3-7-sonnet".to_owned(),
+                api_key: Some("${RUNTIME_SNAPSHOT_ANTHROPIC_KEY}".to_owned()),
+                ..Default::default()
+            },
+        },
+    );
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("rewrite config fixture");
+
+    let snapshot = collect_runtime_snapshot_cli_state(Some(
+        config_path.to_str().expect("config path should be utf-8"),
+    ))
+    .expect("collect runtime snapshot");
+    let payload = build_runtime_snapshot_cli_json_payload(&snapshot);
+
+    let anthropic_profile = array_object_with_string_field(
+        &payload["provider"]["profiles"],
+        "profile_id",
+        "anthropic-lab",
+    )
+    .expect("anthropic provider profile should be present");
+    assert_eq!(anthropic_profile["credential_resolved"], true);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn runtime_snapshot_json_payload_reflects_effective_external_skills_policy_override() {
     let root = unique_temp_dir("loongclaw-runtime-snapshot-policy-override");
     let _env = RuntimeSnapshotEnvGuard::set(&[
@@ -247,6 +306,17 @@ fn runtime_snapshot_json_payload_reflects_effective_external_skills_policy_overr
     ]);
     let (config_path, config) = write_runtime_snapshot_config(&root);
     install_demo_skill(&root, &config, &config_path);
+
+    let enabled_snapshot = collect_runtime_snapshot_cli_state(Some(
+        config_path.to_str().expect("config path should be utf-8"),
+    ))
+    .expect("collect enabled runtime snapshot");
+    let enabled_payload = build_runtime_snapshot_cli_json_payload(&enabled_snapshot);
+    let enabled_digest = enabled_payload["tools"]["capability_snapshot_sha256"].clone();
+    assert!(array_contains_string(
+        &enabled_payload["tools"]["visible_tool_names"],
+        "external_skills.list"
+    ));
 
     let runtime_config = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
         &config,
@@ -291,6 +361,18 @@ fn runtime_snapshot_json_payload_reflects_effective_external_skills_policy_overr
     assert_eq!(payload["external_skills"]["override_active"], true);
     assert_eq!(payload["external_skills"]["inventory_status"], "disabled");
     assert_eq!(payload["external_skills"]["resolved_skill_count"], 0);
+    assert!(!array_contains_string(
+        &payload["tools"]["visible_tool_names"],
+        "external_skills.list"
+    ));
+    assert!(array_contains_string(
+        &payload["tools"]["visible_tool_names"],
+        "external_skills.policy"
+    ));
+    assert_ne!(
+        payload["tools"]["capability_snapshot_sha256"],
+        enabled_digest
+    );
 
     fs::remove_dir_all(&root).ok();
 }

--- a/crates/daemon/tests/integration/runtime_snapshot_cli.rs
+++ b/crates/daemon/tests/integration/runtime_snapshot_cli.rs
@@ -119,7 +119,6 @@ fn write_runtime_snapshot_config(root: &Path) -> (PathBuf, mvp::config::LoongCla
     config.acp.dispatch.enabled = true;
     config.acp.default_agent = Some("codex".to_owned());
     config.acp.allowed_agents = vec!["codex".to_owned(), "planner".to_owned()];
-    config.active_provider = Some("deepseek-lab".to_owned());
     config.providers.insert(
         "openai-main".to_owned(),
         mvp::config::ProviderProfileConfig {
@@ -131,8 +130,8 @@ fn write_runtime_snapshot_config(root: &Path) -> (PathBuf, mvp::config::LoongCla
             },
         },
     );
-    config.providers.insert(
-        "deepseek-lab".to_owned(),
+    config.set_active_provider_profile(
+        "deepseek-lab",
         mvp::config::ProviderProfileConfig {
             default_for_kind: true,
             provider: mvp::config::ProviderConfig {
@@ -208,8 +207,9 @@ fn array_object_with_string_field<'a>(
 fn runtime_snapshot_json_payload_includes_provider_tool_and_external_skill_inventory() {
     let root = unique_temp_dir("loongclaw-runtime-snapshot-json");
     let _env = RuntimeSnapshotEnvGuard::set(&[
-        ("RUNTIME_SNAPSHOT_DEEPSEEK_KEY", Some("demo-token")),
+        ("DEEPSEEK_API_KEY", None),
         ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+        ("OPENAI_API_KEY", None),
     ]);
     let (config_path, config) = write_runtime_snapshot_config(&root);
     install_demo_skill(&root, &config, &config_path);

--- a/crates/daemon/tests/integration/runtime_snapshot_cli.rs
+++ b/crates/daemon/tests/integration/runtime_snapshot_cli.rs
@@ -345,6 +345,27 @@ fn runtime_snapshot_json_payload_reflects_effective_external_skills_policy_overr
     .expect("collect runtime snapshot");
     let payload = build_runtime_snapshot_cli_json_payload(&snapshot);
 
+    assert!(!snapshot.tool_runtime.external_skills.enabled);
+    assert!(
+        snapshot
+            .tool_runtime
+            .external_skills
+            .require_download_approval
+    );
+    assert!(
+        snapshot
+            .tool_runtime
+            .external_skills
+            .allowed_domains
+            .contains("override.example")
+    );
+    assert!(
+        snapshot
+            .tool_runtime
+            .external_skills
+            .blocked_domains
+            .contains("blocked.example")
+    );
     assert_eq!(payload["external_skills"]["policy"]["enabled"], false);
     assert_eq!(
         payload["external_skills"]["policy"]["require_download_approval"],

--- a/crates/daemon/tests/integration/runtime_snapshot_cli.rs
+++ b/crates/daemon/tests/integration/runtime_snapshot_cli.rs
@@ -138,7 +138,7 @@ fn write_runtime_snapshot_config(root: &Path) -> (PathBuf, mvp::config::LoongCla
             provider: mvp::config::ProviderConfig {
                 kind: mvp::config::ProviderKind::Deepseek,
                 model: "deepseek-chat".to_owned(),
-                api_key: Some("${RUNTIME_SNAPSHOT_DEEPSEEK_KEY}".to_owned()),
+                api_key: Some("demo-token".to_owned()),
                 ..Default::default()
             },
         },

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -308,6 +308,7 @@ fn skills_policy_set_cli_parses_domain_and_approval_flags() {
 #[test]
 fn execute_skills_command_enable_browser_preview_persists_runtime_and_installs_helper_skill() {
     let root = unique_temp_dir("loongclaw-skills-cli-browser-preview");
+    let _env = SkillsCliEnvironmentGuard::set(&[]);
     let config_path = write_external_skills_config(&root, false);
 
     let enable = loongclaw_daemon::skills_cli::execute_skills_command(
@@ -373,6 +374,7 @@ fn execute_skills_command_enable_browser_preview_persists_runtime_and_installs_h
 #[test]
 fn execute_skills_command_enable_browser_preview_is_idempotent_after_first_install() {
     let root = unique_temp_dir("loongclaw-skills-cli-browser-preview-idempotent");
+    let _env = SkillsCliEnvironmentGuard::set(&[]);
     let config_path = write_external_skills_config(&root, false);
 
     loongclaw_daemon::skills_cli::execute_skills_command(
@@ -409,6 +411,7 @@ fn execute_skills_command_enable_browser_preview_is_idempotent_after_first_insta
 #[test]
 fn execute_skills_command_enable_browser_preview_rejects_explicit_shell_deny_without_mutation() {
     let root = unique_temp_dir("loongclaw-skills-cli-browser-preview-shell-deny");
+    let _env = SkillsCliEnvironmentGuard::set(&[]);
     let config_path = write_external_skills_config(&root, false);
     let config_string = config_path.display().to_string();
     let (resolved_path, mut config) =
@@ -477,6 +480,7 @@ fn execute_skills_command_enable_browser_preview_rejects_explicit_shell_deny_wit
 #[test]
 fn execute_skills_command_enable_browser_preview_rolls_back_config_on_install_failure() {
     let root = unique_temp_dir("loongclaw-skills-cli-browser-preview-install-failure");
+    let _env = SkillsCliEnvironmentGuard::set(&[]);
     let config_path = write_external_skills_config(&root, false);
     let config_string = config_path.display().to_string();
     fs::write(
@@ -877,6 +881,7 @@ fn execute_skills_command_list_prefers_nearest_project_ancestor_for_duplicate_sk
 #[test]
 fn execute_skills_command_installs_bundled_browser_companion_preview() {
     let root = unique_temp_dir("loongclaw-skills-cli-bundled-install");
+    let _env = SkillsCliEnvironmentGuard::set(&[]);
     let config_path = write_external_skills_config(&root, true);
 
     let install = loongclaw_daemon::skills_cli::execute_skills_command(


### PR DESCRIPTION
## Summary

- add a `loongclaw runtime-snapshot` CLI for capturing a unified runtime snapshot in text or JSON form
- aggregate provider, context engine, memory, ACP, channels, tool runtime, capability digest, and external-skills state into one reproducibility surface
- cover CLI parsing, inventory rendering, and effective external-skills policy override behavior with integration tests

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional validation details:

- `cargo test -p loongclaw-daemon runtime_snapshot --manifest-path Cargo.toml`
- the runtime snapshot now reflects the effective external-skills policy, including in-process override state, and disables inventory capture when the effective policy disables external skills
- the integration tests serialize env-sensitive behavior with the daemon test environment lock and reset the external-skills policy override in a drop guard

## Linked Issues

Closes #204


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Runtime Snapshot CLI command to view the current runtime configuration (providers, profiles, tools, memory, ACP, external skills).
  * Snapshot output available as JSON or human-readable text; includes inventories, credential resolution status, and capability digests.
* **CLI**
  * Command parses --config and --json flags.
* **Tests**
  * New integration tests covering snapshot output, inventories, policy overrides, and text rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->