### PR TITLE
fix(onboard): guide reviewed defaults and auto-model recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ cargo install --path crates/daemon
    personality, optional prompt addendum, and memory profile selection. Use
    `--system-prompt` only when you want to replace the native prompt pack with a
    full inline override.
+   For providers with a reviewed onboarding default model, such as MiniMax,
+   onboarding now prefills an explicit recommended model instead of relying on a
+   hidden runtime fallback.
    Press `Esc`, then `Enter`, at any onboarding prompt to cancel before writing config.
 
    WSL note: CLI onboarding works in WSL. If you want service-style workflows or Linux daemons

--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ cargo install --path crates/daemon
    personality, optional prompt addendum, and memory profile selection. Use
    `--system-prompt` only when you want to replace the native prompt pack with a
    full inline override.
+   Press `Esc`, then `Enter`, at any onboarding prompt to cancel before writing config.
+
+   WSL note: CLI onboarding works in WSL. If you want service-style workflows or Linux daemons
+   that depend on `systemd`, use WSL `0.67.6+`; Ubuntu installed via `wsl --install` now defaults
+   to `systemd`, while other distros may still need `[boot] systemd=true` in `/etc/wsl.conf`.
 
 2. Set your provider credential in the env that onboarding selected:
 

--- a/README.md
+++ b/README.md
@@ -256,9 +256,12 @@ cargo install --path crates/daemon
    personality, optional prompt addendum, and memory profile selection. Use
    `--system-prompt` only when you want to replace the native prompt pack with a
    full inline override.
-   For providers with a reviewed onboarding default model, such as MiniMax,
-   onboarding now prefills an explicit recommended model instead of relying on a
-   hidden runtime fallback.
+   For providers with a reviewed onboarding default model, such as MiniMax and
+   DeepSeek, onboarding now prefills an explicit recommended model instead of
+   relying on a hidden runtime fallback.
+   If model catalog discovery fails while the config still uses `model = auto`,
+   onboarding now tells you to rerun onboarding and accept the reviewed model,
+   or set `provider.model` / `preferred_models` explicitly.
    Press `Esc`, then `Enter`, at any onboarding prompt to cancel before writing config.
 
    WSL note: CLI onboarding works in WSL. If you want service-style workflows or Linux daemons

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -138,6 +138,12 @@ cargo install --path crates/daemon
    当前引导流程会依次带你完成 provider、原生 prompt personality、可选 prompt
    addendum，以及 memory profile 的选择。只有在你明确想放弃原生 prompt pack
    时，才建议改用 `--system-prompt` 做完整的 inline override。
+   在任意 onboarding 提示处按 `Esc` 再按 `Enter`，即可在落盘前退出。
+
+   WSL 说明：CLI onboarding 可以直接在 WSL 中运行。如果你还需要依赖 `systemd`
+   的服务型流程或 Linux daemon，请使用 `0.67.6+` 的 WSL；通过 `wsl --install`
+   安装的 Ubuntu 现在默认启用 `systemd`，其他发行版则可能仍需要在
+   `/etc/wsl.conf` 中设置 `[boot] systemd=true`。
 
 2. 按 onboarding 选中的环境变量名设置 provider 凭据：
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -138,6 +138,8 @@ cargo install --path crates/daemon
    当前引导流程会依次带你完成 provider、原生 prompt personality、可选 prompt
    addendum，以及 memory profile 的选择。只有在你明确想放弃原生 prompt pack
    时，才建议改用 `--system-prompt` 做完整的 inline override。
+   对于 MiniMax 这类已经审查过默认模型的 provider，onboarding 现在会预填一个
+   显式推荐模型，而不是依赖隐藏的 runtime fallback。
    在任意 onboarding 提示处按 `Esc` 再按 `Enter`，即可在落盘前退出。
 
    WSL 说明：CLI onboarding 可以直接在 WSL 中运行。如果你还需要依赖 `systemd`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -138,8 +138,11 @@ cargo install --path crates/daemon
    当前引导流程会依次带你完成 provider、原生 prompt personality、可选 prompt
    addendum，以及 memory profile 的选择。只有在你明确想放弃原生 prompt pack
    时，才建议改用 `--system-prompt` 做完整的 inline override。
-   对于 MiniMax 这类已经审查过默认模型的 provider，onboarding 现在会预填一个
-   显式推荐模型，而不是依赖隐藏的 runtime fallback。
+   对于 MiniMax、DeepSeek 这类已经审查过默认模型的 provider，onboarding 现在会
+   预填一个显式推荐模型，而不是依赖隐藏的 runtime fallback。
+   如果模型目录探测失败且当前配置仍然使用 `model = auto`，onboarding 现在会明确
+   提示你重新运行 onboarding 并接受审查过的模型，或者显式设置
+   `provider.model` / `preferred_models`。
    在任意 onboarding 提示处按 `Esc` 再按 `Enter`，即可在落盘前退出。
 
    WSL 说明：CLI onboarding 可以直接在 WSL 中运行。如果你还需要依赖 `systemd`

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -29,11 +29,12 @@ pub use memory::{
 };
 #[allow(unused_imports)]
 pub use provider::{
-    ProviderAuthScheme, ProviderConfig, ProviderFeatureFamily, ProviderKind, ProviderProfileConfig,
-    ProviderProfileHealthModeConfig, ProviderProfileStateBackendKind, ProviderProtocolFamily,
-    ProviderReasoningExtraBodyModeConfig, ProviderToolSchemaModeConfig, ProviderTransportFallback,
-    ProviderTransportPolicy, ProviderTransportReadiness, ProviderTransportReadinessLevel,
-    ProviderWireApi, ReasoningEffort, parse_provider_kind_id,
+    ModelCatalogProbeRecovery, ProviderAuthScheme, ProviderConfig, ProviderFeatureFamily,
+    ProviderKind, ProviderProfileConfig, ProviderProfileHealthModeConfig,
+    ProviderProfileStateBackendKind, ProviderProtocolFamily, ProviderReasoningExtraBodyModeConfig,
+    ProviderToolSchemaModeConfig, ProviderTransportFallback, ProviderTransportPolicy,
+    ProviderTransportReadiness, ProviderTransportReadinessLevel, ProviderWireApi, ReasoningEffort,
+    parse_provider_kind_id,
 };
 #[allow(unused_imports)]
 pub use runtime::{

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -146,8 +146,6 @@ const ARK_REASONING_EFFORTS: &[ReasoningEffort] = &[
     ReasoningEffort::Medium,
     ReasoningEffort::High,
 ];
-const MINIMAX_DEFAULT_PREFERRED_MODELS: &[&str] = &["MiniMax-M1"];
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ProviderKind {
@@ -672,11 +670,6 @@ impl ProviderConfig {
         let mut provider = Self::default();
         provider.set_kind(kind);
         provider.model = kind.default_model().unwrap_or("auto").to_owned();
-        provider.preferred_models = kind
-            .default_preferred_models()
-            .iter()
-            .map(|model| (*model).to_owned())
-            .collect();
         provider.selection_baseline()
     }
 
@@ -1002,16 +995,7 @@ impl ProviderConfig {
         }
 
         let mut models = Vec::new();
-        let preferred_models = if self.preferred_models.is_empty() {
-            self.kind
-                .default_preferred_models()
-                .iter()
-                .map(|model| (*model).to_owned())
-                .collect::<Vec<_>>()
-        } else {
-            self.preferred_models.clone()
-        };
-        for raw in &preferred_models {
+        for raw in &self.preferred_models {
             let trimmed = raw.trim();
             if trimmed.is_empty() || models.iter().any(|existing| existing == trimmed) {
                 continue;
@@ -1937,11 +1921,11 @@ impl ProviderKind {
         }
     }
 
-    pub const fn default_preferred_models(self) -> &'static [&'static str] {
+    pub const fn recommended_onboarding_model(self) -> Option<&'static str> {
         if matches!(self, ProviderKind::Minimax) {
-            MINIMAX_DEFAULT_PREFERRED_MODELS
+            Some("MiniMax-M2.5")
         } else {
-            &[]
+            self.default_model()
         }
     }
 }
@@ -3056,10 +3040,27 @@ mod tests {
     }
 
     #[test]
-    fn fresh_minimax_provider_seeds_preferred_models_for_auto_fallback() {
+    fn fresh_minimax_provider_does_not_seed_hidden_preferred_models() {
         let config = ProviderConfig::fresh_for_kind(ProviderKind::Minimax);
 
         assert_eq!(config.model, "auto");
-        assert_eq!(config.preferred_models, vec!["MiniMax-M1".to_owned()]);
+        assert!(
+            config.preferred_models.is_empty(),
+            "provider defaults should not inject hidden runtime fallback models: {config:#?}"
+        );
+    }
+
+    #[test]
+    fn configured_auto_model_candidates_require_explicit_preferred_models() {
+        let config = ProviderConfig {
+            kind: ProviderKind::Minimax,
+            model: "auto".to_owned(),
+            ..ProviderConfig::default()
+        };
+
+        assert!(
+            config.configured_auto_model_candidates().is_empty(),
+            "auto-model fallback candidates should only exist when the operator configured preferred_models explicitly"
+        );
     }
 }

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -146,6 +146,7 @@ const ARK_REASONING_EFFORTS: &[ReasoningEffort] = &[
     ReasoningEffort::Medium,
     ReasoningEffort::High,
 ];
+const MINIMAX_DEFAULT_PREFERRED_MODELS: &[&str] = &["MiniMax-M1"];
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -671,6 +672,11 @@ impl ProviderConfig {
         let mut provider = Self::default();
         provider.set_kind(kind);
         provider.model = kind.default_model().unwrap_or("auto").to_owned();
+        provider.preferred_models = kind
+            .default_preferred_models()
+            .iter()
+            .map(|model| (*model).to_owned())
+            .collect();
         provider.selection_baseline()
     }
 
@@ -996,7 +1002,16 @@ impl ProviderConfig {
         }
 
         let mut models = Vec::new();
-        for raw in &self.preferred_models {
+        let preferred_models = if self.preferred_models.is_empty() {
+            self.kind
+                .default_preferred_models()
+                .iter()
+                .map(|model| (*model).to_owned())
+                .collect::<Vec<_>>()
+        } else {
+            self.preferred_models.clone()
+        };
+        for raw in &preferred_models {
             let trimmed = raw.trim();
             if trimmed.is_empty() || models.iter().any(|existing| existing == trimmed) {
                 continue;
@@ -1105,6 +1120,7 @@ impl ProviderConfig {
         Self {
             kind: self.kind,
             model: self.model.clone(),
+            preferred_models: self.preferred_models.clone(),
             base_url: profile.base_url.to_owned(),
             wire_api: self.wire_api,
             chat_completions_path: profile.chat_completions_path.to_owned(),
@@ -1918,6 +1934,13 @@ impl ProviderKind {
             Some("kimi-for-coding")
         } else {
             None
+        }
+    }
+
+    pub const fn default_preferred_models(self) -> &'static [&'static str] {
+        match self {
+            ProviderKind::Minimax => MINIMAX_DEFAULT_PREFERRED_MODELS,
+            _ => &[],
         }
     }
 }
@@ -3029,5 +3052,13 @@ mod tests {
             config.authorization_header().as_deref(),
             Some("Bearer api-key-wins")
         );
+    }
+
+    #[test]
+    fn fresh_minimax_provider_seeds_preferred_models_for_auto_fallback() {
+        let config = ProviderConfig::fresh_for_kind(ProviderKind::Minimax);
+
+        assert_eq!(config.model, "auto");
+        assert_eq!(config.preferred_models, vec!["MiniMax-M1".to_owned()]);
     }
 }

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -1951,7 +1951,7 @@ impl ProviderKind {
         } else if matches!(self, ProviderKind::Minimax) {
             Some("MiniMax-M2.5")
         } else {
-            self.default_model()
+            None
         }
     }
 }
@@ -3091,10 +3091,18 @@ mod tests {
     }
 
     #[test]
