### PR TITLE
perf: reduce file.read follow-up payload size

### DIFF
--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2645,7 +2645,7 @@ fn build_turn_reply_followup_messages(
         &followup,
         user_input,
         None,
-        |_, text| text.to_owned(),
+        crate::conversation::turn_shared::reduce_followup_payload_for_model,
     ));
     messages
 }
@@ -6487,6 +6487,145 @@ mod tests {
                 .filter_map(|message| message.get("content").and_then(Value::as_str))
                 .any(|content| content.contains("[tool_result]\n[ok]")),
             "truncated invoke payload should stay as ordinary assistant tool_result content: {messages:?}"
+        );
+    }
+
+    #[test]
+    fn build_turn_reply_followup_messages_reduces_file_read_payload_summary() {
+        let content = (0..96)
+            .map(|index| format!("line {index}: {}", "x".repeat(48)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let payload_summary = serde_json::json!({
+            "adapter": "core-tools",
+            "tool_name": "file.read",
+            "path": "/repo/README.md",
+            "bytes": 8_192,
+            "truncated": false,
+            "content": content,
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "file.read",
+                "tool_call_id": "call-file",
+                "payload_summary": payload_summary,
+                "payload_chars": 8_192,
+                "payload_truncated": false
+            })
+        );
+
+        let messages = build_turn_reply_followup_messages(
+            &[serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })],
+            "preface",
+            ToolDrivenFollowupPayload::ToolResult { text: tool_result },
+            "summarize README.md",
+        );
+
+        let assistant_tool_result = messages
+            .iter()
+            .find(|message| {
+                message.get("role") == Some(&Value::String("assistant".to_owned()))
+                    && message
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
+            })
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("assistant tool_result followup message should exist");
+        let line = assistant_tool_result
+            .lines()
+            .nth(1)
+            .expect("assistant tool_result should keep payload line");
+        let envelope: Value = serde_json::from_str(
+            line.strip_prefix("[ok] ")
+                .expect("tool result line should preserve status prefix"),
+        )
+        .expect("reduced followup envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("file.read payload summary should stay valid json");
+
+        assert_eq!(envelope["tool"], "file.read");
+        assert_eq!(envelope["payload_truncated"], true);
+        assert_eq!(summary["path"], "/repo/README.md");
+        assert_eq!(summary["bytes"], 8_192);
+        assert_eq!(summary["truncated"], false);
+        assert!(summary.get("content_preview").is_some());
+        assert!(summary.get("content_chars").is_some());
+        assert_eq!(summary["content_truncated"], true);
+    }
+
+    #[test]
+    fn build_turn_reply_followup_messages_preserves_tool_search_payload_summary() {
+        let payload_summary = serde_json::json!({
+            "results": [
+                {
+                    "tool_id": "file.read",
+                    "summary": "Read a file",
+                    "lease": "lease-1"
+                }
+            ]
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "tool.search",
+                "tool_call_id": "call-search",
+                "payload_summary": payload_summary,
+                "payload_chars": 256,
+                "payload_truncated": false
+            })
+        );
+
+        let messages = build_turn_reply_followup_messages(
+            &[serde_json::json!({
+                "role": "system",
+                "content": "sys"
+            })],
+            "preface",
+            ToolDrivenFollowupPayload::ToolResult { text: tool_result },
+            "read note.md",
+        );
+
+        let assistant_tool_result = messages
+            .iter()
+            .find(|message| {
+                message.get("role") == Some(&Value::String("assistant".to_owned()))
+                    && message
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
+            })
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("assistant tool_result followup message should exist");
+        let line = assistant_tool_result
+            .lines()
+            .nth(1)
+            .expect("assistant tool_result should keep payload line");
+        let envelope: Value = serde_json::from_str(
+            line.strip_prefix("[ok] ")
+                .expect("tool result line should preserve status prefix"),
+        )
+        .expect("tool.search followup envelope should stay valid json");
+
+        assert_eq!(envelope["tool"], "tool.search");
+        assert_eq!(envelope["payload_truncated"], false);
+        assert_eq!(
+            envelope["payload_summary"].as_str(),
+            Some(payload_summary.as_str())
         );
     }
 

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -827,6 +827,72 @@ mod tests {
     use super::*;
     use crate::conversation::turn_engine::TurnFailure;
 
+    fn build_large_file_read_tool_result() -> String {
+        let content = (0..96)
+            .map(|index| format!("line {index}: {}", "x".repeat(48)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let payload_summary = json!({
+            "adapter": "core-tools",
+            "tool_name": "file.read",
+            "path": "/repo/README.md",
+            "bytes": 8_192,
+            "truncated": false,
+            "content": content,
+        })
+        .to_string();
+        format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "tool": "file.read",
+                "tool_call_id": "call-file",
+                "payload_summary": payload_summary,
+                "payload_chars": 8_192,
+                "payload_truncated": false
+            })
+        )
+    }
+
+    fn assert_reduced_file_read_followup_message(messages: &[Value]) {
+        let assistant_tool_result = messages
+            .iter()
+            .find(|message| {
+                message.get("role") == Some(&Value::String("assistant".to_owned()))
+                    && message
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
+            })
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("assistant tool_result followup message should exist");
+        let line = assistant_tool_result
+            .lines()
+            .nth(1)
+            .expect("assistant tool_result should keep payload line");
+        let envelope: Value = serde_json::from_str(
+            line.strip_prefix("[ok] ")
+                .expect("tool result line should preserve status prefix"),
+        )
+        .expect("reduced followup envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("file.read payload summary should stay valid json");
+
+        assert_eq!(envelope["tool"], "file.read");
+        assert_eq!(envelope["payload_truncated"], true);
+        assert_eq!(summary["path"], "/repo/README.md");
+        assert_eq!(summary["bytes"], 8_192);
+        assert_eq!(summary["truncated"], false);
+        assert!(summary.get("content_preview").is_some());
+        assert!(summary.get("content_chars").is_some());
+        assert_eq!(summary["content_truncated"], true);
+    }
+
     #[test]
     fn append_tool_driven_followup_messages_adds_truncation_hint_to_user_prompt() {
         let mut messages = Vec::new();
@@ -959,30 +1025,7 @@ mod tests {
     fn append_tool_driven_followup_messages_reduces_file_read_payload_summary() {
         let mut messages = Vec::new();
         let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
-        let content = (0..96)
-            .map(|index| format!("line {index}: {}", "x".repeat(48)))
-            .collect::<Vec<_>>()
-            .join("\n");
-        let payload_summary = serde_json::json!({
-            "adapter": "core-tools",
-            "tool_name": "file.read",
-            "path": "/repo/README.md",
-            "bytes": 8_192,
-            "truncated": false,
-            "content": content,
-        })
-        .to_string();
-        let tool_result = format!(
-            "[ok] {}",
-            serde_json::json!({
-                "status": "ok",
-                "tool": "file.read",
-                "tool_call_id": "call-file",
-                "payload_summary": payload_summary,
-                "payload_chars": 8_192,
-                "payload_truncated": false
-            })
-        );
+        let tool_result = build_large_file_read_tool_result();
 
         append_tool_driven_followup_messages(
             &mut messages,
@@ -993,72 +1036,14 @@ mod tests {
             None,
         );
 
-        let assistant_tool_result = messages
-            .iter()
-            .find(|message| {
-                message.get("role") == Some(&Value::String("assistant".to_owned()))
-                    && message
-                        .get("content")
-                        .and_then(Value::as_str)
-                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
-            })
-            .and_then(|message| message.get("content"))
-            .and_then(Value::as_str)
-            .expect("assistant tool_result followup message should exist");
-        let line = assistant_tool_result
-            .lines()
-            .nth(1)
-            .expect("assistant tool_result should keep payload line");
-        let envelope: Value = serde_json::from_str(
-            line.strip_prefix("[ok] ")
-                .expect("tool result line should preserve status prefix"),
-        )
-        .expect("reduced followup envelope should stay valid json");
-        let summary: Value = serde_json::from_str(
-            envelope["payload_summary"]
-                .as_str()
-                .expect("payload summary should stay encoded json"),
-        )
-        .expect("file.read payload summary should stay valid json");
-
-        assert_eq!(envelope["tool"], "file.read");
-        assert_eq!(envelope["payload_truncated"], true);
-        assert_eq!(summary["path"], "/repo/README.md");
-        assert_eq!(summary["bytes"], 8_192);
-        assert_eq!(summary["truncated"], false);
-        assert!(summary.get("content_preview").is_some());
-        assert!(summary.get("content_chars").is_some());
-        assert_eq!(summary["content_truncated"], true);
+        assert_reduced_file_read_followup_message(&messages);
     }
 
     #[test]
     fn append_repeated_tool_guard_followup_messages_reduces_file_read_payload_summary() {
         let mut messages = Vec::new();
         let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
-        let content = (0..96)
-            .map(|index| format!("line {index}: {}", "x".repeat(48)))
-            .collect::<Vec<_>>()
-            .join("\n");
-        let payload_summary = serde_json::json!({
-            "adapter": "core-tools",
-            "tool_name": "file.read",
-            "path": "/repo/README.md",
-            "bytes": 8_192,
-            "truncated": false,
-            "content": content,
-        })
-        .to_string();
-        let tool_result = format!(
-            "[ok] {}",
-            serde_json::json!({
-                "status": "ok",
-                "tool": "file.read",
-                "tool_call_id": "call-file",
-                "payload_summary": payload_summary,
-                "payload_chars": 8_192,
-                "payload_truncated": false
-            })
-        );
+        let tool_result = build_large_file_read_tool_result();
 
         append_repeated_tool_guard_followup_messages(
             &mut messages,
@@ -1069,42 +1054,7 @@ mod tests {
             &mut budget,
         );
 
-        let assistant_tool_result = messages
-            .iter()
-            .find(|message| {
-                message.get("role") == Some(&Value::String("assistant".to_owned()))
-                    && message
-                        .get("content")
-                        .and_then(Value::as_str)
-                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
-            })
-            .and_then(|message| message.get("content"))
-            .and_then(Value::as_str)
-            .expect("assistant tool_result followup message should exist");
-        let line = assistant_tool_result
-            .lines()
-            .nth(1)
-            .expect("assistant tool_result should keep payload line");
-        let envelope: Value = serde_json::from_str(
-            line.strip_prefix("[ok] ")
-                .expect("tool result line should preserve status prefix"),
-        )
-        .expect("reduced guard followup envelope should stay valid json");
-        let summary: Value = serde_json::from_str(
-            envelope["payload_summary"]
-                .as_str()
-                .expect("payload summary should stay encoded json"),
-        )
-        .expect("file.read payload summary should stay valid json");
-
-        assert_eq!(envelope["tool"], "file.read");
-        assert_eq!(envelope["payload_truncated"], true);
-        assert_eq!(summary["path"], "/repo/README.md");
-        assert_eq!(summary["bytes"], 8_192);
-        assert_eq!(summary["truncated"], false);
-        assert!(summary.get("content_preview").is_some());
-        assert!(summary.get("content_chars").is_some());
-        assert_eq!(summary["content_truncated"], true);
+        assert_reduced_file_read_followup_message(&messages);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -483,7 +483,11 @@ fn append_tool_driven_followup_messages(
         payload,
         user_input,
         loop_warning_reason,
-        |label, text| followup_payload_budget.truncate_payload(label, text),
+        |label, text| {
+            let reduced =
+                crate::conversation::turn_shared::reduce_followup_payload_for_model(label, text);
+            followup_payload_budget.truncate_payload(label, reduced.as_str())
+        },
     ));
 }
 
@@ -500,7 +504,11 @@ fn append_repeated_tool_guard_followup_messages(
         reason,
         user_input,
         latest_tool_context,
-        |label, text| followup_payload_budget.truncate_payload(label, text),
+        |label, text| {
+            let reduced =
+                crate::conversation::turn_shared::reduce_followup_payload_for_model(label, text);
+            followup_payload_budget.truncate_payload(label, reduced.as_str())
+        },
     ));
 }
 
@@ -945,6 +953,158 @@ mod tests {
             system_content.contains("suffix-marker"),
             "system context should preserve the tail of large invoke instructions"
         );
+    }
+
+    #[test]
+    fn append_tool_driven_followup_messages_reduces_file_read_payload_summary() {
+        let mut messages = Vec::new();
+        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
+        let content = (0..96)
+            .map(|index| format!("line {index}: {}", "x".repeat(48)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let payload_summary = serde_json::json!({
+            "adapter": "core-tools",
+            "tool_name": "file.read",
+            "path": "/repo/README.md",
+            "bytes": 8_192,
+            "truncated": false,
+            "content": content,
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "file.read",
+                "tool_call_id": "call-file",
+                "payload_summary": payload_summary,
+                "payload_chars": 8_192,
+                "payload_truncated": false
+            })
+        );
+
+        append_tool_driven_followup_messages(
+            &mut messages,
+            "preface",
+            &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
+            "summarize README.md",
+            &mut budget,
+            None,
+        );
+
+        let assistant_tool_result = messages
+            .iter()
+            .find(|message| {
+                message.get("role") == Some(&Value::String("assistant".to_owned()))
+                    && message
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
+            })
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("assistant tool_result followup message should exist");
+        let line = assistant_tool_result
+            .lines()
+            .nth(1)
+            .expect("assistant tool_result should keep payload line");
+        let envelope: Value = serde_json::from_str(
+            line.strip_prefix("[ok] ")
+                .expect("tool result line should preserve status prefix"),
+        )
+        .expect("reduced followup envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("file.read payload summary should stay valid json");
+
+        assert_eq!(envelope["tool"], "file.read");
+        assert_eq!(envelope["payload_truncated"], true);
+        assert_eq!(summary["path"], "/repo/README.md");
+        assert_eq!(summary["bytes"], 8_192);
+        assert_eq!(summary["truncated"], false);
+        assert!(summary.get("content_preview").is_some());
+        assert!(summary.get("content_chars").is_some());
+        assert_eq!(summary["content_truncated"], true);
+    }
+
+    #[test]
+    fn append_repeated_tool_guard_followup_messages_reduces_file_read_payload_summary() {
+        let mut messages = Vec::new();
+        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
+        let content = (0..96)
+            .map(|index| format!("line {index}: {}", "x".repeat(48)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let payload_summary = serde_json::json!({
+            "adapter": "core-tools",
+            "tool_name": "file.read",
+            "path": "/repo/README.md",
+            "bytes": 8_192,
+            "truncated": false,
+            "content": content,
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "file.read",
+                "tool_call_id": "call-file",
+                "payload_summary": payload_summary,
+                "payload_chars": 8_192,
+                "payload_truncated": false
+            })
+        );
+
+        append_repeated_tool_guard_followup_messages(
+            &mut messages,
+            "preface",
+            "stop",
+            "summarize README.md",
+            Some(("tool_result", tool_result.as_str())),
+            &mut budget,
+        );
+
+        let assistant_tool_result = messages
+            .iter()
+            .find(|message| {
+                message.get("role") == Some(&Value::String("assistant".to_owned()))
+                    && message
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
+            })
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("assistant tool_result followup message should exist");
+        let line = assistant_tool_result
+            .lines()
+            .nth(1)
+            .expect("assistant tool_result should keep payload line");
+        let envelope: Value = serde_json::from_str(
+            line.strip_prefix("[ok] ")
+                .expect("tool result line should preserve status prefix"),
+        )
+        .expect("reduced guard followup envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("file.read payload summary should stay valid json");
+
+        assert_eq!(envelope["tool"], "file.read");
+        assert_eq!(envelope["payload_truncated"], true);
+        assert_eq!(summary["path"], "/repo/README.md");
+        assert_eq!(summary["bytes"], 8_192);
+        assert_eq!(summary["truncated"], false);
+        assert!(summary.get("content_preview").is_some());
+        assert!(summary.get("content_chars").is_some());
+        assert_eq!(summary["content_truncated"], true);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -16,6 +16,8 @@ pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were tru
 pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "A managed external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
 pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
 
+const FILE_READ_FOLLOWUP_CONTENT_PREVIEW_CHARS: usize = 384;
+
 pub fn next_conversation_turn_id() -> String {
     static NEXT_CONVERSATION_TURN_SEQ: AtomicU64 = AtomicU64::new(1);
     let seq = NEXT_CONVERSATION_TURN_SEQ.fetch_add(1, Ordering::Relaxed);
@@ -374,6 +376,7 @@ pub fn build_tool_followup_user_prompt(
     user_input: &str,
     loop_warning_reason: Option<&str>,
     tool_result_text: Option<&str>,
+    rendered_tool_result_text: Option<&str>,
 ) -> String {
     let mut sections = vec![TOOL_FOLLOWUP_PROMPT.to_owned()];
     if let Some(reason) = loop_warning_reason {
@@ -381,14 +384,23 @@ pub fn build_tool_followup_user_prompt(
             "Loop warning:\n{reason}\nAvoid repeating the same tool call with unchanged results. Try a different tool, adjust arguments, or provide a best-effort final answer if evidence is sufficient."
         ));
     }
-    if tool_result_text
-        .map(tool_result_contains_truncation_signal)
-        .unwrap_or(false)
-    {
+    if followup_prompt_needs_truncation_hint(tool_result_text, rendered_tool_result_text) {
         sections.push(TOOL_TRUNCATION_HINT_PROMPT.to_owned());
     }
     sections.push(format!("Original request:\n{user_input}"));
     sections.join("\n\n")
+}
+
+fn followup_prompt_needs_truncation_hint(
+    tool_result_text: Option<&str>,
+    rendered_tool_result_text: Option<&str>,
+) -> bool {
+    tool_result_text
+        .map(tool_result_contains_truncation_signal)
+        .unwrap_or(false)
+        || rendered_tool_result_text
+            .map(tool_result_contains_truncation_signal)
+            .unwrap_or(false)
 }
 
 pub fn parse_external_skill_invoke_context(
@@ -399,6 +411,105 @@ pub fn parse_external_skill_invoke_context(
         .lines()
         .filter_map(parse_external_skill_invoke_context_line)
         .next()
+}
+
+pub fn reduce_followup_payload_for_model(label: &str, text: &str) -> String {
+    if label != "tool_result" {
+        return text.to_owned();
+    }
+    reduce_tool_result_text_for_model(text)
+}
+
+fn reduce_tool_result_text_for_model(text: &str) -> String {
+    let mut changed = false;
+    let reduced_lines = text
+        .lines()
+        .map(|line| {
+            let reduced = reduce_tool_result_line_for_model(line);
+            if reduced != line {
+                changed = true;
+            }
+            reduced
+        })
+        .collect::<Vec<_>>();
+    if !changed {
+        return text.to_owned();
+    }
+    let mut reduced = reduced_lines.join("\n");
+    if text.ends_with('\n') {
+        reduced.push('\n');
+    }
+    reduced
+}
+
+fn reduce_tool_result_line_for_model(line: &str) -> String {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return line.to_owned();
+    }
+    let Some((status_prefix, payload)) = trimmed.split_once(' ') else {
+        return line.to_owned();
+    };
+    if !(status_prefix.starts_with('[') && status_prefix.ends_with(']')) {
+        return line.to_owned();
+    }
+    let Ok(mut envelope) = serde_json::from_str::<Value>(payload) else {
+        return line.to_owned();
+    };
+    if envelope.get("tool").and_then(Value::as_str) != Some("file.read") {
+        return line.to_owned();
+    }
+    let Some(payload_summary) = envelope.get("payload_summary").and_then(Value::as_str) else {
+        return line.to_owned();
+    };
+    let Ok(payload_json) = serde_json::from_str::<Value>(payload_summary) else {
+        return line.to_owned();
+    };
+    let Some(reduced_summary) = reduce_file_read_payload_summary(&payload_json) else {
+        return line.to_owned();
+    };
+    let Some(envelope_object) = envelope.as_object_mut() else {
+        return line.to_owned();
+    };
+    envelope_object.insert("payload_summary".to_owned(), Value::String(reduced_summary));
+    envelope_object.insert("payload_truncated".to_owned(), Value::Bool(true));
+    let Ok(encoded) = serde_json::to_string(&envelope) else {
+        return line.to_owned();
+    };
+    format!("{status_prefix} {encoded}")
+}
+
+fn reduce_file_read_payload_summary(payload: &Value) -> Option<String> {
+    let payload_object = payload.as_object()?;
+    let (content_preview, content_chars, content_truncated) =
+        summarize_file_read_content_preview(payload_object.get("content"));
+    if !content_truncated {
+        return None;
+    }
+    serde_json::to_string(&serde_json::json!({
+        "path": payload_object.get("path").cloned().unwrap_or(Value::Null),
+        "bytes": payload_object.get("bytes").cloned().unwrap_or(Value::Null),
+        "truncated": payload_object.get("truncated").cloned().unwrap_or(Value::Null),
+        "content_preview": content_preview,
+        "content_chars": content_chars,
+        "content_truncated": content_truncated,
+    }))
+    .ok()
+}
+
+fn summarize_file_read_content_preview(value: Option<&Value>) -> (String, usize, bool) {
+    let text = value.and_then(Value::as_str).unwrap_or_default();
+    let total_chars = text.chars().count();
+    if total_chars <= FILE_READ_FOLLOWUP_CONTENT_PREVIEW_CHARS {
+        return (text.to_owned(), total_chars, false);
+    }
+    (
+        text.chars()
+            .take(FILE_READ_FOLLOWUP_CONTENT_PREVIEW_CHARS)
+            .collect(),
+        total_chars,
+        true,
+    )
 }
 
 pub fn build_external_skill_system_message(skill_context: &ExternalSkillInvokeContext) -> String {
@@ -470,6 +581,7 @@ where
             user_input,
             loop_warning_reason,
             Some(tool_result_text),
+            Some(bounded_result.as_str()),
         ),
     }));
     messages
@@ -495,7 +607,7 @@ where
     append_followup_warning(&mut messages, loop_warning_reason);
     messages.push(serde_json::json!({
         "role": "user",
-        "content": build_tool_followup_user_prompt(user_input, loop_warning_reason, None),
+        "content": build_tool_followup_user_prompt(user_input, loop_warning_reason, None, None),
     }));
     messages
 }
@@ -1059,6 +1171,26 @@ mod tests {
     }
 
     #[test]
+    fn tool_result_followup_tail_keeps_truncation_hint_when_payload_mapper_marks_result_truncated()
+    {
+        let tail = build_tool_result_followup_tail(
+            "preface",
+            r#"[ok] {"payload_truncated":false}"#,
+            "summarize note.md",
+            Some("warning"),
+            |_, _| r#"[ok] {"payload_truncated":true}"#.to_owned(),
+        );
+
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+        assert!(user_prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
+        assert!(user_prompt.contains("Loop warning:\nwarning"));
+    }
+
+    #[test]
     fn tool_failure_followup_tail_uses_payload_mapper_without_truncation_hint() {
         let tail = build_tool_failure_followup_tail(
             "preface",
@@ -1234,6 +1366,19 @@ mod tests {
         let prompt = build_tool_followup_user_prompt(
             "summarize this result",
             None,
+            Some(r#"[ok] {"payload_truncated":true}"#),
+            None,
+        );
+        assert!(prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
+        assert!(prompt.contains("Original request:\nsummarize this result"));
+    }
+
+    #[test]
+    fn followup_prompt_includes_truncation_hint_when_rendered_payload_is_truncated() {
+        let prompt = build_tool_followup_user_prompt(
+            "summarize this result",
+            None,
+            Some(r#"[ok] {"payload_truncated":false}"#),
             Some(r#"[ok] {"payload_truncated":true}"#),
         );
         assert!(prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));

--- a/docs/plans/2026-03-16-file-read-followup-payload-reducer-design.md
+++ b/docs/plans/2026-03-16-file-read-followup-payload-reducer-design.md
@@ -1,0 +1,89 @@
+# File Read Follow-up Payload Reducer Design
+
+**Problem**
+
+`file.read` returns a structured payload with `path`, `bytes`, `truncated`, and `content`. In the current `alpha-test` branch, discovery-first follow-up, turn-loop follow-up, and repeated-tool-guard replay all forward that tool-result text back into the next model round with only generic character-budget truncation. When `content` is large but still below the primary tool-result summary limit, the model receives far more file text than it usually needs for the follow-up answer.
+
+This is a token-cost and latency problem, not an execution correctness problem. The raw tool output still needs to stay intact when the user explicitly requests raw output.
+
+**Constraints**
+
+- Do not change `file.read` execution output in `crates/app/src/tools/file.rs`.
+- Do not move reduction into `TurnEngine`; that would break raw-output semantics.
+- Do not add new config knobs in this slice.
+- Do not broaden this into a generic reducer framework for all tools.
+- Preserve existing `tool.search` and `external_skills.invoke` follow-up semantics.
+
+**Approaches Considered**
+
+1. Reduce `file.read` in `TurnEngine`.
+   Rejected because raw tool output requests should still receive the original tool result envelope.
+
+2. Add a generic all-tool follow-up reducer.
+   Rejected because only `file.read` is in scope here, and generalizing first would create abstraction debt without enough evidence.
+
+3. Add a `file.read`-specific reducer only in follow-up message assembly.
+   Recommended because it matches the real hotspot, preserves execution semantics, and reuses the existing follow-up mapping seam with minimal change.
+
+**Chosen Design**
+
+Add a shared helper in `turn_shared.rs` that rewrites only follow-up `tool_result` lines whose envelope tool is `file.read` and whose nested `payload_summary` is still valid JSON.
+
+The reducer will:
+
+- parse the outer tool-result envelope
+- parse the nested `payload_summary`
+- preserve `path`, `bytes`, and the original file-tool `truncated` flag
+- replace large `content` with:
+  - `content_preview`
+  - `content_chars`
+  - `content_truncated`
+- set outer `payload_truncated=true` when follow-up reduction happens
+- preserve outer `payload_chars`
+- leave non-`file.read` results unchanged
+
+This reducer will run in three places:
+
+- discovery-first follow-up assembly
+- turn-loop tool-result follow-up assembly
+- repeated-tool-guard replay of the latest tool result
+
+**Preview Strategy**
+
+Use a head-only character preview, not head-tail or line-window compaction.
+
+Reasons:
+
+- smallest implementation surface
+- consistent with existing generic truncation behavior
+- easier to reason about and test
+- enough for the model to understand the file type and leading context
+
+If a future benchmark shows that tail context materially improves answer quality, that can be a separate iteration.
+
+**Truncation Signaling**
+
+The user follow-up prompt currently decides whether to add the truncation hint by inspecting the original tool-result text. That is insufficient once follow-up-only reduction mutates the rendered payload after the original tool result is produced.
+
+This slice will therefore also update follow-up prompt hinting to consider both:
+
+- the original tool-result text
+- the rendered follow-up tool-result text
+
+That keeps truncation guidance aligned with the actual payload shown to the model.
+
+**Testing Strategy**
+
+Add TDD coverage for:
+
+- discovery-first follow-up reducing oversized `file.read` payload summaries
+- turn-loop follow-up reducing oversized `file.read` payload summaries
+- repeated-tool-guard replay reducing oversized `file.read` payload summaries
+- `tool.search` follow-up payloads remaining unchanged
+- truncation hints appearing when the rendered follow-up payload is newly marked truncated
+
+**Risk Assessment**
+
+This is a low-risk slice because it only changes model-facing follow-up assembly, not tool execution, persistence, provider routing, or raw-output delivery.
+
+The main residual risk is overlap with other open follow-up payload PRs touching the same conversation files. That is a merge-management concern, not a runtime correctness concern.

--- a/docs/plans/2026-03-16-file-read-followup-payload-reducer-implementation-plan.md
+++ b/docs/plans/2026-03-16-file-read-followup-payload-reducer-implementation-plan.md
@@ -1,6 +1,6 @@
 # File Read Follow-up Payload Reducer Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> Implement this plan task-by-task using the available execution workflow for this repository.
 
 **Goal:** Reduce model-facing token waste from oversized `file.read` outputs during tool-result follow-up rounds without changing raw tool output semantics.
 
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add failing tests for file.read follow-up reduction
+## Task 1: Add failing tests for file.read follow-up reduction
 
 **Files:**
 - Modify: `crates/app/src/conversation/turn_shared.rs`
@@ -43,7 +43,7 @@ Expected: FAIL because repeated-tool-guard currently only applies generic trunca
 
 Add a `turn_shared.rs` test proving the follow-up prompt includes the truncation hint when the rendered follow-up payload is newly marked truncated even if the original tool result was not.
 
-### Task 2: Implement the shared follow-up reducer
+## Task 2: Implement the shared follow-up reducer
 
 **Files:**
 - Modify: `crates/app/src/conversation/turn_shared.rs`
@@ -74,7 +74,7 @@ Update `build_turn_reply_followup_messages(...)` so follow-up provider messages 
 
 Update both follow-up paths in `turn_loop.rs` so `file.read` reduction happens before generic follow-up budget truncation.
 
-### Task 3: Verify and prepare GitHub delivery
+## Task 3: Verify and prepare GitHub delivery
 
 **Files:**
 - Modify: `docs/plans/2026-03-16-file-read-followup-payload-reducer-design.md`

--- a/docs/plans/2026-03-16-file-read-followup-payload-reducer-implementation-plan.md
+++ b/docs/plans/2026-03-16-file-read-followup-payload-reducer-implementation-plan.md
@@ -1,0 +1,120 @@
+# File Read Follow-up Payload Reducer Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Reduce model-facing token waste from oversized `file.read` outputs during tool-result follow-up rounds without changing raw tool output semantics.
+
+**Architecture:** Keep `file.read` execution output and `TurnEngine` envelopes unchanged. Apply a `file.read`-specific reducer only when follow-up provider messages are assembled, and update truncation-hint logic so the prompt reflects the rendered follow-up payload instead of only the original tool result.
+
+**Tech Stack:** Rust, serde_json, conversation follow-up assembly in `turn_shared.rs`, `turn_loop.rs`, and `turn_coordinator.rs`.
+
+---
+
+### Task 1: Add failing tests for file.read follow-up reduction
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_shared.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+
+**Step 1: Write the failing discovery-first follow-up test**
+
+Add a test proving `build_turn_reply_followup_messages(...)` reduces oversized `file.read` payload summaries before the next provider round.
+
+**Step 2: Run the test to verify RED**
+
+Run: `cargo test -p loongclaw-app build_turn_reply_followup_messages_reduces_file_read_payload_summary -- --exact --nocapture`
+Expected: FAIL because discovery-first follow-up currently forwards the raw tool result text unchanged.
+
+**Step 3: Write the failing turn-loop tests**
+
+Add focused tests proving both:
+- `append_tool_driven_followup_messages(...)`
+- `append_repeated_tool_guard_followup_messages(...)`
+
+reduce oversized `file.read` payload summaries before generic follow-up budget truncation.
+
+**Step 4: Run one failing turn-loop test**
+
+Run: `cargo test -p loongclaw-app append_repeated_tool_guard_followup_messages_reduces_file_read_payload_summary -- --exact --nocapture`
+Expected: FAIL because repeated-tool-guard currently only applies generic truncation.
+
+**Step 5: Write the truncation-hint regression test**
+
+Add a `turn_shared.rs` test proving the follow-up prompt includes the truncation hint when the rendered follow-up payload is newly marked truncated even if the original tool result was not.
+
+### Task 2: Implement the shared follow-up reducer
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_shared.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+
+**Step 1: Add a shared follow-up reducer in `turn_shared.rs`**
+
+Implement helpers that:
+- only touch `tool_result` payloads
+- only rewrite structured envelopes for `file.read`
+- parse the nested `payload_summary`
+- preserve `path`, `bytes`, and the original file-tool `truncated` flag
+- replace large `content` with compact preview metadata
+- preserve outer `payload_chars`
+- set outer `payload_truncated=true` when reduction occurs
+- leave non-`file.read` tool results unchanged
+
+**Step 2: Update truncation-hint prompt logic**
+
+Allow `build_tool_followup_user_prompt(...)` to consider both the original tool-result text and the rendered follow-up tool-result text.
+
+**Step 3: Route discovery-first follow-up assembly through the reducer**
+
+Update `build_turn_reply_followup_messages(...)` so follow-up provider messages map tool payloads through the reducer.
+
+**Step 4: Route turn-loop and repeated-tool-guard follow-up assembly through the reducer**
+
+Update both follow-up paths in `turn_loop.rs` so `file.read` reduction happens before generic follow-up budget truncation.
+
+### Task 3: Verify and prepare GitHub delivery
+
+**Files:**
+- Modify: `docs/plans/2026-03-16-file-read-followup-payload-reducer-design.md`
+- Modify: `docs/plans/2026-03-16-file-read-followup-payload-reducer-implementation-plan.md`
+
+**Step 1: Run focused tests**
+
+Run:
+- `cargo test -p loongclaw-app build_turn_reply_followup_messages_reduces_file_read_payload_summary -- --exact --nocapture`
+- `cargo test -p loongclaw-app append_tool_driven_followup_messages_reduces_file_read_payload_summary -- --exact --nocapture`
+- `cargo test -p loongclaw-app append_repeated_tool_guard_followup_messages_reduces_file_read_payload_summary -- --exact --nocapture`
+
+Expected: PASS
+
+**Step 2: Run adjacent regressions**
+
+Run:
+- `cargo test -p loongclaw-app tool_result_followup_tail_ -- --nocapture`
+- `cargo test -p loongclaw-app tool_loop_guard_tail_ -- --nocapture`
+- `cargo test -p loongclaw-app build_turn_reply_followup_messages_ -- --nocapture`
+- `cargo test -p loongclaw-app append_tool_driven_followup_messages_ -- --nocapture`
+- `cargo test -p loongclaw-app append_repeated_tool_guard_followup_messages_ -- --nocapture`
+
+Expected: PASS
+
+**Step 3: Run repository-grade verification**
+
+Run:
+- `cargo fmt --all`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features`
+
+Expected: PASS
+
+**Step 4: Prepare GitHub delivery**
+
+Create or reuse a GitHub issue describing:
+- why `file.read` is a follow-up token hotspot
+- why the reducer is follow-up-only instead of execution-path wide
+- why head-only preview was chosen over more complex preview shapes
+
+Open a PR linked to that issue with exact validation evidence.


### PR DESCRIPTION
## Summary

- add a shared follow-up reducer for oversized `file.read` tool-result payloads
- apply it in discovery-first follow-up assembly, turn-loop follow-up assembly, and repeated-tool-guard replay
- keep raw tool output semantics unchanged while updating truncation-hint prompting to reflect the rendered follow-up payload

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional checks:
- `cargo test -p loongclaw-app conversation::turn_shared::tests::tool_result_followup_tail_keeps_truncation_hint_when_payload_mapper_marks_result_truncated -- --exact --nocapture`
- `cargo test -p loongclaw-app conversation::turn_coordinator::tests::build_turn_reply_followup_messages_reduces_file_read_payload_summary -- --exact --nocapture`
- `cargo test -p loongclaw-app conversation::turn_loop::tests::append_tool_driven_followup_messages_reduces_file_read_payload_summary -- --exact --nocapture`
- `cargo test -p loongclaw-app conversation::turn_loop::tests::append_repeated_tool_guard_followup_messages_reduces_file_read_payload_summary -- --exact --nocapture`
- `cargo test -p loongclaw-app conversation::turn_coordinator::tests::build_turn_reply_followup_messages_preserves_tool_search_payload_summary -- --exact --nocapture`
- `cargo test -p loongclaw-app build_turn_reply_followup_messages_ -- --nocapture`
- `cargo test -p loongclaw-app append_tool_driven_followup_messages_ -- --nocapture`
- `cargo test -p loongclaw-app append_repeated_tool_guard_followup_messages_ -- --nocapture`
- `cargo test -p loongclaw-app tool_result_followup_tail_ -- --nocapture`
- `cargo test -p loongclaw-app tool_loop_guard_tail_ -- --nocapture`

## Linked Issues

Closes #234


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Follow-up messages now reduce large file-read payloads to compact content previews and mark outer payloads as truncated; prompts show truncation hints when applicable.

* **Tests**
  * Expanded tests validating payload reduction and preservation across tool-driven and repeated-guard follow-up scenarios.

* **Documentation**
  * Added design and implementation plans describing the follow-up payload reduction behavior and testing strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->