### PR TITLE
perf: compact tool.search follow-up payload summaries

### DIFF
--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -1150,28 +1150,66 @@ mod tests {
             if !content.contains("tool.search") || !content.contains(tool_id) {
                 continue;
             }
-            let Some(payload_start) = content.find("{\"status\":") else {
-                continue;
-            };
-            let Ok(envelope) = serde_json::from_str::<Value>(&content[payload_start..]) else {
-                continue;
-            };
-            let summary_str = envelope["payload_summary"].as_str().unwrap_or("");
-            let Ok(summary) = serde_json::from_str::<Value>(summary_str) else {
-                continue;
-            };
-            let Some(results) = summary["results"].as_array() else {
-                continue;
-            };
-            for result in results {
-                if result["tool_id"].as_str() == Some(tool_id)
-                    && let Some(lease) = result["lease"].as_str()
-                {
-                    return lease.to_owned();
+            for line in content.lines() {
+                let Some(payload) = line.trim().strip_prefix("[ok] ") else {
+                    continue;
+                };
+                let Ok(envelope) = serde_json::from_str::<Value>(payload) else {
+                    continue;
+                };
+                let summary_str = envelope["payload_summary"].as_str().unwrap_or("");
+                let Ok(summary) = serde_json::from_str::<Value>(summary_str) else {
+                    continue;
+                };
+                let Some(results) = summary["results"].as_array() else {
+                    continue;
+                };
+                for result in results {
+                    if result["tool_id"].as_str() == Some(tool_id)
+                        && let Some(lease) = result["lease"].as_str()
+                    {
+                        return lease.to_owned();
+                    }
                 }
             }
         }
         panic!("could not extract lease for {tool_id} from provider request body");
+    }
+
+    #[test]
+    fn extract_lease_from_provider_request_body_accepts_reordered_search_envelope_fields() {
+        let payload_summary = serde_json::to_string(&json!({
+            "query": "feishu card update callback token markdown",
+            "results": [{
+                "tool_id": "feishu.card.update",
+                "summary": "Update a Feishu interactive card after a card callback.",
+                "argument_hint": "callback_token?:string,card?:object,markdown?:string",
+                "lease": "lease-feishu-card-update"
+            }]
+        }))
+        .expect("encode payload summary");
+        let body = serde_json::to_string(&json!({
+            "messages": [{
+                "role": "assistant",
+                "content": format!(
+                    "[tool_result]\n[ok] {}",
+                    json!({
+                        "payload_chars": 256,
+                        "payload_summary": payload_summary,
+                        "payload_truncated": false,
+                        "status": "ok",
+                        "tool": "tool.search",
+                        "tool_call_id": "call_tool_search_1",
+                    })
+                )
+            }]
+        }))
+        .expect("encode provider request body");
+
+        assert_eq!(
+            extract_lease_from_provider_request_body(body.as_str(), "feishu.card.update"),
+            "lease-feishu-card-update"
+        );
     }
 
     async fn spawn_mock_feishu_api_server(

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -1157,6 +1157,12 @@ mod tests {
                 let Ok(envelope) = serde_json::from_str::<Value>(payload) else {
                     continue;
                 };
+                if envelope["tool"].as_str() != Some("tool.search") {
+                    continue;
+                }
+                if envelope["payload_truncated"].as_bool().unwrap_or(false) {
+                    continue;
+                }
                 let summary_str = envelope["payload_summary"].as_str().unwrap_or("");
                 let Ok(summary) = serde_json::from_str::<Value>(summary_str) else {
                     continue;
@@ -1209,6 +1215,57 @@ mod tests {
         assert_eq!(
             extract_lease_from_provider_request_body(body.as_str(), "feishu.card.update"),
             "lease-feishu-card-update"
+        );
+    }
+
+    #[test]
+    fn extract_lease_from_provider_request_body_ignores_non_search_envelopes() {
+        let misleading_summary = serde_json::to_string(&json!({
+            "results": [{
+                "tool_id": "feishu.card.update",
+                "lease": "lease-from-non-search"
+            }]
+        }))
+        .expect("encode misleading payload summary");
+        let search_summary = serde_json::to_string(&json!({
+            "query": "feishu card update callback token markdown",
+            "results": [{
+                "tool_id": "feishu.card.update",
+                "summary": "Update a Feishu interactive card after a card callback.",
+                "argument_hint": "callback_token?:string,card?:object,markdown?:string",
+                "lease": "lease-from-search"
+            }]
+        }))
+        .expect("encode search payload summary");
+        let body = serde_json::to_string(&json!({
+            "messages": [{
+                "role": "assistant",
+                "content": format!(
+                    "[tool_result]\n[ok] {}\n[ok] {}",
+                    json!({
+                        "status": "ok",
+                        "tool": "file.read",
+                        "tool_call_id": "call_file_read_1",
+                        "payload_summary": misleading_summary,
+                        "payload_chars": 64,
+                        "payload_truncated": false,
+                    }),
+                    json!({
+                        "status": "ok",
+                        "tool": "tool.search",
+                        "tool_call_id": "call_tool_search_1",
+                        "payload_summary": search_summary,
+                        "payload_chars": 256,
+                        "payload_truncated": false,
+                    })
+                )
+            }]
+        }))
+        .expect("encode provider request body");
+
+        assert_eq!(
+            extract_lease_from_provider_request_body(body.as_str(), "feishu.card.update"),
+            "lease-from-search"
         );
     }
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -80,7 +80,7 @@ use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ReplyResolutionMode, ToolDrivenFollowupKind,
     ToolDrivenFollowupPayload, ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase,
     build_tool_driven_followup_tail, decide_provider_turn_request_action,
-    format_approval_required_reply, next_conversation_turn_id,
+    format_approval_required_reply, next_conversation_turn_id, reduce_followup_payload_for_model,
     request_completion_with_raw_fallback, tool_driven_followup_payload,
     tool_result_contains_truncation_signal, user_requested_raw_tool_output,
 };
@@ -2645,7 +2645,7 @@ fn build_turn_reply_followup_messages(
         &followup,
         user_input,
         None,
-        crate::conversation::turn_shared::reduce_followup_payload_for_model,
+        |label, text| reduce_followup_payload_for_model(label, text).into_owned(),
     ));
     messages
 }
@@ -6635,24 +6635,44 @@ mod tests {
     }
 
     #[test]
-    fn build_turn_reply_followup_messages_preserves_tool_search_payload_summary() {
+    fn build_turn_reply_followup_messages_compacts_tool_search_payload_summary() {
         let payload_summary = serde_json::json!({
+            "adapter": "core-tools",
+            "tool_name": "tool.search",
+            "query": "read repo file",
+            "returned": 2,
             "results": [
                 {
                     "tool_id": "file.read",
-                    "summary": "Read a file",
-                    "lease": "lease-1"
+                    "summary": "Read a UTF-8 text file from the configured workspace root and return contents.",
+                    "argument_hint": "path:string,offset?:integer,limit?:integer",
+                    "required_fields": ["path"],
+                    "required_field_groups": [["path"]],
+                    "tags": ["core", "file", "read"],
+                    "why": ["summary matches query", "tag matches read"],
+                    "lease": "lease-file"
+                },
+                {
+                    "tool_id": "shell.exec",
+                    "summary": "Execute a shell command in the workspace.",
+                    "argument_hint": "command:string,args?:string[]",
+                    "required_fields": ["command"],
+                    "required_field_groups": [["command"]],
+                    "tags": ["core", "shell", "exec"],
+                    "why": ["summary matches query", "tag matches exec"],
+                    "lease": "lease-shell"
                 }
             ]
         });
+        let payload_summary_str = payload_summary.to_string();
         let tool_result = format!(
             "[ok] {}",
             serde_json::json!({
                 "status": "ok",
                 "tool": "tool.search",
                 "tool_call_id": "call-search",
-                "payload_summary": payload_summary.to_string(),
-                "payload_chars": 256,
+                "payload_chars": 2_048,
+                "payload_summary": payload_summary_str,
                 "payload_truncated": false
             })
         );
@@ -6664,15 +6684,49 @@ mod tests {
             })],
             "preface",
             ToolDrivenFollowupPayload::ToolResult { text: tool_result },
-            "read note.md",
+            "find the right tool",
         );
 
         let (envelope, summary) =
             crate::conversation::turn_shared::parse_tool_result_followup_for_test(&messages);
