### PR TITLE
perf: reduce shell.exec follow-up payload size

### DIFF
--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -6565,37 +6565,6 @@ mod tests {
         assert_eq!(summary["content_truncated"], true);
     }
 
-    fn parse_assistant_tool_result_followup(messages: &[Value]) -> (Value, Value) {
-        let assistant_tool_result = messages
-            .iter()
-            .find(|message| {
-                message.get("role") == Some(&Value::String("assistant".to_owned()))
-                    && message
-                        .get("content")
-                        .and_then(Value::as_str)
-                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
-            })
-            .and_then(|message| message.get("content"))
-            .and_then(Value::as_str)
-            .expect("assistant tool_result followup message should exist");
-        let line = assistant_tool_result
-            .lines()
-            .nth(1)
-            .expect("assistant tool_result should keep payload line");
-        let envelope: Value = serde_json::from_str(
-            line.strip_prefix("[ok] ")
-                .expect("tool result line should preserve status prefix"),
-        )
-        .expect("followup envelope should stay valid json");
-        let summary: Value = serde_json::from_str(
-            envelope["payload_summary"]
-                .as_str()
-                .expect("payload summary should stay encoded json"),
-        )
-        .expect("payload summary should stay valid json");
-        (envelope, summary)
-    }
-
     #[test]
     fn build_turn_reply_followup_messages_reduces_shell_exec_payload_summary() {
         let tool_result = format!(
@@ -6615,7 +6584,10 @@ mod tests {
                         .map(|index| format!("stdout line {index}: {}", "x".repeat(40)))
                         .collect::<Vec<_>>()
                         .join("\n"),
-                    "stderr": ""
+                    "stderr": (0..48)
+                        .map(|index| format!("stderr line {index}: {}", "e".repeat(32)))
+                        .collect::<Vec<_>>()
+                        .join("\n")
                 })
                 .to_string(),
                 "payload_chars": 8_192,
@@ -6633,7 +6605,8 @@ mod tests {
             "summarize the test run",
         );
 
-        let (envelope, summary) = parse_assistant_tool_result_followup(&messages);
+        let (envelope, summary) =
+            crate::conversation::turn_shared::parse_tool_result_followup_for_test(&messages);
 
         assert_eq!(envelope["tool"], "shell.exec");
         assert_eq!(envelope["payload_truncated"], true);
@@ -6642,12 +6615,22 @@ mod tests {
         assert!(summary.get("stdout_preview").is_some());
         assert!(summary.get("stdout_chars").is_some());
         assert_eq!(summary["stdout_truncated"], true);
+        assert!(summary.get("stderr_preview").is_some());
+        assert!(summary.get("stderr_chars").is_some());
+        assert_eq!(summary["stderr_truncated"], true);
         assert!(
             summary["stdout_preview"]
                 .as_str()
                 .expect("stdout preview should exist")
                 .contains("stdout line 0"),
             "expected compact stdout preview, got: {summary:?}"
+        );
+        assert!(
+            summary["stderr_preview"]
+                .as_str()
+                .expect("stderr preview should exist")
+                .contains("stderr line 0"),
+            "expected compact stderr preview, got: {summary:?}"
         );
     }
 
@@ -6684,7 +6667,8 @@ mod tests {
             "read note.md",
         );
 
-        let (envelope, summary) = parse_assistant_tool_result_followup(&messages);
+        let (envelope, summary) =
+            crate::conversation::turn_shared::parse_tool_result_followup_for_test(&messages);
 
         assert_eq!(envelope["tool"], "tool.search");
         assert_eq!(envelope["payload_truncated"], false);

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -6565,45 +6565,7 @@ mod tests {
         assert_eq!(summary["content_truncated"], true);
     }
 
-    #[test]
-    fn build_turn_reply_followup_messages_reduces_shell_exec_payload_summary() {
-        let stdout = (0..80)
-            .map(|index| format!("stdout line {index}: {}", "x".repeat(40)))
-            .collect::<Vec<_>>()
-            .join("\n");
-        let payload_summary = serde_json::json!({
-            "adapter": "core-tools",
-            "tool_name": "shell.exec",
-            "command": "cargo",
-            "args": ["test", "--workspace"],
-            "cwd": "/repo",
-            "exit_code": 0,
-            "stdout": stdout,
-            "stderr": ""
-        })
-        .to_string();
-        let tool_result = format!(
-            "[ok] {}",
-            serde_json::json!({
-                "status": "ok",
-                "tool": "shell.exec",
-                "tool_call_id": "call-shell",
-                "payload_summary": payload_summary,
-                "payload_chars": 8_192,
-                "payload_truncated": false
-            })
-        );
-
-        let messages = build_turn_reply_followup_messages(
-            &[serde_json::json!({
-                "role": "system",
-                "content": "sys"
-            })],
-            "preface",
-            ToolDrivenFollowupPayload::ToolResult { text: tool_result },
-            "summarize the test run",
-        );
-
+    fn parse_assistant_tool_result_followup(messages: &[Value]) -> (Value, Value) {
         let assistant_tool_result = messages
             .iter()
             .find(|message| {
@@ -6624,13 +6586,54 @@ mod tests {
             line.strip_prefix("[ok] ")
                 .expect("tool result line should preserve status prefix"),
         )
-        .expect("reduced followup envelope should stay valid json");
+        .expect("followup envelope should stay valid json");
         let summary: Value = serde_json::from_str(
             envelope["payload_summary"]
                 .as_str()
                 .expect("payload summary should stay encoded json"),
         )
-        .expect("shell payload summary should stay valid json");
+        .expect("payload summary should stay valid json");
+        (envelope, summary)
+    }
+
+    #[test]
+    fn build_turn_reply_followup_messages_reduces_shell_exec_payload_summary() {
+        let tool_result = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "shell.exec",
+                "tool_call_id": "call-shell",
+                "payload_summary": serde_json::json!({
+                    "adapter": "core-tools",
+                    "tool_name": "shell.exec",
+                    "command": "cargo",
+                    "args": ["test", "--workspace"],
+                    "cwd": "/repo",
+                    "exit_code": 0,
+                    "stdout": (0..80)
+                        .map(|index| format!("stdout line {index}: {}", "x".repeat(40)))
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                    "stderr": ""
+                })
+                .to_string(),
+                "payload_chars": 8_192,
+                "payload_truncated": false
+            })
+        );
+
+        let messages = build_turn_reply_followup_messages(
+            &[serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })],
+            "preface",
+            ToolDrivenFollowupPayload::ToolResult { text: tool_result },
+            "summarize the test run",
+        );
+
+        let (envelope, summary) = parse_assistant_tool_result_followup(&messages);
 
         assert_eq!(envelope["tool"], "shell.exec");
         assert_eq!(envelope["payload_truncated"], true);
