### PR TITLE
feat(browser): add governed companion adapter skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,6 +1961,7 @@ dependencies = [
  "time",
  "tokio",
  "toml",
+ "wait-timeout",
 ]
 
 [[package]]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -49,6 +49,7 @@ rusqlite = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 aes = { version = "0.8", optional = true }
 cbc = { version = "0.1", optional = true }
+wait-timeout = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -53,9 +53,9 @@ pub(crate) use runtime::{normalize_dispatch_account_id, normalize_dispatch_chann
 pub use shared::{CLI_COMMAND_NAME, expand_path};
 #[allow(unused_imports)]
 pub use tools::{
-    BrowserCompanionToolConfig, BrowserToolConfig, DEFAULT_BROWSER_MAX_LINKS,
-    DEFAULT_BROWSER_MAX_SESSIONS, DEFAULT_BROWSER_MAX_TEXT_CHARS, DEFAULT_SHELL_ALLOW,
-    DEFAULT_WEB_FETCH_MAX_BYTES, DEFAULT_WEB_FETCH_MAX_REDIRECTS,
+    BrowserCompanionToolConfig, BrowserToolConfig, DEFAULT_BROWSER_COMPANION_TIMEOUT_SECONDS,
+    DEFAULT_BROWSER_MAX_LINKS, DEFAULT_BROWSER_MAX_SESSIONS, DEFAULT_BROWSER_MAX_TEXT_CHARS,
+    DEFAULT_SHELL_ALLOW, DEFAULT_WEB_FETCH_MAX_BYTES, DEFAULT_WEB_FETCH_MAX_REDIRECTS,
     DEFAULT_WEB_FETCH_TIMEOUT_SECONDS, ExternalSkillsConfig, GovernedToolApprovalConfig,
     GovernedToolApprovalMode, MAX_BROWSER_MAX_LINKS, MAX_BROWSER_MAX_SESSIONS,
     MAX_BROWSER_MAX_TEXT_CHARS, MAX_WEB_FETCH_MAX_BYTES, SessionVisibility, ToolConfig,

--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -10,6 +10,7 @@ pub const DEFAULT_WEB_FETCH_MAX_REDIRECTS: usize = 3;
 pub const DEFAULT_BROWSER_MAX_SESSIONS: usize = 8;
 pub const DEFAULT_BROWSER_MAX_LINKS: usize = 40;
 pub const DEFAULT_BROWSER_MAX_TEXT_CHARS: usize = 6000;
+pub const DEFAULT_BROWSER_COMPANION_TIMEOUT_SECONDS: u64 = 30;
 pub(crate) const MIN_WEB_FETCH_MAX_BYTES: usize = 1024;
 pub const MAX_WEB_FETCH_MAX_BYTES: usize = 5 * 1024 * 1024;
 pub(crate) const MIN_WEB_FETCH_TIMEOUT_SECONDS: usize = 1;
@@ -124,7 +125,7 @@ pub struct BrowserToolConfig {
     pub max_text_chars: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BrowserCompanionToolConfig {
     #[serde(default)]
     pub enabled: bool,
@@ -132,6 +133,8 @@ pub struct BrowserCompanionToolConfig {
     pub command: Option<String>,
     #[serde(default)]
     pub expected_version: Option<String>,
+    #[serde(default = "default_browser_companion_timeout_seconds")]
+    pub timeout_seconds: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -154,6 +157,10 @@ pub struct WebToolConfig {
 
 fn default_shell_default_mode() -> String {
     "deny".to_owned()
+}
+
+const fn default_browser_companion_timeout_seconds() -> u64 {
+    DEFAULT_BROWSER_COMPANION_TIMEOUT_SECONDS
 }
 
 /// Default allow list used when the config file omits `shell_allow`.
@@ -206,6 +213,17 @@ impl Default for ToolConfig {
             browser: BrowserToolConfig::default(),
             browser_companion: BrowserCompanionToolConfig::default(),
             web: WebToolConfig::default(),
+        }
+    }
+}
+
+impl Default for BrowserCompanionToolConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            command: None,
+            expected_version: None,
+            timeout_seconds: default_browser_companion_timeout_seconds(),
         }
     }
 }
@@ -467,6 +485,10 @@ mod tests {
         assert!(!config.browser_companion.enabled);
         assert!(config.browser_companion.command.is_none());
         assert!(config.browser_companion.expected_version.is_none());
+        assert_eq!(
+            config.browser_companion.timeout_seconds,
+            DEFAULT_BROWSER_COMPANION_TIMEOUT_SECONDS
+        );
         assert!(config.web.enabled);
         assert!(!config.web.allow_private_hosts);
         assert!(config.web.allowed_domains.is_empty());
@@ -587,6 +609,7 @@ max_text_chars = 2048
 enabled = true
 command = "loongclaw-browser-companion"
 expected_version = "1.2.3"
+timeout_seconds = 7
 "#;
         let parsed =
             toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
@@ -600,6 +623,7 @@ expected_version = "1.2.3"
             parsed.tools.browser_companion.expected_version.as_deref(),
             Some("1.2.3")
         );
+        assert_eq!(parsed.tools.browser_companion.timeout_seconds, 7);
     }
 
     /// When `shell_deny` is absent, it must default to empty — users start

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -601,7 +601,7 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                 .execute_sessions_send(session_context, request.payload)
                 .await;
         }
-        crate::tools::execute_app_tool_with_config(
+        crate::tools::execute_app_tool_with_visibility_checked_config(
             request,
             &session_context.session_id,
             &self.memory_config,
@@ -1724,6 +1724,104 @@ mod tests {
                     "root-session",
                     "turn-browser-companion-exec",
                     "call-browser-companion-exec",
+                    &companion_session_id,
+                ),
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::direct(),
+                None,
+            )
+            .await;
+
+        let reply = match result {
+            TurnResult::FinalText(reply) => reply,
+            other @ TurnResult::NeedsApproval(_)
+            | other @ TurnResult::ToolDenied(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_) => {
+                panic!("expected FinalText, got {other:?}")
+            }
+        };
+        assert!(
+            reply.contains("\"tool\":\"browser.companion.click\""),
+            "reply should include the executed companion tool: {reply}"
+        );
+        assert!(
+            reply.contains("\"status\":\"ok\""),
+            "reply should show a successful tool outcome: {reply}"
+        );
+
+        let request: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&log_path).expect("request log should exist"))
+                .expect("request log should be valid json");
+        assert_eq!(request["session_scope"], "root-session");
+        assert_eq!(request["operation"], "click");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[tokio::test]
+    async fn browser_companion_click_turn_uses_runtime_visible_readiness_without_env_recheck() {
+        let memory_config = isolated_memory_config("browser-companion-click-runtime-ready");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let root =
+            unique_browser_companion_temp_dir("loongclaw-turn-engine-browser-companion-runtime");
+        fs::create_dir_all(&root).expect("create fixture root");
+        let log_path = root.join("request.json");
+        let script_path = write_browser_companion_script(
+            &root,
+            "browser-companion-click-runtime",
+            r#"{"ok":true,"result":{"clicked":true}}"#,
+            &log_path,
+        );
+
+        let mut runtime_config = crate::tools::runtime_config::ToolRuntimeConfig::default();
+        runtime_config.browser_companion.enabled = true;
+        runtime_config.browser_companion.ready = true;
+        runtime_config.browser_companion.command = Some(script_path.display().to_string());
+
+        let start = crate::tools::execute_tool_core_with_config(
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "browser.companion.session.start".to_owned(),
+                payload: json!({
+                    "url": "https://example.com",
+                    crate::tools::BROWSER_SESSION_SCOPE_FIELD: "root-session"
+                }),
+            },
+            &runtime_config,
+        )
+        .expect("browser companion start should succeed");
+        let companion_session_id = start.payload["session_id"]
+            .as_str()
+            .expect("session id should exist")
+            .to_owned();
+
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("LOONGCLAW_BROWSER_COMPANION_READY", "false");
+
+        let mut tool_config = ToolConfig::default();
+        tool_config.browser_companion.enabled = true;
+        tool_config.browser_companion.command = Some(script_path.display().to_string());
+
+        let tool_view = crate::tools::runtime_tool_view_for_runtime_config(&runtime_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config, tool_config);
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &browser_companion_click_turn(
+                    "root-session",
+                    "turn-browser-companion-runtime",
+                    "call-browser-companion-runtime",
                     &companion_session_id,
                 ),
                 &session_context,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1858,6 +1858,106 @@ mod tests {
         fs::remove_dir_all(&root).ok();
     }
 
+    #[tokio::test]
+    async fn browser_companion_click_turn_uses_runtime_visible_policy_when_app_config_is_default() {
+        let memory_config = isolated_memory_config("browser-companion-click-runtime-policy");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let root = unique_browser_companion_temp_dir(
+            "loongclaw-turn-engine-browser-companion-runtime-policy",
+        );
+        fs::create_dir_all(&root).expect("create fixture root");
+        let log_path = root.join("request.json");
+        let script_path = write_browser_companion_script(
+            &root,
+            "browser-companion-click-runtime-policy",
+            r#"{"ok":true,"result":{"clicked":true}}"#,
+            &log_path,
+        );
+
+        let mut runtime_config = crate::tools::runtime_config::ToolRuntimeConfig::default();
+        runtime_config.browser_companion.enabled = true;
+        runtime_config.browser_companion.ready = true;
+        runtime_config.browser_companion.command = Some(script_path.display().to_string());
+
+        let start = crate::tools::execute_tool_core_with_config(
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "browser.companion.session.start".to_owned(),
+                payload: json!({
+                    "url": "https://example.com",
+                    crate::tools::BROWSER_SESSION_SCOPE_FIELD: "root-session"
+                }),
+            },
+            &runtime_config,
+        )
+        .expect("browser companion start should succeed");
+        let companion_session_id = start.payload["session_id"]
+            .as_str()
+            .expect("session id should exist")
+            .to_owned();
+
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("LOONGCLAW_BROWSER_COMPANION_ENABLED", "true");
+        env.set("LOONGCLAW_BROWSER_COMPANION_READY", "false");
+        env.set(
+            "LOONGCLAW_BROWSER_COMPANION_COMMAND",
+            script_path.display().to_string(),
+        );
+
+        let tool_view = crate::tools::runtime_tool_view_for_runtime_config(&runtime_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config, ToolConfig::default());
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &browser_companion_click_turn(
+                    "root-session",
+                    "turn-browser-companion-runtime-policy",
+                    "call-browser-companion-runtime-policy",
+                    &companion_session_id,
+                ),
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::direct(),
+                None,
+            )
+            .await;
+
+        let reply = match result {
+            TurnResult::FinalText(reply) => reply,
+            other @ TurnResult::NeedsApproval(_)
+            | other @ TurnResult::ToolDenied(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_) => {
+                panic!("expected FinalText, got {other:?}")
+            }
+        };
+        assert!(
+            reply.contains("\"tool\":\"browser.companion.click\""),
+            "reply should include the executed companion tool: {reply}"
+        );
+        assert!(
+            reply.contains("\"status\":\"ok\""),
+            "reply should show a successful tool outcome: {reply}"
+        );
+
+        let request: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&log_path).expect("request log should exist"))
+                .expect("request log should be valid json");
+        assert_eq!(request["session_scope"], "root-session");
+        assert_eq!(request["operation"], "click");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
     #[test]
     fn augment_tool_payload_injects_browser_scope_for_companion_tool_invoke() {
         let (tool_name, payload) = crate::tools::synthesize_test_provider_tool_call_with_scope(

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -335,28 +335,43 @@ impl DefaultAppToolDispatcher {
                         )
                     })?;
                 let allow_nested_delegate = depth < self.tool_config.delegate.max_depth;