+        let summary_str = envelope["payload_summary"]
+            .as_str()
+            .expect("payload summary should stay encoded json");
+        let results = summary["results"]
+            .as_array()
+            .expect("results should be an array");
+        let first = &results[0];
 
         assert_eq!(envelope["tool"], "tool.search");
         assert_eq!(envelope["payload_truncated"], false);
-        assert_eq!(summary, payload_summary);
+        assert_ne!(summary_str, payload_summary.to_string());
+        assert_eq!(summary["query"], "read repo file");
+        assert!(summary.get("adapter").is_none());
+        assert!(summary.get("tool_name").is_none());
+        assert!(summary.get("returned").is_none());
+        assert_eq!(results.len(), 2);
+        assert_eq!(first["tool_id"], "file.read");
+        assert_eq!(first["lease"], "lease-file");
+        for entry in results {
+            assert!(entry.get("tool_id").and_then(Value::as_str).is_some());
+            assert!(entry.get("summary").and_then(Value::as_str).is_some());
+            assert!(entry.get("argument_hint").and_then(Value::as_str).is_some());
+            assert!(
+                entry
+                    .get("required_fields")
+                    .and_then(Value::as_array)
+                    .is_some()
+            );
+            assert!(
+                entry
+                    .get("required_field_groups")
+                    .and_then(Value::as_array)
+                    .is_some()
+            );
+            assert!(entry.get("lease").and_then(Value::as_str).is_some());
+            assert!(entry.get("tags").is_none());
+            assert!(entry.get("why").is_none());
+        }
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -19,7 +19,8 @@ use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ToolDrivenFollowupPayload,
     ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase, build_tool_driven_followup_tail,
     build_tool_loop_guard_tail, decide_provider_turn_request_action,
-    request_completion_with_raw_fallback, user_requested_raw_tool_output,
+    reduce_followup_payload_for_model, request_completion_with_raw_fallback,
+    user_requested_raw_tool_output,
 };
 
 #[derive(Default)]
@@ -484,9 +485,8 @@ fn append_tool_driven_followup_messages(
         user_input,
         loop_warning_reason,
         |label, text| {
-            let reduced =
-                crate::conversation::turn_shared::reduce_followup_payload_for_model(label, text);
-            followup_payload_budget.truncate_payload(label, reduced.as_str())
+            let reduced = reduce_followup_payload_for_model(label, text);
+            followup_payload_budget.truncate_payload(label, reduced.as_ref())
         },
     ));
 }
@@ -505,9 +505,8 @@ fn append_repeated_tool_guard_followup_messages(
         user_input,
         latest_tool_context,
         |label, text| {
-            let reduced =
-                crate::conversation::turn_shared::reduce_followup_payload_for_model(label, text);
-            followup_payload_budget.truncate_payload(label, reduced.as_str())
+            let reduced = reduce_followup_payload_for_model(label, text);
+            followup_payload_budget.truncate_payload(label, reduced.as_ref())
         },
     ));
 }
