### PR TITLE
feat(daemon): reuse recorded snapshots for experiment compare

### DIFF
--- a/crates/daemon/src/runtime_experiment_cli.rs
+++ b/crates/daemon/src/runtime_experiment_cli.rs
@@ -83,6 +83,12 @@ pub struct RuntimeExperimentCompareCommandOptions {
     pub baseline_snapshot: Option<String>,
     #[arg(long)]
     pub result_snapshot: Option<String>,
+    #[arg(
+        long,
+        default_value_t = false,
+        conflicts_with_all = ["baseline_snapshot", "result_snapshot"]
+    )]
+    pub recorded_snapshots: bool,
     #[arg(long, default_value_t = false)]
     pub json: bool,
 }
@@ -391,6 +397,7 @@ pub fn execute_runtime_experiment_compare_command(
         &options.run,
         options.baseline_snapshot.as_deref(),
         options.result_snapshot.as_deref(),
+        options.recorded_snapshots,
     )?;
     let compare_mode = if snapshot_delta.is_some() {
         RuntimeExperimentCompareMode::SnapshotDelta
@@ -546,13 +553,56 @@ fn load_runtime_experiment_compare_snapshot_delta(
     run_path: &str,
     baseline_snapshot_path: Option<&str>,
     result_snapshot_path: Option<&str>,
+    recorded_snapshots: bool,
 ) -> CliResult<Option<RuntimeExperimentSnapshotDelta>> {
-    match (baseline_snapshot_path, result_snapshot_path) {
-        (None, None) => Ok(None),
-        (Some(_), None) | (None, Some(_)) => {
+    match (baseline_snapshot_path, result_snapshot_path, recorded_snapshots) {
+        (Some(_), _, true) | (_, Some(_), true) => Err(
+            "runtime experiment compare cannot combine --recorded-snapshots with manual snapshot paths"
+                .to_owned(),
+        ),
+        (None, None, false) => Ok(None),
+        (None, None, true) => {
+            let run_path = Path::new(run_path);
+            let recorded_result_snapshot = artifact.result_snapshot.as_ref().ok_or_else(|| {
+                format!(
+                    "runtime experiment compare cannot load recorded snapshots for run {} because the run has no result snapshot",
+                    run_path.display()
+                )
+            })?;
+            let baseline_snapshot_path = resolve_runtime_experiment_compare_snapshot_path(
+                &artifact.baseline_snapshot,
+                run_path,
+                "baseline",
+            )?;
+            let result_snapshot_path = resolve_runtime_experiment_compare_snapshot_path(
+                recorded_result_snapshot,
+                run_path,
+                "result",
+            )?;
+            let baseline_snapshot =
+                load_runtime_snapshot_artifact(Path::new(&baseline_snapshot_path))?;
+            let result_snapshot = load_runtime_snapshot_artifact(Path::new(&result_snapshot_path))?;
+            validate_compare_snapshot_identity(
+                "baseline",
+                &artifact.baseline_snapshot.snapshot_id,
+                &baseline_snapshot.lineage.snapshot_id,
+                Path::new(&baseline_snapshot_path),
+            )?;
+            validate_compare_snapshot_identity(
+                "result",
+                &recorded_result_snapshot.snapshot_id,
+                &result_snapshot.lineage.snapshot_id,
+                Path::new(&result_snapshot_path),
+            )?;
+            Ok(Some(build_runtime_experiment_snapshot_delta(
+                &baseline_snapshot,
+                &result_snapshot,
+            )))
+        }
+        (Some(_), None, false) | (None, Some(_), false) => {
             Err("runtime experiment compare requires --baseline-snapshot and --result-snapshot together".to_owned())
         }
-        (Some(baseline_snapshot_path), Some(result_snapshot_path)) => {
+        (Some(baseline_snapshot_path), Some(result_snapshot_path), false) => {
             let recorded_result_snapshot = artifact.result_snapshot.as_ref().ok_or_else(|| {
                 format!(
                     "runtime experiment compare cannot load snapshot delta for run {} because the run has no result snapshot",
@@ -580,6 +630,29 @@ fn load_runtime_experiment_compare_snapshot_delta(
             )))
         }
     }
+}
+
+fn resolve_runtime_experiment_compare_snapshot_path(
+    summary: &RuntimeExperimentSnapshotSummary,
+    run_path: &Path,
+    stage: &str,
+) -> CliResult<String> {
+    let artifact_path = summary.artifact_path.as_deref().ok_or_else(|| {
+        format!(
+            "runtime experiment run {} is missing recorded {} snapshot path",
+            run_path.display(),
+            stage
+        )
+    })?;
+
+    canonicalize_snapshot_artifact_path(artifact_path).map_err(|error| {
+        format!(
+            "runtime experiment run {} recorded {} snapshot path {} cannot be resolved: {error}",
+            run_path.display(),
+            stage,
+            artifact_path
+        )
+    })
 }
 
 fn resolve_runtime_experiment_restore_snapshot_path(

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -515,6 +515,7 @@ fn runtime_experiment_cli_parses_compare() {
                     options.result_snapshot.as_deref(),
                     Some("/tmp/runtime-snapshot-result.json")
                 );
+                assert!(!options.recorded_snapshots);
                 assert!(options.json);
             }
             other @ (loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Start(_)
@@ -526,6 +527,60 @@ fn runtime_experiment_cli_parses_compare() {
         },
         other => panic!("unexpected command parsed: {other:?}"),
     }
+}
+
+#[test]
+fn runtime_experiment_cli_parses_compare_with_recorded_snapshots() {
+    let compare = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-experiment",
+        "compare",
+        "--run",
+        "/tmp/runtime-experiment.json",
+        "--recorded-snapshots",
+        "--json",
+    ])
+    .expect("`runtime-experiment compare --recorded-snapshots` should parse");
+
+    match compare.command {
+        Some(Commands::RuntimeExperiment { command }) => match command {
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Compare(
+                options,
+            ) => {
+                assert_eq!(options.run, "/tmp/runtime-experiment.json");
+                assert_eq!(options.baseline_snapshot, None);
+                assert_eq!(options.result_snapshot, None);
+                assert!(options.recorded_snapshots);
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Start(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Finish(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Show(_)
+            | loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCommands::Restore(_)) => {
+                panic!("unexpected runtime-experiment subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn runtime_experiment_cli_rejects_compare_recorded_snapshots_with_manual_paths() {
+    let error = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-experiment",
+        "compare",
+        "--run",
+        "/tmp/runtime-experiment.json",
+        "--recorded-snapshots",
+        "--baseline-snapshot",
+        "/tmp/runtime-snapshot.json",
+        "--result-snapshot",
+        "/tmp/runtime-snapshot-result.json",
+    ])
+    .expect_err("manual snapshot paths should conflict with --recorded-snapshots");
+
+    assert!(error.to_string().contains("--recorded-snapshots"));
 }
 
 #[test]

--- a/crates/daemon/tests/integration/runtime_experiment_cli.rs
+++ b/crates/daemon/tests/integration/runtime_experiment_cli.rs
@@ -791,6 +791,7 @@ fn runtime_experiment_compare_record_only_surfaces_decision_summary() {
                 run: run_path.display().to_string(),
                 baseline_snapshot: None,
                 result_snapshot: None,
+                recorded_snapshots: false,
                 json: true,
             },
         )
@@ -834,6 +835,7 @@ fn runtime_experiment_compare_with_snapshot_delta_reports_changed_runtime_surfac
                 run: run_path.display().to_string(),
                 baseline_snapshot: Some(baseline_snapshot_path.display().to_string()),
                 result_snapshot: Some(result_snapshot_path.display().to_string()),
+                recorded_snapshots: false,
                 json: true,
             },
         )
@@ -882,6 +884,53 @@ fn runtime_experiment_compare_with_snapshot_delta_reports_changed_runtime_surfac
 }
 
 #[test]
+fn runtime_experiment_compare_with_recorded_snapshots_reports_changed_runtime_surfaces() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-compare-recorded-snapshots");
+    let config_path = write_runtime_experiment_config(&root);
+    let (run_path, _baseline_snapshot_path, _result_snapshot_path, _) =
+        finish_runtime_experiment_with_compare_delta(&root, &config_path);
+
+    let report =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_compare_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCompareCommandOptions {
+                run: run_path.display().to_string(),
+                baseline_snapshot: None,
+                result_snapshot: None,
+                recorded_snapshots: true,
+                json: true,
+            },
+        )
+        .expect("recorded snapshot compare should succeed");
+
+    assert_eq!(
+        report.compare_mode,
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCompareMode::SnapshotDelta
+    );
+    let snapshot_delta = report
+        .snapshot_delta
+        .as_ref()
+        .expect("compare should include snapshot delta");
+    assert_eq!(
+        snapshot_delta.provider_active_profile.before.as_deref(),
+        Some("deepseek-lab")
+    );
+    assert_eq!(
+        snapshot_delta.provider_active_profile.after.as_deref(),
+        Some("openai-main")
+    );
+    assert!(
+        snapshot_delta.changed_surface_count >= 4,
+        "recorded snapshot compare should report runtime surface deltas"
+    );
+
+    let rendered =
+        loongclaw_daemon::runtime_experiment_cli::render_runtime_experiment_compare_text(&report);
+    assert!(rendered.contains("compare_mode=snapshot_delta"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn runtime_experiment_compare_requires_both_snapshot_paths_for_deep_compare() {
     let root = unique_temp_dir("loongclaw-runtime-experiment-compare-partial");
     let config_path = write_runtime_experiment_config(&root);
@@ -894,6 +943,7 @@ fn runtime_experiment_compare_requires_both_snapshot_paths_for_deep_compare() {
                 run: run_path.display().to_string(),
                 baseline_snapshot: Some(baseline_snapshot_path.display().to_string()),
                 result_snapshot: None,
+                recorded_snapshots: false,
                 json: false,
             },
         )
@@ -928,6 +978,7 @@ fn runtime_experiment_compare_rejects_snapshot_identity_mismatch() {
                 run: run_path.display().to_string(),
                 baseline_snapshot: Some(baseline_snapshot_path.display().to_string()),
                 result_snapshot: Some(other_result_snapshot_path.display().to_string()),
+                recorded_snapshots: false,
                 json: false,
             },
         )
@@ -952,6 +1003,7 @@ fn runtime_experiment_compare_treats_missing_snapshot_sections_as_absent() {
                 run: run_path.display().to_string(),
                 baseline_snapshot: Some(baseline_snapshot_path.display().to_string()),
                 result_snapshot: Some(result_snapshot_path.display().to_string()),
+                recorded_snapshots: false,
                 json: true,
             },
         )
@@ -968,6 +1020,95 @@ fn runtime_experiment_compare_treats_missing_snapshot_sections_as_absent() {
         snapshot_delta.changed_surface_count >= 3,
         "missing sections should still register as changed surfaces"
     );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_compare_recorded_snapshots_rejects_missing_recorded_result_path() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-compare-recorded-missing-path");
+    let config_path = write_runtime_experiment_config(&root);
+    let (run_path, _, _, _) = finish_runtime_experiment_with_compare_delta(&root, &config_path);
+    rewrite_json_file(&run_path, |payload| {
+        payload["result_snapshot"]
+            .as_object_mut()
+            .expect("result_snapshot should be an object")
+            .remove("artifact_path");
+    });
+
+    let error =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_compare_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCompareCommandOptions {
+                run: run_path.display().to_string(),
+                baseline_snapshot: None,
+                result_snapshot: None,
+                recorded_snapshots: true,
+                json: false,
+            },
+        )
+        .expect_err("recorded snapshot compare should reject missing recorded result path");
+
+    assert!(error.contains("missing recorded result snapshot path"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_compare_recorded_snapshots_rejects_unresolvable_result_path() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-compare-recorded-unresolvable-path");
+    let config_path = write_runtime_experiment_config(&root);
+    let (run_path, _, result_snapshot_path, _) =
+        finish_runtime_experiment_with_compare_delta(&root, &config_path);
+    fs::remove_file(&result_snapshot_path).expect("result snapshot fixture should be removable");
+
+    let error =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_compare_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCompareCommandOptions {
+                run: run_path.display().to_string(),
+                baseline_snapshot: None,
+                result_snapshot: None,
+                recorded_snapshots: true,
+                json: false,
+            },
+        )
+        .expect_err("recorded snapshot compare should reject an unresolvable result path");
+
+    assert!(error.contains("recorded result snapshot path"));
+    assert!(error.contains("cannot be resolved"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_experiment_compare_recorded_snapshots_rejects_unavailable_result_stage() {
+    let root = unique_temp_dir("loongclaw-runtime-experiment-compare-recorded-no-result");
+    let config_path = write_runtime_experiment_config(&root);
+    let (baseline_snapshot_path, _) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-16T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(&root, &baseline_snapshot_path, None);
+
+    let error =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_compare_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentCompareCommandOptions {
+                run: run_path.display().to_string(),
+                baseline_snapshot: None,
+                result_snapshot: None,
+                recorded_snapshots: true,
+                json: false,
+            },
+        )
+        .expect_err("planned run should not deep-compare recorded snapshots");
+
+    assert!(error.contains("has no result snapshot"));
 
     fs::remove_dir_all(&root).ok();
 }


### PR DESCRIPTION
## Summary

- add an explicit `--recorded-snapshots` mode to `runtime-experiment compare` so operators can reuse the canonical baseline/result artifact paths already stored in the run record
- preserve the existing `compare --run <path>` record-only default and reject mixed manual/recorded snapshot input modes
- add regression coverage for CLI parsing, recorded-path compare success, missing recorded paths, unresolved recorded paths, and planned runs without a result snapshot

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

If Track B, include design/risk notes:

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional local validation:
- `cargo test -p loongclaw-daemon runtime_experiment`
- `cargo fmt --all -- --check`
- `cargo clippy -p loongclaw-daemon --all-targets -- -D warnings`

## Linked Issues

Closes #245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--recorded-snapshots` CLI flag for the runtime-experiment compare command to load snapshots from recorded artifacts automatically.
  * Added validation to prevent the flag from being used together with manual snapshot path arguments.

* **Tests**
  * Added comprehensive test coverage for recorded snapshots functionality, including conflict detection and artifact validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->