-                return Ok(delegate_child_tool_view_for_config_with_delegate(
-                    &self.tool_config,
-                    allow_nested_delegate,
+                return Ok(with_runtime_ready_browser_companion_tools(
+                    delegate_child_tool_view_for_config_with_delegate(
+                        &self.tool_config,
+                        allow_nested_delegate,
+                    ),
+                    &session_context.tool_view,
                 ));
             }
-            return Ok(runtime_tool_view_for_config(&self.tool_config));
+            return Ok(with_runtime_ready_browser_companion_tools(
+                runtime_tool_view_for_config(&self.tool_config),
+                &session_context.tool_view,
+            ));
         }
         if repo
             .load_session_summary_with_legacy_fallback(&session_context.session_id)?
             .is_some_and(|session| session.kind == SessionKind::DelegateChild)
         {
-            return Ok(delegate_child_tool_view_for_config(&self.tool_config));
+            return Ok(with_runtime_ready_browser_companion_tools(
+                delegate_child_tool_view_for_config(&self.tool_config),
+                &session_context.tool_view,
+            ));
         }
-        Ok(runtime_tool_view_for_config(&self.tool_config))
+        Ok(with_runtime_ready_browser_companion_tools(
+            runtime_tool_view_for_config(&self.tool_config),
+            &session_context.tool_view,
+        ))
     }
 
     #[cfg(not(feature = "memory-sqlite"))]
     fn effective_tool_view_for_session(
         &self,
-        _session_context: &SessionContext,
+        session_context: &SessionContext,
     ) -> Result<ToolView, String> {
-        Ok(runtime_tool_view_for_config(&self.tool_config))
+        Ok(with_runtime_ready_browser_companion_tools(
+            runtime_tool_view_for_config(&self.tool_config),
+            &session_context.tool_view,
+        ))
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -603,6 +618,20 @@ fn classify_tool_execution_reason(reason: &str) -> KernelFailureClass {
     }
 }
 
+fn with_runtime_ready_browser_companion_tools(
+    base_view: ToolView,
+    session_tool_view: &ToolView,
+) -> ToolView {
+    let mut names: BTreeSet<String> = base_view.tool_names().map(str::to_owned).collect();
+    names.extend(
+        session_tool_view
+            .tool_names()
+            .filter(|name| name.starts_with("browser.companion."))
+            .map(str::to_owned),
+    );
+    ToolView::from_tool_names(names)
+}
+
 pub(crate) fn render_kernel_error_reason(error: &KernelError) -> String {
     #[allow(clippy::wildcard_enum_match_arm)]
     match error {
@@ -620,10 +649,7 @@ fn augment_tool_payload_for_kernel(
     session_id: &str,
 ) -> serde_json::Value {
     // Direct browser tool calls: inject scope at the top level.
-    if matches!(
-        canonical_tool_name,
-        "browser.open" | "browser.extract" | "browser.click"
-    ) {
+    if browser_scope_injection_required(canonical_tool_name) {
         return inject_browser_scope_field(payload, session_id);
     }
 
@@ -633,9 +659,7 @@ fn augment_tool_payload_for_kernel(
             .get("tool_id")
             .and_then(serde_json::Value::as_str)
             .map(crate::tools::canonical_tool_name)
-            .is_some_and(|inner| {
-                matches!(inner, "browser.open" | "browser.extract" | "browser.click")
-            });
+            .is_some_and(browser_scope_injection_required);
     if is_browser_invoke && let serde_json::Value::Object(mut outer) = payload {
         if let Some(arguments) = outer.remove("arguments") {
             outer.insert(
@@ -647,6 +671,22 @@ fn augment_tool_payload_for_kernel(
     }
 
     payload
+}
+
+fn browser_scope_injection_required(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "browser.open"
+            | "browser.extract"
+            | "browser.click"
+            | "browser.companion.session.start"
+            | "browser.companion.navigate"
+            | "browser.companion.snapshot"
+            | "browser.companion.wait"
+            | "browser.companion.session.stop"
+            | "browser.companion.click"
+            | "browser.companion.type"
+    )
 }
 
 fn inject_browser_scope_field(payload: serde_json::Value, session_id: &str) -> serde_json::Value {
@@ -1211,6 +1251,8 @@ fn session_context_from_turn(turn: &ProviderTurn, tool_view: ToolView) -> Sessio
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use serde_json::json;
 
@@ -1263,6 +1305,82 @@ mod tests {
         tool_call_id: &str,
     ) -> ProviderTurn {
         delegate_async_turn(session_id, turn_id, tool_call_id)
+    }
+
+    fn browser_companion_click_turn(
+        session_id: &str,
+        turn_id: &str,
+        tool_call_id: &str,
+        companion_session_id: &str,
+    ) -> ProviderTurn {
+        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call_with_scope(
+            "browser.companion.click",
+            json!({
+                "session_id": companion_session_id,
+                "selector": "#submit"
+            }),
+            Some(session_id),
+            Some(turn_id),
+        );
+        ProviderTurn {
+            assistant_text: "clicking through browser companion".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name,
+                args_json,
+                source: "assistant".to_owned(),
+                session_id: session_id.to_owned(),
+                turn_id: turn_id.to_owned(),
+                tool_call_id: tool_call_id.to_owned(),
+            }],
+            raw_meta: json!({}),
+        }
+    }
+
+    fn unique_browser_companion_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    #[cfg(unix)]
+    fn write_browser_companion_script(
+        root: &Path,
+        name: &str,
+        stdout_body: &str,
+        log_path: &Path,
+    ) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = root.join(name);
+        let script = format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf '1.2.3\\n'\n  exit 0\nfi\nBODY=\"$(cat)\"\nprintf '%s' \"$BODY\" > \"{}\"\nprintf '%s' '{}'\n",
+            log_path.display(),
+            stdout_body.replace('\'', "'\"'\"'")
+        );
+        fs::write(&path, script).expect("write browser companion script");
+        let mut perms = fs::metadata(&path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).expect("chmod script");
+        path
+    }
+
+    #[cfg(windows)]
+    fn write_browser_companion_script(
+        root: &Path,
+        name: &str,
+        stdout_body: &str,
+        log_path: &Path,
+    ) -> PathBuf {
+        let path = root.join(format!("{name}.cmd"));
+        let script = format!(
+            "@echo off\r\nif \"%~1\"==\"--version\" (\r\n  echo 1.2.3\r\n  exit /b 0\r\n)\r\nsetlocal enableextensions\r\nset /p BODY=\r\n> \"{}\" <nul set /p =%BODY%\r\necho {}\r\n",
+            log_path.display(),
+            stdout_body
+        );
+        fs::write(&path, script).expect("write browser companion script");
+        path
     }
 
     #[tokio::test]
@@ -1467,5 +1585,198 @@ mod tests {
             .expect("list approval requests");
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].approval_request_id, first_request_id);
+    }
+
+    #[tokio::test]
+    async fn governed_tool_approval_request_is_persisted_for_browser_companion_click() {
+        let memory_config = isolated_memory_config("browser-companion-click-approval");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let mut tool_config = ToolConfig::default();
+        tool_config.approval.mode = GovernedToolApprovalMode::Strict;
+        tool_config.browser_companion.enabled = true;
+        tool_config.browser_companion.command = Some("browser-companion".to_owned());
+
+        let mut runtime_config = crate::tools::runtime_config::ToolRuntimeConfig::default();
+        runtime_config.browser_companion.enabled = true;
+        runtime_config.browser_companion.ready = true;
+        runtime_config.browser_companion.command = Some("browser-companion".to_owned());
+
+        let tool_view = crate::tools::runtime_tool_view_for_runtime_config(&runtime_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &browser_companion_click_turn(
+                    "root-session",
+                    "turn-browser-companion",
+                    "call-browser-companion",
+                    "browser-companion-123",
+                ),
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::direct(),
+                None,
+            )
+            .await;
+
+        let approval_request_id = match result {
+            TurnResult::NeedsApproval(requirement) => {
+                assert_eq!(
+                    requirement.tool_name.as_deref(),
+                    Some("browser.companion.click")
+                );
+                assert_eq!(
+                    requirement.approval_key.as_deref(),
+                    Some("tool:browser.companion.click")
+                );
+                requirement
+                    .approval_request_id
+                    .expect("approval request id should exist")
+            }
+            other @ TurnResult::FinalText(_)
+            | other @ TurnResult::ToolDenied(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_) => {
+                panic!("expected NeedsApproval, got {other:?}")
+            }
+        };
+
+        let stored = repo
+            .load_approval_request(&approval_request_id)
+            .expect("load approval request")
+            .expect("approval request row");
+        assert_eq!(stored.status, ApprovalRequestStatus::Pending);
+        assert_eq!(stored.tool_name, "browser.companion.click");
+        assert_eq!(
+            stored.request_payload_json["args_json"]["selector"],
+            "#submit"
+        );
+    }
+
+    #[tokio::test]
+    async fn browser_companion_click_turn_executes_when_approval_is_disabled() {
+        let memory_config = isolated_memory_config("browser-companion-click-exec");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let root = unique_browser_companion_temp_dir("loongclaw-turn-engine-browser-companion");
+        fs::create_dir_all(&root).expect("create fixture root");
+        let log_path = root.join("request.json");
+        let script_path = write_browser_companion_script(
+            &root,
+            "browser-companion-click",
+            r#"{"ok":true,"result":{"clicked":true}}"#,
+            &log_path,
+        );
+
+        let mut runtime_config = crate::tools::runtime_config::ToolRuntimeConfig::default();
+        runtime_config.browser_companion.enabled = true;
+        runtime_config.browser_companion.ready = true;
+        runtime_config.browser_companion.command = Some(script_path.display().to_string());
+
+        let start = crate::tools::execute_tool_core_with_config(
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "browser.companion.session.start".to_owned(),
+                payload: json!({
+                    "url": "https://example.com",
+                    crate::tools::BROWSER_SESSION_SCOPE_FIELD: "root-session"
+                }),
+            },
+            &runtime_config,
+        )
+        .expect("browser companion start should succeed");
+        let companion_session_id = start.payload["session_id"]
+            .as_str()
+            .expect("session id should exist")
+            .to_owned();
+
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("LOONGCLAW_BROWSER_COMPANION_READY", "true");
+
+        let mut tool_config = ToolConfig::default();
+        tool_config.browser_companion.enabled = true;
+        tool_config.browser_companion.command = Some(script_path.display().to_string());
+
+        let tool_view = crate::tools::runtime_tool_view_for_runtime_config(&runtime_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config, tool_config);
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &browser_companion_click_turn(
+                    "root-session",
+                    "turn-browser-companion-exec",
+                    "call-browser-companion-exec",
+                    &companion_session_id,
+                ),
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::direct(),
+                None,
+            )
+            .await;
+
+        let reply = match result {
+            TurnResult::FinalText(reply) => reply,
+            other @ TurnResult::NeedsApproval(_)
+            | other @ TurnResult::ToolDenied(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_) => {
+                panic!("expected FinalText, got {other:?}")
+            }
+        };
+        assert!(
+            reply.contains("\"tool\":\"browser.companion.click\""),
+            "reply should include the executed companion tool: {reply}"
+        );
+        assert!(
+            reply.contains("\"status\":\"ok\""),
+            "reply should show a successful tool outcome: {reply}"
+        );
+
+        let request: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&log_path).expect("request log should exist"))
+                .expect("request log should be valid json");
+        assert_eq!(request["session_scope"], "root-session");
+        assert_eq!(request["operation"], "click");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn augment_tool_payload_injects_browser_scope_for_companion_tool_invoke() {
+        let (tool_name, payload) = crate::tools::synthesize_test_provider_tool_call_with_scope(
+            "browser.companion.session.start",
+            json!({
+                "url": "https://example.com"
+            }),
+            Some("root-session"),
+            Some("turn-browser-companion-start"),
+        );
+
+        let augmented = augment_tool_payload_for_kernel(&tool_name, payload, "root-session");
+
+        assert_eq!(augmented["tool_id"], "browser.companion.session.start");
+        assert_eq!(
+            augmented["arguments"][crate::tools::BROWSER_SESSION_SCOPE_FIELD],
+            "root-session"
+        );
     }
 }

