### PR TITLE
feat(daemon): add runtime restore and snapshot lineage

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -389,6 +389,9 @@ pub enum Commands {
         #[arg(long)]
         parent_snapshot_id: Option<String>,
     },
+    #[command(
+        long_about = "Restore a persisted runtime snapshot artifact into the current config and managed skill state.\n\nDry-run by default; pass --apply to mutate config or managed skills."
+    )]
     /// Restore a persisted runtime snapshot artifact into the current config and managed skill state
     RuntimeRestore {
         #[arg(long)]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1658,17 +1658,29 @@ fn build_runtime_snapshot_restore_managed_skills_spec(
     external_skills: &RuntimeSnapshotExternalSkillsState,
     warnings: &mut Vec<String>,
 ) -> RuntimeSnapshotRestoreManagedSkillsSpec {
+    match external_skills.inventory_status {
+        RuntimeSnapshotInventoryStatus::Disabled => {
+            warnings.push(
+                "restore spec could not enumerate managed external skills because runtime inventory is disabled"
+                    .to_owned(),
+            );
+            return RuntimeSnapshotRestoreManagedSkillsSpec::default();
+        }
+        RuntimeSnapshotInventoryStatus::Error => {
+            warnings.push(
+                "restore spec could not enumerate managed external skills because runtime inventory collection failed"
+                    .to_owned(),
+            );
+            return RuntimeSnapshotRestoreManagedSkillsSpec::default();
+        }
+        RuntimeSnapshotInventoryStatus::Ok => {}
+    }
+
     let Some(skills) = external_skills
         .inventory
         .get("skills")
         .and_then(Value::as_array)
     else {
-        if external_skills.inventory_status == RuntimeSnapshotInventoryStatus::Error {
-            warnings.push(
-                "restore spec could not enumerate managed external skills because runtime inventory collection failed"
-                    .to_owned(),
-            );
-        }
         return RuntimeSnapshotRestoreManagedSkillsSpec::default();
     };
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
     future::Future,
-    path::Path,
+    path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
 };
@@ -18,9 +18,10 @@ use kernel::{
     Capability, ConnectorCommand, FixedClock, InMemoryAuditSink, TaskIntent, ToolCoreOutcome,
     ToolCoreRequest,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 pub use loongclaw_app as mvp;
 pub use loongclaw_spec::spec_execution::*;
@@ -48,6 +49,7 @@ pub mod next_actions;
 pub mod onboard_cli;
 pub mod onboard_presentation;
 pub mod provider_presentation;
+pub mod runtime_restore_cli;
 pub mod skills_cli;
 pub mod source_presentation;
 
@@ -378,6 +380,25 @@ pub enum Commands {
         config: Option<String>,
         #[arg(long, default_value_t = false)]
         json: bool,
+        #[arg(long)]
+        output: Option<String>,
+        #[arg(long)]
+        label: Option<String>,
+        #[arg(long)]
+        experiment_id: Option<String>,
+        #[arg(long)]
+        parent_snapshot_id: Option<String>,
+    },
+    /// Restore a persisted runtime snapshot artifact into the current config and managed skill state
+    RuntimeRestore {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long)]
+        snapshot: String,
+        #[arg(long, default_value_t = false)]
+        json: bool,
+        #[arg(long, default_value_t = false)]
+        apply: bool,
     },
     /// List available conversation context engines and selected runtime engine
     ListContextEngines {
@@ -941,6 +962,7 @@ pub async fn run_list_models_cli(config_path: Option<&str>, as_json: bool) -> Cl
 }
 
 pub const RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION: u32 = 1;
