### PR TITLE
Close the browser preview first-run loop with guided recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,16 +466,31 @@ as the built-in browser tools.
 
 ```bash
 loongclaw skills enable-browser-preview --config ~/.loongclaw/config.toml
-agent-browser --help
+npm install -g agent-browser && agent-browser install
 loongclaw doctor --config ~/.loongclaw/config.toml
+loongclaw ask --config ~/.loongclaw/config.toml --message 'Use the browser companion preview to open https://example.com, snapshot the page, and summarize what is visible.'
 ```
 
 It adds a first-party managed helper skill that can route richer multi-step page
 work through `agent-browser` when the runtime, shell policy, and local binary
-are all ready. It does not install or manage the `agent-browser` runtime for
-you; bring that binary yourself, then use `doctor` to confirm it is available
-on `PATH`. A healthy `doctor` run should report `agent-browser` as available and
-avoid browser preview follow-up errors.
+are all ready. `loongclaw skills enable-browser-preview` now turns on the needed
+LoongClaw config, installs the bundled helper skill, and prints concrete next
+steps plus ready-to-run recipes. LoongClaw still does not install or manage the
+`agent-browser` runtime for you, so the intended flow is:
+
+1. Enable the preview with `loongclaw skills enable-browser-preview`.
+2. Install the runtime with `npm install -g agent-browser && agent-browser install`.
+3. Verify the runtime with `agent-browser open example.com` or rerun `loongclaw doctor`.
+4. Try one of the generated recipes, such as:
+   - summarize a page
+   - extract page text
+   - follow a link and summarize the destination
+
+A healthy `doctor` run should then keep the browser preview in the suggested
+next actions instead of dropping the user into low-level runtime wording.
+If you have disabled the CLI surface with `cli.enabled=false`, LoongClaw will
+stop short of printing the ask-based browser preview recipes until you re-enable
+the CLI.
 
 ## Key Features
 

--- a/crates/daemon/src/browser_preview.rs
+++ b/crates/daemon/src/browser_preview.rs
@@ -6,7 +6,29 @@ pub(crate) const BROWSER_PREVIEW_SKILL_ID: &str = mvp::tools::BROWSER_COMPANION_
 pub(crate) const BROWSER_PREVIEW_ENABLE_LABEL: &str = "enable browser preview";
 pub(crate) const BROWSER_PREVIEW_UNBLOCK_LABEL: &str = "allow agent-browser";
 pub(crate) const BROWSER_PREVIEW_READY_LABEL: &str = "browser companion preview";
-const DEFAULT_BROWSER_PREVIEW_ASK_MESSAGE: &str = "Use external_skills.invoke to load browser-companion-preview, then use the browser companion preview to inspect https://example.com and summarize the result.";
+const BROWSER_PREVIEW_INSTALL_COMMAND: &str =
+    "npm install -g agent-browser && agent-browser install";
+const BROWSER_PREVIEW_VERIFY_COMMAND: &str = "agent-browser open example.com";
+const BROWSER_PREVIEW_RECIPES: &[(&str, &str)] = &[
+    (
+        "summarize a page",
+        "Use the browser companion preview to open https://example.com, snapshot the page, and summarize what is visible.",
+    ),
+    (
+        "extract page text",
+        "Use the browser companion preview to open https://example.com, extract the main page text, and return the key points.",
+    ),
+    (
+        "follow a link",
+        "Use the browser companion preview to open https://example.com, click the first relevant link, wait for navigation, and summarize the result.",
+    ),
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BrowserPreviewRecipeCommand {
+    pub(crate) label: String,
+    pub(crate) command: String,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BrowserPreviewState {
@@ -86,8 +108,46 @@ pub(crate) fn browser_preview_unblock_command(config_path: &str) -> String {
     )
 }
 
+pub(crate) fn browser_preview_install_command() -> &'static str {
+    BROWSER_PREVIEW_INSTALL_COMMAND
+}
+
+pub(crate) fn browser_preview_verify_command() -> &'static str {
+    BROWSER_PREVIEW_VERIFY_COMMAND
+}
+
+pub(crate) fn browser_preview_install_step() -> String {
+    format!(
+        "Install browser preview runtime: {}",
+        browser_preview_install_command()
+    )
+}
+
+pub(crate) fn browser_preview_verify_step() -> String {
+    format!(
+        "Verify browser preview runtime: {}",
+        browser_preview_verify_command()
+    )
+}
+
+pub(crate) fn browser_preview_recipe_commands(
+    config_path: &str,
+) -> Vec<BrowserPreviewRecipeCommand> {
+    BROWSER_PREVIEW_RECIPES
+        .iter()
+        .map(|(label, message)| BrowserPreviewRecipeCommand {
+            label: (*label).to_owned(),
+            command: browser_preview_ask_command(config_path, message),
+        })
+        .collect()
+}
+
 pub(crate) fn browser_preview_ready_command(config_path: &str) -> String {
-    crate::cli_handoff::format_ask_with_config(config_path, DEFAULT_BROWSER_PREVIEW_ASK_MESSAGE)
+    browser_preview_recipe_commands(config_path)
+        .into_iter()
+        .next()
+        .map(|recipe| recipe.command)
+        .unwrap_or_else(|| browser_preview_ask_command(config_path, "Use the browser companion preview to open https://example.com and summarize the result."))
 }
 
 pub(crate) fn ensure_browser_preview_config(config: &mut mvp::config::LoongClawConfig) -> bool {
@@ -255,6 +315,9 @@ fn command_candidates(command: &str) -> Vec<String> {
     }
 }
 