--- a/crates/app/src/runtime_env.rs
+++ b/crates/app/src/runtime_env.rs
@@ -81,6 +81,10 @@ pub fn initialize_runtime_environment(
         "LOONGCLAW_BROWSER_COMPANION_ENABLED",
         bool_env(config.tools.browser_companion.enabled),
     );
+    set_env_var(
+        "LOONGCLAW_BROWSER_COMPANION_TIMEOUT_SECONDS",
+        config.tools.browser_companion.timeout_seconds.to_string(),
+    );
     match normalized_optional_str(config.tools.browser_companion.command.as_deref()) {
         Some(command) => set_env_var("LOONGCLAW_BROWSER_COMPANION_COMMAND", command),
         None => remove_env_var("LOONGCLAW_BROWSER_COMPANION_COMMAND"),
@@ -214,6 +218,7 @@ mod tests {
             "LOONGCLAW_BROWSER_MAX_LINKS",
             "LOONGCLAW_BROWSER_MAX_TEXT_CHARS",
             "LOONGCLAW_BROWSER_COMPANION_ENABLED",
+            "LOONGCLAW_BROWSER_COMPANION_TIMEOUT_SECONDS",
             "LOONGCLAW_BROWSER_COMPANION_COMMAND",
             "LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION",
             "LOONGCLAW_WEB_FETCH_ENABLED",
@@ -320,6 +325,12 @@ mod tests {
             Some("true")
         );
         assert_eq!(
+            std::env::var("LOONGCLAW_BROWSER_COMPANION_TIMEOUT_SECONDS")
+                .ok()
+                .as_deref(),
+            Some("30")
+        );
+        assert_eq!(
             std::env::var("LOONGCLAW_BROWSER_COMPANION_COMMAND")
                 .ok()
                 .as_deref(),
@@ -379,11 +390,18 @@ mod tests {
         clear_runtime_environment_exports(&mut env);
         let mut config = LoongClawConfig::default();
         config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.timeout_seconds = 7;
         config.tools.browser_companion.command = Some("   ".to_owned());
         config.tools.browser_companion.expected_version = Some("\n\t".to_owned());
 
         initialize_runtime_environment(&config, None);
 
+        assert_eq!(
+            std::env::var("LOONGCLAW_BROWSER_COMPANION_TIMEOUT_SECONDS")
+                .ok()
+                .as_deref(),
+            Some("7")
+        );
         assert_eq!(
             std::env::var("LOONGCLAW_BROWSER_COMPANION_COMMAND").ok(),
             None

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde::{Deserialize, Serialize};
@@ -103,6 +104,7 @@ trait BrowserCompanionRunner {
     fn invoke(
         &self,
         command: &str,
+        timeout_seconds: u64,
         request: &BrowserCompanionProtocolRequest,
     ) -> Result<Value, String>;
 }
@@ -113,6 +115,7 @@ impl BrowserCompanionRunner for CommandBrowserCompanionRunner {
     fn invoke(
         &self,
         command: &str,
+        timeout_seconds: u64,
         request: &BrowserCompanionProtocolRequest,
     ) -> Result<Value, String> {
         let encoded = serde_json::to_vec(request)
@@ -130,9 +133,7 @@ impl BrowserCompanionRunner for CommandBrowserCompanionRunner {
                 .map_err(|error| format!("browser_companion_stdin_write_failed: {error}"))?;
         }
 
-        let output = child
-            .wait_with_output()
-            .map_err(|error| format!("browser_companion_wait_failed: {error}"))?;
+        let output = wait_for_browser_companion_output(child, timeout_seconds)?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
             return Err(format!(
@@ -156,6 +157,44 @@ impl BrowserCompanionRunner for CommandBrowserCompanionRunner {
                 .message
                 .unwrap_or_else(|| "companion reported failure".to_owned())
         ))
+    }
+}
+
+fn wait_for_browser_companion_output(
+    mut child: std::process::Child,
+    timeout_seconds: u64,
+) -> Result<std::process::Output, String> {
+    let timeout = Duration::from_secs(timeout_seconds.max(1));
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => {
+                return child
+                    .wait_with_output()
+                    .map_err(|error| format!("browser_companion_wait_failed: {error}"));
+            }
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let output = child
+                    .wait_with_output()
+                    .map_err(|error| format!("browser_companion_wait_failed: {error}"))?;
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+                let stderr_suffix = if stderr.is_empty() {
+                    String::new()
+                } else {
+                    format!(" stderr={stderr}")
+                };
+                return Err(format!(
+                    "browser_companion_timeout: command exceeded {timeout_seconds}s{stderr_suffix}"
+                ));
+            }
+            Err(error) => {
+                return Err(format!("browser_companion_wait_failed: {error}"));
+            }
+        }
     }
 }
 
@@ -200,6 +239,33 @@ pub(super) fn execute_browser_companion_app_tool_with_config(
     current_session_id: &str,
     tool_config: &crate::config::ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
+    execute_browser_companion_app_tool_with_readiness_override(
+        request,
+        current_session_id,
+        tool_config,
+        false,
+    )
+}
+
+pub(super) fn execute_browser_companion_visible_app_tool_with_config(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    tool_config: &crate::config::ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    execute_browser_companion_app_tool_with_readiness_override(
+        request,
+        current_session_id,
+        tool_config,
+        true,
+    )
+}
+
+fn execute_browser_companion_app_tool_with_readiness_override(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    tool_config: &crate::config::ToolConfig,
+    assume_runtime_ready: bool,
+) -> Result<ToolCoreOutcome, String> {
     let tool_name = request.tool_name.clone();
     let payload = match &request.payload {
         Value::Object(object) => object.clone(),
@@ -207,8 +273,11 @@ pub(super) fn execute_browser_companion_app_tool_with_config(
             return Err(format!("{tool_name} payload must be an object"));
         }
     };
-    let policy =
+    let mut policy =
         super::runtime_config::browser_companion_runtime_policy_from_tool_config(tool_config);
+    if assume_runtime_ready {
+        policy.ready = true;
+    }
     execute_browser_companion_request(
         request,
         &payload,
@@ -259,6 +328,7 @@ fn execute_browser_companion_request(
 
     let result = runner.invoke(
         command,
+        policy.timeout_seconds,
         &BrowserCompanionProtocolRequest {
             protocol: BROWSER_COMPANION_PROTOCOL,
             tool_name: request.tool_name.clone(),

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -3,11 +3,12 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
+use wait_timeout::ChildExt;
 
 const DEFAULT_BROWSER_COMPANION_SCOPE_ID: &str = "__global";
 const BROWSER_COMPANION_PROTOCOL: &str = "loongclaw.browser_companion.v1";
@@ -165,36 +166,26 @@ fn wait_for_browser_companion_output(
     timeout_seconds: u64,
 ) -> Result<std::process::Output, String> {
     let timeout = Duration::from_secs(timeout_seconds.max(1));
-    let deadline = Instant::now() + timeout;
-    loop {
-        match child.try_wait() {
-            Ok(Some(_status)) => {
-                return child
-                    .wait_with_output()
-                    .map_err(|error| format!("browser_companion_wait_failed: {error}"));
-            }
-            Ok(None) if Instant::now() < deadline => {
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            Ok(None) => {
-                let _ = child.kill();
-                let output = child
-                    .wait_with_output()
-                    .map_err(|error| format!("browser_companion_wait_failed: {error}"))?;
-                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-                let stderr_suffix = if stderr.is_empty() {
-                    String::new()
-                } else {
-                    format!(" stderr={stderr}")
-                };
-                return Err(format!(
-                    "browser_companion_timeout: command exceeded {timeout_seconds}s{stderr_suffix}"
-                ));
-            }
-            Err(error) => {
-                return Err(format!("browser_companion_wait_failed: {error}"));
-            }
+    match child.wait_timeout(timeout) {
+        Ok(Some(_status)) => child
+            .wait_with_output()
+            .map_err(|error| format!("browser_companion_wait_failed: {error}")),
+        Ok(None) => {
+            let _ = child.kill();
+            let output = child
+                .wait_with_output()
+                .map_err(|error| format!("browser_companion_wait_failed: {error}"))?;
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            let stderr_suffix = if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(" stderr={stderr}")
+            };
+            Err(format!(
+                "browser_companion_timeout: command exceeded {timeout_seconds}s{stderr_suffix}"
+            ))
         }
+        Err(error) => Err(format!("browser_companion_wait_failed: {error}")),
     }
 }
 
@@ -273,8 +264,11 @@ fn execute_browser_companion_app_tool_with_readiness_override(
             return Err(format!("{tool_name} payload must be an object"));
         }
     };
-    let mut policy =
-        super::runtime_config::browser_companion_runtime_policy_from_tool_config(tool_config);
+    let mut policy = if assume_runtime_ready {
+        super::runtime_config::browser_companion_runtime_policy_with_env_fallback(tool_config)
+    } else {
+        super::runtime_config::browser_companion_runtime_policy_from_tool_config(tool_config)
+    };
     if assume_runtime_ready {
         policy.ready = true;
     }

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -1,0 +1,412 @@
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+
+const DEFAULT_BROWSER_COMPANION_SCOPE_ID: &str = "__global";
+const BROWSER_COMPANION_PROTOCOL: &str = "loongclaw.browser_companion.v1";
+
+#[derive(Debug, Clone)]
+struct BrowserCompanionSession {
+    sequence: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BrowserCompanionOperation {
+    SessionStart,
+    Navigate,
+    Snapshot,
+    Wait,
+    SessionStop,
+    Click,
+    Type,
+}
+
+impl BrowserCompanionOperation {
+    fn from_tool_name(tool_name: &str) -> Option<Self> {
+        match tool_name {
+            "browser.companion.session.start" => Some(Self::SessionStart),
+            "browser.companion.navigate" => Some(Self::Navigate),
+            "browser.companion.snapshot" => Some(Self::Snapshot),
+            "browser.companion.wait" => Some(Self::Wait),
+            "browser.companion.session.stop" => Some(Self::SessionStop),
+            "browser.companion.click" => Some(Self::Click),
+            "browser.companion.type" => Some(Self::Type),
+            _ => None,
+        }
+    }
+
+    fn action_class(self) -> &'static str {
+        match self {
+            Self::Click | Self::Type => "write",
+            Self::SessionStart
+            | Self::Navigate
+            | Self::Snapshot
+            | Self::Wait
+            | Self::SessionStop => "read",
+        }
+    }
+
+    fn is_core(self) -> bool {
+        !matches!(self, Self::Click | Self::Type)
+    }
+
+    fn is_app(self) -> bool {
+        matches!(self, Self::Click | Self::Type)
+    }
+
+    fn protocol_name(self) -> &'static str {
+        match self {
+            Self::SessionStart => "session.start",
+            Self::Navigate => "navigate",
+            Self::Snapshot => "snapshot",
+            Self::Wait => "wait",
+            Self::SessionStop => "session.stop",
+            Self::Click => "click",
+            Self::Type => "type",
+        }
+    }
+
+    fn requires_existing_session(self) -> bool {
+        !matches!(self, Self::SessionStart)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct BrowserCompanionProtocolRequest {
+    protocol: &'static str,
+    tool_name: String,
+    operation: &'static str,
+    action_class: &'static str,
+    session_scope: String,
+    session_id: String,
+    arguments: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct BrowserCompanionProtocolResponse {
+    ok: bool,
+    #[serde(default)]
+    result: Option<Value>,
+    #[serde(default)]
+    code: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+trait BrowserCompanionRunner {
+    fn invoke(
+        &self,
+        command: &str,
+        request: &BrowserCompanionProtocolRequest,
+    ) -> Result<Value, String>;
+}
+
+struct CommandBrowserCompanionRunner;
+
+impl BrowserCompanionRunner for CommandBrowserCompanionRunner {
+    fn invoke(
+        &self,
+        command: &str,
+        request: &BrowserCompanionProtocolRequest,
+    ) -> Result<Value, String> {
+        let encoded = serde_json::to_vec(request)
+            .map_err(|error| format!("browser_companion_request_encode_failed: {error}"))?;
+        let mut child = Command::new(command)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|error| format!("browser_companion_spawn_failed: {error}"))?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(&encoded)
+                .map_err(|error| format!("browser_companion_stdin_write_failed: {error}"))?;
+        }
+
+        let output = child
+            .wait_with_output()
+            .map_err(|error| format!("browser_companion_wait_failed: {error}"))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            return Err(format!(
+                "browser_companion_command_failed: status={} stderr={stderr}",
+                output.status
+            ));
+        }
+
+        let response: BrowserCompanionProtocolResponse = serde_json::from_slice(&output.stdout)
+            .map_err(|error| format!("browser_companion_protocol_invalid_json: {error}"))?;
+        if response.ok {
+            return response.result.ok_or_else(|| {
+                "browser_companion_protocol_invalid_response: missing result".to_owned()
+            });
+        }
+
+        Err(format!(
+            "browser_companion_protocol_error: {}: {}",
+            response.code.unwrap_or_else(|| "unknown_error".to_owned()),
+            response
+                .message
+                .unwrap_or_else(|| "companion reported failure".to_owned())
+        ))
+    }
+}
+
+static NEXT_BROWSER_COMPANION_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+static BROWSER_COMPANION_SESSIONS: OnceLock<
+    Mutex<BTreeMap<String, BTreeMap<String, BrowserCompanionSession>>>,
+> = OnceLock::new();
+
+fn browser_companion_sessions()
+-> &'static Mutex<BTreeMap<String, BTreeMap<String, BrowserCompanionSession>>> {
+    BROWSER_COMPANION_SESSIONS.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+fn next_browser_companion_sequence() -> u64 {
+    NEXT_BROWSER_COMPANION_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+}
+
+pub(super) fn execute_browser_companion_core_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let tool_name = request.tool_name.clone();
+    let payload = match &request.payload {
+        Value::Object(object) => object.clone(),
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Array(_) => {
+            return Err(format!("{tool_name} payload must be an object"));
+        }
+    };
+    let scope_id = browser_companion_scope_id_from_payload(&payload);
+    execute_browser_companion_request(
+        request,
+        &payload,
+        scope_id.as_str(),
+        &config.browser_companion,
+        &CommandBrowserCompanionRunner,
+        true,
+    )
+}
+
+pub(super) fn execute_browser_companion_app_tool_with_config(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    tool_config: &crate::config::ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let tool_name = request.tool_name.clone();
+    let payload = match &request.payload {
+        Value::Object(object) => object.clone(),
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Array(_) => {
+            return Err(format!("{tool_name} payload must be an object"));
+        }
+    };
+    let policy =
+        super::runtime_config::browser_companion_runtime_policy_from_tool_config(tool_config);
+    execute_browser_companion_request(
+        request,
+        &payload,
+        current_session_id,
+        &policy,
+        &CommandBrowserCompanionRunner,
+        false,
+    )
+}
+
+fn execute_browser_companion_request(
+    request: ToolCoreRequest,
+    payload: &Map<String, Value>,
+    scope_id: &str,
+    policy: &super::runtime_config::BrowserCompanionRuntimePolicy,
+    runner: &dyn BrowserCompanionRunner,
+    require_core_operation: bool,
+) -> Result<ToolCoreOutcome, String> {
+    let operation = BrowserCompanionOperation::from_tool_name(request.tool_name.as_str())
+        .ok_or_else(|| {
+            format!(
+                "tool_not_found: unknown browser companion tool `{}`",
+                request.tool_name
+            )
+        })?;
+    if require_core_operation && !operation.is_core() {
+        return Err(format!(
+            "browser_companion_tool_requires_app_dispatch: {}",
+            request.tool_name
+        ));
+    }
+    if !require_core_operation && !operation.is_app() {
+        return Err(format!(
+            "browser_companion_tool_requires_core_dispatch: {}",
+            request.tool_name
+        ));
+    }
+
+    let command = browser_companion_command(policy)?;
+    let session_id = if operation.requires_existing_session() {
+        let session_id =
+            required_payload_string(payload, "session_id", request.tool_name.as_str())?;
+        ensure_browser_companion_session(scope_id, session_id.as_str())?;
+        session_id
+    } else {
+        format!("browser-companion-{}", next_browser_companion_sequence())
+    };
+
+    let result = runner.invoke(
+        command,
+        &BrowserCompanionProtocolRequest {
+            protocol: BROWSER_COMPANION_PROTOCOL,
+            tool_name: request.tool_name.clone(),
+            operation: operation.protocol_name(),
+            action_class: operation.action_class(),
+            session_scope: scope_id.to_owned(),
+            session_id: session_id.clone(),
+            arguments: browser_companion_arguments(payload),
+        },
+    )?;
+
+    match operation {
+        BrowserCompanionOperation::SessionStart => {
+            store_browser_companion_session(
+                scope_id.to_owned(),
+                session_id.clone(),
+                BrowserCompanionSession {
+                    sequence: next_browser_companion_sequence(),
+                },
+            )?;
+        }
+        BrowserCompanionOperation::SessionStop => {
+            remove_browser_companion_session(scope_id, session_id.as_str())?;
+        }
+        BrowserCompanionOperation::Navigate
+        | BrowserCompanionOperation::Snapshot
+        | BrowserCompanionOperation::Wait
+        | BrowserCompanionOperation::Click
+        | BrowserCompanionOperation::Type => {
+            touch_browser_companion_session(scope_id, session_id.as_str())?;
+        }
+    }
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "browser-companion",
+            "tool_name": request.tool_name,
+            "operation": operation.protocol_name(),
+            "action_class": operation.action_class(),
+            "session_id": session_id,
+            "result": result,
+        }),
+    })
+}
+
+fn browser_companion_command(
+    policy: &super::runtime_config::BrowserCompanionRuntimePolicy,
+) -> Result<&str, String> {
+    if !policy.enabled {
+        return Err("browser_companion_disabled: tools.browser_companion.enabled=false".to_owned());
+    }
+    if !policy.ready {
+        return Err(
+            "browser_companion_not_ready: LOONGCLAW_BROWSER_COMPANION_READY is false".to_owned(),
+        );
+    }
+    policy.command.as_deref().ok_or_else(|| {
+        "browser_companion_not_configured: tools.browser_companion.command is missing".to_owned()
+    })
+}
+
+fn browser_companion_scope_id_from_payload(payload: &Map<String, Value>) -> String {
+    payload
+        .get(super::BROWSER_SESSION_SCOPE_FIELD)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_BROWSER_COMPANION_SCOPE_ID)
+        .to_owned()
+}
+
+fn browser_companion_arguments(payload: &Map<String, Value>) -> Value {
+    let mut arguments = payload.clone();
+    arguments.remove(super::BROWSER_SESSION_SCOPE_FIELD);
+    arguments.remove("session_id");
+    Value::Object(arguments)
+}
+
+fn required_payload_string(
+    payload: &Map<String, Value>,
+    field: &str,
+    tool_name: &str,
+) -> Result<String, String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| format!("{tool_name} requires payload.{field}"))
+}
+
+fn ensure_browser_companion_session(scope_id: &str, session_id: &str) -> Result<(), String> {
+    let sessions = browser_companion_sessions()
+        .lock()
+        .map_err(|error| format!("browser companion session store lock poisoned: {error}"))?;
+    if sessions
+        .get(scope_id)
+        .and_then(|scope_sessions| scope_sessions.get(session_id))
+        .is_some()
+    {
+        return Ok(());
+    }
+    Err(format!("browser_companion_unknown_session: `{session_id}`"))
+}
+
+fn store_browser_companion_session(
+    scope_id: String,
+    session_id: String,
+    session: BrowserCompanionSession,
+) -> Result<(), String> {
+    let mut sessions = browser_companion_sessions()
+        .lock()
+        .map_err(|error| format!("browser companion session store lock poisoned: {error}"))?;
+    sessions
+        .entry(scope_id)
+        .or_default()
+        .insert(session_id, session);
+    Ok(())
+}
+
+fn touch_browser_companion_session(scope_id: &str, session_id: &str) -> Result<(), String> {
+    let mut sessions = browser_companion_sessions()
+        .lock()
+        .map_err(|error| format!("browser companion session store lock poisoned: {error}"))?;
+    let Some(session) = sessions
+        .get_mut(scope_id)
+        .and_then(|scope_sessions| scope_sessions.get_mut(session_id))
+    else {
+        return Err(format!("browser_companion_unknown_session: `{session_id}`"));
+    };
+    session.sequence = next_browser_companion_sequence();
+    Ok(())
+}
+
+fn remove_browser_companion_session(scope_id: &str, session_id: &str) -> Result<(), String> {
+    let mut sessions = browser_companion_sessions()
+        .lock()
+        .map_err(|error| format!("browser companion session store lock poisoned: {error}"))?;
+    let Some(scope_sessions) = sessions.get_mut(scope_id) else {
+        return Err(format!("browser_companion_unknown_session: `{session_id}`"));
+    };
+    if scope_sessions.remove(session_id).is_none() {
+        return Err(format!("browser_companion_unknown_session: `{session_id}`"));
+    }
+    if scope_sessions.is_empty() {
+        sessions.remove(scope_id);
+    }
+    Ok(())
+}

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -79,6 +79,11 @@ pub fn governance_profile_for_tool_name(tool_name: &str) -> ToolGovernanceProfil
             risk_class: ToolRiskClass::High,
             approval_mode: ToolApprovalMode::PolicyDriven,
         },