@@ -1114,6 +1113,125 @@ mod tests {
     }
 
     #[test]
+    fn append_tool_driven_followup_messages_compacts_tool_search_payload_summary() {
+        let mut messages = Vec::new();
+        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
+        let payload_summary = serde_json::json!({
+            "adapter": "core-tools",
+            "tool_name": "tool.search",
+            "query": "read repo file",
+            "returned": 2,
+            "results": [
+                {
+                    "tool_id": "file.read",
+                    "summary": "Read a UTF-8 text file from the configured workspace root and return contents.",
+                    "argument_hint": "path:string,offset?:integer,limit?:integer",
+                    "required_fields": ["path"],
+                    "required_field_groups": [["path"]],
+                    "tags": ["core", "file", "read"],
+                    "why": ["summary matches query", "tag matches read"],
+                    "lease": "lease-file"
+                },
+                {
+                    "tool_id": "shell.exec",
+                    "summary": "Execute a shell command in the workspace.",
+                    "argument_hint": "command:string,args?:string[]",
+                    "required_fields": ["command"],
+                    "required_field_groups": [["command"]],
+                    "tags": ["core", "shell", "exec"],
+                    "why": ["summary matches query", "tag matches exec"],
+                    "lease": "lease-shell"
+                }
+            ]
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "tool.search",
+                "tool_call_id": "call-search",
+                "payload_summary": payload_summary,
+                "payload_chars": 2_048,
+                "payload_truncated": false
+            })
+        );
+
+        append_tool_driven_followup_messages(
+            &mut messages,
+            "preface",
+            &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
+            "find the right tool",
+            &mut budget,
+            None,
+        );
+
+        let assistant_tool_result = messages
+            .iter()
+            .find(|message| {
+                message.get("role") == Some(&Value::String("assistant".to_owned()))
+                    && message
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .is_some_and(|content| content.starts_with("[tool_result]\n[ok] "))
+            })
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("assistant tool_result followup message should exist");
+        let line = assistant_tool_result
+            .lines()
+            .nth(1)
+            .expect("assistant tool_result should keep payload line");
+        let envelope: Value = serde_json::from_str(
+            line.strip_prefix("[ok] ")
+                .expect("tool result line should preserve status prefix"),
+        )
+        .expect("compacted followup envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("compacted payload summary should stay json");
+        let first = summary["results"]
+            .as_array()
+            .and_then(|results| results.first())
+            .expect("compacted results should contain the first entry");
+
+        assert_eq!(envelope["tool"], "tool.search");
+        assert_eq!(envelope["payload_truncated"], false);
+        assert_eq!(summary["query"], "read repo file");
+        assert!(summary.get("adapter").is_none());
+        assert!(summary.get("tool_name").is_none());
+        assert!(summary.get("returned").is_none());
+        assert_eq!(first["tool_id"], "file.read");
+        assert_eq!(first["lease"], "lease-file");
+        for entry in summary["results"]
+            .as_array()
+            .expect("results should be an array")
+        {
+            assert!(entry.get("tool_id").and_then(Value::as_str).is_some());
+            assert!(entry.get("summary").and_then(Value::as_str).is_some());
+            assert!(entry.get("argument_hint").and_then(Value::as_str).is_some());
+            assert!(
+                entry
+                    .get("required_fields")
+                    .and_then(Value::as_array)
+                    .is_some()
+            );
+            assert!(
+                entry
+                    .get("required_field_groups")
+                    .and_then(Value::as_array)
+                    .is_some()
+            );
+            assert!(entry.get("lease").and_then(Value::as_str).is_some());
+            assert!(entry.get("tags").is_none());
+            assert!(entry.get("why").is_none());
+        }
+    }
+
+    #[test]
     fn append_repeated_tool_guard_followup_messages_reduces_file_read_payload_summary() {
         let mut messages = Vec::new();
         let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
@@ -1159,6 +1277,69 @@ mod tests {
         assert!(summary.get("stderr_preview").is_some());
         assert!(summary.get("stderr_chars").is_some());
         assert_eq!(summary["stderr_truncated"], true);
+    }
+
+    #[test]
+    fn append_repeated_tool_guard_followup_messages_compacts_tool_search_payload_summary() {
+        let mut messages = Vec::new();
+        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
+        let payload_summary = serde_json::json!({
+            "adapter": "core-tools",
+            "tool_name": "tool.search",
+            "query": "read repo file",
+            "returned": 1,
+            "results": [
+                {
+                    "tool_id": "file.read",
+                    "summary": "Read a UTF-8 text file from the configured workspace root and return contents.",
+                    "argument_hint": "path:string,offset?:integer,limit?:integer",
+                    "required_fields": ["path"],
+                    "required_field_groups": [["path"]],
+                    "tags": ["core", "file", "read"],
+                    "why": ["summary matches query", "tag matches read"],
+                    "lease": "lease-file"
+                }
+            ]
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "tool.search",
+                "tool_call_id": "call-search",
+                "payload_summary": payload_summary,
+                "payload_chars": 1_024,
+                "payload_truncated": false
+            })
+        );
+
+        append_repeated_tool_guard_followup_messages(
+            &mut messages,
+            "preface",
+            "stop",
+            "find the right tool",
+            Some(("tool_result", tool_result.as_str())),
+            &mut budget,
+        );
+
+        let (envelope, summary) =
+            crate::conversation::turn_shared::parse_tool_result_followup_for_test(&messages);
+        let first = summary["results"]
+            .as_array()
+            .and_then(|results| results.first())
+            .expect("compacted results should contain the first entry");
+
+        assert_eq!(envelope["tool"], "tool.search");
+        assert_eq!(envelope["payload_truncated"], false);
+        assert_eq!(summary["query"], "read repo file");
+        assert!(summary.get("adapter").is_none());
+        assert!(summary.get("tool_name").is_none());
+        assert!(summary.get("returned").is_none());
+        assert_eq!(first["tool_id"], "file.read");
+        assert_eq!(first["lease"], "lease-file");
+        assert!(first.get("tags").is_none());
+        assert!(first.get("why").is_none());
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -5,7 +5,8 @@ use super::runtime::ConversationRuntime;
 use super::runtime_binding::ConversationRuntimeBinding;
 use super::turn_engine::{ApprovalRequirement, ApprovalRequirementKind, ProviderTurn, TurnResult};
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Map, Value};
+use std::borrow::Cow;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -415,14 +416,17 @@ pub fn parse_external_skill_invoke_context(
         .next()
 }
 
