### PR TITLE
Polish first-run handoff across onboard, doctor, and chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,8 @@ cargo install --path crates/daemon
    loongclaw ask --message "Summarize this repository and suggest the best next step."
    ```
 
-   On a healthy setup, onboarding and `doctor` now print this style of ask example directly so the
-   first success path is visible without reading docs first.
+   On a healthy setup, onboarding and `doctor` now print this style of first-answer handoff
+   directly, so the first success path is visible before secondary setup details.
 
 4. Continue with interactive chat when you want to stay in session:
 
@@ -274,11 +274,11 @@ cargo install --path crates/daemon
    Use `loongclaw chat --acp` when you want this chat session to route turns through ACP
    explicitly. Without `--acp` or other ACP-specific chat flags, normal chat stays on the default
    provider/context-engine path. The chat banner now starts with a concrete first prompt and keeps
-   the ACP/runtime context in a compact operator-readable block.
+   session/runtime context in secondary detail sections.
 
 Run `loongclaw doctor --fix` if anything goes wrong, or when onboarding / ask / chat reports a
 local health issue. `doctor` now prints next actions such as credential env hints, safe repair
-commands, and ask/chat follow-ups instead of only raw status lines.
+commands, and clear first-answer/chat follow-ups instead of only raw status lines.
 
 ### Run Tests
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -380,12 +380,14 @@ fn build_cli_chat_startup_summary(
 fn render_cli_chat_startup_lines(summary: &CliChatStartupSummary) -> Vec<String> {
     let mut lines = vec![
         "loongclaw chat ready".to_owned(),
+        "start here".to_owned(),
+        format!("- first prompt: {DEFAULT_FIRST_PROMPT}"),
+        "- type your request, or use /help for commands".to_owned(),
+        "session details".to_owned(),
         format!("- session: {}", summary.session_id),
         format!("- config: {}", summary.config_path),
         format!("- memory: {}", summary.memory_label),
-        "- start typing a request, or use /help for commands".to_owned(),
-        format!("- try this first: {DEFAULT_FIRST_PROMPT}"),
-        "assistant runtime".to_owned(),
+        "runtime details".to_owned(),
     ];
 
     let allowed_channels = if summary.allowed_channels.is_empty() {
@@ -1903,22 +1905,33 @@ mod tests {
         });
 
         assert_eq!(lines[0], "loongclaw chat ready");
-        assert!(lines.iter().any(|line| line == "- session: default"));
         assert!(
-            lines
-                .iter()
-                .any(|line| line == "- start typing a request, or use /help for commands"),
-            "chat startup should read like a product entry point instead of a raw runtime dump: {lines:#?}"
+            lines.iter().any(|line| line == "start here"),
+            "chat startup should lead with a dedicated first-action heading: {lines:#?}"
         );
         assert!(
             lines.iter().any(|line| {
-                line == "- try this first: Summarize this repository and suggest the best next step."
+                line == "- first prompt: Summarize this repository and suggest the best next step."
             }),
             "chat startup should suggest a concrete first prompt: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "assistant runtime"),
-            "chat startup should still preserve a compact runtime section for operator context: {lines:#?}"
+            lines
+                .iter()
+                .any(|line| line == "- type your request, or use /help for commands"),
+            "chat startup should keep the usage hint, but under the assistant-first opening block: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == "session details"),
+            "chat startup should tuck session/config facts into a secondary section: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == "runtime details"),
+            "chat startup should still preserve runtime context in a compact secondary section: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == "- session: default"),
+            "chat startup should continue to show session identity after the handoff block: {lines:#?}"
         );
     }
 

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1186,8 +1186,8 @@ fn build_doctor_next_steps_with_path_env(
             ),
         ) {
             let prefix = match action.kind {
-                crate::next_actions::SetupNextActionKind::Ask => "Try a one-shot task",
-                crate::next_actions::SetupNextActionKind::Chat => "Open interactive chat",
+                crate::next_actions::SetupNextActionKind::Ask => "Get a first answer",
+                crate::next_actions::SetupNextActionKind::Chat => "Continue in chat",
                 crate::next_actions::SetupNextActionKind::Channel => "Open a channel",
                 crate::next_actions::SetupNextActionKind::BrowserPreview => {
                     match action.browser_preview_phase {
@@ -2080,13 +2080,13 @@ mod tests {
 
         assert!(
             next_steps.iter().any(|step| {
-                step == "Try a one-shot task: loongclaw ask --config '/tmp/loongclaw.toml' --message 'Summarize this repository and suggest the best next step.'"
+                step == "Get a first answer: loongclaw ask --config '/tmp/loongclaw.toml' --message 'Summarize this repository and suggest the best next step.'"
             }),
             "green doctor runs should hand the user into ask immediately: {next_steps:#?}"
         );
         assert!(
             next_steps.iter().any(|step| {
-                step == "Open interactive chat: loongclaw chat --config '/tmp/loongclaw.toml'"
+                step == "Continue in chat: loongclaw chat --config '/tmp/loongclaw.toml'"
             }),
             "green doctor runs should still advertise chat as the follow-up path: {next_steps:#?}"
         );

--- a/crates/daemon/src/next_actions.rs
+++ b/crates/daemon/src/next_actions.rs
@@ -49,7 +49,7 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
         actions.push(SetupNextAction {
             kind: SetupNextActionKind::Ask,
             browser_preview_phase: None,
-            label: "ask example".to_owned(),
+            label: "first answer".to_owned(),
             command: crate::cli_handoff::format_ask_with_config(
                 config_path,
                 DEFAULT_FIRST_ASK_MESSAGE,

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2837,6 +2837,39 @@ fn render_onboarding_success_summary_with_width_and_style(
     let mut lines = render_onboard_brand_header(width, "setup complete", color_enabled);
     lines.push(String::new());
     lines.push("onboarding complete".to_owned());
+    if !summary.next_actions.is_empty() {
+        let mut actions = summary.next_actions.iter();
+        if let Some(primary) = actions.next() {
+            if width < 56 {
+                lines.push("start here".to_owned());
+                lines.extend(mvp::presentation::render_wrapped_text_line(
+                    &format!("- {}: ", primary.label),
+                    &primary.command,
+                    width,
+                ));
+            } else {
+                lines.extend(mvp::presentation::render_wrapped_text_line(
+                    "start here: ",
+                    &primary.command,
+                    width,
+                ));
+            }
+        }
+
+        let secondary_actions = actions.collect::<Vec<_>>();
+        if !secondary_actions.is_empty() {
+            lines.push("also available".to_owned());
+            lines.extend(secondary_actions.into_iter().flat_map(|action| {
+                mvp::presentation::render_wrapped_text_line(
+                    &format!("- {}: ", action.label),
+                    &action.command,
+                    width,
+                )
+            }));
+        }
+    }
+
+    lines.push("saved setup".to_owned());
     lines.extend(mvp::presentation::render_wrapped_text_line(
         "- config: ",
         &summary.config_path,
@@ -2931,41 +2964,6 @@ fn render_onboarding_success_summary_with_width_and_style(
             width,
         ));
     }
-    if summary.next_actions.is_empty() {
-        return lines;
-    }
-
-    let mut actions = summary.next_actions.iter();
-    if let Some(primary) = actions.next() {
-        if width < 56 {
-            lines.push("start here".to_owned());
-            lines.extend(mvp::presentation::render_wrapped_text_line(
-                &format!("- {}: ", primary.label),
-                &primary.command,
-                width,
-            ));
-        } else {
-            lines.extend(mvp::presentation::render_wrapped_text_line(
-                "start here: ",
-                &primary.command,
-                width,
-            ));
-        }
-    }
-
-    let secondary_actions = actions.collect::<Vec<_>>();
-    if secondary_actions.is_empty() {
-        return lines;
-    }
-
-    lines.push("also available".to_owned());
-    lines.extend(secondary_actions.into_iter().flat_map(|action| {
-        mvp::presentation::render_wrapped_text_line(
-            &format!("- {}: ", action.label),
-            &action.command,
-            width,
-        )
-    }));
     lines
 }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -4360,7 +4360,7 @@ fn onboarding_success_summary_derives_structured_actions() {
         summary.next_actions[4].kind,
         crate::onboard_cli::OnboardingActionKind::BrowserPreview
     );
-    assert_eq!(summary.next_actions[0].label, "ask example");
+    assert_eq!(summary.next_actions[0].label, "first answer");
     assert_eq!(summary.next_actions[1].label, "chat");
     assert_eq!(summary.next_actions[2].label, "telegram");
     assert_eq!(summary.next_actions[3].label, "feishu");
@@ -5653,7 +5653,7 @@ fn render_onboarding_success_summary_compacts_for_narrow_width() {
     assert!(
         lines
             .iter()
-            .any(|line| line == "- ask example: loongclaw ask --config")
+            .any(|line| line == "- first answer: loongclaw ask --config")
             && lines
                 .iter()
                 .any(|line| line == "  '/tmp/loongclaw-config.toml' --message")
@@ -5661,7 +5661,7 @@ fn render_onboarding_success_summary_compacts_for_narrow_width() {
                 .iter()
                 .any(|line| line == "  'Summarize this repository and suggest the")
             && lines.iter().any(|line| line == "  best next step.'"),
-        "narrow renderer should keep the primary ask example readable even when the command wraps: {lines:#?}"
+        "narrow renderer should keep the primary first-answer handoff readable even when the command wraps: {lines:#?}"
     );
     assert!(
         lines.iter().any(|line| line == "also available"),
@@ -5675,6 +5675,32 @@ fn render_onboarding_success_summary_compacts_for_narrow_width() {
                 .iter()
                 .any(|line| line == "- telegram: loongclaw telegram-serve --config"),
         "narrow renderer should keep secondary chat and channel actions visible after the primary ask example: {lines:#?}"
+    );
+}
+
+#[test]
+fn onboarding_success_summary_surfaces_primary_handoff_before_saved_setup_details() {
+    let path = PathBuf::from("/tmp/loongclaw-config.toml");
+    let summary = loongclaw_daemon::onboard_cli::build_onboarding_success_summary(
+        &path,
+        &mvp::config::LoongClawConfig::default(),
+        None,
+    );
+
+    let lines =
+        loongclaw_daemon::onboard_cli::render_onboarding_success_summary_with_width(&summary, 80);
+    let start_here_index = lines
+        .iter()
+        .position(|line| line.starts_with("start here:"))
+        .expect("start here line should exist");
+    let saved_setup_index = lines
+        .iter()
+        .position(|line| line == "saved setup")
+        .expect("saved setup heading should exist");
+
+    assert!(
+        start_here_index < saved_setup_index,
+        "onboarding should show the first runnable handoff before the saved setup inventory: {lines:#?}"
     );
 }
 

--- a/docs/PRODUCT_SENSE.md
+++ b/docs/PRODUCT_SENSE.md
@@ -15,7 +15,7 @@ LoongClaw is not only a runtime for developers. The current MVP is aimed at:
 1. **First value fast** — a new user should get to a useful assistant answer quickly, not after reading implementation docs.
 2. **Safe by default** — visible capabilities must still honor policy, approval, and audit boundaries.
 3. **Assistant-first surfaces** — user-facing capability should feel like “my assistant can do this”, not only “the platform exposes an adapter”.
-4. **Progressive disclosure** — `onboard`, `ask`, `chat`, and `doctor` carry the common path; advanced config stays available without taking over the story.
+4. **Progressive disclosure** — `onboard`, `ask`, `chat`, and `doctor` carry the common path; each surface should lead with the next user action before exposing runtime detail.
 5. **One runtime, many surfaces** — CLI ask, interactive chat, and future surfaces should share the same conversation, memory, tool, and provider semantics.
 6. **Fail loud with a repair path** — when setup or runtime health breaks, LoongClaw must point users toward `doctor` instead of leaving them in silent failure.
 
@@ -35,6 +35,9 @@ The current product contract is:
 6. Enable Telegram or Feishu only after the base CLI flow is healthy.
 
 This keeps the first-run journey legible while preserving the existing runtime architecture.
+
+For the current MVP, that also means first-run surfaces should feel assistant-first in their copy:
+show the runnable handoff first, then keep config, memory, and runtime facts in secondary detail blocks.
 
 ## Product Specifications
 

--- a/docs/plans/2026-03-16-first-run-handoff-polish-design.md
+++ b/docs/plans/2026-03-16-first-run-handoff-polish-design.md
@@ -1,0 +1,181 @@
+# First-Run Handoff Polish Design
+
+## Goal
+
+Make the first healthy LoongClaw experience feel more like an assistant and
+less like a runtime by elevating the first runnable handoff in `onboard`,
+`doctor`, and `chat` without changing any underlying provider, memory, or tool
+semantics.
+
+## Current State
+
+- `loongclaw onboard` already ends with a branded success summary and structured
+  next actions.
+- `loongclaw doctor` already emits concrete next steps for healthy and repair
+  flows.
+- `loongclaw chat` already suggests a first prompt before dropping into the
+  REPL.
+- The remaining friction is mostly ordering and copy:
+  - onboarding buries the first runnable action below saved config detail
+  - doctor handoff text still reads like command taxonomy
+  - chat still opens with session/runtime metadata before fully settling into an
+    assistant-first posture
+
+## Problem
+
+The runtime behavior is now much closer to the intended MVP, but the first
+impression still leaks operator-internal framing:
+
+1. users see detailed setup state before the "what do I do now?" answer
+2. healthy `doctor` output is actionable, but not yet phrased as a product
+   handoff
+3. `chat` still feels like entering a console before it feels like entering an
+   assistant
+
+That gap is small, but it is exactly the kind of surface-level friction that
+causes the MVP to feel more technical than it is.
+
+## Constraints
+
+- Keep the change narrow and local to first-run UX.
+- Do not add new runtime capabilities.
+- Do not change `ask` execution semantics or add extra output after one-shot
+  responses, because that would make the CLI less script-friendly and would
+  drift from the one-shot ask product contract.
+- Avoid introducing new generic rendering abstractions unless duplication
+  becomes clearly harmful.
+
+## Options
+
+### Option A: Docs-only refresh
+
+Update README and specs, but leave CLI surfaces unchanged.
+
+Pros:
+
+- minimal code risk
+- easy to ship
+
+Cons:
+
+- does not improve the actual first impression inside the product
+- users still encounter the same ordering and copy problems in the CLI
+
+### Option B: Copy-only patch
+
+Change some labels and headings, but keep current surface ordering intact.
+
+Pros:
+
+- low implementation cost
+- can improve wording quickly
+
+Cons:
+
+- does not solve the more important issue that onboarding still presents
+  inventory before action
+- leaves chat startup structurally runtime-first
+
+### Option C: Handoff-first polish with minimal structural changes
+
+Keep the current runtime and renderers, but:
+
+- move the primary onboarding handoff above the saved setup inventory
+- tighten doctor handoff copy around user intent
+- restructure chat startup into assistant-first followed by compact detail
+  sections
+
+Pros:
+
+- directly improves the perceived product quality of the current MVP
+- stays small and local
+- aligns all three surfaces around the same user mental model
+
+Cons:
+
+- touches several separate CLI surfaces and tests
+- requires care to avoid accidental scope creep into larger renderer refactors
+
+## Decision
+
+Choose Option C.
+
+This is the smallest change that materially improves the first-run experience.
+The right fix is not a new abstraction layer or new capability; it is a
+handful of deliberate structural and copy adjustments across the existing
+surfaces.
+
+## Design
+
+### 1. Promote the primary onboarding handoff
+
+`render_onboarding_success_summary_with_width_and_style(...)` should move the
+primary next action directly under the initial completion block, before the
+saved provider/prompt/memory inventory.
+
+The saved configuration details still matter, but they should become a secondary
+"saved setup" section rather than the first thing a user must read.
+
+### 2. Normalize the ask handoff label
+
+`collect_setup_next_actions(...)` should stop labeling the primary ask action as
+`ask example` and instead use a more product-shaped label such as `first
+answer`.
+
+This label is reused naturally by onboarding summaries, which keeps the visible
+language aligned without introducing a new adapter layer.
+
+### 3. Tighten doctor handoff copy
+
+`build_doctor_next_steps_with_path_env(...)` should keep its current logic and
+ordering, but update the healthy-state ask/chat prefixes to read more like next
+steps than command categories.
+
+Recommended direction:
+
+- `Get a first answer`
+- `Continue in chat`
+
+### 4. Reframe chat startup
+
+`render_cli_chat_startup_lines(...)` should open with:
+
+- readiness confirmation
+- a clear first thing to try
+- a compact usage hint
+
+Then it should separate operational metadata into compact secondary sections,
+for example:
+
+- `session details`
+- `runtime details`
+
+This keeps operator context available without letting it dominate the first
+screen.
+
+### 5. Keep one-shot ask unchanged
+
+Do not add extra post-response guidance to `run_cli_ask(...)`.
+
+The current first-run UX gap is already solved by improving how `ask` is
+advertised from `onboard`, `doctor`, and `chat`. Changing one-shot ask output
+itself would make the command noisier for script usage and violate the current
+product spec.
+
+## Non-Goals
+
+- changing the behavior of `loongclaw ask`
+- introducing WebChat
+- reworking onboarding flow control or provider probing
+- adding browser automation work in this slice
+- building a shared UI rendering framework across all daemon/app surfaces
+
+## Acceptance Criteria
+
+- onboarding success summaries show the primary runnable handoff before the
+  saved setup inventory
+- the shared ask handoff label is product-shaped rather than `ask example`
+- healthy doctor next steps read like user actions rather than command taxonomy
+- chat startup leads with a first prompt and relegates runtime metadata to
+  compact secondary sections
+- docs/specs match the shipped first-run handoff behavior

--- a/docs/plans/2026-03-16-first-run-handoff-polish-design.md
+++ b/docs/plans/2026-03-16-first-run-handoff-polish-design.md
@@ -32,7 +32,7 @@ impression still leaks operator-internal framing:
 3. `chat` still feels like entering a console before it feels like entering an
    assistant
 
-That gap is small, but it is exactly the kind of surface-level friction that
+That gap is small, but it is the kind of surface-level friction that
 causes the MVP to feel more technical than it is.
 
 ## Constraints

--- a/docs/plans/2026-03-16-first-run-handoff-polish-implementation.md
+++ b/docs/plans/2026-03-16-first-run-handoff-polish-implementation.md
@@ -1,0 +1,132 @@
+# First-Run Handoff Polish Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Elevate the first runnable assistant handoff across onboarding, doctor, and chat so healthy first-run UX feels assistant-first instead of runtime-first.
+
+**Architecture:** Keep the existing CLI/runtime surfaces intact, but adjust ordering and copy at the renderer boundary. Reuse `collect_setup_next_actions(...)` for shared action labels, move onboarding’s primary handoff above saved setup details, and restructure chat startup into assistant-first followed by compact detail sections.
+
+**Tech Stack:** Rust, daemon/app unit and integration tests, Markdown docs/specs.
+
+---
+
+### Task 1: Lock the UX changes with failing tests
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/onboard_cli.rs`
+- Modify: `crates/app/src/chat.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/daemon/src/next_actions.rs`
+
+**Step 1: Write failing onboarding summary tests**
+
+- Update success-summary assertions so they expect:
+  - the primary handoff to appear before saved setup inventory
+  - the primary ask label to stop saying `ask example`
+
+**Step 2: Write failing doctor copy tests**
+
+- Tighten healthy-state next-step assertions around ask/chat copy.
+
+**Step 3: Write failing chat startup tests**
+
+- Update startup assertions so they expect:
+  - a clearer first action
+  - compact secondary headings for detail sections
+
+**Step 4: Run targeted tests to verify RED**
+
+Run:
+- `cargo test -p loongclaw-app render_cli_chat_startup_lines -- --nocapture`
+- `cargo test -p loongclaw-daemon onboarding_success_summary -- --nocapture`
+- `cargo test -p loongclaw-daemon build_doctor_next_steps_promotes_ask_and_chat_when_green -- --nocapture`
+
+Expected: FAIL because the current ordering/copy still reflects the old UX.
+
+### Task 2: Implement the shared handoff polish
+
+**Files:**
+- Modify: `crates/daemon/src/next_actions.rs`
+- Modify: `crates/daemon/src/onboard_cli.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+- Modify: `crates/app/src/chat.rs`
+
+**Step 1: Update shared ask labeling**
+
+- Rename the shared ask action label to the product-facing wording chosen in
+  the design.
+
+**Step 2: Promote onboarding’s primary handoff**
+
+- Reorder the success summary so:
+  - the primary handoff appears immediately after the opening completion block
+  - saved setup details are still preserved under a secondary heading
+
+**Step 3: Tighten doctor copy**
+
+- Keep doctor logic stable.
+- Update the healthy-state ask/chat prefixes to the new product-shaped wording.
+
+**Step 4: Reframe chat startup**
+
+- Move startup copy into:
+  - first action / usage hint
+  - compact session details
+  - compact runtime details
+
+**Step 5: Run targeted tests to verify GREEN**
+
+Run:
+- `cargo test -p loongclaw-app render_cli_chat_startup_lines -- --nocapture`
+- `cargo test -p loongclaw-daemon onboarding_success_summary -- --nocapture`
+- `cargo test -p loongclaw-daemon build_doctor_next_steps_promotes_ask_and_chat_when_green -- --nocapture`
+
+Expected: PASS
+
+### Task 3: Sync docs and product specs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/PRODUCT_SENSE.md`
+- Modify: `docs/product-specs/onboarding.md`
+- Modify: `docs/product-specs/doctor.md`
+- Modify: `docs/product-specs/one-shot-ask.md`
+
+**Step 1: Update docs**
+
+- Describe the handoff-first first-run contract now shipped by `onboard`,
+  `doctor`, and `chat`.
+
+**Step 2: Run doc consistency checks**
+
+Run:
+- `rg -n "first answer|ask example|start here|Continue in chat|Get a first answer" README.md docs`
+
+Expected: wording is aligned and `ask example` no longer appears in user-facing
+docs/specs for the healthy first-run path.
+
+### Task 4: Full verification and GitHub delivery
+
+**Files:**
+- Modify: one GitHub issue and one PR body
+
+**Step 1: Full local verification**
+
+Run:
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --locked`
+- `cargo test --workspace --all-features --locked`
+
+Expected: PASS
+
+**Step 2: GitHub delivery**
+
+- Reuse the first-run handoff issue for this slice.
+- Commit only this UX polish scope.
+- Push to the operator fork.
+- Open a PR against `alpha-test` with an explicit closing clause.
+
+**Step 3: Workspace cleanup**
+
+- Remove branch-local build artifacts before reporting completion.

--- a/docs/product-specs/doctor.md
+++ b/docs/product-specs/doctor.md
@@ -16,6 +16,9 @@ can recover a broken setup without reverse-engineering runtime internals.
       when doctor can recommend a concrete repair or first-value command.
 - [ ] Text-mode doctor output ends with concrete next actions such as
       credential env hints, `doctor --fix`, and first-turn ask/chat commands.
+- [ ] On a healthy setup, the first-turn recommendations read like the next user
+      action, not just a status report, for example "Get a first answer" and
+      "Continue in chat".
 - [ ] When `onboard`, `ask`, `chat`, or channel setup hits a common health
       failure, the CLI points users toward `doctor`.
 - [ ] Doctor checks cover the current MVP path: config presence, provider

--- a/docs/product-specs/onboarding.md
+++ b/docs/product-specs/onboarding.md
@@ -13,6 +13,8 @@ next.
       available and explains what it found before writing config.
 - [ ] The happy path ends with explicit next-step guidance for:
       a concrete `loongclaw ask --message "..."` example and `loongclaw chat`.
+- [ ] The success summary leads with a runnable `start here` handoff before the
+      saved provider, prompt, memory, and channel inventory.
 - [ ] The primary post-onboard handoff prefers a one-shot `ask` example before
       interactive `chat`, so first success does not require learning the REPL.
 - [ ] Rerunning onboarding does not silently overwrite an existing config unless

--- a/docs/product-specs/one-shot-ask.md
+++ b/docs/product-specs/one-shot-ask.md
@@ -16,6 +16,9 @@ that I can get an answer immediately without entering an interactive shell.
       slash-command behavior.
 - [ ] Onboarding and `doctor` can both promote a concrete `ask` example as the
       first visible success path for a healthy local setup.
+- [ ] When surfaced outside `ask` itself, the one-shot handoff is labeled in
+      product-facing language such as "first answer" rather than only as a
+      technical example.
 - [ ] `ask` help text points users toward `loongclaw chat` for interactive
       follow-up.
 


### PR DESCRIPTION
## Summary

- What changed?
  - polished the first-run handoff across `onboard`, `doctor`, and `chat` so healthy CLI entry points lead with the next user action instead of runtime detail
  - renamed the shared ask handoff label from `ask example` to `first answer`
  - moved onboarding's primary runnable handoff ahead of the saved setup inventory and added a `saved setup` section
  - reshaped chat startup into `start here`, `session details`, and `runtime details`
  - synced README, product sense, and product specs with the shipped handoff-first contract
- Why this change is needed?
  - the MVP already had the right first-run surfaces, but the first impression still felt more like a runtime than an assistant because copy and ordering exposed operator detail before the first clear next step

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional scenario checks:
- `cargo test -p loongclaw-app render_cli_chat_startup_lines_prioritize_first_turn_guidance --target-dir target/codex-first-run-ux-red -- --nocapture`
- `cargo test -p loongclaw-daemon build_doctor_next_steps_promotes_ask_and_chat_when_green --target-dir target/codex-first-run-ux-red -- --nocapture`
- `cargo test -p loongclaw-daemon onboarding_success_summary_surfaces_primary_handoff_before_saved_setup_details --target-dir target/codex-first-run-ux-red -- --nocapture`

Notes:
- config/env defaults were not changed in this slice
- the process-global env mutations exercised by existing test suites remain covered by the existing serialized test helpers; this PR does not introduce a new env-mutation path

## Linked Issues

Closes #229


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat startup shows a "start here" prompt with a concrete first prompt and clearer command hint; onboarding surfaces present a primary runnable handoff before saved setup details.

* **UI/UX Improvements**
  * Action labels clarified to "Get a first answer" and "Continue in chat"; doctor/health output emphasizes actionable follow-ups; session/runtime details moved to secondary sections.

* **Documentation**
  * README, product specs, and design/plans updated to reflect the first-run handoff polish.

* **Tests**
  * Updated and added tests to verify new rendering and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->