+        "browser.companion.click" | "browser.companion.type" => ToolGovernanceProfile {
+            scope: ToolGovernanceScope::Routine,
+            risk_class: ToolRiskClass::High,
+            approval_mode: ToolApprovalMode::PolicyDriven,
+        },
         "session_archive" | "session_cancel" | "session_recover" | "sessions_send" => {
             ToolGovernanceProfile {
                 scope: ToolGovernanceScope::Routine,
@@ -619,6 +624,83 @@ pub fn tool_catalog() -> ToolCatalog {
             provider_definition_builder: browser_click_definition,
         });
         descriptors.push(ToolDescriptor {
+            name: "browser.companion.click",
+            provider_name: "browser_companion_click",
+            aliases: &["browser_companion_click"],
+            description: "Click a page element inside a governed browser companion session after policy review",
+            execution_kind: ToolExecutionKind::App,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            provider_definition_builder: browser_companion_click_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "browser.companion.navigate",
+            provider_name: "browser_companion_navigate",
+            aliases: &["browser_companion_navigate"],
+            description: "Navigate a governed browser companion session to a target URL",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            provider_definition_builder: browser_companion_navigate_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "browser.companion.session.start",
+            provider_name: "browser_companion_session_start",
+            aliases: &["browser_companion_session_start"],
+            description: "Start a governed browser companion session at a target URL",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            provider_definition_builder: browser_companion_session_start_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "browser.companion.session.stop",
+            provider_name: "browser_companion_session_stop",
+            aliases: &["browser_companion_session_stop"],
+            description: "Stop a governed browser companion session and release companion-side state",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            provider_definition_builder: browser_companion_session_stop_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "browser.companion.snapshot",
+            provider_name: "browser_companion_snapshot",
+            aliases: &["browser_companion_snapshot"],
+            description: "Capture a readable snapshot of the current browser companion page",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            provider_definition_builder: browser_companion_snapshot_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "browser.companion.type",
+            provider_name: "browser_companion_type",
+            aliases: &["browser_companion_type"],
+            description: "Type text into a page element inside a governed browser companion session after policy review",
+            execution_kind: ToolExecutionKind::App,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            provider_definition_builder: browser_companion_type_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "browser.companion.wait",
+            provider_name: "browser_companion_wait",
+            aliases: &["browser_companion_wait"],
+            description: "Wait inside a governed browser companion session for a condition or timeout window",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            provider_definition_builder: browser_companion_wait_definition,
+        });
+        descriptors.push(ToolDescriptor {
             name: "browser.extract",
             provider_name: "browser_extract",
             aliases: &["browser_extract"],
@@ -969,6 +1051,184 @@ fn browser_click_definition(descriptor: &ToolDescriptor) -> Value {
                     }
                 },
                 "required": ["session_id", "link_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn browser_companion_session_start_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "HTTP or HTTPS URL to open in the managed browser companion session."
+                    }
+                },
+                "required": ["url"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn browser_companion_navigate_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Browser companion session identifier returned by browser.companion.session.start."
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "HTTP or HTTPS URL to load next."
+                    }
+                },
+                "required": ["session_id", "url"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn browser_companion_snapshot_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Browser companion session identifier returned by browser.companion.session.start."
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": ["summary", "html", "links"],
+                        "description": "Optional snapshot mode. Defaults to `summary`."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn browser_companion_wait_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Browser companion session identifier returned by browser.companion.session.start."
+                    },
+                    "condition": {
+                        "type": "string",
+                        "description": "Optional companion-side wait condition."
+                    },
+                    "timeout_ms": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 30000,
+                        "description": "Optional maximum wait in milliseconds."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn browser_companion_session_stop_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Browser companion session identifier returned by browser.companion.session.start."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn browser_companion_click_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Browser companion session identifier returned by browser.companion.session.start."
+                    },
+                    "selector": {
+                        "type": "string",
+                        "description": "Selector for the element to click."
+                    }
+                },
+                "required": ["session_id", "selector"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn browser_companion_type_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Browser companion session identifier returned by browser.companion.session.start."
+                    },
+                    "selector": {
+                        "type": "string",
+                        "description": "Selector for the element to type into."
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "Text to enter."
+                    }
+                },
+                "required": ["session_id", "selector", "text"],
                 "additionalProperties": false
             }
         }
