### PR TITLE
feat(doctor): add browser companion onboarding diagnostics

### DIFF
--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -1,0 +1,249 @@
+use std::io::ErrorKind;
+use std::time::Duration;
+
+use loongclaw_app as mvp;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+pub(crate) const BROWSER_COMPANION_INSTALL_CHECK_NAME: &str = "browser companion install";
+pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser companion runtime gate";
+
+const BROWSER_COMPANION_VERSION_ARG: &str = "--version";
+const BROWSER_COMPANION_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+
+// Shared readiness snapshot for doctor/onboard so the companion lane is probed once.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BrowserCompanionDiagnostics {
+    pub(crate) command: Option<String>,
+    pub(crate) expected_version: Option<String>,
+    pub(crate) observed_version: Option<String>,
+    pub(crate) runtime_ready: bool,
+    pub(crate) install_status: BrowserCompanionInstallStatus,
+}
+
+impl BrowserCompanionDiagnostics {
+    pub(crate) fn install_ready(&self) -> bool {
+        matches!(self.install_status, BrowserCompanionInstallStatus::Ready)
+    }
+
+    pub(crate) fn install_detail(&self) -> String {
+        match &self.install_status {
+            BrowserCompanionInstallStatus::MissingCommand => {
+                "browser companion is enabled, but no command is configured under `tools.browser_companion.command`"
+                    .to_owned()
+            }
+            BrowserCompanionInstallStatus::MissingBinary { command } => {
+                format!("command `{command}` was not found on PATH")
+            }
+            BrowserCompanionInstallStatus::ProbeTimedOut { command } => {
+                format!(
+                    "command `{command} {BROWSER_COMPANION_VERSION_ARG}` timed out after {}s",
+                    BROWSER_COMPANION_PROBE_TIMEOUT.as_secs()
+                )
+            }
+            BrowserCompanionInstallStatus::ProbeFailed { command, error } => {
+                format!(
+                    "command `{command} {BROWSER_COMPANION_VERSION_ARG}` failed before reporting a version: {error}"
+                )
+            }
+            BrowserCompanionInstallStatus::ProbeExited {
+                command,
+                observed,
+                exit_status,
+            } => {
+                let exit_status = exit_status
+                    .map_or_else(|| "signal".to_owned(), |code| code.to_string());
+                format!(
+                    "command `{command} {BROWSER_COMPANION_VERSION_ARG}` exited with status {exit_status}: {observed}"
+                )
+            }
+            BrowserCompanionInstallStatus::VersionMismatch {
+                command,
+                expected_version,
+                observed_version,
+            } => {
+                format!(
+                    "command `{command}` responded, but expected_version={expected_version} observed_version={observed_version}"
+                )
+            }
+            BrowserCompanionInstallStatus::Ready => {
+                let command = self.command.as_deref().unwrap_or("browser companion");
+                let observed_version = self.observed_version.as_deref().unwrap_or("(empty)");
+                format!("command `{command}` responded with `{observed_version}`")
+            }
+        }
+    }
+
+    pub(crate) fn runtime_gate_detail(&self) -> Option<String> {
+        if !self.install_ready() {
+            return None;
+        }
+
+        let observed_version = self.observed_version.as_deref().unwrap_or("(empty)");
+        Some(if self.runtime_ready {
+            format!("managed browser companion runtime is ready ({observed_version})")
+        } else {
+            format!(
+                "install looks healthy ({observed_version}), but the runtime gate is still closed (`LOONGCLAW_BROWSER_COMPANION_READY` is false)"
+            )
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BrowserCompanionInstallStatus {
+    MissingCommand,
+    MissingBinary {
+        command: String,
+    },
+    ProbeTimedOut {
+        command: String,
+    },
+    ProbeFailed {
+        command: String,
+        error: String,
+    },
+    ProbeExited {
+        command: String,
+        observed: String,
+        exit_status: Option<i32>,
+    },
+    VersionMismatch {
+        command: String,
+        expected_version: String,
+        observed_version: String,
+    },
+    Ready,
+}
+
+#[derive(Debug)]
+enum BrowserCompanionProbeError {
+    MissingBinary,
+    TimedOut,
+    SpawnFailed(String),
+    Exited {
+        observed: String,
+        exit_status: Option<i32>,
+    },
+}
+
+pub(crate) async fn collect_browser_companion_diagnostics(
+    config: &mvp::config::LoongClawConfig,
+) -> Option<BrowserCompanionDiagnostics> {
+    let runtime =
+        mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None)
+            .browser_companion;
+    if !runtime.enabled {
+        return None;
+    }
+
+    let runtime_ready = runtime.is_runtime_ready();
+    let expected_version = runtime.expected_version;
+    let Some(command) = runtime.command else {
+        return Some(BrowserCompanionDiagnostics {
+            command: None,
+            expected_version,
+            observed_version: None,
+            runtime_ready,
+            install_status: BrowserCompanionInstallStatus::MissingCommand,
+        });
+    };
+
+    match probe_browser_companion_version(&command).await {
+        Ok(observed_version) => {
+            let install_status = match expected_version.as_deref() {
+                Some(expected_version) if !observed_version.contains(expected_version) => {
+                    BrowserCompanionInstallStatus::VersionMismatch {
+                        command: command.clone(),
+                        expected_version: expected_version.to_owned(),
+                        observed_version: observed_version.clone(),
+                    }
+                }
+                _ => BrowserCompanionInstallStatus::Ready,
+            };
+            Some(BrowserCompanionDiagnostics {
+                command: Some(command),
+                expected_version,
+                observed_version: Some(observed_version),
+                runtime_ready,
+                install_status,
+            })
+        }
+        Err(BrowserCompanionProbeError::MissingBinary) => Some(BrowserCompanionDiagnostics {
+            command: Some(command.clone()),
+            expected_version,
+            observed_version: None,
+            runtime_ready,
+            install_status: BrowserCompanionInstallStatus::MissingBinary { command },
+        }),
+        Err(BrowserCompanionProbeError::TimedOut) => Some(BrowserCompanionDiagnostics {
+            command: Some(command.clone()),
+            expected_version,
+            observed_version: None,
+            runtime_ready,
+            install_status: BrowserCompanionInstallStatus::ProbeTimedOut { command },
+        }),
+        Err(BrowserCompanionProbeError::SpawnFailed(error)) => Some(BrowserCompanionDiagnostics {
+            command: Some(command.clone()),
+            expected_version,
+            observed_version: None,
+            runtime_ready,
+            install_status: BrowserCompanionInstallStatus::ProbeFailed { command, error },
+        }),
+        Err(BrowserCompanionProbeError::Exited {
+            observed,
+            exit_status,
+        }) => Some(BrowserCompanionDiagnostics {
+            command: Some(command.clone()),
+            expected_version,
+            observed_version: Some(observed.clone()),
+            runtime_ready,
+            install_status: BrowserCompanionInstallStatus::ProbeExited {
+                command,
+                observed,
+                exit_status,
+            },
+        }),
+    }
+}
+
+async fn probe_browser_companion_version(
+    command: &str,
+) -> Result<String, BrowserCompanionProbeError> {
+    let mut probe = Command::new(command);
+    probe.arg(BROWSER_COMPANION_VERSION_ARG);
+    probe.kill_on_drop(true);
+
+    match timeout(BROWSER_COMPANION_PROBE_TIMEOUT, probe.output()).await {
+        Ok(Ok(output)) => {
+            let observed = observed_output(&output.stdout, &output.stderr);
+            if output.status.success() {
+                Ok(observed)
+            } else {
+                Err(BrowserCompanionProbeError::Exited {
+                    observed,
+                    exit_status: output.status.code(),
+                })
+            }
+        }
+        Ok(Err(error)) => {
+            if error.kind() == ErrorKind::NotFound {
+                Err(BrowserCompanionProbeError::MissingBinary)
+            } else {
+                Err(BrowserCompanionProbeError::SpawnFailed(error.to_string()))
+            }
+        }
+        Err(_) => Err(BrowserCompanionProbeError::TimedOut),
+    }
+}
+
+fn observed_output(stdout: &[u8], stderr: &[u8]) -> String {
+    let stdout = String::from_utf8_lossy(stdout).trim().to_owned();
+    let stderr = String::from_utf8_lossy(stderr).trim().to_owned();
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (false, true) => stdout,
+        (true, false) => stderr,
+        (false, false) => format!("{stdout} | {stderr}"),
+        (true, true) => "(empty)".to_owned(),
+    }
+}

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -152,7 +152,9 @@ pub(crate) async fn collect_browser_companion_diagnostics(
     match probe_browser_companion_version(&command).await {
         Ok(observed_version) => {
             let install_status = match expected_version.as_deref() {
-                Some(expected_version) if !observed_version.contains(expected_version) => {
+                Some(expected_version)
+                    if !observed_version_matches_expected(&observed_version, expected_version) =>
+                {
                     BrowserCompanionInstallStatus::VersionMismatch {
                         command: command.clone(),
                         expected_version: expected_version.to_owned(),
@@ -245,5 +247,154 @@ fn observed_output(stdout: &[u8], stderr: &[u8]) -> String {
         (true, false) => stderr,
         (false, false) => format!("{stdout} | {stderr}"),
         (true, true) => "(empty)".to_owned(),
+    }
+}
+
+fn observed_version_matches_expected(observed_version: &str, expected_version: &str) -> bool {
+    observed_version
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '.' && c != '-' && c != '_')
+        .filter(|token| !token.is_empty())
+        .any(|token| token == expected_version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(unix)]
+    use std::ffi::OsString;
+    #[cfg(unix)]
+    use std::io::Write;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    #[cfg(unix)]
+    use std::path::{Path, PathBuf};
+    #[cfg(unix)]
+    use std::sync::MutexGuard;
+    #[cfg(unix)]
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[cfg(unix)]
+    fn browser_companion_temp_dir(label: &str) -> PathBuf {
+        static NEXT_TEMP_DIR_SEED: AtomicU64 = AtomicU64::new(1);
+        let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
+        let temp_dir = std::env::temp_dir().join(format!(
+            "loongclaw-browser-companion-diagnostics-{label}-{}-{seed}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&temp_dir).expect("create browser companion diagnostics temp dir");
+        temp_dir
+    }
+
+    #[cfg(unix)]
+    fn write_browser_companion_script(script_path: &Path, body: &str) {
+        let mut file = std::fs::File::create(script_path).expect("create browser companion script");
+        file.write_all(body.as_bytes())
+            .expect("write browser companion script");
+        let mut permissions = file.metadata().expect("script metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(script_path, permissions).expect("chmod browser companion script");
+    }
+
+    #[cfg(unix)]
+    fn set_browser_companion_env_var(key: &str, value: &str) {
+        // SAFETY: daemon tests serialize process env mutations behind
+        // `lock_daemon_test_environment`, so no concurrent env readers/writers
+        // observe racy updates while these tests run.
+        #[allow(unsafe_code, clippy::disallowed_methods)]
+        unsafe {
+            std::env::set_var(key, value);
+        }
+    }
+
+    #[cfg(unix)]
+    fn remove_browser_companion_env_var(key: &str) {
+        // SAFETY: daemon tests serialize process env mutations behind
+        // `lock_daemon_test_environment`, so removing the variable here is
+        // coordinated with all other env-mutating daemon tests.
+        #[allow(unsafe_code, clippy::disallowed_methods)]
+        unsafe {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[cfg(unix)]
+    struct BrowserCompanionEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        saved_ready: Option<OsString>,
+    }
+
+    #[cfg(unix)]
+    impl BrowserCompanionEnvGuard {
+        fn runtime_gate_closed() -> Self {
+            let lock = crate::test_support::lock_daemon_test_environment();
+            let key = "LOONGCLAW_BROWSER_COMPANION_READY";
+            let saved_ready = std::env::var_os(key);
+            remove_browser_companion_env_var(key);
+            Self {
+                _lock: lock,
+                saved_ready,
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for BrowserCompanionEnvGuard {
+        fn drop(&mut self) {
+            let key = "LOONGCLAW_BROWSER_COMPANION_READY";
+            match self.saved_ready.take() {
+                Some(value) => set_browser_companion_env_var(key, &value.to_string_lossy()),
+                None => remove_browser_companion_env_var(key),
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_browser_companion_diagnostics_rejects_partial_expected_version_matches() {
+        let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
+        let temp_dir = browser_companion_temp_dir("partial-version-match");
+        let script_path = temp_dir.join("browser-companion");
+        write_browser_companion_script(
+            &script_path,
+            "#!/bin/sh\necho 'loongclaw-browser-companion 11.5.0'\n",
+        );
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+
+        let diagnostics = collect_browser_companion_diagnostics(&config)
+            .await
+            .expect("diagnostics should be collected");
+
+        assert!(
+            matches!(
+                diagnostics.install_status,
+                BrowserCompanionInstallStatus::VersionMismatch {
+                    ref expected_version,
+                    ref observed_version,
+                    ..
+                } if expected_version == "1.5.0"
+                    && observed_version == "loongclaw-browser-companion 11.5.0"
+            ),
+            "partial version matches should still warn as mismatches: {diagnostics:#?}"
+        );
+    }
+
+    #[test]
+    fn observed_version_matches_expected_accepts_exact_tokens() {
+        assert!(observed_version_matches_expected(
+            "loongclaw-browser-companion 1.5.0",
+            "1.5.0"
+        ));
+    }
+
+    #[test]
+    fn observed_version_matches_expected_rejects_suffix_variants() {
+        assert!(!observed_version_matches_expected(
+            "loongclaw-browser-companion 1.5.0-beta",
+            "1.5.0"
+        ));
     }
 }

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -130,6 +130,7 @@ pub async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
         &mut fixes,
         "create tool file root",
     ));
+    checks.extend(collect_browser_companion_doctor_checks(&config).await);
 
     checks.extend(check_feishu_integration(&config, options.fix, &mut fixes));
     checks.extend(check_channel_surfaces(&config));
@@ -1023,6 +1024,42 @@ fn collect_channel_doctor_checks(config: &mvp::config::LoongClawConfig) -> Vec<D
         .collect()
 }
 
+async fn collect_browser_companion_doctor_checks(
+    config: &mvp::config::LoongClawConfig,
+) -> Vec<DoctorCheck> {
+    let Some(diagnostics) =
+        crate::browser_companion_diagnostics::collect_browser_companion_diagnostics(config).await
+    else {
+        return Vec::new();
+    };
+
+    let install_level = if diagnostics.install_ready() {
+        DoctorCheckLevel::Pass
+    } else {
+        DoctorCheckLevel::Warn
+    };
+    let mut checks = vec![DoctorCheck {
+        name: crate::browser_companion_diagnostics::BROWSER_COMPANION_INSTALL_CHECK_NAME.to_owned(),
+        level: install_level,
+        detail: diagnostics.install_detail(),
+    }];
+
+    if let Some(detail) = diagnostics.runtime_gate_detail() {
+        checks.push(DoctorCheck {
+            name: crate::browser_companion_diagnostics::BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME
+                .to_owned(),
+            level: if diagnostics.runtime_ready {
+                DoctorCheckLevel::Pass
+            } else {
+                DoctorCheckLevel::Warn
+            },
+            detail,
+        });
+    }
+
+    checks
+}
+
 pub fn resolve_secret_value(inline: Option<&str>, env_key: Option<&str>) -> Option<String> {
     if let Some(value) = inline.map(str::trim).filter(|value| !value.is_empty()) {
         return Some(value.to_owned());
@@ -1155,6 +1192,41 @@ fn build_doctor_next_steps_with_path_env(
             &mut steps,
             format!(
                 "If your provider blocks model listing during setup, retry with: {rerun_command} --skip-model-probe"
+            ),
+        );
+    }
+
+    if checks.iter().any(|check| {
+        check.name == crate::browser_companion_diagnostics::BROWSER_COMPANION_INSTALL_CHECK_NAME
+            && check.level != DoctorCheckLevel::Pass
+    }) {
+        push_unique_step(
+            &mut steps,
+            format!(
+                "Install or expose the browser companion command on PATH, then re-run: {rerun_command}"
+            ),
+        );
+        if checks.iter().any(|check| {
+            check.name == crate::browser_companion_diagnostics::BROWSER_COMPANION_INSTALL_CHECK_NAME
+                && check.detail.contains("expected_version=")
+        }) {
+            push_unique_step(
+                &mut steps,
+                "Align `tools.browser_companion.expected_version` with the installed companion build before retrying."
+                    .to_owned(),
+            );
+        }
+    }
+
+    if checks.iter().any(|check| {
+        check.name
+            == crate::browser_companion_diagnostics::BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME
+            && check.level != DoctorCheckLevel::Pass
+    }) {
+        push_unique_step(
+            &mut steps,
+            format!(
+                "Keep using the built-in browser lane, or disable `tools.browser_companion.enabled` until the managed companion runtime is ready, then re-run: {rerun_command}"
             ),
         );
     }
@@ -1302,6 +1374,16 @@ fn push_unique_step(steps: &mut Vec<String>, step: String) {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::ffi::OsString;
+    #[cfg(unix)]
+    use std::io::Write;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    #[cfg(unix)]
+    use std::path::{Path, PathBuf};
+    #[cfg(unix)]
+    use std::sync::MutexGuard;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1312,6 +1394,92 @@ mod tests {
         ChannelOperationHealth, ChannelOperationRuntime, ChannelOperationStatus,
         ChannelStatusSnapshot,
     };
+
+    #[cfg(unix)]
+    fn browser_companion_temp_dir(label: &str) -> PathBuf {
+        static NEXT_TEMP_DIR_SEED: AtomicU64 = AtomicU64::new(1);
+        let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
+        let temp_dir = std::env::temp_dir().join(format!(
+            "loongclaw-browser-companion-doctor-{label}-{}-{seed}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&temp_dir).expect("create browser companion temp dir");
+        temp_dir
+    }
+
+    #[cfg(unix)]
+    fn write_browser_companion_script(script_path: &Path, body: &str) {
+        let mut file = std::fs::File::create(script_path).expect("create browser companion script");
+        file.write_all(body.as_bytes())
+            .expect("write browser companion script");
+        let mut permissions = file.metadata().expect("script metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(script_path, permissions).expect("chmod browser companion script");
+    }
+
+    #[cfg(unix)]
+    struct BrowserCompanionEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        saved_ready: Option<OsString>,
+    }
+
+    #[cfg(unix)]
+    fn set_browser_companion_env_var(key: &str, value: &str) {
+        // SAFETY: daemon tests serialize process env mutations behind
+        // `lock_daemon_test_environment`, so no concurrent env readers/writers
+        // observe racy updates while these tests run.
+        #[allow(unsafe_code, clippy::disallowed_methods)]
+        unsafe {
+            std::env::set_var(key, value);
+        }
+    }
+
+    #[cfg(unix)]
+    fn remove_browser_companion_env_var(key: &str) {
+        // SAFETY: daemon tests serialize process env mutations behind
+        // `lock_daemon_test_environment`, so removing the variable here is
+        // coordinated with all other env-mutating daemon tests.
+        #[allow(unsafe_code, clippy::disallowed_methods)]
+        unsafe {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[cfg(unix)]
+    impl BrowserCompanionEnvGuard {
+        fn runtime_gate_closed() -> Self {
+            Self::set_ready(None)
+        }
+
+        fn runtime_gate_open() -> Self {
+            Self::set_ready(Some("true"))
+        }
+
+        fn set_ready(value: Option<&str>) -> Self {
+            let lock = crate::test_support::lock_daemon_test_environment();
+            let key = "LOONGCLAW_BROWSER_COMPANION_READY";
+            let saved_ready = std::env::var_os(key);
+            match value {
+                Some(value) => set_browser_companion_env_var(key, value),
+                None => remove_browser_companion_env_var(key),
+            }
+            Self {
+                _lock: lock,
+                saved_ready,
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for BrowserCompanionEnvGuard {
+        fn drop(&mut self) {
+            let key = "LOONGCLAW_BROWSER_COMPANION_READY";
+            match self.saved_ready.take() {
+                Some(value) => set_browser_companion_env_var(key, &value.to_string_lossy()),
+                None => remove_browser_companion_env_var(key),
+            }
+        }
+    }
 
     #[test]
     fn resolve_secret_prefers_inline_value() {
@@ -2054,6 +2222,142 @@ mod tests {
                 step == "Re-run diagnostics: loongclaw doctor --config '/tmp/loongclaw'\"'\"'s config.toml'"
             }),
             "doctor should shell-quote config paths with single quotes in rerun commands: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_guides_browser_companion_repair() {
+        let checks = vec![DoctorCheck {
+            name: "browser companion install".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: "command `loongclaw-browser-companion` was not found on PATH".to_owned(),
+        }];
+        let next_steps = build_doctor_next_steps(
+            &checks,
+            Path::new("/tmp/loongclaw.toml"),
+            &mvp::config::LoongClawConfig::default(),
+            false,
+        );
+
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Install or expose the browser companion command on PATH, then re-run: loongclaw doctor --config '/tmp/loongclaw.toml'"
+            }),
+            "doctor should turn browser companion warnings into a concrete repair path: {next_steps:#?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn browser_companion_doctor_checks_warn_when_command_is_missing() {
+        let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.browser_companion.enabled = true;
+
+        let checks = collect_browser_companion_doctor_checks(&config).await;
+
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "browser companion install"
+                    && check.level == DoctorCheckLevel::Warn
+                    && check.detail.contains("no command is configured")
+            }),
+            "doctor should warn when browser companion is enabled without a command: {checks:#?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn browser_companion_doctor_checks_warn_when_expected_version_mismatches() {
+        let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
+        let temp_dir = browser_companion_temp_dir("version-mismatch");
+        let script_path = temp_dir.join("browser-companion");
+        write_browser_companion_script(
+            &script_path,
+            "#!/bin/sh\necho 'loongclaw-browser-companion 1.4.0'\n",
+        );
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+
+        let checks = collect_browser_companion_doctor_checks(&config).await;
+
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "browser companion install"
+                    && check.level == DoctorCheckLevel::Warn
+                    && check.detail.contains("expected_version=1.5.0")
+                    && check
+                        .detail
+                        .contains("observed_version=loongclaw-browser-companion 1.4.0")
+            }),
+            "doctor should surface version mismatches for the managed companion lane: {checks:#?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn browser_companion_doctor_checks_warn_when_runtime_gate_is_closed() {
+        let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
+        let temp_dir = browser_companion_temp_dir("runtime-gate");
+        let script_path = temp_dir.join("browser-companion");
+        write_browser_companion_script(
+            &script_path,
+            "#!/bin/sh\necho 'loongclaw-browser-companion 1.5.0'\n",
+        );
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+
+        let checks = collect_browser_companion_doctor_checks(&config).await;
+
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "browser companion runtime gate"
+                    && check.level == DoctorCheckLevel::Warn
+                    && check.detail.contains("install looks healthy")
+            }),
+            "doctor should distinguish healthy companion installs from a still-closed runtime gate: {checks:#?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn browser_companion_doctor_checks_pass_when_runtime_gate_is_open() {
+        let _env_guard = BrowserCompanionEnvGuard::runtime_gate_open();
+        let temp_dir = browser_companion_temp_dir("runtime-ready");
+        let script_path = temp_dir.join("browser-companion");
+        write_browser_companion_script(
+            &script_path,
+            "#!/bin/sh\necho 'loongclaw-browser-companion 1.5.0'\n",
+        );
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+
+        let checks = collect_browser_companion_doctor_checks(&config).await;
+
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "browser companion install"
+                    && check.level == DoctorCheckLevel::Pass
+                    && check.detail.contains("responded with")
+            }),
+            "doctor should mark the companion install healthy when the version probe matches: {checks:#?}"
+        );
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "browser companion runtime gate"
+                    && check.level == DoctorCheckLevel::Pass
+                    && check.detail.contains("runtime is ready")
+            }),
+            "doctor should mark the runtime gate healthy when the companion lane is opened: {checks:#?}"
         );
     }
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -37,6 +37,7 @@ pub use kernel;
 pub use sha2;
 
 pub mod browser_preview;
+pub mod browser_companion_diagnostics;
 mod cli_handoff;
 pub mod doctor_cli;
 pub mod feishu_cli;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -36,8 +36,8 @@ pub use base64;
 pub use kernel;
 pub use sha2;
 
+mod browser_companion_diagnostics;
 pub mod browser_preview;
-pub mod browser_companion_diagnostics;
 mod cli_handoff;
 pub mod doctor_cli;
 pub mod feishu_cli;

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1345,6 +1345,7 @@ async fn run_preflight_checks(
     let file_root = config.tools.resolved_file_root();
     checks.push(directory_preflight_check("tool file root", &file_root));
 
+    checks.extend(collect_browser_companion_preflight_checks(config).await);
     checks.extend(collect_channel_preflight_checks(config));
 
     checks
@@ -1377,6 +1378,36 @@ fn provider_model_probe_failure_check(
         detail: format!("{}: {error}", provider_check_detail_prefix(config)),
         non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
     }
+}
+
+async fn collect_browser_companion_preflight_checks(
+    config: &mvp::config::LoongClawConfig,
+) -> Vec<OnboardCheck> {
+    let Some(diagnostics) =
+        crate::browser_companion_diagnostics::collect_browser_companion_diagnostics(config).await
+    else {
+        return Vec::new();
+    };
+
+    let level = if diagnostics.install_ready() && diagnostics.runtime_ready {
+        OnboardCheckLevel::Pass
+    } else {
+        OnboardCheckLevel::Warn
+    };
+    let detail = if diagnostics.install_ready() {
+        diagnostics
+            .runtime_gate_detail()
+            .unwrap_or_else(|| diagnostics.install_detail())
+    } else {
+        diagnostics.install_detail()
+    };
+
+    vec![OnboardCheck {
+        name: crate::browser_companion_diagnostics::BROWSER_COMPANION_INSTALL_CHECK_NAME,
+        level,
+        detail,
+        non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+    }]
 }
 
 pub fn provider_credential_check(config: &mvp::config::LoongClawConfig) -> OnboardCheck {
@@ -5032,6 +5063,8 @@ fn format_backup_timestamp_at(timestamp: OffsetDateTime) -> CliResult<String> {
 mod tests {
     use super::*;
     use std::collections::VecDeque;
+    use std::ffi::OsString;
+    use std::sync::MutexGuard;
 
     struct TestOnboardUi {
         inputs: VecDeque<String>,
@@ -5069,6 +5102,65 @@ mod tests {
                 .pop_front()
                 .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "y" | "yes"))
                 .unwrap_or(default))
+        }
+    }
+
+    struct BrowserCompanionEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        saved_ready: Option<OsString>,
+    }
+
+    fn set_browser_companion_env_var(key: &str, value: &str) {
+        // SAFETY: daemon tests serialize process env mutations behind
+        // `lock_daemon_test_environment`, so no concurrent env readers/writers
+        // observe racy updates while these tests run.
+        #[allow(unsafe_code, clippy::disallowed_methods)]
+        unsafe {
+            std::env::set_var(key, value);
+        }
+    }
+
+    fn remove_browser_companion_env_var(key: &str) {
+        // SAFETY: daemon tests serialize process env mutations behind
+        // `lock_daemon_test_environment`, so removing the variable here is
+        // coordinated with all other env-mutating daemon tests.
+        #[allow(unsafe_code, clippy::disallowed_methods)]
+        unsafe {
+            std::env::remove_var(key);
+        }
+    }
+
+    impl BrowserCompanionEnvGuard {
+        fn runtime_gate_closed() -> Self {
+            Self::set_ready(None)
+        }
+
+        fn runtime_gate_open() -> Self {
+            Self::set_ready(Some("true"))
+        }
+
+        fn set_ready(value: Option<&str>) -> Self {
+            let lock = crate::test_support::lock_daemon_test_environment();
+            let key = "LOONGCLAW_BROWSER_COMPANION_READY";
+            let saved_ready = std::env::var_os(key);
+            match value {
+                Some(value) => set_browser_companion_env_var(key, value),
+                None => remove_browser_companion_env_var(key),
+            }
+            Self {
+                _lock: lock,
+                saved_ready,
+            }
+        }
+    }
+
+    impl Drop for BrowserCompanionEnvGuard {
+        fn drop(&mut self) {
+            let key = "LOONGCLAW_BROWSER_COMPANION_READY";
+            match self.saved_ready.take() {
+                Some(value) => set_browser_companion_env_var(key, &value.to_string_lossy()),
+                None => remove_browser_companion_env_var(key),
+            }
         }
     }
 
@@ -5138,6 +5230,111 @@ mod tests {
                         .contains("retry chat_completions automatically")
             }),
             "preflight should surface transport review before writing a Responses-compatible config: {checks:#?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn browser_companion_onboard_preflight_warns_when_enabled_without_command() {
+        let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.api_key = Some("inline-openai-key".to_owned());
+        config.tools.browser_companion.enabled = true;
+
+        let checks = run_preflight_checks(&config, true).await;
+
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "browser companion install"
+                    && check.level == OnboardCheckLevel::Warn
+                    && check.detail.contains("no command is configured")
+            }),
+            "onboard preflight should flag companion configs that cannot be executed yet: {checks:#?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn browser_companion_onboard_preflight_warns_when_runtime_gate_is_closed() {
+        let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
+        let temp_dir = std::env::temp_dir().join(format!(
+            "loongclaw-browser-companion-onboard-runtime-gate-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&temp_dir).expect("create browser companion onboard temp dir");
+        let script_path = temp_dir.join("browser-companion");
+        std::fs::write(
+            &script_path,
+            "#!/bin/sh\necho 'loongclaw-browser-companion 1.5.0'\n",
+        )
+        .expect("write browser companion onboard script");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&script_path)
+                .expect("script metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&script_path, permissions)
+                .expect("chmod browser companion onboard script");
+        }
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.api_key = Some("inline-openai-key".to_owned());
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+
+        let checks = run_preflight_checks(&config, true).await;
+
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "browser companion install"
+                    && check.level == OnboardCheckLevel::Warn
+                    && check.detail.contains("runtime gate is still closed")
+            }),
+            "onboard preflight should surface that a healthy install still is not runtime-ready: {checks:#?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn browser_companion_onboard_preflight_passes_when_runtime_gate_is_open() {
+        let _env_guard = BrowserCompanionEnvGuard::runtime_gate_open();
+        let temp_dir = std::env::temp_dir().join(format!(
+            "loongclaw-browser-companion-onboard-runtime-ready-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&temp_dir).expect("create browser companion onboard temp dir");
+        let script_path = temp_dir.join("browser-companion");
+        std::fs::write(
+            &script_path,
+            "#!/bin/sh\necho 'loongclaw-browser-companion 1.5.0'\n",
+        )
+        .expect("write browser companion onboard script");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&script_path)
+                .expect("script metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&script_path, permissions)
+                .expect("chmod browser companion onboard script");
+        }
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.api_key = Some("inline-openai-key".to_owned());
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+
+        let checks = run_preflight_checks(&config, true).await;
+
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "browser companion install"
+                    && check.level == OnboardCheckLevel::Pass
+                    && check.detail.contains("runtime is ready")
+            }),
+            "onboard preflight should mark the companion lane healthy when the runtime gate is open: {checks:#?}"
         );
     }
 