@@ -6658,15 +6661,14 @@ mod tests {
                     "lease": "lease-1"
                 }
             ]
-        })
-        .to_string();
+        });
         let tool_result = format!(
             "[ok] {}",
             serde_json::json!({
                 "status": "ok",
                 "tool": "tool.search",
                 "tool_call_id": "call-search",
-                "payload_summary": payload_summary,
+                "payload_summary": payload_summary.to_string(),
                 "payload_chars": 256,
                 "payload_truncated": false
             })
@@ -6682,34 +6684,11 @@ mod tests {
             "read note.md",
         );
 
-        let assistant_tool_result = messages
-            .iter()
-            .find(|message| {
-                message.get("role") == Some(&Value::String("assistant".to_owned()))
-                    && message
-                        .get("content")
-                        .and_then(Value::as_str)
-                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
-            })
-            .and_then(|message| message.get("content"))
-            .and_then(Value::as_str)
-            .expect("assistant tool_result followup message should exist");
-        let line = assistant_tool_result
-            .lines()
-            .nth(1)
-            .expect("assistant tool_result should keep payload line");
-        let envelope: Value = serde_json::from_str(
-            line.strip_prefix("[ok] ")
-                .expect("tool result line should preserve status prefix"),
-        )
-        .expect("tool.search followup envelope should stay valid json");
+        let (envelope, summary) = parse_assistant_tool_result_followup(&messages);
 
         assert_eq!(envelope["tool"], "tool.search");
         assert_eq!(envelope["payload_truncated"], false);
-        assert_eq!(
-            envelope["payload_summary"].as_str(),
-            Some(payload_summary.as_str())
-        );
+        assert_eq!(summary, payload_summary);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -6566,6 +6566,89 @@ mod tests {
     }
 
     #[test]
+    fn build_turn_reply_followup_messages_reduces_shell_exec_payload_summary() {
+        let stdout = (0..80)
+            .map(|index| format!("stdout line {index}: {}", "x".repeat(40)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let payload_summary = serde_json::json!({
+            "adapter": "core-tools",
+            "tool_name": "shell.exec",
+            "command": "cargo",
+            "args": ["test", "--workspace"],
+            "cwd": "/repo",
+            "exit_code": 0,
+            "stdout": stdout,
+            "stderr": ""
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "shell.exec",
+                "tool_call_id": "call-shell",
+                "payload_summary": payload_summary,
+                "payload_chars": 8_192,
+                "payload_truncated": false
+            })
+        );
+
+        let messages = build_turn_reply_followup_messages(
+            &[serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })],
+            "preface",
+            ToolDrivenFollowupPayload::ToolResult { text: tool_result },
+            "summarize the test run",
+        );
+
+        let assistant_tool_result = messages
+            .iter()
+            .find(|message| {
+                message.get("role") == Some(&Value::String("assistant".to_owned()))
+                    && message
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
+            })
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("assistant tool_result followup message should exist");
+        let line = assistant_tool_result
+            .lines()
+            .nth(1)
+            .expect("assistant tool_result should keep payload line");
+        let envelope: Value = serde_json::from_str(
+            line.strip_prefix("[ok] ")
+                .expect("tool result line should preserve status prefix"),
+        )
+        .expect("reduced followup envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("shell payload summary should stay valid json");
+
+        assert_eq!(envelope["tool"], "shell.exec");
+        assert_eq!(envelope["payload_truncated"], true);
+        assert_eq!(summary["command"], "cargo");
+        assert_eq!(summary["exit_code"], 0);
+        assert!(summary.get("stdout_preview").is_some());
+        assert!(summary.get("stdout_chars").is_some());
+        assert_eq!(summary["stdout_truncated"], true);
+        assert!(
+            summary["stdout_preview"]
+                .as_str()
+                .expect("stdout preview should exist")
+                .contains("stdout line 0"),
+            "expected compact stdout preview, got: {summary:?}"
+        );
+    }
+
+    #[test]
     fn build_turn_reply_followup_messages_preserves_tool_search_payload_summary() {
         let payload_summary = serde_json::json!({
             "results": [

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -1057,44 +1057,16 @@ mod tests {
                         .map(|index| format!("stdout line {index}: {}", "x".repeat(40)))
                         .collect::<Vec<_>>()
                         .join("\n"),
-                    "stderr": ""
+                    "stderr": (0..48)
+                        .map(|index| format!("stderr line {index}: {}", "e".repeat(32)))
+                        .collect::<Vec<_>>()
+                        .join("\n")
                 })
                 .to_string(),
                 "payload_chars": 8_192,
                 "payload_truncated": false
             })
         )
-    }
-
-    fn parse_assistant_tool_result_followup(messages: &[Value]) -> (Value, Value) {
-        let assistant_tool_result = messages
-            .iter()
-            .find(|message| {
-                message.get("role") == Some(&Value::String("assistant".to_owned()))
-                    && message
-                        .get("content")
-                        .and_then(Value::as_str)
-                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
-            })
-            .and_then(|message| message.get("content"))
-            .and_then(Value::as_str)
-            .expect("assistant tool_result followup message should exist");
-        let line = assistant_tool_result
-            .lines()
-            .nth(1)
-            .expect("assistant tool_result should keep payload line");
-        let envelope: Value = serde_json::from_str(
-            line.strip_prefix("[ok] ")
-                .expect("tool result line should preserve status prefix"),
-        )
-        .expect("followup envelope should stay valid json");
-        let summary: Value = serde_json::from_str(
-            envelope["payload_summary"]
-                .as_str()
-                .expect("payload summary should stay encoded json"),
-        )
-        .expect("payload summary should stay valid json");
-        (envelope, summary)
     }
 
     #[test]
@@ -1112,7 +1084,8 @@ mod tests {
             None,
         );
 
-        let (envelope, summary) = parse_assistant_tool_result_followup(&messages);
+        let (envelope, summary) =
+            crate::conversation::turn_shared::parse_tool_result_followup_for_test(&messages);
 
         assert_eq!(envelope["tool"], "shell.exec");
         assert_eq!(envelope["payload_truncated"], true);
