### PR TITLE
feat(daemon): add runtime experiment stage restore

### DIFF
--- a/crates/daemon/src/runtime_experiment_cli.rs
+++ b/crates/daemon/src/runtime_experiment_cli.rs
@@ -25,6 +25,8 @@ pub enum RuntimeExperimentCommands {
     Show(RuntimeExperimentShowCommandOptions),
     /// Compare one experiment run and, optionally, matching runtime snapshots
     Compare(RuntimeExperimentCompareCommandOptions),
+    /// Restore one recorded baseline/result stage through the snapshot restore pipeline
+    Restore(RuntimeExperimentRestoreCommandOptions),
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -85,6 +87,20 @@ pub struct RuntimeExperimentCompareCommandOptions {
     pub json: bool,
 }
 
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeExperimentRestoreCommandOptions {
+    #[arg(long)]
+    pub run: String,
+    #[arg(long, value_enum)]
+    pub stage: RuntimeExperimentRestoreStage,
+    #[arg(long)]
+    pub config: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+    #[arg(long, default_value_t = false)]
+    pub apply: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeExperimentDecision {
@@ -114,6 +130,13 @@ pub enum RuntimeExperimentCompareMode {
     SnapshotDelta,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeExperimentRestoreStage {
+    Baseline,
+    Result,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeExperimentArtifactSchema {
     pub version: u32,
@@ -134,6 +157,7 @@ pub struct RuntimeExperimentSnapshotSummary {
     pub label: Option<String>,
     pub experiment_id: Option<String>,
     pub parent_snapshot_id: Option<String>,
+    pub artifact_path: Option<String>,
     pub capability_snapshot_sha256: Option<String>,
 }
 
@@ -173,6 +197,15 @@ pub struct RuntimeExperimentCompareReport {
     pub evaluation: Option<RuntimeExperimentEvaluation>,
     pub compare_mode: RuntimeExperimentCompareMode,
     pub snapshot_delta: Option<RuntimeExperimentSnapshotDelta>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeExperimentRestoreExecution {
+    pub run_id: String,
+    pub experiment_id: String,
+    pub stage: RuntimeExperimentRestoreStage,
+    pub snapshot_path: String,
+    pub restore: crate::runtime_restore_cli::RuntimeRestoreExecution,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -239,6 +272,11 @@ pub fn run_runtime_experiment_cli(command: RuntimeExperimentCommands) -> CliResu
             let report = execute_runtime_experiment_compare_command(options)?;
             emit_runtime_experiment_compare_report(&report, as_json)
         }
+        RuntimeExperimentCommands::Restore(options) => {
+            let as_json = options.json;
+            let execution = execute_runtime_experiment_restore_command(options)?;
+            emit_runtime_experiment_restore_execution(&execution, as_json)
+        }
     }
 }
 
@@ -254,7 +292,7 @@ pub fn execute_runtime_experiment_start_command(
     let label = optional_arg(options.label.as_deref());
     let mutation_summary = required_trimmed_arg("mutation_summary", &options.mutation_summary)?;
     let tags = normalize_repeated_values(&options.tag);
-    let baseline_snapshot = build_snapshot_summary(&baseline);
+    let baseline_snapshot = build_snapshot_summary(&baseline, Some(Path::new(&options.snapshot)))?;
     let run_id = compute_run_id(
         &created_at,
         label.as_deref(),
@@ -325,7 +363,10 @@ pub fn execute_runtime_experiment_finish_command(
         RuntimeExperimentFinishStatus::Aborted => RuntimeExperimentStatus::Aborted,
     };
     artifact.decision = options.decision;
-    artifact.result_snapshot = Some(build_snapshot_summary(&result_snapshot));
+    artifact.result_snapshot = Some(build_snapshot_summary(
+        &result_snapshot,
+        Some(Path::new(&options.result_snapshot)),
+    )?);
     artifact.evaluation = Some(RuntimeExperimentEvaluation {
         summary: required_trimmed_arg("evaluation_summary", &options.evaluation_summary)?,
         metrics: parse_metrics(&options.metric)?,
@@ -372,6 +413,37 @@ pub fn execute_runtime_experiment_compare_command(
     })
 }
 
+pub fn execute_runtime_experiment_restore_command(
+    options: RuntimeExperimentRestoreCommandOptions,
+) -> CliResult<RuntimeExperimentRestoreExecution> {
+    let RuntimeExperimentRestoreCommandOptions {
+        run,
+        stage,
+        config,
+        json: _,
+        apply,
+    } = options;
+    let artifact = load_runtime_experiment_artifact(Path::new(&run))?;
+    let snapshot_path =
+        resolve_runtime_experiment_restore_snapshot_path(&artifact, Path::new(&run), stage)?;
+    let restore = crate::runtime_restore_cli::execute_runtime_restore_command(
+        crate::runtime_restore_cli::RuntimeRestoreCommandOptions {
+            config,
+            snapshot: snapshot_path.clone(),
+            json: false,
+            apply,
+        },
+    )?;
+
+    Ok(RuntimeExperimentRestoreExecution {
+        run_id: artifact.run_id,
+        experiment_id: artifact.experiment_id,
+        stage,
+        snapshot_path,
+        restore,
+    })
+}
+
 fn emit_runtime_experiment_artifact(
     artifact: &RuntimeExperimentArtifactDocument,
     as_json: bool,
@@ -400,6 +472,22 @@ fn emit_runtime_experiment_compare_report(
     }
 
     println!("{}", render_runtime_experiment_compare_text(report));
+    Ok(())
+}
+
+fn emit_runtime_experiment_restore_execution(
+    execution: &RuntimeExperimentRestoreExecution,
+    as_json: bool,
+) -> CliResult<()> {
+    if as_json {
+        let pretty = serde_json::to_string_pretty(execution).map_err(|error| {
+            format!("serialize runtime experiment restore execution failed: {error}")
+        })?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_experiment_restore_text(execution));
     Ok(())
 }
 
@@ -492,6 +580,40 @@ fn load_runtime_experiment_compare_snapshot_delta(
             )))
         }
     }
+}
+
+fn resolve_runtime_experiment_restore_snapshot_path(
+    artifact: &RuntimeExperimentArtifactDocument,
+    run_path: &Path,
+    stage: RuntimeExperimentRestoreStage,
+) -> CliResult<String> {
+    let summary = match stage {
+        RuntimeExperimentRestoreStage::Baseline => &artifact.baseline_snapshot,
+        RuntimeExperimentRestoreStage::Result => {
+            artifact.result_snapshot.as_ref().ok_or_else(|| {
+                format!(
+                    "runtime experiment run {} has no recorded result snapshot to restore",
+                    run_path.display()
+                )
+            })?
+        }
+    };
+    let artifact_path = summary.artifact_path.as_deref().ok_or_else(|| {
+        format!(
+            "runtime experiment run {} is missing recorded {} snapshot path",
+            run_path.display(),
+            stage.as_str()
+        )
+    })?;
+
+    canonicalize_snapshot_artifact_path(artifact_path).map_err(|error| {
+        format!(
+            "runtime experiment run {} recorded {} snapshot path {} cannot be resolved: {error}",
+            run_path.display(),
+            stage.as_str(),
+            artifact_path
+        )
+    })
 }
 
 fn validate_compare_snapshot_identity(
@@ -592,19 +714,34 @@ fn parse_metrics(values: &[String]) -> CliResult<BTreeMap<String, f64>> {
 
 fn build_snapshot_summary(
     artifact: &RuntimeSnapshotArtifactDocument,
-) -> RuntimeExperimentSnapshotSummary {
-    RuntimeExperimentSnapshotSummary {
+    artifact_path: Option<&Path>,
+) -> CliResult<RuntimeExperimentSnapshotSummary> {
+    Ok(RuntimeExperimentSnapshotSummary {
         snapshot_id: artifact.lineage.snapshot_id.clone(),
         created_at: artifact.lineage.created_at.clone(),
         label: artifact.lineage.label.clone(),
         experiment_id: artifact.lineage.experiment_id.clone(),
         parent_snapshot_id: artifact.lineage.parent_snapshot_id.clone(),
+        artifact_path: artifact_path
+            .map(|path| canonicalize_snapshot_artifact_path(&path.display().to_string()))
+            .transpose()?,
         capability_snapshot_sha256: artifact
             .tools
             .get("capability_snapshot_sha256")
             .and_then(Value::as_str)
             .map(str::to_owned),
-    }
+    })
+}
+
+fn canonicalize_snapshot_artifact_path(path: &str) -> CliResult<String> {
+    fs::canonicalize(path)
+        .map(|resolved| resolved.display().to_string())
+        .map_err(|error| {
+            format!(
+                "canonicalize snapshot artifact path {} failed: {error}",
+                path
+            )
+        })
 }
 
 fn build_runtime_experiment_snapshot_delta(
@@ -972,6 +1109,22 @@ pub fn render_runtime_experiment_text(artifact: &RuntimeExperimentArtifactDocume
         format!("decision={}", render_decision(artifact.decision)),
         format!("metrics={}", render_metrics(artifact.evaluation.as_ref())),
         format!("warnings={}", render_warnings(artifact.evaluation.as_ref())),
+        format!(
+            "baseline_snapshot_path={}",
+            artifact
+                .baseline_snapshot
+                .artifact_path
+                .as_deref()
+                .unwrap_or("-")
+        ),
+        format!(
+            "result_snapshot_path={}",
+            artifact
+                .result_snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.artifact_path.as_deref())
+                .unwrap_or("-")
+        ),
         format!("mutation_summary={}", artifact.mutation.summary),
         format!(
             "mutation_tags={}",
@@ -1005,6 +1158,22 @@ pub fn render_runtime_experiment_compare_text(report: &RuntimeExperimentCompareR
         ),
         format!("metrics={}", render_metrics(report.evaluation.as_ref())),
         format!("warnings={}", render_warnings(report.evaluation.as_ref())),
+        format!(
+            "baseline_snapshot_path={}",
+            report
+                .baseline_snapshot
+                .artifact_path
+                .as_deref()
+                .unwrap_or("-")
+        ),
+        format!(
+            "result_snapshot_path={}",
+            report
+                .result_snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.artifact_path.as_deref())
+                .unwrap_or("-")
+        ),
         format!("compare_mode={}", render_compare_mode(report.compare_mode)),
         format!("mutation_summary={}", report.mutation.summary),
         format!(
@@ -1077,6 +1246,16 @@ pub fn render_runtime_experiment_compare_text(report: &RuntimeExperimentCompareR
     }
 
     lines.join("\n")
+}
+
+fn render_runtime_experiment_restore_text(execution: &RuntimeExperimentRestoreExecution) -> String {
+    [
+        format!("run_id={}", execution.run_id),
+        format!("experiment_id={}", execution.experiment_id),
+        format!("stage={}", execution.stage.as_str()),
+        crate::runtime_restore_cli::render_runtime_restore_text(&execution.restore),
+    ]
+    .join("\n")
 }
 
 fn render_evaluation_summary(evaluation: Option<&RuntimeExperimentEvaluation>) -> String {
@@ -1191,5 +1370,14 @@ fn render_compare_mode(mode: RuntimeExperimentCompareMode) -> &'static str {
     match mode {
         RuntimeExperimentCompareMode::RecordOnly => "record_only",
         RuntimeExperimentCompareMode::SnapshotDelta => "snapshot_delta",
+    }
+}
+
+impl RuntimeExperimentRestoreStage {
+    fn as_str(self) -> &'static str {
+        match self {
+            RuntimeExperimentRestoreStage::Baseline => "baseline",
+            RuntimeExperimentRestoreStage::Result => "result",
+        }
     }
 }

--- a/crates/daemon/src/runtime_restore_cli.rs
+++ b/crates/daemon/src/runtime_restore_cli.rs
@@ -773,7 +773,7 @@ fn expected_capability_snapshot_sha256(artifact: &RuntimeSnapshotArtifactDocumen
         .and_then(Value::as_str)
 }
 
-fn render_runtime_restore_text(execution: &RuntimeRestoreExecution) -> String {
+pub(crate) fn render_runtime_restore_text(execution: &RuntimeRestoreExecution) -> String {
     let mut lines = vec![
         format!("config={}", execution.resolved_config_path),
         format!("snapshot={}", execution.snapshot_path),

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -303,6 +303,48 @@ fn runtime_restore_cli_parses() {
 }
 
 #[test]
+fn runtime_experiment_cli_parses_restore() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-experiment",
+        "restore",
+        "--run",
+        "/tmp/runtime-experiment.json",
+        "--stage",
+        "result",
+        "--config",
+        "/tmp/loongclaw.toml",
+        "--json",
+        "--apply",
+    ])
+    .expect("`runtime-experiment restore` should parse");
+
+    match cli.command {
+        Some(Commands::RuntimeExperiment { command }) => match command {
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Restore(
+                options,
+            ) => {
+                assert_eq!(options.run, "/tmp/runtime-experiment.json");
+                assert_eq!(
+                    options.stage,
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentRestoreStage::Result
+                );
+                assert_eq!(options.config.as_deref(), Some("/tmp/loongclaw.toml"));
+                assert!(options.json);
+                assert!(options.apply);
+            }
+            other @ (loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Start(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Finish(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Show(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Compare(_)) => {
+                panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
 fn runtime_experiment_cli_parses_start_finish_and_show() {
     let start = Cli::try_parse_from([
         "loongclaw",
@@ -342,7 +384,8 @@ fn runtime_experiment_cli_parses_start_finish_and_show() {
             }
             other @ (loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Finish(_)
             | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Show(_)
-            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Compare(_)) => {
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Compare(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Restore(_)) => {
                 panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
             }
         },
@@ -405,6 +448,9 @@ fn runtime_experiment_cli_parses_start_finish_and_show() {
             )
             | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Compare(
                 _,
+            )
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Restore(
+                _,
             )) => {
                 panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
             }
@@ -430,7 +476,8 @@ fn runtime_experiment_cli_parses_start_finish_and_show() {
             }
             other @ (loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Start(_)
             | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Finish(_)
-            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Compare(_)) => {
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Compare(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Restore(_)) => {
                 panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
             }
         },
@@ -472,7 +519,8 @@ fn runtime_experiment_cli_parses_compare() {
             }
             other @ (loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Start(_)
             | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Finish(_)
-            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Show(_)) => {
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Show(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Restore(_)) => {
                 panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
             }
         },

--- a/crates/daemon/tests/integration/runtime_experiment_cli.rs
+++ b/crates/daemon/tests/integration/runtime_experiment_cli.rs
@@ -96,6 +96,13 @@ fn snapshot_id_from_payload(payload: &Value) -> String {
         .expect("snapshot payload should include lineage.snapshot_id")
 }
 
+fn canonical_display_path(path: &Path) -> String {
+    fs::canonicalize(path)
+        .expect("canonicalize fixture path")
+        .display()
+        .to_string()
+}
+
 fn rewrite_json_file(path: &Path, mutate: impl FnOnce(&mut Value)) {
     let raw = fs::read_to_string(path).expect("read json fixture");
     let mut payload = serde_json::from_str::<Value>(&raw).expect("decode json fixture");
@@ -961,6 +968,112 @@ fn runtime_experiment_compare_treats_missing_snapshot_sections_as_absent() {
         snapshot_delta.changed_surface_count >= 3,
         "missing sections should still register as changed surfaces"
     );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_restore_uses_recorded_result_snapshot_path() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-restore-stage-result");
+    let config_path = write_runtime_experiment_config(&root);
+    let (run_path, _, result_snapshot_path, finished) =
+        finish_runtime_experiment_with_compare_delta(&root, &config_path);
+
+    let execution =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_restore_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentRestoreCommandOptions {
+                run: run_path.display().to_string(),
+                stage:
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentRestoreStage::Result,
+                config: Some(config_path.display().to_string()),
+                json: false,
+                apply: false,
+            },
+        )
+        .expect("runtime experiment restore should resolve the result snapshot");
+
+    assert_eq!(
+        execution.stage,
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentRestoreStage::Result
+    );
+    assert_eq!(
+        execution.snapshot_path,
+        canonical_display_path(&result_snapshot_path)
+    );
+    assert_eq!(
+        execution.restore.lineage.snapshot_id,
+        finished
+            .result_snapshot
+            .as_ref()
+            .expect("finished run should record result snapshot")
+            .snapshot_id
+    );
+    assert!(!execution.restore.applied);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_restore_rejects_missing_recorded_stage_path() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-restore-stage-missing-path");
+    let config_path = write_runtime_experiment_config(&root);
+    let (run_path, _, _, _) = finish_runtime_experiment_with_compare_delta(&root, &config_path);
+    rewrite_json_file(&run_path, |payload| {
+        payload["result_snapshot"]
+            .as_object_mut()
+            .expect("result_snapshot should be an object")
+            .remove("artifact_path");
+    });
+
+    let error =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_restore_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentRestoreCommandOptions {
+                run: run_path.display().to_string(),
+                stage:
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentRestoreStage::Result,
+                config: Some(config_path.display().to_string()),
+                json: false,
+                apply: false,
+            },
+        )
+        .expect_err("runtime experiment restore should reject old artifacts without a path");
+
+    assert!(error.contains("missing recorded result snapshot path"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_restore_rejects_unavailable_result_stage() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-restore-stage-unavailable");
+    let config_path = write_runtime_experiment_config(&root);
+    let (baseline_snapshot_path, _) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(&root, &baseline_snapshot_path, None);
+
+    let error =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_restore_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentRestoreCommandOptions {
+                run: run_path.display().to_string(),
+                stage:
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentRestoreStage::Result,
+                config: Some(config_path.display().to_string()),
+                json: false,
+                apply: false,
+            },
+        )
+        .expect_err("planned runs should not expose a result stage restore");
+
+    assert!(error.contains("has no recorded result snapshot to restore"));
 
     fs::remove_dir_all(&root).ok();
 }


### PR DESCRIPTION
## Summary

- add `runtime-experiment restore` so operators can restore the recorded `baseline` or `result` stage from an experiment-run artifact
- persist canonical snapshot artifact paths in experiment-run records and reuse the existing `runtime-restore` dry-run/apply/verification flow instead of introducing a second restore pipeline
- add regression coverage for CLI parsing, recorded-path replay, missing recorded paths, and unavailable `result` stages on planned runs

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional local validation:
- `cargo test -p loongclaw-daemon runtime_experiment`
- `cargo test -p loongclaw-daemon runtime_restore`
- `cargo clippy -p loongclaw-daemon --all-targets -- -D warnings`

## Linked Issues

Closes #243


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added restore command for runtime experiments to revert to baseline or result snapshots
  * Support for JSON output format and configuration options during restoration
  * Added apply flag for restoration workflows

* **Tests**
  * Added test coverage for restore command parsing and execution scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->