-    fn deepseek_provider_exposes_reviewed_onboarding_model() {
+    fn only_reviewed_providers_expose_onboarding_models() {
         assert_eq!(
             ProviderKind::Deepseek.recommended_onboarding_model(),
             Some("deepseek-chat")
+        );
+        assert_eq!(
+            ProviderKind::Minimax.recommended_onboarding_model(),
+            Some("MiniMax-M2.5")
+        );
+        assert_eq!(
+            ProviderKind::KimiCoding.recommended_onboarding_model(),
+            None
         );
         assert_eq!(ProviderKind::Openai.recommended_onboarding_model(), None);
     }

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -1938,9 +1938,10 @@ impl ProviderKind {
     }
 
     pub const fn default_preferred_models(self) -> &'static [&'static str] {
-        match self {
-            ProviderKind::Minimax => MINIMAX_DEFAULT_PREFERRED_MODELS,
-            _ => &[],
+        if matches!(self, ProviderKind::Minimax) {
+            MINIMAX_DEFAULT_PREFERRED_MODELS
+        } else {
+            &[]
         }
     }
 }

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -113,6 +113,15 @@ pub struct ProviderTransportPolicy {
     pub fallback: Option<ProviderTransportFallback>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModelCatalogProbeRecovery {
+    ExplicitModel(String),
+    ConfiguredPreferredModels(Vec<String>),
+    RequiresExplicitModel {
+        recommended_onboarding_model: Option<&'static str>,
+    },
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
@@ -1003,6 +1012,21 @@ impl ProviderConfig {
             models.push(trimmed.to_owned());
         }
         models
+    }
+
+    pub fn model_catalog_probe_recovery(&self) -> ModelCatalogProbeRecovery {
+        if let Some(model) = self.explicit_model() {
+            return ModelCatalogProbeRecovery::ExplicitModel(model);
+        }
+
+        let preferred_models = self.configured_auto_model_candidates();
+        if !preferred_models.is_empty() {
+            return ModelCatalogProbeRecovery::ConfiguredPreferredModels(preferred_models);
+        }
+
+        ModelCatalogProbeRecovery::RequiresExplicitModel {
+            recommended_onboarding_model: self.kind.recommended_onboarding_model(),
+        }
     }
 
     pub fn resolved_model(&self) -> Option<String> {
@@ -1922,7 +1946,9 @@ impl ProviderKind {
     }
 
     pub const fn recommended_onboarding_model(self) -> Option<&'static str> {
-        if matches!(self, ProviderKind::Minimax) {
+        if matches!(self, ProviderKind::Deepseek) {
+            Some("deepseek-chat")
+        } else if matches!(self, ProviderKind::Minimax) {
             Some("MiniMax-M2.5")
         } else {
             self.default_model()
@@ -3061,6 +3087,62 @@ mod tests {
         assert!(
             config.configured_auto_model_candidates().is_empty(),
             "auto-model fallback candidates should only exist when the operator configured preferred_models explicitly"
+        );
+    }
+
+    #[test]
+    fn deepseek_provider_exposes_reviewed_onboarding_model() {
+        assert_eq!(
+            ProviderKind::Deepseek.recommended_onboarding_model(),
+            Some("deepseek-chat")
+        );
+        assert_eq!(ProviderKind::Openai.recommended_onboarding_model(), None);
+    }
+
+    #[test]
+    fn model_catalog_probe_recovery_requires_explicit_model_for_reviewed_auto_provider() {
+        let config = ProviderConfig {
+            kind: ProviderKind::Deepseek,
+            model: "auto".to_owned(),
+            ..ProviderConfig::default()
+        };
+
+        assert_eq!(
+            config.model_catalog_probe_recovery(),
+            ModelCatalogProbeRecovery::RequiresExplicitModel {
+                recommended_onboarding_model: Some("deepseek-chat"),
+            }
+        );
+    }
+
+    #[test]
+    fn model_catalog_probe_recovery_prefers_explicit_runtime_configuration() {
+        let explicit = ProviderConfig {
+            kind: ProviderKind::Deepseek,
+            model: "deepseek-chat".to_owned(),
+            ..ProviderConfig::default()
+        };
+        assert_eq!(
+            explicit.model_catalog_probe_recovery(),
+            ModelCatalogProbeRecovery::ExplicitModel("deepseek-chat".to_owned())
+        );
+
+        let preferred = ProviderConfig {
+            kind: ProviderKind::Deepseek,
+            model: "auto".to_owned(),
+            preferred_models: vec![
+                "deepseek-chat".to_owned(),
+                "deepseek-chat".to_owned(),
+                "deepseek-reasoner".to_owned(),
+            ],
+            ..ProviderConfig::default()
+        };
+        assert_eq!(
+            preferred.model_catalog_probe_recovery(),
+            ModelCatalogProbeRecovery::ConfiguredPreferredModels(vec![
+                "deepseek-chat".to_owned(),
+                "deepseek-reasoner".to_owned(),
+            ])
         );
     }
 }

--- a/crates/app/src/provider/model_candidate_resolver_runtime.rs
+++ b/crates/app/src/provider/model_candidate_resolver_runtime.rs
@@ -203,4 +203,18 @@ mod tests {
             "explicit models should not rely on preferred-model auto fallback"
         );
     }
+
+    #[test]
+    fn preferred_model_fallback_candidates_do_not_infer_provider_defaults() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::Minimax,
+            model: "auto".to_owned(),
+            ..ProviderConfig::default()
+        };
+
+        assert!(
+            preferred_model_fallback_candidates(&provider).is_empty(),
+            "runtime should not infer provider-owned fallback models when the operator did not configure preferred_models"
+        );
+    }
 }

--- a/crates/app/src/provider/model_candidate_resolver_runtime.rs
+++ b/crates/app/src/provider/model_candidate_resolver_runtime.rs
@@ -28,6 +28,7 @@ pub(super) async fn resolve_request_models(
     if let Some(model) = config.provider.resolved_model() {
         return Ok(vec![model]);
     }
+    let preferred_fallback_models = preferred_model_fallback_candidates(&config.provider);
     let cache_ttl_ms = config.provider.resolved_model_catalog_cache_ttl_ms();
     let stale_if_error_ms = config.provider.resolved_model_catalog_stale_if_error_ms();
     let cache_max_entries = config.provider.resolved_model_catalog_cache_max_entries();
@@ -96,6 +97,12 @@ pub(super) async fn resolve_request_models(
                     ));
                 }
             }
+            if !preferred_fallback_models.is_empty() {
+                return Ok(prioritize_model_candidates_by_cooldown(
+                    preferred_fallback_models,
+                    model_candidate_cooldown_policy,
+                ));
+            }
             return Err(error);
         }
     };
@@ -152,4 +159,48 @@ fn push_unique_model(out: &mut Vec<String>, model: &str) {
         return;
     }
     out.push(model.to_owned());
+}
+
+fn preferred_model_fallback_candidates(provider: &ProviderConfig) -> Vec<String> {
+    provider.configured_auto_model_candidates()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ProviderConfig, ProviderKind};
+
+    #[test]
+    fn preferred_model_fallback_candidates_preserve_unique_order_for_auto_model() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::Minimax,
+            model: "auto".to_owned(),
+            preferred_models: vec![
+                "MiniMax-M1".to_owned(),
+                "MiniMax-M1".to_owned(),
+                "MiniMax-Text-01".to_owned(),
+            ],
+            ..ProviderConfig::default()
+        };
+
+        assert_eq!(
+            preferred_model_fallback_candidates(&provider),
+            vec!["MiniMax-M1", "MiniMax-Text-01"],
+        );
+    }
+
+    #[test]
+    fn preferred_model_fallback_candidates_ignore_explicit_model() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::Minimax,
+            model: "MiniMax-M1".to_owned(),
+            preferred_models: vec!["MiniMax-M1".to_owned(), "MiniMax-Text-01".to_owned()],
+            ..ProviderConfig::default()
+        };
+
+        assert!(
+            preferred_model_fallback_candidates(&provider).is_empty(),
+            "explicit models should not rely on preferred-model auto fallback"
+        );
+    }
 }

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -12,8 +12,8 @@ use wait_timeout::ChildExt;
 
 const DEFAULT_BROWSER_COMPANION_SCOPE_ID: &str = "__global";
 const BROWSER_COMPANION_PROTOCOL: &str = "loongclaw.browser_companion.v1";