--- a/docs/plans/2026-03-16-browser-companion-doctor-onboard.md
+++ b/docs/plans/2026-03-16-browser-companion-doctor-onboard.md
@@ -1,0 +1,128 @@
+# Browser Companion Doctor Onboard Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Surface browser companion readiness and blockers through the existing
+`loongclaw doctor` and `loongclaw onboard` flows without changing the current
+tool visibility contract.
+
+**Architecture:** Add one shared browser companion diagnostic snapshot that
+turns config, command probe, version expectations, and runtime-ready flags into
+typed health facts. Reuse that snapshot in daemon doctor checks, doctor next
+steps, and onboarding preflight warnings so the same managed-lane truth reaches
+both operator diagnostics and first-run guidance.
+
+**Tech Stack:** Rust, Clap CLI, existing LoongClaw daemon/app config/runtime
+helpers
+
+---
+
+### Task 1: Add failing browser companion doctor tests
+
+**Files:**
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/src/tests/mod.rs`
+
+**Step 1: Write failing tests for browser companion doctor checks**
+
+Cover:
+- enabled companion with no command configured
+- enabled companion with missing binary command
+- enabled companion with mismatched expected version
+- enabled companion with matching command/version but runtime-ready flag absent
+
+**Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon browser_companion_doctor -- --nocapture
+```
+
+Expected: FAIL because browser companion doctor checks do not exist yet.
+
+### Task 2: Add failing onboarding preflight tests
+
+**Files:**
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `crates/daemon/src/tests/onboard_cli.rs`
+
+**Step 1: Write failing onboarding tests**
+
+Cover:
+- preflight surfaces browser companion warnings when current config enables it
+- non-interactive onboarding blocks on browser companion failures
+- interactive preflight screen includes browser companion detail rows
+
+**Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon browser_companion_onboard -- --nocapture
+```
+
+Expected: FAIL because onboarding does not yet reuse browser companion
+diagnostics.
+
+### Task 3: Implement shared browser companion diagnostics
+
+**Files:**
+- Create or modify under: `crates/daemon/src/doctor_cli.rs`
+- Modify if needed: `crates/app/src/tools/runtime_config.rs`
+
+**Step 1: Add a typed browser companion diagnostic snapshot**
+
+The snapshot should capture:
+- whether companion is requested by config
+- effective command
+- expected version
+- command probe result
+- detected version text
+- runtime-ready flag state
+- actionable failure reason
+
+**Step 2: Keep the runtime visibility contract unchanged**
+
+Do not change catalog gating or tool exposure behavior introduced by the
+foundation branch. This feature is diagnostic-only.
+
+### Task 4: Reuse diagnostics in doctor and onboarding
+
+**Files:**
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `crates/daemon/src/next_actions.rs` only if browser companion next
+  actions need shared wording
+
+**Step 1: Add doctor checks and next steps**
+
+Doctor should emit browser companion checks only when the companion lane is
+requested or explicitly configured, and should end with concrete next steps.
+
+**Step 2: Add onboarding preflight integration**
+
+Onboarding should reuse the same diagnostic facts instead of duplicating probe
+logic.
+
+**Step 3: Keep user language concrete**
+
+Messages should tell operators exactly what to fix:
+- configure command
+- install/fix PATH
+- align expected version
+- rerun doctor
+
+### Task 5: Verify and commit cleanly
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon browser_companion_doctor -- --nocapture
+cargo test -p loongclaw-daemon browser_companion_onboard -- --nocapture
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features --locked
+```
+
+Expected result: PASS

