### PR TITLE
test: harden browser companion script fixtures

### DIFF
--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1250,9 +1250,9 @@ fn session_context_from_turn(turn: &ProviderTurn, tool_view: ToolView) -> Sessio
 
 #[cfg(test)]
 mod tests {
+    use crate::test_support::unique_temp_dir;
     use std::fs;
     use std::path::{Path, PathBuf};
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     use serde_json::json;
 
@@ -1337,11 +1337,7 @@ mod tests {
     }
 
     fn unique_browser_companion_temp_dir(prefix: &str) -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        unique_temp_dir(prefix)
     }
 
     #[cfg(unix)]
@@ -1351,18 +1347,14 @@ mod tests {
         stdout_body: &str,
         log_path: &Path,
     ) -> PathBuf {
-        use std::os::unix::fs::PermissionsExt;
-
         let path = root.join(name);
         let script = format!(
             "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf '1.2.3\\n'\n  exit 0\nfi\nBODY=\"$(cat)\"\nprintf '%s' \"$BODY\" > \"{}\"\nprintf '%s' '{}'\n",
             log_path.display(),
             stdout_body.replace('\'', "'\"'\"'")
         );
-        fs::write(&path, script).expect("write browser companion script");
-        let mut perms = fs::metadata(&path).expect("metadata").permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&path, perms).expect("chmod script");
+        crate::test_support::write_executable_script_atomically(&path, &script)
+            .expect("write browser companion script");
         path
     }
 

