### PR TITLE
feat(daemon): add runtime experiment compare

### DIFF
--- a/crates/daemon/src/runtime_experiment_cli.rs
+++ b/crates/daemon/src/runtime_experiment_cli.rs
@@ -23,6 +23,8 @@ pub enum RuntimeExperimentCommands {
     Finish(RuntimeExperimentFinishCommandOptions),
     /// Load and render one persisted experiment-run artifact
     Show(RuntimeExperimentShowCommandOptions),
+    /// Compare one experiment run and, optionally, matching runtime snapshots
+    Compare(RuntimeExperimentCompareCommandOptions),
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -71,6 +73,18 @@ pub struct RuntimeExperimentShowCommandOptions {
     pub json: bool,
 }
 
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeExperimentCompareCommandOptions {
+    #[arg(long)]
+    pub run: String,
+    #[arg(long)]
+    pub baseline_snapshot: Option<String>,
+    #[arg(long)]
+    pub result_snapshot: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeExperimentDecision {
@@ -91,6 +105,13 @@ pub enum RuntimeExperimentStatus {
 pub enum RuntimeExperimentFinishStatus {
     Completed,
     Aborted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeExperimentCompareMode {
+    RecordOnly,
+    SnapshotDelta,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -139,6 +160,63 @@ pub struct RuntimeExperimentArtifactDocument {
     pub evaluation: Option<RuntimeExperimentEvaluation>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeExperimentCompareReport {
+    pub run_id: String,
+    pub experiment_id: String,
+    pub label: Option<String>,
+    pub status: RuntimeExperimentStatus,
+    pub decision: RuntimeExperimentDecision,
+    pub mutation: RuntimeExperimentMutationSummary,
+    pub baseline_snapshot: RuntimeExperimentSnapshotSummary,
+    pub result_snapshot: Option<RuntimeExperimentSnapshotSummary>,
+    pub evaluation: Option<RuntimeExperimentEvaluation>,
+    pub compare_mode: RuntimeExperimentCompareMode,
+    pub snapshot_delta: Option<RuntimeExperimentSnapshotDelta>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeExperimentSnapshotDelta {
+    pub changed_surface_count: usize,
+    pub provider_active_profile: RuntimeExperimentScalarCompare,
+    pub provider_active_model: RuntimeExperimentScalarCompare,
+    pub context_engine_selected: RuntimeExperimentScalarCompare,
+    pub context_engine_compaction: RuntimeExperimentScalarCompare,
+    pub memory_selected: RuntimeExperimentScalarCompare,
+    pub memory_policy: RuntimeExperimentScalarCompare,
+    pub acp_selected: RuntimeExperimentScalarCompare,
+    pub acp_policy: RuntimeExperimentScalarCompare,
+    pub enabled_channel_ids: RuntimeExperimentSetCompare,
+    pub enabled_service_channel_ids: RuntimeExperimentSetCompare,
+    pub visible_tool_names: RuntimeExperimentSetCompare,
+    pub capability_snapshot_sha256: RuntimeExperimentScalarCompare,
+    pub external_skill_ids: RuntimeExperimentSetCompare,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeExperimentScalarCompare {
+    pub before: Option<String>,
+    pub after: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeExperimentSetCompare {
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+}
+
+impl RuntimeExperimentScalarCompare {
+    fn changed(&self) -> bool {
+        self.before != self.after
+    }
+}
+
+impl RuntimeExperimentSetCompare {
+    fn changed(&self) -> bool {
+        !self.added.is_empty() || !self.removed.is_empty()
+    }
+}
+
 pub fn run_runtime_experiment_cli(command: RuntimeExperimentCommands) -> CliResult<()> {
     match command {
         RuntimeExperimentCommands::Start(options) => {
@@ -155,6 +233,11 @@ pub fn run_runtime_experiment_cli(command: RuntimeExperimentCommands) -> CliResu
             let as_json = options.json;
             let artifact = execute_runtime_experiment_show_command(options)?;
             emit_runtime_experiment_artifact(&artifact, as_json)
+        }
+        RuntimeExperimentCommands::Compare(options) => {
+            let as_json = options.json;
+            let report = execute_runtime_experiment_compare_command(options)?;
+            emit_runtime_experiment_compare_report(&report, as_json)
         }
     }
 }
@@ -258,6 +341,37 @@ pub fn execute_runtime_experiment_show_command(
     load_runtime_experiment_artifact(Path::new(&options.run))
 }
 
+pub fn execute_runtime_experiment_compare_command(
+    options: RuntimeExperimentCompareCommandOptions,
+) -> CliResult<RuntimeExperimentCompareReport> {
+    let artifact = load_runtime_experiment_artifact(Path::new(&options.run))?;
+    let snapshot_delta = load_runtime_experiment_compare_snapshot_delta(
+        &artifact,
+        &options.run,
+        options.baseline_snapshot.as_deref(),
+        options.result_snapshot.as_deref(),
+    )?;
+    let compare_mode = if snapshot_delta.is_some() {
+        RuntimeExperimentCompareMode::SnapshotDelta
+    } else {
+        RuntimeExperimentCompareMode::RecordOnly
+    };
+
+    Ok(RuntimeExperimentCompareReport {
+        run_id: artifact.run_id,
+        experiment_id: artifact.experiment_id,
+        label: artifact.label,
+        status: artifact.status,
+        decision: artifact.decision,
+        mutation: artifact.mutation,
+        baseline_snapshot: artifact.baseline_snapshot,
+        result_snapshot: artifact.result_snapshot,
+        evaluation: artifact.evaluation,
+        compare_mode,
+        snapshot_delta,
+    })
+}
+
 fn emit_runtime_experiment_artifact(
     artifact: &RuntimeExperimentArtifactDocument,
     as_json: bool,
@@ -270,6 +384,22 @@ fn emit_runtime_experiment_artifact(
     }
 
     println!("{}", render_runtime_experiment_text(artifact));
+    Ok(())
+}
+
+fn emit_runtime_experiment_compare_report(
+    report: &RuntimeExperimentCompareReport,
+    as_json: bool,
+) -> CliResult<()> {
+    if as_json {
+        let pretty = serde_json::to_string_pretty(report).map_err(|error| {
+            format!("serialize runtime experiment compare report failed: {error}")
+        })?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_experiment_compare_text(report));
     Ok(())
 }
 
@@ -321,6 +451,62 @@ fn load_runtime_experiment_artifact(path: &Path) -> CliResult<RuntimeExperimentA
         ));
     }
     Ok(artifact)
+}
+
+fn load_runtime_experiment_compare_snapshot_delta(
+    artifact: &RuntimeExperimentArtifactDocument,
+    run_path: &str,
+    baseline_snapshot_path: Option<&str>,
+    result_snapshot_path: Option<&str>,
+) -> CliResult<Option<RuntimeExperimentSnapshotDelta>> {
+    match (baseline_snapshot_path, result_snapshot_path) {
+        (None, None) => Ok(None),
+        (Some(_), None) | (None, Some(_)) => {
+            Err("runtime experiment compare requires --baseline-snapshot and --result-snapshot together".to_owned())
+        }
+        (Some(baseline_snapshot_path), Some(result_snapshot_path)) => {
+            let recorded_result_snapshot = artifact.result_snapshot.as_ref().ok_or_else(|| {
+                format!(
+                    "runtime experiment compare cannot load snapshot delta for run {} because the run has no result snapshot",
+                    run_path
+                )
+            })?;
+            let baseline_snapshot =
+                load_runtime_snapshot_artifact(Path::new(baseline_snapshot_path))?;
+            let result_snapshot = load_runtime_snapshot_artifact(Path::new(result_snapshot_path))?;
+            validate_compare_snapshot_identity(
+                "baseline",
+                &artifact.baseline_snapshot.snapshot_id,
+                &baseline_snapshot.lineage.snapshot_id,
+                Path::new(baseline_snapshot_path),
+            )?;
+            validate_compare_snapshot_identity(
+                "result",
+                &recorded_result_snapshot.snapshot_id,
+                &result_snapshot.lineage.snapshot_id,
+                Path::new(result_snapshot_path),
+            )?;
+            Ok(Some(build_runtime_experiment_snapshot_delta(
+                &baseline_snapshot,
+                &result_snapshot,
+            )))
+        }
+    }
+}
+
+fn validate_compare_snapshot_identity(
+    kind: &str,
+    expected_snapshot_id: &str,
+    actual_snapshot_id: &str,
+    path: &Path,
+) -> CliResult<()> {
+    if expected_snapshot_id == actual_snapshot_id {
+        return Ok(());
+    }
+    Err(format!(
+        "runtime experiment compare {kind} snapshot {} has snapshot_id `{actual_snapshot_id}` but run recorded `{expected_snapshot_id}`",
+        path.display()
+    ))
 }
 
 fn resolve_experiment_id(explicit: Option<&str>, baseline: Option<&str>) -> CliResult<String> {
@@ -421,6 +607,298 @@ fn build_snapshot_summary(
     }
 }
 
+fn build_runtime_experiment_snapshot_delta(
+    baseline: &RuntimeSnapshotArtifactDocument,
+    result: &RuntimeSnapshotArtifactDocument,
+) -> RuntimeExperimentSnapshotDelta {
+    let provider_active_profile = compare_optional_strings(
+        snapshot_provider_active_profile_id(baseline),
+        snapshot_provider_active_profile_id(result),
+    );
+    let provider_active_model = compare_optional_strings(
+        snapshot_provider_active_model(baseline),
+        snapshot_provider_active_model(result),
+    );
+    let context_engine_selected = compare_optional_strings(
+        snapshot_context_engine_selected_id(baseline),
+        snapshot_context_engine_selected_id(result),
+    );
+    let context_engine_compaction = compare_optional_strings(
+        snapshot_context_engine_compaction_summary(baseline),
+        snapshot_context_engine_compaction_summary(result),
+    );
+    let memory_selected = compare_optional_strings(
+        snapshot_memory_selected_id(baseline),
+        snapshot_memory_selected_id(result),
+    );
+    let memory_policy = compare_optional_strings(
+        snapshot_memory_policy_summary(baseline),
+        snapshot_memory_policy_summary(result),
+    );
+    let acp_selected = compare_optional_strings(
+        snapshot_acp_selected_id(baseline),
+        snapshot_acp_selected_id(result),
+    );
+    let acp_policy = compare_optional_strings(
+        snapshot_acp_policy_summary(baseline),
+        snapshot_acp_policy_summary(result),
+    );
+    let enabled_channel_ids = compare_string_sets(
+        snapshot_enabled_channel_ids(baseline),
+        snapshot_enabled_channel_ids(result),
+    );
+    let enabled_service_channel_ids = compare_string_sets(
+        snapshot_enabled_service_channel_ids(baseline),
+        snapshot_enabled_service_channel_ids(result),
+    );
+    let visible_tool_names = compare_string_sets(
+        snapshot_visible_tool_names(baseline),
+        snapshot_visible_tool_names(result),
+    );
+    let capability_snapshot_sha256 = compare_optional_strings(
+        snapshot_capability_snapshot_sha256(baseline),
+        snapshot_capability_snapshot_sha256(result),
+    );
+    let external_skill_ids = compare_string_sets(
+        snapshot_external_skill_ids(baseline),
+        snapshot_external_skill_ids(result),
+    );
+    let changed_surface_count = usize::from(provider_active_profile.changed())
+        + usize::from(provider_active_model.changed())
+        + usize::from(context_engine_selected.changed())
+        + usize::from(context_engine_compaction.changed())
+        + usize::from(memory_selected.changed())
+        + usize::from(memory_policy.changed())
+        + usize::from(acp_selected.changed())
+        + usize::from(acp_policy.changed())
+        + usize::from(enabled_channel_ids.changed())
+        + usize::from(enabled_service_channel_ids.changed())
+        + usize::from(visible_tool_names.changed())
+        + usize::from(capability_snapshot_sha256.changed())
+        + usize::from(external_skill_ids.changed());
+
+    RuntimeExperimentSnapshotDelta {
+        changed_surface_count,
+        provider_active_profile,
+        provider_active_model,
+        context_engine_selected,
+        context_engine_compaction,
+        memory_selected,
+        memory_policy,
+        acp_selected,
+        acp_policy,
+        enabled_channel_ids,
+        enabled_service_channel_ids,
+        visible_tool_names,
+        capability_snapshot_sha256,
+        external_skill_ids,
+    }
+}
+
+fn compare_optional_strings(
+    before: Option<String>,
+    after: Option<String>,
+) -> RuntimeExperimentScalarCompare {
+    RuntimeExperimentScalarCompare { before, after }
+}
+
+fn compare_string_sets(before: Vec<String>, after: Vec<String>) -> RuntimeExperimentSetCompare {
+    let before = before.into_iter().collect::<BTreeSet<_>>();
+    let after = after.into_iter().collect::<BTreeSet<_>>();
+    RuntimeExperimentSetCompare {
+        added: after.difference(&before).cloned().collect(),
+        removed: before.difference(&after).cloned().collect(),
+    }
+}
+
+fn snapshot_provider_active_profile_id(
+    snapshot: &RuntimeSnapshotArtifactDocument,
+) -> Option<String> {
+    json_string_path(&snapshot.provider, &["active_profile_id"])
+}
+
+fn snapshot_provider_active_model(snapshot: &RuntimeSnapshotArtifactDocument) -> Option<String> {
+    let active_profile_id = snapshot_provider_active_profile_id(snapshot)?;
+    snapshot
+        .provider
+        .get("profiles")
+        .and_then(Value::as_array)?
+        .iter()
+        .find(|profile| {
+            profile
+                .get("profile_id")
+                .and_then(Value::as_str)
+                .is_some_and(|profile_id| profile_id == active_profile_id)
+        })
+        .and_then(|profile| profile.get("model"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+fn snapshot_context_engine_selected_id(
+    snapshot: &RuntimeSnapshotArtifactDocument,
+) -> Option<String> {
+    json_string_path(&snapshot.context_engine, &["selected", "id"])
+}
+
+fn snapshot_context_engine_compaction_summary(
+    snapshot: &RuntimeSnapshotArtifactDocument,
+) -> Option<String> {
+    let enabled = render_optional_bool(json_bool_path(
+        &snapshot.context_engine,
+        &["compaction", "enabled"],
+    ));
+    let min_messages = render_optional_u64(json_u64_path(
+        &snapshot.context_engine,
+        &["compaction", "min_messages"],
+    ));
+    let trigger_estimated_tokens = render_optional_u64(json_u64_path(
+        &snapshot.context_engine,
+        &["compaction", "trigger_estimated_tokens"],
+    ));
+    let fail_open = render_optional_bool(json_bool_path(
+        &snapshot.context_engine,
+        &["compaction", "fail_open"],
+    ));
+    Some(format!(
+        "enabled:{enabled} min_messages:{min_messages} trigger_estimated_tokens:{trigger_estimated_tokens} fail_open:{fail_open}"
+    ))
+}
+
+fn snapshot_memory_selected_id(snapshot: &RuntimeSnapshotArtifactDocument) -> Option<String> {
+    json_string_path(&snapshot.memory_system, &["selected", "id"])
+}
+
+fn snapshot_memory_policy_summary(snapshot: &RuntimeSnapshotArtifactDocument) -> Option<String> {
+    Some(format!(
+        "backend:{} profile:{} mode:{} ingest_mode:{} fail_open:{} strict_mode_requested:{} strict_mode_active:{} effective_fail_open:{}",
+        json_string_path(&snapshot.memory_system, &["policy", "backend"])
+            .unwrap_or_else(|| "-".to_owned()),
+        json_string_path(&snapshot.memory_system, &["policy", "profile"])
+            .unwrap_or_else(|| "-".to_owned()),
+        json_string_path(&snapshot.memory_system, &["policy", "mode"])
+            .unwrap_or_else(|| "-".to_owned()),
+        json_string_path(&snapshot.memory_system, &["policy", "ingest_mode"])
+            .unwrap_or_else(|| "-".to_owned()),
+        render_optional_bool(json_bool_path(
+            &snapshot.memory_system,
+            &["policy", "fail_open"]
+        )),
+        render_optional_bool(json_bool_path(
+            &snapshot.memory_system,
+            &["policy", "strict_mode_requested"]
+        )),
+        render_optional_bool(json_bool_path(
+            &snapshot.memory_system,
+            &["policy", "strict_mode_active"]
+        )),
+        render_optional_bool(json_bool_path(
+            &snapshot.memory_system,
+            &["policy", "effective_fail_open"]
+        )),
+    ))
+}
+
+fn snapshot_acp_selected_id(snapshot: &RuntimeSnapshotArtifactDocument) -> Option<String> {
+    json_string_path(&snapshot.acp, &["selected", "id"])
+}
+
+fn snapshot_acp_policy_summary(snapshot: &RuntimeSnapshotArtifactDocument) -> Option<String> {
+    Some(format!(
+        "enabled:{} dispatch_enabled:{} conversation_routing:{} thread_routing:{} default_agent:{} allowed_agents:{}",
+        render_optional_bool(json_bool_path(&snapshot.acp, &["enabled"])),
+        render_optional_bool(json_bool_path(
+            &snapshot.acp,
+            &["control_plane", "dispatch_enabled"]
+        )),
+        json_string_path(&snapshot.acp, &["control_plane", "conversation_routing"])
+            .unwrap_or_else(|| "-".to_owned()),
+        json_string_path(&snapshot.acp, &["control_plane", "thread_routing"])
+            .unwrap_or_else(|| "-".to_owned()),
+        json_string_path(&snapshot.acp, &["control_plane", "default_agent"])
+            .unwrap_or_else(|| "-".to_owned()),
+        render_string_values(&json_string_array_path(
+            &snapshot.acp,
+            &["control_plane", "allowed_agents"]
+        )),
+    ))
+}
+
+fn snapshot_enabled_channel_ids(snapshot: &RuntimeSnapshotArtifactDocument) -> Vec<String> {
+    json_string_array_path(&snapshot.channels, &["enabled_channel_ids"])
+}
+
+fn snapshot_enabled_service_channel_ids(snapshot: &RuntimeSnapshotArtifactDocument) -> Vec<String> {
+    json_string_array_path(&snapshot.channels, &["enabled_service_channel_ids"])
+}
+
+fn snapshot_visible_tool_names(snapshot: &RuntimeSnapshotArtifactDocument) -> Vec<String> {
+    json_string_array_path(&snapshot.tools, &["visible_tool_names"])
+}
+
+fn snapshot_capability_snapshot_sha256(
+    snapshot: &RuntimeSnapshotArtifactDocument,
+) -> Option<String> {
+    json_string_path(&snapshot.tools, &["capability_snapshot_sha256"])
+}
+
+fn snapshot_external_skill_ids(snapshot: &RuntimeSnapshotArtifactDocument) -> Vec<String> {
+    json_object_array_string_field_path(
+        &snapshot.external_skills,
+        &["inventory", "skills"],
+        "skill_id",
+    )
+}
+
+fn json_value_path<'a>(value: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    Some(current)
+}
+
+fn json_string_path(value: &Value, path: &[&str]) -> Option<String> {
+    json_value_path(value, path)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+fn json_bool_path(value: &Value, path: &[&str]) -> Option<bool> {
+    json_value_path(value, path).and_then(Value::as_bool)
+}
+
+fn json_u64_path(value: &Value, path: &[&str]) -> Option<u64> {
+    json_value_path(value, path).and_then(Value::as_u64)
+}
+
+fn json_string_array_path(value: &Value, path: &[&str]) -> Vec<String> {
+    let values = json_value_path(value, path)
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+    values.into_iter().collect()
+}
+
+fn json_object_array_string_field_path(value: &Value, path: &[&str], field: &str) -> Vec<String> {
+    let values = json_value_path(value, path)
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.get(field))
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+    values.into_iter().collect()
+}
+
 fn compute_run_id(
     created_at: &str,
     label: Option<&str>,
@@ -468,34 +946,6 @@ fn persist_runtime_experiment_artifact(
 }
 
 pub fn render_runtime_experiment_text(artifact: &RuntimeExperimentArtifactDocument) -> String {
-    let metrics = artifact
-        .evaluation
-        .as_ref()
-        .map(|evaluation| {
-            if evaluation.metrics.is_empty() {
-                "-".to_owned()
-            } else {
-                evaluation
-                    .metrics
-                    .iter()
-                    .map(|(key, value)| format!("{key}:{value}"))
-                    .collect::<Vec<_>>()
-                    .join(",")
-            }
-        })
-        .unwrap_or_else(|| "-".to_owned());
-    let warnings = artifact
-        .evaluation
-        .as_ref()
-        .map(|evaluation| {
-            if evaluation.warnings.is_empty() {
-                "-".to_owned()
-            } else {
-                evaluation.warnings.join(" | ")
-            }
-        })
-        .unwrap_or_else(|| "-".to_owned());
-
     [
         format!("run_id={}", artifact.run_id),
         format!("experiment_id={}", artifact.experiment_id),
@@ -513,19 +963,205 @@ pub fn render_runtime_experiment_text(artifact: &RuntimeExperimentArtifactDocume
         ),
         format!("status={}", render_status(artifact.status)),
         format!("decision={}", render_decision(artifact.decision)),
-        format!("metrics={metrics}"),
-        format!("warnings={warnings}"),
+        format!("metrics={}", render_metrics(artifact.evaluation.as_ref())),
+        format!("warnings={}", render_warnings(artifact.evaluation.as_ref())),
         format!("mutation_summary={}", artifact.mutation.summary),
         format!(
             "mutation_tags={}",
-            if artifact.mutation.tags.is_empty() {
-                "-".to_owned()
-            } else {
-                artifact.mutation.tags.join(",")
-            }
+            render_string_values(&artifact.mutation.tags)
         ),
     ]
     .join("\n")
+}
+
+pub fn render_runtime_experiment_compare_text(report: &RuntimeExperimentCompareReport) -> String {
+    let mut lines = vec![
+        format!("run_id={}", report.run_id),
+        format!("experiment_id={}", report.experiment_id),
+        format!(
+            "baseline_snapshot_id={}",
+            report.baseline_snapshot.snapshot_id
+        ),
+        format!(
+            "result_snapshot_id={}",
+            report
+                .result_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.snapshot_id.as_str())
+                .unwrap_or("-")
+        ),
+        format!("status={}", render_status(report.status)),
+        format!("decision={}", render_decision(report.decision)),
+        format!(
+            "evaluation_summary={}",
+            render_evaluation_summary(report.evaluation.as_ref())
+        ),
+        format!("metrics={}", render_metrics(report.evaluation.as_ref())),
+        format!("warnings={}", render_warnings(report.evaluation.as_ref())),
+        format!("compare_mode={}", render_compare_mode(report.compare_mode)),
+        format!("mutation_summary={}", report.mutation.summary),
+        format!(
+            "mutation_tags={}",
+            render_string_values(&report.mutation.tags)
+        ),
+    ];
+
+    if let Some(snapshot_delta) = report.snapshot_delta.as_ref() {
+        lines.push(format!(
+            "snapshot_delta_changed_surfaces={}",
+            snapshot_delta.changed_surface_count
+        ));
+        push_scalar_compare_line(
+            &mut lines,
+            "provider_active_profile",
+            &snapshot_delta.provider_active_profile,
+        );
+        push_scalar_compare_line(
+            &mut lines,
+            "provider_active_model",
+            &snapshot_delta.provider_active_model,
+        );
+        push_scalar_compare_line(
+            &mut lines,
+            "context_engine_selected",
+            &snapshot_delta.context_engine_selected,
+        );
+        push_scalar_compare_line(
+            &mut lines,
+            "context_engine_compaction",
+            &snapshot_delta.context_engine_compaction,
+        );
+        push_scalar_compare_line(
+            &mut lines,
+            "memory_selected",
+            &snapshot_delta.memory_selected,
+        );
+        push_scalar_compare_line(&mut lines, "memory_policy", &snapshot_delta.memory_policy);
+        push_scalar_compare_line(&mut lines, "acp_selected", &snapshot_delta.acp_selected);
+        push_scalar_compare_line(&mut lines, "acp_policy", &snapshot_delta.acp_policy);
+        push_set_compare_lines(
+            &mut lines,
+            "enabled_channel_ids",
+            &snapshot_delta.enabled_channel_ids,
+        );
+        push_set_compare_lines(
+            &mut lines,
+            "enabled_service_channel_ids",
+            &snapshot_delta.enabled_service_channel_ids,
+        );
+        push_set_compare_lines(
+            &mut lines,
+            "visible_tool_names",
+            &snapshot_delta.visible_tool_names,
+        );
+        push_scalar_compare_line(
+            &mut lines,
+            "capability_snapshot_sha256",
+            &snapshot_delta.capability_snapshot_sha256,
+        );
+        push_set_compare_lines(
+            &mut lines,
+            "external_skill_ids",
+            &snapshot_delta.external_skill_ids,
+        );
+        if snapshot_delta.changed_surface_count == 0 {
+            lines.push("snapshot_delta=none".to_owned());
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn render_evaluation_summary(evaluation: Option<&RuntimeExperimentEvaluation>) -> String {
+    evaluation
+        .map(|evaluation| evaluation.summary.as_str())
+        .filter(|summary| !summary.is_empty())
+        .unwrap_or("-")
+        .to_owned()
+}
+
+fn render_metrics(evaluation: Option<&RuntimeExperimentEvaluation>) -> String {
+    evaluation
+        .map(|evaluation| {
+            if evaluation.metrics.is_empty() {
+                "-".to_owned()
+            } else {
+                evaluation
+                    .metrics
+                    .iter()
+                    .map(|(key, value)| format!("{key}:{value}"))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            }
+        })
+        .unwrap_or_else(|| "-".to_owned())
+}
+
+fn render_warnings(evaluation: Option<&RuntimeExperimentEvaluation>) -> String {
+    evaluation
+        .map(|evaluation| {
+            if evaluation.warnings.is_empty() {
+                "-".to_owned()
+            } else {
+                evaluation.warnings.join(" | ")
+            }
+        })
+        .unwrap_or_else(|| "-".to_owned())
+}
+
+fn render_string_values(values: &[String]) -> String {
+    if values.is_empty() {
+        "-".to_owned()
+    } else {
+        values.join(",")
+    }
+}
+
+fn render_optional_string(value: Option<&str>) -> &str {
+    value.unwrap_or("-")
+}
+
+fn render_optional_bool(value: Option<bool>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned())
+}
+
+fn render_optional_u64(value: Option<u64>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned())
+}
+
+fn push_scalar_compare_line(
+    lines: &mut Vec<String>,
+    name: &str,
+    compare: &RuntimeExperimentScalarCompare,
+) {
+    if compare.changed() {
+        lines.push(format!(
+            "{name}={} -> {}",
+            render_optional_string(compare.before.as_deref()),
+            render_optional_string(compare.after.as_deref())
+        ));
+    }
+}
+
+fn push_set_compare_lines(
+    lines: &mut Vec<String>,
+    name: &str,
+    compare: &RuntimeExperimentSetCompare,
+) {
+    if compare.changed() {
+        lines.push(format!(
+            "{name}_added={}",
+            render_string_values(&compare.added)
+        ));
+        lines.push(format!(
+            "{name}_removed={}",
+            render_string_values(&compare.removed)
+        ));
+    }
 }
 
 fn render_status(status: RuntimeExperimentStatus) -> &'static str {
@@ -541,5 +1177,12 @@ fn render_decision(decision: RuntimeExperimentDecision) -> &'static str {
         RuntimeExperimentDecision::Undecided => "undecided",
         RuntimeExperimentDecision::Promoted => "promoted",
         RuntimeExperimentDecision::Rejected => "rejected",
+    }
+}
+
+fn render_compare_mode(mode: RuntimeExperimentCompareMode) -> &'static str {
+    match mode {
+        RuntimeExperimentCompareMode::RecordOnly => "record_only",
+        RuntimeExperimentCompareMode::SnapshotDelta => "snapshot_delta",
     }
 }

--- a/crates/daemon/src/runtime_experiment_cli.rs
+++ b/crates/daemon/src/runtime_experiment_cli.rs
@@ -744,6 +744,9 @@ fn snapshot_context_engine_selected_id(
 fn snapshot_context_engine_compaction_summary(
     snapshot: &RuntimeSnapshotArtifactDocument,
 ) -> Option<String> {
+    json_value_path(&snapshot.context_engine, &["compaction"])
+        .and_then(Value::as_object)
+        .filter(|compaction| !compaction.is_empty())?;
     let enabled = render_optional_bool(json_bool_path(
         &snapshot.context_engine,
         &["compaction", "enabled"],
@@ -770,6 +773,9 @@ fn snapshot_memory_selected_id(snapshot: &RuntimeSnapshotArtifactDocument) -> Op
 }
 
 fn snapshot_memory_policy_summary(snapshot: &RuntimeSnapshotArtifactDocument) -> Option<String> {
+    json_value_path(&snapshot.memory_system, &["policy"])
+        .and_then(Value::as_object)
+        .filter(|policy| !policy.is_empty())?;
     Some(format!(
         "backend:{} profile:{} mode:{} ingest_mode:{} fail_open:{} strict_mode_requested:{} strict_mode_active:{} effective_fail_open:{}",
         json_string_path(&snapshot.memory_system, &["policy", "backend"])
@@ -804,6 +810,7 @@ fn snapshot_acp_selected_id(snapshot: &RuntimeSnapshotArtifactDocument) -> Optio
 }
 
 fn snapshot_acp_policy_summary(snapshot: &RuntimeSnapshotArtifactDocument) -> Option<String> {
+    snapshot.acp.as_object().filter(|acp| !acp.is_empty())?;
     Some(format!(
         "enabled:{} dispatch_enabled:{} conversation_routing:{} thread_routing:{} default_agent:{} allowed_agents:{}",
         render_optional_bool(json_bool_path(&snapshot.acp, &["enabled"])),

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -341,7 +341,8 @@ fn runtime_experiment_cli_parses_start_finish_and_show() {
                 assert!(options.json);
             }
             other @ (loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Finish(_)
-            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Show(_)) => {
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Show(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Compare(_)) => {
                 panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
             }
         },
@@ -401,6 +402,9 @@ fn runtime_experiment_cli_parses_start_finish_and_show() {
             )
             | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Show(
                 _,
+            )
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Compare(
+                _,
             )) => {
                 panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
             }
@@ -425,7 +429,50 @@ fn runtime_experiment_cli_parses_start_finish_and_show() {
                 assert!(options.json);
             }
             other @ (loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Start(_)
-            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Finish(_)) => {
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Finish(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Compare(_)) => {
+                panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn runtime_experiment_cli_parses_compare() {
+    let compare = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-experiment",
+        "compare",
+        "--run",
+        "/tmp/runtime-experiment.json",
+        "--baseline-snapshot",
+        "/tmp/runtime-snapshot.json",
+        "--result-snapshot",
+        "/tmp/runtime-snapshot-result.json",
+        "--json",
+    ])
+    .expect("`runtime-experiment compare` should parse");
+
+    match compare.command {
+        Some(Commands::RuntimeExperiment { command }) => match command {
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Compare(
+                options,
+            ) => {
+                assert_eq!(options.run, "/tmp/runtime-experiment.json");
+                assert_eq!(
+                    options.baseline_snapshot.as_deref(),
+                    Some("/tmp/runtime-snapshot.json")
+                );
+                assert_eq!(
+                    options.result_snapshot.as_deref(),
+                    Some("/tmp/runtime-snapshot-result.json")
+                );
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Start(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Finish(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Show(_)) => {
                 panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
             }
         },

--- a/crates/daemon/tests/integration/runtime_experiment_cli.rs
+++ b/crates/daemon/tests/integration/runtime_experiment_cli.rs
@@ -96,6 +96,17 @@ fn snapshot_id_from_payload(payload: &Value) -> String {
         .expect("snapshot payload should include lineage.snapshot_id")
 }
 
+fn rewrite_json_file(path: &Path, mutate: impl FnOnce(&mut Value)) {
+    let raw = fs::read_to_string(path).expect("read json fixture");
+    let mut payload = serde_json::from_str::<Value>(&raw).expect("decode json fixture");
+    mutate(&mut payload);
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&payload).expect("encode json fixture"),
+    )
+    .expect("write json fixture");
+}
+
 fn rewrite_runtime_experiment_compare_config(config_path: &Path) {
     let (_, mut config) = mvp::config::load(Some(
         config_path
@@ -244,6 +255,76 @@ fn finish_runtime_experiment_with_compare_delta(
                 evaluation_summary: "provider and tool policy updated".to_owned(),
                 metric: vec!["task_success=1".to_owned(), "cost_delta=-0.2".to_owned()],
                 warning: vec!["manual verification only".to_owned()],
+                decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+                status: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+
+    (
+        run_path,
+        baseline_snapshot_path,
+        result_snapshot_path,
+        finished,
+    )
+}
+
+fn finish_runtime_experiment_with_missing_compare_sections(
+    root: &Path,
+    config_path: &Path,
+) -> (
+    PathBuf,
+    PathBuf,
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    rewrite_json_file(&baseline_snapshot_path, |payload| {
+        payload["context_engine"]
+            .as_object_mut()
+            .expect("context_engine should be an object")
+            .remove("compaction");
+        payload["memory_system"]
+            .as_object_mut()
+            .expect("memory_system should be an object")
+            .remove("policy");
+        payload["acp"] = Value::Null;
+    });
+
+    let (run_path, _) = start_runtime_experiment(root, &baseline_snapshot_path, None);
+    rewrite_runtime_experiment_compare_config(config_path);
+
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot-result.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:30:00Z".to_owned(),
+            label: Some("candidate".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: "filled missing runtime sections".to_owned(),
+                metric: vec!["task_success=1".to_owned()],
+                warning: Vec::new(),
                 decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
                 status: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
                 json: false,
@@ -847,6 +928,39 @@ fn runtime_experiment_compare_rejects_snapshot_identity_mismatch() {
 
     assert!(error.contains("result snapshot"));
     assert!(error.contains("snapshot_id"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_compare_treats_missing_snapshot_sections_as_absent() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-compare-missing-sections");
+    let config_path = write_runtime_experiment_config(&root);
+    let (run_path, baseline_snapshot_path, result_snapshot_path, _) =
+        finish_runtime_experiment_with_missing_compare_sections(&root, &config_path);
+
+    let report =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_compare_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCompareCommandOptions {
+                run: run_path.display().to_string(),
+                baseline_snapshot: Some(baseline_snapshot_path.display().to_string()),
+                result_snapshot: Some(result_snapshot_path.display().to_string()),
+                json: true,
+            },
+        )
+        .expect("compare should tolerate missing snapshot sections");
+
+    let snapshot_delta = report
+        .snapshot_delta
+        .as_ref()
+        .expect("compare should include snapshot delta");
+    assert_eq!(snapshot_delta.context_engine_compaction.before, None);
+    assert_eq!(snapshot_delta.memory_policy.before, None);
+    assert_eq!(snapshot_delta.acp_policy.before, None);
+    assert!(
+        snapshot_delta.changed_surface_count >= 3,
+        "missing sections should still register as changed surfaces"
+    );
 
     fs::remove_dir_all(&root).ok();
 }

--- a/crates/daemon/tests/integration/runtime_experiment_cli.rs
+++ b/crates/daemon/tests/integration/runtime_experiment_cli.rs
@@ -96,6 +96,36 @@ fn snapshot_id_from_payload(payload: &Value) -> String {
         .expect("snapshot payload should include lineage.snapshot_id")
 }
 
+fn rewrite_runtime_experiment_compare_config(config_path: &Path) {
+    let (_, mut config) = mvp::config::load(Some(
+        config_path
+            .to_str()
+            .expect("config path should be valid utf-8"),
+    ))
+    .expect("load config fixture");
+    let openai = config
+        .providers
+        .get("openai-main")
+        .cloned()
+        .expect("openai-main provider should exist");
+    config.set_active_provider_profile("openai-main", openai);
+    config.tools.browser.enabled = false;
+    config.tools.web.enabled = false;
+    config.acp.dispatch.enabled = false;
+    config.acp.default_agent = Some("codex".to_owned());
+    config.acp.allowed_agents = vec!["codex".to_owned()];
+    mvp::config::write(
+        Some(
+            config_path
+                .to_str()
+                .expect("config path should be valid utf-8"),
+        ),
+        &config,
+        true,
+    )
+    .expect("rewrite config fixture");
+}
+
 fn start_runtime_experiment(
     root: &Path,
     snapshot_path: &Path,
@@ -167,6 +197,66 @@ fn finish_runtime_experiment(
         )
         .expect("runtime experiment finish should succeed");
     (run_path, finished)
+}
+
+fn finish_runtime_experiment_with_compare_delta(
+    root: &Path,
+    config_path: &Path,
+) -> (
+    PathBuf,
+    PathBuf,
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(root, &baseline_snapshot_path, None);
+
+    rewrite_runtime_experiment_compare_config(config_path);
+
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot-result.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:30:00Z".to_owned(),
+            label: Some("candidate".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: "provider and tool policy updated".to_owned(),
+                metric: vec!["task_success=1".to_owned(), "cost_delta=-0.2".to_owned()],
+                warning: vec!["manual verification only".to_owned()],
+                decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+                status: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+
+    (
+        run_path,
+        baseline_snapshot_path,
+        result_snapshot_path,
+        finished,
+    )
 }
 
 #[test]
@@ -597,6 +687,166 @@ fn runtime_experiment_show_text_surfaces_decision_fields_first() {
     assert_eq!(lines[5], "decision=promoted");
     assert_eq!(lines[6], "metrics=task_success:1,token_delta:0");
     assert_eq!(lines[7], "warnings=manual verification only");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_compare_record_only_surfaces_decision_summary() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-compare-record-only");
+    let config_path = write_runtime_experiment_config(&root);
+    let (run_path, finished) = finish_runtime_experiment(&root, &config_path);
+
+    let report =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_compare_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCompareCommandOptions {
+                run: run_path.display().to_string(),
+                baseline_snapshot: None,
+                result_snapshot: None,
+                json: true,
+            },
+        )
+        .expect("record-only compare should succeed");
+
+    assert_eq!(
+        report.compare_mode,
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCompareMode::RecordOnly
+    );
+    assert_eq!(report.run_id, finished.run_id);
+    assert_eq!(report.status, finished.status);
+    assert_eq!(report.decision, finished.decision);
+    assert_eq!(
+        report
+            .evaluation
+            .as_ref()
+            .expect("compare should carry evaluation")
+            .summary,
+        "task success improved"
+    );
+    assert!(report.snapshot_delta.is_none());
+
+    let rendered =
+        loongclaw_daemon::runtime_experiment_cli::render_runtime_experiment_compare_text(&report);
+    assert!(rendered.contains("compare_mode=record_only"));
+    assert!(rendered.contains("evaluation_summary=task success improved"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_compare_with_snapshot_delta_reports_changed_runtime_surfaces() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-compare-snapshot-delta");
+    let config_path = write_runtime_experiment_config(&root);
+    let (run_path, baseline_snapshot_path, result_snapshot_path, _) =
+        finish_runtime_experiment_with_compare_delta(&root, &config_path);
+
+    let report =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_compare_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCompareCommandOptions {
+                run: run_path.display().to_string(),
+                baseline_snapshot: Some(baseline_snapshot_path.display().to_string()),
+                result_snapshot: Some(result_snapshot_path.display().to_string()),
+                json: true,
+            },
+        )
+        .expect("snapshot-delta compare should succeed");
+
+    assert_eq!(
+        report.compare_mode,
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCompareMode::SnapshotDelta
+    );
+    let snapshot_delta = report
+        .snapshot_delta
+        .as_ref()
+        .expect("compare should include snapshot delta");
+    assert_eq!(
+        snapshot_delta.provider_active_profile.before.as_deref(),
+        Some("deepseek-lab")
+    );
+    assert_eq!(
+        snapshot_delta.provider_active_profile.after.as_deref(),
+        Some("openai-main")
+    );
+    assert_eq!(
+        snapshot_delta.provider_active_model.before.as_deref(),
+        Some("deepseek-chat")
+    );
+    assert_eq!(
+        snapshot_delta.provider_active_model.after.as_deref(),
+        Some("gpt-4.1-mini")
+    );
+    assert!(
+        !snapshot_delta.visible_tool_names.removed.is_empty(),
+        "tool diff should report removed tools after disabling browser and web"
+    );
+    assert!(
+        snapshot_delta.changed_surface_count >= 4,
+        "compare should report multiple changed runtime surfaces"
+    );
+
+    let rendered =
+        loongclaw_daemon::runtime_experiment_cli::render_runtime_experiment_compare_text(&report);
+    assert!(rendered.contains("compare_mode=snapshot_delta"));
+    assert!(rendered.contains("provider_active_profile=deepseek-lab -> openai-main"));
+    assert!(rendered.contains("provider_active_model=deepseek-chat -> gpt-4.1-mini"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_compare_requires_both_snapshot_paths_for_deep_compare() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-compare-partial");
+    let config_path = write_runtime_experiment_config(&root);
+    let (run_path, baseline_snapshot_path, _, _) =
+        finish_runtime_experiment_with_compare_delta(&root, &config_path);
+
+    let error =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_compare_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCompareCommandOptions {
+                run: run_path.display().to_string(),
+                baseline_snapshot: Some(baseline_snapshot_path.display().to_string()),
+                result_snapshot: None,
+                json: false,
+            },
+        )
+        .expect_err("partial snapshot input should be rejected");
+
+    assert!(error.contains("requires --baseline-snapshot and --result-snapshot together"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_compare_rejects_snapshot_identity_mismatch() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-compare-mismatch");
+    let config_path = write_runtime_experiment_config(&root);
+    let (run_path, baseline_snapshot_path, _, _) =
+        finish_runtime_experiment_with_compare_delta(&root, &config_path);
+    let (other_result_snapshot_path, _) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot-other.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:45:00Z".to_owned(),
+            label: Some("other".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+
+    let error =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_compare_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCompareCommandOptions {
+                run: run_path.display().to_string(),
+                baseline_snapshot: Some(baseline_snapshot_path.display().to_string()),
+                result_snapshot: Some(other_result_snapshot_path.display().to_string()),
+                json: false,
+            },
+        )
+        .expect_err("mismatched result snapshot should be rejected");
+
+    assert!(error.contains("result snapshot"));
+    assert!(error.contains("snapshot_id"));
 
     fs::remove_dir_all(&root).ok();
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -288,7 +288,7 @@ Delivered in current baseline:
 - experiment-state operator surface foundation:
   - `runtime-snapshot` persists lineage-aware runtime checkpoint artifacts
   - `runtime-restore` replays a persisted checkpoint as a dry-run or apply plan
-  - `runtime-experiment start|finish|show` records baseline snapshot, mutation summary, result snapshot, evaluation metrics, warnings, and final decision
+  - `runtime-experiment start|finish|show|compare` records baseline snapshot, mutation summary, result snapshot, evaluation metrics, warnings, final decision, and optional snapshot-backed runtime deltas for operator review
 - modular channel/provider architecture for extension-safe evolution:
   - `app/channel/feishu/*` split into adapter/payload/webhook layers
   - Feishu encrypted webhook payload decrypt lane with signature verification

--- a/docs/plans/2026-03-16-alpha-test-runtime-experiment-compare-design.md
+++ b/docs/plans/2026-03-16-alpha-test-runtime-experiment-compare-design.md
@@ -1,0 +1,178 @@
+# Alpha-Test Runtime Experiment Compare Design
+
+## Goal
+
+Add a minimal `runtime-experiment compare` surface that helps an operator judge a
+finished experiment run against its baseline without turning the record layer
+into an autonomous optimizer.
+
+## Problem
+
+`runtime-experiment start|finish|show` made snapshot-based experiment runs
+persistable and inspectable, but an operator still has to manually stitch
+together three different artifacts to answer the practical question:
+
+> what actually changed between the baseline runtime state and the result state,
+> and does that change support the recorded decision?
+
+Today that answer requires reading raw JSON or separately rendering snapshots.
+That is workable for one-off debugging, but not for a reusable middle-layer
+experiment service.
+
+## Constraints
+
+- Keep `runtime-experiment` as a record-and-compare layer above
+  `runtime-snapshot` and `runtime-restore`
+- Do not add automatic mutation, promotion, rollback, or orchestration
+- Avoid schema churn in the persisted run artifact unless strictly necessary
+- Reuse existing artifact and rendering conventions instead of introducing a
+  generic diff engine
+
+## Options Considered
+
+### Option A: Artifact-only compare
+
+Add `runtime-experiment compare --run <path>` and render only the persisted run
+fields plus evaluation metrics and warnings.
+
+Pros:
+
+- smallest code change
+- no extra inputs
+- no schema change
+
+Cons:
+
+- too little new information beyond `show`
+- does not explain runtime-surface drift
+- weak operator value for promotion/rejection review
+
+### Option B: Run-aware compare with explicit snapshot inputs
+
+Add `runtime-experiment compare --run <path>` and allow the operator to supply
+matching `--baseline-snapshot` and `--result-snapshot` artifacts to produce a
+targeted runtime delta summary.
+
+Pros:
+
+- no persisted schema change
+- materially more useful than `show`
+- validates that supplied snapshots match the run's recorded snapshot ids
+- keeps portability boundaries clear because local file paths are not embedded
+  into persisted artifacts
+
+Cons:
+
+- operators must provide snapshot paths when they want deep comparison
+- compare output must choose a narrow set of stable fields instead of dumping
+  everything
+
+### Option C: Embed snapshot paths or full snapshots into the run artifact
+
+Extend `start` / `finish` to persist snapshot source paths or full snapshot
+documents so `compare --run` can always deep-diff without extra inputs.
+
+Pros:
+
+- most convenient compare UX
+
+Cons:
+
+- couples persisted experiment records to machine-local paths or bloated payloads
+- expands artifact versioning and migration burden
+- pulls the record layer toward archive management too early
+
+## Decision
+
+Choose Option B.
+
+This is the smallest change that materially improves experiment review while
+preserving the current architecture. The operator gets an explicit compare
+surface, but the run artifact remains a portable record rather than a bundled
+archive.
+
+## Proposed CLI
+
+Add a new subcommand:
+
+```text
+loongclaw runtime-experiment compare \
+  --run path/to/run.json \
+  [--baseline-snapshot path/to/baseline.json] \
+  [--result-snapshot path/to/result.json] \
+  [--json]
+```
+
+Behavior:
+
+- always load the run artifact
+- render a decision-oriented comparison summary even when no snapshot artifacts
+  are provided
+- require `--baseline-snapshot` and `--result-snapshot` together when loading
+  runtime-surface deltas
+- verify that the supplied snapshot ids match the run's recorded baseline and
+  result snapshot summaries
+- reject deep comparison when the run has no recorded result snapshot
+
+## Comparison Model
+
+The compare command should not implement a generic JSON diff. It should surface
+only the runtime areas that are already stable and meaningful in the existing
+snapshot contract:
+
+- run status, decision, mutation summary, evaluation summary, metrics, warnings
+- baseline/result snapshot ids, labels, timestamps, and experiment ids
+- provider active profile and active model
+- context-engine selected backend and compaction policy
+- memory-system selected backend and policy mode/profile/backend
+- ACP selected backend, enablement, dispatch routing, default agent, and allowed
+  agents
+- enabled channel ids and enabled service channel ids
+- visible tool names plus capability snapshot sha256
+- external-skill ids discovered in inventory
+
+For list-like surfaces, compare should emit `added` and `removed` sets. For
+scalar surfaces, compare should emit `before` and `after`.
+
+## Output Shape
+
+Text output should keep decision-critical fields first, then show loaded delta
+sections:
+
+- `run_id`
+- `experiment_id`
+- `baseline_snapshot_id`
+- `result_snapshot_id`
+- `status`
+- `decision`
+- `evaluation_summary`
+- `metrics`
+- `warnings`
+- `compare_mode` (`record_only` or `snapshot_delta`)
+- targeted delta lines
+
+JSON output should expose the same information through an explicit compare
+report payload instead of reusing the run artifact schema.
+
+## Error Handling
+
+- fail if only one of `--baseline-snapshot` or `--result-snapshot` is supplied
+- fail if the supplied baseline snapshot id does not match the run artifact
+- fail if the supplied result snapshot id does not match the run artifact
+- fail if deep compare is requested for a `planned` run with no result snapshot
+- tolerate missing optional nested fields inside snapshot payloads and render
+  `null` / empty deltas rather than panicking
+
+## Non-Goals
+
+- automatic promotion or rollback
+- path discovery, snapshot indexing, or experiment-run listing
+- arbitrary JSON diff or per-field patch output
+- evaluator execution or metric delta computation against a baseline evaluator
+
+## Validation
+
+- CLI parse coverage for the new `compare` subcommand
+- integration coverage for record-only compare output
+- integration coverage for snapshot-delta compare output
+- regression coverage for mismatched snapshot ids and partial snapshot inputs

--- a/docs/plans/2026-03-16-alpha-test-runtime-experiment-compare-implementation-plan.md
+++ b/docs/plans/2026-03-16-alpha-test-runtime-experiment-compare-implementation-plan.md
@@ -1,0 +1,153 @@
+# Runtime Experiment Compare Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a minimal `runtime-experiment compare` CLI that summarizes a run
+and, when explicit snapshot artifacts are supplied, reports a targeted runtime
+delta between baseline and result snapshots.
+
+**Architecture:** Extend the existing `runtime_experiment_cli` module with a new
+subcommand, a small compare-report model, and targeted snapshot readers that
+reuse the current runtime snapshot artifact schema. Keep the persisted
+experiment-run artifact unchanged and validate snapshot-to-run identity through
+recorded snapshot ids.
+
+**Tech Stack:** Rust, `clap`, `serde`, existing daemon integration-test harness
+
+---
+
+### Task 1: Add failing CLI parsing coverage for `runtime-experiment compare`
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/cli_tests.rs`
+
+**Step 1: Write the failing test**
+
+Add a parsing test that expects:
+
+- `runtime-experiment compare --run artifacts/run.json`
+- optional `--baseline-snapshot` and `--result-snapshot`
+- `--json`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-daemon --test integration runtime_experiment_cli_parses_start_finish_and_show -- --exact`
+
+Expected: FAIL because the CLI does not parse `compare` yet.
+
+**Step 3: Write minimal implementation**
+
+Add the `Compare` variant and command options to the runtime experiment CLI.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-daemon --test integration runtime_experiment_cli_parses_start_finish_and_show -- --exact`
+
+Expected: PASS.
+
+### Task 2: Add failing compare integration tests
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/runtime_experiment_cli.rs`
+
+**Step 1: Write the failing tests**
+
+Add focused tests for:
+
+- record-only compare output from a finished run
+- snapshot-delta compare with matching baseline/result artifacts
+- rejection when only one snapshot path is supplied
+- rejection when supplied snapshot ids do not match the run artifact
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p loongclaw-daemon --test integration runtime_experiment_compare -- --nocapture`
+
+Expected: FAIL because compare execution and rendering are missing.
+
+**Step 3: Write minimal implementation**
+
+Add compare execution, validation, snapshot delta extraction, and text / JSON
+rendering in `runtime_experiment_cli.rs`.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p loongclaw-daemon --test integration runtime_experiment_compare -- --nocapture`
+
+Expected: PASS.
+
+### Task 3: Refactor compare helpers to stay narrow and readable
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_experiment_cli.rs`
+
+**Step 1: Clean up helper boundaries**
+
+Extract small helpers for:
+
+- snapshot identity validation
+- scalar before/after compare entries
+- set added/removed compare entries
+- nested JSON field lookups used by compare
+
+**Step 2: Re-run focused tests**
+
+Run: `cargo test -p loongclaw-daemon --test integration runtime_experiment_compare runtime_experiment_show_round_trips_the_persisted_artifact`
+
+Expected: PASS.
+
+### Task 4: Update product docs
+
+**Files:**
+- Modify: `docs/product-specs/runtime-experiment.md`
+- Modify: `docs/ROADMAP.md`
+
+**Step 1: Update docs**
+
+Document that:
+
+- `runtime-experiment compare` is the decision-support layer above run records
+- deep comparison is opt-in through explicit snapshot artifacts
+- the command remains non-autonomous and non-mutating
+
+**Step 2: Verify doc references**
+
+Run: `rg -n "runtime-experiment|compare" docs/product-specs/runtime-experiment.md docs/ROADMAP.md`
+
+Expected: matches include the new compare wording.
+
+### Task 5: Run final verification and prepare delivery
+
+**Files:**
+- Modify: staged task files only
+
+**Step 1: Format**
+
+Run: `cargo fmt --all -- --check`
+
+Expected: PASS.
+
+**Step 2: Run focused test coverage**
+
+Run: `cargo test -p loongclaw-daemon --test integration runtime_experiment`
+
+Expected: PASS.
+
+**Step 3: Run daemon clippy coverage**
+
+Run: `cargo clippy -p loongclaw-daemon --all-targets -- -D warnings`
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-03-16-alpha-test-runtime-experiment-compare-design.md \
+  docs/plans/2026-03-16-alpha-test-runtime-experiment-compare-implementation-plan.md \
+  crates/daemon/src/runtime_experiment_cli.rs \
+  crates/daemon/tests/integration/cli_tests.rs \
+  crates/daemon/tests/integration/runtime_experiment_cli.rs \
+  docs/product-specs/runtime-experiment.md \
+  docs/ROADMAP.md
+git commit -m "feat(daemon): add runtime experiment compare"
+```

--- a/docs/product-specs/runtime-experiment.md
+++ b/docs/product-specs/runtime-experiment.md
@@ -9,7 +9,7 @@ explicit promotion or rejection decision.
 ## Acceptance Criteria
 
 - [ ] LoongClaw exposes a `runtime-experiment` command family with `start`,
-      `finish`, and `show` subcommands.
+      `finish`, `show`, and `compare` subcommands.
 - [ ] `runtime-experiment start` creates a persisted experiment-run artifact
       that records a baseline snapshot summary, mutation summary, optional tags,
       and an explicit `planned` / `undecided` starting state.
@@ -20,6 +20,10 @@ explicit promotion or rejection decision.
       without mutating live runtime state.
 - [ ] `runtime-experiment show` round-trips the persisted artifact as JSON and
       renders the decision-critical fields first in text output.
+- [ ] `runtime-experiment compare` always renders a decision-oriented summary
+      from the persisted run artifact and, when both matching snapshot artifacts
+      are supplied, reports targeted runtime-surface deltas without mutating
+      runtime state or changing the persisted run schema.
 - [ ] Product docs describe `runtime-experiment` as the record layer above
       `runtime-snapshot` and `runtime-restore`, not as an autonomous optimizer
       or automatic promotion system.
@@ -29,4 +33,5 @@ explicit promotion or rejection decision.
 - Running arbitrary shell commands as part of an experiment run
 - Automatically mutating skills, providers, or daemon config
 - Automatic promotion, rollback, or branch management policy
+- Snapshot indexing, artifact discovery, or bundled archive management
 - Evaluator pipelines, dashboards, or autonomous skill-optimization loops


### PR DESCRIPTION
## Summary

- add `runtime-experiment compare` with record-only and snapshot-delta modes for operator decision support
- validate supplied baseline/result snapshot ids against the persisted run artifact and render targeted runtime-surface deltas without changing the run schema
- add CLI/integration coverage plus runtime-experiment product-spec, roadmap, and local plan updates

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional focused daemon checks:
- [x] `cargo clippy -p loongclaw-daemon --all-targets -- -D warnings`
- [x] `cargo test -p loongclaw-daemon --test integration runtime_experiment`
- [ ] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

## Linked Issues

Closes #237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Compare subcommand for runtime experiments to summarize runs and, when provided, produce snapshot delta reports in JSON or human-readable text.

* **Tests**
  * Added integration tests and test helpers covering parsing, record-only summaries, snapshot-delta reports, identity validation, missing-section handling, and error cases.

* **Documentation**
  * Updated roadmap, product spec, and design/implementation plans to describe compare behavior, validation rules, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->