### PR TITLE
fix(daemon): harden runtime restore artifact safety

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1571,7 +1571,11 @@ fn normalize_runtime_snapshot_restore_provider_profile(
         .headers
         .iter()
         .filter(|(header_name, header_value)| {
-            !runtime_snapshot_provider_header_is_safe_to_persist(header_name, header_value)
+            !runtime_snapshot_provider_header_is_safe_to_persist(
+                profile.provider.kind,
+                header_name,
+                header_value,
+            )
         })
         .map(|(header_name, _)| header_name.clone())
         .collect::<Vec<_>>();
@@ -1602,6 +1606,7 @@ fn runtime_snapshot_redact_provider_secret_field(
 }
 
 fn runtime_snapshot_provider_header_is_safe_to_persist(
+    provider_kind: mvp::config::ProviderKind,
     header_name: &str,
     header_value: &str,
 ) -> bool {
@@ -1616,13 +1621,18 @@ fn runtime_snapshot_provider_header_is_safe_to_persist(
             | "accept-charset"
             | "accept-encoding"
             | "accept-language"
+            | "anthropic-version"
             | "cache-control"
             | "content-language"
             | "content-type"
             | "pragma"
             | "user-agent"
-    ) || normalized.ends_with("-version")
-        || normalized.ends_with("-beta")
+            | "anthropic-beta"
+            | "openai-beta"
+    ) || provider_kind
+        .default_headers()
+        .iter()
+        .any(|(default_name, _)| default_name.eq_ignore_ascii_case(&normalized))
 }
 
 fn runtime_snapshot_canonical_env_reference(env_name: Option<&str>) -> Option<String> {
@@ -1707,8 +1717,14 @@ fn build_runtime_snapshot_restore_managed_skills_spec(
         .filter(|skill| skill.get("scope").and_then(Value::as_str) == Some("managed"))
         .filter_map(|skill| {
             let skill_id = skill.get("skill_id").and_then(Value::as_str)?;
-            let display_name = skill.get("display_name").and_then(Value::as_str)?;
-            let summary = skill.get("summary").and_then(Value::as_str)?;
+            let display_name = skill
+                .get("display_name")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let summary = skill
+                .get("summary")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
             let source_kind = skill.get("source_kind").and_then(Value::as_str)?;
             let source_path = skill.get("source_path").and_then(Value::as_str)?;
             let sha256 = skill.get("sha256").and_then(Value::as_str)?;
@@ -1725,6 +1741,82 @@ fn build_runtime_snapshot_restore_managed_skills_spec(
     managed_skills.sort_by(|left, right| left.skill_id.cmp(&right.skill_id));
     RuntimeSnapshotRestoreManagedSkillsSpec {
         skills: managed_skills,
+    }
+}
+
+#[cfg(test)]
+mod runtime_snapshot_restore_spec_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn runtime_snapshot_restore_managed_skills_keeps_entries_without_display_metadata() {
+        let mut warnings = Vec::new();
+        let spec = build_runtime_snapshot_restore_managed_skills_spec(
+            &RuntimeSnapshotExternalSkillsState {
+                policy: mvp::tools::runtime_config::ExternalSkillsRuntimePolicy::default(),
+                override_active: false,
+                inventory_status: RuntimeSnapshotInventoryStatus::Ok,
+                inventory_error: None,
+                inventory: json!({
+                    "skills": [{
+                        "scope": "managed",
+                        "skill_id": "demo-skill",
+                        "source_kind": "directory",
+                        "source_path": "/tmp/demo-skill",
+                        "sha256": "deadbeef"
+                    }]
+                }),
+                resolved_skill_count: 1,
+                shadowed_skill_count: 0,
+            },
+            &mut warnings,
+        );
+
+        assert!(warnings.is_empty());
+        assert_eq!(spec.skills.len(), 1);
+        assert_eq!(spec.skills[0].skill_id, "demo-skill");
+        assert!(spec.skills[0].display_name.is_empty());
+        assert!(spec.skills[0].summary.is_empty());
+    }
+
+    #[test]
+    fn runtime_snapshot_provider_header_safety_uses_explicit_safe_names_only() {
+        assert!(runtime_snapshot_provider_header_is_safe_to_persist(
+            mvp::config::ProviderKind::Anthropic,
+            "anthropic-version",
+            "2023-06-01",
+        ));
+        assert!(runtime_snapshot_provider_header_is_safe_to_persist(
+            mvp::config::ProviderKind::Deepseek,
+            "anthropic-version",
+            "2023-06-01",
+        ));
+        assert!(runtime_snapshot_provider_header_is_safe_to_persist(
+            mvp::config::ProviderKind::Anthropic,
+            "anthropic-beta",
+            "prompt-caching-2024-07-31",
+        ));
+        assert!(runtime_snapshot_provider_header_is_safe_to_persist(
+            mvp::config::ProviderKind::Openai,
+            "openai-beta",
+            "assistants=v2",
+        ));
+        assert!(runtime_snapshot_provider_header_is_safe_to_persist(
+            mvp::config::ProviderKind::Deepseek,
+            "x-goog-api-key",
+            "${GOOGLE_API_KEY}",
+        ));
+        assert!(!runtime_snapshot_provider_header_is_safe_to_persist(
+            mvp::config::ProviderKind::Deepseek,
+            "x-secret-beta",
+            "literal-secret",
+        ));
+        assert!(!runtime_snapshot_provider_header_is_safe_to_persist(
+            mvp::config::ProviderKind::Deepseek,
+            "x-secret-version",
+            "literal-secret",
+        ));
     }
 }
 

--- a/crates/daemon/tests/integration/runtime_restore_cli.rs
+++ b/crates/daemon/tests/integration/runtime_restore_cli.rs
@@ -328,6 +328,7 @@ fn runtime_snapshot_artifact_json_redacts_inline_provider_secrets_from_restore_s
                         "literal-header-secret".to_owned(),
                     ),
                     ("anthropic-version".to_owned(), "2023-06-01".to_owned()),
+                    ("x-secret-beta".to_owned(), "literal-beta-secret".to_owned()),
                     ("x-goog-api-key".to_owned(), "${GOOGLE_API_KEY}".to_owned()),
                     ("user-agent".to_owned(), "loongclaw-test-suite".to_owned()),
                 ]),
