### PR TITLE
fix(onboard): align credential source with provider binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,11 @@ cargo install --path crates/daemon
 
 2. Set your provider credential in the env that onboarding selected:
 
+   For OpenAI Codex account auth this will usually be `OPENAI_CODEX_OAUTH_TOKEN`; for
+   API-key providers it will usually be a `*_API_KEY` env such as `ARK_API_KEY`.
+
    ```bash
-   export PROVIDER_API_KEY=sk-...
+   export <ENV_NAME>=...
    ```
 
 3. Get a first one-shot answer:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -152,8 +152,11 @@ cargo install --path crates/daemon
 
 2. 按 onboarding 选中的环境变量名设置 provider 凭据：
 
+   对于 OpenAI Codex 账号登录，这通常会是 `OPENAI_CODEX_OAUTH_TOKEN`；对于
+   走 API key 的 provider，则通常会是 `ARK_API_KEY` 这类 `*_API_KEY` 环境变量。
+
    ```bash
-   export PROVIDER_API_KEY=sk-...
+   export <ENV_NAME>=...
    ```
 
 3. 先拿到一次性回答：

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -626,17 +626,14 @@ mod tests {
     }
 
     #[test]
-    fn volcengine_coding_plan_oauth_can_override_api_key_auth() {
+    fn volcengine_coding_plan_defaults_to_api_key_auth() {
         let config = ProviderConfig {
             kind: ProviderKind::VolcengineCoding,
             oauth_access_token: Some("vc-oauth-token".to_owned()),
             api_key: Some("api-key-should-not-win".to_owned()),
             ..ProviderConfig::default()
         };
-        assert_eq!(
-            config.default_oauth_access_token_env().as_deref(),
-            Some("VOLCENGINE_CODING_PLAN_OAUTH_TOKEN")
-        );
+        assert_eq!(config.default_oauth_access_token_env().as_deref(), None);
         assert_eq!(
             config.authorization_header(),
             Some("Bearer vc-oauth-token".to_owned())

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -626,7 +626,7 @@ mod tests {
     }
 
     #[test]
-    fn volcengine_coding_plan_defaults_to_api_key_auth() {
+    fn volcengine_coding_plan_has_no_default_oauth_env_but_accepts_explicit_oauth_token() {
         let config = ProviderConfig {
             kind: ProviderKind::VolcengineCoding,
             oauth_access_token: Some("vc-oauth-token".to_owned()),

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -860,7 +860,7 @@ kind = "volcengine_coding"
         );
         assert_eq!(
             parsed.provider.default_oauth_access_token_env().as_deref(),
-            Some("VOLCENGINE_CODING_PLAN_OAUTH_TOKEN")
+            None
         );
     }
 

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -2645,8 +2645,8 @@ const PROVIDER_PROFILES: [ProviderProfile; 39] = [
         default_api_key_env: Some("ARK_API_KEY"),
         api_key_env_aliases: &[],
         default_user_agent: None,
-        default_oauth_access_token_env: Some("VOLCENGINE_CODING_PLAN_OAUTH_TOKEN"),
-        oauth_access_token_env_aliases: &["ARK_OAUTH_ACCESS_TOKEN"],
+        default_oauth_access_token_env: None,
+        oauth_access_token_env_aliases: &[],
         feature_family: ProviderFeatureFamily::Volcengine,
     },
     ProviderProfile {

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1120,7 +1120,7 @@ fn resolve_api_key_env_selection(
             true,
         ),
     )?;
-    let value = ui.prompt_with_default("API key env var", initial)?;
+    let value = ui.prompt_with_default("Credential env var", initial)?;
     if is_explicit_onboard_clear_input(&value) {
         return Ok(String::new());
     }
@@ -1134,13 +1134,22 @@ fn apply_selected_api_key_env(
     let selected_api_key_env = selected_api_key_env.trim();
     if selected_api_key_env.is_empty() {
         provider.set_api_key_env(None);
+        provider.set_oauth_access_token_env(None);
         return;
     }
 
     provider.api_key = None;
     provider.oauth_access_token = None;
-    provider.set_oauth_access_token_env(None);
-    provider.set_api_key_env(Some(selected_api_key_env.to_owned()));
+    match selected_provider_credential_env_field(provider, selected_api_key_env) {
+        ProviderCredentialEnvField::ApiKey => {
+            provider.set_oauth_access_token_env(None);
+            provider.set_api_key_env(Some(selected_api_key_env.to_owned()));
+        }
+        ProviderCredentialEnvField::OAuthAccessToken => {
+            provider.set_api_key_env(None);
+            provider.set_oauth_access_token_env(Some(selected_api_key_env.to_owned()));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1642,6 +1651,81 @@ pub fn preferred_provider_credential_env_binding(
         })
 }
 
+fn configured_provider_credential_env_binding(
+    provider: &mvp::config::ProviderConfig,
+) -> Option<ProviderCredentialEnvBinding> {
+    provider
+        .oauth_access_token_env
+        .as_deref()
+        .and_then(normalize_provider_credential_env_name)
+        .map(|env_name| ProviderCredentialEnvBinding {
+            field: ProviderCredentialEnvField::OAuthAccessToken,
+            env_name,
+        })
+        .or_else(|| {
+            provider
+                .api_key_env
+                .as_deref()
+                .and_then(normalize_provider_credential_env_name)
+                .map(|env_name| ProviderCredentialEnvBinding {
+                    field: ProviderCredentialEnvField::ApiKey,
+                    env_name,
+                })
+        })
+}
+
+fn provider_has_inline_credential(provider: &mvp::config::ProviderConfig) -> bool {
+    provider
+        .api_key
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+        || provider
+            .oauth_access_token
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty())
+}
+
+fn selected_provider_credential_env_field(
+    provider: &mvp::config::ProviderConfig,
+    selected_env_name: &str,
+) -> ProviderCredentialEnvField {
+    let normalized = normalize_provider_credential_env_name(selected_env_name);
+    let matches_oauth = normalized.as_deref().is_some_and(|env_name| {
+        provider.kind.default_oauth_access_token_env() == Some(env_name)
+            || provider
+                .kind
+                .oauth_access_token_env_aliases()
+                .contains(&env_name)
+            || provider
+                .oauth_access_token_env
+                .as_deref()
+                .and_then(normalize_provider_credential_env_name)
+                .as_deref()
+                == Some(env_name)
+    });
+    let matches_api_key = normalized.as_deref().is_some_and(|env_name| {
+        provider.kind.default_api_key_env() == Some(env_name)
+            || provider.kind.api_key_env_aliases().contains(&env_name)
+            || provider
+                .api_key_env
+                .as_deref()
+                .and_then(normalize_provider_credential_env_name)
+                .as_deref()
+                == Some(env_name)
+    });
+
+    match (matches_oauth, matches_api_key) {
+        (true, false) => ProviderCredentialEnvField::OAuthAccessToken,
+        (false, true) => ProviderCredentialEnvField::ApiKey,
+        _ => configured_provider_credential_env_binding(provider)
+            .or_else(|| preferred_provider_credential_env_binding(provider))
+            .map(|binding| binding.field)
+            .unwrap_or(ProviderCredentialEnvField::ApiKey),
+    }
+}
+
 fn push_provider_credential_env_hint(hints: &mut Vec<String>, maybe_env_name: Option<&str>) {
     let Some(env_name) = maybe_env_name.and_then(normalize_provider_credential_env_name) else {
         return;
@@ -1665,40 +1749,15 @@ fn render_provider_credential_source_value(raw: Option<&str>) -> Option<String> 
 
 pub fn preferred_api_key_env_default(config: &mvp::config::LoongClawConfig) -> String {
     let provider = &config.provider;
-    if let Some(api_key_env) = provider
-        .api_key_env
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        return api_key_env.to_owned();
+    if let Some(binding) = configured_provider_credential_env_binding(provider) {
+        return binding.env_name;
     }
-    let inline_or_oauth_auth = provider
-        .api_key
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|value| !value.is_empty())
-        || provider
-            .oauth_access_token
-            .as_deref()
-            .map(str::trim)
-            .is_some_and(|value| !value.is_empty())
-        || provider
-            .oauth_access_token_env
-            .as_deref()
-            .map(str::trim)
-            .is_some_and(|value| !value.is_empty());
-    if inline_or_oauth_auth {
+    if provider_has_inline_credential(provider) {
         return String::new();
     }
-    if provider.api_key().is_some() {
-        return provider_default_api_key_env(provider.kind)
-            .unwrap_or_default()
-            .to_owned();
-    }
-    provider_default_api_key_env(provider.kind)
+    preferred_provider_credential_env_binding(provider)
+        .map(|binding| binding.env_name)
         .unwrap_or_default()
-        .to_owned()
 }
 
 pub fn directory_preflight_check(name: &'static str, target: &Path) -> OnboardCheck {
@@ -3197,11 +3256,10 @@ fn render_api_key_env_selection_default_hint_line(
         .unwrap_or_else(|| prompt_default.trim().to_owned());
     let suggested_env = render_provider_credential_source_value(Some(suggested_env))
         .unwrap_or_else(|| suggested_env.trim().to_owned());
-    let current_env = config
-        .provider
-        .api_key_env
-        .as_deref()
-        .and_then(|value| render_provider_credential_source_value(Some(value)));
+    let current_env =
+        configured_provider_credential_env_binding(&config.provider).and_then(|binding| {
+            render_provider_credential_source_value(Some(binding.env_name.as_str()))
+        });
 
     if prompt_default.is_empty() {
         return render_default_input_hint_line("leave this blank");
@@ -4183,11 +4241,10 @@ fn render_api_key_env_selection_screen_lines_with_style(
         "- provider: {}",
         crate::provider_presentation::guided_provider_label(config.provider.kind)
     )];
-    if let Some(current_env) = config
-        .provider
-        .api_key_env
-        .as_deref()
-        .and_then(|value| render_provider_credential_source_value(Some(value)))
+    if let Some(current_env) = configured_provider_credential_env_binding(&config.provider)
+        .and_then(|binding| {
+            render_provider_credential_source_value(Some(binding.env_name.as_str()))
+        })
     {
         context_lines.push(format!("- current source: {current_env}"));
     }
@@ -4202,14 +4259,14 @@ fn render_api_key_env_selection_screen_lines_with_style(
         default_api_key_env,
         prompt_default,
     )];
-    if provider_supports_blank_api_key_env(config) {
-        if prompt_default.trim().is_empty() {
-            hint_lines.push("- leave this blank to keep inline or oauth credentials".to_owned());
-        } else {
-            hint_lines.push(render_clear_input_hint_line(
-                "keep inline or oauth credentials",
-            ));
+    if prompt_default.trim().is_empty() {
+        if provider_has_inline_credential(&config.provider) {
+            hint_lines.push("- leave this blank to keep inline credentials".to_owned());
         }
+    } else if provider_supports_blank_api_key_env(config) {
+        hint_lines.push(render_clear_input_hint_line(
+            "clear the configured credential env",
+        ));
     }
 
     render_onboard_input_screen(
@@ -4608,41 +4665,19 @@ fn summarize_provider_credential(
             value: "inline api key".to_owned(),
         });
     }
-    provider
-        .api_key_env
-        .as_deref()
-        .and_then(|value| render_provider_credential_source_value(Some(value)))
-        .or_else(|| {
-            provider
-                .kind
-                .default_api_key_env()
-                .and_then(|value| render_provider_credential_source_value(Some(value)))
+    preferred_provider_credential_env_binding(provider)
+        .and_then(|binding| {
+            render_provider_credential_source_value(Some(binding.env_name.as_str()))
         })
-        .map(|api_key_env| OnboardingCredentialSummary {
+        .map(|credential_env| OnboardingCredentialSummary {
             label: "credential source",
-            value: api_key_env,
+            value: credential_env,
         })
 }
 
 fn provider_supports_blank_api_key_env(config: &mvp::config::LoongClawConfig) -> bool {
-    config
-        .provider
-        .api_key
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|value| !value.is_empty())
-        || config
-            .provider
-            .oauth_access_token
-            .as_deref()
-            .map(str::trim)
-            .is_some_and(|value| !value.is_empty())
-        || config
-            .provider
-            .oauth_access_token_env
-            .as_deref()
-            .map(str::trim)
-            .is_some_and(|value| !value.is_empty())
+    provider_has_inline_credential(&config.provider)
+        || configured_provider_credential_env_binding(&config.provider).is_some()
 }
 
 fn prompt_import_candidate_choice(
@@ -5670,6 +5705,24 @@ mod tests {
         assert!(
             selected.is_empty(),
             "typing :clear should explicitly clear the api-key env selection instead of persisting the literal token: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn apply_selected_api_key_env_routes_openai_oauth_env_to_oauth_binding() {
+        let mut provider = mvp::config::ProviderConfig::default();
+        provider.kind = mvp::config::ProviderKind::Openai;
+        provider.api_key_env = Some("OPENAI_API_KEY".to_owned());
+
+        apply_selected_api_key_env(&mut provider, "OPENAI_CODEX_OAUTH_TOKEN".to_owned());
+
+        assert_eq!(
+            provider.oauth_access_token_env.as_deref(),
+            Some("OPENAI_CODEX_OAUTH_TOKEN")
+        );
+        assert_eq!(
+            provider.api_key_env, None,
+            "switching to the OpenAI oauth env should clear the stale api-key env binding"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2163,12 +2163,10 @@ fn render_onboard_entry_screen_lines_with_style(
     let recommended_plan_available = import_candidates.iter().any(|candidate| {
         candidate.source_kind == crate::migration::ImportSourceKind::RecommendedPlan
     });
-    let mut lines = mvp::presentation::style_brand_lines(
-        &mvp::presentation::render_brand_header(
-            width,
-            &mvp::presentation::BuildVersionInfo::current(),
-            Some("guided setup for provider, channels, and workspace guidance"),
-        ),
+    let mut lines = render_onboard_header(
+        OnboardHeaderStyle::Compact,
+        width,
+        "guided setup for provider, channels, and workspace guidance",
         color_enabled,
     );
     lines.push(String::new());
@@ -2629,7 +2627,7 @@ fn render_single_detected_setup_preview_screen_lines_with_style(
     ));
 
     render_onboard_choice_screen(
-        OnboardHeaderStyle::Brand,
+        OnboardHeaderStyle::Compact,
         width,
         crate::onboard_presentation::single_detected_starting_point_preview_subtitle(),
         crate::onboard_presentation::single_detected_starting_point_preview_title(),
@@ -2847,7 +2845,8 @@ fn render_onboard_review_lines_with_guidance_and_style(
     flow_style: ReviewFlowStyle,
     color_enabled: bool,
 ) -> Vec<String> {
-    let mut lines = render_onboard_brand_header(width, flow_style.header_subtitle(), color_enabled);
+    let mut lines =
+        render_onboard_compact_header(width, flow_style.header_subtitle(), color_enabled);
     lines.push(String::new());
     lines.push("review setup".to_owned());
     lines.push(flow_style.progress_line());
@@ -3007,7 +3006,7 @@ fn render_onboarding_success_summary_with_width_and_style(
     width: usize,
     color_enabled: bool,
 ) -> Vec<String> {
-    let mut lines = render_onboard_brand_header(width, "setup complete", color_enabled);
+    let mut lines = render_onboard_compact_header(width, "setup complete", color_enabled);
     lines.push(String::new());
     lines.push("onboarding complete".to_owned());
     if !summary.next_actions.is_empty() {
@@ -3422,7 +3421,7 @@ fn render_onboard_shortcut_screen_lines_with_style(
     context_lines.push(shortcut_kind.summary_line().to_owned());
 
     render_onboard_choice_screen(
-        OnboardHeaderStyle::Brand,
+        OnboardHeaderStyle::Compact,
         width,
         shortcut_kind.subtitle(),
         shortcut_kind.title(),
@@ -4019,7 +4018,7 @@ fn render_starting_point_selection_screen_lines_with_style(
     let footer_lines = render_starting_point_selection_footer_lines(&sorted_candidates);
 
     render_onboard_choice_screen(
-        OnboardHeaderStyle::Brand,
+        OnboardHeaderStyle::Compact,
         width,
         crate::onboard_presentation::starting_point_selection_subtitle(),
         crate::onboard_presentation::starting_point_selection_title(),
@@ -4085,7 +4084,7 @@ fn render_provider_selection_screen_lines_with_style(
         })
         .collect::<Vec<_>>();
     render_onboard_choice_screen(
-        OnboardHeaderStyle::Brand,
+        OnboardHeaderStyle::Compact,
         width,
         "choose the current provider",
         "choose active provider",
@@ -4384,7 +4383,7 @@ fn render_personality_selection_screen_lines_with_style(
     .collect::<Vec<_>>();
 
     render_onboard_choice_screen(
-        OnboardHeaderStyle::Brand,
+        OnboardHeaderStyle::Compact,
         width,
         "choose how LoongClaw should speak and take initiative",
         "choose personality",
@@ -4492,7 +4491,7 @@ fn render_memory_profile_selection_screen_lines_with_style(
     .collect::<Vec<_>>();
 
     render_onboard_choice_screen(
-        OnboardHeaderStyle::Brand,
+        OnboardHeaderStyle::Compact,
         width,
         "choose how much memory context LoongClaw should inject",
         "choose memory profile",

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -5709,9 +5709,11 @@ mod tests {
 
     #[test]
     fn apply_selected_api_key_env_routes_openai_oauth_env_to_oauth_binding() {
-        let mut provider = mvp::config::ProviderConfig::default();
-        provider.kind = mvp::config::ProviderKind::Openai;
-        provider.api_key_env = Some("OPENAI_API_KEY".to_owned());
+        let mut provider = mvp::config::ProviderConfig {
+            kind: mvp::config::ProviderKind::Openai,
+            api_key_env: Some("OPENAI_API_KEY".to_owned()),
+            ..mvp::config::ProviderConfig::default()
+        };
 
         apply_selected_api_key_env(&mut provider, "OPENAI_CODEX_OAUTH_TOKEN".to_owned());
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -3464,7 +3464,7 @@ fn render_onboarding_risk_screen_lines_with_style(
 ) -> Vec<String> {
     let copy = crate::onboard_presentation::risk_screen_copy();
     render_onboard_choice_screen(
-        OnboardHeaderStyle::Compact,
+        OnboardHeaderStyle::Brand,
         width,
         copy.subtitle,
         copy.title,
@@ -6067,6 +6067,19 @@ mod tests {
             .expect("missing input should keep the configured default");
 
         assert_eq!(value, "\u{1b}");
+    }
+
+    #[test]
+    fn explicit_onboard_cancel_input_requires_escape_byte() {
+        assert!(is_explicit_onboard_cancel_input("\u{1b}"));
+        assert!(
+            !is_explicit_onboard_cancel_input("esc"),
+            "literal text should remain valid operator input instead of being treated as an escape keystroke"
+        );
+        assert!(
+            !is_explicit_onboard_cancel_input("ESC"),
+            "case variants of plain text should not trigger onboarding cancellation"
+        );
     }
 
     #[test]

--- a/crates/daemon/src/onboard_presentation.rs
+++ b/crates/daemon/src/onboard_presentation.rs
@@ -150,11 +150,9 @@ pub fn import_option_detail(
     }
 
     if detected_source_count == 1 {
-        "1 reusable source was detected for provider, channels, or workspace guidance.".to_owned()
+        "1 reusable source was detected for provider, channels, or guidance.".to_owned()
     } else {
-        format!(
-            "{reusable_source_phrase} were detected for provider, channels, or workspace guidance."
-        )
+        format!("{reusable_source_phrase} were detected for provider, channels, or guidance.")
     }
 }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -763,13 +763,18 @@ async fn non_interactive_onboard_allows_explicit_skip_model_probe_warning() {
         .expect("load written onboarding config");
     assert_eq!(config.provider.model, "openai/gpt-5.1-codex");
     assert_eq!(
-        config.provider.api_key.as_deref(),
-        Some("${OPENAI_API_KEY}")
+        config.provider.oauth_access_token.as_deref(),
+        Some("${OPENAI_CODEX_OAUTH_TOKEN}"),
+        "reloaded config should keep the canonical oauth credential source after provider-aligned routing"
     );
     assert_eq!(
-        config.provider.api_key(),
-        Some("test-openai-key".to_owned()),
-        "loaded config should still resolve the canonical env reference at runtime"
+        config.provider.api_key, None,
+        "reloaded config should not repopulate the legacy api_key field for the oauth-backed openai route"
+    );
+    assert_eq!(
+        config.provider.authorization_header(),
+        Some("Bearer test-openai-key".to_owned()),
+        "runtime auth resolution should still fall back to OPENAI_API_KEY when the oauth env is unset"
     );
 }
 
@@ -2425,14 +2430,7 @@ fn onboard_entry_screen_uses_compact_header_and_detected_setup_digest() {
         80,
     );
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW"),
-        "entry screen should switch to the compact LOONGCLAW header after the initial risk gate: {lines:#?}"
-    );
-    assert!(
-        lines[0].contains("v"),
-        "entry screen should keep the build/version visible inside the compact header: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "entry screen");
     assert!(
         lines.iter().all(|line| !line.starts_with("██╗")),
         "entry screen should not repeat the large LOONGCLAW banner after the first screen: {lines:#?}"
@@ -2506,14 +2504,7 @@ fn onboard_entry_screen_compacts_to_plain_wordmark_on_narrow_width() {
         40,
     );
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW"),
-        "narrow layout should keep the compact LOONGCLAW wordmark at the start of the header line: {lines:#?}"
-    );
-    assert!(
-        lines[0].contains("v"),
-        "narrow layout should keep the compact header metadata on the same line as the wordmark: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "narrow entry screen");
     assert!(
         lines.iter().any(|line| line == "Detected settings"),
         "narrow layout should retain the detected-settings section heading: {lines:#?}"
@@ -5498,14 +5489,7 @@ fn onboard_review_lines_use_compact_header() {
         80,
     );
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW"),
-        "review screen should use the compact LOONGCLAW header after the first screen: {lines:#?}"
-    );
-    assert!(
-        lines[0].contains("v"),
-        "review screen should keep the version visible inside the compact header: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "review screen");
     assert!(
         lines.iter().all(|line| !line.starts_with("██╗")),
         "review screen should not repeat the large LOONGCLAW banner: {lines:#?}"
@@ -5867,14 +5851,7 @@ fn onboarding_success_summary_uses_compact_header() {
 
     let lines =
         loongclaw_daemon::onboard_cli::render_onboarding_success_summary_with_width(&summary, 80);
-    assert!(
-        lines[0].starts_with("LOONGCLAW"),
-        "success summary should use the compact LOONGCLAW header after the first screen: {lines:#?}"
-    );
-    assert!(
-        lines[0].contains("v"),
-        "success summary should keep the version visible inside the compact header: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "success summary");
     assert!(
         lines.iter().all(|line| !line.starts_with("██╗")),
         "success summary should not repeat the large LOONGCLAW banner after onboarding has already started: {lines:#?}"

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -1472,13 +1472,19 @@ fn backup_existing_config_copies_without_removing_original() {
 }
 
 #[test]
-fn onboard_risk_screen_uses_compact_header_and_continue_cancel_options() {
+fn onboard_risk_screen_uses_brand_header_and_continue_cancel_options() {
     let lines = loongclaw_daemon::onboard_cli::render_onboarding_risk_screen_lines(80);
 
-    assert_compact_loongclaw_header(&lines, "risk screen");
     assert!(
-        !lines[0].starts_with("██╗"),
-        "risk screen should avoid the oversized block-logo banner on the guard screen: {lines:#?}"
+        lines[0].starts_with("██╗"),
+        "risk screen should keep the oversized LOONGCLAW brand banner on the initial guard screen: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .take_while(|line| !line.is_empty())
+            .any(|line| line.contains(concat!("v", env!("CARGO_PKG_VERSION")))),
+        "risk screen should keep the current build version visible under the brand banner: {lines:#?}"
     );
     assert!(
         lines.iter().any(|line| line == "security check"),

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -1078,6 +1078,62 @@ async fn interactive_onboard_clear_token_restores_builtin_system_prompt() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn interactive_onboard_only_shows_large_logo_on_the_initial_screen() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", "openai-test-token");
+    }
+
+    let output_path = unique_temp_path("interactive-single-banner.toml");
+    let mut existing = mvp::config::LoongClawConfig::default();
+    existing.provider.model = "gpt-4.1".to_owned();
+    existing.provider.api_key_env = Some("OPENAI_API_KEY".to_owned());
+    mvp::config::write(output_path.to_str(), &existing, true).expect("write existing config");
+
+    let transcript = run_scripted_onboard_flow(
+        crate::onboard_cli::OnboardCommandOptions {
+            output: output_path.to_str().map(str::to_owned),
+            force: false,
+            non_interactive: false,
+            accept_risk: false,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            personality: None,
+            memory_profile: None,
+            system_prompt: None,
+            skip_model_probe: true,
+        },
+        ["y", "1", "2", "", "", "", "", "", "", "y"],
+        None,
+        None,
+    )
+    .await
+    .expect("run interactive onboarding with the risk gate enabled");
+
+    assert_eq!(
+        transcript
+            .iter()
+            .filter(|line| line.contains("██╗      ██████╗"))
+            .count(),
+        1,
+        "interactive onboarding should show the large LOONGCLAW banner only once, on the initial risk screen: {transcript:#?}"
+    );
+    assert!(
+        transcript
+            .iter()
+            .filter(|line| line.contains("LOONGCLAW"))
+            .count()
+            >= 3,
+        "follow-up screens should keep using the compact LOONGCLAW header instead of dropping branding entirely: {transcript:#?}"
+    );
+    assert!(
+        transcript.iter().any(|line| line == "choose personality"),
+        "regression flow should still reach the later onboarding steps where repeated banner reports came from: {transcript:#?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn non_interactive_onboard_uses_the_same_detected_starting_point_order_as_interactive_default()
  {
     let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
@@ -2049,8 +2105,12 @@ fn onboard_presentation_entry_and_digest_copy_stays_canonical() {
         "A suggested starting point is ready, built from 2 reusable sources."
     );
     assert_eq!(
+        loongclaw_daemon::onboard_presentation::import_option_detail(false, false, 1),
+        "1 reusable source was detected for provider, channels, or guidance."
+    );
+    assert_eq!(
         loongclaw_daemon::onboard_presentation::import_option_detail(false, false, 2),
-        "2 reusable sources were detected for provider, channels, or workspace guidance."
+        "2 reusable sources were detected for provider, channels, or guidance."
     );
     assert_eq!(
         loongclaw_daemon::onboard_presentation::detected_coverage_prefix(true),
@@ -2305,7 +2365,7 @@ fn onboard_entry_import_option_explains_detected_additions_when_current_setup_ex
 }
 
 #[test]
-fn onboard_entry_screen_includes_brand_block_and_detected_setup_digest() {
+fn onboard_entry_screen_uses_compact_header_and_detected_setup_digest() {
     let current = import_candidate_with_kind(
         loongclaw_daemon::migration::types::ImportSourceKind::ExistingLoongClawConfig,
         "existing config at ~/.config/loongclaw/config.toml",
@@ -2356,12 +2416,16 @@ fn onboard_entry_screen_includes_brand_block_and_detected_setup_digest() {
     );
 
     assert!(
-        lines[0].starts_with("██╗"),
-        "entry screen should start with the shared LOONGCLAW brand block: {lines:#?}"
+        lines[0].starts_with("LOONGCLAW"),
+        "entry screen should switch to the compact LOONGCLAW header after the initial risk gate: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line.starts_with('v')),
-        "entry screen should include a build/version line under the banner: {lines:#?}"
+        lines[0].contains("v"),
+        "entry screen should keep the build/version visible inside the compact header: {lines:#?}"
+    );
+    assert!(
+        lines.iter().all(|line| !line.starts_with("██╗")),
+        "entry screen should not repeat the large LOONGCLAW banner after the first screen: {lines:#?}"
     );
     assert!(
         lines
@@ -2653,8 +2717,12 @@ fn onboard_provider_selection_screen_includes_focus_title_and_choices() {
     let lines = loongclaw_daemon::onboard_cli::render_provider_selection_screen_lines(&plan, 80);
 
     assert!(
-        lines[0].starts_with("██╗"),
-        "provider choice screen should start with the shared LOONGCLAW brand block: {lines:#?}"
+        lines[0].starts_with("LOONGCLAW"),
+        "provider choice screen should use the compact LOONGCLAW header after the initial screen: {lines:#?}"
+    );
+    assert!(
+        lines.iter().all(|line| !line.starts_with("██╗")),
+        "provider choice screen should not re-render the large LOONGCLAW banner mid-onboarding: {lines:#?}"
     );
     assert!(
         lines.iter().any(|line| line == "choose active provider"),
@@ -3039,8 +3107,8 @@ fn onboard_current_setup_shortcut_screen_summarizes_existing_setup_and_choices()
         loongclaw_daemon::onboard_cli::render_continue_current_setup_screen_lines(&config, 80);
 
     assert!(
-        lines[0].starts_with("██╗"),
-        "current-setup shortcut should start with the shared LOONGCLAW brand block: {lines:#?}"
+        lines[0].starts_with("LOONGCLAW"),
+        "current-setup shortcut should use the compact LOONGCLAW header after the entry screen: {lines:#?}"
     );
     assert!(
         lines.iter().any(|line| line == "continue current setup"),
@@ -3139,8 +3207,8 @@ fn onboard_detected_setup_shortcut_screen_summarizes_starting_point_and_choices(
     );
 
     assert!(
-        lines[0].starts_with("██╗"),
-        "detected-setup shortcut should start with the shared LOONGCLAW brand block: {lines:#?}"
+        lines[0].starts_with("LOONGCLAW"),
+        "detected-setup shortcut should use the compact LOONGCLAW header after the entry screen: {lines:#?}"
     );
     assert!(
         lines
@@ -3269,7 +3337,7 @@ fn onboard_detected_setup_shortcut_is_limited_to_interactive_import_flow_with_de
 }
 
 #[test]
-fn onboard_starting_point_selection_screen_includes_brand_header_and_detected_options() {
+fn onboard_starting_point_selection_screen_uses_compact_header_and_detected_options() {
     let mut recommended = import_candidate_with_provider(
         loongclaw_daemon::migration::types::ImportSourceKind::RecommendedPlan,
         "recommended import plan",
@@ -3300,8 +3368,8 @@ fn onboard_starting_point_selection_screen_includes_brand_header_and_detected_op
     );
 
     assert!(
-        lines[0].starts_with("██╗"),
-        "starting-point screen should start with the shared LOONGCLAW brand block: {lines:#?}"
+        lines[0].starts_with("LOONGCLAW"),
+        "starting-point screen should use the compact LOONGCLAW header after the entry screen: {lines:#?}"
     );
     assert!(
         lines
@@ -3454,7 +3522,7 @@ fn onboard_starting_point_selection_screen_summarizes_multi_source_origin() {
 }
 
 #[test]
-fn onboard_single_detected_setup_preview_screen_uses_branded_preview_layout() {
+fn onboard_single_detected_setup_preview_screen_uses_compact_follow_up_layout() {
     let candidate = import_candidate_with_provider(
         loongclaw_daemon::migration::types::ImportSourceKind::CodexConfig,
         "Codex config at ~/.codex/config.toml",
@@ -3470,8 +3538,8 @@ fn onboard_single_detected_setup_preview_screen_uses_branded_preview_layout() {
     );
 
     assert!(
-        lines[0].starts_with("██╗"),
-        "single detected-setup preview should start with the shared LOONGCLAW brand block: {lines:#?}"
+        lines[0].starts_with("LOONGCLAW"),
+        "single detected-setup preview should use the compact LOONGCLAW header after the entry screen: {lines:#?}"
     );
     assert!(
         lines
@@ -4200,6 +4268,14 @@ fn onboard_personality_selection_screen_shows_native_personality_choices() {
     let lines = crate::onboard_cli::render_personality_selection_screen_lines(&config, 80);
 
     assert!(
+        lines[0].starts_with("LOONGCLAW"),
+        "personality screen should keep the compact LOONGCLAW header instead of re-showing the large banner: {lines:#?}"
+    );
+    assert!(
+        lines.iter().all(|line| !line.starts_with("██╗")),
+        "personality screen should not repeat the large LOONGCLAW banner mid-onboarding: {lines:#?}"
+    );
+    assert!(
         lines.iter().any(|line| line == "choose personality"),
         "personality screen should use a focused title: {lines:#?}"
     );
@@ -4251,6 +4327,10 @@ fn onboard_memory_profile_screen_shows_supported_profiles() {
 
     let lines = crate::onboard_cli::render_memory_profile_selection_screen_lines(&config, 80);
 
+    assert!(
+        lines[0].starts_with("LOONGCLAW"),
+        "memory-profile screen should keep the compact LOONGCLAW header instead of re-showing the large banner: {lines:#?}"
+    );
     assert!(
         lines.iter().any(|line| line == "choose memory profile"),
         "memory-profile screen should use a focused title: {lines:#?}"
@@ -4439,8 +4519,8 @@ fn onboard_existing_config_write_screen_offers_replace_backup_and_cancel() {
 
     assert_compact_loongclaw_header(&lines, "existing-config write screen");
     assert!(
-        !lines[0].starts_with("██╗"),
-        "existing-config write screen should avoid the oversized block-logo banner on the write guard screen: {lines:#?}"
+        lines.iter().all(|line| !line.starts_with("██╗")),
+        "existing-config write screen should not repeat the large LOONGCLAW banner after the first screen: {lines:#?}"
     );
     assert!(
         lines.iter().any(|line| line == "existing config found"),
@@ -5393,7 +5473,7 @@ fn onboard_review_lines_include_starting_point_and_domain_preview() {
 }
 
 #[test]
-fn onboard_review_lines_include_brand_header() {
+fn onboard_review_lines_use_compact_header() {
     let lines = loongclaw_daemon::onboard_cli::render_onboard_review_lines_with_guidance(
         &mvp::config::LoongClawConfig::default(),
         None,
@@ -5402,12 +5482,16 @@ fn onboard_review_lines_include_brand_header() {
     );
 
     assert!(
-        lines[0].starts_with("██╗"),
-        "review screen should start with the shared LOONGCLAW brand block: {lines:#?}"
+        lines[0].starts_with("LOONGCLAW"),
+        "review screen should use the compact LOONGCLAW header after the first screen: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line.starts_with('v')),
-        "review screen should include a version line: {lines:#?}"
+        lines[0].contains("v"),
+        "review screen should keep the version visible inside the compact header: {lines:#?}"
+    );
+    assert!(
+        lines.iter().all(|line| !line.starts_with("██╗")),
+        "review screen should not repeat the large LOONGCLAW banner: {lines:#?}"
     );
     assert!(
         lines.iter().any(|line| line == "review setup"),
@@ -5756,7 +5840,7 @@ fn onboarding_success_summary_uses_starting_point_language() {
 }
 
 #[test]
-fn onboarding_success_summary_includes_brand_header() {
+fn onboarding_success_summary_uses_compact_header() {
     let path = PathBuf::from("/tmp/loongclaw-config.toml");
     let summary = loongclaw_daemon::onboard_cli::build_onboarding_success_summary(
         &path,
@@ -5767,12 +5851,16 @@ fn onboarding_success_summary_includes_brand_header() {
     let lines =
         loongclaw_daemon::onboard_cli::render_onboarding_success_summary_with_width(&summary, 80);
     assert!(
-        lines[0].starts_with("██╗"),
-        "success summary should start with the shared LOONGCLAW brand block: {lines:#?}"
+        lines[0].starts_with("LOONGCLAW"),
+        "success summary should use the compact LOONGCLAW header after the first screen: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line.starts_with('v')),
-        "success summary should include a version line under the banner: {lines:#?}"
+        lines[0].contains("v"),
+        "success summary should keep the version visible inside the compact header: {lines:#?}"
+    );
+    assert!(
+        lines.iter().all(|line| !line.starts_with("██╗")),
+        "success summary should not repeat the large LOONGCLAW banner after onboarding has already started: {lines:#?}"
     );
     assert!(
         lines.iter().any(|line| line == "onboarding complete"),

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -1358,6 +1358,23 @@ fn preferred_api_key_env_default_stays_blank_when_provider_has_no_default_env() 
 }
 
 #[test]
+fn preferred_api_key_env_default_prefers_oauth_default_for_fresh_openai() {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.kind = mvp::config::ProviderKind::Openai;
+    config.provider.api_key = None;
+    config.provider.api_key_env = None;
+    config.provider.oauth_access_token = None;
+    config.provider.oauth_access_token_env = None;
+
+    let value = loongclaw_daemon::onboard_cli::preferred_api_key_env_default(&config);
+
+    assert_eq!(
+        value, "OPENAI_CODEX_OAUTH_TOKEN",
+        "fresh OpenAI onboarding should surface the provider-preferred oauth env before the api-key fallback: {value:?}"
+    );
+}
+
+#[test]
 fn directory_preflight_check_has_no_filesystem_side_effects() {
     let base = unique_temp_path("preflight-root");
     let target = base.join("nested").join("tool-root");
@@ -3986,6 +4003,12 @@ fn onboard_api_key_env_screen_explains_suggested_env_and_blank_behavior() {
     assert!(
         lines
             .iter()
+            .any(|line| line.contains("- current source: ${OPENAI_CODEX_OAUTH_TOKEN}")),
+        "credential-env screen should show the active oauth credential source instead of hiding it behind api-key-only rendering: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
             .any(|line| line.contains("- suggested source: ${OPENAI_API_KEY}")),
         "credential-env screen should surface the suggested env var name: {lines:#?}"
     );
@@ -3998,8 +4021,8 @@ fn onboard_api_key_env_screen_explains_suggested_env_and_blank_behavior() {
     assert!(
         lines
             .iter()
-            .any(|line| line == "- type :clear to keep inline or oauth credentials"),
-        "credential-env screen should explain the explicit clear token when Enter uses a non-empty default: {lines:#?}"
+            .any(|line| line == "- type :clear to clear the configured credential env"),
+        "credential-env screen should explain the explicit clear token when another credential env is already configured: {lines:#?}"
     );
 }
 
@@ -5416,8 +5439,8 @@ fn onboard_review_lines_include_core_setup_summary_for_fresh_setup() {
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("- credential source: ${OPENAI_API_KEY}")),
-        "review should keep the suggested credential env visible for fresh setup flows: {lines:#?}"
+            .any(|line| line.contains("- credential source: ${OPENAI_CODEX_OAUTH_TOKEN}")),
+        "review should keep the provider-preferred credential env visible for fresh setup flows: {lines:#?}"
     );
     assert!(
         lines

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -747,8 +747,12 @@ async fn non_interactive_onboard_allows_explicit_skip_model_probe_warning() {
 
     let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
     assert!(
-        raw.contains("api_key = \"${OPENAI_API_KEY}\""),
-        "onboarding should persist the default provider credential as a canonical env reference: {raw}"
+        raw.contains("oauth_access_token = \"${OPENAI_CODEX_OAUTH_TOKEN}\""),
+        "onboarding should persist the openai oauth binding as the canonical env reference after provider-aligned credential routing: {raw}"
+    );
+    assert!(
+        !raw.contains("api_key = "),
+        "provider-aligned onboarding should not fall back to the legacy api_key field for the openai oauth route: {raw}"
     );
     assert!(
         !raw.contains("api_key_env"),
@@ -2502,7 +2506,14 @@ fn onboard_entry_screen_compacts_to_plain_wordmark_on_narrow_width() {
         40,
     );
 
-    assert_eq!(lines[0], "LOONGCLAW");
+    assert!(
+        lines[0].starts_with("LOONGCLAW"),
+        "narrow layout should keep the compact LOONGCLAW wordmark at the start of the header line: {lines:#?}"
+    );
+    assert!(
+        lines[0].contains("v"),
+        "narrow layout should keep the compact header metadata on the same line as the wordmark: {lines:#?}"
+    );
     assert!(
         lines.iter().any(|line| line == "Detected settings"),
         "narrow layout should retain the detected-settings section heading: {lines:#?}"

--- a/docs/plans/2026-03-16-provider-onboarding-default-model-implementation-plan.md
+++ b/docs/plans/2026-03-16-provider-onboarding-default-model-implementation-plan.md
@@ -181,4 +181,4 @@ Reflect the corrected architecture:
 
 **Step 2: Keep issue/PR traceability intact**
 
-Continue on issue `#214` and PR `#215` rather than opening replacement artifacts.
+Continue on issue `#236` and PR `#215` rather than opening replacement artifacts.


### PR DESCRIPTION
## Summary

- Align onboarding credential-source selection, rendering, apply logic, and review summary with the shared provider-aware credential binding helper already used by `doctor`.
- Prefer the provider-reviewed OpenAI OAuth credential source during fresh onboarding, while still allowing explicit API-key env overrides and clearing stale cross-field bindings.
- Remove the stale Volcengine Coding default OAuth env/profile alias and document that onboarding may select either `OPENAI_CODEX_OAUTH_TOKEN` or provider-specific `*_API_KEY` envs.
- Keep the large `LOONGCLAW` banner on the initial risk screen only; switch follow-up onboarding screens to the compact header so the banner does not repeat after each choice/input step.
- Shorten the reusable-source onboarding copy so the detected-source summary stays on one line more often.
- Stacked on #215: once #215 lands on `alpha-test`, this PR diff should collapse to the new follow-up commit only.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Targeted verification run:

- `rustfmt --edition 2024 crates/daemon/src/onboard_cli.rs crates/daemon/src/onboard_presentation.rs crates/daemon/tests/integration/onboard_cli.rs`
- `cargo test -p loongclaw-daemon --test integration compact_header -- --nocapture`
- `cargo test -p loongclaw-daemon --test integration integration::onboard_cli::onboard_personality_selection_screen_shows_native_personality_choices -- --exact --nocapture`
- `cargo test -p loongclaw-daemon --test integration integration::onboard_cli::onboard_memory_profile_screen_shows_supported_profiles -- --exact --nocapture`
- `cargo test -p loongclaw-daemon --test integration shortcut_screen_summarizes -- --nocapture`
- `cargo test -p loongclaw-daemon --test integration integration::onboard_cli::onboard_provider_selection_screen_includes_focus_title_and_choices -- --exact --nocapture`
- `cargo test -p loongclaw-daemon --test integration integration::onboard_cli::onboard_existing_config_write_screen_offers_replace_backup_and_cancel -- --exact --nocapture`
- `cargo test -p loongclaw-daemon --test integration integration::onboard_cli::onboard_single_detected_setup_preview_screen_uses_compact_follow_up_layout -- --exact --nocapture`
- `cargo test -p loongclaw-daemon --test integration integration::onboard_cli::interactive_onboard_only_shows_large_logo_on_the_initial_screen -- --exact --nocapture`
- `cargo test -p loongclaw-daemon --test integration integration::onboard_cli::onboard_presentation_entry_and_digest_copy_stays_canonical -- --exact --nocapture`

Before / after behavior:

- Before: `doctor` preferred provider-aware credential bindings, but onboarding still defaulted to `api_key_env`-centric rendering/apply/review paths; fresh OpenAI onboarding surfaced `${OPENAI_API_KEY}` even though the reviewed provider binding preferred `${OPENAI_CODEX_OAUTH_TOKEN}`.
- After: onboarding and `doctor` share the same provider-aware credential-source preference, explicit env input can switch between OAuth and API-key bindings cleanly, and Volcengine Coding no longer advertises an unreviewed default OAuth env.
- Before: several follow-up onboarding screens reused the full `LOONGCLAW` banner, so the banner reappeared after accepting risk and again after later guided steps such as credential entry.
- After: only the initial risk screen keeps the large banner; follow-up entry/choice/review/success screens use the compact header and the reusable-source summary copy is shorter.

## Linked Issues

Closes #236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding now prefills reviewed recommended models for certain providers, shows compact header branding, and surfaces explicit remediation when catalog discovery fails.
  * Press Esc then Enter to cancel onboarding before changes are written; onboarding works in WSL with systemd notes.

* **Bug Fixes**
  * Clearer handling when model catalog discovery fails: rerun onboarding to accept the reviewed model or set provider.model / preferred_models.

* **Documentation**
  * Expanded credential env guidance and updated shell examples (uses <ENV_NAME>=...), with examples like OPENAI_CODEX_OAUTH_TOKEN and ARK_API_KEY.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->