--- a/docs/product-specs/doctor.md
+++ b/docs/product-specs/doctor.md
@@ -20,6 +20,9 @@ can recover a broken setup without reverse-engineering runtime internals.
       failure, the CLI points users toward `doctor`.
 - [ ] Doctor checks cover the current MVP path: config presence, provider
       readiness, SQLite memory readiness, and shipped channel prerequisites.
+- [ ] When `tools.browser_companion.enabled=true`, doctor surfaces companion
+      install/runtime readiness as warnings with concrete repair steps instead
+      of turning the optional managed lane into a hard core-runtime failure.
 
 ## Out of Scope
 

--- a/docs/product-specs/onboarding.md
+++ b/docs/product-specs/onboarding.md
@@ -21,6 +21,9 @@ next.
       surfaces that the runtime uses after setup.
 - [ ] When preflight checks fail, onboarding points users to `loongclaw doctor`
       or `loongclaw doctor --fix` as the repair path.
+- [ ] Onboarding preflight reuses the same browser companion diagnostics as
+      `loongclaw doctor`, surfacing optional managed-lane blockers before write
+      without redefining runtime truth inside onboarding.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary
- add a shared browser companion diagnostics snapshot and version probe for daemon CLI health flows
- surface optional companion install and runtime-gate warnings in `loongclaw doctor` with concrete next steps
- reuse the same diagnostics in `loongclaw onboard` preflight and document the warning-only managed-lane behavior

## Validation
- cargo test -p loongclaw-daemon browser_companion -- --nocapture
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features --locked

## Notes
- One intermediate full-suite run hit two unrelated `process_stdio` integration timeouts; both isolated reruns passed, and the final fresh full-suite rerun passed.

Closes #206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added browser companion diagnostics checks to doctor and onboarding workflows, providing detailed installation status, version validation, and runtime readiness assessment with repair guidance.

* **Documentation**
  * Added implementation plan documenting browser companion diagnostics integration.
  * Updated product specifications with browser companion health-check requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->