+fn browser_preview_ask_command(config_path: &str, message: &str) -> String {
+    crate::cli_handoff::format_ask_with_config(config_path, message)
+}
 #[cfg(unix)]
 fn command_candidate_is_available(path: &std::path::Path) -> bool {
     use std::os::unix::fs::PermissionsExt;

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1148,8 +1148,6 @@ fn build_doctor_next_steps_with_path_env(
     let config_path_display = config_path.display().to_string();
     let rerun_command =
         crate::cli_handoff::format_subcommand_with_config("doctor", &config_path_display);
-    let browser_preview =
-        crate::browser_preview::inspect_browser_preview_state_with_path_env(config, path_env);
 
     if !fix_requested
         && checks.iter().any(|check| {
@@ -1250,6 +1248,7 @@ fn build_doctor_next_steps_with_path_env(
     }
 
     if doctor_ready_for_first_turn(checks) {
+        let mut browser_preview_needs_runtime_verify = false;
         for action in select_doctor_first_turn_actions(
             crate::next_actions::collect_setup_next_actions_with_path_env(
                 config,
@@ -1270,7 +1269,7 @@ fn build_doctor_next_steps_with_path_env(
                             "Unblock browser preview"
                         }
                         Some(crate::next_actions::BrowserPreviewActionPhase::InstallRuntime) => {
-                            "Verify `agent-browser` is available"
+                            "Install browser preview runtime"
                         }
                         Some(crate::next_actions::BrowserPreviewActionPhase::Ready) | None => {
                             "Try browser companion preview"
@@ -1279,13 +1278,18 @@ fn build_doctor_next_steps_with_path_env(
                 }
                 crate::next_actions::SetupNextActionKind::Doctor => "Run diagnostics",
             };
+            if action.kind == crate::next_actions::SetupNextActionKind::BrowserPreview
+                && action.browser_preview_phase
+                    == Some(crate::next_actions::BrowserPreviewActionPhase::InstallRuntime)
+            {
+                browser_preview_needs_runtime_verify = true;
+            }
             push_unique_step(&mut steps, format!("{prefix}: {}", action.command));
         }
-        if !browser_preview.runtime_available {
+        if browser_preview_needs_runtime_verify {
             push_unique_step(
                 &mut steps,
-                "Install `agent-browser` and verify the CLI is available on PATH: agent-browser --help"
-                    .to_owned(),
+                crate::browser_preview::browser_preview_verify_step(),
             );
         }
     }
@@ -1328,6 +1332,7 @@ fn select_doctor_first_turn_actions(
                 Some(crate::next_actions::BrowserPreviewActionPhase::Ready)
                     | Some(crate::next_actions::BrowserPreviewActionPhase::Unblock)
                     | Some(crate::next_actions::BrowserPreviewActionPhase::Enable)
+                    | Some(crate::next_actions::BrowserPreviewActionPhase::InstallRuntime)
             )
     });
 
@@ -1395,7 +1400,6 @@ mod tests {
         ChannelStatusSnapshot,
     };
 
-    #[cfg(unix)]
     fn browser_companion_temp_dir(label: &str) -> PathBuf {
         static NEXT_TEMP_DIR_SEED: AtomicU64 = AtomicU64::new(1);
         let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
@@ -2173,11 +2177,12 @@ mod tests {
                 detail: "/tmp/loongclaw-memory is missing".to_owned(),
             },
         ];
-        let next_steps = build_doctor_next_steps(
+        let next_steps = build_doctor_next_steps_with_path_env(
             &checks,
             Path::new("/tmp/loongclaw.toml"),
             &mvp::config::LoongClawConfig::default(),
             false,
+            Some(std::ffi::OsStr::new("")),
         );
 
         assert_eq!(
@@ -2232,11 +2237,12 @@ mod tests {
             level: DoctorCheckLevel::Warn,
             detail: "command `loongclaw-browser-companion` was not found on PATH".to_owned(),
         }];
-        let next_steps = build_doctor_next_steps(
+        let next_steps = build_doctor_next_steps_with_path_env(
             &checks,
             Path::new("/tmp/loongclaw.toml"),
             &mvp::config::LoongClawConfig::default(),
             false,
+            Some(std::ffi::OsStr::new("")),
         );
 
         assert!(
@@ -2375,11 +2381,12 @@ mod tests {
                 detail: "responses api".to_owned(),
             },
         ];
-        let next_steps = build_doctor_next_steps(
+        let next_steps = build_doctor_next_steps_with_path_env(
             &checks,
             Path::new("/tmp/loongclaw.toml"),
             &mvp::config::LoongClawConfig::default(),
             false,
+            Some(std::ffi::OsStr::new("")),
         );
 
         assert!(
@@ -2400,16 +2407,44 @@ mod tests {
             }),
             "green doctor runs should surface the optional browser preview with a single concrete command: {next_steps:#?}"
         );
+        assert!(
+            !next_steps.iter().any(|step| {
+                step == "Install browser preview runtime: npm install -g agent-browser && agent-browser install"
+            }),
+            "green doctor runs should not push runtime install steps before preview has been enabled: {next_steps:#?}"
+        );
+        assert!(
+            !next_steps.iter().any(
+                |step| step == "Verify browser preview runtime: agent-browser open example.com"
+            ),
+            "green doctor runs should not ask for runtime verification before preview has been enabled: {next_steps:#?}"
+        );
     }
 
     #[test]
     fn build_doctor_next_steps_guides_browser_companion_preview_setup() {
+        let root = browser_companion_temp_dir("preview-runtime-missing");
+        let install_root = root.join("managed-skills");
+        std::fs::create_dir_all(install_root.join("browser-companion-preview"))
+            .expect("create managed skill directory");
+        std::fs::write(
+            install_root
+                .join("browser-companion-preview")
+                .join("SKILL.md"),
+            "# Browser Companion Preview\n\nUse agent-browser through shell.exec.\n",
+        )
+        .expect("write managed preview skill");
         let checks = vec![DoctorCheck {
             name: "provider credentials".to_owned(),
             level: DoctorCheckLevel::Pass,
             detail: "provider credentials are available".to_owned(),
         }];
-        let config = mvp::config::LoongClawConfig::default();
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.file_root = Some(root.display().to_string());
+        config.tools.shell_allow.push("agent-browser".to_owned());
+        config.external_skills.enabled = true;
+        config.external_skills.auto_expose_installed = true;
+        config.external_skills.install_root = Some(install_root.display().to_string());
 
         let next_steps = build_doctor_next_steps_with_path_env(
             &checks,
@@ -2421,16 +2456,24 @@ mod tests {
 
         assert!(
             next_steps.iter().any(|step| {
-                step == "Optional browser preview: loongclaw skills enable-browser-preview --config '/tmp/loongclaw.toml'"
+                step == "Install browser preview runtime: npm install -g agent-browser && agent-browser install"
             }),
-            "doctor should collapse preview setup into one operator-facing enable step by default: {next_steps:#?}"
+            "doctor should point preview-enabled operators at a concrete runtime install action when agent-browser is missing: {next_steps:#?}"
         );
         assert!(
             next_steps.iter().any(|step| {
-                step == "Install `agent-browser` and verify the CLI is available on PATH: agent-browser --help"
+                step == "Verify browser preview runtime: agent-browser open example.com"
             }),
-            "doctor should still point to the missing agent-browser runtime dependency: {next_steps:#?}"
+            "doctor should still surface a verification step after the runtime install hint: {next_steps:#?}"
         );
+        assert!(
+            !next_steps.iter().any(|step| {
+                step == "Optional browser preview: loongclaw skills enable-browser-preview --config '/tmp/loongclaw.toml'"
+            }),
+            "doctor should not fall back to the optional enable step after preview has already been configured: {next_steps:#?}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/crates/daemon/src/next_actions.rs
+++ b/crates/daemon/src/next_actions.rs
@@ -98,8 +98,8 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
             Some(SetupNextAction {
                 kind: SetupNextActionKind::BrowserPreview,
                 browser_preview_phase: Some(BrowserPreviewActionPhase::InstallRuntime),
-                label: format!("{} check", mvp::tools::BROWSER_COMPANION_COMMAND),
-                command: format!("{} --help", mvp::tools::BROWSER_COMPANION_COMMAND),
+                label: format!("install {}", mvp::tools::BROWSER_COMPANION_COMMAND),
+                command: crate::browser_preview::browser_preview_install_command().to_owned(),
             })
         } else {
             None
@@ -210,8 +210,8 @@ mod tests {
         assert!(
             actions[2]
                 .command
-                .contains("Use external_skills.invoke to load browser-companion-preview"),
-            "ready preview action should hand users into a truthful one-shot ask flow: {actions:#?}"
+                .contains("Use the browser companion preview to open https://example.com"),
+            "ready preview action should hand users into a task-shaped first browser recipe: {actions:#?}"
         );
 
         fs::remove_dir_all(&root).ok();
@@ -319,11 +319,15 @@ mod tests {
         );
         assert_eq!(
             actions[2].label,
-            format!("{} check", mvp::tools::BROWSER_COMPANION_COMMAND)
+            format!("install {}", mvp::tools::BROWSER_COMPANION_COMMAND)
         );
         assert_eq!(
             actions[2].command,
-            format!("{} --help", mvp::tools::BROWSER_COMPANION_COMMAND)
+            format!(
+                "npm install -g {} && {} install",
+                mvp::tools::BROWSER_COMPANION_COMMAND,
+                mvp::tools::BROWSER_COMPANION_COMMAND
+            )
         );
 
         fs::remove_dir_all(&root).ok();

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -382,6 +382,37 @@ fn execute_enable_browser_preview_command(
         }
     };
     *config = updated_config;
+    let resolved_config_path = resolved_path.display().to_string();
+    let runtime_available =
+        crate::browser_preview::inspect_browser_preview_state(config).runtime_available;
+    let cli_enabled = config.cli.enabled;
+    let recipes = if cli_enabled {
+        crate::browser_preview::browser_preview_recipe_commands(&resolved_config_path)
+    } else {
+        Vec::new()
+    };
+    let doctor_command =
+        crate::cli_handoff::format_subcommand_with_config("doctor", &resolved_config_path);
+    let mut next_steps = if runtime_available {
+        let mut steps = Vec::new();
+        if cli_enabled && let Some(first_recipe) = recipes.first() {
+            steps.push(format!(
+                "Try browser companion preview: {}",
+                first_recipe.command
+            ));
+        }
+        steps.push(format!("Run diagnostics: {doctor_command}"));
+        steps
+    } else {
+        vec![
+            crate::browser_preview::browser_preview_install_step(),
+            crate::browser_preview::browser_preview_verify_step(),
+            format!("Run diagnostics: {doctor_command}"),
+        ]
+    };
+    if !cli_enabled {
+        next_steps.push("Re-enable `cli.enabled` before running the preview recipes.".to_owned());
+    }
 
     if let Some(payload) = outcome.payload.as_object_mut() {
         payload.insert(
@@ -392,7 +423,21 @@ fn execute_enable_browser_preview_command(
         payload.insert("browser_preview_enabled".to_owned(), json!(true));
         payload.insert(
             "runtime_binary_available".to_owned(),
-            json!(crate::browser_preview::inspect_browser_preview_state(config).runtime_available),
+            json!(runtime_available),
+        );
+        payload.insert("cli_enabled".to_owned(), json!(cli_enabled));
+        payload.insert("next_steps".to_owned(), json!(next_steps));
+        payload.insert(
+            "recipes".to_owned(),
+            json!(
+                recipes
+                    .into_iter()
+                    .map(|recipe| json!({
+                        "label": recipe.label,
+                        "command": recipe.command,
+                    }))
+                    .collect::<Vec<_>>()
+            ),
         );
     }
 
@@ -569,6 +614,7 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                     .unwrap_or(false)
             ));
             if tool_name == "skills.enable-browser-preview" {
+                lines.push("browser preview enabled via bundled helper skill".to_owned());
                 lines.push(format!(
                     "config_updated={}",
                     payload
@@ -583,6 +629,13 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                         .and_then(Value::as_bool)
                         .unwrap_or(false)
                 ));
+                render_string_section(
+                    &mut lines,
+                    "next steps:",
+                    payload.get("next_steps"),
+                    "skills enable-browser-preview payload missing `next_steps` array",
+                )?;
+                render_recipe_section(&mut lines, payload.get("recipes"))?;
             }
         }
         "external_skills.remove" => {
@@ -682,6 +735,52 @@ fn render_string_list(value: Option<&Value>) -> String {
             }
         })
         .unwrap_or_else(|| "-".to_owned())
+}
+
+fn render_string_section(
+    lines: &mut Vec<String>,
+    heading: &str,
+    value: Option<&Value>,
+    missing_error: &str,
+) -> CliResult<()> {
+    let items = value
+        .and_then(Value::as_array)
+        .ok_or_else(|| missing_error.to_owned())?;
+    if items.is_empty() {
+        return Ok(());
+    }
+
+    lines.push(heading.to_owned());
+    for item in items {
+        let rendered = item
+            .as_str()
+            .ok_or_else(|| format!("{missing_error}: entries must be strings"))?;
+        lines.push(format!("- {rendered}"));
+    }
+    Ok(())
+}
+
+fn render_recipe_section(lines: &mut Vec<String>, value: Option<&Value>) -> CliResult<()> {
+    let recipes = value.and_then(Value::as_array).ok_or_else(|| {
+        "skills enable-browser-preview payload missing `recipes` array".to_owned()
+    })?;
+    if recipes.is_empty() {
+        return Ok(());
+    }
+
+    lines.push("recipes:".to_owned());
+    for recipe in recipes {
+        let label = recipe
+            .get("label")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "browser preview recipe is missing `label`".to_owned())?;
+        let command = recipe
+            .get("command")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "browser preview recipe is missing `command`".to_owned())?;
+        lines.push(format!("- {label}: {command}"));
+    }
+    Ok(())
 }
 
 fn render_skill_summary_line(skill: &Value) -> String {

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -30,16 +30,25 @@ fn write_file(root: &Path, relative: &str, content: &str) {
     fs::write(path, content).expect("write fixture");
 }
 
-fn write_external_skills_config(root: &Path, enabled: bool) -> PathBuf {
+fn write_external_skills_config_with_cli(root: &Path, enabled: bool, cli_enabled: bool) -> PathBuf {
     fs::create_dir_all(root).expect("create fixture root");
     let config_path = root.join("loongclaw.toml");
     let mut config = mvp::config::LoongClawConfig::default();
+    config.cli.enabled = cli_enabled;
     config.tools.file_root = Some(root.display().to_string());
     config.external_skills.enabled = enabled;
     config.external_skills.install_root = Some(root.join("managed-skills").display().to_string());
     mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
         .expect("write config fixture");
     config_path
+}
+
+fn write_external_skills_config(root: &Path, enabled: bool) -> PathBuf {
+    write_external_skills_config_with_cli(root, enabled, true)
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
 struct SkillsCliEnvironmentGuard {
@@ -330,6 +339,14 @@ fn execute_skills_command_enable_browser_preview_persists_runtime_and_installs_h
         enable.outcome.payload["display_name"],
         "Browser Companion Preview"
     );
+    assert!(
+        enable.outcome.payload["next_steps"].is_array(),
+        "enable browser preview should surface follow-up steps in the payload"
+    );
+    assert!(
+        enable.outcome.payload["recipes"].is_array(),
+        "enable browser preview should surface ready-to-run recipe commands in the payload"
+    );
 
     let reloaded = mvp::config::load(Some(config_path.to_string_lossy().as_ref()))
         .expect("reload config")
@@ -366,6 +383,110 @@ fn execute_skills_command_enable_browser_preview_persists_runtime_and_installs_h
             .iter()
             .any(|skill| skill["skill_id"] == "browser-companion-preview"),
         "browser preview helper skill should be installed into the managed skills runtime"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn execute_skills_command_enable_browser_preview_quotes_follow_up_config_path() {
+    let root = unique_temp_dir("loongclaw's-skills-cli-browser-preview");
+    let _env = SkillsCliEnvironmentGuard::set(&[]);
+    let config_path = write_external_skills_config(&root, false);
+
+    let enable = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                replace: false,
+            },
+        },
+    )
+    .expect("enable browser preview should succeed");
+
+    let next_steps = enable.outcome.payload["next_steps"]
+        .as_array()
+        .expect("enable browser preview should return next_steps");
+    let expected = format!(
+        "Run diagnostics: loongclaw doctor --config {}",
+        shell_quote(&config_path.display().to_string())
+    );
+    assert!(
+        next_steps
+            .iter()
+            .any(|step| step.as_str() == Some(expected.as_str())),
+        "follow-up steps should shell-quote config paths: {next_steps:#?}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn execute_skills_command_enable_browser_preview_hides_recipes_when_cli_is_disabled() {
+    let root = unique_temp_dir("loongclaw-skills-cli-browser-preview-cli-disabled");
+    let _env = SkillsCliEnvironmentGuard::set(&[("PATH", Some(""))]);
+    let config_path = write_external_skills_config_with_cli(&root, false, false);
+
+    let enable = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                replace: false,
+            },
+        },
+    )
+    .expect("enable browser preview should succeed even when cli is disabled");
+
+    assert_eq!(enable.outcome.payload["cli_enabled"], false);
+    let next_steps = enable.outcome.payload["next_steps"]
+        .as_array()
+        .expect("enable browser preview should return next_steps");
+    let expected_doctor_step = format!(
+        "Run diagnostics: loongclaw doctor --config {}",
+        shell_quote(&config_path.display().to_string())
+    );
+    assert!(
+        next_steps.iter().any(|step| {
+            step.as_str()
+                == Some(
+                    "Install browser preview runtime: npm install -g agent-browser && agent-browser install",
+                )
+        }),
+        "cli-disabled configs should still surface the runtime install step: {next_steps:#?}"
+    );
+    assert!(
+        next_steps.iter().any(|step| {
+            step.as_str() == Some("Verify browser preview runtime: agent-browser open example.com")
+        }),
+        "cli-disabled configs should still surface the runtime verification step: {next_steps:#?}"
+    );
+    assert!(
+        next_steps
+            .iter()
+            .any(|step| step.as_str() == Some(expected_doctor_step.as_str())),
+        "cli-disabled configs should keep the doctor follow-up step: {next_steps:#?}"
+    );
+    assert!(
+        next_steps.iter().any(|step| {
+            step.as_str() == Some("Re-enable `cli.enabled` before running the preview recipes.")
+        }),
+        "cli-disabled configs should explicitly explain why preview recipes are withheld: {next_steps:#?}"
+    );
+    assert!(
+        !next_steps.iter().any(|step| {
+            step.as_str()
+                .is_some_and(|step| step.contains("Try browser companion preview: loongclaw ask"))
+        }),
+        "cli-disabled configs should not advertise ask-based preview follow-up: {next_steps:#?}"
+    );
+    let recipes = enable.outcome.payload["recipes"]
+        .as_array()
+        .expect("enable browser preview should return recipes");
+    assert!(
+        recipes.is_empty(),
+        "cli-disabled configs should not expose ready-to-run ask recipes: {recipes:#?}"
     );
 
     fs::remove_dir_all(&root).ok();
@@ -1257,6 +1378,99 @@ fn render_skills_cli_text_surfaces_operator_install_summary() {
     assert!(rendered.contains("installed skill_id=demo-skill"));
     assert!(rendered.contains("display_name=Demo Skill"));
     assert!(rendered.contains("replaced=true"));
+}
+
+#[test]
+fn render_skills_cli_text_surfaces_browser_preview_guidance() {
+    let config_path = "/tmp/loongclaw's config.toml";
+    let rendered = loongclaw_daemon::skills_cli::render_skills_cli_text(
+        &loongclaw_daemon::skills_cli::SkillsCommandExecution {
+            resolved_config_path: config_path.to_owned(),
+            outcome: kernel::ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: serde_json::json!({
+                    "tool_name": "skills.enable-browser-preview",
+                    "skill_id": "browser-companion-preview",
+                    "display_name": "Browser Companion Preview",
+                    "source_path": "bundled://browser-companion-preview",
+                    "install_path": "/tmp/managed/browser-companion-preview",
+                    "replaced": false,
+                    "config_updated": true,
+                    "runtime_binary_available": false,
+                    "next_steps": [
+                        "Install browser preview runtime: npm install -g agent-browser && agent-browser install",
+                        "Verify browser preview runtime: agent-browser open example.com",
+                        "Run diagnostics: loongclaw doctor --config '/tmp/loongclaw'\"'\"'s config.toml'"
+                    ],
+                    "recipes": [
+                        {
+                            "label": "summarize a page",
+                            "command": "loongclaw ask --config '/tmp/loongclaw'\"'\"'s config.toml' --message 'Use the browser companion preview to open https://example.com, snapshot the page, and summarize what is visible.'"
+                        },
+                        {
+                            "label": "extract page text",
+                            "command": "loongclaw ask --config '/tmp/loongclaw'\"'\"'s config.toml' --message 'Use the browser companion preview to open https://example.com, extract the main page text, and return the key points.'"
+                        }
+                    ]
+                }),
+            },
+        },
+    )
+    .expect("browser preview payload should render");
+
+    assert!(rendered.contains("config=/tmp/loongclaw's config.toml"));
+    assert!(rendered.contains("runtime_binary_available=false"));
+    assert!(rendered.contains("next steps:"));
+    assert!(rendered.contains(
+        "Install browser preview runtime: npm install -g agent-browser && agent-browser install"
+    ));
+    assert!(rendered.contains(
+        "Run diagnostics: loongclaw doctor --config '/tmp/loongclaw'\"'\"'s config.toml'"
+    ));
+    assert!(rendered.contains("recipes:"));
+    assert!(rendered.contains("- summarize a page: loongclaw ask --config '/tmp/loongclaw'\"'\"'s config.toml' --message 'Use the browser companion preview to open https://example.com, snapshot the page, and summarize what is visible.'"));
+}
+
+#[test]
+fn render_skills_cli_text_hides_browser_preview_recipes_when_cli_is_disabled() {
+    let rendered = loongclaw_daemon::skills_cli::render_skills_cli_text(
+        &loongclaw_daemon::skills_cli::SkillsCommandExecution {
+            resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+            outcome: kernel::ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: serde_json::json!({
+                    "tool_name": "skills.enable-browser-preview",
+                    "skill_id": "browser-companion-preview",
+                    "display_name": "Browser Companion Preview",
+                    "source_path": "bundled://browser-companion-preview",
+                    "install_path": "/tmp/managed/browser-companion-preview",
+                    "replaced": false,
+                    "config_updated": true,
+                    "runtime_binary_available": false,
+                    "cli_enabled": false,
+                    "next_steps": [
+                        "Install browser preview runtime: npm install -g agent-browser && agent-browser install",
+                        "Verify browser preview runtime: agent-browser open example.com",
+                        "Run diagnostics: loongclaw doctor --config '/tmp/loongclaw.toml'",
+                        "Re-enable `cli.enabled` before running the preview recipes."
+                    ],
+                    "recipes": []
+                }),
+            },
+        },
+    )
+    .expect("browser preview payload should render");
+
+    assert!(rendered.contains("next steps:"));
+    assert!(rendered.contains("Re-enable `cli.enabled` before running the preview recipes."));
+    assert!(
+        !rendered.contains("recipes:"),
+        "cli-disabled payloads should not render an empty recipes section: {rendered}"
+    );
+    assert!(
+        !rendered.contains("Try browser companion preview:"),
+        "cli-disabled payloads should not advertise ask-based preview follow-up: {rendered}"
+    );
 }
 
 #[test]

--- a/docs/plans/2026-03-16-browser-preview-first-run-loop-design.md
+++ b/docs/plans/2026-03-16-browser-preview-first-run-loop-design.md
@@ -1,0 +1,203 @@
+# Browser Preview First-Run Loop Design
+
+## Goal
+
+Close the user-facing browser preview loop so LoongClaw can truthfully guide a
+normal operator from "optional browser preview exists" to "I enabled it, I know
+what is missing, and I have a concrete first task to try" without expanding
+into a heavyweight browser runtime project.
+
+## Current State
+
+- LoongClaw already has a safe built-in browser lane through `browser.open`,
+  `browser.extract`, and `browser.click`.
+- LoongClaw also ships an optional `browser-companion-preview` bundled skill
+  plus `loongclaw skills enable-browser-preview`.
+- `onboard` and `doctor` already reuse `crates/daemon/src/next_actions.rs` to
+  surface first-run next actions.
+- The current browser preview guidance is still too operator-internal:
+  - ready state hands users a prompt built around `external_skills.invoke`
+    instead of a user task
+  - missing runtime guidance falls back to `agent-browser --help`
+  - `skills enable-browser-preview` text output is mostly key/value status
+  - users are not handed 2 to 3 concrete recipes after enabling the preview
+- PR #197 is already using the same first-run surfaces for build metadata and
+  compact headers, so this slice must avoid overlapping that work.
+
+## Problem
+
+The browser preview already exists structurally, but not yet as a polished MVP
+experience:
+
+1. enabling it is one command, but understanding what to do next still requires
+   reading README or the bundled skill
+2. doctor can tell users the preview is missing `agent-browser`, but it does
+   not yet tell them a concrete install action
+3. the first runnable browser-preview example still reads like internal runtime
+   mechanics instead of a user-visible task
+4. first-run surfaces therefore still feel more like tooling than assistant
+   value
+
+## Constraints
+
+- Do not turn this slice into a new managed browser runtime project.
+- Do not overlap the open `#195` / PR `#197` header and build-metadata work.
+- Keep the source of truth shared across `onboard`, `doctor`, and
+  `skills enable-browser-preview`, instead of hand-writing separate copy in each
+  command.
+- Stay truthful about the current preview architecture: this is still the
+  `agent-browser` companion path on top of `shell.exec`, not a new native core
+  browser API.
+
+## Options
+
+### Option A: Docs and copy only
+
+Update README and specs, but leave CLI behavior mostly unchanged.
+
+Pros:
+
+- very low implementation cost
+- no behavior risk
+
+Cons:
+
+- the real first-run path remains broken inside the product
+- users still have to infer install steps and recipes themselves
+
+### Option B: Shared browser-preview guidance layer across CLI surfaces
+
+Keep the current runtime shape, but add one shared guidance model that powers:
+
+- `skills enable-browser-preview` text output
+- `doctor` next steps
+- ready-state browser preview first-task prompts
+- product docs/spec examples
+
+Pros:
+
+- directly improves user-visible value without new runtime architecture
+- keeps `onboard`, `doctor`, and skills CLI in sync through shared logic
+- fits the current MVP need: enable, diagnose, try
+
+Cons:
+
+- still depends on the external `agent-browser` runtime
+- requires some careful wording so preview truthfulness is preserved
+
+### Option C: Auto-install or fully manage the browser runtime now
+
+Make LoongClaw responsible for installing and maintaining `agent-browser`.
+
+Pros:
+
+- strongest product feel
+- least operator setup after the fact
+
+Cons:
+
+- expands scope into external runtime lifecycle management
+- increases platform, packaging, and support complexity immediately
+- no longer a narrow MVP polish slice
+
+## Decision
+
+Choose Option B.
+
+This slice should productize the existing preview path rather than replace it:
+
+- `enable-browser-preview` remains the one-command activation path
+- doctor should name the missing runtime and give the operator an exact install
+  plus verify sequence
+- ready browser preview states should hand users task-shaped recipes, not
+  internal implementation jargon
+- the same recipe and install guidance should be reusable across CLI surfaces
+
+## Design
+
+### 1. Shared browser preview install guidance
+
+Add a small shared set of browser preview install and verification steps in
+`crates/daemon/src/browser_preview.rs`.
+
+This module should provide:
+
+- one recommended install command for `agent-browser`
+- one verification command
+- optional supporting copy for README/spec text
+
+The install command should be concrete and cross-platform enough for CLI copy.
+The current best fit is the upstream npm path plus the runtime's own install
+step, followed by `agent-browser --help`.
+
+### 2. Shared browser preview recipes
+
+Add 2 to 3 browser-preview first-task recipes as shared data, not ad-hoc copy.
+
+Recommended recipes:
+
+1. open a page and summarize what is visible
+2. extract the main page text and key points
+3. click a discovered link, wait for navigation, and summarize the result
+
+Each recipe should compile down to a `loongclaw ask --config ... --message "..."`
+command so users can run it immediately.
+
+### 3. Upgrade ready-state guidance
+
+Replace the current ready-state browser preview prompt with the first shared
+recipe. The message should still be truthful about using the preview skill, but
+it should read like a user task rather than "load `external_skills.invoke`".
+
+### 4. Improve missing-runtime guidance
+
+When the preview is enabled but `agent-browser` is missing, the CLI should show:
+
+- install command
+- verify command
+- the normal `doctor` follow-up path
+
+This should replace the current bare `agent-browser --help` action.
+
+### 5. Productize `skills enable-browser-preview`
+
+Keep JSON payload stability, but make text mode feel like a product command:
+
+- show whether config was updated
+- show whether the runtime is already available
+- show the next steps
+- if the runtime is available, show 2 to 3 recipe commands immediately
+- if the runtime is missing, show install plus verify, then the same recipes as
+  "after install, try"
+
+### 6. Keep onboarding and doctor aligned
+
+`onboard` and `doctor` should continue to consume `next_actions`, but the
+browser-preview actions they see should now be better:
+
+- enable action stays the same
+- unblock action stays the same
+- install-runtime action becomes a real install step
+- ready action becomes a concrete first task
+
+This keeps the surfaces aligned without duplicating UX logic.
+
+## Non-Goals
+
+- auto-downloading or auto-updating the `agent-browser` runtime
+- replacing the built-in browser tools
+- adding new browser automation core APIs
+- bundling Chromium or Playwright into the main LoongClaw install
+- redesigning the full `ask` or `chat` rendering stack outside this browser
+  preview touchpoint
+
+## Acceptance Criteria
+
+- `skills enable-browser-preview` text output gives actionable next steps and
+  browser task recipes.
+- `doctor` next steps give a concrete `agent-browser` install action instead of
+  only `agent-browser --help`.
+- The browser preview ready-state action handed to `onboard` / `doctor` is a
+  task-shaped recipe rather than an implementation-shaped prompt.
+- Relevant product specs and README/browser preview docs match the shipped
+  behavior.

--- a/docs/plans/2026-03-16-browser-preview-first-run-loop-implementation.md
+++ b/docs/plans/2026-03-16-browser-preview-first-run-loop-implementation.md
@@ -1,0 +1,163 @@
+# Browser Preview First-Run Loop Implementation Plan
+
+> **Required execution note:** follow this plan task-by-task using the available execution tooling.
+
+**Goal:** Productize the existing browser preview path so users can enable it, diagnose missing runtime state, and try concrete first recipes directly from LoongClaw CLI surfaces.
+
+**Architecture:** Extend the shared browser-preview guidance in `crates/daemon/src/browser_preview.rs`, route `next_actions` and `doctor` through that richer guidance, and upgrade `skills enable-browser-preview` text mode to surface install steps and recipes without changing the underlying preview runtime model.
+
+**Tech Stack:** Rust, existing daemon CLI integration tests, Markdown docs/specs.
+
+---
+
+## Task 1: Lock the slice with failing tests
+
+**Files:**
+- Modify: `crates/daemon/src/next_actions.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/tests/integration/onboard_cli.rs`
+- Modify: `crates/daemon/tests/integration/skills_cli.rs`
+
+**Step 1: Write failing next-action tests**
+
+- Add or tighten assertions so:
+  - browser preview ready state expects a task-shaped recipe command
+  - browser preview install-runtime state expects a real install action, not
+    `agent-browser open example.com`
+
+**Step 2: Write failing doctor guidance tests**
+
+- Add assertions that doctor next steps include:
+  - an exact `agent-browser` install command
+  - a verify command
+  - the browser preview action still visible beside ask/chat when relevant
+
+**Step 3: Write failing skills CLI text test**
+
+- Add a text-rendering regression test for `skills.enable-browser-preview`
+  output that expects:
+  - config/runtime summary
+  - next-step install or verify guidance
+  - 2 to 3 recipe commands
+
+**Step 4: Run failing tests**
+
+Run:
+- `cargo test -p loongclaw-daemon next_actions -- --nocapture`
+- `cargo test -p loongclaw-daemon doctor -- --nocapture`
+- `cargo test -p loongclaw-daemon skills_cli -- --nocapture`
+
+Expected: FAIL because the current guidance is still too technical.
+
+## Task 2: Implement shared browser preview guidance
+
+**Files:**
+- Modify: `crates/daemon/src/browser_preview.rs`
+- Modify: `crates/daemon/src/next_actions.rs`
+
+**Step 1: Add shared install and verify commands**
+
+- Introduce shared helpers for:
+  - recommended `agent-browser` install command
+  - verify command
+
+**Step 2: Add shared recipes**
+
+- Add 2 to 3 browser preview recipe definitions and a helper that formats them
+  into `loongclaw ask --config ... --message "..."` commands.
+
+**Step 3: Update next-actions behavior**
+
+- Ready state returns the first shared recipe command.
+- Install-runtime state returns the shared install action and a clearer label.
+
+**Step 4: Run targeted tests**
+
+Run:
+- `cargo test -p loongclaw-daemon next_actions -- --nocapture`
+
+Expected: PASS
+
+## Task 3: Upgrade doctor and skills CLI surfaces
+
+**Files:**
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/src/skills_cli.rs`
+- Modify: `crates/daemon/tests/integration/skills_cli.rs`
+
+**Step 1: Improve doctor next steps**
+
+- Replace the raw missing-runtime message with:
+  - install command
+  - verify command
+- Keep ask/chat/browser ordering stable.
+
+**Step 2: Improve `skills enable-browser-preview` text mode**
+
+- Keep JSON behavior compatible.
+- Add product-style text output showing:
+  - preview enabled summary
+  - runtime readiness
+  - next actions
+  - 2 to 3 recipe commands
+
+**Step 3: Run targeted tests**
+
+Run:
+- `cargo test -p loongclaw-daemon doctor -- --nocapture`
+- `cargo test -p loongclaw-daemon skills_cli -- --nocapture`
+
+Expected: PASS
+
+## Task 4: Sync docs and specs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/product-specs/onboarding.md`
+- Modify: `docs/product-specs/doctor.md`
+- Modify: `docs/product-specs/browser-automation-companion.md`
+
+**Step 1: Update browser preview README copy**
+
+- Document the one-command enable path, the runtime install truth, and the new
+  recipes.
+
+**Step 2: Update product specs**
+
+- Mark shipped acceptance items that now match behavior.
+- Add any precise wording needed for runtime install hints and first-task
+  recipes.
+
+**Step 3: Re-run doc spot checks**
+
+Run:
+- `rg -n "enable-browser-preview|agent-browser|browser companion preview|ask --config" README.md docs/product-specs`
+
+Expected: updated wording is consistent.
+
+## Task 5: Verify, publish, and clean up
+
+**Files:**
+- Modify: one GitHub issue and one PR body
+
+**Step 1: Full local verification**
+
+Run:
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --locked`
+- `cargo test --workspace --all-features --locked`
+
+Expected: PASS
+
+**Step 2: GitHub delivery**
+
+- Reuse an existing issue if a narrow one already matches; otherwise open a new
+  issue linked back to umbrella `#168`.
+- Commit only this browser-preview first-run loop slice.
+- Push to the operator fork.
+- Open a PR against `alpha-test` with an explicit closing clause.
+
+**Step 3: Workspace cleanup**
+
+- Remove branch-local `target/` before reporting completion.

--- a/docs/product-specs/browser-automation-companion.md
+++ b/docs/product-specs/browser-automation-companion.md
@@ -31,6 +31,15 @@ runtime into a heavyweight browser platform.
 The currently shipped preview scope is narrower than the final managed browser
 automation companion:
 
+- a first-party bundled `browser-companion-preview` managed skill
+- `loongclaw skills enable-browser-preview` as the operator-facing fast path
+- `loongclaw skills enable-browser-preview` now returns concrete install,
+  verify, and first-task recipe guidance instead of only install metadata
+- when `cli.enabled=false`, the preview enable flow withholds ask-based recipes
+  and tells the operator to re-enable the CLI before running them
+- `onboard` and `doctor` next actions that surface the preview truthfully,
+  including enable, install, verify, or first-recipe handoffs depending on
+  readiness
 - continued default shipping of only `browser.open`, `browser.extract`, and
   `browser.click` as built-in browser tools
 - a partial governed adapter skeleton behind companion runtime readiness:
@@ -43,8 +52,8 @@ automation companion:
     session-scoped companion state instead of raw shell text passthrough
   - bounded companion command execution so hung adapter processes fail closed
     instead of wedging the turn
-- a first-party bundled `browser-companion-preview` managed skill as guidance
-  on top of the runtime surface
+- the bundled `browser-companion-preview` managed skill acts as guidance on top
+  of the runtime surface, not as the source of truth for runtime availability
 
 The install/release lifecycle, `onboard` and `doctor` readiness integration,
 isolated browser profile management, stronger approval evidence UX, and broader

--- a/docs/product-specs/doctor.md
+++ b/docs/product-specs/doctor.md
@@ -15,14 +15,16 @@ can recover a broken setup without reverse-engineering runtime internals.
       automation and support tooling, including machine-readable `next_steps`
       when doctor can recommend a concrete repair or first-value command.
 - [ ] Text-mode doctor output ends with concrete next actions such as
-      credential env hints, `doctor --fix`, and first-turn ask/chat commands.
+      credential env hints, `doctor --fix`, first-turn ask/chat commands, and
+      optional browser preview enable or runtime setup commands when relevant.
 - [ ] On a healthy setup, the first-turn recommendations read like the next user
       action, not just a status report, for example "Get a first answer" and
       "Continue in chat".
 - [ ] When `onboard`, `ask`, `chat`, or channel setup hits a common health
       failure, the CLI points users toward `doctor`.
 - [ ] Doctor checks cover the current MVP path: config presence, provider
-      readiness, SQLite memory readiness, and shipped channel prerequisites.
+      readiness, SQLite memory readiness, shipped channel prerequisites, and
+      the optional browser preview companion readiness path.
 - [ ] When `tools.browser_companion.enabled=true`, doctor surfaces companion
       install/runtime readiness as warnings with concrete repair steps instead
       of turning the optional managed lane into a hard core-runtime failure.

--- a/docs/product-specs/onboarding.md
+++ b/docs/product-specs/onboarding.md
@@ -17,6 +17,9 @@ next.
       saved provider, prompt, memory, and channel inventory.
 - [ ] The primary post-onboard handoff prefers a one-shot `ask` example before
       interactive `chat`, so first success does not require learning the REPL.
+- [ ] The shared post-onboard next-step model can also surface optional browser
+      preview enable, runtime install, or first-recipe guidance when that lane
+      is available for the current config.
 - [ ] Rerunning onboarding does not silently overwrite an existing config unless
       the user explicitly opts into a destructive path such as `--force`.
 - [ ] Onboarding uses the same provider, memory, and channel configuration


### PR DESCRIPTION
## Summary

- add one shared browser preview guidance source for install, verify, and first-task recipes
- route that guidance into `next_actions`, `doctor`, and `skills enable-browser-preview`
- update README and product specs so the shipped browser preview flow matches the CLI behavior

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features --locked`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional targeted checks:
- `cargo test -p loongclaw-daemon collect_setup_next_actions_ -- --nocapture`
- `cargo test -p loongclaw-daemon build_doctor_next_steps_guides_browser_companion_preview_setup -- --nocapture`
- `cargo test -p loongclaw-daemon execute_skills_command_enable_browser_preview_persists_runtime_and_installs_helper_skill -- --nocapture`
- `cargo test -p loongclaw-daemon render_skills_cli_text_surfaces_browser_preview_guidance -- --nocapture`
- `cargo test --workspace --locked`

## Linked Issues

Closes #207


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guided browser preview first-run: enable → install → verify → try ready-to-run recipes. CLI output now shows structured next-steps and recipe commands; recipes are hidden when CLI is disabled and verification steps appear after install.

* **Documentation**
  * README, product specs, onboarding, design, and planning docs updated with the multi-step preview flow and concrete install/verify/try guidance.

* **Tests**
  * Added/updated tests for enablement, install/verify sequencing, CLI-disabled behavior, quoted follow-up paths, and rendered guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->