@@ -345,18 +346,24 @@ fn runtime_snapshot_artifact_json_redacts_inline_provider_secrets_from_restore_s
     assert!(profile["oauth_access_token"].is_null());
     assert!(profile["headers"]["anthropic-api-key"].is_null());
     assert_eq!(profile["headers"]["anthropic-version"], "2023-06-01");
+    assert!(profile["headers"]["x-secret-beta"].is_null());
     assert_eq!(profile["headers"]["x-goog-api-key"], "${GOOGLE_API_KEY}");
     assert_eq!(profile["headers"]["user-agent"], "loongclaw-test-suite");
+    let warnings = payload["restore_spec"]["warnings"]
+        .as_array()
+        .expect("warnings should be an array");
     assert!(
-        payload["restore_spec"]["warnings"]
-            .as_array()
-            .expect("warnings should be an array")
+        warnings.iter().filter_map(Value::as_str).any(
+            |warning| warning.contains("deepseek-lab") && warning.contains("anthropic-api-key")
+        ),
+        "restore spec should surface a warning for the redacted anthropic api key header"
+    );
+    assert!(
+        warnings
             .iter()
             .filter_map(Value::as_str)
-            .any(|warning| {
-                warning.contains("deepseek-lab") && warning.contains("anthropic-api-key")
-            }),
-        "restore spec should surface a warning for redacted inline provider headers"
+            .any(|warning| warning.contains("deepseek-lab") && warning.contains("x-secret-beta")),
+        "restore spec should surface a warning for the redacted beta-style secret header"
     );
 }
 


### PR DESCRIPTION
## Summary

- follow up merged `#211` by tightening restore artifact header persistence to explicit safe names, env references, and provider default metadata headers
- keep managed skill entries in `restore_spec` when only descriptive metadata is missing but the restore-critical identity fields are present
- add unit and integration regression coverage for both cases, including the redacted `x-secret-beta` path and the known-safe `anthropic-version` path

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:
this follows up a merged restore-path change where broad suffix matching could persist inline secret headers into snapshot artifacts. the fix keeps the allowlist explicit while preserving known safe protocol metadata, and it prevents restore fidelity loss when managed skill inventory omits display-only fields.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [ ] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

before: managed skills without `display_name` or `summary` were dropped from `restore_spec`, and suffix-style `*-beta` / `*-version` matching could preserve broader inline headers than intended.
after: restore-critical managed skill entries stay present, provider headers persist only through the explicit safe path, and regression coverage proves both the redaction path and the known-safe metadata path.

the affected restore CLI integration tests already serialize and restore process-global env through `RuntimeRestoreEnvGuard`.

## Linked Issues

Closes #230


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider header validation to properly recognize safe headers based on provider type.
  * Enhanced managed skills metadata handling to gracefully use defaults when display information is missing.

* **Tests**
  * Added comprehensive tests for header safety validation across different provider configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->