### PR TITLE
feat(daemon): add runtime experiment record CLI

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -49,6 +49,7 @@ pub mod next_actions;
 pub mod onboard_cli;
 pub mod onboard_presentation;
 pub mod provider_presentation;
+pub mod runtime_experiment_cli;
 pub mod runtime_restore_cli;
 pub mod skills_cli;
 pub mod source_presentation;
@@ -402,6 +403,11 @@ pub enum Commands {
         json: bool,
         #[arg(long, default_value_t = false)]
         apply: bool,
+    },
+    /// Manage snapshot-linked experiment run records
+    RuntimeExperiment {
+        #[command(subcommand)]
+        command: runtime_experiment_cli::RuntimeExperimentCommands,
     },
     /// List available conversation context engines and selected runtime engine
     ListContextEngines {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -208,6 +208,9 @@ async fn main() {
                 apply,
             },
         ),
+        Commands::RuntimeExperiment { command } => {
+            runtime_experiment_cli::run_runtime_experiment_cli(command)
+        }
         Commands::ListContextEngines { config, json } => {
             run_list_context_engines_cli(config.as_deref(), json)
         }

--- a/crates/daemon/src/runtime_experiment_cli.rs
+++ b/crates/daemon/src/runtime_experiment_cli.rs
@@ -1,0 +1,545 @@
+use crate::{
+    RUNTIME_SNAPSHOT_ARTIFACT_JSON_SCHEMA_VERSION, RuntimeSnapshotArtifactDocument,
+    sha2::{self, Digest},
+};
+use clap::{Args, Subcommand, ValueEnum};
+use loongclaw_spec::CliResult;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Path, PathBuf},
+};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+pub const RUNTIME_EXPERIMENT_ARTIFACT_JSON_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeExperimentCommands {
+    /// Create a new experiment-run artifact from a baseline runtime snapshot
+    Start(RuntimeExperimentStartCommandOptions),
+    /// Attach result snapshot and evaluation details to an experiment run
+    Finish(RuntimeExperimentFinishCommandOptions),
+    /// Load and render one persisted experiment-run artifact
+    Show(RuntimeExperimentShowCommandOptions),
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeExperimentStartCommandOptions {
+    #[arg(long)]
+    pub snapshot: String,
+    #[arg(long)]
+    pub output: String,
+    #[arg(long)]
+    pub mutation_summary: String,
+    #[arg(long)]
+    pub experiment_id: Option<String>,
+    #[arg(long)]
+    pub label: Option<String>,
+    #[arg(long = "tag")]
+    pub tag: Vec<String>,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeExperimentFinishCommandOptions {
+    #[arg(long)]
+    pub run: String,
+    #[arg(long)]
+    pub result_snapshot: String,
+    #[arg(long)]
+    pub evaluation_summary: String,
+    #[arg(long = "metric")]
+    pub metric: Vec<String>,
+    #[arg(long = "warning")]
+    pub warning: Vec<String>,
+    #[arg(long, value_enum)]
+    pub decision: RuntimeExperimentDecision,
+    #[arg(long, value_enum, default_value_t = RuntimeExperimentFinishStatus::Completed)]
+    pub status: RuntimeExperimentFinishStatus,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeExperimentShowCommandOptions {
+    #[arg(long)]
+    pub run: String,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeExperimentDecision {
+    Undecided,
+    Promoted,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeExperimentStatus {
+    Planned,
+    Completed,
+    Aborted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum RuntimeExperimentFinishStatus {
+    Completed,
+    Aborted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeExperimentArtifactSchema {
+    pub version: u32,
+    pub surface: String,
+    pub purpose: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeExperimentMutationSummary {
+    pub summary: String,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeExperimentSnapshotSummary {
+    pub snapshot_id: String,
+    pub created_at: String,
+    pub label: Option<String>,
+    pub experiment_id: Option<String>,
+    pub parent_snapshot_id: Option<String>,
+    pub capability_snapshot_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeExperimentEvaluation {
+    pub summary: String,
+    pub metrics: BTreeMap<String, f64>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeExperimentArtifactDocument {
+    pub schema: RuntimeExperimentArtifactSchema,
+    pub run_id: String,
+    pub created_at: String,
+    pub finished_at: Option<String>,
+    pub label: Option<String>,
+    pub experiment_id: String,
+    pub status: RuntimeExperimentStatus,
+    pub decision: RuntimeExperimentDecision,
+    pub mutation: RuntimeExperimentMutationSummary,
+    pub baseline_snapshot: RuntimeExperimentSnapshotSummary,
+    pub result_snapshot: Option<RuntimeExperimentSnapshotSummary>,
+    pub evaluation: Option<RuntimeExperimentEvaluation>,
+}
+
+pub fn run_runtime_experiment_cli(command: RuntimeExperimentCommands) -> CliResult<()> {
+    match command {
+        RuntimeExperimentCommands::Start(options) => {
+            let as_json = options.json;
+            let artifact = execute_runtime_experiment_start_command(options)?;
+            emit_runtime_experiment_artifact(&artifact, as_json)
+        }
+        RuntimeExperimentCommands::Finish(options) => {
+            let as_json = options.json;
+            let artifact = execute_runtime_experiment_finish_command(options)?;
+            emit_runtime_experiment_artifact(&artifact, as_json)
+        }
+        RuntimeExperimentCommands::Show(options) => {
+            let as_json = options.json;
+            let artifact = execute_runtime_experiment_show_command(options)?;
+            emit_runtime_experiment_artifact(&artifact, as_json)
+        }
+    }
+}
+
+pub fn execute_runtime_experiment_start_command(
+    options: RuntimeExperimentStartCommandOptions,
+) -> CliResult<RuntimeExperimentArtifactDocument> {
+    let baseline = load_runtime_snapshot_artifact(Path::new(&options.snapshot))?;
+    let experiment_id = resolve_experiment_id(
+        options.experiment_id.as_deref(),
+        baseline.lineage.experiment_id.as_deref(),
+    )?;
+    let created_at = now_rfc3339()?;
+    let label = optional_arg(options.label.as_deref());
+    let mutation_summary = required_trimmed_arg("mutation_summary", &options.mutation_summary)?;
+    let tags = normalize_repeated_values(&options.tag);
+    let baseline_snapshot = build_snapshot_summary(&baseline);
+    let run_id = compute_run_id(
+        &created_at,
+        label.as_deref(),
+        &experiment_id,
+        &baseline_snapshot,
+        &mutation_summary,
+        &tags,
+    )?;
+    let artifact = RuntimeExperimentArtifactDocument {
+        schema: RuntimeExperimentArtifactSchema {
+            version: RUNTIME_EXPERIMENT_ARTIFACT_JSON_SCHEMA_VERSION,
+            surface: "runtime_experiment".to_owned(),
+            purpose: "snapshot_evaluation_record".to_owned(),
+        },
+        run_id,
+        created_at,
+        finished_at: None,
+        label,
+        experiment_id,
+        status: RuntimeExperimentStatus::Planned,
+        decision: RuntimeExperimentDecision::Undecided,
+        mutation: RuntimeExperimentMutationSummary {
+            summary: mutation_summary,
+            tags,
+        },
+        baseline_snapshot,
+        result_snapshot: None,
+        evaluation: None,
+    };
+    persist_runtime_experiment_artifact(&options.output, &artifact)?;
+    Ok(artifact)
+}
+
+pub fn execute_runtime_experiment_finish_command(
+    options: RuntimeExperimentFinishCommandOptions,
+) -> CliResult<RuntimeExperimentArtifactDocument> {
+    let mut artifact = load_runtime_experiment_artifact(Path::new(&options.run))?;
+    if artifact.status != RuntimeExperimentStatus::Planned {
+        return Err(format!(
+            "runtime experiment run {} is already {}",
+            options.run,
+            render_status(artifact.status)
+        ));
+    }
+
+    let result_snapshot = load_runtime_snapshot_artifact(Path::new(&options.result_snapshot))?;
+    let result_experiment_id = optional_arg(result_snapshot.lineage.experiment_id.as_deref());
+    if let Some(result_experiment_id) = result_experiment_id.as_deref()
+        && result_experiment_id != artifact.experiment_id
+    {
+        return Err(format!(
+            "runtime experiment result snapshot experiment_id `{result_experiment_id}` does not match run experiment_id `{}`",
+            artifact.experiment_id
+        ));
+    }
+
+    let mut warnings = normalize_warnings(&options.warning);
+    if result_experiment_id.is_none() {
+        warnings.push(format!(
+            "result snapshot {} is missing experiment_id; operator-confirmed lineage is required",
+            options.result_snapshot
+        ));
+    }
+
+    artifact.finished_at = Some(now_rfc3339()?);
+    artifact.status = match options.status {
+        RuntimeExperimentFinishStatus::Completed => RuntimeExperimentStatus::Completed,
+        RuntimeExperimentFinishStatus::Aborted => RuntimeExperimentStatus::Aborted,
+    };
+    artifact.decision = options.decision;
+    artifact.result_snapshot = Some(build_snapshot_summary(&result_snapshot));
+    artifact.evaluation = Some(RuntimeExperimentEvaluation {
+        summary: required_trimmed_arg("evaluation_summary", &options.evaluation_summary)?,
+        metrics: parse_metrics(&options.metric)?,
+        warnings,
+    });
+    persist_runtime_experiment_artifact(&options.run, &artifact)?;
+    Ok(artifact)
+}
+
+pub fn execute_runtime_experiment_show_command(
+    options: RuntimeExperimentShowCommandOptions,
+) -> CliResult<RuntimeExperimentArtifactDocument> {
+    load_runtime_experiment_artifact(Path::new(&options.run))
+}
+
+fn emit_runtime_experiment_artifact(
+    artifact: &RuntimeExperimentArtifactDocument,
+    as_json: bool,
+) -> CliResult<()> {
+    if as_json {
+        let pretty = serde_json::to_string_pretty(artifact)
+            .map_err(|error| format!("serialize runtime experiment artifact failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_experiment_text(artifact));
+    Ok(())
+}
+
+fn load_runtime_snapshot_artifact(path: &Path) -> CliResult<RuntimeSnapshotArtifactDocument> {
+    let raw = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read runtime snapshot artifact {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let artifact =
+        serde_json::from_str::<RuntimeSnapshotArtifactDocument>(&raw).map_err(|error| {
+            format!(
+                "decode runtime snapshot artifact {} failed: {error}",
+                path.display()
+            )
+        })?;
+    if artifact.schema.version != RUNTIME_SNAPSHOT_ARTIFACT_JSON_SCHEMA_VERSION {
+        return Err(format!(
+            "runtime snapshot artifact {} uses unsupported schema version {}; expected {}",
+            path.display(),
+            artifact.schema.version,
+            RUNTIME_SNAPSHOT_ARTIFACT_JSON_SCHEMA_VERSION
+        ));
+    }
+    Ok(artifact)
+}
+
+fn load_runtime_experiment_artifact(path: &Path) -> CliResult<RuntimeExperimentArtifactDocument> {
+    let raw = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read runtime experiment artifact {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let artifact =
+        serde_json::from_str::<RuntimeExperimentArtifactDocument>(&raw).map_err(|error| {
+            format!(
+                "decode runtime experiment artifact {} failed: {error}",
+                path.display()
+            )
+        })?;
+    if artifact.schema.version != RUNTIME_EXPERIMENT_ARTIFACT_JSON_SCHEMA_VERSION {
+        return Err(format!(
+            "runtime experiment artifact {} uses unsupported schema version {}; expected {}",
+            path.display(),
+            artifact.schema.version,
+            RUNTIME_EXPERIMENT_ARTIFACT_JSON_SCHEMA_VERSION
+        ));
+    }
+    Ok(artifact)
+}
+
+fn resolve_experiment_id(explicit: Option<&str>, baseline: Option<&str>) -> CliResult<String> {
+    let explicit = optional_arg(explicit);
+    let baseline = optional_arg(baseline);
+    match (explicit, baseline) {
+        (Some(explicit), Some(baseline)) if explicit != baseline => Err(format!(
+            "runtime experiment start --experiment-id `{explicit}` does not match baseline snapshot experiment_id `{baseline}`"
+        )),
+        (Some(explicit), _) => Ok(explicit),
+        (None, Some(baseline)) => Ok(baseline),
+        (None, None) => Err(
+            "runtime experiment start requires --experiment-id when the baseline snapshot artifact does not declare experiment_id".to_owned(),
+        ),
+    }
+}
+
+fn now_rfc3339() -> CliResult<String> {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(|error| format!("format runtime experiment timestamp failed: {error}"))
+}
+
+fn optional_arg(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn required_trimmed_arg(name: &str, raw: &str) -> CliResult<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(format!("runtime experiment {name} cannot be empty"));
+    }
+    Ok(trimmed.to_owned())
+}
+
+fn normalize_repeated_values(values: &[String]) -> Vec<String> {
+    let mut normalized = values
+        .iter()
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized
+}
+
+fn normalize_warnings(values: &[String]) -> Vec<String> {
+    normalize_repeated_values(values)
+}
+
+fn parse_metrics(values: &[String]) -> CliResult<BTreeMap<String, f64>> {
+    let mut metrics = BTreeMap::new();
+    for raw in values {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err("runtime experiment metric entries cannot be empty".to_owned());
+        }
+        let (key, value) = trimmed.split_once('=').ok_or_else(|| {
+            format!("runtime experiment metric `{trimmed}` must use key=value syntax")
+        })?;
+        let key = key.trim();
+        if key.is_empty() {
+            return Err(format!(
+                "runtime experiment metric `{trimmed}` is missing a metric name"
+            ));
+        }
+        let value = value.trim().parse::<f64>().map_err(|error| {
+            format!("runtime experiment metric `{trimmed}` must be numeric: {error}")
+        })?;
+        if metrics.insert(key.to_owned(), value).is_some() {
+            return Err(format!(
+                "runtime experiment metric `{key}` was provided more than once"
+            ));
+        }
+    }
+    Ok(metrics)
+}
+
+fn build_snapshot_summary(
+    artifact: &RuntimeSnapshotArtifactDocument,
+) -> RuntimeExperimentSnapshotSummary {
+    RuntimeExperimentSnapshotSummary {
+        snapshot_id: artifact.lineage.snapshot_id.clone(),
+        created_at: artifact.lineage.created_at.clone(),
+        label: artifact.lineage.label.clone(),
+        experiment_id: artifact.lineage.experiment_id.clone(),
+        parent_snapshot_id: artifact.lineage.parent_snapshot_id.clone(),
+        capability_snapshot_sha256: artifact
+            .tools
+            .get("capability_snapshot_sha256")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+    }
+}
+
+fn compute_run_id(
+    created_at: &str,
+    label: Option<&str>,
+    experiment_id: &str,
+    baseline_snapshot: &RuntimeExperimentSnapshotSummary,
+    mutation_summary: &str,
+    tags: &[String],
+) -> CliResult<String> {
+    let encoded = serde_json::to_vec(&json!({
+        "created_at": created_at,
+        "label": label,
+        "experiment_id": experiment_id,
+        "baseline_snapshot_id": baseline_snapshot.snapshot_id,
+        "mutation_summary": mutation_summary,
+        "tags": tags,
+    }))
+    .map_err(|error| format!("serialize runtime experiment run_id input failed: {error}"))?;
+    Ok(format!("{:x}", sha2::Sha256::digest(encoded)))
+}
+
+fn persist_runtime_experiment_artifact(
+    output: &str,
+    artifact: &RuntimeExperimentArtifactDocument,
+) -> CliResult<()> {
+    let output_path = PathBuf::from(output);
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create runtime experiment artifact directory {} failed: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let encoded = serde_json::to_string_pretty(artifact)
+        .map_err(|error| format!("serialize runtime experiment artifact failed: {error}"))?;
+    fs::write(&output_path, encoded).map_err(|error| {
+        format!(
+            "write runtime experiment artifact {} failed: {error}",
+            output_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+pub fn render_runtime_experiment_text(artifact: &RuntimeExperimentArtifactDocument) -> String {
+    let metrics = artifact
+        .evaluation
+        .as_ref()
+        .map(|evaluation| {
+            if evaluation.metrics.is_empty() {
+                "-".to_owned()
+            } else {
+                evaluation
+                    .metrics
+                    .iter()
+                    .map(|(key, value)| format!("{key}:{value}"))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            }
+        })
+        .unwrap_or_else(|| "-".to_owned());
+    let warnings = artifact
+        .evaluation
+        .as_ref()
+        .map(|evaluation| {
+            if evaluation.warnings.is_empty() {
+                "-".to_owned()
+            } else {
+                evaluation.warnings.join(" | ")
+            }
+        })
+        .unwrap_or_else(|| "-".to_owned());
+
+    [
+        format!("run_id={}", artifact.run_id),
+        format!("experiment_id={}", artifact.experiment_id),
+        format!(
+            "baseline_snapshot_id={}",
+            artifact.baseline_snapshot.snapshot_id
+        ),
+        format!(
+            "result_snapshot_id={}",
+            artifact
+                .result_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.snapshot_id.as_str())
+                .unwrap_or("-")
+        ),
+        format!("status={}", render_status(artifact.status)),
+        format!("decision={}", render_decision(artifact.decision)),
+        format!("metrics={metrics}"),
+        format!("warnings={warnings}"),
+        format!("mutation_summary={}", artifact.mutation.summary),
+        format!(
+            "mutation_tags={}",
+            if artifact.mutation.tags.is_empty() {
+                "-".to_owned()
+            } else {
+                artifact.mutation.tags.join(",")
+            }
+        ),
+    ]
+    .join("\n")
+}
+
+fn render_status(status: RuntimeExperimentStatus) -> &'static str {
+    match status {
+        RuntimeExperimentStatus::Planned => "planned",
+        RuntimeExperimentStatus::Completed => "completed",
+        RuntimeExperimentStatus::Aborted => "aborted",
+    }
+}
+
+fn render_decision(decision: RuntimeExperimentDecision) -> &'static str {
+    match decision {
+        RuntimeExperimentDecision::Undecided => "undecided",
+        RuntimeExperimentDecision::Promoted => "promoted",
+        RuntimeExperimentDecision::Rejected => "rejected",
+    }
+}

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -303,6 +303,137 @@ fn runtime_restore_cli_parses() {
 }
 
 #[test]
+fn runtime_experiment_cli_parses_start_finish_and_show() {
+    let start = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-experiment",
+        "start",
+        "--snapshot",
+        "/tmp/runtime-snapshot.json",
+        "--output",
+        "/tmp/runtime-experiment.json",
+        "--mutation-summary",
+        "enable browser preview skill",
+        "--experiment-id",
+        "exp-42",
+        "--label",
+        "browser-preview-a",
+        "--tag",
+        "browser",
+        "--tag",
+        "preview",
+        "--json",
+    ])
+    .expect("`runtime-experiment start` should parse");
+
+    match start.command {
+        Some(Commands::RuntimeExperiment { command }) => match command {
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Start(options) => {
+                assert_eq!(options.snapshot, "/tmp/runtime-snapshot.json");
+                assert_eq!(options.output, "/tmp/runtime-experiment.json");
+                assert_eq!(options.mutation_summary, "enable browser preview skill");
+                assert_eq!(options.experiment_id.as_deref(), Some("exp-42"));
+                assert_eq!(options.label.as_deref(), Some("browser-preview-a"));
+                assert_eq!(
+                    options.tag,
+                    vec!["browser".to_owned(), "preview".to_owned()]
+                );
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Finish(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Show(_)) => {
+                panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+
+    let finish = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-experiment",
+        "finish",
+        "--run",
+        "/tmp/runtime-experiment.json",
+        "--result-snapshot",
+        "/tmp/runtime-snapshot-result.json",
+        "--evaluation-summary",
+        "task success improved",
+        "--metric",
+        "task_success=1",
+        "--metric",
+        "token_delta=0",
+        "--decision",
+        "promoted",
+        "--warning",
+        "manual verification only",
+        "--status",
+        "completed",
+        "--json",
+    ])
+    .expect("`runtime-experiment finish` should parse");
+
+    match finish.command {
+        Some(Commands::RuntimeExperiment { command }) => match command {
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Finish(
+                options,
+            ) => {
+                assert_eq!(options.run, "/tmp/runtime-experiment.json");
+                assert_eq!(options.result_snapshot, "/tmp/runtime-snapshot-result.json");
+                assert_eq!(options.evaluation_summary, "task success improved");
+                assert_eq!(
+                    options.metric,
+                    vec!["task_success=1".to_owned(), "token_delta=0".to_owned()]
+                );
+                assert_eq!(options.warning, vec!["manual verification only".to_owned()]);
+                assert_eq!(
+                    options.decision,
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted
+                );
+                assert_eq!(
+                    options.status,
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed
+                );
+                assert!(options.json);
+            }
+            other
+            @ (loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Start(
+                _,
+            )
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Show(
+                _,
+            )) => {
+                panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+
+    let show = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-experiment",
+        "show",
+        "--run",
+        "/tmp/runtime-experiment.json",
+        "--json",
+    ])
+    .expect("`runtime-experiment show` should parse");
+
+    match show.command {
+        Some(Commands::RuntimeExperiment { command }) => match command {
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Show(options) => {
+                assert_eq!(options.run, "/tmp/runtime-experiment.json");
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Start(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Finish(_)) => {
+                panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
 fn acp_event_summary_cli_rejects_zero_limit() {
     let error = run_acp_event_summary_cli(None, Some("session-a"), 0, false)
         .expect_err("zero limit must be rejected");

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -32,6 +32,7 @@ mod import_cli;
 mod migration;
 mod onboard_cli;
 mod programmatic;
+mod runtime_experiment_cli;
 mod runtime_restore_cli;
 mod runtime_snapshot_cli;
 mod skills_cli;

--- a/crates/daemon/tests/integration/runtime_experiment_cli.rs
+++ b/crates/daemon/tests/integration/runtime_experiment_cli.rs
@@ -1,0 +1,602 @@
+#![allow(unsafe_code)]
+#![allow(
+    clippy::disallowed_methods,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::undocumented_unsafe_blocks
+)]
+
+use super::*;
+use serde_json::Value;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+}
+
+fn write_runtime_experiment_config(root: &Path) -> PathBuf {
+    fs::create_dir_all(root).expect("create fixture root");
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.tools.file_root = Some(root.display().to_string());
+    config.tools.browser.enabled = true;
+    config.tools.web.enabled = true;
+    config.acp.enabled = true;
+    config.acp.dispatch.enabled = true;
+    config.acp.default_agent = Some("planner".to_owned());
+    config.acp.allowed_agents = vec!["planner".to_owned(), "codex".to_owned()];
+    config.providers.insert(
+        "openai-main".to_owned(),
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: false,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Openai,
+                model: "gpt-4.1-mini".to_owned(),
+                ..Default::default()
+            },
+        },
+    );
+    config.set_active_provider_profile(
+        "deepseek-lab",
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Deepseek,
+                model: "deepseek-chat".to_owned(),
+                api_key: Some("demo-token".to_owned()),
+                ..Default::default()
+            },
+        },
+    );
+
+    let config_path = root.join("loongclaw.toml");
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write config fixture");
+    config_path
+}
+
+fn write_snapshot_artifact(
+    root: &Path,
+    config_path: &Path,
+    relative: &str,
+    metadata: loongclaw_daemon::RuntimeSnapshotArtifactMetadata,
+) -> (PathBuf, Value) {
+    let snapshot = collect_runtime_snapshot_cli_state(Some(
+        config_path.to_str().expect("config path should be utf-8"),
+    ))
+    .expect("collect runtime snapshot");
+    let payload =
+        loongclaw_daemon::build_runtime_snapshot_artifact_json_payload(&snapshot, &metadata)
+            .expect("build runtime snapshot artifact");
+    let artifact_path = root.join(relative);
+    if let Some(parent) = artifact_path.parent() {
+        fs::create_dir_all(parent).expect("create artifact directory");
+    }
+    fs::write(
+        &artifact_path,
+        serde_json::to_string_pretty(&payload).expect("encode snapshot artifact"),
+    )
+    .expect("write snapshot artifact");
+    (artifact_path, payload)
+}
+
+fn snapshot_id_from_payload(payload: &Value) -> String {
+    payload
+        .get("lineage")
+        .and_then(|lineage| lineage.get("snapshot_id"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .expect("snapshot payload should include lineage.snapshot_id")
+}
+
+fn start_runtime_experiment(
+    root: &Path,
+    snapshot_path: &Path,
+    experiment_id: Option<&str>,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let run_path = root.join("artifacts/runtime-experiment.json");
+    let run = loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_start_command(
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentStartCommandOptions {
+            snapshot: snapshot_path.display().to_string(),
+            output: run_path.display().to_string(),
+            mutation_summary: "enable browser preview skill".to_owned(),
+            experiment_id: experiment_id.map(str::to_owned),
+            label: Some("browser-preview-a".to_owned()),
+            tag: vec!["browser".to_owned(), "preview".to_owned()],
+            json: false,
+        },
+    )
+    .expect("runtime experiment start should succeed");
+    (run_path, run)
+}
+
+fn finish_runtime_experiment(
+    root: &Path,
+    config_path: &Path,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(root, &baseline_snapshot_path, None);
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot-result.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:30:00Z".to_owned(),
+            label: Some("candidate".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: "task success improved".to_owned(),
+                metric: vec!["task_success=1".to_owned(), "token_delta=0".to_owned()],
+                warning: vec!["manual verification only".to_owned()],
+                decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+                status: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+    (run_path, finished)
+}
+
+#[test]
+fn runtime_experiment_start_creates_planned_run_and_inherits_baseline_lineage() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-start");
+    let config_path = write_runtime_experiment_config(&root);
+    let (snapshot_path, snapshot_payload) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let run_path = root.join("artifacts/runtime-experiment.json");
+
+    let run = loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_start_command(
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentStartCommandOptions {
+            snapshot: snapshot_path.display().to_string(),
+            output: run_path.display().to_string(),
+            mutation_summary: "enable browser preview skill".to_owned(),
+            experiment_id: None,
+            label: Some("browser-preview-a".to_owned()),
+            tag: vec!["browser".to_owned(), "preview".to_owned()],
+            json: false,
+        },
+    )
+    .expect("runtime experiment start should succeed");
+
+    assert!(
+        !run.run_id.is_empty(),
+        "run_id should be populated for persisted experiment records"
+    );
+    assert_eq!(run.experiment_id, "exp-42");
+    assert_eq!(
+        run.baseline_snapshot.snapshot_id,
+        snapshot_id_from_payload(&snapshot_payload)
+    );
+    assert_eq!(run.baseline_snapshot.label.as_deref(), Some("baseline"));
+    assert_eq!(
+        run.baseline_snapshot.parent_snapshot_id.as_deref(),
+        Some("snapshot-parent")
+    );
+    assert_eq!(
+        run.status,
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentStatus::Planned
+    );
+    assert_eq!(
+        run.decision,
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Undecided
+    );
+    assert_eq!(run.mutation.summary, "enable browser preview skill");
+    assert_eq!(
+        run.mutation.tags,
+        vec!["browser".to_owned(), "preview".to_owned()]
+    );
+    assert_eq!(run.result_snapshot, None);
+    assert_eq!(run.evaluation, None);
+    assert!(
+        run_path.exists(),
+        "start should persist the experiment-run artifact"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_start_requires_explicit_experiment_id_when_baseline_is_missing_one() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-start-missing-id");
+    let config_path = write_runtime_experiment_config(&root);
+    let (snapshot_path, _) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: None,
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let run_path = root.join("artifacts/runtime-experiment.json");
+
+    let error = loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_start_command(
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentStartCommandOptions {
+            snapshot: snapshot_path.display().to_string(),
+            output: run_path.display().to_string(),
+            mutation_summary: "enable browser preview skill".to_owned(),
+            experiment_id: None,
+            label: None,
+            tag: Vec::new(),
+            json: false,
+        },
+    )
+    .expect_err("missing experiment id should be rejected");
+
+    assert!(error.contains("experiment_id"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_finish_persists_result_metrics_and_warnings() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-finish");
+    let config_path = write_runtime_experiment_config(&root);
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(&root, &baseline_snapshot_path, None);
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot-result.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:30:00Z".to_owned(),
+            label: Some("candidate".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: "task success improved".to_owned(),
+                metric: vec!["task_success=1".to_owned(), "token_delta=0".to_owned()],
+                warning: vec!["manual verification only".to_owned()],
+                decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+                status: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+
+    assert_eq!(
+        finished.status,
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentStatus::Completed
+    );
+    assert_eq!(
+        finished.decision,
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted
+    );
+    assert!(
+        finished.finished_at.is_some(),
+        "finish should record a completion timestamp"
+    );
+    assert_eq!(
+        finished
+            .result_snapshot
+            .as_ref()
+            .expect("finish should attach result snapshot")
+            .label
+            .as_deref(),
+        Some("candidate")
+    );
+    assert_eq!(
+        finished
+            .evaluation
+            .as_ref()
+            .expect("finish should attach evaluation")
+            .summary,
+        "task success improved"
+    );
+    assert_eq!(
+        finished
+            .evaluation
+            .as_ref()
+            .expect("finish should attach evaluation")
+            .metrics,
+        std::collections::BTreeMap::from([
+            ("task_success".to_owned(), 1.0),
+            ("token_delta".to_owned(), 0.0),
+        ])
+    );
+    assert_eq!(
+        finished
+            .evaluation
+            .as_ref()
+            .expect("finish should attach evaluation")
+            .warnings,
+        vec!["manual verification only".to_owned()]
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_finish_rejects_conflicting_result_snapshot_experiment_id() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-finish-conflict");
+    let config_path = write_runtime_experiment_config(&root);
+    let (baseline_snapshot_path, _) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(&root, &baseline_snapshot_path, None);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot-result.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:30:00Z".to_owned(),
+            label: Some("candidate".to_owned()),
+            experiment_id: Some("exp-other".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+
+    let error =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: "task success improved".to_owned(),
+                metric: vec!["task_success=1".to_owned()],
+                warning: Vec::new(),
+                decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Rejected,
+                status: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect_err("conflicting result snapshot experiment id must fail");
+
+    assert!(error.contains("experiment_id"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_finish_warns_when_result_snapshot_has_no_experiment_id() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-finish-missing-id");
+    let config_path = write_runtime_experiment_config(&root);
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(&root, &baseline_snapshot_path, None);
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot-result.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:30:00Z".to_owned(),
+            label: Some("candidate".to_owned()),
+            experiment_id: None,
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: "task success improved".to_owned(),
+                metric: vec!["task_success=1".to_owned()],
+                warning: Vec::new(),
+                decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Rejected,
+                status: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("missing result snapshot experiment id should downgrade to a warning");
+
+    assert!(
+        finished
+            .evaluation
+            .as_ref()
+            .expect("finish should attach evaluation")
+            .warnings
+            .iter()
+            .any(|warning: &String| warning.contains("missing experiment_id")),
+        "finish should record a warning for result snapshots missing experiment_id"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_finish_rejects_mutating_a_finalized_run() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-finish-finalized");
+    let config_path = write_runtime_experiment_config(&root);
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(&root, &baseline_snapshot_path, None);
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot-result.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:30:00Z".to_owned(),
+            label: Some("candidate".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let first_finish =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: "task success improved".to_owned(),
+                metric: vec!["task_success=1".to_owned()],
+                warning: Vec::new(),
+                decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+                status: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("first finish should succeed");
+    assert_eq!(
+        first_finish.status,
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentStatus::Completed
+    );
+
+    let error =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: "task success improved again".to_owned(),
+                metric: vec!["task_success=2".to_owned()],
+                warning: Vec::new(),
+                decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+                status: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect_err("finalized run should reject further mutation");
+
+    assert!(error.contains("completed"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_show_round_trips_the_persisted_artifact() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-show");
+    let config_path = write_runtime_experiment_config(&root);
+    let (run_path, finished) = finish_runtime_experiment(&root, &config_path);
+
+    let shown = loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_show_command(
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentShowCommandOptions {
+            run: run_path.display().to_string(),
+            json: true,
+        },
+    )
+    .expect("show should load the persisted artifact");
+
+    assert_eq!(shown, finished);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_show_text_surfaces_decision_fields_first() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-show-text");
+    let config_path = write_runtime_experiment_config(&root);
+    let (_, finished) = finish_runtime_experiment(&root, &config_path);
+
+    let rendered =
+        loongclaw_daemon::runtime_experiment_cli::render_runtime_experiment_text(&finished);
+    let lines = rendered.lines().take(8).collect::<Vec<_>>();
+
+    assert_eq!(lines[0], format!("run_id={}", finished.run_id));
+    assert_eq!(
+        lines[1],
+        format!("experiment_id={}", finished.experiment_id)
+    );
+    assert_eq!(
+        lines[2],
+        format!(
+            "baseline_snapshot_id={}",
+            finished.baseline_snapshot.snapshot_id
+        )
+    );
+    assert_eq!(
+        lines[3],
+        format!(
+            "result_snapshot_id={}",
+            finished
+                .result_snapshot
+                .as_ref()
+                .expect("finish should attach result snapshot")
+                .snapshot_id
+        )
+    );
+    assert_eq!(lines[4], "status=completed");
+    assert_eq!(lines[5], "decision=promoted");
+    assert_eq!(lines[6], "metrics=task_success:1,token_delta:0");
+    assert_eq!(lines[7], "warnings=manual verification only");
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -284,7 +284,11 @@ Delivered in current baseline:
 - release-first install flow with checksum-verified prebuilt binaries and explicit source fallback (`scripts/install.sh`, `scripts/install.ps1`)
 - runtime-visible tool advertising so capability snapshots and provider tool schemas follow the actually enabled tool surface
 - Cargo feature flags for MVP packaging controls
-- product specs for installation, onboarding, one-shot ask, doctor, browser automation, tool surface, channel setup, and WebChat expectations
+- product specs for installation, onboarding, one-shot ask, doctor, browser automation, tool surface, channel setup, runtime experiment, and WebChat expectations
+- experiment-state operator surface foundation:
+  - `runtime-snapshot` persists lineage-aware runtime checkpoint artifacts
+  - `runtime-restore` replays a persisted checkpoint as a dry-run or apply plan
+  - `runtime-experiment start|finish|show` records baseline snapshot, mutation summary, result snapshot, evaluation metrics, warnings, and final decision
 - modular channel/provider architecture for extension-safe evolution:
   - `app/channel/feishu/*` split into adapter/payload/webhook layers
   - Feishu encrypted webhook payload decrypt lane with signature verification
@@ -302,10 +306,8 @@ Remaining deliverables:
 - beginner installation hardening:
   - sustain tagged release publishing across macOS/Linux/Windows
   - expand beyond installer scripts into package-manager distribution only after release adoption is stable
-- experiment-state operator surface:
-  - keep runtime snapshot lineage and runtime restore as the checkpoint/replay substrate
-  - add a minimal experiment-run record layer that links baseline snapshot, mutation summary, result snapshot, evaluation metrics, and promotion decision
-  - use that record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
+- experiment-state operator surface follow-through:
+  - use the shipped snapshot/restore/experiment record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
 - managed browser automation companion:
   - keep `browser.open`, `browser.extract`, and `browser.click` as the shipped safe browser lane
   - partial governed adapter skeleton now exists for richer page actions:

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -16,6 +16,7 @@ Product specs describe **what** the product does from the user's perspective, no
 - [Browser Automation Companion](browser-automation-companion.md)
 - [Channel Setup](channel-setup.md)
 - [Tool Surface](tool-surface.md)
+- [Runtime Experiment](runtime-experiment.md)
 - [WebChat](webchat.md)
 - [Prompt And Personality](prompt-and-personality.md)
 - [Memory Profiles](memory-profiles.md)
@@ -23,6 +24,7 @@ Product specs describe **what** the product does from the user's perspective, no
 ## Notes
 
 - `Installation`, `Onboarding`, `One-Shot Ask`, `Doctor`, `Browser Automation`, `Tool Surface`, and `Channel Setup` define the shipped first-run and support journey for the current MVP.
+- `Runtime Experiment` defines the shipped local experiment-record surface layered on top of runtime snapshot and restore artifacts.
 - `Browser Automation Companion` and `WebChat` are expectation-setting specs for the next user-facing surfaces. They should not be documented as generally available before the implementation exists.
 
 Template for new specs:

--- a/docs/product-specs/runtime-experiment.md
+++ b/docs/product-specs/runtime-experiment.md
@@ -1,0 +1,32 @@
+# Runtime Experiment
+
+## User Story
+
+As a LoongClaw operator, I want to record one snapshot-based experiment run so
+that I can compare a proposed runtime change against a baseline and make an
+explicit promotion or rejection decision.
+
+## Acceptance Criteria
+
+- [ ] LoongClaw exposes a `runtime-experiment` command family with `start`,
+      `finish`, and `show` subcommands.
+- [ ] `runtime-experiment start` creates a persisted experiment-run artifact
+      that records a baseline snapshot summary, mutation summary, optional tags,
+      and an explicit `planned` / `undecided` starting state.
+- [ ] The experiment run inherits `experiment_id` from the baseline snapshot
+      when present, and otherwise requires the operator to provide one.
+- [ ] `runtime-experiment finish` attaches a result snapshot summary,
+      evaluation summary, numeric metrics, warnings, final status, and decision
+      without mutating live runtime state.
+- [ ] `runtime-experiment show` round-trips the persisted artifact as JSON and
+      renders the decision-critical fields first in text output.
+- [ ] Product docs describe `runtime-experiment` as the record layer above
+      `runtime-snapshot` and `runtime-restore`, not as an autonomous optimizer
+      or automatic promotion system.
+
+## Out of Scope
+
+- Running arbitrary shell commands as part of an experiment run
+- Automatically mutating skills, providers, or daemon config
+- Automatic promotion, rollback, or branch management policy
+- Evaluator pipelines, dashboards, or autonomous skill-optimization loops


### PR DESCRIPTION
## Summary

- Add `runtime-experiment start|finish|show` as a file-backed daemon CLI surface for snapshot-based experiment records.
- Persist experiment artifacts with baseline/result snapshot summaries, mutation notes, numeric metrics, warnings, and decision/status rendering.
- Add integration coverage for parsing and start/finish/show flows, and update the roadmap plus product spec docs for the shipped operator surface.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional validation:

- `<local-absolute-path> clippy -p loongclaw-daemon --all-targets --manifest-path Cargo.toml -- -D warnings`
- `<local-absolute-path> test -p loongclaw-daemon --test integration runtime_ --manifest-path Cargo.toml`
- `rg -n "runtime-experiment|Runtime Experiment" docs`

## Linked Issues

Closes #223


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced runtime-experiment CLI command family with three subcommands: start (create experiment runs with baseline), finish (complete runs with results and evaluation), and show (display artifact records in JSON or text format)

* **Documentation**
  * Added runtime experiment product specification defining the experiment record surface
  * Updated roadmap with runtime experiment feature and related components

* **Tests**
  * Added comprehensive integration tests for runtime experiment workflow covering start, finish, and show operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->