-pub fn reduce_followup_payload_for_model(label: &str, text: &str) -> String {
+pub fn reduce_followup_payload_for_model<'a>(label: &str, text: &'a str) -> Cow<'a, str> {
     if label != "tool_result" {
-        return text.to_owned();
+        return Cow::Borrowed(text);
     }
+
     reduce_tool_result_text_for_model(text)
+        .map(Cow::Owned)
+        .unwrap_or(Cow::Borrowed(text))
 }
 
-fn reduce_tool_result_text_for_model(text: &str) -> String {
+fn reduce_tool_result_text_for_model(text: &str) -> Option<String> {
     let mut changed = false;
     let reduced_lines = text
         .lines()
@@ -435,13 +439,13 @@ fn reduce_tool_result_text_for_model(text: &str) -> String {
         })
         .collect::<Vec<_>>();
     if !changed {
-        return text.to_owned();
+        return None;
     }
     let mut reduced = reduced_lines.join("\n");
     if text.ends_with('\n') {
         reduced.push('\n');
     }
-    reduced
+    Some(reduced)
 }
 
 fn reduce_tool_result_line_for_model(line: &str) -> String {
@@ -458,26 +462,47 @@ fn reduce_tool_result_line_for_model(line: &str) -> String {
     let Ok(mut envelope) = serde_json::from_str::<Value>(payload) else {
         return line.to_owned();
     };
-    let tool_name = envelope.get("tool").and_then(Value::as_str);
+    let Some(tool) = envelope.get("tool").and_then(Value::as_str) else {
+        return line.to_owned();
+    };
+
+    let payload_truncated = envelope
+        .get("payload_truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
     let Some(payload_summary) = envelope.get("payload_summary").and_then(Value::as_str) else {
         return line.to_owned();
     };
-    let Ok(mut payload_json) = serde_json::from_str::<Value>(payload_summary) else {
-        return line.to_owned();
-    };
-    let reduced_summary = match tool_name {
-        Some("file.read") => reduce_file_read_payload_summary(&payload_json),
-        Some("shell.exec") => reduce_shell_payload_summary(&mut payload_json),
+
+    let reduction = match tool {
+        "file.read" => {
+            let Ok(payload_json) = serde_json::from_str::<Value>(payload_summary) else {
+                return line.to_owned();
+            };
+            reduce_file_read_payload_summary(&payload_json).map(|summary| (summary, true))
+        }
+        "shell.exec" => {
+            let Ok(mut payload_json) = serde_json::from_str::<Value>(payload_summary) else {
+                return line.to_owned();
+            };
+            reduce_shell_payload_summary(&mut payload_json).map(|summary| (summary, true))
+        }
+        "tool.search" if !payload_truncated => {
+            compact_tool_search_payload_summary_str(payload_summary).map(|summary| (summary, false))
+        }
         _ => None,
     };
-    let Some(reduced_summary) = reduced_summary else {
+    let Some((reduced_summary, mark_truncated)) = reduction else {
         return line.to_owned();
     };
+
     let Some(envelope_object) = envelope.as_object_mut() else {
         return line.to_owned();
     };
     envelope_object.insert("payload_summary".to_owned(), Value::String(reduced_summary));
-    envelope_object.insert("payload_truncated".to_owned(), Value::Bool(true));
+    if mark_truncated {
+        envelope_object.insert("payload_truncated".to_owned(), Value::Bool(true));
+    }
     let Ok(encoded) = serde_json::to_string(&envelope) else {
         return line.to_owned();
     };
@@ -606,6 +631,68 @@ pub fn build_external_skill_followup_user_prompt(
     }
     sections.push(format!("Original request:\n{user_input}"));
     sections.join("\n\n")
+}
+
+fn compact_tool_search_payload_summary_str(payload_summary: &str) -> Option<String> {
+    let payload_json = serde_json::from_str::<Value>(payload_summary).ok()?;
+    let compacted_summary = compact_tool_search_payload_summary(&payload_json)?;
+    let compacted_summary_str = serde_json::to_string(&compacted_summary).ok()?;
+    (compacted_summary_str.len() < payload_summary.len()).then_some(compacted_summary_str)
+}
+
+fn compact_tool_search_payload_summary(payload: &Value) -> Option<Value> {
+    let payload_object = payload.as_object()?;
+    let results = payload_object.get("results")?.as_array()?;
+
+    let mut compacted = Map::new();
+    if let Some(query) = payload_object.get("query") {
+        compacted.insert("query".to_owned(), query.clone());
+    }
+    compacted.insert(
+        "results".to_owned(),
+        Value::Array(
+            results
+                .iter()
+                .map(compact_tool_search_payload_result)
+                .collect(),
+        ),
+    );
+
+    Some(Value::Object(compacted))
+}
+
+fn compact_tool_search_payload_result(result: &Value) -> Value {
+    let Some(result_object) = result.as_object() else {
+        return result.clone();
+    };
+
+    let mut compacted = Map::new();
+    clone_field_if_present(result_object, &mut compacted, "tool_id");
+    clone_field_if_present(result_object, &mut compacted, "summary");
+    clone_field_if_present(result_object, &mut compacted, "argument_hint");
+    clone_array_field_if_present(result_object, &mut compacted, "required_fields");
+    clone_array_field_if_present(result_object, &mut compacted, "required_field_groups");
+    clone_field_if_present(result_object, &mut compacted, "lease");
+    Value::Object(compacted)
+}
+
+fn clone_field_if_present(source: &Map<String, Value>, target: &mut Map<String, Value>, key: &str) {
+    if let Some(value) = source.get(key) {
+        target.insert(key.to_owned(), value.clone());
+    }
+}
+
+fn clone_array_field_if_present(
+    source: &Map<String, Value>,
+    target: &mut Map<String, Value>,
+    key: &str,
+) {
+    let Some(value) = source.get(key) else {
+        return;
+    };
+    if value.as_array().is_some() {
+        target.insert(key.to_owned(), value.clone());
+    }
 }
 
 pub fn build_tool_result_followup_tail<F>(
@@ -1739,5 +1826,126 @@ mod tests {
             parse_external_skill_invoke_context(line.as_str()).is_none(),
             "truncated external skill payload should not activate managed skill context"
         );
+    }
+
+    #[test]
+    fn reduce_followup_payload_for_model_compacts_tool_search_summary() {
+        let payload_summary = json!({
+            "adapter": "core-tools",
+            "tool_name": "tool.search",
+            "query": "read repo file",
+            "returned": 1,
+            "results": [
+                {
+                    "tool_id": "file.read",
+                    "summary": "Read a UTF-8 text file from the configured workspace root and return contents.",
+                    "argument_hint": "path:string",
+                    "required_fields": ["path"],
+                    "required_field_groups": [["path"]],
+                    "tags": ["core", "file", "read"],
+                    "why": ["summary matches query"],
+                    "lease": "lease-file"
+                }
+            ]
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "tool": "tool.search",
+                "tool_call_id": "call-search",
+                "payload_summary": payload_summary,
+                "payload_chars": 512,
+                "payload_truncated": false
+            })
+        );
+
+        let reduced = reduce_followup_payload_for_model("tool_result", tool_result.as_str());
+        let envelope: Value = serde_json::from_str(
+            reduced
+                .strip_prefix("[ok] ")
+                .expect("tool result should keep status prefix"),
+        )
+        .expect("reduced envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("reduced payload summary should stay valid json");
+        let first = summary["results"]
+            .as_array()
+            .and_then(|results| results.first())
+            .expect("reduced payload should keep the first result");
+
+        assert_eq!(summary["query"], "read repo file");
+        assert!(summary.get("adapter").is_none());
+        assert!(summary.get("tool_name").is_none());
+        assert!(summary.get("returned").is_none());
+        assert_eq!(first["tool_id"], "file.read");
+        assert_eq!(first["lease"], "lease-file");
+        assert!(first.get("tags").is_none());
+        assert!(first.get("why").is_none());
+    }
+
+    #[test]
+    fn reduce_followup_payload_for_model_preserves_empty_required_arrays() {
+        let payload_summary = json!({
+            "query": "install a skill",
+            "results": [
+                {
+                    "tool_id": "external_skills.install",
+                    "summary": "Install a bundled skill or a local skill path.",
+                    "argument_hint": "bundled_skill_id?:string,path?:string",
+                    "required_fields": [],
+                    "required_field_groups": [],
+                    "lease": "lease-install"
+                }
+            ]
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "tool": "tool.search",
+                "tool_call_id": "call-search",
+                "payload_summary": payload_summary,
+                "payload_chars": 512,
+                "payload_truncated": false
+            })
+        );
+
+        let reduced = reduce_followup_payload_for_model("tool_result", tool_result.as_str());
+        let envelope: Value = serde_json::from_str(
+            reduced
+                .strip_prefix("[ok] ")
+                .expect("tool result should keep status prefix"),
+        )
+        .expect("reduced envelope should stay valid json");
+        let summary: Value = serde_json::from_str(
+            envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should stay encoded json"),
+        )
+        .expect("reduced payload summary should stay valid json");
+        let first = summary["results"]
+            .as_array()
+            .and_then(|results| results.first())
+            .expect("reduced payload should keep the first result");
+
+        assert_eq!(first["required_fields"], json!([]));
+        assert_eq!(first["required_field_groups"], json!([]));
+    }
+
+    #[test]
+    fn reduce_followup_payload_for_model_borrows_unmodified_tool_results() {
+        let tool_result = r#"[ok] {"status":"ok","tool":"shell.exec","tool_call_id":"call-shell","payload_summary":"{\"stdout\":\"hello\"}","payload_chars":32,"payload_truncated":false}"#;
+
+        let reduced = reduce_followup_payload_for_model("tool_result", tool_result);
+
+        assert_eq!(reduced.as_ref(), tool_result);
+        assert_eq!(reduced.as_ptr(), tool_result.as_ptr());
     }
 }

--- a/crates/app/src/provider/shape.rs
+++ b/crates/app/src/provider/shape.rs
@@ -1510,6 +1510,43 @@ mod tests {
     }
 
     #[test]
+    fn bridge_context_accepts_compacted_search_results() {
+        let payload_summary = serde_json::to_string(&json!({
+            "query": "read repo file",
+            "results": [
+                {
+                    "tool_id": "file.read",
+                    "summary": "Read a UTF-8 text file from the configured workspace root and return contents.",
+                    "argument_hint": "path:string,offset?:integer,limit?:integer",
+                    "required_fields": ["path"],
+                    "required_field_groups": [["path"]],
+                    "lease": "lease-compacted"
+                }
+            ]
+        }))
+        .expect("encode compacted search payload summary");
+        let envelope = serde_json::to_string(&json!({
+            "status": "ok",
+            "tool": "tool.search",
+            "tool_call_id": "call-search",
+            "payload_summary": payload_summary,
+            "payload_chars": payload_summary.chars().count(),
+            "payload_truncated": false,
+        }))
+        .expect("encode search envelope");
+        let messages = vec![json!({
+            "role": "assistant",
+            "content": format!("[tool_result]\n[ok] {envelope}"),
+        })];
+
+        let context = provider_tool_bridge_context_from_messages(&messages);
+        assert_eq!(
+            context.discoverable_leases.get("file.read"),
+            Some(&"lease-compacted".to_owned())
+        );
+    }
+
+    #[test]
     fn extract_provider_turn_handles_text_only() {
         let body = serde_json::json!({
             "choices": [{

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -170,7 +170,7 @@ where
     F: FnMut() -> std::io::Result<T>,
 {
     retry_executable_file_busy_with_pause(&mut operation, || {
-        pause_before_browser_companion_spawn_retry(BROWSER_COMPANION_SPAWN_RETRY_DELAY);
+        pause_before_browser_companion_spawn_retry(BROWSER_COMPANION_SPAWN_RETRY_DELAY)
     })
 }
 
@@ -180,7 +180,7 @@ fn retry_executable_file_busy_with_pause<T, F, P>(
 ) -> std::io::Result<T>
 where
     F: FnMut() -> std::io::Result<T>,
-    P: FnMut(),
+    P: FnMut() -> std::io::Result<()>,
 {
     let mut attempt = 0;
     loop {
@@ -191,22 +191,59 @@ where
                 if should_retry_spawn_error(&error)
                     && attempt < BROWSER_COMPANION_SPAWN_RETRY_ATTEMPTS =>
             {
-                pause();
+                pause()?;
             }
             Err(error) => return Err(error),
         }
     }
 }
 
-fn pause_before_browser_companion_spawn_retry(delay: Duration) {
-    if let Ok(handle) = tokio::runtime::Handle::try_current()
-        && handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread
-    {
-        tokio::task::block_in_place(|| std::thread::park_timeout(delay));
-        return;
+fn pause_before_browser_companion_spawn_retry(delay: Duration) -> std::io::Result<()> {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(|| {
+                handle.block_on(async move {
+                    tokio::time::sleep(delay).await;
+                })
+            });
+            Ok(())
+        }
+        Ok(_) => std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let runtime = tokio::runtime::Builder::new_current_thread()
+                        .enable_time()
+                        .build()
+                        .map_err(|error| {
+                            std::io::Error::other(format!(
+                                "browser_companion_retry_runtime_create_failed: {error}"
+                            ))
+                        })?;
+                    runtime.block_on(async move {
+                        tokio::time::sleep(delay).await;
+                    });
+                    Ok(())
+                })
+                .join()
+                .map_err(|_panic| {
+                    std::io::Error::other("browser_companion_retry_worker_thread_panicked")
+                })?
+        }),
+        Err(_) => {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .build()
+                .map_err(|error| {
+                    std::io::Error::other(format!(
+                        "browser_companion_retry_runtime_create_failed: {error}"
+                    ))
+                })?;
+            runtime.block_on(async move {
+                tokio::time::sleep(delay).await;
+            });
+            Ok(())
+        }
     }
-
-    std::thread::park_timeout(delay);
 }
 
 fn should_retry_spawn_error(error: &std::io::Error) -> bool {
@@ -635,6 +672,7 @@ mod tests {
             },
             || {
                 pauses.fetch_add(1, Ordering::Relaxed);
+                Ok(())
             },
         )
         .expect("retry should pause between retryable executable-busy failures");
@@ -672,7 +710,14 @@ mod tests {
             .expect("build current-thread runtime");
 
         runtime.block_on(async {
-            super::pause_before_browser_companion_spawn_retry(Duration::from_millis(0));
+            super::pause_before_browser_companion_spawn_retry(Duration::from_millis(0))
+                .expect("pause should work under a current-thread runtime");
         });
+    }
+
+    #[test]
+    fn pause_before_browser_companion_spawn_retry_succeeds_without_runtime() {
+        super::pause_before_browser_companion_spawn_retry(Duration::ZERO)
+            .expect("pause should work without a tokio runtime");
     }
 }

--- a/docs/plans/2026-03-16-tool-search-followup-payload-compactor-design.md
+++ b/docs/plans/2026-03-16-tool-search-followup-payload-compactor-design.md
@@ -1,0 +1,98 @@
+# Tool Search Follow-up Payload Compactor Design
+
+**Problem**
+
+`tool.search` returns a structured payload that can include up to eight results, and each result currently carries lease-bearing discovery data plus search-only explanation fields such as `why` and `tags`. In the current `alpha-test` branch, discovery-first follow-up, turn-loop follow-up, and repeated-tool-guard replay forward that payload back into the next model round largely unchanged unless generic character-budget truncation fires.
+
+This is a model-context efficiency problem. The follow-up model needs enough information to choose and invoke a discovered tool, but it does not need the full raw discovery payload shape in every round.
+
+**Critical Constraint**
+
+Unlike `file.read`, `tool.search` follow-up payloads cannot be safely handled by simply setting `payload_truncated=true`.
+
+`provider/shape.rs` deliberately skips truncated `tool.search` envelopes when reconstructing discovery bridge context because that bridge trusts only intact discovery results when extracting `tool_id -> lease` bindings for later `tool.invoke` calls.
+
+That means this slice must preserve bridge-safe semantics while still shrinking the payload.
+
+**Constraints**
+
+- Do not change `tool.search` execution output in `crates/app/src/tools/mod.rs`.
+- Do not change `TurnEngine` tool-result envelope generation.
+- Do not add a new runtime config knob.
+- Do not widen this into a generic all-tool reducer framework.
+- Do not break `provider/shape.rs` lease extraction for discovery follow-up.
+- Do not change `external_skills.invoke` follow-up semantics.
+
+**Approaches Considered**
+
+1. Mark reduced `tool.search` follow-up payloads as truncated.
+   Rejected because `provider/shape.rs` intentionally ignores truncated discovery results, which would break later `tool.invoke` lease reconstruction.
+
+2. Relax provider bridge parsing so it accepts truncated `tool.search` payloads.
+   Rejected because it changes trust semantics in the bridge layer and broadens the blast radius beyond a performance-focused follow-up slice.
+
+3. Apply a follow-up-only structural compactor that preserves bridge-required fields and avoids setting `payload_truncated=true`.
+   Recommended because it keeps execution semantics unchanged, preserves discovery bridge behavior, and reduces token waste by pruning low-value fields instead of changing trust semantics.
+
+**Chosen Design**
+
+Add a shared helper in `turn_shared.rs` that rewrites only follow-up `tool_result` lines whose envelope tool is `tool.search` and whose nested `payload_summary` is valid JSON.
+
+The compactor will:
+
+- parse the outer tool-result envelope
+- parse the nested `payload_summary`
+- preserve outer `payload_chars`
+- preserve outer `payload_truncated` as `false`
+- preserve every returned result entry so the model can still choose among all visible discovered tools
+- preserve per-result fields required for follow-up action:
+  - `tool_id`
+  - `summary`
+  - `argument_hint`
+  - `required_fields` when non-empty
+  - `required_field_groups` when non-empty
+  - `lease`
+- drop follow-up-only low-value fields:
+  - top-level `adapter`
+  - top-level `tool_name`
+  - top-level `returned`
+  - per-result `tags`
+  - per-result `why`
+- preserve top-level `query` because the provider-generated discovery query can differ from the original user wording and still helps explain why these results were surfaced
+- leave non-`tool.search` payloads unchanged
+
+**Why This Shape**
+
+This is the smallest safe compaction that still preserves the information needed for:
+
+- provider bridge lease reconstruction
+- model-side tool selection
+- model-side argument planning for `tool.invoke`
+
+Keeping all returned results avoids a recall regression where the correct candidate is omitted from the follow-up context. Pruning per-result explanation metadata removes noise without changing the actionable semantics of discovery.
+
+**Integration Points**
+
+Run the compactor only in follow-up message assembly:
+
+- discovery-first follow-up assembly in `turn_coordinator.rs`
+- turn-loop tool-result follow-up assembly in `turn_loop.rs`
+- repeated-tool-guard replay in `turn_loop.rs`
+
+Do not apply it to raw tool output delivery.
+
+**Testing Strategy**
+
+Add focused coverage for:
+
+- discovery-first follow-up compacting `tool.search` payload summaries
+- turn-loop follow-up compacting `tool.search` payload summaries
+- repeated-tool-guard replay compacting `tool.search` payload summaries
+- provider bridge lease extraction continuing to work with compacted discovery follow-up payloads
+- `external_skills.invoke` payload handling remaining unchanged
+
+**Risk Assessment**
+
+This is a low-risk slice because it only changes model-facing follow-up assembly and leaves tool execution plus outer envelope generation untouched.
+
+The main residual risk is merge overlap with other open performance PRs that touch the same conversation follow-up files. That is a branch-management concern, not a runtime design concern.

--- a/docs/plans/2026-03-16-tool-search-followup-payload-compactor-implementation-plan.md
+++ b/docs/plans/2026-03-16-tool-search-followup-payload-compactor-implementation-plan.md
@@ -1,0 +1,117 @@
+# Tool Search Follow-up Payload Compactor Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Reduce follow-up token waste from `tool.search` tool results without changing raw execution output or breaking discovery lease bridging.
+
+**Architecture:** Keep `tool.search` execution output and `TurnEngine` envelopes unchanged. Add a follow-up-only structural compactor that rewrites `tool.search` payload summaries in conversation follow-up assembly while preserving bridge-required fields and leaving `payload_truncated` untouched.
+
+**Tech Stack:** Rust, serde_json, conversation follow-up assembly in `turn_shared.rs`, `turn_coordinator.rs`, `turn_loop.rs`, and provider bridge validation in `provider/shape.rs`.
+
+---
+
+### Task 1: Add failing tests for bridge-safe tool.search compaction
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_shared.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/provider/shape.rs`
+
+**Step 1: Write the failing discovery-first follow-up test**
+
+Add a test proving `build_turn_reply_followup_messages(...)` compacts an oversized `tool.search` payload summary before the next provider round while keeping `payload_truncated=false`.
+
+**Step 2: Run the test to verify RED**
+
+Run: `cargo test -p loongclaw-app build_turn_reply_followup_messages_compacts_tool_search_payload_summary -- --exact --nocapture`
+Expected: FAIL because discovery-first follow-up currently forwards the raw `tool.search` payload unchanged.
+
+**Step 3: Write the failing turn-loop tests**
+
+Add focused tests proving both:
+- `append_tool_driven_followup_messages(...)`
+- `append_repeated_tool_guard_followup_messages(...)`
+
+compact `tool.search` payload summaries before generic follow-up budget truncation.
+
+**Step 4: Run one failing turn-loop test**
+
+Run: `cargo test -p loongclaw-app append_tool_driven_followup_messages_compacts_tool_search_payload_summary -- --exact --nocapture`
+Expected: FAIL because turn-loop follow-up currently forwards the raw `tool.search` payload unchanged.
+
+**Step 5: Write the provider bridge safety regression test**
+
+Add a provider bridge test proving a compacted `tool.search` follow-up payload still exposes `tool_id` and `lease` well enough for lease reconstruction.
+
+### Task 2: Implement the minimal follow-up compactor
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_shared.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+
+**Step 1: Add a shared `tool.search` follow-up compactor in `turn_shared.rs`**
+
+Implement helpers that:
+- only touch `tool_result` payloads
+- only rewrite structured envelopes for `tool.search`
+- parse the nested `payload_summary`
+- preserve bridge-safe fields for every result
+- prune low-value search explanation metadata
+- preserve outer `payload_chars`
+- avoid setting `payload_truncated=true`
+- leave non-`tool.search` payloads unchanged
+
+**Step 2: Route discovery-first follow-up assembly through the compactor**
+
+Update `build_turn_reply_followup_messages(...)` so provider follow-up messages compact `tool.search` payloads before sending them back to the model.
+
+**Step 3: Route turn-loop and repeated-tool-guard follow-up assembly through the compactor**
+
+Update both follow-up paths in `turn_loop.rs` so search compaction happens before generic follow-up budget truncation.
+
+### Task 3: Verify and prepare GitHub delivery
+
+**Files:**
+- Modify: `docs/plans/2026-03-16-tool-search-followup-payload-compactor-design.md`
+- Modify: `docs/plans/2026-03-16-tool-search-followup-payload-compactor-implementation-plan.md`
+
+**Step 1: Run focused tests**
+
+Run:
+- `cargo test -p loongclaw-app build_turn_reply_followup_messages_compacts_tool_search_payload_summary -- --exact --nocapture`
+- `cargo test -p loongclaw-app append_tool_driven_followup_messages_compacts_tool_search_payload_summary -- --exact --nocapture`
+- `cargo test -p loongclaw-app append_repeated_tool_guard_followup_messages_compacts_tool_search_payload_summary -- --exact --nocapture`
+- `cargo test -p loongclaw-app bridge_context_accepts_compacted_search_results -- --exact --nocapture`
+
+Expected: PASS
+
+**Step 2: Run adjacent regressions**
+
+Run:
+- `cargo test -p loongclaw-app build_turn_reply_followup_messages_ -- --nocapture`
+- `cargo test -p loongclaw-app append_tool_driven_followup_messages_ -- --nocapture`
+- `cargo test -p loongclaw-app append_repeated_tool_guard_followup_messages_ -- --nocapture`
+- `cargo test -p loongclaw-app bridge_context_ -- --nocapture`
+
+Expected: PASS
+
+**Step 3: Run repository-grade verification**
+
+Run:
+- `cargo fmt --all`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features`
+
+Expected: PASS
+
+**Step 4: Prepare GitHub delivery**
+
+Create a new GitHub issue describing:
+- why `tool.search` is a follow-up token hotspot
+- why this slice uses structural compaction instead of truncation
+- why `payload_truncated` must stay untouched for bridge safety
+
+Open a PR linked to that issue with exact validation evidence.


### PR DESCRIPTION
## Summary

- Compact model follow-up copies of `tool.search` payload summaries by pruning low-value search metadata while preserving query context, actionable result fields, and lease-bearing bridge fields.
- Route discovery-first and turn-loop follow-up assembly through a shared reducer without changing raw tool execution output or `TurnEngine` envelope generation.
- Harden the Feishu webhook lease-extraction test helper so follow-up envelope field reordering does not break delayed-update callback regressions.

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [x] No config/env fallback/default behavior changed in this slice
- [x] No tests in this slice mutate process-global env

Additional checks:
- `cargo test -p loongclaw-app --all-features channel::feishu::webhook::tests::extract_lease_from_provider_request_body_accepts_reordered_search_envelope_fields -- --exact --nocapture`
- `cargo test -p loongclaw-app --all-features channel::feishu::webhook::tests::feishu_webhook_card_callback_delayed_update -- --nocapture`
- `cargo test -p loongclaw-app --no-default-features --features 'channel-telegram,config-toml,memory-sqlite,tool-shell,tool-file' conversation::turn_coordinator::tests::build_turn_reply_followup_messages_compacts_tool_search_payload_summary -- --exact --nocapture`
- `cargo test -p loongclaw-app --no-default-features --features 'channel-telegram,config-toml,memory-sqlite,tool-shell,tool-file' conversation::turn_loop::tests::append_tool_driven_followup_messages_compacts_tool_search_payload_summary -- --exact --nocapture`
- `cargo test -p loongclaw-app --no-default-features --features 'channel-telegram,config-toml,memory-sqlite,tool-shell,tool-file' conversation::turn_loop::tests::append_repeated_tool_guard_followup_messages_compacts_tool_search_payload_summary -- --exact --nocapture`
- `cargo test -p loongclaw-app --no-default-features --features 'channel-telegram,config-toml,memory-sqlite,tool-shell,tool-file' provider::shape::tests::bridge_context_accepts_compacted_search_results -- --exact --nocapture`

## Linked Issues

Closes #238


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Compacts tool.search follow-up payloads to reduce token usage while preserving essential result fields.

* **Reliability**
  * More robust webhook parsing to extract leases from per-line tool-result envelopes.
  * Added retry logic for launching the browser companion to handle transient executable-busy errors.

* **Tests**
  * Extensive tests covering compaction, follow-up assembly, retry behavior, and provider bridge lease extraction.

* **Documentation**
  * Added design and implementation plans detailing the compactor and testing strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->