@@ -1121,12 +1094,22 @@ mod tests {
         assert!(summary.get("stdout_preview").is_some());
         assert!(summary.get("stdout_chars").is_some());
         assert_eq!(summary["stdout_truncated"], true);
+        assert!(summary.get("stderr_preview").is_some());
+        assert!(summary.get("stderr_chars").is_some());
+        assert_eq!(summary["stderr_truncated"], true);
         assert!(
             summary["stdout_preview"]
                 .as_str()
                 .expect("stdout preview should exist")
                 .contains("stdout line 0"),
             "expected compact stdout preview, got: {summary:?}"
+        );
+        assert!(
+            summary["stderr_preview"]
+                .as_str()
+                .expect("stderr preview should exist")
+                .contains("stderr line 0"),
+            "expected compact stderr preview, got: {summary:?}"
         );
     }
 
@@ -1163,7 +1146,8 @@ mod tests {
             &mut budget,
         );
 
-        let (envelope, summary) = parse_assistant_tool_result_followup(&messages);
+        let (envelope, summary) =
+            crate::conversation::turn_shared::parse_tool_result_followup_for_test(&messages);
 
         assert_eq!(envelope["tool"], "shell.exec");
         assert_eq!(envelope["payload_truncated"], true);
@@ -1172,6 +1156,9 @@ mod tests {
         assert!(summary.get("stdout_preview").is_some());
         assert!(summary.get("stdout_chars").is_some());
         assert_eq!(summary["stdout_truncated"], true);
+        assert!(summary.get("stderr_preview").is_some());
+        assert!(summary.get("stderr_chars").is_some());
+        assert_eq!(summary["stderr_truncated"], true);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -1039,46 +1039,34 @@ mod tests {
         assert_reduced_file_read_followup_message(&messages);
     }
 
-    #[test]
-    fn append_tool_driven_followup_messages_reduces_shell_exec_payload_summary() {
-        let mut messages = Vec::new();
-        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
-        let stdout = (0..80)
-            .map(|index| format!("stdout line {index}: {}", "x".repeat(40)))
-            .collect::<Vec<_>>()
-            .join("\n");
-        let payload_summary = serde_json::json!({
-            "adapter": "core-tools",
-            "tool_name": "shell.exec",
-            "command": "cargo",
-            "args": ["test", "--workspace"],
-            "cwd": "/repo",
-            "exit_code": 0,
-            "stdout": stdout,
-            "stderr": ""
-        })
-        .to_string();
-        let tool_result = format!(
+    fn build_large_shell_exec_tool_result() -> String {
+        format!(
             "[ok] {}",
             serde_json::json!({
                 "status": "ok",
                 "tool": "shell.exec",
                 "tool_call_id": "call-shell",
-                "payload_summary": payload_summary,
+                "payload_summary": serde_json::json!({
+                    "adapter": "core-tools",
+                    "tool_name": "shell.exec",
+                    "command": "cargo",
+                    "args": ["test", "--workspace"],
+                    "cwd": "/repo",
+                    "exit_code": 0,
+                    "stdout": (0..80)
+                        .map(|index| format!("stdout line {index}: {}", "x".repeat(40)))
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                    "stderr": ""
+                })
+                .to_string(),
                 "payload_chars": 8_192,
                 "payload_truncated": false
             })
-        );
+        )
+    }
 
-        append_tool_driven_followup_messages(
-            &mut messages,
-            "preface",
-            &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
-            "summarize the test run",
-            &mut budget,
-            None,
-        );
-
+    fn parse_assistant_tool_result_followup(messages: &[Value]) -> (Value, Value) {
         let assistant_tool_result = messages
             .iter()
             .find(|message| {
@@ -1099,13 +1087,32 @@ mod tests {
             line.strip_prefix("[ok] ")
                 .expect("tool result line should preserve status prefix"),
         )
-        .expect("reduced followup envelope should stay valid json");
+        .expect("followup envelope should stay valid json");
         let summary: Value = serde_json::from_str(
             envelope["payload_summary"]
                 .as_str()
                 .expect("payload summary should stay encoded json"),
         )
-        .expect("shell payload summary should stay valid json");
+        .expect("payload summary should stay valid json");
+        (envelope, summary)
+    }
+
+    #[test]
+    fn append_tool_driven_followup_messages_reduces_shell_exec_payload_summary() {
+        let mut messages = Vec::new();
+        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
+        let tool_result = build_large_shell_exec_tool_result();
+
+        append_tool_driven_followup_messages(
+            &mut messages,
+            "preface",
+            &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
+            "summarize the test run",
+            &mut budget,
+            None,
+        );
+
+        let (envelope, summary) = parse_assistant_tool_result_followup(&messages);
 
         assert_eq!(envelope["tool"], "shell.exec");
         assert_eq!(envelope["payload_truncated"], true);
@@ -1145,32 +1152,7 @@ mod tests {
     fn append_repeated_tool_guard_followup_messages_reduces_shell_exec_payload_summary() {
         let mut messages = Vec::new();
         let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
-        let stdout = (0..80)
-            .map(|index| format!("stdout line {index}: {}", "x".repeat(40)))
-            .collect::<Vec<_>>()
-            .join("\n");
-        let payload_summary = serde_json::json!({
-            "adapter": "core-tools",
-            "tool_name": "shell.exec",
-            "command": "cargo",
-            "args": ["test", "--workspace"],
-            "cwd": "/repo",
-            "exit_code": 0,
-            "stdout": stdout,
-            "stderr": ""
-        })
-        .to_string();
-        let tool_result = format!(
-            "[ok] {}",
-            serde_json::json!({
-                "status": "ok",
-                "tool": "shell.exec",
-                "tool_call_id": "call-shell",
-                "payload_summary": payload_summary,
-                "payload_chars": 8_192,
-                "payload_truncated": false
-            })
-        );
+        let tool_result = build_large_shell_exec_tool_result();
 
         append_repeated_tool_guard_followup_messages(
             &mut messages,
@@ -1181,33 +1163,7 @@ mod tests {
             &mut budget,
         );
 
-        let assistant_tool_result = messages
-            .iter()
-            .find(|message| {
-                message.get("role") == Some(&Value::String("assistant".to_owned()))
-                    && message
-                        .get("content")
-                        .and_then(Value::as_str)
-                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
-            })
-            .and_then(|message| message.get("content"))
-            .and_then(Value::as_str)
-            .expect("assistant tool_result followup message should exist");
-        let line = assistant_tool_result
-            .lines()
-            .nth(1)
-            .expect("assistant tool_result should keep payload line");
-        let envelope: Value = serde_json::from_str(
-            line.strip_prefix("[ok] ")
-                .expect("tool result line should preserve status prefix"),
-        )
-        .expect("reduced guard followup envelope should stay valid json");
-        let summary: Value = serde_json::from_str(
-            envelope["payload_summary"]
-                .as_str()
-                .expect("payload summary should stay encoded json"),
-        )
-        .expect("shell payload summary should stay valid json");
+        let (envelope, summary) = parse_assistant_tool_result_followup(&messages);
 
         assert_eq!(envelope["tool"], "shell.exec");
         assert_eq!(envelope["payload_truncated"], true);

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -1040,6 +1040,90 @@ mod tests {
     }
 
     #[test]
+    fn append_tool_driven_followup_messages_reduces_shell_exec_payload_summary() {
+        let mut messages = Vec::new();
+        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
+        let stdout = (0..80)
+            .map(|index| format!("stdout line {index}: {}", "x".repeat(40)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let payload_summary = serde_json::json!({
+            "adapter": "core-tools",
+            "tool_name": "shell.exec",
+            "command": "cargo",
+            "args": ["test", "--workspace"],
+            "cwd": "/repo",
+            "exit_code": 0,
+            "stdout": stdout,
+            "stderr": ""
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "shell.exec",
+                "tool_call_id": "call-shell",
+                "payload_summary": payload_summary,
+                "payload_chars": 8_192,
+                "payload_truncated": false
+            })
+        );
+
+        append_tool_driven_followup_messages(
+            &mut messages,
+            "preface",
+            &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
+            "summarize the test run",
+            &mut budget,
+            None,
+        );
+
+        let assistant_tool_result = messages
+            .iter()
+            .find(|message| {
+                message.get("role") == Some(&Value::String("assistant".to_owned()))
+                    && message
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
+            })
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("assistant tool_result followup message should exist");
+        let line = assistant_tool_result
+            .lines()
+            .nth(1)
+            .expect("assistant tool_result should keep payload line");
+        let envelope: Value = serde_json::from_str(
+            line.strip_prefix("[ok] ")
+                .expect("tool result line should preserve status prefix"),
+        )
+        .expect("reduced followup envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("shell payload summary should stay valid json");
+
+        assert_eq!(envelope["tool"], "shell.exec");
+        assert_eq!(envelope["payload_truncated"], true);
+        assert_eq!(summary["command"], "cargo");
+        assert_eq!(summary["exit_code"], 0);
+        assert!(summary.get("stdout_preview").is_some());
+        assert!(summary.get("stdout_chars").is_some());
+        assert_eq!(summary["stdout_truncated"], true);
+        assert!(
+            summary["stdout_preview"]
+                .as_str()
+                .expect("stdout preview should exist")
+                .contains("stdout line 0"),
+            "expected compact stdout preview, got: {summary:?}"
+        );
+    }
+
+    #[test]
     fn append_repeated_tool_guard_followup_messages_reduces_file_read_payload_summary() {
         let mut messages = Vec::new();
         let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
@@ -1055,6 +1139,83 @@ mod tests {
         );
 
         assert_reduced_file_read_followup_message(&messages);
+    }
+
+    #[test]
+    fn append_repeated_tool_guard_followup_messages_reduces_shell_exec_payload_summary() {
+        let mut messages = Vec::new();
+        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
+        let stdout = (0..80)
+            .map(|index| format!("stdout line {index}: {}", "x".repeat(40)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let payload_summary = serde_json::json!({
+            "adapter": "core-tools",
+            "tool_name": "shell.exec",
+            "command": "cargo",
+            "args": ["test", "--workspace"],
+            "cwd": "/repo",
+            "exit_code": 0,
+            "stdout": stdout,
+            "stderr": ""
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "shell.exec",
+                "tool_call_id": "call-shell",
+                "payload_summary": payload_summary,
+                "payload_chars": 8_192,
+                "payload_truncated": false
+            })
+        );
+
+        append_repeated_tool_guard_followup_messages(
+            &mut messages,
+            "preface",
+            "stop",
+            "summarize the test run",
+            Some(("tool_result", tool_result.as_str())),
+            &mut budget,
+        );
+
+        let assistant_tool_result = messages
+            .iter()
+            .find(|message| {
+                message.get("role") == Some(&Value::String("assistant".to_owned()))
+                    && message
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
+            })
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("assistant tool_result followup message should exist");
+        let line = assistant_tool_result
+            .lines()
+            .nth(1)
+            .expect("assistant tool_result should keep payload line");
+        let envelope: Value = serde_json::from_str(
+            line.strip_prefix("[ok] ")
+                .expect("tool result line should preserve status prefix"),
+        )
+        .expect("reduced guard followup envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("shell payload summary should stay valid json");
+
+        assert_eq!(envelope["tool"], "shell.exec");
+        assert_eq!(envelope["payload_truncated"], true);
+        assert_eq!(summary["command"], "cargo");
+        assert_eq!(summary["exit_code"], 0);
+        assert!(summary.get("stdout_preview").is_some());
+        assert!(summary.get("stdout_chars").is_some());
+        assert_eq!(summary["stdout_truncated"], true);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -502,27 +502,28 @@ fn reduce_file_read_payload_summary(payload: &Value) -> Option<String> {
 }
 
 fn reduce_shell_payload_summary(payload: &Value) -> Option<String> {
-    let payload_object = payload.as_object()?;
-    let (stdout_preview, stdout_chars, stdout_truncated) =
-        summarize_shell_output_preview(payload_object.get("stdout"));
-    let (stderr_preview, stderr_chars, stderr_truncated) =
-        summarize_shell_output_preview(payload_object.get("stderr"));
+    let mut reduced_payload = payload.as_object()?.clone();
+    let stdout_truncated = replace_shell_stdio_with_preview(&mut reduced_payload, "stdout");
+    let stderr_truncated = replace_shell_stdio_with_preview(&mut reduced_payload, "stderr");
     if !stdout_truncated && !stderr_truncated {
         return None;
     }
-    serde_json::to_string(&serde_json::json!({
-        "command": payload_object.get("command").cloned().unwrap_or(Value::Null),
-        "args": payload_object.get("args").cloned().unwrap_or_else(|| serde_json::json!([])),
-        "cwd": payload_object.get("cwd").cloned().unwrap_or(Value::Null),
-        "exit_code": payload_object.get("exit_code").cloned().unwrap_or(Value::Null),
-        "stdout_preview": stdout_preview,
-        "stdout_chars": stdout_chars,
-        "stdout_truncated": stdout_truncated,
-        "stderr_preview": stderr_preview,
-        "stderr_chars": stderr_chars,
-        "stderr_truncated": stderr_truncated,
-    }))
-    .ok()
+    serde_json::to_string(&Value::Object(reduced_payload)).ok()
+}
+
+fn replace_shell_stdio_with_preview(
+    payload_object: &mut serde_json::Map<String, Value>,
+    field: &str,
+) -> bool {
+    let (preview, chars, truncated) = summarize_shell_output_preview(payload_object.get(field));
+    if !truncated {
+        return false;
+    }
+    payload_object.remove(field);
+    payload_object.insert(format!("{field}_preview"), Value::String(preview));
+    payload_object.insert(format!("{field}_chars"), serde_json::json!(chars));
+    payload_object.insert(format!("{field}_truncated"), Value::Bool(true));
+    true
 }
 
 fn summarize_file_read_content_preview(value: Option<&Value>) -> (String, usize, bool) {
@@ -697,9 +698,15 @@ where
     F: FnMut(&str, &str) -> String,
 {
     let mut messages = Vec::new();
+    let mut original_tool_result_text = None;
+    let mut rendered_tool_result_text = None;
     append_followup_preface(&mut messages, assistant_preface);
     if let Some((label, text)) = latest_tool_context {
         let bounded = payload_mapper(label, text);
+        if label == "tool_result" {
+            original_tool_result_text = Some(text);
+            rendered_tool_result_text = Some(bounded.clone());
+        }
         messages.push(serde_json::json!({
             "role": "assistant",
             "content": format!("[{label}]\n{bounded}"),
@@ -711,7 +718,12 @@ where
     }));
     messages.push(serde_json::json!({
         "role": "user",
-        "content": build_tool_loop_guard_prompt(user_input, reason),
+        "content": build_tool_loop_guard_prompt(
+            user_input,
+            reason,
+            original_tool_result_text,
+            rendered_tool_result_text.as_deref(),
+        ),
     }));
     messages
 }
@@ -764,10 +776,21 @@ fn append_followup_warning(messages: &mut Vec<Value>, loop_warning_reason: Optio
     }
 }
 
-fn build_tool_loop_guard_prompt(user_input: &str, reason: &str) -> String {
-    format!(
-        "{TOOL_LOOP_GUARD_PROMPT}\n\nLoop guard reason:\n{reason}\n\nOriginal request:\n{user_input}"
-    )
+fn build_tool_loop_guard_prompt(
+    user_input: &str,
+    reason: &str,
+    tool_result_text: Option<&str>,
+    rendered_tool_result_text: Option<&str>,
+) -> String {
+    let mut sections = vec![
+        TOOL_LOOP_GUARD_PROMPT.to_owned(),
+        format!("Loop guard reason:\n{reason}"),
+    ];
+    if followup_prompt_needs_truncation_hint(tool_result_text, rendered_tool_result_text) {
+        sections.push(TOOL_TRUNCATION_HINT_PROMPT.to_owned());
+    }
+    sections.push(format!("Original request:\n{user_input}"));
+    sections.join("\n\n")
 }
 
 fn parse_external_skill_invoke_context_line(line: &str) -> Option<ExternalSkillInvokeContext> {
@@ -1368,6 +1391,26 @@ mod tests {
     }
 
     #[test]
+    fn tool_loop_guard_tail_includes_truncation_hint_when_payload_mapper_truncates_result() {
+        let tail = build_tool_loop_guard_tail(
+            "preface",
+            "stop",
+            "summarize note.md",
+            Some(("tool_result", r#"[ok] {"payload_truncated":false}"#)),
+            |_, _| r#"[ok] {"payload_truncated":true}"#.to_owned(),
+        );
+
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+        assert!(user_prompt.contains(TOOL_LOOP_GUARD_PROMPT));
+        assert!(user_prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
+        assert!(user_prompt.contains("Loop guard reason:\nstop"));
+    }
+
+    #[test]
     fn tool_loop_guard_tail_skips_latest_tool_context_without_payload_mapping() {
         let tail = build_tool_loop_guard_tail("", "stop", "summarize note.md", None, |_, _| {
             panic!("missing latest tool context should bypass payload mapper")
@@ -1429,6 +1472,54 @@ mod tests {
         );
         assert!(prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
         assert!(prompt.contains("Original request:\nsummarize this result"));
+    }
+
+    #[test]
+    fn reduce_followup_payload_for_model_preserves_shell_payload_metadata() {
+        let payload = json!({
+            "adapter": "core-tools",
+            "tool_name": "shell.exec",
+            "command": "cargo",
+            "args": ["test", "--workspace"],
+            "cwd": "/repo",
+            "exit_code": 0,
+            "stdout": format!("prefix {}", "x".repeat(512)),
+            "stderr": "",
+            "trace_id": "trace-123",
+        });
+        let line = format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "tool": "shell.exec",
+                "tool_call_id": "call-shell",
+                "payload_summary": serde_json::to_string(&payload).expect("encode payload"),
+                "payload_chars": 8_192,
+                "payload_truncated": false
+            })
+        );
+
+        let reduced = reduce_followup_payload_for_model("tool_result", line.as_str());
+        let envelope: Value = serde_json::from_str(
+            reduced
+                .strip_prefix("[ok] ")
+                .expect("tool result line should preserve status prefix"),
+        )
+        .expect("reduced followup envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("shell payload summary should stay valid json");
+
+        assert_eq!(summary["adapter"], "core-tools");
+        assert_eq!(summary["tool_name"], "shell.exec");
+        assert_eq!(summary["trace_id"], "trace-123");
+        assert_eq!(summary["command"], "cargo");
+        assert_eq!(summary["exit_code"], 0);
+        assert!(summary.get("stdout_preview").is_some());
+        assert_eq!(summary["stdout_truncated"], true);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -461,12 +461,12 @@ fn reduce_tool_result_line_for_model(line: &str) -> String {
     let Some(payload_summary) = envelope.get("payload_summary").and_then(Value::as_str) else {
         return line.to_owned();
     };
-    let Ok(payload_json) = serde_json::from_str::<Value>(payload_summary) else {
+    let Ok(mut payload_json) = serde_json::from_str::<Value>(payload_summary) else {
         return line.to_owned();
     };
     let reduced_summary = match tool_name {
         Some("file.read") => reduce_file_read_payload_summary(&payload_json),
-        Some("shell.exec") => reduce_shell_payload_summary(&payload_json),
+        Some("shell.exec") => reduce_shell_payload_summary(&mut payload_json),
         _ => None,
     };
     let Some(reduced_summary) = reduced_summary else {
@@ -501,14 +501,14 @@ fn reduce_file_read_payload_summary(payload: &Value) -> Option<String> {
     .ok()
 }
 
-fn reduce_shell_payload_summary(payload: &Value) -> Option<String> {
-    let mut reduced_payload = payload.as_object()?.clone();
-    let stdout_truncated = replace_shell_stdio_with_preview(&mut reduced_payload, "stdout");
-    let stderr_truncated = replace_shell_stdio_with_preview(&mut reduced_payload, "stderr");
+fn reduce_shell_payload_summary(payload: &mut Value) -> Option<String> {
+    let payload_object = payload.as_object_mut()?;
+    let stdout_truncated = replace_shell_stdio_with_preview(payload_object, "stdout");
+    let stderr_truncated = replace_shell_stdio_with_preview(payload_object, "stderr");
     if !stdout_truncated && !stderr_truncated {
         return None;
     }
-    serde_json::to_string(&Value::Object(reduced_payload)).ok()
+    serde_json::to_string(payload).ok()
 }
 
 fn replace_shell_stdio_with_preview(
@@ -542,10 +542,7 @@ fn summarize_file_read_content_preview(value: Option<&Value>) -> (String, usize,
 }
 
 fn summarize_shell_output_preview(value: Option<&Value>) -> (String, usize, bool) {
-    let text = value
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .unwrap_or_default();
+    let text = value.and_then(Value::as_str).unwrap_or_default();
     let total_chars = text.chars().count();
     if total_chars <= SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS {
         return (text.to_owned(), total_chars, false);
@@ -837,6 +834,38 @@ fn parse_external_skill_invoke_context_line(line: &str) -> Option<ExternalSkillI
         display_name,
         instructions,
     })
+}
+
+#[cfg(test)]
+pub(crate) fn parse_tool_result_followup_for_test(messages: &[Value]) -> (Value, Value) {
+    let assistant_tool_result = messages
+        .iter()
+        .find(|message| {
+            message.get("role") == Some(&Value::String("assistant".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
+        })
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_str)
+        .expect("assistant tool_result followup message should exist");
+    let line = assistant_tool_result
+        .lines()
+        .nth(1)
+        .expect("assistant tool_result should keep payload line");
+    let envelope: Value = serde_json::from_str(
+        line.strip_prefix("[ok] ")
+            .expect("tool result line should preserve status prefix"),
+    )
+    .expect("followup envelope should stay valid json");
+    let summary: Value = serde_json::from_str(
+        envelope["payload_summary"]
+            .as_str()
+            .expect("payload summary should stay encoded json"),
+    )
+    .expect("payload summary should stay valid json");
+    (envelope, summary)
 }
 
 #[cfg(test)]
@@ -1520,6 +1549,59 @@ mod tests {
         assert_eq!(summary["exit_code"], 0);
         assert!(summary.get("stdout_preview").is_some());
         assert_eq!(summary["stdout_truncated"], true);
+    }
+
+    #[test]
+    fn reduce_followup_payload_for_model_counts_raw_shell_whitespace() {
+        let payload = json!({
+            "adapter": "core-tools",
+            "tool_name": "shell.exec",
+            "command": "printf",
+            "args": ["%s", " "],
+            "cwd": "/repo",
+            "exit_code": 0,
+            "stdout": " ".repeat(SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS + 32),
+            "stderr": "",
+        });
+        let line = format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "tool": "shell.exec",
+                "tool_call_id": "call-shell",
+                "payload_summary": serde_json::to_string(&payload).expect("encode payload"),
+                "payload_chars": 8_192,
+                "payload_truncated": false
+            })
+        );
+
+        let reduced = reduce_followup_payload_for_model("tool_result", line.as_str());
+        let envelope: Value = serde_json::from_str(
+            reduced
+                .strip_prefix("[ok] ")
+                .expect("tool result line should preserve status prefix"),
+        )
+        .expect("reduced followup envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("shell payload summary should stay valid json");
+
+        assert_eq!(summary["stdout_truncated"], true);
+        assert_eq!(
+            summary["stdout_chars"],
+            json!(SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS + 32)
+        );
+        assert_eq!(
+            summary["stdout_preview"]
+                .as_str()
+                .expect("stdout preview should exist")
+                .chars()
+                .count(),
+            SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS
+        );
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -18,6 +18,7 @@ pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rou
 
 const FILE_READ_FOLLOWUP_CONTENT_PREVIEW_CHARS: usize = 384;
 const SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS: usize = 384;
+const SHELL_FOLLOWUP_STDIO_OMISSION_MARKER: &str = "\n[... omitted ...]\n";
 
 pub fn next_conversation_turn_id() -> String {
     static NEXT_CONVERSATION_TURN_SEQ: AtomicU64 = AtomicU64::new(1);
@@ -547,10 +548,33 @@ fn summarize_shell_output_preview(value: Option<&Value>) -> (String, usize, bool
     if total_chars <= SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS {
         return (text.to_owned(), total_chars, false);
     }
+    let marker_chars = SHELL_FOLLOWUP_STDIO_OMISSION_MARKER.chars().count();
+    let Some(available_chars) = SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS.checked_sub(marker_chars) else {
+        return (
+            text.chars()
+                .take(SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS)
+                .collect(),
+            total_chars,
+            true,
+        );
+    };
+    if available_chars < 2 {
+        return (
+            text.chars()
+                .take(SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS)
+                .collect(),
+            total_chars,
+            true,
+        );
+    }
+
+    let tail_chars = available_chars / 2;
+    let head_chars = available_chars - tail_chars;
+    let head: String = text.chars().take(head_chars).collect();
+    let tail: String = text.chars().skip(total_chars - tail_chars).collect();
+
     (
-        text.chars()
-            .take(SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS)
-            .collect(),
+        format!("{head}{SHELL_FOLLOWUP_STDIO_OMISSION_MARKER}{tail}"),
         total_chars,
         true,
     )
@@ -1601,6 +1625,67 @@ mod tests {
                 .chars()
                 .count(),
             SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS
+        );
+    }
+
+    #[test]
+    fn reduce_followup_payload_for_model_preserves_shell_tail_context() {
+        let stdout = format!(
+            "{}\n{}\n{}",
+            "build log ".repeat(80),
+            "intermediate output ".repeat(80),
+            "final status: test suite failed on browser companion startup"
+        );
+        let payload = json!({
+            "adapter": "core-tools",
+            "tool_name": "shell.exec",
+            "command": "cargo",
+            "args": ["test", "--workspace"],
+            "cwd": "/repo",
+            "exit_code": 1,
+            "stdout": stdout,
+            "stderr": "",
+        });
+        let line = format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "tool": "shell.exec",
+                "tool_call_id": "call-shell",
+                "payload_summary": serde_json::to_string(&payload).expect("encode payload"),
+                "payload_chars": 8_192,
+                "payload_truncated": false
+            })
+        );
+
+        let reduced = reduce_followup_payload_for_model("tool_result", line.as_str());
+        let envelope: Value = serde_json::from_str(
+            reduced
+                .strip_prefix("[ok] ")
+                .expect("tool result line should preserve status prefix"),
+        )
+        .expect("reduced followup envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("shell payload summary should stay valid json");
+        let preview = summary["stdout_preview"]
+            .as_str()
+            .expect("stdout preview should exist");
+
+        assert!(
+            preview.contains("build log"),
+            "preview should keep shell prefix"
+        );
+        assert!(
+            preview.contains("final status: test suite failed on browser companion startup"),
+            "preview should keep the final shell status"
+        );
+        assert!(
+            preview.contains("[... omitted ...]"),
+            "preview should signal when middle content is omitted"
         );
     }
 

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -17,6 +17,7 @@ pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "A managed external skill has b
 pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
 
 const FILE_READ_FOLLOWUP_CONTENT_PREVIEW_CHARS: usize = 384;
+const SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS: usize = 384;
 
 pub fn next_conversation_turn_id() -> String {
     static NEXT_CONVERSATION_TURN_SEQ: AtomicU64 = AtomicU64::new(1);
@@ -456,16 +457,19 @@ fn reduce_tool_result_line_for_model(line: &str) -> String {
     let Ok(mut envelope) = serde_json::from_str::<Value>(payload) else {
         return line.to_owned();
     };
-    if envelope.get("tool").and_then(Value::as_str) != Some("file.read") {
-        return line.to_owned();
-    }
+    let tool_name = envelope.get("tool").and_then(Value::as_str);
     let Some(payload_summary) = envelope.get("payload_summary").and_then(Value::as_str) else {
         return line.to_owned();
     };
     let Ok(payload_json) = serde_json::from_str::<Value>(payload_summary) else {
         return line.to_owned();
     };
-    let Some(reduced_summary) = reduce_file_read_payload_summary(&payload_json) else {
+    let reduced_summary = match tool_name {
+        Some("file.read") => reduce_file_read_payload_summary(&payload_json),
+        Some("shell.exec") => reduce_shell_payload_summary(&payload_json),
+        _ => None,
+    };
+    let Some(reduced_summary) = reduced_summary else {
         return line.to_owned();
     };
     let Some(envelope_object) = envelope.as_object_mut() else {
@@ -497,6 +501,30 @@ fn reduce_file_read_payload_summary(payload: &Value) -> Option<String> {
     .ok()
 }
 
+fn reduce_shell_payload_summary(payload: &Value) -> Option<String> {
+    let payload_object = payload.as_object()?;
+    let (stdout_preview, stdout_chars, stdout_truncated) =
+        summarize_shell_output_preview(payload_object.get("stdout"));
+    let (stderr_preview, stderr_chars, stderr_truncated) =
+        summarize_shell_output_preview(payload_object.get("stderr"));
+    if !stdout_truncated && !stderr_truncated {
+        return None;
+    }
+    serde_json::to_string(&serde_json::json!({
+        "command": payload_object.get("command").cloned().unwrap_or(Value::Null),
+        "args": payload_object.get("args").cloned().unwrap_or_else(|| serde_json::json!([])),
+        "cwd": payload_object.get("cwd").cloned().unwrap_or(Value::Null),
+        "exit_code": payload_object.get("exit_code").cloned().unwrap_or(Value::Null),
+        "stdout_preview": stdout_preview,
+        "stdout_chars": stdout_chars,
+        "stdout_truncated": stdout_truncated,
+        "stderr_preview": stderr_preview,
+        "stderr_chars": stderr_chars,
+        "stderr_truncated": stderr_truncated,
+    }))
+    .ok()
+}
+
 fn summarize_file_read_content_preview(value: Option<&Value>) -> (String, usize, bool) {
     let text = value.and_then(Value::as_str).unwrap_or_default();
     let total_chars = text.chars().count();
@@ -506,6 +534,24 @@ fn summarize_file_read_content_preview(value: Option<&Value>) -> (String, usize,
     (
         text.chars()
             .take(FILE_READ_FOLLOWUP_CONTENT_PREVIEW_CHARS)
+            .collect(),
+        total_chars,
+        true,
+    )
+}
+
+fn summarize_shell_output_preview(value: Option<&Value>) -> (String, usize, bool) {
+    let text = value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default();
+    let total_chars = text.chars().count();
+    if total_chars <= SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS {
+        return (text.to_owned(), total_chars, false);
+    }
+    (
+        text.chars()
+            .take(SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS)
             .collect(),
         total_chars,
         true,

--- a/docs/plans/2026-03-16-shell-followup-payload-reducer-implementation-plan.md
+++ b/docs/plans/2026-03-16-shell-followup-payload-reducer-implementation-plan.md
@@ -21,7 +21,7 @@
 Add tests that prove:
 - discovery-first follow-up messages reduce oversized `shell.exec` payload summaries before the next provider round
 - reduced shell payloads mark `payload_truncated=true`
-- `tool.search` follow-up payloads remain untouched so lease parsing semantics are preserved
+- `tool.search` follow-up payloads remain untouched so payload parsing semantics are preserved
 - raw-output reply behavior is not part of this reducer path
 
 **Step 2: Run test to verify it fails**

--- a/docs/plans/2026-03-16-shell-followup-payload-reducer-implementation-plan.md
+++ b/docs/plans/2026-03-16-shell-followup-payload-reducer-implementation-plan.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add failing tests for shell follow-up payload reduction
+## Task 1: Add failing tests for shell follow-up payload reduction
 
 **Files:**
 - Modify: `crates/app/src/conversation/turn_coordinator.rs`
@@ -38,7 +38,7 @@ Add focused tests proving turn-loop follow-up assembly also reduces shell payloa
 Run: `cargo test -p loongclaw-app append_tool_driven_followup_messages_reduces_shell_exec_payload_summary -- --exact --nocapture`
 Expected: FAIL because the turn-loop path currently only applies generic text truncation.
 
-### Task 2: Implement the reducer in shared follow-up assembly
+## Task 2: Implement the reducer in shared follow-up assembly
 
 **Files:**
 - Modify: `crates/app/src/conversation/turn_shared.rs`
@@ -71,7 +71,7 @@ Do not:
 - add new config surface in this slice
 - add reducer behavior for `file.read`, `web.fetch`, or `tool.search`
 
-### Task 3: Verify and document the slice
+## Task 3: Verify and document the slice
 
 **Files:**
 - Modify: `docs/plans/2026-03-16-shell-followup-payload-reducer-implementation-plan.md`

--- a/docs/plans/2026-03-16-shell-followup-payload-reducer-implementation-plan.md
+++ b/docs/plans/2026-03-16-shell-followup-payload-reducer-implementation-plan.md
@@ -1,0 +1,110 @@
+# Shell Follow-up Payload Reducer Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Reduce model-facing token waste from oversized `shell.exec` outputs during tool-result follow-up rounds without changing raw tool output semantics.
+
+**Architecture:** Keep `ToolCoreOutcome` and `TurnEngine` output unchanged so explicit raw-output requests still receive the original tool result envelope. Apply a shell-specific reducer only when follow-up provider messages are assembled, reusing the existing structured tool-result envelope and truncation signaling instead of adding a new transport or storage path.
+
+**Tech Stack:** Rust, serde_json, existing conversation follow-up assembly in `turn_shared.rs`, `turn_loop.rs`, and `turn_coordinator.rs`.
+
+---
+
+### Task 1: Add failing tests for shell follow-up payload reduction
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+- discovery-first follow-up messages reduce oversized `shell.exec` payload summaries before the next provider round
+- reduced shell payloads mark `payload_truncated=true`
+- `tool.search` follow-up payloads remain untouched so lease parsing semantics are preserved
+- raw-output reply behavior is not part of this reducer path
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app build_turn_reply_followup_messages_reduces_shell_exec_payload_summary -- --exact --nocapture`
+Expected: FAIL because discovery-first follow-up currently uses the raw tool result text unchanged.
+
+**Step 3: Add a turn-loop failing test**
+
+Add focused tests proving turn-loop follow-up assembly also reduces shell payloads before applying its generic payload budget, including the repeated-tool guard path that replays the latest tool context back to the provider.
+
+**Step 4: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-app append_tool_driven_followup_messages_reduces_shell_exec_payload_summary -- --exact --nocapture`
+Expected: FAIL because the turn-loop path currently only applies generic text truncation.
+
+### Task 2: Implement the reducer in shared follow-up assembly
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_shared.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+
+**Step 1: Add a shared shell follow-up reducer**
+
+Implement a helper in `turn_shared.rs` that:
+- only touches `[tool_result]` payloads
+- only rewrites structured envelopes for `shell.exec`
+- parses the envelope and nested `payload_summary`
+- replaces large `stdout`/`stderr` blobs with compact previews plus counts
+- preserves original `payload_chars`
+- flips `payload_truncated=true` whenever reduction happened
+- leaves non-shell tool results unchanged
+
+**Step 2: Route discovery-first follow-up assembly through the reducer**
+
+Update `build_turn_reply_followup_messages(...)` in `turn_coordinator.rs` so follow-up provider messages map tool payloads through the new reducer.
+
+**Step 3: Route turn-loop follow-up assembly through the reducer before budget truncation**
+
+Update `append_tool_driven_followup_messages(...)` and `append_repeated_tool_guard_followup_messages(...)` in `turn_loop.rs` so shell-specific reduction happens before the generic follow-up payload budget is applied.
+
+**Step 4: Keep the change minimal**
+
+Do not:
+- change `shell.exec` tool execution output
+- add new config surface in this slice
+- add reducer behavior for `file.read`, `web.fetch`, or `tool.search`
+
+### Task 3: Verify and document the slice
+
+**Files:**
+- Modify: `docs/plans/2026-03-16-shell-followup-payload-reducer-implementation-plan.md`
+
+**Step 1: Run focused tests**
+
+Run:
+- `cargo test -p loongclaw-app build_turn_reply_followup_messages_reduces_shell_exec_payload_summary -- --exact --nocapture`
+- `cargo test -p loongclaw-app append_tool_driven_followup_messages_reduces_shell_exec_payload_summary -- --exact --nocapture`
+- `cargo test -p loongclaw-app append_repeated_tool_guard_followup_messages_reduces_shell_exec_payload_summary -- --exact --nocapture`
+
+Expected: PASS
+
+**Step 2: Run adjacent regression tests**
+
+Run:
+- `cargo test -p loongclaw-app build_turn_reply_followup_messages_include_truncation_hint_for_truncated_tool_results -- --exact --nocapture`
+- `cargo test -p loongclaw-app build_turn_reply_followup_messages_promotes_external_skill_invoke_to_system_context -- --exact --nocapture`
+- `cargo test -p loongclaw-app build_turn_reply_followup_messages_rejects_truncated_external_skill_invoke_payload -- --exact --nocapture`
+- `cargo test -p loongclaw-app tool_loop_guard_tail_ -- --nocapture`
+
+Expected: PASS
+
+**Step 3: Run broader package verification**
+
+Run: `cargo test -p loongclaw-app conversation::turn_shared -- --nocapture`
+Expected: PASS
+
+**Step 4: Prepare GitHub delivery**
+
+Create or reuse a GitHub issue describing:
+- why `shell.exec` is a token hotspot
+- why the reducer is follow-up-only instead of execution-path wide
+- follow-on work for `file.read` and `web.fetch`
+
+Open a PR linked to that issue with validation evidence from the commands above.


### PR DESCRIPTION
## Summary

- add a shared follow-up reducer for oversized `shell.exec` tool-result payloads
- apply it in discovery-first follow-up assembly, turn-loop follow-up assembly, and repeated-tool guard replay
- preserve raw tool output semantics and leave non-shell follow-up payloads such as `tool.search` unchanged

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional checks:
- `cargo test -p loongclaw-app build_turn_reply_followup_messages_ -- --nocapture`
- `cargo test -p loongclaw-app append_tool_driven_followup_messages_ -- --nocapture`
- `cargo test -p loongclaw-app append_repeated_tool_guard_followup_messages_ -- --nocapture`
- `cargo test -p loongclaw-app tool_result_followup_tail_ -- --nocapture`
- `cargo test -p loongclaw-app tool_loop_guard_tail_ -- --nocapture`

## Linked Issues

Closes #227


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell command outputs in tool follow-ups are now condensed with previews and truncation indicators, reducing payload size while preserving essential information.

* **Tests**
  * Added comprehensive tests validating shell output reduction behavior, preview generation, and truncation signaling in tool follow-up messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->