-const BROWSER_COMPANION_SPAWN_RETRY_ATTEMPTS: usize = 5;
-const BROWSER_COMPANION_SPAWN_RETRY_DELAY: Duration = Duration::from_millis(25);
+const BROWSER_COMPANION_SPAWN_RETRY_ATTEMPTS: usize = 20;
+const BROWSER_COMPANION_SPAWN_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 #[derive(Debug, Clone)]
 struct BrowserCompanionSession {
@@ -236,7 +236,6 @@ fn cleanup_browser_companion_after_stdin_write_failure(child: &mut std::process:
     let _ = child.kill();
     let _ = child.wait();
 }
-
 fn wait_for_browser_companion_output(
     mut child: std::process::Child,
     timeout_seconds: u64,

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1005,7 +1005,7 @@ fn provider_model_probe_failure_check(
             name: "provider model probe".to_owned(),
             level: DoctorCheckLevel::Warn,
             detail: format!(
-                "{}: model catalog probe failed ({error}); runtime will try preferred model fallback(s): {}",
+                "{}: model catalog probe failed ({error}); runtime will try configured preferred model fallback(s): {}",
                 crate::provider_presentation::active_provider_detail_label(config),
                 fallback_models
                     .iter()
@@ -1707,8 +1707,8 @@ mod tests {
         assert_eq!(check.name, "provider model probe");
         assert_eq!(check.level, DoctorCheckLevel::Warn);
         assert!(
-            check.detail.contains("preferred model"),
-            "doctor should explain when runtime can continue with preferred auto-model fallbacks: {check:#?}"
+            check.detail.contains("configured preferred"),
+            "doctor should only advertise fallback continuation for explicitly configured preferred models: {check:#?}"
         );
         assert!(
             check.detail.contains("MiniMax-M1"),

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -999,6 +999,23 @@ fn provider_model_probe_failure_check(
         };
     }
 
+    let fallback_models = config.provider.configured_auto_model_candidates();
+    if !fallback_models.is_empty() {
+        return DoctorCheck {
+            name: "provider model probe".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: format!(
+                "{}: model catalog probe failed ({error}); runtime will try preferred model fallback(s): {}",
+                crate::provider_presentation::active_provider_detail_label(config),
+                fallback_models
+                    .iter()
+                    .map(|model| format!("`{model}`"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        };
+    }
+
     DoctorCheck {
         name: "provider model probe".to_owned(),
         level: DoctorCheckLevel::Fail,
@@ -1672,6 +1689,30 @@ mod tests {
         assert!(
             check.detail.contains("OpenAI [openai]"),
             "doctor failures should still identify the active provider context: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_warns_for_preferred_model_fallbacks() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        config.provider.model = "auto".to_owned();
+        config.provider.preferred_models = vec!["MiniMax-M1".to_owned()];
+
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider rejected the model list".to_owned(),
+        );
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, DoctorCheckLevel::Warn);
+        assert!(
+            check.detail.contains("preferred model"),
+            "doctor should explain when runtime can continue with preferred auto-model fallbacks: {check:#?}"
+        );
+        assert!(
+            check.detail.contains("MiniMax-M1"),
+            "doctor warning should surface the fallback candidate to keep remediation concrete: {check:#?}"
         );
     }
 

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -988,40 +988,55 @@ fn provider_model_probe_failure_check(
     config: &mvp::config::LoongClawConfig,
     error: String,
 ) -> DoctorCheck {
-    if let Some(model) = config.provider.explicit_model() {
-        return DoctorCheck {
-            name: "provider model probe".to_owned(),
-            level: DoctorCheckLevel::Warn,
-            detail: format!(
-                "{}: model catalog probe failed ({error}); chat may still work because model `{model}` is explicitly configured",
-                crate::provider_presentation::active_provider_detail_label(config)
+    let provider_prefix = crate::provider_presentation::active_provider_detail_label(config);
+    let (level, detail) = match config.provider.model_catalog_probe_recovery() {
+        mvp::config::ModelCatalogProbeRecovery::ExplicitModel(model) => (
+            DoctorCheckLevel::Warn,
+            format!(
+                "{provider_prefix}: model catalog probe failed ({error}); chat may still work because model `{model}` is explicitly configured"
             ),
-        };
-    }
-
-    let fallback_models = config.provider.configured_auto_model_candidates();
-    if !fallback_models.is_empty() {
-        return DoctorCheck {
-            name: "provider model probe".to_owned(),
-            level: DoctorCheckLevel::Warn,
-            detail: format!(
-                "{}: model catalog probe failed ({error}); runtime will try configured preferred model fallback(s): {}",
-                crate::provider_presentation::active_provider_detail_label(config),
+        ),
+        mvp::config::ModelCatalogProbeRecovery::ConfiguredPreferredModels(fallback_models) => (
+            DoctorCheckLevel::Warn,
+            format!(
+                "{provider_prefix}: model catalog probe failed ({error}); runtime will try configured preferred model fallback(s): {}",
                 fallback_models
                     .iter()
                     .map(|model| format!("`{model}`"))
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
-        };
-    }
+        ),
+        mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
+            recommended_onboarding_model,
+        } => (
+            DoctorCheckLevel::Fail,
+            provider_model_probe_requires_explicit_model_detail(
+                provider_prefix.as_str(),
+                error.as_str(),
+                recommended_onboarding_model,
+            ),
+        ),
+    };
 
     DoctorCheck {
         name: "provider model probe".to_owned(),
-        level: DoctorCheckLevel::Fail,
-        detail: format!(
-            "{}: {error}",
-            crate::provider_presentation::active_provider_detail_label(config)
+        level,
+        detail,
+    }
+}
+
+fn provider_model_probe_requires_explicit_model_detail(
+    provider_prefix: &str,
+    error: &str,
+    recommended_onboarding_model: Option<&str>,
+) -> String {
+    match recommended_onboarding_model {
+        Some(model) => format!(
+            "{provider_prefix}: model catalog probe failed ({error}); current config still uses `model = auto`; rerun onboarding and accept reviewed model `{model}`, or set `provider.model` / `preferred_models` explicitly"
+        ),
+        None => format!(
+            "{provider_prefix}: model catalog probe failed ({error}); current config still uses `model = auto`; set `provider.model` explicitly or configure `preferred_models` before retrying"
         ),
     }
 }
@@ -1165,6 +1180,10 @@ fn build_doctor_next_steps_with_path_env(
     let config_path_display = config_path.display().to_string();
     let rerun_command =
         crate::cli_handoff::format_subcommand_with_config("doctor", &config_path_display);
+    let rerun_onboard_command =
+        crate::cli_handoff::format_subcommand_with_config("onboard", &config_path_display);
+    let browser_preview =
+        crate::browser_preview::inspect_browser_preview_state_with_path_env(config, path_env);
 
     if !fix_requested
         && checks.iter().any(|check| {
@@ -1199,16 +1218,49 @@ fn build_doctor_next_steps_with_path_env(
         .iter()
         .any(|check| check.name == "provider model probe" && check.level == DoctorCheckLevel::Fail)
     {
-        push_unique_step(
-            &mut steps,
-            format!("Retry provider probe only after credentials are ready: {rerun_command}"),
-        );
-        push_unique_step(
-            &mut steps,
-            format!(
-                "If your provider blocks model listing during setup, retry with: {rerun_command} --skip-model-probe"
-            ),
-        );
+        match config.provider.model_catalog_probe_recovery() {
+            mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
+                recommended_onboarding_model: Some(model),
+            } => {
+                push_unique_step(
+                    &mut steps,
+                    format!(
+                        "Rerun onboarding and accept reviewed model `{model}`: {rerun_onboard_command}"
+                    ),
+                );
+                push_unique_step(
+                    &mut steps,
+                    format!(
+                        "Or set `provider.model` / `preferred_models` explicitly, then re-run diagnostics: {rerun_command}"
+                    ),
+                );
+            }
+            mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
+                recommended_onboarding_model: None,
+            } => {
+                push_unique_step(
+                    &mut steps,
+                    format!(
+                        "Set `provider.model` / `preferred_models` explicitly, then re-run diagnostics: {rerun_command}"
+                    ),
+                );
+            }
+            mvp::config::ModelCatalogProbeRecovery::ExplicitModel(_)
+            | mvp::config::ModelCatalogProbeRecovery::ConfiguredPreferredModels(_) => {
+                push_unique_step(
+                    &mut steps,
+                    format!(
+                        "Retry provider probe only after credentials are ready: {rerun_command}"
+                    ),
+                );
+                push_unique_step(
+                    &mut steps,
+                    format!(
+                        "If your provider blocks model listing during setup, retry with: {rerun_command} --skip-model-probe"
+                    ),
+                );
+            }
+        }
     }
 
     if checks.iter().any(|check| {
@@ -1690,6 +1742,18 @@ mod tests {
             check.detail.contains("OpenAI [openai]"),
             "doctor failures should still identify the active provider context: {check:#?}"
         );
+        assert!(
+            check.detail.contains("model = auto"),
+            "doctor failures should explain why runtime cannot rely on an unresolved automatic model: {check:#?}"
+        );
+        assert!(
+            check.detail.contains("provider.model"),
+            "doctor failures should point users to an explicit provider.model remediation path: {check:#?}"
+        );
+        assert!(
+            check.detail.contains("preferred_models"),
+            "doctor failures should point users to preferred_models when catalog probing is unavailable: {check:#?}"
+        );
     }
 
     #[test]
@@ -1713,6 +1777,29 @@ mod tests {
         assert!(
             check.detail.contains("MiniMax-M1"),
             "doctor warning should surface the fallback candidate to keep remediation concrete: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_guides_reviewed_default_for_auto_model() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "auto".to_owned();
+
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider rejected the model list".to_owned(),
+        );
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, DoctorCheckLevel::Fail);
+        assert!(
+            check.detail.contains("deepseek-chat"),
+            "reviewed providers should point users to the reviewed onboarding default when doctor cannot list models: {check:#?}"
+        );
+        assert!(
+            check.detail.contains("rerun onboarding"),
+            "doctor should suggest rerunning onboarding to accept the reviewed model instead of leaving recovery implicit: {check:#?}"
         );
     }
 
@@ -2405,6 +2492,40 @@ mod tests {
                     && check.detail.contains("runtime is ready")
             }),
             "doctor should mark the runtime gate healthy when the companion lane is opened: {checks:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_guides_reviewed_onboarding_default_for_auto_model_probe_failures() {
+        let checks = vec![DoctorCheck {
+            name: "provider model probe".to_owned(),
+            level: DoctorCheckLevel::Fail,
+            detail: "DeepSeek [deepseek]: model catalog probe failed (401 Unauthorized); current config still uses `model = auto`; rerun onboarding and accept reviewed model `deepseek-chat`, or set `provider.model` / `preferred_models` explicitly".to_owned(),
+        }];
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "auto".to_owned();
+
+        let next_steps =
+            build_doctor_next_steps(&checks, Path::new("/tmp/loongclaw.toml"), &config, false);
+
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Rerun onboarding and accept reviewed model `deepseek-chat`: loongclaw onboard --config '/tmp/loongclaw.toml'"
+            }),
+            "doctor should point reviewed providers back to onboarding when auto-model recovery needs an explicit reviewed default: {next_steps:#?}"
+        );
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Or set `provider.model` / `preferred_models` explicitly, then re-run diagnostics: loongclaw doctor --config '/tmp/loongclaw.toml'"
+            }),
+            "doctor should also keep the manual remediation path explicit for operators who do not want to rerun onboarding: {next_steps:#?}"
+        );
+        assert!(
+            next_steps
+                .iter()
+                .all(|step| !step.contains("--skip-model-probe")),
+            "doctor should not suggest --skip-model-probe when the real blocker is still `model = auto` without explicit recovery candidates: {next_steps:#?}"
         );
     }
 

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -8,6 +8,8 @@ use loongclaw_app as mvp;
 use loongclaw_spec::CliResult;
 use serde_json::json;
 
+const MODEL_CATALOG_PROBE_FAILED_MARKER: &str = "model catalog probe failed";
+
 #[derive(Debug, Clone)]
 pub struct DoctorCommandOptions {
     pub config: Option<String>,
@@ -993,13 +995,13 @@ fn provider_model_probe_failure_check(
         mvp::config::ModelCatalogProbeRecovery::ExplicitModel(model) => (
             DoctorCheckLevel::Warn,
             format!(
-                "{provider_prefix}: model catalog probe failed ({error}); chat may still work because model `{model}` is explicitly configured"
+                "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); chat may still work because model `{model}` is explicitly configured"
             ),
         ),
         mvp::config::ModelCatalogProbeRecovery::ConfiguredPreferredModels(fallback_models) => (
             DoctorCheckLevel::Warn,
             format!(
-                "{provider_prefix}: model catalog probe failed ({error}); runtime will try configured preferred model fallback(s): {}",
+                "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); runtime will try configured preferred model fallback(s): {}",
                 fallback_models
                     .iter()
                     .map(|model| format!("`{model}`"))
@@ -1033,10 +1035,10 @@ fn provider_model_probe_requires_explicit_model_detail(
 ) -> String {
     match recommended_onboarding_model {
         Some(model) => format!(
-            "{provider_prefix}: model catalog probe failed ({error}); current config still uses `model = auto`; rerun onboarding and accept reviewed model `{model}`, or set `provider.model` / `preferred_models` explicitly"
+            "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); current config still uses `model = auto`; rerun onboarding and accept reviewed model `{model}`, or set `provider.model` / `preferred_models` explicitly"
         ),
         None => format!(
-            "{provider_prefix}: model catalog probe failed ({error}); current config still uses `model = auto`; set `provider.model` explicitly or configure `preferred_models` before retrying"
+            "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); current config still uses `model = auto`; set `provider.model` explicitly or configure `preferred_models` before retrying"
         ),
     }
 }
@@ -1182,8 +1184,6 @@ fn build_doctor_next_steps_with_path_env(
         crate::cli_handoff::format_subcommand_with_config("doctor", &config_path_display);
     let rerun_onboard_command =
         crate::cli_handoff::format_subcommand_with_config("onboard", &config_path_display);
-    let browser_preview =
-        crate::browser_preview::inspect_browser_preview_state_with_path_env(config, path_env);
 
     if !fix_requested
         && checks.iter().any(|check| {
@@ -1214,10 +1214,11 @@ fn build_doctor_next_steps_with_path_env(
         }
     }
 
-    if checks
-        .iter()
-        .any(|check| check.name == "provider model probe" && check.level == DoctorCheckLevel::Fail)
-    {
+    if checks.iter().any(|check| {
+        check.name == "provider model probe"
+            && check.level != DoctorCheckLevel::Pass
+            && check.detail.contains(MODEL_CATALOG_PROBE_FAILED_MARKER)
+    }) {
         match config.provider.model_catalog_probe_recovery() {
             mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
                 recommended_onboarding_model: Some(model),
@@ -2526,6 +2527,92 @@ mod tests {
                 .iter()
                 .all(|step| !step.contains("--skip-model-probe")),
             "doctor should not suggest --skip-model-probe when the real blocker is still `model = auto` without explicit recovery candidates: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_guides_warn_level_explicit_model_probe_recovery() {
+        let checks = vec![DoctorCheck {
+            name: "provider model probe".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: "DeepSeek [deepseek]: model catalog probe failed (401 Unauthorized); chat may still work because model `deepseek-chat` is explicitly configured".to_owned(),
+        }];
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "deepseek-chat".to_owned();
+
+        let next_steps =
+            build_doctor_next_steps(&checks, Path::new("/tmp/loongclaw.toml"), &config, false);
+
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Retry provider probe only after credentials are ready: loongclaw doctor --config '/tmp/loongclaw.toml'"
+            }),
+            "warn-level explicit model recovery should still tell operators how to retry diagnostics: {next_steps:#?}"
+        );
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "If your provider blocks model listing during setup, retry with: loongclaw doctor --config '/tmp/loongclaw.toml' --skip-model-probe"
+            }),
+            "warn-level explicit model recovery should still keep the skip-model-probe escape hatch visible: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_guides_warn_level_preferred_model_probe_recovery() {
+        let checks = vec![DoctorCheck {
+            name: "provider model probe".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: "DeepSeek [deepseek]: model catalog probe failed (401 Unauthorized); runtime will try configured preferred model fallback(s): `deepseek-chat`, `deepseek-reasoner`".to_owned(),
+        }];
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "auto".to_owned();
+        config.provider.preferred_models =
+            vec!["deepseek-chat".to_owned(), "deepseek-reasoner".to_owned()];
+
+        let next_steps =
+            build_doctor_next_steps(&checks, Path::new("/tmp/loongclaw.toml"), &config, false);
+
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Retry provider probe only after credentials are ready: loongclaw doctor --config '/tmp/loongclaw.toml'"
+            }),
+            "warn-level preferred-model recovery should still tell operators how to retry diagnostics: {next_steps:#?}"
+        );
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "If your provider blocks model listing during setup, retry with: loongclaw doctor --config '/tmp/loongclaw.toml' --skip-model-probe"
+            }),
+            "warn-level preferred-model recovery should still keep the skip-model-probe escape hatch visible: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_ignores_non_failure_model_probe_warnings() {
+        let checks = vec![DoctorCheck {
+            name: "provider model probe".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: "skipped because credentials are missing".to_owned(),
+        }];
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "deepseek-chat".to_owned();
+
+        let next_steps =
+            build_doctor_next_steps(&checks, Path::new("/tmp/loongclaw.toml"), &config, false);
+
+        assert!(
+            next_steps
+                .iter()
+                .all(|step| !step.contains("Retry provider probe only after credentials are ready")),
+            "skipped probe warnings should not look like real model catalog failures: {next_steps:#?}"
+        );
+        assert!(
+            next_steps
+                .iter()
+                .all(|step| !step.contains("--skip-model-probe")),
+            "skipped probe warnings should not advertise the skip-model-probe recovery branch: {next_steps:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -12,6 +12,7 @@ use time::macros::format_description;
 const BACKUP_TIMESTAMP_FORMAT: &[FormatItem<'static>] =
     format_description!("[year][month][day]-[hour][minute][second]");
 const ONBOARD_CLEAR_INPUT_TOKEN: &str = ":clear";
+const ONBOARD_ESCAPE_CANCEL_HINT: &str = "- press Esc then Enter to cancel onboarding";
 
 #[derive(Debug, Clone)]
 pub struct OnboardCommandOptions {
@@ -82,6 +83,7 @@ impl OnboardUi for StdioOnboardUi {
         io::stdin()
             .read_line(&mut line)
             .map_err(|error| format!("read stdin failed: {error}"))?;
+        let line = ensure_onboard_input_not_cancelled(line)?;
         let trimmed = line.trim();
         if trimmed.is_empty() {
             return Ok(default.to_owned());
@@ -98,6 +100,7 @@ impl OnboardUi for StdioOnboardUi {
         io::stdin()
             .read_line(&mut line)
             .map_err(|error| format!("read stdin failed: {error}"))?;
+        let line = ensure_onboard_input_not_cancelled(line)?;
         Ok(line.trim().to_owned())
     }
 
@@ -111,6 +114,7 @@ impl OnboardUi for StdioOnboardUi {
         io::stdin()
             .read_line(&mut line)
             .map_err(|error| format!("read stdin failed: {error}"))?;
+        let line = ensure_onboard_input_not_cancelled(line)?;
         let value = line.trim().to_ascii_lowercase();
         if value.is_empty() {
             return Ok(default);
@@ -132,6 +136,17 @@ fn print_message(ui: &mut impl OnboardUi, line: impl Into<String>) -> CliResult<
 
 fn is_explicit_onboard_clear_input(raw: &str) -> bool {
     raw.trim().eq_ignore_ascii_case(ONBOARD_CLEAR_INPUT_TOKEN)
+}
+
+fn is_explicit_onboard_cancel_input(raw: &str) -> bool {
+    matches!(raw.trim(), "\u{1b}") || raw.trim().eq_ignore_ascii_case("esc")
+}
+
+fn ensure_onboard_input_not_cancelled(raw: String) -> CliResult<String> {
+    if is_explicit_onboard_cancel_input(raw.as_str()) {
+        return Err("onboarding cancelled: escape input received".to_owned());
+    }
+    Ok(raw)
 }
 
 fn prompt_optional(
@@ -166,6 +181,7 @@ pub enum OnboardNonInteractiveWarningPolicy {
     Block,
     AcceptedBySkipModelProbe,
     AcceptedByExplicitModel,
+    AcceptedByPreferredModels,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -1355,6 +1371,14 @@ fn provider_check_detail_prefix(config: &mvp::config::LoongClawConfig) -> String
     crate::provider_presentation::active_provider_detail_label(config)
 }
 
+fn render_onboard_model_candidate_list(models: &[String]) -> String {
+    models
+        .iter()
+        .map(|model| format!("`{model}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 fn provider_model_probe_failure_check(
     config: &mvp::config::LoongClawConfig,
     error: String,
@@ -1369,6 +1393,21 @@ fn provider_model_probe_failure_check(
             ),
             non_interactive_warning_policy:
                 OnboardNonInteractiveWarningPolicy::AcceptedByExplicitModel,
+        };
+    }
+
+    let fallback_models = config.provider.configured_auto_model_candidates();
+    if !fallback_models.is_empty() {
+        return OnboardCheck {
+            name: "provider model probe",
+            level: OnboardCheckLevel::Warn,
+            detail: format!(
+                "{}: model catalog probe failed ({error}); runtime will try preferred model fallback(s): {}",
+                provider_check_detail_prefix(config),
+                render_onboard_model_candidate_list(&fallback_models)
+            ),
+            non_interactive_warning_policy:
+                OnboardNonInteractiveWarningPolicy::AcceptedByPreferredModels,
         };
     }
 
@@ -1490,6 +1529,7 @@ fn is_explicitly_accepted_non_interactive_warning(
         || matches!(
             check.non_interactive_warning_policy,
             OnboardNonInteractiveWarningPolicy::AcceptedByExplicitModel
+                | OnboardNonInteractiveWarningPolicy::AcceptedByPreferredModels
         )
 }
 
@@ -3176,9 +3216,15 @@ fn render_onboard_choice_screen(
     step: Option<(GuidedOnboardStep, GuidedPromptPath)>,
     intro_lines: Vec<String>,
     options: Vec<OnboardScreenOption>,
-    footer_lines: Vec<String>,
+    mut footer_lines: Vec<String>,
     color_enabled: bool,
 ) -> Vec<String> {
+    if !footer_lines
+        .iter()
+        .any(|line| line.contains("Esc") && line.contains("cancel"))
+    {
+        footer_lines.push(ONBOARD_ESCAPE_CANCEL_HINT.to_owned());
+    }
     let mut lines = render_onboard_header(header_style, width, subtitle, color_enabled);
     lines.push(String::new());
     lines.extend(render_onboard_wrapped_display_lines([title], width));
@@ -3206,9 +3252,15 @@ fn render_onboard_input_screen(
     step: GuidedOnboardStep,
     guided_prompt_path: GuidedPromptPath,
     context_lines: Vec<String>,
-    hint_lines: Vec<String>,
+    mut hint_lines: Vec<String>,
     color_enabled: bool,
 ) -> Vec<String> {
+    if !hint_lines
+        .iter()
+        .any(|line| line.contains("Esc") && line.contains("cancel"))
+    {
+        hint_lines.push(ONBOARD_ESCAPE_CANCEL_HINT.to_owned());
+    }
     let mut lines = render_onboard_header(OnboardHeaderStyle::Compact, width, "", color_enabled);
     lines.push(String::new());
     lines.extend(render_onboard_wrapped_display_lines([title], width));
@@ -4004,6 +4056,7 @@ fn render_model_selection_screen_lines_with_style(
     width: usize,
     color_enabled: bool,
 ) -> Vec<String> {
+    let preferred_fallback_models = config.provider.configured_auto_model_candidates();
     let mut context_lines = vec![
         format!(
             "- provider: {}",
@@ -4019,6 +4072,23 @@ fn render_model_selection_screen_lines_with_style(
     {
         context_lines.push(format!("- provider default: {default_model}"));
     }
+    if !preferred_fallback_models.is_empty() {
+        context_lines.push(format!(
+            "- preferred fallback: {}",
+            preferred_fallback_models.join(", ")
+        ));
+    }
+
+    let mut hint_lines = vec![
+        render_model_selection_default_hint_line(config, prompt_default),
+        "- type any provider model id to override it".to_owned(),
+    ];
+    if !preferred_fallback_models.is_empty() && config.provider.explicit_model().is_none() {
+        hint_lines.push(format!(
+            "- leave `auto` to let runtime try preferred fallbacks first: {}",
+            preferred_fallback_models.join(", ")
+        ));
+    }
 
     render_onboard_input_screen(
         width,
@@ -4026,10 +4096,7 @@ fn render_model_selection_screen_lines_with_style(
         GuidedOnboardStep::Model,
         guided_prompt_path,
         context_lines,
-        vec![
-            render_model_selection_default_hint_line(config, prompt_default),
-            "- type any provider model id to override it".to_owned(),
-        ],
+        hint_lines,
         color_enabled,
     )
 }
@@ -5082,24 +5149,36 @@ mod tests {
         }
 
         fn prompt_with_default(&mut self, _label: &str, default: &str) -> CliResult<String> {
-            Ok(self
-                .inputs
-                .pop_front()
-                .unwrap_or_else(|| default.to_owned()))
+            let value = ensure_onboard_input_not_cancelled(
+                self.inputs
+                    .pop_front()
+                    .unwrap_or_else(|| default.to_owned()),
+            )?;
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return Ok(default.to_owned());
+            }
+            Ok(trimmed.to_owned())
         }
 
         fn prompt_required(&mut self, _label: &str) -> CliResult<String> {
-            self.inputs
+            let value = self
+                .inputs
                 .pop_front()
-                .ok_or_else(|| "missing required test input".to_owned())
+                .ok_or_else(|| "missing required test input".to_owned())?;
+            ensure_onboard_input_not_cancelled(value)
         }
 
         fn prompt_confirm(&mut self, _message: &str, default: bool) -> CliResult<bool> {
-            Ok(self
-                .inputs
-                .pop_front()
-                .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "y" | "yes"))
-                .unwrap_or(default))
+            let Some(value) = self.inputs.pop_front() else {
+                return Ok(default);
+            };
+            let value = ensure_onboard_input_not_cancelled(value)?;
+            let value = value.trim().to_ascii_lowercase();
+            if value.is_empty() {
+                return Ok(default);
+            }
+            Ok(matches!(value.as_str(), "y" | "yes"))
         }
     }
 
@@ -5373,6 +5452,34 @@ mod tests {
     }
 
     #[test]
+    fn provider_model_probe_failure_warns_for_preferred_model_fallbacks() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        config.provider.model = "auto".to_owned();
+        config.provider.preferred_models = vec![
+            "MiniMax-M1".to_owned(),
+            "MiniMax-M1".to_owned(),
+            "MiniMax-Text-01".to_owned(),
+        ];
+
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider rejected the model list".to_owned(),
+        );
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, OnboardCheckLevel::Warn);
+        assert!(
+            check.detail.contains("preferred model"),
+            "preferred-model fallback should be explained when catalog discovery is unavailable: {check:#?}"
+        );
+        assert!(
+            check.detail.contains("MiniMax-M1"),
+            "onboard warning should surface the first fallback model to keep the first-run path actionable: {check:#?}"
+        );
+    }
+
+    #[test]
     fn explicit_model_probe_warning_is_accepted_non_interactively() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.model = "openai/gpt-5.1-codex".to_owned();
@@ -5397,6 +5504,36 @@ mod tests {
         assert!(
             is_explicitly_accepted_non_interactive_warning(&check, &options),
             "explicit-model probe warnings should not block non-interactive onboarding because model discovery is advisory: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn preferred_model_probe_warning_is_accepted_non_interactively() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        config.provider.model = "auto".to_owned();
+        config.provider.preferred_models = vec!["MiniMax-M1".to_owned()];
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider rejected the model list".to_owned(),
+        );
+        let options = OnboardCommandOptions {
+            output: None,
+            force: false,
+            non_interactive: true,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            personality: None,
+            memory_profile: None,
+            system_prompt: None,
+            skip_model_probe: false,
+        };
+
+        assert!(
+            is_explicitly_accepted_non_interactive_warning(&check, &options),
+            "preferred-model fallback warnings should not block non-interactive onboarding because runtime can still try the seeded models: {check:#?}"
         );
     }
 
@@ -5579,6 +5716,52 @@ mod tests {
         assert!(
             is_explicitly_accepted_non_interactive_warning(&check, &options),
             "non-interactive warning acceptance should follow structured policy rather than fragile display strings"
+        );
+    }
+
+    #[test]
+    fn render_model_selection_screen_surfaces_preferred_fallback_models() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        config.provider.model = "auto".to_owned();
+        config.provider.preferred_models =
+            vec!["MiniMax-M1".to_owned(), "MiniMax-Text-01".to_owned()];
+
+        let lines = render_model_selection_screen_lines_with_default(&config, "auto", 80);
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("MiniMax-M1") && line.contains("preferred")),
+            "model selection should surface runtime fallback hints when auto-model setup depends on curated preferred models: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn prompt_onboard_shortcut_choice_cancels_on_escape_input() {
+        let mut ui = TestOnboardUi::with_inputs(["\u{1b}"]);
+
+        let error = prompt_onboard_shortcut_choice(&mut ui)
+            .expect_err("escape input should cancel instead of silently falling through");
+
+        assert!(
+            error.contains("cancelled"),
+            "escape cancellation should produce a user-facing cancel error: {error}"
+        );
+    }
+
+    #[test]
+    fn shortcut_screen_footer_mentions_escape_cancel() {
+        let lines = render_continue_current_setup_screen_lines(
+            &mvp::config::LoongClawConfig::default(),
+            80,
+        );
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("Esc") && line.contains("cancel")),
+            "choice screens should teach the exit gesture explicitly: {lines:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -5163,11 +5163,8 @@ mod tests {
         }
 
         fn prompt_with_default(&mut self, _label: &str, default: &str) -> CliResult<String> {
-            let value = ensure_onboard_input_not_cancelled(
-                self.inputs
-                    .pop_front()
-                    .unwrap_or_else(|| default.to_owned()),
-            )?;
+            let value =
+                ensure_onboard_input_not_cancelled(self.inputs.pop_front().unwrap_or_default())?;
             let trimmed = value.trim();
             if trimmed.is_empty() {
                 return Ok(default.to_owned());
@@ -5180,7 +5177,7 @@ mod tests {
                 .inputs
                 .pop_front()
                 .ok_or_else(|| "missing required test input".to_owned())?;
-            ensure_onboard_input_not_cancelled(value)
+            Ok(ensure_onboard_input_not_cancelled(value)?.trim().to_owned())
         }
 
         fn prompt_confirm(&mut self, _message: &str, default: bool) -> CliResult<bool> {
@@ -5814,6 +5811,28 @@ mod tests {
             error.contains("cancelled"),
             "escape cancellation should produce a user-facing cancel error: {error}"
         );
+    }
+
+    #[test]
+    fn test_onboard_ui_prompt_with_default_only_checks_user_input_for_cancel() {
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+
+        let value = ui
+            .prompt_with_default("Provider", "\u{1b}")
+            .expect("missing input should keep the configured default");
+
+        assert_eq!(value, "\u{1b}");
+    }
+
+    #[test]
+    fn test_onboard_ui_prompt_required_trims_input_like_stdio() {
+        let mut ui = TestOnboardUi::with_inputs(["  minimax  "]);
+
+        let value = ui
+            .prompt_required("Provider")
+            .expect("required prompt should preserve stdio trimming semantics");
+
+        assert_eq!(value, "minimax");
     }
 
     #[test]

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -139,7 +139,7 @@ fn is_explicit_onboard_clear_input(raw: &str) -> bool {
 }
 
 fn is_explicit_onboard_cancel_input(raw: &str) -> bool {
-    matches!(raw.trim(), "\u{1b}") || raw.trim().eq_ignore_ascii_case("esc")
+    matches!(raw.trim(), "\u{1b}")
 }
 
 fn ensure_onboard_input_not_cancelled(raw: String) -> CliResult<String> {
@@ -1033,6 +1033,12 @@ fn resolve_model_selection(
     ui: &mut impl OnboardUi,
     context: &OnboardRuntimeContext,
 ) -> CliResult<String> {
+    if let Some(model) = options.model.as_deref()
+        && model.trim().is_empty()
+    {
+        return Err("model cannot be empty".to_owned());
+    }
+
     let default_model = resolve_onboarding_model_prompt_default(options, config);
     if options.non_interactive {
         return Ok(default_model);
@@ -1060,13 +1066,8 @@ fn resolve_onboarding_model_prompt_default(
     options: &OnboardCommandOptions,
     config: &mvp::config::LoongClawConfig,
 ) -> String {
-    if let Some(model) = options
-        .model
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        return model.to_owned();
+    if let Some(model) = options.model.as_deref() {
+        return model.trim().to_owned();
     }
 
     if let Some(model) = config.provider.explicit_model() {
@@ -5959,6 +5960,40 @@ mod tests {
     }
 
     #[test]
+    fn resolve_model_selection_rejects_blank_explicit_model_non_interactively() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "auto".to_owned();
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let error = resolve_model_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: true,
+                accept_risk: true,
+                provider: None,
+                model: Some("   ".to_owned()),
+                api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect_err(
+            "blank explicit --model should fail instead of falling back to a recommended model",
+        );
+
+        assert_eq!(error, "model cannot be empty");
+    }
+
+    #[test]
     fn prompt_onboard_shortcut_choice_cancels_on_escape_input() {
         let mut ui = TestOnboardUi::with_inputs(["\u{1b}"]);
 
@@ -5980,6 +6015,14 @@ mod tests {
             .expect("missing input should keep the configured default");
 
         assert_eq!(value, "\u{1b}");
+    }
+
+    #[test]
+    fn literal_esc_text_is_not_treated_as_cancel_input() {
+        let value = ensure_onboard_input_not_cancelled("esc".to_owned())
+            .expect("literal esc text should remain valid input");
+
+        assert_eq!(value, "esc");
     }
 
     #[test]

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1036,39 +1036,53 @@ fn resolve_model_selection(
     ui: &mut impl OnboardUi,
     context: &OnboardRuntimeContext,
 ) -> CliResult<String> {
+    let default_model = resolve_onboarding_model_prompt_default(options, config);
     if options.non_interactive {
-        if let Some(model) = options.model.as_deref() {
-            let trimmed = model.trim();
-            if trimmed.is_empty() {
-                return Err("--model cannot be empty".to_owned());
-            }
-            return Ok(trimmed.to_owned());
-        }
-        return Ok(config.provider.model.clone());
+        return Ok(default_model);
     }
 
-    let default_model = options
-        .model
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(config.provider.model.as_str());
     print_lines(
         ui,
         render_model_selection_screen_lines_with_style(
             config,
-            default_model,
+            default_model.as_str(),
             guided_prompt_path,
             context.render_width,
             true,
         ),
     )?;
-    let value = ui.prompt_with_default("Model", default_model)?;
+    let value = ui.prompt_with_default("Model", default_model.as_str())?;
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return Err("model cannot be empty".to_owned());
     }
     Ok(trimmed.to_owned())
+}
+
+fn resolve_onboarding_model_prompt_default(
+    options: &OnboardCommandOptions,
+    config: &mvp::config::LoongClawConfig,
+) -> String {
+    if let Some(model) = options
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return model.to_owned();
+    }
+
+    if let Some(model) = config.provider.explicit_model() {
+        return model;
+    }
+
+    if config.provider.configured_model_value() == "auto"
+        && let Some(model) = config.provider.kind.recommended_onboarding_model()
+    {
+        return model.to_owned();
+    }
+
+    config.provider.configured_model_value()
 }
 
 fn resolve_api_key_env_selection(
@@ -1402,7 +1416,7 @@ fn provider_model_probe_failure_check(
             name: "provider model probe",
             level: OnboardCheckLevel::Warn,
             detail: format!(
-                "{}: model catalog probe failed ({error}); runtime will try preferred model fallback(s): {}",
+                "{}: model catalog probe failed ({error}); runtime will try configured preferred model fallback(s): {}",
                 provider_check_detail_prefix(config),
                 render_onboard_model_candidate_list(&fallback_models)
             ),
@@ -4067,14 +4081,14 @@ fn render_model_selection_screen_lines_with_style(
     if let Some(default_model) = config
         .provider
         .kind
-        .default_model()
+        .recommended_onboarding_model()
         .filter(|default_model| *default_model != config.provider.model)
     {
-        context_lines.push(format!("- provider default: {default_model}"));
+        context_lines.push(format!("- recommended model: {default_model}"));
     }
     if !preferred_fallback_models.is_empty() {
         context_lines.push(format!(
-            "- preferred fallback: {}",
+            "- configured preferred fallback: {}",
             preferred_fallback_models.join(", ")
         ));
     }
@@ -4085,7 +4099,7 @@ fn render_model_selection_screen_lines_with_style(
     ];
     if !preferred_fallback_models.is_empty() && config.provider.explicit_model().is_none() {
         hint_lines.push(format!(
-            "- leave `auto` to let runtime try preferred fallbacks first: {}",
+            "- leave `auto` to let runtime try configured preferred fallbacks first: {}",
             preferred_fallback_models.join(", ")
         ));
     }
@@ -5470,8 +5484,8 @@ mod tests {
         assert_eq!(check.name, "provider model probe");
         assert_eq!(check.level, OnboardCheckLevel::Warn);
         assert!(
-            check.detail.contains("preferred model"),
-            "preferred-model fallback should be explained when catalog discovery is unavailable: {check:#?}"
+            check.detail.contains("configured preferred"),
+            "onboarding should only advertise fallback continuation for explicitly configured preferred models: {check:#?}"
         );
         assert!(
             check.detail.contains("MiniMax-M1"),
@@ -5508,7 +5522,7 @@ mod tests {
     }
 
     #[test]
-    fn preferred_model_probe_warning_is_accepted_non_interactively() {
+    fn configured_preferred_model_probe_warning_is_accepted_non_interactively() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Minimax;
         config.provider.model = "auto".to_owned();
@@ -5533,7 +5547,7 @@ mod tests {
 
         assert!(
             is_explicitly_accepted_non_interactive_warning(&check, &options),
-            "preferred-model fallback warnings should not block non-interactive onboarding because runtime can still try the seeded models: {check:#?}"
+            "configured preferred-model fallback warnings should not block non-interactive onboarding because runtime can still try the operator-configured models: {check:#?}"
         );
     }
 
@@ -5720,20 +5734,72 @@ mod tests {
     }
 
     #[test]
-    fn render_model_selection_screen_surfaces_preferred_fallback_models() {
+    fn resolve_model_selection_prefills_minimax_recommended_model_interactively() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Minimax;
         config.provider.model = "auto".to_owned();
-        config.provider.preferred_models =
-            vec!["MiniMax-M1".to_owned(), "MiniMax-Text-01".to_owned()];
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
 
-        let lines = render_model_selection_screen_lines_with_default(&config, "auto", 80);
+        let selected = resolve_model_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect("resolve model selection");
 
         assert!(
-            lines
-                .iter()
-                .any(|line| line.contains("MiniMax-M1") && line.contains("preferred")),
-            "model selection should surface runtime fallback hints when auto-model setup depends on curated preferred models: {lines:#?}"
+            selected == "MiniMax-M2.5",
+            "interactive onboarding should prefill the provider-recommended explicit model for MiniMax instead of leaving the operator on hidden runtime fallbacks: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_model_selection_prefills_minimax_recommended_model_non_interactively() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        config.provider.model = "auto".to_owned();
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_model_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: true,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect("resolve model selection");
+
+        assert!(
+            selected == "MiniMax-M2.5",
+            "non-interactive onboarding should pick the provider-recommended explicit model for MiniMax instead of preserving auto: {selected:?}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2110,12 +2110,14 @@ fn render_onboard_entry_screen_lines_with_style(
         })
         .collect::<Vec<_>>();
     lines.extend(render_onboard_option_lines(&screen_options, width));
-    if let Some(default_choice_line) = render_onboard_entry_default_choice_footer_line(options) {
+    let footer_lines = append_escape_cancel_hint(
+        render_onboard_entry_default_choice_footer_line(options)
+            .into_iter()
+            .collect::<Vec<_>>(),
+    );
+    if !footer_lines.is_empty() {
         lines.push(String::new());
-        lines.extend(render_onboard_wrapped_display_lines(
-            [default_choice_line],
-            width,
-        ));
+        lines.extend(render_onboard_wrapped_display_lines(footer_lines, width));
     }
     lines
 }
@@ -3222,6 +3224,16 @@ fn with_default_choice_footer(
     footer_lines
 }
 
+fn append_escape_cancel_hint(mut lines: Vec<String>) -> Vec<String> {
+    if !lines
+        .iter()
+        .any(|line| line.contains("Esc") && line.contains("cancel"))
+    {
+        lines.push(ONBOARD_ESCAPE_CANCEL_HINT.to_owned());
+    }
+    lines
+}
+
 fn render_onboard_choice_screen(
     header_style: OnboardHeaderStyle,
     width: usize,
@@ -3230,15 +3242,10 @@ fn render_onboard_choice_screen(
     step: Option<(GuidedOnboardStep, GuidedPromptPath)>,
     intro_lines: Vec<String>,
     options: Vec<OnboardScreenOption>,
-    mut footer_lines: Vec<String>,
+    footer_lines: Vec<String>,
     color_enabled: bool,
 ) -> Vec<String> {
-    if !footer_lines
-        .iter()
-        .any(|line| line.contains("Esc") && line.contains("cancel"))
-    {
-        footer_lines.push(ONBOARD_ESCAPE_CANCEL_HINT.to_owned());
-    }
+    let footer_lines = append_escape_cancel_hint(footer_lines);
     let mut lines = render_onboard_header(header_style, width, subtitle, color_enabled);
     lines.push(String::new());
     lines.extend(render_onboard_wrapped_display_lines([title], width));
@@ -3266,15 +3273,10 @@ fn render_onboard_input_screen(
     step: GuidedOnboardStep,
     guided_prompt_path: GuidedPromptPath,
     context_lines: Vec<String>,
-    mut hint_lines: Vec<String>,
+    hint_lines: Vec<String>,
     color_enabled: bool,
 ) -> Vec<String> {
-    if !hint_lines
-        .iter()
-        .any(|line| line.contains("Esc") && line.contains("cancel"))
-    {
-        hint_lines.push(ONBOARD_ESCAPE_CANCEL_HINT.to_owned());
-    }
+    let hint_lines = append_escape_cancel_hint(hint_lines);
     let mut lines = render_onboard_header(OnboardHeaderStyle::Compact, width, "", color_enabled);
     lines.push(String::new());
     lines.extend(render_onboard_wrapped_display_lines([title], width));
@@ -3506,13 +3508,11 @@ fn render_preflight_summary_screen_lines_with_style(
         lines.push(String::new());
         lines.extend(render_onboard_option_lines(&options, width));
         lines.push(String::new());
-        lines.extend(render_onboard_wrapped_display_lines(
-            [render_default_choice_footer_line(
-                "n",
-                crate::onboard_presentation::preflight_default_choice_description(),
-            )],
-            width,
-        ));
+        let footer_lines = append_escape_cancel_hint(vec![render_default_choice_footer_line(
+            "n",
+            crate::onboard_presentation::preflight_default_choice_description(),
+        )]);
+        lines.extend(render_onboard_wrapped_display_lines(footer_lines, width));
     }
     lines
 }
@@ -3600,13 +3600,11 @@ fn render_write_confirmation_screen_lines_with_style(
     lines.push(String::new());
     lines.extend(render_onboard_option_lines(&options, width));
     lines.push(String::new());
-    lines.extend(render_onboard_wrapped_display_lines(
-        [render_default_choice_footer_line(
-            "y",
-            crate::onboard_presentation::write_confirmation_default_choice_description(),
-        )],
-        width,
-    ));
+    let footer_lines = append_escape_cancel_hint(vec![render_default_choice_footer_line(
+        "y",
+        crate::onboard_presentation::write_confirmation_default_choice_description(),
+    )]);
+    lines.extend(render_onboard_wrapped_display_lines(footer_lines, width));
     lines
 }
 
@@ -4099,7 +4097,7 @@ fn render_model_selection_screen_lines_with_style(
     ];
     if !preferred_fallback_models.is_empty() && config.provider.explicit_model().is_none() {
         hint_lines.push(format!(
-            "- leave `auto` to let runtime try configured preferred fallbacks first: {}",
+            "- type `auto` to let runtime try configured preferred fallbacks first: {}",
             preferred_fallback_models.join(", ")
         ));
     }
@@ -5847,6 +5845,79 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("Esc") && line.contains("cancel")),
             "choice screens should teach the exit gesture explicitly: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn preflight_summary_screen_footer_mentions_escape_cancel() {
+        let checks = vec![OnboardCheck {
+            name: "provider model probe",
+            level: OnboardCheckLevel::Warn,
+            detail: "catalog probe failed".to_owned(),
+            non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+        }];
+
+        let lines = render_preflight_summary_screen_lines(&checks, 80);
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("Esc") && line.contains("cancel")),
+            "interactive preflight review should teach the exit gesture explicitly: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn entry_screen_footer_mentions_escape_cancel() {
+        let options = build_onboard_entry_options(crate::migration::CurrentSetupState::Absent, &[]);
+        let lines = render_onboard_entry_screen_lines(
+            crate::migration::CurrentSetupState::Absent,
+            None,
+            &[],
+            &options,
+            None,
+            80,
+        );
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("Esc") && line.contains("cancel")),
+            "interactive entry selection should teach the exit gesture explicitly: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn write_confirmation_screen_footer_mentions_escape_cancel() {
+        let lines = render_write_confirmation_screen_lines("/tmp/loongclaw.toml", false, 80);
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("Esc") && line.contains("cancel")),
+            "write confirmation should teach the exit gesture explicitly: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn model_selection_screen_tells_users_to_type_auto_for_fallbacks() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        config.provider.model = "auto".to_owned();
+        config.provider.preferred_models = vec!["MiniMax-M1".to_owned()];
+
+        let lines = render_model_selection_screen_lines_with_default(&config, "MiniMax-M2.5", 80);
+        let rendered = lines.join("\n");
+
+        assert!(
+            rendered.contains("type `auto`")
+                && rendered.contains("configured preferred fallbacks first")
+                && rendered.contains("MiniMax-M1"),
+            "explicit prefill flows should tell users to type `auto` when they want configured fallback behavior: {lines:#?}"
+        );
+        assert!(
+            !rendered.contains("leave `auto`"),
+            "explicit prefill flows should not imply Enter keeps `auto`: {lines:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -3251,10 +3251,10 @@ fn with_default_choice_footer(
 }
 
 fn append_escape_cancel_hint(mut lines: Vec<String>) -> Vec<String> {
-    if !lines
-        .iter()
-        .any(|line| line.contains("Esc") && line.contains("cancel"))
-    {
+    if !lines.iter().any(|line| {
+        let lower = line.to_ascii_lowercase();
+        lower.contains("esc") && lower.contains("cancel")
+    }) {
         lines.push(ONBOARD_ESCAPE_CANCEL_HINT.to_owned());
     }
     lines
@@ -6056,6 +6056,19 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("Esc") && line.contains("cancel")),
             "write confirmation should teach the exit gesture explicitly: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn append_escape_cancel_hint_dedupes_case_insensitively() {
+        let footer_lines = append_escape_cancel_hint(vec![
+            "- press esc then enter to cancel onboarding".to_owned(),
+        ]);
+
+        assert_eq!(
+            footer_lines,
+            vec!["- press esc then enter to cancel onboarding".to_owned()],
+            "case-only changes should not duplicate the escape cancel footer: {footer_lines:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -677,10 +677,7 @@ pub async fn run_onboard_cli_with_ui(
             ));
         }
         if has_failures {
-            return Err(
-                "onboard preflight failed. rerun with --skip-model-probe if your provider blocks model listing during setup"
-                    .to_owned(),
-            );
+            return Err(non_interactive_preflight_failure_message(&checks));
         }
         if has_blocking_non_interactive_warnings {
             return Err(
@@ -1397,39 +1394,44 @@ fn provider_model_probe_failure_check(
     config: &mvp::config::LoongClawConfig,
     error: String,
 ) -> OnboardCheck {
-    if let Some(model) = config.provider.explicit_model() {
-        return OnboardCheck {
-            name: "provider model probe",
-            level: OnboardCheckLevel::Warn,
-            detail: format!(
-                "{}: model catalog probe failed ({error}); chat may still work because model `{model}` is explicitly configured",
-                provider_check_detail_prefix(config)
+    let provider_prefix = provider_check_detail_prefix(config);
+    let (level, detail, non_interactive_warning_policy) = match config
+        .provider
+        .model_catalog_probe_recovery()
+    {
+        mvp::config::ModelCatalogProbeRecovery::ExplicitModel(model) => (
+            OnboardCheckLevel::Warn,
+            format!(
+                "{provider_prefix}: model catalog probe failed ({error}); chat may still work because model `{model}` is explicitly configured"
             ),
-            non_interactive_warning_policy:
-                OnboardNonInteractiveWarningPolicy::AcceptedByExplicitModel,
-        };
-    }
-
-    let fallback_models = config.provider.configured_auto_model_candidates();
-    if !fallback_models.is_empty() {
-        return OnboardCheck {
-            name: "provider model probe",
-            level: OnboardCheckLevel::Warn,
-            detail: format!(
-                "{}: model catalog probe failed ({error}); runtime will try configured preferred model fallback(s): {}",
-                provider_check_detail_prefix(config),
+            OnboardNonInteractiveWarningPolicy::AcceptedByExplicitModel,
+        ),
+        mvp::config::ModelCatalogProbeRecovery::ConfiguredPreferredModels(fallback_models) => (
+            OnboardCheckLevel::Warn,
+            format!(
+                "{provider_prefix}: model catalog probe failed ({error}); runtime will try configured preferred model fallback(s): {}",
                 render_onboard_model_candidate_list(&fallback_models)
             ),
-            non_interactive_warning_policy:
-                OnboardNonInteractiveWarningPolicy::AcceptedByPreferredModels,
-        };
-    }
+            OnboardNonInteractiveWarningPolicy::AcceptedByPreferredModels,
+        ),
+        mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
+            recommended_onboarding_model,
+        } => (
+            OnboardCheckLevel::Fail,
+            provider_model_probe_requires_explicit_model_detail(
+                provider_prefix.as_str(),
+                error.as_str(),
+                recommended_onboarding_model,
+            ),
+            OnboardNonInteractiveWarningPolicy::Block,
+        ),
+    };
 
     OnboardCheck {
         name: "provider model probe",
-        level: OnboardCheckLevel::Fail,
-        detail: format!("{}: {error}", provider_check_detail_prefix(config)),
-        non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+        level,
+        detail,
+        non_interactive_warning_policy,
     }
 }
 
@@ -1461,6 +1463,30 @@ async fn collect_browser_companion_preflight_checks(
         detail,
         non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
     }]
+}
+
+fn provider_model_probe_requires_explicit_model_detail(
+    provider_prefix: &str,
+    error: &str,
+    recommended_onboarding_model: Option<&str>,
+) -> String {
+    match recommended_onboarding_model {
+        Some(model) => format!(
+            "{provider_prefix}: model catalog probe failed ({error}); current config still uses `model = auto`; rerun onboarding and accept reviewed model `{model}`, or set `provider.model` / `preferred_models` explicitly"
+        ),
+        None => format!(
+            "{provider_prefix}: model catalog probe failed ({error}); current config still uses `model = auto`; set `provider.model` explicitly or configure `preferred_models` before retrying"
+        ),
+    }
+}
+
+fn non_interactive_preflight_failure_message(checks: &[OnboardCheck]) -> String {
+    let detail = checks
+        .iter()
+        .find(|check| check.level == OnboardCheckLevel::Fail)
+        .map(|check| check.detail.as_str())
+        .unwrap_or("preflight checks failed");
+    format!("onboard preflight failed: {detail}")
 }
 
 pub fn provider_credential_check(config: &mvp::config::LoongClawConfig) -> OnboardCheck {
@@ -5458,6 +5484,18 @@ mod tests {
             check.detail.contains("OpenAI [openai]"),
             "onboard failures should still identify the active provider context: {check:#?}"
         );
+        assert!(
+            check.detail.contains("model = auto"),
+            "auto-model probe failures should explain why onboarding cannot continue with an unresolved automatic model: {check:#?}"
+        );
+        assert!(
+            check.detail.contains("provider.model"),
+            "auto-model probe failures should point users to an explicit provider.model remediation path: {check:#?}"
+        );
+        assert!(
+            check.detail.contains("preferred_models"),
+            "auto-model probe failures should point users to preferred_models when catalog probing is unavailable: {check:#?}"
+        );
     }
 
     #[test]
@@ -5485,6 +5523,29 @@ mod tests {
         assert!(
             check.detail.contains("MiniMax-M1"),
             "onboard warning should surface the first fallback model to keep the first-run path actionable: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_guides_reviewed_default_for_auto_model() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "auto".to_owned();
+
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider rejected the model list".to_owned(),
+        );
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, OnboardCheckLevel::Fail);
+        assert!(
+            check.detail.contains("deepseek-chat"),
+            "reviewed providers should point users to the reviewed onboarding default when catalog probing is unavailable: {check:#?}"
+        );
+        assert!(
+            check.detail.contains("rerun onboarding"),
+            "reviewed providers should suggest rerunning onboarding to accept the reviewed model instead of leaving recovery implicit: {check:#?}"
         );
     }
 
@@ -5543,6 +5604,35 @@ mod tests {
         assert!(
             is_explicitly_accepted_non_interactive_warning(&check, &options),
             "configured preferred-model fallback warnings should not block non-interactive onboarding because runtime can still try the operator-configured models: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn non_interactive_preflight_failure_message_uses_first_failing_check_detail() {
+        let checks = vec![
+            OnboardCheck {
+                name: "provider credentials",
+                level: OnboardCheckLevel::Pass,
+                detail: "credentials ok".to_owned(),
+                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+            },
+            OnboardCheck {
+                name: "provider model probe",
+                level: OnboardCheckLevel::Fail,
+                detail: "DeepSeek [deepseek]: model catalog probe failed (401 Unauthorized); current config still uses `model = auto`; rerun onboarding and accept reviewed model `deepseek-chat`, or set `provider.model` / `preferred_models` explicitly".to_owned(),
+                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+            },
+        ];
+
+        let message = non_interactive_preflight_failure_message(&checks);
+
+        assert!(
+            message.contains("onboard preflight failed: DeepSeek [deepseek]"),
+            "non-interactive onboarding should return the actionable failing-check detail instead of a generic probe hint: {message}"
+        );
+        assert!(
+            message.contains("provider.model"),
+            "non-interactive onboarding should preserve the explicit remediation from the failing check: {message}"
         );
     }
 
@@ -5795,6 +5885,76 @@ mod tests {
         assert!(
             selected == "MiniMax-M2.5",
             "non-interactive onboarding should pick the provider-recommended explicit model for MiniMax instead of preserving auto: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_model_selection_prefills_deepseek_recommended_model_interactively() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "auto".to_owned();
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_model_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect("resolve model selection");
+
+        assert!(
+            selected == "deepseek-chat",
+            "interactive onboarding should prefill the provider-recommended explicit model for DeepSeek instead of leaving the operator on auto: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_model_selection_prefills_deepseek_recommended_model_non_interactively() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "auto".to_owned();
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_model_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: true,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect("resolve model selection");
+
+        assert!(
+            selected == "deepseek-chat",
+            "non-interactive onboarding should pick the provider-recommended explicit model for DeepSeek instead of preserving auto: {selected:?}"
         );
     }
 

--- a/docs/plans/2026-03-16-provider-onboarding-default-model-design.md
+++ b/docs/plans/2026-03-16-provider-onboarding-default-model-design.md
@@ -1,0 +1,186 @@
+# Provider Onboarding Default Model Design
+
+## Problem
+
+The current alpha-test fix correctly improves onboarding exit UX, but the
+provider-model part is still shaped incorrectly.
+
+The branch currently seeds provider-owned `preferred_models` and lets runtime,
+onboarding, and doctor treat those hidden defaults as an acceptable fallback
+when model catalog discovery fails.
+
+That creates three avoidable problems:
+
+- provider model names must now be maintained as hidden runtime defaults across
+  many providers
+- first-run behavior depends on invisible fallback state instead of explicit
+  configuration the user can inspect
+- onboarding, doctor, and runtime blur together: a catalog failure can look
+  "fixed" even though the actual configured model is still `auto`
+
+The MiniMax `401` report exposed this issue first, but the design problem is
+broader than MiniMax.
+
+## Goal
+
+Keep the validated onboarding exit improvements, but replace hidden provider
+runtime fallbacks with a simpler and more explicit model-selection rule:
+
+1. onboarding may suggest or apply a provider-specific recommended model
+2. runtime should only use:
+   - an explicit configured model
+   - a successfully fetched or cached model catalog
+   - user-configured `preferred_models`
+3. doctor/onboarding messaging should only promise fallback behavior when it was
+   explicitly configured by the operator
+
+## Non-Goals
+
+- building a full provider model registry with live metadata fetch
+- auditing and seeding recommended onboarding models for every provider in this
+  slice
+- removing user-configurable `preferred_models`
+- redesigning provider migration or general config import
+
+## Constraints
+
+- keep the fix small and local to the active branch/PR
+- preserve the already-correct `Esc` onboarding cancellation behavior
+- avoid introducing new hidden defaults in runtime
+- keep existing user-configured `preferred_models` behavior intact
+
+## Approach Options
+
+### Option A: Keep hidden provider fallback lists and expand them
+
+Pros:
+
+- minimal code churn from the current branch
+- more providers could keep `model = auto` when discovery fails
+
+Cons:
+
+- turns provider model maintenance into an open-ended hidden-default catalog
+- runtime behavior drifts from what the user explicitly configured
+- every new provider needs curated hidden model names or inconsistent behavior
+
+### Option B: Remove hidden runtime defaults and use onboarding-only explicit defaults
+
+Pros:
+
+- matches the shape used by OpenClaw: provider defaults are explicit in setup,
+  not magical runtime guesses
+- fixes MiniMax first-run success without introducing a generalized hidden
+  fallback mechanism
+- keeps runtime semantics simple and auditable
+
+Cons:
+
+- providers without a recommended onboarding model still need catalog discovery
+  or manual `--model`
+- requires a small onboarding-specific provider metadata path
+
+### Option C: Remove all fallback behavior including user-configured
+`preferred_models`
+
+Pros:
+
+- simplest runtime logic
+
+Cons:
+
+- removes an existing explicit operator control with real value
+- broader behavior change than the current issue requires
+
+## Decision
+
+Choose Option B.
+
+The right fix is not "never maintain provider defaults". The right fix is to
+keep those defaults in the onboarding/configuration layer where they are
+explicit and user-visible, while removing hidden runtime fallback defaults.
+
+This keeps the MiniMax repair path, aligns better with OpenClaw's model setup
+shape, and avoids turning `preferred_models` into an internal provider catalog.
+
+## Design
+
+### 1. Add onboarding-only provider default model metadata
+
+Introduce a provider metadata method for recommended onboarding defaults, scoped
+to first-run setup.
+
+Initial scope:
+
+- MiniMax: recommended onboarding model `MiniMax-M2.5`
+
+Important boundary:
+
+- this metadata is not used as a runtime fallback
+- it is only consulted when onboarding is choosing a model and the current value
+  is still `auto`
+
+### 2. Change onboarding model selection behavior
+
+When onboarding resolves the model:
+
+- if the operator passed `--model`, use it
+- else if the current provider model is explicit, keep it
+- else if the provider has a recommended onboarding model, prefill and accept
+  that explicit model
+- else keep `auto`
+
+This should apply to both interactive and non-interactive onboarding so
+`loongclaw onboard --provider minimax` produces a usable explicit model without
+requiring a live model-list probe.
+
+### 3. Remove hidden provider default fallbacks
+
+Delete the provider-level built-in `default_preferred_models()` usage for
+runtime fallback seeding.
+
+Behavior after change:
+
+- `preferred_models` remains supported when the user configures it
+- `configured_auto_model_candidates()` returns only explicit operator-configured
+  values
+- runtime no longer invents provider fallback candidates from provider kind
+
+### 4. Tighten doctor and onboarding messaging
+
+If model probe fails:
+
+- explicit model: warn, but say chat may still work because the model is
+  explicitly configured
+- user-configured `preferred_models`: warn, but say runtime will try configured
+  fallbacks
+- otherwise: fail
+
+This keeps the message truthful and operator-auditable.
+
+### 5. Documentation
+
+Update the onboarding spec and README copy to describe explicit provider
+defaults rather than hidden preferred fallbacks.
+
+## Testing Strategy
+
+Add or adjust tests to prove:
+
+- MiniMax onboarding default model is explicit and user-visible
+- non-interactive onboarding with MiniMax defaults to the explicit recommended
+  model instead of hidden runtime fallback state
+- `fresh_for_kind(ProviderKind::Minimax)` no longer seeds hidden
+  `preferred_models`
+- runtime fallback still works for user-configured `preferred_models`
+- doctor/onboarding only report fallback continuation for explicitly configured
+  preferred models
+
+## Why This Is Simpler
+
+This design removes hidden behavior instead of adding more heuristics.
+
+It keeps provider-specific knowledge in the one place where users expect it
+(setup defaults) and keeps runtime behavior tied to explicit config or real
+catalog data. That is a smaller and more explainable system than a growing
+runtime list of provider-owned fallback model IDs.

--- a/docs/plans/2026-03-16-provider-onboarding-default-model-design.md
+++ b/docs/plans/2026-03-16-provider-onboarding-default-model-design.md
@@ -96,7 +96,7 @@ Cons:
 
 Choose Option B.
 
-The right fix is not "never maintain provider defaults". The right fix is to
+The right fix is not "never maintain provider defaults". A better approach is to
 keep those defaults in the onboarding/configuration layer where they are
 explicit and user-visible, while removing hidden runtime fallback defaults.
 

--- a/docs/plans/2026-03-16-provider-onboarding-default-model-implementation-plan.md
+++ b/docs/plans/2026-03-16-provider-onboarding-default-model-implementation-plan.md
@@ -1,0 +1,186 @@
+# Provider Onboarding Default Model Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace hidden provider-owned runtime preferred-model fallbacks with
+explicit onboarding default models while preserving `Esc` onboarding exit UX and
+user-configured fallback behavior.
+
+**Architecture:** Add onboarding-only provider default model metadata, teach the
+onboarding flow to use it when `model` is still `auto`, and remove built-in
+runtime fallback seeding from `preferred_models`. Runtime, doctor, and onboarding
+should only advertise fallback continuation when the operator explicitly
+configured `preferred_models`.
+
+**Tech Stack:** Rust, cargo test, cargo clippy
+
+---
+
+### Task 1: Add failing provider-config tests
+
+**Files:**
+- Modify: `crates/app/src/config/provider.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- `fresh_for_kind(ProviderKind::Minimax)` does not seed hidden
+  `preferred_models`
+- user-configured `preferred_models` still round-trip through
+  `configured_auto_model_candidates()`
+- MiniMax exposes an onboarding recommended model distinct from runtime fallback
+  state
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app fresh_minimax_provider_does_not_seed_hidden_preferred_models
+cargo test -p loongclaw-app minimax_provider_exposes_onboarding_recommended_model
+```
+
+Expected: FAIL before implementation.
+
+### Task 2: Add failing onboarding tests
+
+**Files:**
+- Modify: `crates/daemon/src/onboard_cli.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- interactive model selection screen for MiniMax shows the explicit recommended
+  model as the prefilled default rather than promising hidden fallback behavior
+- non-interactive onboarding with `provider = minimax` and no `--model` writes
+  `MiniMax-M2.5`
+- onboarding probe warnings only mention fallback continuation when
+  `preferred_models` is explicitly configured
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon render_model_selection_screen_lines_with_default
+cargo test -p loongclaw-daemon provider_model_probe_failure_check
+```
+
+Expected: FAIL before implementation.
+
+### Task 3: Add failing runtime messaging tests
+
+**Files:**
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/app/src/provider/model_candidate_resolver_runtime.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- runtime does not fall back to provider-owned hidden defaults
+- runtime still falls back to explicitly configured `preferred_models`
+- doctor probe warnings distinguish explicit configuration from missing config
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app preferred_model_fallback
+cargo test -p loongclaw-daemon doctor_cli::tests::
+```
+
+Expected: FAIL before implementation.
+
+### Task 4: Implement onboarding-only default model metadata
+
+**Files:**
+- Modify: `crates/app/src/config/provider.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+
+**Step 1: Add onboarding metadata**
+
+Add a provider-kind method for onboarding recommended model IDs.
+
+**Step 2: Use it in onboarding**
+
+When onboarding resolves the model and the current selection is still `auto`,
+switch the default/prefill to the onboarding recommended model.
+
+**Step 3: Keep runtime semantics unchanged**
+
+Do not use this metadata in runtime model resolution.
+
+### Task 5: Remove hidden provider fallback seeding
+
+**Files:**
+- Modify: `crates/app/src/config/provider.rs`
+- Modify: `crates/app/src/provider/model_candidate_resolver_runtime.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+
+**Step 1: Stop seeding built-in preferred models**
+
+Remove provider-kind built-in default preferred model lists.
+
+**Step 2: Keep explicit operator behavior**
+
+`configured_auto_model_candidates()` should only return user-configured
+`preferred_models`.
+
+**Step 3: Make messages truthful**
+
+Update onboarding/doctor wording from "preferred model fallback(s)" to
+"configured preferred model fallback(s)" where applicable.
+
+### Task 6: Update docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+- Modify: `docs/product-specs/onboarding.md`
+
+**Step 1: Remove hidden-fallback framing**
+
+Document that onboarding may prefill a provider-recommended explicit model.
+
+**Step 2: Preserve exit guidance**
+
+Keep the `Esc` cancellation guidance and WSL note from the earlier fix.
+
+### Task 7: Verification
+
+Run:
+
+```bash
+cargo test -p loongclaw-app config::provider::tests::
+cargo test -p loongclaw-app preferred_model_fallback -- --nocapture
+cargo test -p loongclaw-daemon onboard_cli::tests:: -- --nocapture
+cargo test -p loongclaw-daemon doctor_cli::tests:: -- --nocapture
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+```
+
+Expected: PASS
+
+### Task 8: GitHub follow-through
+
+**Files:**
+- No code changes required if verification passes
+
+**Step 1: Update the existing PR description if needed**
+
+Reflect the corrected architecture:
+
+- keep explicit `Esc` onboarding exit guidance
+- replace hidden provider fallback defaults with onboarding explicit defaults
+- retain fallback continuation only for explicit operator-configured
+  `preferred_models`
+
+**Step 2: Keep issue/PR traceability intact**
+
+Continue on issue `#214` and PR `#215` rather than opening replacement artifacts.

--- a/docs/plans/2026-03-16-provider-onboarding-default-model-implementation-plan.md
+++ b/docs/plans/2026-03-16-provider-onboarding-default-model-implementation-plan.md
@@ -16,7 +16,7 @@ configured `preferred_models`.
 
 ---
 
-### Task 1: Add failing provider-config tests
+## Task 1: Add failing provider-config tests
 
 **Files:**
 - Modify: `crates/app/src/config/provider.rs`
@@ -43,7 +43,7 @@ cargo test -p loongclaw-app minimax_provider_exposes_onboarding_recommended_mode
 
 Expected: FAIL before implementation.
 
-### Task 2: Add failing onboarding tests
+## Task 2: Add failing onboarding tests
 
 **Files:**
 - Modify: `crates/daemon/src/onboard_cli.rs`
@@ -70,7 +70,7 @@ cargo test -p loongclaw-daemon provider_model_probe_failure_check
 
 Expected: FAIL before implementation.
 
-### Task 3: Add failing runtime messaging tests
+## Task 3: Add failing runtime messaging tests
 
 **Files:**
 - Modify: `crates/daemon/src/doctor_cli.rs`
@@ -95,7 +95,7 @@ cargo test -p loongclaw-daemon doctor_cli::tests::
 
 Expected: FAIL before implementation.
 
-### Task 4: Implement onboarding-only default model metadata
+## Task 4: Implement onboarding-only default model metadata
 
 **Files:**
 - Modify: `crates/app/src/config/provider.rs`
@@ -114,7 +114,7 @@ switch the default/prefill to the onboarding recommended model.
 
 Do not use this metadata in runtime model resolution.
 
-### Task 5: Remove hidden provider fallback seeding
+## Task 5: Remove hidden provider fallback seeding
 
 **Files:**
 - Modify: `crates/app/src/config/provider.rs`
@@ -136,7 +136,7 @@ Remove provider-kind built-in default preferred model lists.
 Update onboarding/doctor wording from "preferred model fallback(s)" to
 "configured preferred model fallback(s)" where applicable.
 
-### Task 6: Update docs
+## Task 6: Update docs
 
 **Files:**
 - Modify: `README.md`
@@ -151,7 +151,7 @@ Document that onboarding may prefill a provider-recommended explicit model.
 
 Keep the `Esc` cancellation guidance and WSL note from the earlier fix.
 
-### Task 7: Verification
+## Task 7: Verification
 
 Run:
 
@@ -167,7 +167,7 @@ cargo test --workspace --all-features
 
 Expected: PASS
 
-### Task 8: GitHub follow-through
+## Task 8: GitHub follow-through
 
 **Files:**
 - No code changes required if verification passes

--- a/docs/plans/2026-03-16-provider-onboarding-default-model-implementation-plan.md
+++ b/docs/plans/2026-03-16-provider-onboarding-default-model-implementation-plan.md
@@ -1,7 +1,5 @@
 # Provider Onboarding Default Model Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Replace hidden provider-owned runtime preferred-model fallbacks with
 explicit onboarding default models while preserving `Esc` onboarding exit UX and
 user-configured fallback behavior.
@@ -108,7 +106,7 @@ Add a provider-kind method for onboarding recommended model IDs.
 **Step 2: Use it in onboarding**
 
 When onboarding resolves the model and the current selection is still `auto`,
-switch the default/prefill to the onboarding recommended model.
+switch the default prefill to the onboarding-recommended model.
 
 **Step 3: Keep runtime semantics unchanged**
 

--- a/docs/product-specs/onboarding.md
+++ b/docs/product-specs/onboarding.md
@@ -20,6 +20,8 @@ next.
 - [ ] The shared post-onboard next-step model can also surface optional browser
       preview enable, runtime install, or first-recipe guidance when that lane
       is available for the current config.
+- [ ] Interactive onboarding explains how to exit cleanly, including an
+      explicit `Esc` cancellation hint before any config write.
 - [ ] Rerunning onboarding does not silently overwrite an existing config unless
       the user explicitly opts into a destructive path such as `--force`.
 - [ ] Onboarding uses the same provider, memory, and channel configuration
@@ -29,6 +31,8 @@ next.
 - [ ] Onboarding preflight reuses the same browser companion diagnostics as
       `loongclaw doctor`, surfacing optional managed-lane blockers before write
       without redefining runtime truth inside onboarding.
+- [ ] Providers that can run with explicit or curated fallback models are not
+      blocked solely because model catalog discovery is unavailable during setup.
 
 ## Out of Scope
 

--- a/docs/product-specs/onboarding.md
+++ b/docs/product-specs/onboarding.md
@@ -28,11 +28,19 @@ next.
       surfaces that the runtime uses after setup.
 - [ ] When preflight checks fail, onboarding points users to `loongclaw doctor`
       or `loongclaw doctor --fix` as the repair path.
+<<<<<<< HEAD
 - [ ] Onboarding preflight reuses the same browser companion diagnostics as
       `loongclaw doctor`, surfacing optional managed-lane blockers before write
       without redefining runtime truth inside onboarding.
 - [ ] Providers that can run with explicit or curated fallback models are not
       blocked solely because model catalog discovery is unavailable during setup.
+=======
+- [ ] Providers with a reviewed onboarding default model can complete setup with
+      an explicit model even when model catalog discovery is unavailable during
+      setup.
+- [ ] `preferred_models` remains an explicit operator-configured fallback path
+      rather than a hidden provider-owned runtime default.
+>>>>>>> 71f604a (fix(onboard): prefer explicit provider defaults over hidden fallback)
 
 ## Out of Scope
 

--- a/docs/product-specs/onboarding.md
+++ b/docs/product-specs/onboarding.md
@@ -28,19 +28,18 @@ next.
       surfaces that the runtime uses after setup.
 - [ ] When preflight checks fail, onboarding points users to `loongclaw doctor`
       or `loongclaw doctor --fix` as the repair path.
-<<<<<<< HEAD
 - [ ] Onboarding preflight reuses the same browser companion diagnostics as
       `loongclaw doctor`, surfacing optional managed-lane blockers before write
       without redefining runtime truth inside onboarding.
-- [ ] Providers that can run with explicit or curated fallback models are not
-      blocked solely because model catalog discovery is unavailable during setup.
-=======
-- [ ] Providers with a reviewed onboarding default model can complete setup with
-      an explicit model even when model catalog discovery is unavailable during
-      setup.
+- [ ] Providers with a reviewed onboarding default model, such as MiniMax and
+      DeepSeek, can complete setup with an explicit model even when model
+      catalog discovery is unavailable during setup.
 - [ ] `preferred_models` remains an explicit operator-configured fallback path
       rather than a hidden provider-owned runtime default.
->>>>>>> 71f604a (fix(onboard): prefer explicit provider defaults over hidden fallback)
+- [ ] When model catalog discovery fails while the config still uses
+      `model = auto`, onboarding gives actionable remediation: rerun onboarding
+      to accept a reviewed explicit model when one exists, or set
+      `provider.model` / `preferred_models` explicitly.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

- What changed?
  - Added shared `ModelCatalogProbeRecovery` so provider config, onboarding, and doctor classify model-catalog probe failures from the same recovery source.
  - Added DeepSeek to the reviewed onboarding defaults with `deepseek-chat`, alongside MiniMax `MiniMax-M2.5`, so reviewed providers can land on an explicit model even when setup-time catalog probing is unavailable.
  - Onboarding and doctor now turn `model = auto` probe failures into actionable remediation: rerun onboarding and accept the reviewed model when available, or set `provider.model` / `preferred_models` explicitly.
  - `doctor` next steps and non-interactive onboarding failures now surface the correct recovery path instead of only pointing operators at `--skip-model-probe`.
  - Updated README, `README.zh-CN`, and onboarding product specs to document reviewed defaults and explicit auto-model recovery guidance.
- Why this change is needed?
  - Alpha-test feedback exposed MiniMax `401` failures, but the real bug was broader: any provider left on `model = auto` without explicit recovery candidates would fail catalog probing without giving the operator a clear next step.
  - Official provider docs and OpenClaw’s onboarding pattern both favor explicit first-run model selection or manual model entry over hidden runtime guesses.
  - This keeps `preferred_models` operator-owned, reduces provider drift, and makes first-run recovery consistent across reviewed providers instead of shipping another provider-specific patch.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional notes:
- Fresh local validation on head `3aeb941` included:
  - `cargo test -p loongclaw-app provider::tests:: -- --nocapture`
  - `cargo test -p loongclaw-daemon onboard_cli::tests:: -- --nocapture`
  - `cargo test -p loongclaw-daemon doctor_cli::tests:: -- --nocapture`
  - `cargo test --workspace --all-features`
- The current head is rebased onto the existing PR branch follow-up commit `f696a19`, so the earlier onboarding exit-guidance/prompt-wording fixes remain intact.
- Before: DeepSeek still behaved like a generic `model = auto` provider during probe failure, and `onboard`, `doctor`, and doctor next steps could drift or over-suggest `--skip-model-probe`.
- After: reviewed providers surface explicit onboarding defaults, and `model = auto` failures now branch into reviewed-onboarding recovery vs manual `provider.model` / `preferred_models` recovery from a shared classification.
- Regression coverage includes provider config defaults, onboarding model selection defaults, onboarding/doctor failure messaging, doctor next-step guidance, and non-interactive preflight error surfacing.
- Env-mutating onboarding tests continue to serialize and restore provider/channel environment state via `DetectedEnvironmentGuard`.
- Independent review on the final diff reported no findings.

## Linked Issues

Closes #214


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancel onboarding with Esc (then Enter) before config is written
  * Onboarding pre-fills reviewed recommended models for MiniMax and DeepSeek
  * Onboarding accepts configured preferred-model fallbacks as a non-interactive remediation

* **Bug Fixes / UX**
  * Clearer actionable remediation when model discovery fails (rerun onboarding or set explicit model/preferred_models)

* **Documentation**
  * Expanded onboarding docs and WSL/systemd guidance; added onboarding design/plan notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->