--- a/crates/app/src/test_support.rs
+++ b/crates/app/src/test_support.rs
@@ -70,6 +70,81 @@ impl Drop for ScopedEnv {
 /// Monotonic counter for unique harness IDs (avoids temp dir collisions).
 static HARNESS_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+#[cfg(test)]
+static TEST_TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(test)]
+pub(crate) fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let id = TEST_TEMP_DIR_COUNTER.fetch_add(1, Ordering::SeqCst);
+    std::env::temp_dir().join(format!("{prefix}-{}-{id}", std::process::id()))
+}
+
+#[cfg(all(test, unix))]
+pub(crate) fn write_executable_script_atomically(
+    script_path: &std::path::Path,
+    contents: &str,
+) -> std::io::Result<()> {
+    write_executable_script_atomically_with(script_path, |file| {
+        std::io::Write::write_all(file, contents.as_bytes())
+    })
+}
+
+#[cfg(all(test, unix))]
+fn write_executable_script_atomically_with<F>(
+    script_path: &std::path::Path,
+    writer: F,
+) -> std::io::Result<()>
+where
+    F: FnOnce(&mut std::fs::File) -> std::io::Result<()>,
+{
+    static NEXT_STAGING_FILE_SEED: AtomicU64 = AtomicU64::new(1);
+
+    let Some(parent) = script_path.parent() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "script path `{}` has no parent directory",
+                script_path.display()
+            ),
+        ));
+    };
+    let Some(file_name) = script_path.file_name().and_then(|name| name.to_str()) else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "script path `{}` has no UTF-8 file name",
+                script_path.display()
+            ),
+        ));
+    };
+
+    let seed = NEXT_STAGING_FILE_SEED.fetch_add(1, Ordering::Relaxed);
+    let staged_path = parent.join(format!(".{file_name}.{}.{seed}.tmp", std::process::id()));
+    let mut staged_file = std::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&staged_path)?;
+    let write_result = writer(&mut staged_file).and_then(|()| staged_file.sync_all());
+    drop(staged_file);
+
+    if let Err(error) = write_result {
+        let _ = std::fs::remove_file(&staged_path);
+        return Err(error);
+    }
+
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = std::fs::metadata(&staged_path)?.permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&staged_path, permissions)?;
+    if let Err(error) = std::fs::rename(&staged_path, script_path) {
+        let _ = std::fs::remove_file(&staged_path);
+        return Err(error);
+    }
+
+    Ok(())
+}
+
 /// Ergonomic builder for constructing fake `ProviderTurn` responses in tests.
 pub struct FakeProviderBuilder {
     text: String,
@@ -255,7 +330,10 @@ impl Drop for TurnTestHarness {
 
 #[cfg(test)]
 mod tests {
-    use super::ScopedEnv;
+    use super::{ScopedEnv, unique_temp_dir};
+
+    #[cfg(unix)]
+    use super::{write_executable_script_atomically, write_executable_script_atomically_with};
 
     #[test]
     fn scoped_env_recovers_after_mutex_poison() {
@@ -272,5 +350,36 @@ mod tests {
             recovery.is_ok(),
             "ScopedEnv::new should recover from a poisoned env lock"
         );
+    }
+
+    #[test]
+    fn unique_temp_dir_uses_distinct_paths() {
+        let first = unique_temp_dir("loongclaw-test-support");
+        let second = unique_temp_dir("loongclaw-test-support");
+
+        assert_ne!(first, second);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_executable_script_atomically_preserves_existing_script_when_write_fails() {
+        let root = unique_temp_dir("loongclaw-test-support-script-write-failure");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let script_path = root.join("fixture-script");
+
+        write_executable_script_atomically(&script_path, "#!/bin/sh\necho old\n")
+            .expect("write baseline script");
+
+        let error = write_executable_script_atomically_with(&script_path, |_file| {
+            Err(std::io::Error::other("forced write failure"))
+        })
+        .expect_err("failed staged write should surface an error");
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(
+            std::fs::read_to_string(&script_path).expect("baseline script should remain readable"),
+            "#!/bin/sh\necho old\n"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1472,9 +1472,8 @@ fn _shape_examples() -> BTreeMap<&'static str, Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::ScopedEnv;
+    use crate::test_support::{ScopedEnv, unique_temp_dir};
     use std::path::{Path, PathBuf};
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn test_tool_runtime_config(root: PathBuf) -> runtime_config::ToolRuntimeConfig {
         runtime_config::ToolRuntimeConfig {
@@ -1516,11 +1515,7 @@ mod tests {
     }
 
     fn unique_tool_temp_dir(prefix: &str) -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+        unique_temp_dir(prefix)
     }
 
     fn browser_companion_runtime_config(
@@ -1541,19 +1536,14 @@ mod tests {
         stdout_body: &str,
         log_path: &Path,
     ) -> PathBuf {
-        use std::fs;
-        use std::os::unix::fs::PermissionsExt;
-
         let path = root.join(name);
         let script = format!(
             "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf '1.2.3\\n'\n  exit 0\nfi\nBODY=\"$(cat)\"\nprintf '%s' \"$BODY\" > \"{}\"\nprintf '%s' '{}'\n",
             log_path.display(),
             stdout_body.replace('\'', "'\"'\"'")
         );
-        fs::write(&path, script).expect("write browser companion script");
-        let mut perms = fs::metadata(&path).expect("metadata").permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&path, perms).expect("chmod script");
+        crate::test_support::write_executable_script_atomically(&path, &script)
+            .expect("write browser companion script");
         path
     }
 
@@ -1582,17 +1572,12 @@ mod tests {
         name: &str,
         sleep_seconds: u64,
     ) -> PathBuf {
-        use std::fs;
-        use std::os::unix::fs::PermissionsExt;
-
         let path = root.join(name);
         let script = format!(
             "#!/bin/sh\nsleep {sleep_seconds}\nprintf '%s' '{{\"ok\":true,\"result\":{{\"delayed\":true}}}}'\n"
         );
-        fs::write(&path, script).expect("write browser companion sleep script");
-        let mut perms = fs::metadata(&path).expect("metadata").permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&path, perms).expect("chmod script");
+        crate::test_support::write_executable_script_atomically(&path, &script)
+            .expect("write browser companion sleep script");
         path
     }
 


### PR DESCRIPTION
## Summary

- follow up the merged browser preview work from `#210` by hardening unix browser companion test fixtures
- move monotonic temp-dir generation and atomic executable script writes into shared test support helpers
- switch browser companion test fixtures to the shared helpers and add regression coverage for failed staged writes preserving the existing script

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Added regression coverage for failed staged writes preserving the previous script

Follow-up to `#210`. No linked issue closure remains in this diff.