@@ -1884,6 +2144,13 @@ fn tool_argument_hint(name: &str) -> &'static str {
             "action?:string,enabled?:boolean,allowed_domains?:string[],blocked_domains?:string[]"
         }
         "external_skills.remove" => "skill_id:string",
+        "browser.companion.session.start" => "url:string",
+        "browser.companion.navigate" => "session_id:string,url:string",
+        "browser.companion.snapshot" => "session_id:string,mode?:string",
+        "browser.companion.wait" => "session_id:string,condition?:string,timeout_ms?:integer",
+        "browser.companion.session.stop" => "session_id:string",
+        "browser.companion.click" => "session_id:string,selector:string",
+        "browser.companion.type" => "session_id:string,selector:string,text:string",
         "file.read" => "path:string,max_bytes?:integer",
         "file.write" => "path:string,content:string,create_dirs?:boolean",
         "shell.exec" => "command:string,args?:string[]",
@@ -1926,6 +2193,21 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
             ("replace", "boolean"),
         ],
         "external_skills.list" => &[],
+        "browser.companion.session.start" => &[("url", "string")],
+        "browser.companion.navigate" => &[("session_id", "string"), ("url", "string")],
+        "browser.companion.snapshot" => &[("session_id", "string"), ("mode", "string")],
+        "browser.companion.wait" => &[
+            ("session_id", "string"),
+            ("condition", "string"),
+            ("timeout_ms", "integer"),
+        ],
+        "browser.companion.session.stop" => &[("session_id", "string")],
+        "browser.companion.click" => &[("session_id", "string"), ("selector", "string")],
+        "browser.companion.type" => &[
+            ("session_id", "string"),
+            ("selector", "string"),
+            ("text", "string"),
+        ],
         "external_skills.policy" => &[
             ("action", "string"),
             ("enabled", "boolean"),
@@ -1967,6 +2249,13 @@ fn tool_required_fields(name: &str) -> &'static [&'static str] {
         }
         // Grouped requirements are the source of truth for this tool's anyOf shape.
         "external_skills.install" => &[],
+        "browser.companion.session.start" => &["url"],
+        "browser.companion.navigate" => &["session_id", "url"],
+        "browser.companion.snapshot"
+        | "browser.companion.wait"
+        | "browser.companion.session.stop" => &["session_id"],
+        "browser.companion.click" => &["session_id", "selector"],
+        "browser.companion.type" => &["session_id", "selector", "text"],
         "file.read" => &["path"],
         "file.write" => &["path", "content"],
         "shell.exec" => &["command"],