+pub const RUNTIME_SNAPSHOT_ARTIFACT_JSON_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone)]
 pub struct RuntimeSnapshotCliState {
@@ -957,6 +979,7 @@ pub struct RuntimeSnapshotCliState {
     pub capability_snapshot: String,
     pub capability_snapshot_sha256: String,
     pub external_skills: RuntimeSnapshotExternalSkillsState,
+    pub restore_spec: RuntimeSnapshotRestoreSpec,
 }
 
 #[derive(Debug, Clone)]
@@ -1019,18 +1042,109 @@ pub struct RuntimeSnapshotExternalSkillsState {
     pub shadowed_skill_count: usize,
 }
 
-pub fn run_runtime_snapshot_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeSnapshotArtifactMetadata {
+    pub created_at: String,
+    pub label: Option<String>,
+    pub experiment_id: Option<String>,
+    pub parent_snapshot_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeSnapshotArtifactLineage {
+    pub snapshot_id: String,
+    pub created_at: String,
+    pub label: Option<String>,
+    pub experiment_id: Option<String>,
+    pub parent_snapshot_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeSnapshotRestoreSpec {
+    pub provider: RuntimeSnapshotRestoreProviderSpec,
+    pub conversation: mvp::config::ConversationConfig,
+    pub memory: mvp::config::MemoryConfig,
+    pub acp: mvp::config::AcpConfig,
+    pub tools: mvp::config::ToolConfig,
+    pub external_skills: mvp::config::ExternalSkillsConfig,
+    pub managed_skills: RuntimeSnapshotRestoreManagedSkillsSpec,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeSnapshotRestoreProviderSpec {
+    pub active_provider: Option<String>,
+    pub last_provider: Option<String>,
+    pub profiles: BTreeMap<String, mvp::config::ProviderProfileConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct RuntimeSnapshotRestoreManagedSkillsSpec {
+    pub skills: Vec<RuntimeSnapshotRestoreManagedSkillSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeSnapshotRestoreManagedSkillSpec {
+    pub skill_id: String,
+    pub display_name: String,
+    pub summary: String,
+    pub source_kind: String,
+    pub source_path: String,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeSnapshotArtifactSchema {
+    pub version: u32,
+    pub surface: String,
+    pub purpose: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeSnapshotArtifactDocument {
+    pub config: String,
+    pub schema: RuntimeSnapshotArtifactSchema,
+    pub lineage: RuntimeSnapshotArtifactLineage,
+    pub provider: Value,
+    pub context_engine: Value,
+    pub memory_system: Value,
+    pub acp: Value,
+    pub channels: Value,
+    pub tool_runtime: Value,
+    pub tools: Value,
+    pub external_skills: Value,
+    pub restore_spec: RuntimeSnapshotRestoreSpec,
+}
+
+pub fn run_runtime_snapshot_cli(
+    config_path: Option<&str>,
+    as_json: bool,
+    output_path: Option<&str>,
+    label: Option<&str>,
+    experiment_id: Option<&str>,
+    parent_snapshot_id: Option<&str>,
+) -> CliResult<()> {
     let snapshot = collect_runtime_snapshot_cli_state(config_path)?;
+    let metadata =
+        runtime_snapshot_artifact_metadata_now(label, experiment_id, parent_snapshot_id)?;
+    let artifact_payload = build_runtime_snapshot_artifact_json_payload(&snapshot, &metadata)?;
+
+    if let Some(output_path) = output_path {
+        persist_runtime_snapshot_artifact(output_path, &artifact_payload)?;
+    }
 
     if as_json {
-        let payload = build_runtime_snapshot_cli_json_payload(&snapshot);
-        let pretty = serde_json::to_string_pretty(&payload)
-            .map_err(|error| format!("serialize runtime snapshot output failed: {error}"))?;
+        let pretty = serde_json::to_string_pretty(&artifact_payload).map_err(|error| {
+            format!("serialize runtime snapshot artifact output failed: {error}")
+        })?;
         println!("{pretty}");
         return Ok(());
     }
 
-    println!("{}", render_runtime_snapshot_text(&snapshot));
+    println!(
+        "{}",
+        render_runtime_snapshot_artifact_text(&snapshot, &artifact_payload)
+    );
     Ok(())
 }
 
@@ -1060,6 +1174,7 @@ pub fn collect_runtime_snapshot_cli_state(
     let capability_snapshot = mvp::tools::capability_snapshot_with_config(&snapshot_tool_runtime);
     let capability_snapshot_sha256 =
         runtime_snapshot_tool_digest(&visible_tool_names, &capability_snapshot)?;
+    let restore_spec = build_runtime_snapshot_restore_spec(&config, &external_skills);
 
     Ok(RuntimeSnapshotCliState {
         config: config_display,
@@ -1075,6 +1190,7 @@ pub fn collect_runtime_snapshot_cli_state(
         capability_snapshot,
         capability_snapshot_sha256,
         external_skills,
+        restore_spec,
     })
 }
 
@@ -1361,6 +1477,366 @@ fn json_string_array_to_set(
                 .ok_or_else(|| format!("{context} must contain only strings"))
         })
         .collect()
+}
+
+fn build_runtime_snapshot_restore_spec(
+    config: &mvp::config::LoongClawConfig,
+    external_skills: &RuntimeSnapshotExternalSkillsState,
+) -> RuntimeSnapshotRestoreSpec {
+    let mut warnings = Vec::new();
+    let mut profiles = runtime_snapshot_restore_provider_profiles(config);
+    for (profile_id, profile) in &mut profiles {
+        normalize_runtime_snapshot_restore_provider_profile(profile_id, profile, &mut warnings);
+    }
+
+    RuntimeSnapshotRestoreSpec {
+        provider: RuntimeSnapshotRestoreProviderSpec {
+            active_provider: config.active_provider_id().map(str::to_owned),
+            last_provider: config.last_provider_id().map(str::to_owned),
+            profiles,
+        },
+        conversation: config.conversation.clone(),
+        memory: config.memory.clone(),
+        acp: config.acp.clone(),
+        tools: config.tools.clone(),
+        external_skills: config.external_skills.clone(),
+        managed_skills: build_runtime_snapshot_restore_managed_skills_spec(
+            external_skills,
+            &mut warnings,
+        ),
+        warnings,
+    }
+}
+
+fn runtime_snapshot_restore_provider_profiles(
+    config: &mvp::config::LoongClawConfig,
+) -> BTreeMap<String, mvp::config::ProviderProfileConfig> {
+    if !config.providers.is_empty() {
+        return config.providers.clone();
+    }
+
+    let profile_id = config
+        .active_provider_id()
+        .unwrap_or(config.provider.kind.profile().id)
+        .to_owned();
+    BTreeMap::from([(
+        profile_id,
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: config.provider.clone(),
+        },
+    )])
+}
+
+fn normalize_runtime_snapshot_restore_provider_profile(
+    profile_id: &str,
+    profile: &mut mvp::config::ProviderProfileConfig,
+    warnings: &mut Vec<String>,
+) {
+    if profile.provider.api_key.is_none() {
+        profile.provider.api_key =
+            runtime_snapshot_canonical_env_reference(profile.provider.api_key_env.as_deref());
+    }
+    if profile.provider.oauth_access_token.is_none() {
+        profile.provider.oauth_access_token = runtime_snapshot_canonical_env_reference(
+            profile.provider.oauth_access_token_env.as_deref(),
+        );
+    }
+
+    profile.provider.api_key_env = None;
+    profile.provider.oauth_access_token_env = None;
+
+    if runtime_snapshot_redact_provider_secret_field(
+        profile.provider.api_key.as_mut(),
+        profile_id,
+        "api_key",
+        warnings,
+    ) {
+        profile.provider.api_key = None;
+    }
+    if runtime_snapshot_redact_provider_secret_field(
+        profile.provider.oauth_access_token.as_mut(),
+        profile_id,
+        "oauth_access_token",
+        warnings,
+    ) {
+        profile.provider.oauth_access_token = None;
+    }
+
+    let header_keys_to_remove = profile
+        .provider
+        .headers
+        .iter()
+        .filter_map(|(header_name, header_value)| {
+            runtime_snapshot_provider_header_is_secret(header_name)
+                .then_some((header_name, header_value))
+        })
+        .filter(|(_, header_value)| !runtime_snapshot_is_env_reference_literal(header_value))
+        .map(|(header_name, _)| header_name.clone())
+        .collect::<Vec<_>>();
+    for header_name in header_keys_to_remove {
+        profile.provider.headers.remove(&header_name);
+        warnings.push(format!(
+            "restore spec redacted inline provider header `{header_name}` for profile `{profile_id}`"
+        ));
+    }
+}
+
+fn runtime_snapshot_redact_provider_secret_field(
+    raw: Option<&mut String>,
+    profile_id: &str,
+    field_name: &str,
+    warnings: &mut Vec<String>,
+) -> bool {
+    let Some(raw) = raw else {
+        return false;
+    };
+    if raw.trim().is_empty() || runtime_snapshot_is_env_reference_literal(raw) {
+        return false;
+    }
+    warnings.push(format!(
+        "restore spec redacted inline provider credential `{field_name}` for profile `{profile_id}`"
+    ));
+    true
+}
+
+fn runtime_snapshot_provider_header_is_secret(header_name: &str) -> bool {
+    matches!(
+        header_name.trim().to_ascii_lowercase().as_str(),
+        "authorization" | "proxy-authorization" | "x-api-key" | "api-key"
+    )
+}
+
+fn runtime_snapshot_canonical_env_reference(env_name: Option<&str>) -> Option<String> {
+    let env_name = env_name.map(str::trim).filter(|value| !value.is_empty())?;
+    Some(format!("${{{env_name}}}"))
+}
+
+fn runtime_snapshot_is_env_reference_literal(raw: &str) -> bool {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    if let Some(inner) = trimmed
+        .strip_prefix("${")
+        .and_then(|value| value.strip_suffix('}'))
+    {
+        return runtime_snapshot_is_valid_env_name(inner);
+    }
+
+    if let Some(inner) = trimmed.strip_prefix('$') {
+        return runtime_snapshot_is_valid_env_name(inner);
+    }
+
+    if let Some(inner) = trimmed.strip_prefix("env:") {
+        return runtime_snapshot_is_valid_env_name(inner);
+    }
+
+    if let Some(inner) = trimmed
+        .strip_prefix('%')
+        .and_then(|value| value.strip_suffix('%'))
+    {
+        return runtime_snapshot_is_valid_env_name(inner);
+    }
+
+    false
+}
+
+fn runtime_snapshot_is_valid_env_name(raw: &str) -> bool {
+    let mut chars = raw.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn build_runtime_snapshot_restore_managed_skills_spec(
+    external_skills: &RuntimeSnapshotExternalSkillsState,
+    warnings: &mut Vec<String>,
+) -> RuntimeSnapshotRestoreManagedSkillsSpec {
+    let Some(skills) = external_skills
+        .inventory
+        .get("skills")
+        .and_then(Value::as_array)
+    else {
+        if external_skills.inventory_status == RuntimeSnapshotInventoryStatus::Error {
+            warnings.push(
+                "restore spec could not enumerate managed external skills because runtime inventory collection failed"
+                    .to_owned(),
+            );
+        }
+        return RuntimeSnapshotRestoreManagedSkillsSpec::default();
+    };
+
+    let mut managed_skills = skills
+        .iter()
+        .filter(|skill| skill.get("scope").and_then(Value::as_str) == Some("managed"))
+        .filter_map(|skill| {
+            let skill_id = skill.get("skill_id").and_then(Value::as_str)?;
+            let display_name = skill.get("display_name").and_then(Value::as_str)?;
+            let summary = skill.get("summary").and_then(Value::as_str)?;
+            let source_kind = skill.get("source_kind").and_then(Value::as_str)?;
+            let source_path = skill.get("source_path").and_then(Value::as_str)?;
+            let sha256 = skill.get("sha256").and_then(Value::as_str)?;
+            Some(RuntimeSnapshotRestoreManagedSkillSpec {
+                skill_id: skill_id.to_owned(),
+                display_name: display_name.to_owned(),
+                summary: summary.to_owned(),
+                source_kind: source_kind.to_owned(),
+                source_path: source_path.to_owned(),
+                sha256: sha256.to_owned(),
+            })
+        })
+        .collect::<Vec<_>>();
+    managed_skills.sort_by(|left, right| left.skill_id.cmp(&right.skill_id));
+    RuntimeSnapshotRestoreManagedSkillsSpec {
+        skills: managed_skills,
+    }
+}
+
+fn runtime_snapshot_artifact_metadata_now(
+    label: Option<&str>,
+    experiment_id: Option<&str>,
+    parent_snapshot_id: Option<&str>,
+) -> CliResult<RuntimeSnapshotArtifactMetadata> {
+    let created_at = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(|error| format!("format runtime snapshot artifact timestamp failed: {error}"))?;
+    Ok(RuntimeSnapshotArtifactMetadata {
+        created_at,
+        label: runtime_snapshot_optional_arg(label),
+        experiment_id: runtime_snapshot_optional_arg(experiment_id),
+        parent_snapshot_id: runtime_snapshot_optional_arg(parent_snapshot_id),
+    })
+}
+
+fn runtime_snapshot_optional_arg(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn persist_runtime_snapshot_artifact(output_path: &str, payload: &Value) -> CliResult<()> {
+    let output_path = PathBuf::from(output_path);
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create runtime snapshot artifact directory {} failed: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let encoded = serde_json::to_string_pretty(payload)
+        .map_err(|error| format!("serialize runtime snapshot artifact failed: {error}"))?;
+    fs::write(&output_path, encoded).map_err(|error| {
+        format!(
+            "write runtime snapshot artifact {} failed: {error}",
+            output_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+pub fn build_runtime_snapshot_artifact_json_payload(
+    snapshot: &RuntimeSnapshotCliState,
+    metadata: &RuntimeSnapshotArtifactMetadata,
+) -> CliResult<Value> {
+    let base_payload = build_runtime_snapshot_cli_json_payload(snapshot);
+    let lineage = runtime_snapshot_artifact_lineage(snapshot, metadata)?;
+    let document = RuntimeSnapshotArtifactDocument {
+        config: snapshot.config.clone(),
+        schema: RuntimeSnapshotArtifactSchema {
+            version: RUNTIME_SNAPSHOT_ARTIFACT_JSON_SCHEMA_VERSION,
+            surface: "runtime_snapshot".to_owned(),
+            purpose: "experiment_reproducibility".to_owned(),
+        },
+        lineage,
+        provider: base_payload.get("provider").cloned().unwrap_or(Value::Null),
+        context_engine: base_payload
+            .get("context_engine")
+            .cloned()
+            .unwrap_or(Value::Null),
+        memory_system: base_payload
+            .get("memory_system")
+            .cloned()
+            .unwrap_or(Value::Null),
+        acp: base_payload.get("acp").cloned().unwrap_or(Value::Null),
+        channels: base_payload.get("channels").cloned().unwrap_or(Value::Null),
+        tool_runtime: base_payload
+            .get("tool_runtime")
+            .cloned()
+            .unwrap_or(Value::Null),
+        tools: base_payload.get("tools").cloned().unwrap_or(Value::Null),
+        external_skills: base_payload
+            .get("external_skills")
+            .cloned()
+            .unwrap_or(Value::Null),
+        restore_spec: snapshot.restore_spec.clone(),
+    };
+    serde_json::to_value(document)
+        .map_err(|error| format!("serialize runtime snapshot artifact payload failed: {error}"))
+}
+
+fn runtime_snapshot_artifact_lineage(
+    snapshot: &RuntimeSnapshotCliState,
+    metadata: &RuntimeSnapshotArtifactMetadata,
+) -> CliResult<RuntimeSnapshotArtifactLineage> {
+    let serialized = serde_json::to_vec(&json!({
+        "config": snapshot.config,
+        "created_at": metadata.created_at,
+        "label": metadata.label,
+        "experiment_id": metadata.experiment_id,
+        "parent_snapshot_id": metadata.parent_snapshot_id,
+        "capability_snapshot_sha256": snapshot.capability_snapshot_sha256,
+        "active_provider": snapshot.provider.active_profile_id,
+    }))
+    .map_err(|error| format!("serialize runtime snapshot lineage input failed: {error}"))?;
+    Ok(RuntimeSnapshotArtifactLineage {
+        snapshot_id: format!("{:x}", Sha256::digest(serialized)),
+        created_at: metadata.created_at.clone(),
+        label: metadata.label.clone(),
+        experiment_id: metadata.experiment_id.clone(),
+        parent_snapshot_id: metadata.parent_snapshot_id.clone(),
+    })
+}
+
+fn render_runtime_snapshot_artifact_text(
+    snapshot: &RuntimeSnapshotCliState,
+    artifact_payload: &Value,
+) -> String {
+    let lineage = artifact_payload
+        .get("lineage")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let schema_version = artifact_payload
+        .get("schema")
+        .and_then(|schema| schema.get("version"))
+        .and_then(Value::as_u64)
+        .unwrap_or(u64::from(RUNTIME_SNAPSHOT_ARTIFACT_JSON_SCHEMA_VERSION));
+
+    [
+        format!("schema.version={schema_version}"),
+        format!("snapshot_id={}", json_string_field(&lineage, "snapshot_id")),
+        format!("created_at={}", json_string_field(&lineage, "created_at")),
+        format!("label={}", json_string_field(&lineage, "label")),
+        format!(
+            "experiment_id={}",
+            json_string_field(&lineage, "experiment_id")
+        ),
+        format!(
+            "parent_snapshot_id={}",
+            json_string_field(&lineage, "parent_snapshot_id")
+        ),
+        format!("restore_warnings={}", snapshot.restore_spec.warnings.len()),
+        render_runtime_snapshot_text(snapshot),
+    ]
+    .join("\n")
 }
 
 pub fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1570,11 +1570,9 @@ fn normalize_runtime_snapshot_restore_provider_profile(
         .provider
         .headers
         .iter()
-        .filter_map(|(header_name, header_value)| {
-            runtime_snapshot_provider_header_is_secret(header_name)
-                .then_some((header_name, header_value))
+        .filter(|(header_name, header_value)| {
+            !runtime_snapshot_provider_header_is_safe_to_persist(header_name, header_value)
         })
-        .filter(|(_, header_value)| !runtime_snapshot_is_env_reference_literal(header_value))
         .map(|(header_name, _)| header_name.clone())
         .collect::<Vec<_>>();
     for header_name in header_keys_to_remove {
@@ -1603,11 +1601,28 @@ fn runtime_snapshot_redact_provider_secret_field(
     true
 }
 
-fn runtime_snapshot_provider_header_is_secret(header_name: &str) -> bool {
+fn runtime_snapshot_provider_header_is_safe_to_persist(
+    header_name: &str,
+    header_value: &str,
+) -> bool {
+    if header_value.trim().is_empty() || runtime_snapshot_is_env_reference_literal(header_value) {
+        return true;
+    }
+
+    let normalized = header_name.trim().to_ascii_lowercase();
     matches!(
-        header_name.trim().to_ascii_lowercase().as_str(),
-        "authorization" | "proxy-authorization" | "x-api-key" | "api-key"
-    )
+        normalized.as_str(),
+        "accept"
+            | "accept-charset"
+            | "accept-encoding"
+            | "accept-language"
+            | "cache-control"
+            | "content-language"
+            | "content-type"
+            | "pragma"
+            | "user-agent"
+    ) || normalized.ends_with("-version")
+        || normalized.ends_with("-beta")
 }
 
 fn runtime_snapshot_canonical_env_reference(env_name: Option<&str>) -> Option<String> {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -180,9 +180,34 @@ async fn main() {
         }),
         Commands::Channels { config, json } => run_channels_cli(config.as_deref(), json),
         Commands::ListModels { config, json } => run_list_models_cli(config.as_deref(), json).await,
-        Commands::RuntimeSnapshot { config, json } => {
-            run_runtime_snapshot_cli(config.as_deref(), json)
-        }
+        Commands::RuntimeSnapshot {
+            config,
+            json,
+            output,
+            label,
+            experiment_id,
+            parent_snapshot_id,
+        } => run_runtime_snapshot_cli(
+            config.as_deref(),
+            json,
+            output.as_deref(),
+            label.as_deref(),
+            experiment_id.as_deref(),
+            parent_snapshot_id.as_deref(),
+        ),
+        Commands::RuntimeRestore {
+            config,
+            snapshot,
+            json,
+            apply,
+        } => runtime_restore_cli::run_runtime_restore_cli(
+            runtime_restore_cli::RuntimeRestoreCommandOptions {
+                config,
+                snapshot,
+                json,
+                apply,
+            },
+        ),
         Commands::ListContextEngines { config, json } => {
             run_list_context_engines_cli(config.as_deref(), json)
         }

--- a/crates/daemon/src/runtime_restore_cli.rs
+++ b/crates/daemon/src/runtime_restore_cli.rs
@@ -1,0 +1,582 @@
+use crate::{
+    RuntimeSnapshotArtifactDocument, RuntimeSnapshotRestoreManagedSkillSpec,
+    collect_runtime_snapshot_cli_state,
+};
+use clap::Parser;
+use kernel::ToolCoreRequest;
+use loongclaw_app as mvp;
+use loongclaw_spec::CliResult;
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::{collections::BTreeMap, fs, path::Path};
+
+#[derive(Parser, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeRestoreCommandOptions {
+    pub config: Option<String>,
+    pub snapshot: String,
+    pub json: bool,
+    pub apply: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeRestoreExecution {
+    pub resolved_config_path: String,
+    pub snapshot_path: String,
+    pub lineage: RuntimeRestoreLineageSummary,
+    pub plan: RuntimeRestorePlan,
+    pub applied: bool,
+    pub verification: Option<RuntimeRestoreVerification>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeRestoreLineageSummary {
+    pub snapshot_id: String,
+    pub created_at: String,
+    pub label: Option<String>,
+    pub experiment_id: Option<String>,
+    pub parent_snapshot_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeRestorePlan {
+    pub can_apply: bool,
+    pub changed_surfaces: Vec<String>,
+    pub warnings: Vec<String>,
+    pub managed_skill_actions: Vec<RuntimeRestoreManagedSkillAction>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeRestoreManagedSkillAction {
+    pub action: String,
+    pub skill_id: String,
+    pub source_kind: String,
+    pub source_path: String,
+    pub current_sha256: Option<String>,
+    pub target_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeRestoreVerification {
+    pub restored_exactly: bool,
+    pub verified_surfaces: Vec<String>,
+    pub mismatches: Vec<String>,
+    pub capability_snapshot_sha256: String,
+}
+
+#[derive(Debug, Clone)]
+struct RuntimeRestoreArtifactInput {
+    document: RuntimeSnapshotArtifactDocument,
+}
+
+#[derive(Debug, Clone)]
+struct ManagedSkillInventoryEntry {
+    source_kind: String,
+    source_path: String,
+    sha256: String,
+}
+
+pub fn run_runtime_restore_cli(options: RuntimeRestoreCommandOptions) -> CliResult<()> {
+    let as_json = options.json;
+    let execution = execute_runtime_restore_command(options)?;
+    if as_json {
+        let pretty = serde_json::to_string_pretty(&execution)
+            .map_err(|error| format!("serialize runtime restore output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_restore_text(&execution));
+    Ok(())
+}
+
+pub fn execute_runtime_restore_command(
+    options: RuntimeRestoreCommandOptions,
+) -> CliResult<RuntimeRestoreExecution> {
+    let (resolved_path, current_config) = mvp::config::load(options.config.as_deref())?;
+    let artifact = load_runtime_restore_artifact(Path::new(&options.snapshot))?;
+    let target_config = build_restored_config(&current_config, &artifact.document)?;
+    let plan =
+        build_runtime_restore_plan(&resolved_path, &current_config, &target_config, &artifact)?;
+
+    if options.apply && !plan.can_apply {
+        return Err("runtime restore plan cannot be safely applied".to_owned());
+    }
+
+    let verification = if options.apply {
+        Some(apply_runtime_restore(
+            &resolved_path,
+            &current_config,
+            &target_config,
+            &plan,
+            &artifact,
+        )?)
+    } else {
+        None
+    };
+    let lineage = artifact.document.lineage;
+
+    Ok(RuntimeRestoreExecution {
+        resolved_config_path: resolved_path.display().to_string(),
+        snapshot_path: options.snapshot,
+        lineage: RuntimeRestoreLineageSummary {
+            snapshot_id: lineage.snapshot_id,
+            created_at: lineage.created_at,
+            label: lineage.label,
+            experiment_id: lineage.experiment_id,
+            parent_snapshot_id: lineage.parent_snapshot_id,
+        },
+        plan,
+        applied: options.apply,
+        verification,
+    })
+}
+
+fn load_runtime_restore_artifact(path: &Path) -> CliResult<RuntimeRestoreArtifactInput> {
+    let raw = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read runtime snapshot artifact {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let value = serde_json::from_str::<Value>(&raw).map_err(|error| {
+        format!(
+            "parse runtime snapshot artifact {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let document =
+        serde_json::from_value::<RuntimeSnapshotArtifactDocument>(value).map_err(|error| {
+            format!(
+                "decode runtime snapshot artifact {} failed: {error}",
+                path.display()
+            )
+        })?;
+    if document.schema.version != crate::RUNTIME_SNAPSHOT_ARTIFACT_JSON_SCHEMA_VERSION {
+        return Err(format!(
+            "runtime snapshot artifact {} uses unsupported schema version {}; expected {}",
+            path.display(),
+            document.schema.version,
+            crate::RUNTIME_SNAPSHOT_ARTIFACT_JSON_SCHEMA_VERSION
+        ));
+    }
+    Ok(RuntimeRestoreArtifactInput { document })
+}
+
+fn build_restored_config(
+    current_config: &mvp::config::LoongClawConfig,
+    artifact: &RuntimeSnapshotArtifactDocument,
+) -> CliResult<mvp::config::LoongClawConfig> {
+    let mut restored = current_config.clone();
+    restored.conversation = artifact.restore_spec.conversation.clone();
+    restored.memory = artifact.restore_spec.memory.clone();
+    restored.acp = artifact.restore_spec.acp.clone();
+    restored.tools = artifact.restore_spec.tools.clone();
+    restored.external_skills = artifact.restore_spec.external_skills.clone();
+    restored.providers = artifact.restore_spec.provider.profiles.clone();
+    restored.active_provider = artifact.restore_spec.provider.active_provider.clone();
+    restored.last_provider = artifact.restore_spec.provider.last_provider.clone();
+
+    let active_profile_id = restored
+        .active_provider
+        .clone()
+        .or_else(|| restored.providers.keys().next().cloned())
+        .ok_or_else(|| "runtime restore artifact is missing a provider profile".to_owned())?;
+    let active_profile = restored
+        .providers
+        .get(&active_profile_id)
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "runtime restore artifact references unknown active provider `{active_profile_id}`"
+            )
+        })?;
+    restored.provider = active_profile.provider;
+    restored.active_provider = Some(active_profile_id);
+    Ok(restored)
+}
+
+fn build_runtime_restore_plan(
+    resolved_path: &Path,
+    current_config: &mvp::config::LoongClawConfig,
+    target_config: &mvp::config::LoongClawConfig,
+    artifact: &RuntimeRestoreArtifactInput,
+) -> CliResult<RuntimeRestorePlan> {
+    let current_managed_skills = collect_managed_skill_inventory(resolved_path, target_config)?;
+    let managed_skill_actions = plan_managed_skill_actions(
+        &current_managed_skills,
+        &artifact.document.restore_spec.managed_skills.skills,
+    );
+
+    let mut changed_surfaces = Vec::new();
+    if provider_runtime_changed(current_config, target_config) {
+        changed_surfaces.push("provider".to_owned());
+    }
+    if current_config.conversation != target_config.conversation {
+        changed_surfaces.push("conversation".to_owned());
+    }
+    if current_config.memory != target_config.memory {
+        changed_surfaces.push("memory".to_owned());
+    }
+    if current_config.acp != target_config.acp {
+        changed_surfaces.push("acp".to_owned());
+    }
+    if current_config.tools != target_config.tools {
+        changed_surfaces.push("tools".to_owned());
+    }
+    if current_config.external_skills != target_config.external_skills {
+        changed_surfaces.push("external_skills".to_owned());
+    }
+    if !managed_skill_actions.is_empty() {
+        changed_surfaces.push("managed_skills".to_owned());
+    }
+
+    let mut warnings = artifact.document.restore_spec.warnings.clone();
+    let can_apply = managed_skill_actions
+        .iter()
+        .all(|action| validate_managed_skill_action(action, &mut warnings));
+
+    Ok(RuntimeRestorePlan {
+        can_apply,
+        changed_surfaces,
+        warnings,
+        managed_skill_actions,
+    })
+}
+
+fn provider_runtime_changed(
+    current_config: &mvp::config::LoongClawConfig,
+    target_config: &mvp::config::LoongClawConfig,
+) -> bool {
+    current_config.provider != target_config.provider
+        || current_config.providers != target_config.providers
+        || current_config.active_provider != target_config.active_provider
+        || current_config.last_provider != target_config.last_provider
+}
+
+fn collect_managed_skill_inventory(
+    resolved_path: &Path,
+    target_config: &mvp::config::LoongClawConfig,
+) -> CliResult<BTreeMap<String, ManagedSkillInventoryEntry>> {
+    let tool_runtime = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+        target_config,
+        Some(resolved_path),
+    );
+    let outcome = mvp::tools::execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "external_skills.list".to_owned(),
+            payload: json!({}),
+        },
+        &tool_runtime,
+    )
+    .map_err(|error| format!("list current managed external skills failed: {error}"))?;
+    let skills = outcome
+        .payload
+        .get("skills")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "managed external skill inventory payload missing `skills`".to_owned())?;
+
+    Ok(skills
+        .iter()
+        .filter(|skill| skill.get("scope").and_then(Value::as_str) == Some("managed"))
+        .filter_map(|skill| {
+            Some((
+                skill.get("skill_id").and_then(Value::as_str)?.to_owned(),
+                ManagedSkillInventoryEntry {
+                    source_kind: skill.get("source_kind").and_then(Value::as_str)?.to_owned(),
+                    source_path: skill.get("source_path").and_then(Value::as_str)?.to_owned(),
+                    sha256: skill.get("sha256").and_then(Value::as_str)?.to_owned(),
+                },
+            ))
+        })
+        .collect())
+}
+
+fn plan_managed_skill_actions(
+    current: &BTreeMap<String, ManagedSkillInventoryEntry>,
+    target: &[RuntimeSnapshotRestoreManagedSkillSpec],
+) -> Vec<RuntimeRestoreManagedSkillAction> {
+    let target = target
+        .iter()
+        .map(|skill| (skill.skill_id.clone(), skill))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut actions = Vec::new();
+    for skill_id in current
+        .keys()
+        .chain(target.keys())
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>()
+    {
+        match (current.get(&skill_id), target.get(&skill_id)) {
+            (None, Some(target_skill)) => actions.push(RuntimeRestoreManagedSkillAction {
+                action: "install".to_owned(),
+                skill_id: skill_id.clone(),
+                source_kind: target_skill.source_kind.clone(),
+                source_path: target_skill.source_path.clone(),
+                current_sha256: None,
+                target_sha256: Some(target_skill.sha256.clone()),
+            }),
+            (Some(current_skill), None) => actions.push(RuntimeRestoreManagedSkillAction {
+                action: "remove".to_owned(),
+                skill_id: skill_id.clone(),
+                source_kind: current_skill.source_kind.clone(),
+                source_path: current_skill.source_path.clone(),
+                current_sha256: Some(current_skill.sha256.clone()),
+                target_sha256: None,
+            }),
+            (Some(current_skill), Some(target_skill))
+                if current_skill.sha256 != target_skill.sha256
+                    || current_skill.source_kind != target_skill.source_kind
+                    || current_skill.source_path != target_skill.source_path =>
+            {
+                actions.push(RuntimeRestoreManagedSkillAction {
+                    action: "replace".to_owned(),
+                    skill_id: skill_id.clone(),
+                    source_kind: target_skill.source_kind.clone(),
+                    source_path: target_skill.source_path.clone(),
+                    current_sha256: Some(current_skill.sha256.clone()),
+                    target_sha256: Some(target_skill.sha256.clone()),
+                });
+            }
+            _ => {}
+        }
+    }
+    actions.sort_by(|left, right| left.skill_id.cmp(&right.skill_id));
+    actions
+}
+
+fn validate_managed_skill_action(
+    action: &RuntimeRestoreManagedSkillAction,
+    warnings: &mut Vec<String>,
+) -> bool {
+    if action.action == "remove" {
+        return true;
+    }
+    if action.source_kind == "bundled" {
+        return action.source_path.starts_with("bundled://");
+    }
+    if Path::new(&action.source_path).exists() {
+        return true;
+    }
+    warnings.push(format!(
+        "restore action for managed skill `{}` cannot find source path {}",
+        action.skill_id, action.source_path
+    ));
+    false
+}
+
+fn apply_runtime_restore(
+    resolved_path: &Path,
+    current_config: &mvp::config::LoongClawConfig,
+    target_config: &mvp::config::LoongClawConfig,
+    plan: &RuntimeRestorePlan,
+    artifact: &RuntimeRestoreArtifactInput,
+) -> CliResult<RuntimeRestoreVerification> {
+    let path_string = resolved_path.to_string_lossy();
+    mvp::config::write(Some(path_string.as_ref()), target_config, true).map_err(|error| {
+        format!(
+            "persist runtime restore config {} failed: {error}",
+            resolved_path.display()
+        )
+    })?;
+
+    let tool_runtime = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+        target_config,
+        Some(resolved_path),
+    );
+    if let Err(error) = apply_managed_skill_actions(&tool_runtime, &plan.managed_skill_actions) {
+        let _ = mvp::config::write(Some(path_string.as_ref()), current_config, true);
+        return Err(format!(
+            "runtime restore managed skill sync failed after config update: {error}"
+        ));
+    }
+
+    let post_snapshot = collect_runtime_snapshot_cli_state(Some(path_string.as_ref()))?;
+    Ok(verify_runtime_restore(plan, artifact, &post_snapshot))
+}
+
+fn apply_managed_skill_actions(
+    tool_runtime: &mvp::tools::runtime_config::ToolRuntimeConfig,
+    actions: &[RuntimeRestoreManagedSkillAction],
+) -> CliResult<()> {
+    for action in actions {
+        match action.action.as_str() {
+            "install" | "replace" => {
+                let payload = if action.source_kind == "bundled" {
+                    json!({
+                        "bundled_skill_id": bundled_skill_id_for_action(action)?,
+                        "replace": action.action == "replace",
+                    })
+                } else {
+                    json!({
+                        "path": action.source_path,
+                        "replace": action.action == "replace",
+                    })
+                };
+                mvp::tools::execute_tool_core_with_config(
+                    ToolCoreRequest {
+                        tool_name: "external_skills.install".to_owned(),
+                        payload,
+                    },
+                    tool_runtime,
+                )
+                .map_err(|error| {
+                    format!(
+                        "{} managed external skill `{}` failed: {error}",
+                        action.action, action.skill_id
+                    )
+                })?;
+            }
+            "remove" => {
+                mvp::tools::execute_tool_core_with_config(
+                    ToolCoreRequest {
+                        tool_name: "external_skills.remove".to_owned(),
+                        payload: json!({
+                            "skill_id": action.skill_id,
+                        }),
+                    },
+                    tool_runtime,
+                )
+                .map_err(|error| {
+                    format!(
+                        "remove managed external skill `{}` failed: {error}",
+                        action.skill_id
+                    )
+                })?;
+            }
+            other => {
+                return Err(format!("unknown managed skill restore action `{other}`"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn bundled_skill_id_for_action(action: &RuntimeRestoreManagedSkillAction) -> CliResult<String> {
+    action
+        .source_path
+        .strip_prefix("bundled://")
+        .map(str::to_owned)
+        .or_else(|| (!action.skill_id.trim().is_empty()).then_some(action.skill_id.clone()))
+        .ok_or_else(|| {
+            format!(
+                "restore action for bundled skill `{}` is missing a bundled source identifier",
+                action.skill_id
+            )
+        })
+}
+
+fn verify_runtime_restore(
+    plan: &RuntimeRestorePlan,
+    artifact: &RuntimeRestoreArtifactInput,
+    post_snapshot: &crate::RuntimeSnapshotCliState,
+) -> RuntimeRestoreVerification {
+    let mut mismatches = Vec::new();
+    if post_snapshot.restore_spec.provider != artifact.document.restore_spec.provider {
+        mismatches.push("provider".to_owned());
+    }
+    if post_snapshot.restore_spec.conversation != artifact.document.restore_spec.conversation {
+        mismatches.push("conversation".to_owned());
+    }
+    if post_snapshot.restore_spec.memory != artifact.document.restore_spec.memory {
+        mismatches.push("memory".to_owned());
+    }
+    if post_snapshot.restore_spec.acp != artifact.document.restore_spec.acp {
+        mismatches.push("acp".to_owned());
+    }
+    if post_snapshot.restore_spec.tools != artifact.document.restore_spec.tools {
+        mismatches.push("tools".to_owned());
+    }
+    if post_snapshot.restore_spec.external_skills != artifact.document.restore_spec.external_skills
+    {
+        mismatches.push("external_skills".to_owned());
+    }
+    if post_snapshot.restore_spec.managed_skills != artifact.document.restore_spec.managed_skills {
+        mismatches.push("managed_skills".to_owned());
+    }
+    if expected_capability_snapshot_sha256(&artifact.document)
+        .is_some_and(|digest| digest != post_snapshot.capability_snapshot_sha256)
+    {
+        mismatches.push("capability_digest".to_owned());
+    }
+
+    let verified_surfaces = plan
+        .changed_surfaces
+        .iter()
+        .filter(|surface| !mismatches.iter().any(|mismatch| mismatch == *surface))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    RuntimeRestoreVerification {
+        restored_exactly: mismatches.is_empty(),
+        verified_surfaces,
+        mismatches,
+        capability_snapshot_sha256: post_snapshot.capability_snapshot_sha256.clone(),
+    }
+}
+
+fn expected_capability_snapshot_sha256(artifact: &RuntimeSnapshotArtifactDocument) -> Option<&str> {
+    artifact
+        .tools
+        .get("capability_snapshot_sha256")
+        .and_then(Value::as_str)
+}
+
+fn render_runtime_restore_text(execution: &RuntimeRestoreExecution) -> String {
+    let mut lines = vec![
+        format!("config={}", execution.resolved_config_path),
+        format!("snapshot={}", execution.snapshot_path),
+        format!("snapshot_id={}", execution.lineage.snapshot_id),
+        format!("created_at={}", execution.lineage.created_at),
+        format!("apply_requested={}", execution.applied),
+        format!("can_apply={}", execution.plan.can_apply),
+        format!(
+            "changed_surfaces={}",
+            render_string_list(execution.plan.changed_surfaces.iter().map(String::as_str))
+        ),
+    ];
+
+    if !execution.plan.warnings.is_empty() {
+        lines.push("warnings:".to_owned());
+        for warning in &execution.plan.warnings {
+            lines.push(format!("- {warning}"));
+        }
+    }
+
+    if !execution.plan.managed_skill_actions.is_empty() {
+        lines.push("managed_skill_actions:".to_owned());
+        for action in &execution.plan.managed_skill_actions {
+            lines.push(format!(
+                "- {} {} source_kind={} source_path={}",
+                action.action, action.skill_id, action.source_kind, action.source_path
+            ));
+        }
+    }
+
+    if let Some(verification) = &execution.verification {
+        lines.push(format!(
+            "restored_exactly={}",
+            verification.restored_exactly
+        ));
+        if !verification.mismatches.is_empty() {
+            lines.push(format!(
+                "mismatches={}",
+                render_string_list(verification.mismatches.iter().map(String::as_str))
+            ));
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn render_string_list<'a>(values: impl IntoIterator<Item = &'a str>) -> String {
+    let rendered = values
+        .into_iter()
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    if rendered.is_empty() {
+        "-".to_owned()
+    } else {
+        rendered.join(",")
+    }
+}

--- a/crates/daemon/src/runtime_restore_cli.rs
+++ b/crates/daemon/src/runtime_restore_cli.rs
@@ -69,6 +69,7 @@ pub struct RuntimeRestoreVerification {
     pub verified_surfaces: Vec<String>,
     pub mismatches: Vec<String>,
     pub capability_snapshot_sha256: String,
+    pub verification_error: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -458,6 +459,7 @@ fn runtime_restore_has_blocking_warnings(warnings: &[String]) -> bool {
     warnings.iter().any(|warning| {
         warning.contains("redacted inline provider credential")
             || warning.contains("redacted inline provider header")
+            || warning.contains("restore spec could not enumerate managed external skills")
     })
 }
 
@@ -520,8 +522,18 @@ fn apply_runtime_restore(
         ));
     }
 
-    let post_snapshot = collect_runtime_snapshot_cli_state(Some(path_string.as_ref()))?;
-    Ok(verify_runtime_restore(plan, artifact, &post_snapshot))
+    match collect_runtime_snapshot_cli_state(Some(path_string.as_ref())) {
+        Ok(post_snapshot) => Ok(verify_runtime_restore(plan, artifact, &post_snapshot)),
+        Err(error) => Ok(RuntimeRestoreVerification {
+            restored_exactly: false,
+            verified_surfaces: Vec::new(),
+            mismatches: vec!["verification_unavailable".to_owned()],
+            capability_snapshot_sha256: String::new(),
+            verification_error: Some(format!(
+                "post-apply runtime snapshot verification failed: {error}"
+            )),
+        }),
+    }
 }
 
 fn apply_managed_skill_actions(
@@ -750,6 +762,7 @@ fn verify_runtime_restore(
         verified_surfaces,
         mismatches,
         capability_snapshot_sha256: post_snapshot.capability_snapshot_sha256.clone(),
+        verification_error: None,
     }
 }
 
@@ -801,6 +814,9 @@ fn render_runtime_restore_text(execution: &RuntimeRestoreExecution) -> String {
                 "mismatches={}",
                 render_string_list(verification.mismatches.iter().map(String::as_str))
             ));
+        }
+        if let Some(error) = verification.verification_error.as_deref() {
+            lines.push(format!("verification_error={error}"));
         }
     }
 

--- a/crates/daemon/src/runtime_restore_cli.rs
+++ b/crates/daemon/src/runtime_restore_cli.rs
@@ -8,7 +8,11 @@ use loongclaw_app as mvp;
 use loongclaw_spec::CliResult;
 use serde::Serialize;
 use serde_json::{Value, json};
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
 
 #[derive(Parser, Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeRestoreCommandOptions {
@@ -53,6 +57,10 @@ pub struct RuntimeRestoreManagedSkillAction {
     pub source_path: String,
     pub current_sha256: Option<String>,
     pub target_sha256: Option<String>,
+    use_target_config: bool,
+    apply_install_root: Option<String>,
+    current_source_kind: Option<String>,
+    current_source_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -66,6 +74,12 @@ pub struct RuntimeRestoreVerification {
 #[derive(Debug, Clone)]
 struct RuntimeRestoreArtifactInput {
     document: RuntimeSnapshotArtifactDocument,
+}
+
+#[derive(Debug, Clone)]
+struct ManagedSkillInventorySnapshot {
+    install_root: Option<String>,
+    skills: BTreeMap<String, ManagedSkillInventoryEntry>,
 }
 
 #[derive(Debug, Clone)]
@@ -201,10 +215,19 @@ fn build_runtime_restore_plan(
     target_config: &mvp::config::LoongClawConfig,
     artifact: &RuntimeRestoreArtifactInput,
 ) -> CliResult<RuntimeRestorePlan> {
-    let current_managed_skills = collect_managed_skill_inventory(resolved_path, target_config)?;
+    let current_managed_skills = collect_managed_skill_inventory(
+        resolved_path,
+        current_config,
+        current_config.external_skills.resolved_install_root(),
+    )?;
+    let target_install_root = target_config
+        .external_skills
+        .resolved_install_root()
+        .map(|path| path.display().to_string());
     let managed_skill_actions = plan_managed_skill_actions(
         &current_managed_skills,
         &artifact.document.restore_spec.managed_skills.skills,
+        target_install_root.clone(),
     );
 
     let mut changed_surfaces = Vec::new();
@@ -231,9 +254,22 @@ fn build_runtime_restore_plan(
     }
 
     let mut warnings = artifact.document.restore_spec.warnings.clone();
-    let can_apply = managed_skill_actions
-        .iter()
-        .all(|action| validate_managed_skill_action(action, &mut warnings));
+    if current_managed_skills.install_root != target_install_root
+        && !managed_skill_actions.is_empty()
+    {
+        warnings.push(format!(
+            "runtime restore will switch managed external skill install root from {} to {}",
+            current_managed_skills
+                .install_root
+                .as_deref()
+                .unwrap_or("-"),
+            target_install_root.as_deref().unwrap_or("-")
+        ));
+    }
+    let can_apply = !runtime_restore_has_blocking_warnings(&warnings)
+        && managed_skill_actions
+            .iter()
+            .all(|action| validate_managed_skill_action(action, &mut warnings));
 
     Ok(RuntimeRestorePlan {
         can_apply,
@@ -255,10 +291,21 @@ fn provider_runtime_changed(
 
 fn collect_managed_skill_inventory(
     resolved_path: &Path,
-    target_config: &mvp::config::LoongClawConfig,
-) -> CliResult<BTreeMap<String, ManagedSkillInventoryEntry>> {
+    base_config: &mvp::config::LoongClawConfig,
+    install_root: Option<PathBuf>,
+) -> CliResult<ManagedSkillInventorySnapshot> {
+    let mut inventory_config = base_config.clone();
+    inventory_config.external_skills.enabled = true;
+    if let Some(install_root) = install_root {
+        inventory_config.external_skills.install_root = Some(install_root.display().to_string());
+    }
+
+    let resolved_install_root = inventory_config
+        .external_skills
+        .resolved_install_root()
+        .map(|path| path.display().to_string());
     let tool_runtime = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
-        target_config,
+        &inventory_config,
         Some(resolved_path),
     );
     let outcome = mvp::tools::execute_tool_core_with_config(
@@ -275,25 +322,29 @@ fn collect_managed_skill_inventory(
         .and_then(Value::as_array)
         .ok_or_else(|| "managed external skill inventory payload missing `skills`".to_owned())?;
 
-    Ok(skills
-        .iter()
-        .filter(|skill| skill.get("scope").and_then(Value::as_str) == Some("managed"))
-        .filter_map(|skill| {
-            Some((
-                skill.get("skill_id").and_then(Value::as_str)?.to_owned(),
-                ManagedSkillInventoryEntry {
-                    source_kind: skill.get("source_kind").and_then(Value::as_str)?.to_owned(),
-                    source_path: skill.get("source_path").and_then(Value::as_str)?.to_owned(),
-                    sha256: skill.get("sha256").and_then(Value::as_str)?.to_owned(),
-                },
-            ))
-        })
-        .collect())
+    Ok(ManagedSkillInventorySnapshot {
+        install_root: resolved_install_root,
+        skills: skills
+            .iter()
+            .filter(|skill| skill.get("scope").and_then(Value::as_str) == Some("managed"))
+            .filter_map(|skill| {
+                Some((
+                    skill.get("skill_id").and_then(Value::as_str)?.to_owned(),
+                    ManagedSkillInventoryEntry {
+                        source_kind: skill.get("source_kind").and_then(Value::as_str)?.to_owned(),
+                        source_path: skill.get("source_path").and_then(Value::as_str)?.to_owned(),
+                        sha256: skill.get("sha256").and_then(Value::as_str)?.to_owned(),
+                    },
+                ))
+            })
+            .collect(),
+    })
 }
 
 fn plan_managed_skill_actions(
-    current: &BTreeMap<String, ManagedSkillInventoryEntry>,
+    current: &ManagedSkillInventorySnapshot,
     target: &[RuntimeSnapshotRestoreManagedSkillSpec],
+    target_install_root: Option<String>,
 ) -> Vec<RuntimeRestoreManagedSkillAction> {
     let target = target
         .iter()
@@ -301,48 +352,113 @@ fn plan_managed_skill_actions(
         .collect::<BTreeMap<_, _>>();
 
     let mut actions = Vec::new();
+    let current_install_root = current.install_root.clone();
+    let install_root_changed = current_install_root != target_install_root;
     for skill_id in current
+        .skills
         .keys()
         .chain(target.keys())
         .cloned()
         .collect::<std::collections::BTreeSet<_>>()
     {
-        match (current.get(&skill_id), target.get(&skill_id)) {
-            (None, Some(target_skill)) => actions.push(RuntimeRestoreManagedSkillAction {
-                action: "install".to_owned(),
-                skill_id: skill_id.clone(),
-                source_kind: target_skill.source_kind.clone(),
-                source_path: target_skill.source_path.clone(),
-                current_sha256: None,
-                target_sha256: Some(target_skill.sha256.clone()),
-            }),
-            (Some(current_skill), None) => actions.push(RuntimeRestoreManagedSkillAction {
-                action: "remove".to_owned(),
-                skill_id: skill_id.clone(),
-                source_kind: current_skill.source_kind.clone(),
-                source_path: current_skill.source_path.clone(),
-                current_sha256: Some(current_skill.sha256.clone()),
-                target_sha256: None,
-            }),
-            (Some(current_skill), Some(target_skill))
-                if current_skill.sha256 != target_skill.sha256
-                    || current_skill.source_kind != target_skill.source_kind
-                    || current_skill.source_path != target_skill.source_path =>
-            {
-                actions.push(RuntimeRestoreManagedSkillAction {
-                    action: "replace".to_owned(),
-                    skill_id: skill_id.clone(),
-                    source_kind: target_skill.source_kind.clone(),
-                    source_path: target_skill.source_path.clone(),
-                    current_sha256: Some(current_skill.sha256.clone()),
-                    target_sha256: Some(target_skill.sha256.clone()),
-                });
+        match (current.skills.get(&skill_id), target.get(&skill_id)) {
+            (None, Some(target_skill)) => actions.push(build_install_action(
+                &skill_id,
+                target_skill,
+                target_install_root.clone(),
+            )),
+            (Some(current_skill), None) if !install_root_changed => {
+                actions.push(build_remove_action(
+                    &skill_id,
+                    current_skill,
+                    current_install_root.clone(),
+                ));
             }
+            (Some(current_skill), Some(target_skill))
+                if current_skill.sha256 != target_skill.sha256 =>
+            {
+                actions.push(build_replace_action(
+                    &skill_id,
+                    current_skill,
+                    target_skill,
+                    target_install_root
+                        .clone()
+                        .or_else(|| current_install_root.clone()),
+                ));
+            }
+            (Some(_current_skill), Some(target_skill)) if install_root_changed => actions.push(
+                build_install_action(&skill_id, target_skill, target_install_root.clone()),
+            ),
             _ => {}
         }
     }
     actions.sort_by(|left, right| left.skill_id.cmp(&right.skill_id));
     actions
+}
+
+fn build_install_action(
+    skill_id: &str,
+    target_skill: &RuntimeSnapshotRestoreManagedSkillSpec,
+    target_install_root: Option<String>,
+) -> RuntimeRestoreManagedSkillAction {
+    RuntimeRestoreManagedSkillAction {
+        action: "install".to_owned(),
+        skill_id: skill_id.to_owned(),
+        source_kind: target_skill.source_kind.clone(),
+        source_path: target_skill.source_path.clone(),
+        current_sha256: None,
+        target_sha256: Some(target_skill.sha256.clone()),
+        use_target_config: true,
+        apply_install_root: target_install_root,
+        current_source_kind: None,
+        current_source_path: None,
+    }
+}
+
+fn build_remove_action(
+    skill_id: &str,
+    current_skill: &ManagedSkillInventoryEntry,
+    current_install_root: Option<String>,
+) -> RuntimeRestoreManagedSkillAction {
+    RuntimeRestoreManagedSkillAction {
+        action: "remove".to_owned(),
+        skill_id: skill_id.to_owned(),
+        source_kind: current_skill.source_kind.clone(),
+        source_path: current_skill.source_path.clone(),
+        current_sha256: Some(current_skill.sha256.clone()),
+        target_sha256: None,
+        use_target_config: false,
+        apply_install_root: current_install_root,
+        current_source_kind: Some(current_skill.source_kind.clone()),
+        current_source_path: Some(current_skill.source_path.clone()),
+    }
+}
+
+fn build_replace_action(
+    skill_id: &str,
+    current_skill: &ManagedSkillInventoryEntry,
+    target_skill: &RuntimeSnapshotRestoreManagedSkillSpec,
+    apply_install_root: Option<String>,
+) -> RuntimeRestoreManagedSkillAction {
+    RuntimeRestoreManagedSkillAction {
+        action: "replace".to_owned(),
+        skill_id: skill_id.to_owned(),
+        source_kind: target_skill.source_kind.clone(),
+        source_path: target_skill.source_path.clone(),
+        current_sha256: Some(current_skill.sha256.clone()),
+        target_sha256: Some(target_skill.sha256.clone()),
+        use_target_config: true,
+        apply_install_root,
+        current_source_kind: Some(current_skill.source_kind.clone()),
+        current_source_path: Some(current_skill.source_path.clone()),
+    }
+}
+
+fn runtime_restore_has_blocking_warnings(warnings: &[String]) -> bool {
+    warnings.iter().any(|warning| {
+        warning.contains("redacted inline provider credential")
+            || warning.contains("redacted inline provider header")
+    })
 }
 
 fn validate_managed_skill_action(
@@ -353,7 +469,14 @@ fn validate_managed_skill_action(
         return true;
     }
     if action.source_kind == "bundled" {
-        return action.source_path.starts_with("bundled://");
+        let is_valid = action.source_path.starts_with("bundled://");
+        if !is_valid {
+            warnings.push(format!(
+                "restore action for bundled skill `{}` is missing a bundled source identifier",
+                action.skill_id
+            ));
+        }
+        return is_valid;
     }
     if Path::new(&action.source_path).exists() {
         return true;
@@ -373,21 +496,27 @@ fn apply_runtime_restore(
     artifact: &RuntimeRestoreArtifactInput,
 ) -> CliResult<RuntimeRestoreVerification> {
     let path_string = resolved_path.to_string_lossy();
-    mvp::config::write(Some(path_string.as_ref()), target_config, true).map_err(|error| {
-        format!(
-            "persist runtime restore config {} failed: {error}",
-            resolved_path.display()
-        )
-    })?;
-
-    let tool_runtime = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+    let rollback_actions = apply_managed_skill_actions(
+        resolved_path,
+        current_config,
         target_config,
-        Some(resolved_path),
-    );
-    if let Err(error) = apply_managed_skill_actions(&tool_runtime, &plan.managed_skill_actions) {
-        let _ = mvp::config::write(Some(path_string.as_ref()), current_config, true);
+        &plan.managed_skill_actions,
+    )?;
+    if let Err(error) = mvp::config::write(Some(path_string.as_ref()), target_config, true) {
+        if let Err(rollback_error) = rollback_managed_skill_actions(
+            resolved_path,
+            current_config,
+            target_config,
+            &rollback_actions,
+        ) {
+            return Err(format!(
+                "persist runtime restore config {} failed: {error}; managed skill rollback also failed: {rollback_error}",
+                resolved_path.display()
+            ));
+        }
         return Err(format!(
-            "runtime restore managed skill sync failed after config update: {error}"
+            "persist runtime restore config {} failed after reverting managed skill changes: {error}",
+            resolved_path.display()
         ));
     }
 
@@ -396,60 +525,169 @@ fn apply_runtime_restore(
 }
 
 fn apply_managed_skill_actions(
-    tool_runtime: &mvp::tools::runtime_config::ToolRuntimeConfig,
+    resolved_path: &Path,
+    current_config: &mvp::config::LoongClawConfig,
+    target_config: &mvp::config::LoongClawConfig,
     actions: &[RuntimeRestoreManagedSkillAction],
-) -> CliResult<()> {
+) -> CliResult<Vec<RuntimeRestoreManagedSkillAction>> {
+    let mut rollback_actions = Vec::new();
     for action in actions {
-        match action.action.as_str() {
-            "install" | "replace" => {
-                let payload = if action.source_kind == "bundled" {
-                    json!({
-                        "bundled_skill_id": bundled_skill_id_for_action(action)?,
-                        "replace": action.action == "replace",
-                    })
-                } else {
-                    json!({
-                        "path": action.source_path,
-                        "replace": action.action == "replace",
-                    })
-                };
-                mvp::tools::execute_tool_core_with_config(
-                    ToolCoreRequest {
-                        tool_name: "external_skills.install".to_owned(),
-                        payload,
-                    },
-                    tool_runtime,
-                )
-                .map_err(|error| {
-                    format!(
-                        "{} managed external skill `{}` failed: {error}",
-                        action.action, action.skill_id
-                    )
-                })?;
+        if let Err(error) =
+            apply_single_managed_skill_action(resolved_path, current_config, target_config, action)
+        {
+            if let Err(rollback_error) = rollback_managed_skill_actions(
+                resolved_path,
+                current_config,
+                target_config,
+                &rollback_actions,
+            ) {
+                return Err(format!(
+                    "{error}; managed skill rollback also failed: {rollback_error}"
+                ));
             }
-            "remove" => {
-                mvp::tools::execute_tool_core_with_config(
-                    ToolCoreRequest {
-                        tool_name: "external_skills.remove".to_owned(),
-                        payload: json!({
-                            "skill_id": action.skill_id,
-                        }),
-                    },
-                    tool_runtime,
-                )
-                .map_err(|error| {
-                    format!(
-                        "remove managed external skill `{}` failed: {error}",
-                        action.skill_id
-                    )
-                })?;
-            }
-            other => {
-                return Err(format!("unknown managed skill restore action `{other}`"));
-            }
+            return Err(error);
+        }
+        if let Some(rollback_action) = rollback_action_for_success(action) {
+            rollback_actions.push(rollback_action);
         }
     }
-    Ok(())
+    Ok(rollback_actions)
+}
+
+fn rollback_managed_skill_actions(
+    resolved_path: &Path,
+    current_config: &mvp::config::LoongClawConfig,
+    target_config: &mvp::config::LoongClawConfig,
+    rollback_actions: &[RuntimeRestoreManagedSkillAction],
+) -> CliResult<()> {
+    let mut rollback_errors = Vec::new();
+    for action in rollback_actions.iter().rev() {
+        if let Err(error) =
+            apply_single_managed_skill_action(resolved_path, current_config, target_config, action)
+        {
+            rollback_errors.push(error);
+        }
+    }
+    if rollback_errors.is_empty() {
+        Ok(())
+    } else {
+        Err(rollback_errors.join("; "))
+    }
+}
+
+fn rollback_action_for_success(
+    action: &RuntimeRestoreManagedSkillAction,
+) -> Option<RuntimeRestoreManagedSkillAction> {
+    match action.action.as_str() {
+        "install" => Some(RuntimeRestoreManagedSkillAction {
+            action: "remove".to_owned(),
+            skill_id: action.skill_id.clone(),
+            source_kind: action.source_kind.clone(),
+            source_path: action.source_path.clone(),
+            current_sha256: action.target_sha256.clone(),
+            target_sha256: None,
+            use_target_config: true,
+            apply_install_root: action.apply_install_root.clone(),
+            current_source_kind: None,
+            current_source_path: None,
+        }),
+        "remove" | "replace" => Some(RuntimeRestoreManagedSkillAction {
+            action: if action.action == "replace" {
+                "replace".to_owned()
+            } else {
+                "install".to_owned()
+            },
+            skill_id: action.skill_id.clone(),
+            source_kind: action.current_source_kind.clone()?,
+            source_path: action.current_source_path.clone()?,
+            current_sha256: None,
+            target_sha256: action.current_sha256.clone(),
+            use_target_config: false,
+            apply_install_root: action.apply_install_root.clone(),
+            current_source_kind: None,
+            current_source_path: None,
+        }),
+        _ => None,
+    }
+}
+
+fn apply_single_managed_skill_action(
+    resolved_path: &Path,
+    current_config: &mvp::config::LoongClawConfig,
+    target_config: &mvp::config::LoongClawConfig,
+    action: &RuntimeRestoreManagedSkillAction,
+) -> CliResult<()> {
+    let tool_runtime =
+        build_action_tool_runtime(resolved_path, current_config, target_config, action);
+    match action.action.as_str() {
+        "install" | "replace" => {
+            let payload = if action.source_kind == "bundled" {
+                json!({
+                    "bundled_skill_id": bundled_skill_id_for_action(action)?,
+                    "replace": action.action == "replace",
+                })
+            } else {
+                json!({
+                    "path": action.source_path,
+                    "replace": action.action == "replace",
+                })
+            };
+            mvp::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload,
+                },
+                &tool_runtime,
+            )
+            .map_err(|error| {
+                format!(
+                    "{} managed external skill `{}` failed: {error}",
+                    action.action, action.skill_id
+                )
+            })?;
+            Ok(())
+        }
+        "remove" => {
+            mvp::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.remove".to_owned(),
+                    payload: json!({
+                        "skill_id": action.skill_id,
+                    }),
+                },
+                &tool_runtime,
+            )
+            .map_err(|error| {
+                format!(
+                    "remove managed external skill `{}` failed: {error}",
+                    action.skill_id
+                )
+            })?;
+            Ok(())
+        }
+        other => Err(format!("unknown managed skill restore action `{other}`")),
+    }
+}
+
+fn build_action_tool_runtime(
+    resolved_path: &Path,
+    current_config: &mvp::config::LoongClawConfig,
+    target_config: &mvp::config::LoongClawConfig,
+    action: &RuntimeRestoreManagedSkillAction,
+) -> mvp::tools::runtime_config::ToolRuntimeConfig {
+    let mut config = if action.use_target_config {
+        target_config.clone()
+    } else {
+        current_config.clone()
+    };
+    config.external_skills.enabled = true;
+    if let Some(install_root) = action.apply_install_root.as_ref() {
+        config.external_skills.install_root = Some(install_root.clone());
+    }
+    mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+        &config,
+        Some(resolved_path),
+    )
 }
 
 fn bundled_skill_id_for_action(action: &RuntimeRestoreManagedSkillAction) -> CliResult<String> {

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -241,13 +241,62 @@ fn runtime_snapshot_cli_parses() {
         "--config",
         "/tmp/loongclaw.toml",
         "--json",
+        "--output",
+        "/tmp/runtime-snapshot.json",
+        "--label",
+        "baseline",
+        "--experiment-id",
+        "exp-42",
+        "--parent-snapshot-id",
+        "snapshot-parent",
     ])
     .expect("`runtime-snapshot` should parse");
 
     match cli.command {
-        Some(Commands::RuntimeSnapshot { config, json }) => {
+        Some(Commands::RuntimeSnapshot {
+            config,
+            json,
+            output,
+            label,
+            experiment_id,
+            parent_snapshot_id,
+        }) => {
             assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
             assert!(json);
+            assert_eq!(output.as_deref(), Some("/tmp/runtime-snapshot.json"));
+            assert_eq!(label.as_deref(), Some("baseline"));
+            assert_eq!(experiment_id.as_deref(), Some("exp-42"));
+            assert_eq!(parent_snapshot_id.as_deref(), Some("snapshot-parent"));
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn runtime_restore_cli_parses() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-restore",
+        "--config",
+        "/tmp/loongclaw.toml",
+        "--snapshot",
+        "/tmp/runtime-snapshot.json",
+        "--json",
+        "--apply",
+    ])
+    .expect("`runtime-restore` should parse");
+
+    match cli.command {
+        Some(Commands::RuntimeRestore {
+            config,
+            snapshot,
+            json,
+            apply,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert_eq!(snapshot, "/tmp/runtime-snapshot.json");
+            assert!(json);
+            assert!(apply);
         }
         other => panic!("unexpected command parsed: {other:?}"),
     }

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -32,6 +32,7 @@ mod import_cli;
 mod migration;
 mod onboard_cli;
 mod programmatic;
+mod runtime_restore_cli;
 mod runtime_snapshot_cli;
 mod skills_cli;
 mod spec_runtime;

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -139,6 +139,28 @@ fn cli_ask_help_mentions_one_shot_assistant_usage() {
 }
 
 #[test]
+fn cli_runtime_restore_help_mentions_dry_run_default() {
+    let mut command = Cli::command();
+    let runtime_restore = command
+        .find_subcommand_mut("runtime-restore")
+        .expect("runtime-restore subcommand should exist");
+    let mut help = Vec::new();
+    runtime_restore
+        .write_long_help(&mut help)
+        .expect("render runtime-restore help");
+    let help = String::from_utf8(help).expect("help should be utf8");
+
+    assert!(
+        help.contains("Dry-run by default"),
+        "runtime-restore help should explain the default dry-run behavior: {help}"
+    );
+    assert!(
+        help.contains("--apply"),
+        "runtime-restore help should explain how to perform mutations: {help}"
+    );
+}
+
+#[test]
 fn ask_cli_accepts_message_session_and_acp_flags() {
     let cli = Cli::try_parse_from([
         "loongclaw",

--- a/crates/daemon/tests/integration/runtime_restore_cli.rs
+++ b/crates/daemon/tests/integration/runtime_restore_cli.rs
@@ -486,6 +486,51 @@ fn runtime_restore_dry_run_blocks_apply_when_provider_credentials_were_redacted(
 }
 
 #[test]
+fn runtime_restore_dry_run_blocks_apply_when_managed_skill_inventory_was_not_captured() {
+    let root = unique_temp_dir("loongclaw-runtime-restore-missing-managed-inventory");
+    let _env = RuntimeRestoreEnvGuard::set(&[
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+        ("OPENAI_API_KEY", None),
+        ("RUNTIME_RESTORE_DEEPSEEK_KEY", Some("deepseek-demo-token")),
+    ]);
+    let (config_path, mut config) = write_runtime_restore_config(&root);
+    config.external_skills.enabled = false;
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write disabled inventory restore config");
+
+    let (artifact_path, _snapshot, payload) = write_snapshot_artifact(&root, &config_path);
+    assert!(
+        payload["restore_spec"]["warnings"]
+            .as_array()
+            .expect("warnings should be an array")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|warning| warning.contains("could not enumerate managed external skills")),
+        "fixture should capture the managed-skill inventory warning"
+    );
+
+    let dry_run = loongclaw_daemon::runtime_restore_cli::execute_runtime_restore_command(
+        loongclaw_daemon::runtime_restore_cli::RuntimeRestoreCommandOptions {
+            config: Some(config_path.display().to_string()),
+            snapshot: artifact_path.display().to_string(),
+            json: false,
+            apply: false,
+        },
+    )
+    .expect("runtime restore dry-run should still load the artifact");
+
+    assert!(!dry_run.plan.can_apply);
+    assert!(
+        dry_run
+            .plan
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("could not enumerate managed external skills")),
+        "dry-run should keep the managed-skill inventory warning visible"
+    );
+}
+
+#[test]
 fn runtime_restore_dry_run_collects_current_inventory_when_target_snapshot_disables_external_skills()
  {
     let root = unique_temp_dir("loongclaw-runtime-restore-target-disabled");
@@ -633,6 +678,65 @@ fn runtime_restore_apply_replays_snapshot_state_and_verifies_post_apply_match() 
             .expect("skills should be an array")
             .iter()
             .any(|skill| skill["skill_id"] == "demo-skill")
+    );
+}
+
+#[test]
+fn runtime_restore_apply_reports_verification_failure_without_reverting_applied_state() {
+    let root = unique_temp_dir("loongclaw-runtime-restore-verification-failure");
+    let _env = RuntimeRestoreEnvGuard::set(&[
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+        ("OPENAI_API_KEY", None),
+        ("RUNTIME_RESTORE_DEEPSEEK_KEY", Some("deepseek-demo-token")),
+    ]);
+    let (config_path, config) = write_runtime_restore_config(&root);
+    install_demo_skill(&root, &config, &config_path);
+    let (_artifact_path, _snapshot, mut payload) = write_snapshot_artifact(&root, &config_path);
+
+    mutate_runtime_restore_config(&config_path, &root);
+
+    payload["restore_spec"]["conversation"]["context_engine"] =
+        Value::String("missing-engine".to_owned());
+    let artifact_path = write_snapshot_artifact_payload(
+        &root,
+        "artifacts/runtime-snapshot-invalid-verification.json",
+        &payload,
+    );
+
+    let execution = loongclaw_daemon::runtime_restore_cli::execute_runtime_restore_command(
+        loongclaw_daemon::runtime_restore_cli::RuntimeRestoreCommandOptions {
+            config: Some(config_path.display().to_string()),
+            snapshot: artifact_path.display().to_string(),
+            json: false,
+            apply: true,
+        },
+    )
+    .expect("apply should surface verification failure instead of returning an error");
+
+    let verification = execution
+        .verification
+        .as_ref()
+        .expect("apply should still emit verification metadata");
+    assert!(!verification.restored_exactly);
+    assert!(
+        verification
+            .mismatches
+            .iter()
+            .any(|mismatch| mismatch == "verification_unavailable"),
+        "verification failure should be explicit in the mismatch list"
+    );
+    assert!(
+        verification
+            .verification_error
+            .as_deref()
+            .is_some_and(|error| error.contains("post-apply runtime snapshot verification failed")),
+        "verification error should preserve the post-apply failure context"
+    );
+
+    let raw_config = fs::read_to_string(&config_path).expect("read mutated config");
+    assert!(
+        raw_config.contains("context_engine = \"missing-engine\""),
+        "apply should have already persisted the requested restore state"
     );
 }
 

--- a/crates/daemon/tests/integration/runtime_restore_cli.rs
+++ b/crates/daemon/tests/integration/runtime_restore_cli.rs
@@ -195,6 +195,19 @@ fn write_snapshot_artifact(
     (artifact_path, snapshot, payload)
 }
 
+fn write_snapshot_artifact_payload(root: &Path, relative: &str, payload: &Value) -> PathBuf {
+    let artifact_path = root.join(relative);
+    if let Some(parent) = artifact_path.parent() {
+        fs::create_dir_all(parent).expect("create artifact parent");
+    }
+    fs::write(
+        &artifact_path,
+        serde_json::to_string_pretty(payload).expect("encode artifact payload"),
+    )
+    .expect("write artifact payload");
+    artifact_path
+}
+
 fn mutate_runtime_restore_config(config_path: &Path, root: &Path) {
     let (_, mut config) = mvp::config::load(Some(
         config_path
@@ -332,6 +345,32 @@ fn runtime_snapshot_artifact_json_redacts_inline_provider_secrets_from_restore_s
 }
 
 #[test]
+fn runtime_snapshot_artifact_json_warns_when_managed_skill_inventory_is_disabled() {
+    let root = unique_temp_dir("loongclaw-runtime-restore-disabled-inventory");
+    let _env = RuntimeRestoreEnvGuard::set(&[
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+        ("OPENAI_API_KEY", None),
+        ("RUNTIME_RESTORE_DEEPSEEK_KEY", Some("deepseek-demo-token")),
+    ]);
+    let (config_path, mut config) = write_runtime_restore_config(&root);
+    config.external_skills.enabled = false;
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write disabled inventory fixture");
+
+    let (_artifact_path, _snapshot, payload) = write_snapshot_artifact(&root, &config_path);
+
+    assert!(
+        payload["restore_spec"]["warnings"]
+            .as_array()
+            .expect("warnings should be an array")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|warning| warning.contains("inventory is disabled")),
+        "restore spec should warn when managed skill inventory is disabled"
+    );
+}
+
+#[test]
 fn runtime_restore_dry_run_reports_pending_mutations_and_leaves_config_unchanged() {
     let root = unique_temp_dir("loongclaw-runtime-restore-dry-run");
     let _env = RuntimeRestoreEnvGuard::set(&[
@@ -385,6 +424,146 @@ fn runtime_restore_dry_run_reports_pending_mutations_and_leaves_config_unchanged
     assert_eq!(
         reloaded.memory.profile,
         mvp::config::MemoryProfile::WindowOnly
+    );
+}
+
+#[test]
+fn runtime_restore_dry_run_blocks_apply_when_provider_credentials_were_redacted() {
+    let root = unique_temp_dir("loongclaw-runtime-restore-redacted-block");
+    let _env = RuntimeRestoreEnvGuard::set(&[
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+        ("OPENAI_API_KEY", None),
+        ("RUNTIME_RESTORE_DEEPSEEK_KEY", None),
+    ]);
+    let (config_path, mut config) = write_runtime_restore_config(&root);
+    config.set_active_provider_profile(
+        "deepseek-lab",
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Deepseek,
+                model: "deepseek-chat".to_owned(),
+                api_key: Some("literal-secret-value".to_owned()),
+                ..Default::default()
+            },
+        },
+    );
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write redacted restore config");
+
+    let (artifact_path, _snapshot, _payload) = write_snapshot_artifact(&root, &config_path);
+
+    let dry_run = loongclaw_daemon::runtime_restore_cli::execute_runtime_restore_command(
+        loongclaw_daemon::runtime_restore_cli::RuntimeRestoreCommandOptions {
+            config: Some(config_path.display().to_string()),
+            snapshot: artifact_path.display().to_string(),
+            json: false,
+            apply: false,
+        },
+    )
+    .expect("runtime restore dry-run should surface blocking warnings");
+
+    assert!(!dry_run.plan.can_apply);
+    assert!(
+        dry_run
+            .plan
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("redacted inline provider credential")),
+        "dry-run should keep the redacted credential warning visible"
+    );
+
+    let apply_error = loongclaw_daemon::runtime_restore_cli::execute_runtime_restore_command(
+        loongclaw_daemon::runtime_restore_cli::RuntimeRestoreCommandOptions {
+            config: Some(config_path.display().to_string()),
+            snapshot: artifact_path.display().to_string(),
+            json: false,
+            apply: true,
+        },
+    )
+    .expect_err("apply should reject snapshots with redacted inline credentials");
+    assert!(apply_error.contains("cannot be safely applied"));
+}
+
+#[test]
+fn runtime_restore_dry_run_collects_current_inventory_when_target_snapshot_disables_external_skills()
+ {
+    let root = unique_temp_dir("loongclaw-runtime-restore-target-disabled");
+    let _env = RuntimeRestoreEnvGuard::set(&[
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+        ("OPENAI_API_KEY", None),
+        ("RUNTIME_RESTORE_DEEPSEEK_KEY", Some("deepseek-demo-token")),
+    ]);
+    let (config_path, config) = write_runtime_restore_config(&root);
+    install_demo_skill(&root, &config, &config_path);
+    let (_artifact_path, _snapshot, mut payload) = write_snapshot_artifact(&root, &config_path);
+
+    payload["restore_spec"]["external_skills"]["enabled"] = Value::Bool(false);
+    payload["restore_spec"]["managed_skills"]["skills"] = Value::Array(Vec::new());
+    let disabled_artifact_path = write_snapshot_artifact_payload(
+        &root,
+        "artifacts/runtime-snapshot-disabled.json",
+        &payload,
+    );
+
+    let execution = loongclaw_daemon::runtime_restore_cli::execute_runtime_restore_command(
+        loongclaw_daemon::runtime_restore_cli::RuntimeRestoreCommandOptions {
+            config: Some(config_path.display().to_string()),
+            snapshot: disabled_artifact_path.display().to_string(),
+            json: false,
+            apply: false,
+        },
+    )
+    .expect("restore planning should not depend on the target snapshot runtime being enabled");
+
+    assert!(execution.plan.can_apply);
+    assert!(
+        execution
+            .plan
+            .managed_skill_actions
+            .iter()
+            .any(|action| action.skill_id == "demo-skill" && action.action == "remove"),
+        "current managed inventory should still be collected and planned for removal"
+    );
+}
+
+#[test]
+fn runtime_restore_dry_run_ignores_source_path_only_drift_for_managed_skills() {
+    let root = unique_temp_dir("loongclaw-runtime-restore-source-drift");
+    let _env = RuntimeRestoreEnvGuard::set(&[
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+        ("OPENAI_API_KEY", None),
+        ("RUNTIME_RESTORE_DEEPSEEK_KEY", Some("deepseek-demo-token")),
+    ]);
+    let (config_path, config) = write_runtime_restore_config(&root);
+    install_demo_skill(&root, &config, &config_path);
+    let (_artifact_path, _snapshot, mut payload) = write_snapshot_artifact(&root, &config_path);
+
+    payload["restore_spec"]["managed_skills"]["skills"][0]["source_path"] =
+        Value::String("/tmp/other-machine/demo-skill".to_owned());
+    let artifact_path = write_snapshot_artifact_payload(
+        &root,
+        "artifacts/runtime-snapshot-source-drift.json",
+        &payload,
+    );
+
+    let execution = loongclaw_daemon::runtime_restore_cli::execute_runtime_restore_command(
+        loongclaw_daemon::runtime_restore_cli::RuntimeRestoreCommandOptions {
+            config: Some(config_path.display().to_string()),
+            snapshot: artifact_path.display().to_string(),
+            json: false,
+            apply: false,
+        },
+    )
+    .expect("source-path-only drift should remain a no-op when content digest matches");
+
+    assert!(execution.plan.managed_skill_actions.is_empty());
+    assert!(
+        !execution
+            .plan
+            .changed_surfaces
+            .iter()
+            .any(|surface| surface == "managed_skills")
     );
 }
 
@@ -455,4 +634,58 @@ fn runtime_restore_apply_replays_snapshot_state_and_verifies_post_apply_match() 
             .iter()
             .any(|skill| skill["skill_id"] == "demo-skill")
     );
+}
+
+#[test]
+fn runtime_restore_apply_rolls_back_managed_skill_changes_when_config_write_fails() {
+    let root = unique_temp_dir("loongclaw-runtime-restore-rollback");
+    let _env = RuntimeRestoreEnvGuard::set(&[
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+        ("OPENAI_API_KEY", None),
+        ("RUNTIME_RESTORE_DEEPSEEK_KEY", Some("deepseek-demo-token")),
+    ]);
+    let (config_path, config) = write_runtime_restore_config(&root);
+    install_demo_skill(&root, &config, &config_path);
+    let (artifact_path, _snapshot, _payload) = write_snapshot_artifact(&root, &config_path);
+
+    mutate_runtime_restore_config(&config_path, &root);
+
+    let metadata = fs::metadata(&config_path).expect("read config metadata");
+    let original_permissions = metadata.permissions();
+    let mut readonly_permissions = original_permissions.clone();
+    readonly_permissions.set_readonly(true);
+    fs::set_permissions(&config_path, readonly_permissions).expect("mark config read-only");
+
+    let apply_error = loongclaw_daemon::runtime_restore_cli::execute_runtime_restore_command(
+        loongclaw_daemon::runtime_restore_cli::RuntimeRestoreCommandOptions {
+            config: Some(config_path.display().to_string()),
+            snapshot: artifact_path.display().to_string(),
+            json: false,
+            apply: true,
+        },
+    )
+    .expect_err("apply should fail when config persistence fails");
+
+    fs::set_permissions(&config_path, original_permissions).expect("restore config write access");
+
+    assert!(apply_error.contains("persist runtime restore config"));
+    assert!(
+        !root.join("managed-skills").join("demo-skill").exists(),
+        "managed skill install should be rolled back when config persistence fails"
+    );
+
+    let index_path = root.join("managed-skills").join("index.json");
+    if index_path.exists() {
+        let index = serde_json::from_str::<Value>(
+            &fs::read_to_string(&index_path).expect("read managed skill index"),
+        )
+        .expect("decode managed skill index");
+        assert!(
+            index["skills"]
+                .as_array()
+                .expect("index skills should be an array")
+                .is_empty(),
+            "rollback should leave the managed skill index empty"
+        );
+    }
 }

--- a/crates/daemon/tests/integration/runtime_restore_cli.rs
+++ b/crates/daemon/tests/integration/runtime_restore_cli.rs
@@ -1,0 +1,458 @@
+#![allow(unsafe_code)]
+#![allow(
+    clippy::disallowed_methods,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::undocumented_unsafe_blocks
+)]
+
+use super::*;
+use serde_json::Value;
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+    sync::MutexGuard,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+}
+
+fn write_file(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent directory");
+    }
+    fs::write(path, content).expect("write fixture");
+}
+
+struct RuntimeRestoreEnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: Vec<(String, Option<OsString>)>,
+}
+
+impl RuntimeRestoreEnvGuard {
+    fn set(pairs: &[(&str, Option<&str>)]) -> Self {
+        let lock = super::lock_daemon_test_environment();
+        let mut saved = Vec::new();
+        for (key, value) in pairs {
+            saved.push(((*key).to_owned(), std::env::var_os(key)));
+            match value {
+                Some(value) => unsafe {
+                    std::env::set_var(key, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(key);
+                },
+            }
+        }
+        Self { _lock: lock, saved }
+    }
+}
+
+impl Drop for RuntimeRestoreEnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..).rev() {
+            match value {
+                Some(value) => unsafe {
+                    std::env::set_var(&key, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(&key);
+                },
+            }
+        }
+    }
+}
+
+fn write_runtime_restore_config(root: &Path) -> (PathBuf, mvp::config::LoongClawConfig) {
+    fs::create_dir_all(root).expect("create fixture root");
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.tools.file_root = Some(root.display().to_string());
+    config.tools.shell_allow = vec!["git".to_owned(), "cargo".to_owned()];
+    config.tools.shell_deny = vec!["rm".to_owned()];
+    config.tools.browser.enabled = true;
+    config.tools.browser.max_sessions = 4;
+    config.tools.browser.max_links = 32;
+    config.tools.browser.max_text_chars = 4096;
+    config.tools.browser_companion.enabled = true;
+    config.tools.browser_companion.command = Some("browser-companion".to_owned());
+    config.tools.browser_companion.expected_version = Some("1.2.3".to_owned());
+    config.tools.web.enabled = true;
+    config.tools.web.allowed_domains = vec!["docs.example.com".to_owned()];
+    config.tools.web.blocked_domains = vec!["internal.example".to_owned()];
+
+    config.conversation.context_engine = Some("default".to_owned());
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(6);
+    config.conversation.compact_trigger_estimated_tokens = Some(900);
+    config.conversation.compact_fail_open = false;
+
+    config.memory.profile = mvp::config::MemoryProfile::WindowPlusSummary;
+    config.memory.fail_open = false;
+    config.memory.ingest_mode = mvp::config::MemoryIngestMode::AsyncBackground;
+    config.memory.profile_note = Some("restore-target".to_owned());
+
+    config.external_skills.enabled = true;
+    config.external_skills.require_download_approval = false;
+    config.external_skills.auto_expose_installed = true;
+    config.external_skills.allowed_domains = vec!["skills.sh".to_owned()];
+    config.external_skills.install_root = Some(root.join("managed-skills").display().to_string());
+
+    config.acp.enabled = true;
+    config.acp.dispatch.enabled = true;
+    config.acp.default_agent = Some("planner".to_owned());
+    config.acp.allowed_agents = vec!["planner".to_owned(), "codex".to_owned()];
+    config.acp.dispatch.allowed_channels = vec!["feishu".to_owned()];
+    config.acp.dispatch.working_directory = Some(root.join("workspace").display().to_string());
+
+    config.providers.insert(
+        "openai-main".to_owned(),
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: false,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Openai,
+                model: "gpt-4.1-mini".to_owned(),
+                api_key: Some("${OPENAI_API_KEY}".to_owned()),
+                ..Default::default()
+            },
+        },
+    );
+    config.set_active_provider_profile(
+        "deepseek-lab",
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Deepseek,
+                model: "deepseek-chat".to_owned(),
+                api_key: Some("${RUNTIME_RESTORE_DEEPSEEK_KEY}".to_owned()),
+                ..Default::default()
+            },
+        },
+    );
+
+    let config_path = root.join("loongclaw.toml");
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write config fixture");
+    (config_path, config)
+}
+
+fn install_demo_skill(root: &Path, config: &mvp::config::LoongClawConfig, config_path: &Path) {
+    write_file(
+        root,
+        "source/demo-skill/SKILL.md",
+        "# Demo Skill\n\nInstalled for runtime restore coverage.\n",
+    );
+
+    let runtime_config = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+        config,
+        Some(config_path),
+    );
+    mvp::tools::execute_tool_core_with_config(
+        kernel::ToolCoreRequest {
+            tool_name: "external_skills.install".to_owned(),
+            payload: serde_json::json!({
+                "path": "source/demo-skill"
+            }),
+        },
+        &runtime_config,
+    )
+    .expect("install demo skill");
+}
+
+fn write_snapshot_artifact(
+    root: &Path,
+    config_path: &Path,
+) -> (PathBuf, loongclaw_daemon::RuntimeSnapshotCliState, Value) {
+    let snapshot = collect_runtime_snapshot_cli_state(Some(
+        config_path.to_str().expect("config path should be utf-8"),
+    ))
+    .expect("collect runtime snapshot");
+    let metadata = loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+        created_at: "2026-03-16T11:30:00Z".to_owned(),
+        label: Some("baseline".to_owned()),
+        experiment_id: Some("exp-runtime-restore".to_owned()),
+        parent_snapshot_id: Some("snapshot-parent".to_owned()),
+    };
+    let payload =
+        loongclaw_daemon::build_runtime_snapshot_artifact_json_payload(&snapshot, &metadata)
+            .expect("build runtime snapshot artifact");
+    let artifact_path = root.join("artifacts/runtime-snapshot.json");
+    if let Some(parent) = artifact_path.parent() {
+        fs::create_dir_all(parent).expect("create artifact directory");
+    }
+    fs::write(
+        &artifact_path,
+        serde_json::to_string_pretty(&payload).expect("encode snapshot artifact"),
+    )
+    .expect("write snapshot artifact");
+    (artifact_path, snapshot, payload)
+}
+
+fn mutate_runtime_restore_config(config_path: &Path, root: &Path) {
+    let (_, mut config) = mvp::config::load(Some(
+        config_path
+            .to_str()
+            .expect("config path should be valid utf-8"),
+    ))
+    .expect("reload fixture config");
+
+    config.tools.shell_allow = vec!["git".to_owned()];
+    config.tools.shell_deny.clear();
+    config.tools.browser.enabled = false;
+    config.tools.browser_companion.enabled = false;
+    config.tools.web.allowed_domains.clear();
+    config.tools.web.blocked_domains.clear();
+
+    config.conversation.compact_min_messages = Some(2);
+    config.conversation.compact_trigger_estimated_tokens = Some(128);
+    config.conversation.compact_fail_open = true;
+
+    config.memory.profile = mvp::config::MemoryProfile::WindowOnly;
+    config.memory.fail_open = true;
+    config.memory.ingest_mode = mvp::config::MemoryIngestMode::SyncMinimal;
+    config.memory.profile_note = Some("mutated".to_owned());
+
+    config.external_skills.enabled = false;
+    config.external_skills.require_download_approval = true;
+    config.external_skills.auto_expose_installed = false;
+    config.external_skills.allowed_domains.clear();
+
+    config.acp.enabled = false;
+    config.acp.dispatch.enabled = false;
+    config.acp.default_agent = Some("codex".to_owned());
+    config.acp.allowed_agents = vec!["codex".to_owned()];
+    config.acp.dispatch.allowed_channels.clear();
+    config.acp.dispatch.working_directory =
+        Some(root.join("other-workspace").display().to_string());
+
+    config.set_active_provider_profile(
+        "openai-main",
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Openai,
+                model: "gpt-4.1".to_owned(),
+                api_key: Some("${OPENAI_API_KEY}".to_owned()),
+                ..Default::default()
+            },
+        },
+    );
+    config.last_provider = Some("deepseek-lab".to_owned());
+
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write mutated config");
+
+    let managed_root = root.join("managed-skills");
+    if managed_root.exists() {
+        fs::remove_dir_all(&managed_root).expect("remove managed skills root");
+    }
+}
+
+#[test]
+fn runtime_snapshot_artifact_json_includes_lineage_and_restore_spec() {
+    let root = unique_temp_dir("loongclaw-runtime-restore-artifact");
+    let _env = RuntimeRestoreEnvGuard::set(&[
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+        ("OPENAI_API_KEY", None),
+        ("RUNTIME_RESTORE_DEEPSEEK_KEY", Some("deepseek-demo-token")),
+    ]);
+    let (config_path, config) = write_runtime_restore_config(&root);
+    install_demo_skill(&root, &config, &config_path);
+
+    let (_artifact_path, _snapshot, payload) = write_snapshot_artifact(&root, &config_path);
+
+    assert_eq!(payload["schema"]["version"], 2);
+    assert_eq!(payload["lineage"]["label"], "baseline");
+    assert_eq!(payload["lineage"]["experiment_id"], "exp-runtime-restore");
+    assert_eq!(payload["lineage"]["parent_snapshot_id"], "snapshot-parent");
+    assert!(
+        payload["lineage"]["snapshot_id"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+    );
+    assert_eq!(
+        payload["restore_spec"]["provider"]["active_provider"],
+        "deepseek-lab"
+    );
+    assert_eq!(
+        payload["restore_spec"]["managed_skills"]["skills"][0]["skill_id"],
+        "demo-skill"
+    );
+    assert_eq!(
+        payload["restore_spec"]["managed_skills"]["skills"][0]["source_kind"],
+        "directory"
+    );
+}
+
+#[test]
+fn runtime_snapshot_artifact_json_redacts_inline_provider_secrets_from_restore_spec() {
+    let root = unique_temp_dir("loongclaw-runtime-restore-redaction");
+    let _env = RuntimeRestoreEnvGuard::set(&[
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+        ("OPENAI_API_KEY", None),
+        ("RUNTIME_RESTORE_DEEPSEEK_KEY", None),
+    ]);
+    let (config_path, mut config) = write_runtime_restore_config(&root);
+    config.set_active_provider_profile(
+        "deepseek-lab",
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Deepseek,
+                model: "deepseek-chat".to_owned(),
+                api_key: Some("literal-secret-value".to_owned()),
+                ..Default::default()
+            },
+        },
+    );
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write redaction fixture");
+
+    let (_artifact_path, _snapshot, payload) = write_snapshot_artifact(&root, &config_path);
+
+    let provider = &payload["restore_spec"]["provider"]["profiles"]["deepseek-lab"]["provider"];
+    assert!(provider["api_key"].is_null());
+    assert!(provider["oauth_access_token"].is_null());
+    assert!(
+        payload["restore_spec"]["warnings"]
+            .as_array()
+            .expect("warnings should be an array")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|warning| warning.contains("deepseek-lab")),
+        "restore spec should surface a warning for redacted inline credentials"
+    );
+}
+
+#[test]
+fn runtime_restore_dry_run_reports_pending_mutations_and_leaves_config_unchanged() {
+    let root = unique_temp_dir("loongclaw-runtime-restore-dry-run");
+    let _env = RuntimeRestoreEnvGuard::set(&[
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+        ("OPENAI_API_KEY", None),
+        ("RUNTIME_RESTORE_DEEPSEEK_KEY", Some("deepseek-demo-token")),
+    ]);
+    let (config_path, config) = write_runtime_restore_config(&root);
+    install_demo_skill(&root, &config, &config_path);
+    let (artifact_path, _snapshot, _payload) = write_snapshot_artifact(&root, &config_path);
+
+    mutate_runtime_restore_config(&config_path, &root);
+
+    let execution = loongclaw_daemon::runtime_restore_cli::execute_runtime_restore_command(
+        loongclaw_daemon::runtime_restore_cli::RuntimeRestoreCommandOptions {
+            config: Some(config_path.display().to_string()),
+            snapshot: artifact_path.display().to_string(),
+            json: false,
+            apply: false,
+        },
+    )
+    .expect("runtime restore dry-run should succeed");
+
+    assert!(execution.plan.can_apply);
+    assert!(
+        execution
+            .plan
+            .changed_surfaces
+            .iter()
+            .any(|surface| surface == "provider")
+    );
+    assert!(
+        execution
+            .plan
+            .changed_surfaces
+            .iter()
+            .any(|surface| surface == "external_skills")
+    );
+    assert!(
+        execution
+            .plan
+            .managed_skill_actions
+            .iter()
+            .any(|action| action.skill_id == "demo-skill" && action.action == "install")
+    );
+
+    let (_, reloaded) = mvp::config::load(Some(config_path.to_string_lossy().as_ref()))
+        .expect("reload dry-run config");
+    assert_eq!(reloaded.active_provider_id(), Some("openai-main"));
+    assert!(!reloaded.external_skills.enabled);
+    assert_eq!(
+        reloaded.memory.profile,
+        mvp::config::MemoryProfile::WindowOnly
+    );
+}
+
+#[test]
+fn runtime_restore_apply_replays_snapshot_state_and_verifies_post_apply_match() {
+    let root = unique_temp_dir("loongclaw-runtime-restore-apply");
+    let _env = RuntimeRestoreEnvGuard::set(&[
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+        ("OPENAI_API_KEY", None),
+        ("RUNTIME_RESTORE_DEEPSEEK_KEY", Some("deepseek-demo-token")),
+    ]);
+    let (config_path, config) = write_runtime_restore_config(&root);
+    install_demo_skill(&root, &config, &config_path);
+    let (artifact_path, _snapshot, _payload) = write_snapshot_artifact(&root, &config_path);
+
+    mutate_runtime_restore_config(&config_path, &root);
+
+    let execution = loongclaw_daemon::runtime_restore_cli::execute_runtime_restore_command(
+        loongclaw_daemon::runtime_restore_cli::RuntimeRestoreCommandOptions {
+            config: Some(config_path.display().to_string()),
+            snapshot: artifact_path.display().to_string(),
+            json: false,
+            apply: true,
+        },
+    )
+    .expect("runtime restore apply should succeed");
+
+    assert!(execution.applied);
+    assert!(
+        execution
+            .verification
+            .as_ref()
+            .expect("apply should produce verification")
+            .restored_exactly
+    );
+
+    let (_, reloaded) = mvp::config::load(Some(config_path.to_string_lossy().as_ref()))
+        .expect("reload restored config");
+    assert_eq!(reloaded.active_provider_id(), Some("deepseek-lab"));
+    assert!(reloaded.external_skills.enabled);
+    assert_eq!(
+        reloaded.memory.profile,
+        mvp::config::MemoryProfile::WindowPlusSummary
+    );
+    assert!(!reloaded.memory.fail_open);
+    assert!(reloaded.acp.enabled);
+    assert!(reloaded.tools.browser.enabled);
+    assert_eq!(
+        reloaded.tools.browser_companion.expected_version.as_deref(),
+        Some("1.2.3")
+    );
+
+    let snapshot = collect_runtime_snapshot_cli_state(Some(
+        config_path.to_str().expect("config path should be utf-8"),
+    ))
+    .expect("collect restored snapshot");
+    let payload = build_runtime_snapshot_cli_json_payload(&snapshot);
+    assert_eq!(payload["provider"]["active_profile_id"], "deepseek-lab");
+    assert!(
+        payload["external_skills"]["policy"]["enabled"]
+            .as_bool()
+            .expect("enabled should be boolean")
+    );
+    assert!(
+        payload["external_skills"]["inventory"]["skills"]
+            .as_array()
+            .expect("skills should be an array")
+            .iter()
+            .any(|skill| skill["skill_id"] == "demo-skill")
+    );
+}

--- a/crates/daemon/tests/integration/runtime_restore_cli.rs
+++ b/crates/daemon/tests/integration/runtime_restore_cli.rs
@@ -327,10 +327,7 @@ fn runtime_snapshot_artifact_json_redacts_inline_provider_secrets_from_restore_s
                         "anthropic-api-key".to_owned(),
                         "literal-header-secret".to_owned(),
                     ),
-                    (
-                        "anthropic-version".to_owned(),
-                        "2023-06-01".to_owned(),
-                    ),
+                    ("anthropic-version".to_owned(), "2023-06-01".to_owned()),
                     ("x-goog-api-key".to_owned(), "${GOOGLE_API_KEY}".to_owned()),
                     ("user-agent".to_owned(), "loongclaw-test-suite".to_owned()),
                 ]),

--- a/crates/daemon/tests/integration/runtime_restore_cli.rs
+++ b/crates/daemon/tests/integration/runtime_restore_cli.rs
@@ -8,6 +8,7 @@
 use super::*;
 use serde_json::Value;
 use std::{
+    collections::BTreeMap,
     ffi::OsString,
     fs,
     path::{Path, PathBuf},
@@ -321,6 +322,18 @@ fn runtime_snapshot_artifact_json_redacts_inline_provider_secrets_from_restore_s
                 kind: mvp::config::ProviderKind::Deepseek,
                 model: "deepseek-chat".to_owned(),
                 api_key: Some("literal-secret-value".to_owned()),
+                headers: BTreeMap::from([
+                    (
+                        "anthropic-api-key".to_owned(),
+                        "literal-header-secret".to_owned(),
+                    ),
+                    (
+                        "anthropic-version".to_owned(),
+                        "2023-06-01".to_owned(),
+                    ),
+                    ("x-goog-api-key".to_owned(), "${GOOGLE_API_KEY}".to_owned()),
+                    ("user-agent".to_owned(), "loongclaw-test-suite".to_owned()),
+                ]),
                 ..Default::default()
             },
         },
@@ -330,17 +343,23 @@ fn runtime_snapshot_artifact_json_redacts_inline_provider_secrets_from_restore_s
 
     let (_artifact_path, _snapshot, payload) = write_snapshot_artifact(&root, &config_path);
 
-    let provider = &payload["restore_spec"]["provider"]["profiles"]["deepseek-lab"]["provider"];
-    assert!(provider["api_key"].is_null());
-    assert!(provider["oauth_access_token"].is_null());
+    let profile = &payload["restore_spec"]["provider"]["profiles"]["deepseek-lab"];
+    assert!(profile["api_key"].is_null());
+    assert!(profile["oauth_access_token"].is_null());
+    assert!(profile["headers"]["anthropic-api-key"].is_null());
+    assert_eq!(profile["headers"]["anthropic-version"], "2023-06-01");
+    assert_eq!(profile["headers"]["x-goog-api-key"], "${GOOGLE_API_KEY}");
+    assert_eq!(profile["headers"]["user-agent"], "loongclaw-test-suite");
     assert!(
         payload["restore_spec"]["warnings"]
             .as_array()
             .expect("warnings should be an array")
             .iter()
             .filter_map(Value::as_str)
-            .any(|warning| warning.contains("deepseek-lab")),
-        "restore spec should surface a warning for redacted inline credentials"
+            .any(|warning| {
+                warning.contains("deepseek-lab") && warning.contains("anthropic-api-key")
+            }),
+        "restore spec should surface a warning for redacted inline provider headers"
     );
 }
 


### PR DESCRIPTION
## Summary

- add snapshot artifact lineage metadata plus a redacted `restore_spec` so experiment runs can be captured as replayable documents
- add `runtime-restore` with dry-run planning, `--apply` replay, managed external skill sync, and post-apply verification
- add integration coverage for artifact lineage, provider secret redaction, dry-run no-op behavior, and full apply replay

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:
- `runtime-restore` defaults to dry-run; `--apply` is required before config or managed skill mutations happen.
- Snapshot `restore_spec` redacts inline provider credentials and records warnings instead of serializing secrets.
- This PR is intentionally stacked on top of #205; until #205 lands, the diff includes the snapshot substrate commits as context.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Validation notes:
- Focused replay coverage: `cargo test -p loongclaw-daemon --test integration runtime_restore --manifest-path Cargo.toml`
- Full daemon integration coverage: `cargo test -p loongclaw-daemon --test integration --manifest-path Cargo.toml`
- Before: `runtime-snapshot` emitted an observational runtime report only.
- After: `runtime-snapshot` can persist lineage-rich replay artifacts, and `runtime-restore --apply` can rehydrate provider, conversation, memory, ACP, tool, external-skill policy, and managed skill state.
- Env-mutating tests use `RuntimeRestoreEnvGuard` plus `lock_daemon_test_environment()` to serialize and restore process-global state.

## Linked Issues

Closes #208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to capture and restore runtime snapshots with artifact export (JSON/text) and options for output path, label, experiment ID, and parent snapshot ID.
  * Restore workflow runs as a dry-run by default; use --apply to perform changes. Outputs include planned actions, warnings (including redacted secrets), verification results, and rollback reporting.

* **Tests**
  * Added extensive integration tests covering snapshot capture, artifact content, dry-run vs apply flows, verification, and rollback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->