@@ -1997,6 +2286,14 @@ fn tool_tags(name: &str) -> &'static [&'static str] {
         "external_skills.list" => &["skills", "list", "discover"],
         "external_skills.policy" => &["skills", "policy", "security"],
         "external_skills.remove" => &["skills", "remove", "uninstall"],
+        "browser.companion.session.start"
+        | "browser.companion.navigate"
+        | "browser.companion.snapshot"
+        | "browser.companion.wait"
+        | "browser.companion.session.stop" => &["browser", "companion", "session", "read"],
+        "browser.companion.click" | "browser.companion.type" => {
+            &["browser", "companion", "write", "approval"]
+        }
         "file.read" => &["file", "read", "filesystem", "repo"],
         "file.write" => &["file", "write", "filesystem"],
         "shell.exec" => &["shell", "command", "process", "exec"],
@@ -2014,6 +2311,49 @@ fn tool_tags(name: &str) -> &'static [&'static str] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn browser_companion_visibility_surface_requires_runtime_readiness_for_all_companion_tools() {
+        let catalog = tool_catalog();
+        let expected = [
+            ("browser.companion.session.start", ToolExecutionKind::Core),
+            ("browser.companion.navigate", ToolExecutionKind::Core),
+            ("browser.companion.snapshot", ToolExecutionKind::Core),
+            ("browser.companion.wait", ToolExecutionKind::Core),
+            ("browser.companion.session.stop", ToolExecutionKind::Core),
+            ("browser.companion.click", ToolExecutionKind::App),
+            ("browser.companion.type", ToolExecutionKind::App),
+        ];
+
+        let mut hidden = ToolRuntimeConfig::default();
+        hidden.browser_companion.enabled = true;
+        hidden.browser_companion.ready = false;
+        let hidden_view = runtime_tool_view_for_runtime_config(&hidden);
+
+        let mut visible = ToolRuntimeConfig::default();
+        visible.browser_companion.enabled = true;
+        visible.browser_companion.ready = true;
+        let visible_view = runtime_tool_view_for_runtime_config(&visible);
+
+        for (tool_name, execution_kind) in expected {
+            let descriptor = catalog
+                .resolve(tool_name)
+                .unwrap_or_else(|| panic!("missing browser companion descriptor `{tool_name}`"));
+            assert_eq!(
+                descriptor.visibility_gate,
+                ToolVisibilityGate::BrowserCompanion
+            );
+            assert_eq!(descriptor.execution_kind, execution_kind);
+            assert!(
+                !hidden_view.contains(tool_name),
+                "tool should stay hidden until runtime-ready: {tool_name}"
+            );
+            assert!(
+                visible_view.contains(tool_name),
+                "tool should appear once runtime-ready: {tool_name}"
+            );
+        }
+    }
 
     #[test]
     fn browser_companion_visibility_gate_requires_runtime_readiness() {

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -2312,6 +2312,7 @@ fn tool_tags(name: &str) -> &'static [&'static str] {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "tool-browser")]
     #[test]
     fn browser_companion_visibility_surface_requires_runtime_readiness_for_all_companion_tools() {
         let catalog = tool_catalog();
@@ -2328,11 +2329,13 @@ mod tests {
         let mut hidden = ToolRuntimeConfig::default();
         hidden.browser_companion.enabled = true;
         hidden.browser_companion.ready = false;
+        hidden.browser_companion.command = Some("browser-companion".to_owned());
         let hidden_view = runtime_tool_view_for_runtime_config(&hidden);
 
         let mut visible = ToolRuntimeConfig::default();
         visible.browser_companion.enabled = true;
         visible.browser_companion.ready = true;
+        visible.browser_companion.command = Some("browser-companion".to_owned());
         let visible_view = runtime_tool_view_for_runtime_config(&visible);
 
         for (tool_name, execution_kind) in expected {
@@ -2360,6 +2363,7 @@ mod tests {
         let mut config = ToolRuntimeConfig::default();
         config.browser_companion.enabled = true;
         config.browser_companion.ready = false;
+        config.browser_companion.command = Some("browser-companion".to_owned());
 
         assert!(!tool_visibility_gate_enabled_for_runtime_policy(
             ToolVisibilityGate::BrowserCompanion,

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -22,6 +22,8 @@ use crate::memory::runtime_config::MemoryRuntimeConfig;
 pub(crate) mod approval;
 #[cfg(feature = "tool-browser")]
 mod browser;
+#[cfg(feature = "tool-browser")]
+mod browser_companion;
 mod bundled_skills;
 mod catalog;
 mod claw_import;
@@ -201,6 +203,14 @@ pub fn execute_app_tool_with_config(
                 request,
                 current_session_id,
                 memory_config,
+                tool_config,
+            )
+        }
+        #[cfg(feature = "tool-browser")]
+        "browser.companion.click" | "browser.companion.type" => {
+            browser_companion::execute_browser_companion_app_tool_with_config(
+                request,
+                current_session_id,
                 tool_config,
             )
         }
@@ -579,6 +589,14 @@ fn execute_discoverable_tool_core_with_config(
         }
         "external_skills.remove" => {
             external_skills::execute_external_skills_remove_tool_with_config(request, config)
+        }
+        #[cfg(feature = "tool-browser")]
+        "browser.companion.session.start"
+        | "browser.companion.navigate"
+        | "browser.companion.snapshot"
+        | "browser.companion.wait"
+        | "browser.companion.session.stop" => {
+            browser_companion::execute_browser_companion_core_tool_with_config(request, config)
         }
         #[cfg(feature = "tool-browser")]
         "browser.open" | "browser.extract" | "browser.click" => {
@@ -1416,7 +1434,8 @@ fn _shape_examples() -> BTreeMap<&'static str, Value> {
 mod tests {
     use super::*;
     use crate::test_support::ScopedEnv;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn test_tool_runtime_config(root: PathBuf) -> runtime_config::ToolRuntimeConfig {
         runtime_config::ToolRuntimeConfig {
@@ -1455,6 +1474,67 @@ mod tests {
         } else {
             super::execute_tool_core_with_config(request, config)
         }
+    }
+
+    fn unique_tool_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    fn browser_companion_runtime_config(
+        root: &Path,
+        command: String,
+    ) -> runtime_config::ToolRuntimeConfig {
+        let mut config = test_tool_runtime_config(root.to_path_buf());
+        config.browser_companion.enabled = true;
+        config.browser_companion.ready = true;
+        config.browser_companion.command = Some(command);
+        config
+    }
+
+    #[cfg(unix)]
+    fn write_browser_companion_script(
+        root: &Path,
+        name: &str,
+        stdout_body: &str,
+        log_path: &Path,
+    ) -> PathBuf {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = root.join(name);
+        let script = format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf '1.2.3\\n'\n  exit 0\nfi\nBODY=\"$(cat)\"\nprintf '%s' \"$BODY\" > \"{}\"\nprintf '%s' '{}'\n",
+            log_path.display(),
+            stdout_body.replace('\'', "'\"'\"'")
+        );
+        fs::write(&path, script).expect("write browser companion script");
+        let mut perms = fs::metadata(&path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).expect("chmod script");
+        path
+    }
+
+    #[cfg(windows)]
+    fn write_browser_companion_script(
+        root: &Path,
+        name: &str,
+        stdout_body: &str,
+        log_path: &Path,
+    ) -> PathBuf {
+        use std::fs;
+
+        let path = root.join(format!("{name}.cmd"));
+        let script = format!(
+            "@echo off\r\nif \"%~1\"==\"--version\" (\r\n  echo 1.2.3\r\n  exit /b 0\r\n)\r\nsetlocal enableextensions\r\nset /p BODY=\r\n> \"{}\" <nul set /p =%BODY%\r\necho {}\r\n",
+            log_path.display(),
+            stdout_body
+        );
+        fs::write(&path, script).expect("write browser companion script");
+        path
     }
 
     #[test]
@@ -2252,6 +2332,252 @@ mod tests {
             entry["tool_id"] == "shell.exec"
                 && entry["argument_hint"].as_str() == Some("command:string,args?:string[]")
         }));
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-browser")]
+    #[test]
+    fn browser_companion_tool_search_returns_runtime_ready_companion_entries() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-tool-search-browser-companion-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let mut config = test_tool_runtime_config(root.clone());
+        config.browser_companion.enabled = true;
+        config.browser_companion.ready = true;
+
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({"query": "browser companion session navigate click", "limit": 8}),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert!(
+            results
+                .iter()
+                .any(|entry| entry["tool_id"] == "browser.companion.session.start"),
+            "session start should be discoverable once runtime-ready: {results:?}"
+        );
+        assert!(
+            results
+                .iter()
+                .any(|entry| entry["tool_id"] == "browser.companion.navigate"),
+            "navigate should be discoverable once runtime-ready: {results:?}"
+        );
+        assert!(
+            results
+                .iter()
+                .any(|entry| entry["tool_id"] == "browser.companion.click"),
+            "click should be discoverable once runtime-ready: {results:?}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-browser")]
+    #[test]
+    fn browser_companion_tools_split_read_and_write_execution_kinds() {
+        let read = resolve_tool_execution("browser.companion.snapshot")
+            .expect("snapshot tool should resolve");
+        assert_eq!(read.canonical_name, "browser.companion.snapshot");
+        assert_eq!(read.execution_kind, ToolExecutionKind::Core);
+
+        let write =
+            resolve_tool_execution("browser.companion.click").expect("click tool should resolve");
+        assert_eq!(write.canonical_name, "browser.companion.click");
+        assert_eq!(write.execution_kind, ToolExecutionKind::App);
+    }
+
+    #[cfg(feature = "tool-browser")]
+    #[test]
+    fn browser_companion_protocol_start_issues_managed_session_id_and_records_request() {
+        let root = unique_tool_temp_dir("loongclaw-browser-companion-start");
+        std::fs::create_dir_all(&root).expect("create fixture root");
+        let log_path = root.join("request.json");
+        let script_path = write_browser_companion_script(
+            &root,
+            "browser-companion-ok",
+            r#"{"ok":true,"result":{"page_url":"https://example.com","title":"Example Domain"}}"#,
+            &log_path,
+        );
+        let config = browser_companion_runtime_config(&root, script_path.display().to_string());
+
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "browser.companion.session.start".to_owned(),
+                payload: json!({
+                    "url": "https://example.com"
+                }),
+            },
+            &config,
+        )
+        .expect("browser companion start should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["adapter"], "browser-companion");
+        assert_eq!(
+            outcome.payload["tool_name"],
+            "browser.companion.session.start"
+        );
+        let session_id = outcome.payload["session_id"]
+            .as_str()
+            .expect("session id should be text");
+        assert!(
+            session_id.starts_with("browser-companion-"),
+            "session id should be issued by LoongClaw: {session_id}"
+        );
+        assert_eq!(outcome.payload["result"]["page_url"], "https://example.com");
+
+        let request: Value = serde_json::from_str(
+            &std::fs::read_to_string(&log_path).expect("request log should exist"),
+        )
+        .expect("request log should be valid json");
+        assert_eq!(request["tool_name"], "browser.companion.session.start");
+        assert_eq!(request["operation"], "session.start");
+        assert_eq!(request["action_class"], "read");
+        assert_eq!(request["arguments"]["url"], "https://example.com");
+        assert_eq!(request["session_id"], session_id);
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-browser")]
+    #[test]
+    fn browser_companion_protocol_rejects_unknown_session_for_read_tools() {
+        let root = unique_tool_temp_dir("loongclaw-browser-companion-unknown-session");
+        std::fs::create_dir_all(&root).expect("create fixture root");
+        let log_path = root.join("request.json");
+        let script_path = write_browser_companion_script(
+            &root,
+            "browser-companion-unused",
+            r#"{"ok":true,"result":{"page_url":"https://example.com"}}"#,
+            &log_path,
+        );
+        let config = browser_companion_runtime_config(&root, script_path.display().to_string());
+
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "browser.companion.navigate".to_owned(),
+                payload: json!({
+                    "session_id": "browser-companion-missing",
+                    "url": "https://example.com/next"
+                }),
+            },
+            &config,
+        )
+        .expect_err("unknown companion session should fail closed");
+
+        assert!(
+            error.contains("browser_companion_unknown_session"),
+            "error={error}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-browser")]
+    #[test]
+    fn browser_companion_protocol_surfaces_invalid_json_from_command() {
+        let root = unique_tool_temp_dir("loongclaw-browser-companion-invalid-json");
+        std::fs::create_dir_all(&root).expect("create fixture root");
+        let log_path = root.join("request.json");
+        let script_path = write_browser_companion_script(
+            &root,
+            "browser-companion-invalid-json",
+            "not-json",
+            &log_path,
+        );
+        let config = browser_companion_runtime_config(&root, script_path.display().to_string());
+
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "browser.companion.session.start".to_owned(),
+                payload: json!({
+                    "url": "https://example.com"
+                }),
+            },
+            &config,
+        )
+        .expect_err("invalid json should become a typed adapter failure");
+
+        assert!(
+            error.contains("browser_companion_protocol_invalid_json"),
+            "error={error}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-browser")]
+    #[test]
+    fn browser_companion_app_tool_click_uses_current_session_scope() {
+        let root = unique_tool_temp_dir("loongclaw-browser-companion-app-click");
+        std::fs::create_dir_all(&root).expect("create fixture root");
+        let log_path = root.join("request.json");
+        let script_path = write_browser_companion_script(
+            &root,
+            "browser-companion-app-click",
+            r#"{"ok":true,"result":{"clicked":true}}"#,
+            &log_path,
+        );
+        let runtime_config =
+            browser_companion_runtime_config(&root, script_path.display().to_string());
+        let start = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "browser.companion.session.start".to_owned(),
+                payload: json!({
+                    "url": "https://example.com",
+                    BROWSER_SESSION_SCOPE_FIELD: "root-session"
+                }),
+            },
+            &runtime_config,
+        )
+        .expect("browser companion start should succeed");
+        let session_id = start.payload["session_id"]
+            .as_str()
+            .expect("session id should exist")
+            .to_owned();
+
+        let mut env = ScopedEnv::new();
+        env.set("LOONGCLAW_BROWSER_COMPANION_READY", "true");
+
+        let mut tool_config = crate::config::ToolConfig::default();
+        tool_config.browser_companion.enabled = true;
+        tool_config.browser_companion.command = Some(script_path.display().to_string());
+
+        let outcome = execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "browser.companion.click".to_owned(),
+                payload: json!({
+                    "session_id": session_id,
+                    "selector": "#submit"
+                }),
+            },
+            "root-session",
+            &crate::memory::runtime_config::MemoryRuntimeConfig::default(),
+            &tool_config,
+        )
+        .expect("browser companion click should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["action_class"], "write");
+        assert_eq!(outcome.payload["result"]["clicked"], true);
+
+        let request: Value = serde_json::from_str(
+            &std::fs::read_to_string(&log_path).expect("request log should exist"),
+        )
+        .expect("request log should be valid json");
+        assert_eq!(request["operation"], "click");
+        assert_eq!(request["action_class"], "write");
+        assert_eq!(request["session_scope"], "root-session");
+        assert_eq!(request["arguments"]["selector"], "#submit");
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -182,6 +182,37 @@ pub fn execute_app_tool_with_config(
     memory_config: &MemoryRuntimeConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
+    execute_app_tool_with_browser_companion_readiness(
+        request,
+        current_session_id,
+        memory_config,
+        tool_config,
+        false,
+    )
+}
+
+pub(crate) fn execute_app_tool_with_visibility_checked_config(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    execute_app_tool_with_browser_companion_readiness(
+        request,
+        current_session_id,
+        memory_config,
+        tool_config,
+        true,
+    )
+}
+
+fn execute_app_tool_with_browser_companion_readiness(
+    request: ToolCoreRequest,
+    current_session_id: &str,
+    memory_config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+    assume_browser_companion_ready: bool,
+) -> Result<ToolCoreOutcome, String> {
     let canonical_name = canonical_tool_name(request.tool_name.as_str());
     let request = ToolCoreRequest {
         tool_name: canonical_name.to_owned(),
@@ -208,11 +239,19 @@ pub fn execute_app_tool_with_config(
         }
         #[cfg(feature = "tool-browser")]
         "browser.companion.click" | "browser.companion.type" => {
-            browser_companion::execute_browser_companion_app_tool_with_config(
-                request,
-                current_session_id,
-                tool_config,
-            )
+            if assume_browser_companion_ready {
+                browser_companion::execute_browser_companion_visible_app_tool_with_config(
+                    request,
+                    current_session_id,
+                    tool_config,
+                )
+            } else {
+                browser_companion::execute_browser_companion_app_tool_with_config(
+                    request,
+                    current_session_id,
+                    tool_config,
+                )
+            }
         }
         _ => Err(format!(
             "app_tool_not_found: unknown app tool `{}`",
@@ -1537,6 +1576,40 @@ mod tests {
         path
     }
 
+    #[cfg(unix)]
+    fn write_browser_companion_sleep_script(
+        root: &Path,
+        name: &str,
+        sleep_seconds: u64,
+    ) -> PathBuf {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = root.join(name);
+        let script = format!(
+            "#!/bin/sh\nsleep {sleep_seconds}\nprintf '%s' '{{\"ok\":true,\"result\":{{\"delayed\":true}}}}'\n"
+        );
+        fs::write(&path, script).expect("write browser companion sleep script");
+        let mut perms = fs::metadata(&path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).expect("chmod script");
+        path
+    }
+
+    #[cfg(windows)]
+    fn write_browser_companion_sleep_script(
+        root: &Path,
+        name: &str,
+        _sleep_seconds: u64,
+    ) -> PathBuf {
+        use std::fs;
+
+        let path = root.join(format!("{name}.cmd"));
+        let script = "@echo off\r\nping -n 3 127.0.0.1 > nul\r\necho {\"ok\":true,\"result\":{\"delayed\":true}}\r\n";
+        fs::write(&path, script).expect("write browser companion sleep script");
+        path
+    }
+
     #[test]
     fn capability_snapshot_is_deterministic() {
         let snapshot = capability_snapshot();
@@ -2344,10 +2417,14 @@ mod tests {
             std::process::id()
         ));
         std::fs::create_dir_all(&root).expect("create fixture root");
-
-        let mut config = test_tool_runtime_config(root.clone());
-        config.browser_companion.enabled = true;
-        config.browser_companion.ready = true;
+        let log_path = root.join("request.json");
+        let script_path = write_browser_companion_script(
+            &root,
+            "browser-companion-search",
+            r#"{"ok":true,"result":{"ready":true}}"#,
+            &log_path,
+        );
+        let config = browser_companion_runtime_config(&root, script_path.display().to_string());
 
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
@@ -2511,6 +2588,32 @@ mod tests {
             error.contains("browser_companion_protocol_invalid_json"),
             "error={error}"
         );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-browser")]
+    #[test]
+    fn browser_companion_protocol_times_out_stalled_command() {
+        let root = unique_tool_temp_dir("loongclaw-browser-companion-timeout");
+        std::fs::create_dir_all(&root).expect("create fixture root");
+        let script_path =
+            write_browser_companion_sleep_script(&root, "browser-companion-timeout", 2);
+        let mut config = browser_companion_runtime_config(&root, script_path.display().to_string());
+        config.browser_companion.timeout_seconds = 1;
+
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "browser.companion.session.start".to_owned(),
+                payload: json!({
+                    "url": "https://example.com"
+                }),
+            },
+            &config,
+        )
+        .expect_err("hung command should time out");
+
+        assert!(error.contains("browser_companion_timeout"), "error={error}");
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -50,18 +50,31 @@ impl Default for BrowserRuntimePolicy {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserCompanionRuntimePolicy {
     pub enabled: bool,
     pub ready: bool,
     pub command: Option<String>,
     pub expected_version: Option<String>,
+    pub timeout_seconds: u64,
+}
+
+impl Default for BrowserCompanionRuntimePolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            ready: false,
+            command: None,
+            expected_version: None,
+            timeout_seconds: crate::config::DEFAULT_BROWSER_COMPANION_TIMEOUT_SECONDS,
+        }
+    }
 }
 
 impl BrowserCompanionRuntimePolicy {
     #[must_use]
     pub fn is_runtime_ready(&self) -> bool {
-        self.enabled && self.ready
+        self.enabled && self.ready && self.command.is_some()
     }
 }
 
@@ -190,16 +203,13 @@ impl ToolRuntimeConfig {
                 max_links: config.tools.browser.max_links,
                 max_text_chars: config.tools.browser.max_text_chars,
             },
-            browser_companion: BrowserCompanionRuntimePolicy {
-                enabled: config.tools.browser_companion.enabled,
-                ready: parse_env_bool("LOONGCLAW_BROWSER_COMPANION_READY").unwrap_or(false),
-                command: normalize_optional_string(
-                    config.tools.browser_companion.command.as_deref(),
-                ),
-                expected_version: normalize_optional_string(
-                    config.tools.browser_companion.expected_version.as_deref(),
-                ),
-            },
+            browser_companion: browser_companion_runtime_policy(
+                config.tools.browser_companion.enabled,
+                parse_env_bool("LOONGCLAW_BROWSER_COMPANION_READY").unwrap_or(false),
+                config.tools.browser_companion.command.as_deref(),
+                config.tools.browser_companion.expected_version.as_deref(),
+                config.tools.browser_companion.timeout_seconds,
+            ),
             web_fetch: WebFetchRuntimePolicy {
                 enabled: config.tools.web.enabled,
                 allow_private_hosts: config.tools.web.allow_private_hosts,
@@ -266,6 +276,9 @@ impl ToolRuntimeConfig {
         let browser_companion_command = parse_env_string("LOONGCLAW_BROWSER_COMPANION_COMMAND");
         let browser_companion_expected_version =
             parse_env_string("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION");
+        let browser_companion_timeout_seconds =
+            parse_env_u64("LOONGCLAW_BROWSER_COMPANION_TIMEOUT_SECONDS")
+                .unwrap_or(crate::config::DEFAULT_BROWSER_COMPANION_TIMEOUT_SECONDS);
         let web_fetch_enabled = parse_env_bool("LOONGCLAW_WEB_FETCH_ENABLED").unwrap_or(true);
         let web_fetch_allow_private_hosts =
             parse_env_bool("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS").unwrap_or(false);
@@ -302,12 +315,13 @@ impl ToolRuntimeConfig {
                 max_links: browser_max_links,
                 max_text_chars: browser_max_text_chars,
             },
-            browser_companion: BrowserCompanionRuntimePolicy {
-                enabled: browser_companion_enabled,
-                ready: browser_companion_ready,
-                command: browser_companion_command,
-                expected_version: browser_companion_expected_version,
-            },
+            browser_companion: browser_companion_runtime_policy(
+                browser_companion_enabled,
+                browser_companion_ready,
+                browser_companion_command.as_deref(),
+                browser_companion_expected_version.as_deref(),
+                browser_companion_timeout_seconds,
+            ),
             web_fetch: WebFetchRuntimePolicy {
                 enabled: web_fetch_enabled,
                 allow_private_hosts: web_fetch_allow_private_hosts,
@@ -342,13 +356,28 @@ impl ToolRuntimeConfig {
 pub(crate) fn browser_companion_runtime_policy_from_tool_config(
     config: &crate::config::ToolConfig,
 ) -> BrowserCompanionRuntimePolicy {
+    browser_companion_runtime_policy(
+        config.browser_companion.enabled,
+        parse_env_bool("LOONGCLAW_BROWSER_COMPANION_READY").unwrap_or(false),
+        config.browser_companion.command.as_deref(),
+        config.browser_companion.expected_version.as_deref(),
+        config.browser_companion.timeout_seconds,
+    )
+}
+
+fn browser_companion_runtime_policy(
+    enabled: bool,
+    ready: bool,
+    command: Option<&str>,
+    expected_version: Option<&str>,
+    timeout_seconds: u64,
+) -> BrowserCompanionRuntimePolicy {
     BrowserCompanionRuntimePolicy {
-        enabled: config.browser_companion.enabled,
-        ready: parse_env_bool("LOONGCLAW_BROWSER_COMPANION_READY").unwrap_or(false),
-        command: normalize_optional_string(config.browser_companion.command.as_deref()),
-        expected_version: normalize_optional_string(
-            config.browser_companion.expected_version.as_deref(),
-        ),
+        enabled,
+        ready,
+        command: normalize_optional_string(command),
+        expected_version: normalize_optional_string(expected_version),
+        timeout_seconds: timeout_seconds.max(1),
     }
 }
 
@@ -497,6 +526,7 @@ mod tests {
             "LOONGCLAW_BROWSER_MAX_TEXT_CHARS",
             "LOONGCLAW_BROWSER_COMPANION_ENABLED",
             "LOONGCLAW_BROWSER_COMPANION_READY",
+            "LOONGCLAW_BROWSER_COMPANION_TIMEOUT_SECONDS",
             "LOONGCLAW_BROWSER_COMPANION_COMMAND",
             "LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION",
             "LOONGCLAW_WEB_FETCH_ENABLED",
@@ -584,6 +614,7 @@ mod tests {
                 ready: true,
                 command: Some("loongclaw-browser-companion".to_owned()),
                 expected_version: Some("1.2.3".to_owned()),
+                timeout_seconds: 9,
             },
             web_fetch: WebFetchRuntimePolicy {
                 enabled: false,
@@ -683,6 +714,7 @@ mod tests {
         env.set("LOONGCLAW_BROWSER_COMPANION_READY", "true");
         let mut config = crate::config::LoongClawConfig::default();
         config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.timeout_seconds = 7;
         config.tools.browser_companion.command = Some("loongclaw-browser-companion".to_owned());
         config.tools.browser_companion.expected_version = Some("1.2.3".to_owned());
 
@@ -697,6 +729,7 @@ mod tests {
             runtime.browser_companion.expected_version.as_deref(),
             Some("1.2.3")
         );
+        assert_eq!(runtime.browser_companion.timeout_seconds, 7);
     }
 
     #[cfg(feature = "tool-shell")]
@@ -740,6 +773,7 @@ mod tests {
         env.set("LOONGCLAW_BROWSER_MAX_TEXT_CHARS", "2048");
         env.set("LOONGCLAW_BROWSER_COMPANION_ENABLED", "true");
         env.set("LOONGCLAW_BROWSER_COMPANION_READY", "true");
+        env.set("LOONGCLAW_BROWSER_COMPANION_TIMEOUT_SECONDS", "11");
         env.set(
             "LOONGCLAW_BROWSER_COMPANION_COMMAND",
             "loongclaw-browser-companion",
@@ -792,6 +826,7 @@ mod tests {
             config.browser_companion.expected_version.as_deref(),
             Some("1.2.3")
         );
+        assert_eq!(config.browser_companion.timeout_seconds, 11);
         assert!(!config.web_fetch.enabled);
         assert!(config.web_fetch.allow_private_hosts);
         assert!(
@@ -877,6 +912,7 @@ mod tests {
             ready: false,
             command: Some("loongclaw-browser-companion".to_owned()),
             expected_version: Some("1.2.3".to_owned()),
+            timeout_seconds: 9,
         };
 
         assert!(policy.enabled);
@@ -887,6 +923,20 @@ mod tests {
             Some("loongclaw-browser-companion")
         );
         assert_eq!(policy.expected_version.as_deref(), Some("1.2.3"));
+        assert_eq!(policy.timeout_seconds, 9);
+    }
+
+    #[test]
+    fn browser_companion_policy_from_tool_config_clamps_zero_timeout() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        let mut config = crate::config::ToolConfig::default();
+        config.browser_companion.enabled = true;
+        config.browser_companion.timeout_seconds = 0;
+
+        let policy = browser_companion_runtime_policy_from_tool_config(&config);
+
+        assert_eq!(policy.timeout_seconds, 1);
     }
 
     #[test]

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -339,6 +339,19 @@ impl ToolRuntimeConfig {
     }
 }
 
+pub(crate) fn browser_companion_runtime_policy_from_tool_config(
+    config: &crate::config::ToolConfig,
+) -> BrowserCompanionRuntimePolicy {
+    BrowserCompanionRuntimePolicy {
+        enabled: config.browser_companion.enabled,
+        ready: parse_env_bool("LOONGCLAW_BROWSER_COMPANION_READY").unwrap_or(false),
+        command: normalize_optional_string(config.browser_companion.command.as_deref()),
+        expected_version: normalize_optional_string(
+            config.browser_companion.expected_version.as_deref(),
+        ),
+    }
+}
+
 fn parse_env_bool(key: &str) -> Option<bool> {
     std::env::var(key).ok().and_then(|raw| {
         let value = raw.trim().to_ascii_lowercase();

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -365,6 +365,30 @@ pub(crate) fn browser_companion_runtime_policy_from_tool_config(
     )
 }
 
+pub(crate) fn browser_companion_runtime_policy_with_env_fallback(
+    config: &crate::config::ToolConfig,
+) -> BrowserCompanionRuntimePolicy {
+    let env_command = parse_env_string("LOONGCLAW_BROWSER_COMPANION_COMMAND");
+    let env_expected_version = parse_env_string("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION");
+    browser_companion_runtime_policy(
+        config.browser_companion.enabled
+            || parse_env_bool("LOONGCLAW_BROWSER_COMPANION_ENABLED").unwrap_or(false),
+        parse_env_bool("LOONGCLAW_BROWSER_COMPANION_READY").unwrap_or(false),
+        config
+            .browser_companion
+            .command
+            .as_deref()
+            .or(env_command.as_deref()),
+        config
+            .browser_companion
+            .expected_version
+            .as_deref()
+            .or(env_expected_version.as_deref()),
+        parse_env_u64("LOONGCLAW_BROWSER_COMPANION_TIMEOUT_SECONDS")
+            .unwrap_or(config.browser_companion.timeout_seconds),
+    )
+}
+
 fn browser_companion_runtime_policy(
     enabled: bool,
     ready: bool,
@@ -937,6 +961,33 @@ mod tests {
         let policy = browser_companion_runtime_policy_from_tool_config(&config);
 
         assert_eq!(policy.timeout_seconds, 1);
+    }
+
+    #[test]
+    fn browser_companion_policy_with_env_fallback_uses_runtime_exports_for_default_config() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        env.set("LOONGCLAW_BROWSER_COMPANION_ENABLED", "true");
+        env.set("LOONGCLAW_BROWSER_COMPANION_READY", "false");
+        env.set(
+            "LOONGCLAW_BROWSER_COMPANION_COMMAND",
+            "loongclaw-browser-companion",
+        );
+        env.set("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION", "1.2.3");
+        env.set("LOONGCLAW_BROWSER_COMPANION_TIMEOUT_SECONDS", "11");
+
+        let policy = browser_companion_runtime_policy_with_env_fallback(
+            &crate::config::ToolConfig::default(),
+        );
+
+        assert!(policy.enabled);
+        assert!(!policy.ready);
+        assert_eq!(
+            policy.command.as_deref(),
+            Some("loongclaw-browser-companion")
+        );
+        assert_eq!(policy.expected_version.as_deref(), Some("1.2.3"));
+        assert_eq!(policy.timeout_seconds, 11);
     }
 
     #[test]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -304,9 +304,11 @@ Remaining deliverables:
   - expand beyond installer scripts into package-manager distribution only after release adoption is stable
 - managed browser automation companion:
   - keep `browser.open`, `browser.extract`, and `browser.click` as the shipped safe browser lane
-  - add an optional first-party managed browser companion for richer page actions
-  - wire install, `onboard`, and `doctor` into companion presence, version, and isolated profile health
-  - expose richer browser automation only through truthful runtime-visible tool advertising and governed tool contracts
+  - partial governed adapter skeleton now exists for richer page actions:
+    `browser.companion.*` becomes runtime-visible only when the companion is ready, read actions stay in the Core lane, and write actions stay in the governed App lane
+  - still wire install, `onboard`, and `doctor` into companion presence, version, and isolated profile health
+  - still add isolated browser profile lifecycle and release packaging around the companion runtime
+  - keep richer browser automation exposed only through truthful runtime-visible tool advertising and governed tool contracts
 - browser-facing assistant surface:
   - WebChat implementation as a thin shell over existing ask/chat and browser semantics, not a separate assistant runtime
 

--- a/docs/plans/2026-03-16-browser-companion-adapter-skeleton.md
+++ b/docs/plans/2026-03-16-browser-companion-adapter-skeleton.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add failing browser companion tool-surface tests
+## Task 1: Add failing browser companion tool-surface tests
 
 **Files:**
 - Modify: `crates/app/src/tools/catalog.rs`
@@ -50,7 +50,7 @@ Run: `cargo test -p loongclaw-app browser_companion_tool_search -- --nocapture`
 
 Expected: FAIL because catalog/search metadata does not yet include the companion family.
 
-### Task 2: Add failing browser companion protocol tests
+## Task 2: Add failing browser companion protocol tests
 
 **Files:**
 - Create: `crates/app/src/tools/browser_companion.rs`
@@ -84,7 +84,7 @@ Run: `cargo test -p loongclaw-app browser_companion_protocol -- --nocapture`
 
 Expected: PASS
 
-### Task 3: Add failing governed write-action tests
+## Task 3: Add failing governed write-action tests
 
 **Files:**
 - Modify: `crates/app/src/conversation/turn_engine.rs`
@@ -119,7 +119,7 @@ Run: `cargo test -p loongclaw-app browser_companion_approval -- --nocapture`
 
 Expected: PASS
 
-### Task 4: Sync product docs with the shipped partial adapter surface
+## Task 4: Sync product docs with the shipped partial adapter surface
 
 **Files:**
 - Modify: `docs/product-specs/browser-automation-companion.md`
@@ -135,7 +135,7 @@ Run: `rg -n "adapter skeleton|browser.companion|partial governed" docs/product-s
 
 Expected: PASS with the updated wording.
 
-### Task 5: Verify, commit, and prepare PR delivery
+## Task 5: Verify, commit, and prepare PR delivery
 
 **Files:**
 - Modify only files in this task scope

--- a/docs/plans/2026-03-16-browser-companion-adapter-skeleton.md
+++ b/docs/plans/2026-03-16-browser-companion-adapter-skeleton.md
@@ -1,0 +1,178 @@
+# Browser Companion Adapter Skeleton Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add the first LoongClaw-owned governed browser companion adapter surface so browser companion runtime readiness can unlock real discoverable tools instead of only a helper-skill preview path.
+
+**Architecture:** Keep the shipped lightweight browser lane unchanged, then add a new `browser.companion.*` family behind the existing browser companion runtime gate. Read-oriented companion actions should execute as discoverable core tools with LoongClaw-owned session scope and typed protocol failures, while write-oriented companion actions should execute as discoverable app tools so the existing governed approval path can require review before execution.
+
+**Tech Stack:** Rust, existing tool catalog/runtime config infrastructure, conversation turn engine, app-tool dispatcher, Markdown docs
+
+---
+
+### Task 1: Add failing browser companion tool-surface tests
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write failing catalog visibility tests**
+
+Add tests that prove:
+
+- `browser.companion.session.start`
+- `browser.companion.navigate`
+- `browser.companion.snapshot`
+- `browser.companion.wait`
+- `browser.companion.session.stop`
+- `browser.companion.click`
+- `browser.companion.type`
+
+all stay hidden until `browser_companion.enabled=true` and `browser_companion.ready=true`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app browser_companion_visibility -- --nocapture`
+
+Expected: FAIL because no governed browser companion tools exist yet.
+
+**Step 3: Write failing tool discovery tests**
+
+Add tests that prove:
+
+- `tool.search` can find the companion tools once runtime-ready
+- read-oriented actions resolve as core tools
+- write-oriented actions resolve as app tools
+
+**Step 4: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app browser_companion_tool_search -- --nocapture`
+
+Expected: FAIL because catalog/search metadata does not yet include the companion family.
+
+### Task 2: Add failing browser companion protocol tests
+
+**Files:**
+- Create: `crates/app/src/tools/browser_companion.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+
+**Step 1: Write failing protocol execution tests**
+
+Add tests that prove:
+
+- read-oriented tools fail closed when the companion runtime is disabled or not ready
+- the configured companion command is invoked through a structured protocol boundary instead of raw shell text
+- command spawn failures, non-zero exits, invalid JSON, and protocol-declared errors become typed adapter failures
+- successful `session.start`, `navigate`, `snapshot`, `wait`, and `session.stop` responses preserve LoongClaw-issued session IDs and typed payload fields
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app browser_companion_protocol -- --nocapture`
+
+Expected: FAIL because the browser companion adapter implementation does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- add a new browser companion module
+- define a small request/response protocol around the configured companion command
+- generate LoongClaw-owned companion session IDs and scope them per conversation session
+- wire read-oriented tools through the core tool executor path
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app browser_companion_protocol -- --nocapture`
+
+Expected: PASS
+
+### Task 3: Add failing governed write-action tests
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/catalog.rs`
+- Modify: `crates/app/src/tools/browser_companion.rs`
+
+**Step 1: Write failing turn-engine approval tests**
+
+Add tests that prove:
+
+- `browser.companion.click` and `browser.companion.type` are discoverable app tools
+- strict approval mode turns those write actions into persisted approval requests
+- approved write actions execute through the app-tool dispatcher and preserve companion session scope
+- read-oriented companion actions do not create governed approval requests under the same runtime state
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app browser_companion_approval -- --nocapture`
+
+Expected: FAIL because the companion write actions are not yet routed through the governed app-tool path.
+
+**Step 3: Write minimal implementation**
+
+- assign approval-capable governance metadata to write-oriented companion actions
+- extend app-tool dispatch to execute companion write requests
+- keep read/write routing explicit and testable
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-app browser_companion_approval -- --nocapture`
+
+Expected: PASS
+
+### Task 4: Sync product docs with the shipped partial adapter surface
+
+**Files:**
+- Modify: `docs/product-specs/browser-automation-companion.md`
+- Modify: `docs/ROADMAP.md` if wording needs to distinguish adapter skeleton from full runtime
+
+**Step 1: Update the product spec**
+
+Document that LoongClaw now ships a partial governed adapter skeleton for the managed companion lane, while install/release lifecycle, isolated profile management, and broader runtime packaging remain planned work.
+
+**Step 2: Verify docs mention the new scope truthfully**
+
+Run: `rg -n "adapter skeleton|browser.companion|partial governed" docs/product-specs docs/ROADMAP.md`
+
+Expected: PASS with the updated wording.
+
+### Task 5: Verify, commit, and prepare PR delivery
+
+**Files:**
+- Modify only files in this task scope
+
+**Step 1: Run focused validation**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app browser_companion_visibility -- --nocapture
+cargo test -p loongclaw-app browser_companion_tool_search -- --nocapture
+cargo test -p loongclaw-app browser_companion_protocol -- --nocapture
+cargo test -p loongclaw-app browser_companion_approval -- --nocapture
+```
+
+Expected: PASS
+
+**Step 2: Run repository validation**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features --locked
+```
+
+Expected: PASS
+
+**Step 3: Commit cleanly**
+
+Run:
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```
+
+Confirm only browser companion adapter skeleton files are staged, then commit with a focused message.

--- a/docs/product-specs/browser-automation-companion.md
+++ b/docs/product-specs/browser-automation-companion.md
@@ -31,14 +31,22 @@ runtime into a heavyweight browser platform.
 The currently shipped preview scope is narrower than the final managed browser
 automation companion:
 
-- a first-party bundled `browser-companion-preview` managed skill
-- `loongclaw skills enable-browser-preview` as the operator-facing fast path
-- `onboard` and `doctor` next actions that surface the preview truthfully
 - continued default shipping of only `browser.open`, `browser.extract`, and
   `browser.click` as built-in browser tools
+- a partial governed adapter skeleton behind companion runtime readiness:
+  - runtime-visible `browser.companion.session.start`,
+    `browser.companion.navigate`, `browser.companion.snapshot`,
+    `browser.companion.wait`, and `browser.companion.session.stop`
+  - governed write actions `browser.companion.click` and
+    `browser.companion.type` routed through the App-tool approval path
+  - a structured command protocol, LoongClaw-issued companion session IDs, and
+    session-scoped companion state instead of raw shell text passthrough
+- a first-party bundled `browser-companion-preview` managed skill as guidance
+  on top of the runtime surface
 
-The fully governed companion runtime, richer tool catalog, isolated browser
-profile lifecycle, and stronger approval/audit semantics remain planned work.
+The install/release lifecycle, `onboard` and `doctor` readiness integration,
+isolated browser profile management, stronger approval evidence UX, and broader
+runtime packaging still remain planned work.
 
 ## Out of Scope
 

--- a/docs/product-specs/browser-automation-companion.md
+++ b/docs/product-specs/browser-automation-companion.md
@@ -41,6 +41,8 @@ automation companion:
     `browser.companion.type` routed through the App-tool approval path
   - a structured command protocol, LoongClaw-issued companion session IDs, and
     session-scoped companion state instead of raw shell text passthrough
+  - bounded companion command execution so hung adapter processes fail closed
+    instead of wedging the turn
 - a first-party bundled `browser-companion-preview` managed skill as guidance
   on top of the runtime surface
 


### PR DESCRIPTION
## Summary

- What changed?
  - Added a runtime-gated `browser.companion.*` discoverable tool family with a governed Core/App split.
  - Added a structured browser companion adapter executor with LoongClaw-issued session IDs, session-scoped state, and typed protocol failures.
  - Routed companion write actions through the existing governed App-tool approval path and synced product docs to the partial adapter skeleton truthfully.
- Why this change is needed?
  - The browser companion lane previously stopped at helper-skill guidance, so runtime readiness could not unlock a real governed tool surface. This adds the first mergeable adapter skeleton without forcing the heavyweight browser lane into core.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:
- Companion tools remain hidden unless the runtime is both enabled and ready.
- Read actions stay in the Core lane; write actions stay in the governed App lane so existing approval persistence still applies.
- The shipped lightweight browser lane (`browser.open`, `browser.extract`, `browser.click`) remains unchanged.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Additional validation notes:
- Focused regression coverage included `cargo test -p loongclaw-app browser_companion -- --nocapture` and `cargo test -p loongclaw-app augment_tool_payload_injects_browser_scope_for_companion_tool_invoke -- --nocapture`.
- Before: browser companion readiness could not unlock a governed discoverable runtime surface; write actions were not routed through App-tool approval, and `tool.invoke` did not inject companion scope for discoverable companion calls.
- After: runtime-ready companion tools are visible truthfully, write actions persist governed approval requests in strict mode, direct execution works when approval is disabled, and companion scope is injected for discoverable browser companion calls.
- Process-global env mutation in tests is scoped through `ScopedEnv`, which restores prior environment state on drop.

## Linked Issues

Closes #213


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added browser companion tool suite with session lifecycle management, navigation, clicking, typing, snapshots, and wait operations.
  * Browser companion tools are runtime-visible when companion is ready and include governance approval for write actions.

* **Documentation**
  * Updated product specifications and roadmap to reflect partial governed adapter surface for browser automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->