### PR TITLE
Surface region endpoint guidance for region-sensitive providers

### DIFF
--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -916,6 +916,116 @@ kind = "volcengine_coding"
     }
 
     #[test]
+    fn minimax_region_endpoint_note_points_to_global_alternative() {
+        let config = ProviderConfig {
+            kind: ProviderKind::Minimax,
+            ..ProviderConfig::default()
+        };
+
+        let note = config
+            .region_endpoint_note()
+            .expect("minimax should surface region endpoint guidance");
+        assert!(note.contains("CN default"));
+        assert!(note.contains("https://api.minimaxi.com"));
+        assert!(note.contains("https://api.minimax.io"));
+    }
+
+    #[test]
+    fn kimi_region_endpoint_note_respects_explicit_global_override() {
+        let config = ProviderConfig {
+            kind: ProviderKind::Kimi,
+            base_url: "https://api.moonshot.ai".to_owned(),
+            ..ProviderConfig::default()
+        };
+
+        let note = config
+            .region_endpoint_note()
+            .expect("kimi should surface region endpoint guidance");
+        assert!(note.contains("using Global"));
+        assert!(note.contains("https://api.moonshot.ai"));
+        assert!(note.contains("https://api.moonshot.cn"));
+    }
+
+    #[test]
+    fn zhipu_region_endpoint_failure_hint_points_to_global_zai_endpoint() {
+        let config = ProviderConfig {
+            kind: ProviderKind::Zhipu,
+            ..ProviderConfig::default()
+        };
+
+        let hint = config
+            .region_endpoint_failure_hint()
+            .expect("zhipu should surface a region retry hint");
+        assert!(hint.contains("provider.base_url"));
+        assert!(hint.contains("https://open.bigmodel.cn"));
+        assert!(hint.contains("https://api.z.ai"));
+    }
+
+    #[test]
+    fn minimax_region_endpoint_hint_respects_explicit_endpoint_override() {
+        let mut config = ProviderConfig {
+            kind: ProviderKind::Minimax,
+            ..ProviderConfig::default()
+        };
+        config.set_endpoint(Some(
+            "https://api.minimax.io/v1/chat/completions".to_owned(),
+        ));
+
+        let note = config
+            .region_endpoint_note()
+            .expect("minimax should surface explicit endpoint override guidance");
+        assert!(note.contains("provider.endpoint"));
+        assert!(note.contains("https://api.minimax.io/v1/chat/completions"));
+
+        let hint = config
+            .region_endpoint_failure_hint()
+            .expect("minimax should surface explicit endpoint override failure guidance");
+        assert!(hint.contains("provider.endpoint"));
+        assert!(hint.contains("Changing `provider.base_url` alone will not affect"));
+    }
+
+    #[test]
+    fn zai_region_endpoint_hint_respects_explicit_models_endpoint_override() {
+        let mut config = ProviderConfig {
+            kind: ProviderKind::Zai,
+            ..ProviderConfig::default()
+        };
+        config.set_models_endpoint(Some("https://open.bigmodel.cn/v1/models".to_owned()));
+
+        let note = config
+            .region_endpoint_note()
+            .expect("zai should surface explicit models endpoint override guidance");
+        assert!(note.contains("provider.models_endpoint"));
+        assert!(note.contains("https://open.bigmodel.cn/v1/models"));
+
+        let hint = config
+            .region_endpoint_failure_hint()
+            .expect("zai should surface explicit models endpoint override failure guidance");
+        assert!(hint.contains("provider.models_endpoint"));
+        assert!(hint.contains("Changing `provider.base_url` alone will not affect"));
+    }
+
+    #[test]
+    fn minimax_region_endpoint_note_for_custom_explicit_endpoint_labels_official_hosts_correctly() {
+        let mut config = ProviderConfig {
+            kind: ProviderKind::Minimax,
+            ..ProviderConfig::default()
+        };
+        config.set_endpoint(Some(
+            "https://proxy.example.test/v1/chat/completions".to_owned(),
+        ));
+
+        let note = config
+            .region_endpoint_note()
+            .expect("minimax should surface explicit endpoint override guidance");
+
+        assert!(note.contains("provider.endpoint"));
+        assert!(note.contains("https://proxy.example.test/v1/chat/completions"));
+        assert!(note.contains("official CN endpoint `https://api.minimaxi.com`"));
+        assert!(note.contains("official Global endpoint `https://api.minimax.io`"));
+    }
+
+    #[test]
     fn models_endpoint_resolution_for_supported_provider_profiles_includes_new_first_class_providers()
      {
         let cases = vec![

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -122,6 +122,200 @@ pub enum ModelCatalogProbeRecovery {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProviderRegionEndpointVariant {
+    label: &'static str,
+    base_url: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProviderRegionEndpointGuide {
+    family_label: &'static str,
+    default_variant: ProviderRegionEndpointVariant,
+    alternate_variant: ProviderRegionEndpointVariant,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ProviderRegionEndpointSelection {
+    BaseUrl(String),
+    Endpoint(String),
+    ModelsEndpoint(String),
+    EndpointAndModels {
+        endpoint: String,
+        models_endpoint: String,
+    },
+}
+
+impl ProviderRegionEndpointGuide {
+    fn note(self, provider: &ProviderConfig) -> String {
+        match self.selection(provider) {
+            ProviderRegionEndpointSelection::BaseUrl(resolved_base_url) => {
+                self.base_url_note(provider, resolved_base_url.as_str())
+            }
+            ProviderRegionEndpointSelection::Endpoint(endpoint) => {
+                self.override_note("provider.endpoint", endpoint.as_str())
+            }
+            ProviderRegionEndpointSelection::ModelsEndpoint(models_endpoint) => {
+                self.override_note("provider.models_endpoint", models_endpoint.as_str())
+            }
+            ProviderRegionEndpointSelection::EndpointAndModels {
+                endpoint,
+                models_endpoint,
+            } => format!(
+                "{} region endpoint: explicit endpoint overrides are in use (`provider.endpoint` = `{endpoint}`, `provider.models_endpoint` = `{models_endpoint}`); official {} endpoint `{}`; official {} endpoint `{}`",
+                self.family_label,
+                self.default_variant.label,
+                self.default_variant.base_url,
+                self.alternate_variant.label,
+                self.alternate_variant.base_url
+            ),
+        }
+    }
+
+    fn failure_hint(self, provider: &ProviderConfig) -> String {
+        match self.selection(provider) {
+            ProviderRegionEndpointSelection::BaseUrl(_) => self.base_url_failure_hint(),
+            ProviderRegionEndpointSelection::Endpoint(endpoint) => {
+                self.override_failure_hint("provider.endpoint", endpoint.as_str())
+            }
+            ProviderRegionEndpointSelection::ModelsEndpoint(models_endpoint) => {
+                self.override_failure_hint("provider.models_endpoint", models_endpoint.as_str())
+            }
+            ProviderRegionEndpointSelection::EndpointAndModels {
+                endpoint,
+                models_endpoint,
+            } => format!(
+                "{} keys can be region-scoped. Verify the explicit endpoint overrides match your account region: use `{}` for {} accounts or `{}` for {} accounts. Changing `provider.base_url` alone will not affect `provider.endpoint` (`{endpoint}`) or `provider.models_endpoint` (`{models_endpoint}`).",
+                self.family_label,
+                self.default_variant.base_url,
+                self.default_variant.label,
+                self.alternate_variant.base_url,
+                self.alternate_variant.label
+            ),
+        }
+    }
+
+    fn request_failure_hint(self, provider: &ProviderConfig) -> String {
+        if provider.endpoint_explicit {
+            return self.override_failure_hint("provider.endpoint", provider.endpoint().as_str());
+        }
+
+        self.base_url_failure_hint()
+    }
+
+    fn selection(self, provider: &ProviderConfig) -> ProviderRegionEndpointSelection {
+        match (
+            provider.endpoint_explicit,
+            provider.models_endpoint_explicit,
+        ) {
+            (true, true) => ProviderRegionEndpointSelection::EndpointAndModels {
+                endpoint: provider.endpoint(),
+                models_endpoint: provider.models_endpoint(),
+            },
+            (true, false) => ProviderRegionEndpointSelection::Endpoint(provider.endpoint()),
+            (false, true) => {
+                ProviderRegionEndpointSelection::ModelsEndpoint(provider.models_endpoint())
+            }
+            (false, false) => {
+                ProviderRegionEndpointSelection::BaseUrl(provider.resolved_base_url())
+            }
+        }
+    }
+
+    fn base_url_note(self, provider: &ProviderConfig, resolved_base_url: &str) -> String {
+        if is_same_base_url(resolved_base_url, self.alternate_variant.base_url) {
+            return format!(
+                "{} region endpoint: using {} endpoint (`{}`); use `{}` for {} accounts",
+                self.family_label,
+                self.alternate_variant.label,
+                self.alternate_variant.base_url,
+                self.default_variant.base_url,
+                self.default_variant.label
+            );
+        }
+        if is_same_base_url(resolved_base_url, self.default_variant.base_url)
+            || provider.base_url_is_profile_default_like()
+        {
+            return format!(
+                "{} region endpoint: {} default (`{}`); switch `provider.base_url` to `{}` for {} accounts",
+                self.family_label,
+                self.default_variant.label,
+                self.default_variant.base_url,
+                self.alternate_variant.base_url,
+                self.alternate_variant.label
+            );
+        }
+
+        format!(
+            "{} region endpoint: using custom endpoint (`{}`); official {} endpoint `{}`; official {} endpoint `{}`",
+            self.family_label,
+            resolved_base_url,
+            self.default_variant.label,
+            self.default_variant.base_url,
+            self.alternate_variant.label,
+            self.alternate_variant.base_url
+        )
+    }
+
+    fn override_note(self, field_name: &str, endpoint: &str) -> String {
+        if let Some(active_variant) = self.override_variant(endpoint) {
+            let alternate_variant = if active_variant == self.default_variant {
+                self.alternate_variant
+            } else {
+                self.default_variant
+            };
+            return format!(
+                "{} region endpoint: using explicit `{field_name}` {} endpoint (`{endpoint}`); use `{}` for {} accounts",
+                self.family_label,
+                active_variant.label,
+                alternate_variant.base_url,
+                alternate_variant.label
+            );
+        }
+
+        format!(
+            "{} region endpoint: using explicit `{field_name}` (`{endpoint}`); official {} endpoint `{}`; official {} endpoint `{}`",
+            self.family_label,
+            self.default_variant.label,
+            self.default_variant.base_url,
+            self.alternate_variant.label,
+            self.alternate_variant.base_url
+        )
+    }
+
+    fn base_url_failure_hint(self) -> String {
+        format!(
+            "{} keys can be region-scoped. Verify `provider.base_url` matches your account region: use `{}` for {} accounts or `{}` for {} accounts.",
+            self.family_label,
+            self.default_variant.base_url,
+            self.default_variant.label,
+            self.alternate_variant.base_url,
+            self.alternate_variant.label
+        )
+    }
+
+    fn override_failure_hint(self, field_name: &str, endpoint: &str) -> String {
+        format!(
+            "{} keys can be region-scoped. Verify explicit `{field_name}` matches your account region: use `{}` for {} accounts or `{}` for {} accounts. Changing `provider.base_url` alone will not affect `{field_name}` (`{endpoint}`).",
+            self.family_label,
+            self.default_variant.base_url,
+            self.default_variant.label,
+            self.alternate_variant.base_url,
+            self.alternate_variant.label
+        )
+    }
+
+    fn override_variant(self, endpoint: &str) -> Option<ProviderRegionEndpointVariant> {
+        if matches_region_endpoint_url(endpoint, self.default_variant.base_url) {
+            return Some(self.default_variant);
+        }
+        if matches_region_endpoint_url(endpoint, self.alternate_variant.base_url) {
+            return Some(self.alternate_variant);
+        }
+        None
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
@@ -1336,6 +1530,22 @@ impl ProviderConfig {
         None
     }
 
+    pub fn region_endpoint_note(&self) -> Option<String> {
+        Some(self.kind.region_endpoint_guide()?.note(self))
+    }
+
+    pub fn region_endpoint_failure_hint(&self) -> Option<String> {
+        Some(self.kind.region_endpoint_guide()?.failure_hint(self))
+    }
+
+    pub fn request_region_endpoint_failure_hint(&self) -> Option<String> {
+        Some(
+            self.kind
+                .region_endpoint_guide()?
+                .request_failure_hint(self),
+        )
+    }
+
     fn uses_byteplus_coding_plan_path(&self) -> bool {
         if self.kind != ProviderKind::Byteplus {
             return false;
@@ -1934,6 +2144,91 @@ impl ProviderKind {
             )
         } else {
             None
+        }
+    }
+
+    fn region_endpoint_guide(self) -> Option<ProviderRegionEndpointGuide> {
+        let profile = self.profile();
+        match self {
+            ProviderKind::Kimi => Some(ProviderRegionEndpointGuide {
+                family_label: "Moonshot Kimi",
+                default_variant: ProviderRegionEndpointVariant {
+                    label: "CN",
+                    base_url: profile.base_url,
+                },
+                alternate_variant: ProviderRegionEndpointVariant {
+                    label: "Global",
+                    base_url: "https://api.moonshot.ai",
+                },
+            }),
+            ProviderKind::Minimax => Some(ProviderRegionEndpointGuide {
+                family_label: "MiniMax",
+                default_variant: ProviderRegionEndpointVariant {
+                    label: "CN",
+                    base_url: profile.base_url,
+                },
+                alternate_variant: ProviderRegionEndpointVariant {
+                    label: "Global",
+                    base_url: "https://api.minimax.io",
+                },
+            }),
+            ProviderKind::Zai => Some(ProviderRegionEndpointGuide {
+                family_label: "Z.ai / BigModel",
+                default_variant: ProviderRegionEndpointVariant {
+                    label: "Global",
+                    base_url: profile.base_url,
+                },
+                alternate_variant: ProviderRegionEndpointVariant {
+                    label: "CN",
+                    base_url: "https://open.bigmodel.cn",
+                },
+            }),
+            ProviderKind::Zhipu => Some(ProviderRegionEndpointGuide {
+                family_label: "Z.ai / BigModel",
+                default_variant: ProviderRegionEndpointVariant {
+                    label: "CN",
+                    base_url: profile.base_url,
+                },
+                alternate_variant: ProviderRegionEndpointVariant {
+                    label: "Global",
+                    base_url: "https://api.z.ai",
+                },
+            }),
+            ProviderKind::Anthropic
+            | ProviderKind::Bedrock
+            | ProviderKind::Byteplus
+            | ProviderKind::ByteplusCoding
+            | ProviderKind::Cerebras
+            | ProviderKind::CloudflareAiGateway
+            | ProviderKind::Cohere
+            | ProviderKind::Custom
+            | ProviderKind::Deepseek
+            | ProviderKind::Fireworks
+            | ProviderKind::Gemini
+            | ProviderKind::Groq
+            | ProviderKind::KimiCoding
+            | ProviderKind::Llamacpp
+            | ProviderKind::LmStudio
+            | ProviderKind::Mistral
+            | ProviderKind::Novita
+            | ProviderKind::Nvidia
+            | ProviderKind::Ollama
+            | ProviderKind::Openai
+            | ProviderKind::Openrouter
+            | ProviderKind::Perplexity
+            | ProviderKind::Qianfan
+            | ProviderKind::Qwen
+            | ProviderKind::Sambanova
+            | ProviderKind::Sglang
+            | ProviderKind::Siliconflow
+            | ProviderKind::Stepfun
+            | ProviderKind::Together
+            | ProviderKind::Venice
+            | ProviderKind::VercelAiGateway
+            | ProviderKind::Vllm
+            | ProviderKind::Volcengine
+            | ProviderKind::VolcengineCoding
+            | ProviderKind::Xai => None,
         }
     }
 
@@ -2956,6 +3251,15 @@ fn normalize_api_path(path: &str) -> String {
 
 fn is_same_base_url(left: &str, right: &str) -> bool {
     left.trim().trim_end_matches('/') == right.trim().trim_end_matches('/')
+}
+
+fn matches_region_endpoint_url(endpoint: &str, base_url: &str) -> bool {
+    let endpoint = endpoint.trim().trim_end_matches('/');
+    let base_url = base_url.trim().trim_end_matches('/');
+    endpoint == base_url
+        || endpoint
+            .strip_prefix(base_url)
+            .is_some_and(|suffix| suffix.starts_with('/'))
 }
 
 fn is_same_chat_path(left: &str, right: &str) -> bool {

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -48,6 +48,13 @@ pub use shape::{
     extract_provider_turn_with_scope_and_messages,
 };
 
+pub fn is_auth_style_failure_message(message: &str) -> bool {
+    matches!(
+        profile_health_policy::classify_profile_failure_reason_from_message(message),
+        ProviderFailoverReason::AuthRejected
+    )
+}
+
 #[cfg(test)]
 use auth_profile_runtime::{ProviderAuthProfile, resolve_provider_auth_profiles};
 use catalog_query_runtime::fetch_available_models_with_profiles;

--- a/crates/app/src/provider/request_executor.rs
+++ b/crates/app/src/provider/request_executor.rs
@@ -84,6 +84,27 @@ fn plan_model_status_outcome(
     }
 }
 
+fn render_status_failure_message(
+    provider: &ProviderConfig,
+    reason: ProviderFailoverReason,
+    status_code: u16,
+    model: &str,
+    attempt: usize,
+    max_attempts: usize,
+    response_body: &Value,
+) -> String {
+    let mut message = format!(
+        "provider returned status {status_code} for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}"
+    );
+    if matches!(reason, ProviderFailoverReason::AuthRejected)
+        && let Some(hint) = provider.request_region_endpoint_failure_hint()
+    {
+        message.push(' ');
+        message.push_str(hint.as_str());
+    }
+    message
+}
+
 pub(super) async fn execute_model_request<T, BuildBody, ParseSuccess, PreStatusError>(
     runtime: ModelRequestRuntime<'_>,
     mut build_body: BuildBody,
@@ -311,10 +332,14 @@ where
                     }
                     ModelStatusOutcome::Fail { reason } => {
                         return Err(build_model_request_error(
-                            format!(
-                                "provider returned status {status_code} for model `{}` on attempt {attempt}/{max_attempts}: {response_body}",
+                            render_status_failure_message(
+                                runtime.provider,
+                                reason,
+                                status_code,
                                 runtime.model,
-                                max_attempts = runtime.request_policy.max_attempts
+                                attempt,
+                                runtime.request_policy.max_attempts,
+                                &response_body,
                             ),
                             false,
                             reason,
@@ -377,6 +402,7 @@ where
 mod tests {
     use super::*;
     use crate::provider::contracts::provider_runtime_contract;
+    use serde_json::json;
 
     struct ModelStatusCase {
         status_code: u16,
@@ -471,5 +497,59 @@ mod tests {
                 case.status_code, case.attempt, case.auto_model_mode, case.api_error
             );
         }
+    }
+
+    #[test]
+    fn render_status_failure_message_includes_region_hint_for_auth_rejection() {
+        let provider = ProviderConfig {
+            kind: crate::config::ProviderKind::Minimax,
+            ..ProviderConfig::default()
+        };
+
+        let message = render_status_failure_message(
+            &provider,
+            ProviderFailoverReason::AuthRejected,
+            401,
+            "MiniMax-M2.5",
+            1,
+            3,
+            &json!({
+                "error": {
+                    "message": "invalid api key"
+                }
+            }),
+        );
+
+        assert!(message.contains("provider.base_url"));
+        assert!(message.contains("https://api.minimax.io"));
+        assert!(message.contains("https://api.minimaxi.com"));
+    }
+
+    #[test]
+    fn render_status_failure_message_ignores_models_endpoint_override_for_request_auth_hint() {
+        let mut provider = ProviderConfig {
+            kind: crate::config::ProviderKind::Zai,
+            ..ProviderConfig::default()
+        };
+        provider.set_models_endpoint(Some("https://open.bigmodel.cn/v1/models".to_owned()));
+
+        let message = render_status_failure_message(
+            &provider,
+            ProviderFailoverReason::AuthRejected,
+            401,
+            "glm-4.5",
+            1,
+            3,
+            &json!({
+                "error": {
+                    "message": "invalid api key"
+                }
+            }),
+        );
+
+        assert!(message.contains("provider.base_url"));
+        assert!(!message.contains("provider.models_endpoint"));
+        assert!(message.contains("https://api.z.ai"));
+        assert!(message.contains("https://open.bigmodel.cn"));
     }
 }

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -991,33 +991,41 @@ fn provider_model_probe_failure_check(
     error: String,
 ) -> DoctorCheck {
     let provider_prefix = crate::provider_presentation::active_provider_detail_label(config);
+    let auth_style_failure = mvp::provider::is_auth_style_failure_message(error.as_str());
+    let append_region_hint = |mut detail: String| {
+        if auth_style_failure && let Some(hint) = config.provider.region_endpoint_failure_hint() {
+            detail.push(' ');
+            detail.push_str(hint.as_str());
+        }
+        detail
+    };
     let (level, detail) = match config.provider.model_catalog_probe_recovery() {
         mvp::config::ModelCatalogProbeRecovery::ExplicitModel(model) => (
             DoctorCheckLevel::Warn,
-            format!(
+            append_region_hint(format!(
                 "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); chat may still work because model `{model}` is explicitly configured"
-            ),
+            )),
         ),
         mvp::config::ModelCatalogProbeRecovery::ConfiguredPreferredModels(fallback_models) => (
             DoctorCheckLevel::Warn,
-            format!(
+            append_region_hint(format!(
                 "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); runtime will try configured preferred model fallback(s): {}",
                 fallback_models
                     .iter()
                     .map(|model| format!("`{model}`"))
                     .collect::<Vec<_>>()
                     .join(", ")
-            ),
+            )),
         ),
         mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
             recommended_onboarding_model,
         } => (
             DoctorCheckLevel::Fail,
-            provider_model_probe_requires_explicit_model_detail(
+            append_region_hint(provider_model_probe_requires_explicit_model_detail(
                 provider_prefix.as_str(),
                 error.as_str(),
                 recommended_onboarding_model,
-            ),
+            )),
         ),
     };
 
@@ -1042,6 +1050,7 @@ fn provider_model_probe_requires_explicit_model_detail(
         ),
     }
 }
+
 #[allow(dead_code)]
 fn collect_channel_doctor_checks(config: &mvp::config::LoongClawConfig) -> Vec<DoctorCheck> {
     crate::migration::channels::collect_channel_doctor_checks(config)
@@ -1219,6 +1228,12 @@ fn build_doctor_next_steps_with_path_env(
             && check.level != DoctorCheckLevel::Pass
             && check.detail.contains(MODEL_CATALOG_PROBE_FAILED_MARKER)
     }) {
+        let provider_model_probe_auth_failure = checks.iter().any(|check| {
+            check.name == "provider model probe"
+                && check.level != DoctorCheckLevel::Pass
+                && check.detail.contains(MODEL_CATALOG_PROBE_FAILED_MARKER)
+                && mvp::provider::is_auth_style_failure_message(check.detail.as_str())
+        });
         match config.provider.model_catalog_probe_recovery() {
             mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
                 recommended_onboarding_model: Some(model),
@@ -1261,6 +1276,11 @@ fn build_doctor_next_steps_with_path_env(
                     ),
                 );
             }
+        }
+        if provider_model_probe_auth_failure
+            && let Some(hint) = config.provider.region_endpoint_failure_hint()
+        {
+            push_unique_step(&mut steps, hint);
         }
     }
 
@@ -1801,6 +1821,112 @@ mod tests {
         assert!(
             check.detail.contains("rerun onboarding"),
             "doctor should suggest rerunning onboarding to accept the reviewed model instead of leaving recovery implicit: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_includes_region_hint_for_zhipu() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Zhipu;
+        config.provider.model = "auto".to_owned();
+
+        let check =
+            provider_model_probe_failure_check(&config, "provider returned status 401".to_owned());
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, DoctorCheckLevel::Fail);
+        assert!(
+            check.detail.contains("https://api.z.ai"),
+            "doctor probe failures should surface the alternate regional endpoint when auth can be region-bound: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_skips_region_hint_for_non_auth_errors() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Zhipu;
+        config.provider.model = "auto".to_owned();
+
+        let check =
+            provider_model_probe_failure_check(&config, "provider returned status 503".to_owned());
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, DoctorCheckLevel::Fail);
+        assert!(
+            !check.detail.contains("provider.base_url"),
+            "non-auth doctor probe failures should not steer operators toward region endpoint changes: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_includes_region_endpoint_step_for_minimax_probe_failures() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        let checks = vec![
+            DoctorCheck {
+                name: "provider credentials".to_owned(),
+                level: DoctorCheckLevel::Pass,
+                detail: "provider credentials are available".to_owned(),
+            },
+            DoctorCheck {
+                name: "provider model probe".to_owned(),
+                level: DoctorCheckLevel::Fail,
+                detail:
+                    "MiniMax [minimax]: model catalog probe failed (provider returned status 401)"
+                        .to_owned(),
+            },
+        ];
+
+        let next_steps = build_doctor_next_steps_with_path_env(
+            &checks,
+            Path::new("/tmp/loongclaw.toml"),
+            &config,
+            false,
+            Some(std::ffi::OsStr::new("")),
+        );
+
+        assert!(
+            next_steps.iter().any(|step| {
+                step.contains("provider.base_url")
+                    && step.contains("https://api.minimax.io")
+                    && step.contains("https://api.minimaxi.com")
+            }),
+            "doctor next steps should include a concrete region endpoint adjustment for MiniMax auth/probe failures: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_skips_region_endpoint_step_for_non_auth_probe_failures() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        let checks = vec![
+            DoctorCheck {
+                name: "provider credentials".to_owned(),
+                level: DoctorCheckLevel::Pass,
+                detail: "provider credentials are available".to_owned(),
+            },
+            DoctorCheck {
+                name: "provider model probe".to_owned(),
+                level: DoctorCheckLevel::Fail,
+                detail:
+                    "MiniMax [minimax]: model catalog probe failed (provider returned status 503)"
+                        .to_owned(),
+            },
+        ];
+
+        let next_steps = build_doctor_next_steps_with_path_env(
+            &checks,
+            Path::new("/tmp/loongclaw.toml"),
+            &config,
+            false,
+            Some(std::ffi::OsStr::new("")),
+        );
+
+        assert!(
+            !next_steps
+                .iter()
+                .any(|step| step.contains("provider.base_url")),
+            "doctor next steps should not include a region endpoint adjustment for non-auth probe failures: {next_steps:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -461,6 +461,7 @@ pub struct OnboardingSuccessSummary {
     pub saved_provider_profiles: Vec<String>,
     pub model: String,
     pub transport: String,
+    pub provider_endpoint: Option<String>,
     pub credential: Option<OnboardingCredentialSummary>,
     pub prompt_mode: String,
     pub personality: Option<String>,
@@ -1411,34 +1412,42 @@ fn provider_model_probe_failure_check(
     error: String,
 ) -> OnboardCheck {
     let provider_prefix = provider_check_detail_prefix(config);
+    let auth_style_failure = mvp::provider::is_auth_style_failure_message(error.as_str());
+    let append_region_hint = |mut detail: String| {
+        if auth_style_failure && let Some(hint) = config.provider.region_endpoint_failure_hint() {
+            detail.push(' ');
+            detail.push_str(hint.as_str());
+        }
+        detail
+    };
     let (level, detail, non_interactive_warning_policy) = match config
         .provider
         .model_catalog_probe_recovery()
     {
         mvp::config::ModelCatalogProbeRecovery::ExplicitModel(model) => (
             OnboardCheckLevel::Warn,
-            format!(
+            append_region_hint(format!(
                 "{provider_prefix}: model catalog probe failed ({error}); chat may still work because model `{model}` is explicitly configured"
-            ),
+            )),
             OnboardNonInteractiveWarningPolicy::AcceptedByExplicitModel,
         ),
         mvp::config::ModelCatalogProbeRecovery::ConfiguredPreferredModels(fallback_models) => (
             OnboardCheckLevel::Warn,
-            format!(
+            append_region_hint(format!(
                 "{provider_prefix}: model catalog probe failed ({error}); runtime will try configured preferred model fallback(s): {}",
                 render_onboard_model_candidate_list(&fallback_models)
-            ),
+            )),
             OnboardNonInteractiveWarningPolicy::AcceptedByPreferredModels,
         ),
         mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
             recommended_onboarding_model,
         } => (
             OnboardCheckLevel::Fail,
-            provider_model_probe_requires_explicit_model_detail(
+            append_region_hint(provider_model_probe_requires_explicit_model_detail(
                 provider_prefix.as_str(),
                 error.as_str(),
                 recommended_onboarding_model,
-            ),
+            )),
             if recommended_onboarding_model.is_some() {
                 OnboardNonInteractiveWarningPolicy::RequiresExplicitModel
             } else {
@@ -2938,6 +2947,7 @@ fn build_onboarding_success_summary_with_memory(
         saved_provider_profiles: crate::provider_presentation::saved_provider_profile_ids(config),
         model: config.provider.model.clone(),
         transport: config.provider.transport_readiness().summary,
+        provider_endpoint: config.provider.region_endpoint_note(),
         credential: summarize_provider_credential(&config.provider),
         prompt_mode: summarize_prompt_mode(config),
         personality: config
@@ -3090,6 +3100,13 @@ fn render_onboarding_success_summary_with_width_and_style(
         &summary.transport,
         width,
     ));
+    if let Some(provider_endpoint) = summary.provider_endpoint.as_deref() {
+        lines.extend(mvp::presentation::render_wrapped_text_line(
+            "- provider endpoint: ",
+            provider_endpoint,
+            width,
+        ));
+    }
     if let Some(credential) = summary.credential.as_ref() {
         lines.extend(mvp::presentation::render_wrapped_text_line(
             &format!("- {}: ", credential.label),
@@ -4607,6 +4624,13 @@ fn render_onboard_review_digest_lines(
         &config.provider.transport_readiness().summary,
         width,
     ));
+    if let Some(provider_endpoint) = config.provider.region_endpoint_note() {
+        lines.extend(mvp::presentation::render_wrapped_text_line(
+            "- provider endpoint: ",
+            &provider_endpoint,
+            width,
+        ));
+    }
 
     if let Some(credential_line) = render_onboard_review_credential_line(&config.provider) {
         lines.push(credential_line);
@@ -5616,6 +5640,44 @@ mod tests {
         assert!(
             check.detail.contains("rerun onboarding"),
             "reviewed providers should suggest rerunning onboarding to accept the reviewed model instead of leaving recovery implicit: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_includes_region_hint_for_minimax() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        config.provider.model = "auto".to_owned();
+
+        let check =
+            provider_model_probe_failure_check(&config, "provider returned status 401".to_owned());
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, OnboardCheckLevel::Fail);
+        assert!(
+            check.detail.contains("https://api.minimax.io"),
+            "onboard probe failures for region-sensitive providers should surface the alternate endpoint: {check:#?}"
+        );
+        assert!(
+            check.detail.contains("provider.base_url"),
+            "onboard probe failures should explain the concrete config knob to change: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_skips_region_hint_for_non_auth_errors() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        config.provider.model = "auto".to_owned();
+
+        let check =
+            provider_model_probe_failure_check(&config, "provider returned status 503".to_owned());
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, OnboardCheckLevel::Fail);
+        assert!(
+            !check.detail.contains("provider.base_url"),
+            "non-auth probe failures should not steer operators toward region endpoint changes: {check:#?}"
         );
     }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -6031,6 +6031,7 @@ fn onboarding_success_summary_reports_existing_config_kept() {
         saved_provider_profiles: Vec::new(),
         model: "auto".to_owned(),
         transport: "chat_completions compatibility mode".to_owned(),
+        provider_endpoint: None,
         credential: Some(loongclaw_daemon::onboard_cli::OnboardingCredentialSummary {
             label: "credential source",
             value: "${OPENAI_API_KEY}".to_owned(),
@@ -6108,6 +6109,7 @@ fn onboarding_success_summary_groups_domain_outcomes_by_decision() {
         saved_provider_profiles: Vec::new(),
         model: "openai/gpt-5.1-codex".to_owned(),
         transport: "chat_completions compatibility mode".to_owned(),
+        provider_endpoint: None,
         credential: Some(loongclaw_daemon::onboard_cli::OnboardingCredentialSummary {
             label: "credential source",
             value: "${OPENAI_API_KEY}".to_owned(),
@@ -6172,6 +6174,7 @@ fn onboarding_success_summary_wraps_domain_outcomes_for_narrow_width() {
         saved_provider_profiles: Vec::new(),
         model: "openai/gpt-5.1-codex".to_owned(),
         transport: "chat_completions compatibility mode".to_owned(),
+        provider_endpoint: None,
         credential: Some(loongclaw_daemon::onboard_cli::OnboardingCredentialSummary {
             label: "credential source",
             value: "${OPENAI_API_KEY}".to_owned(),
@@ -6342,6 +6345,25 @@ fn onboard_review_lines_surface_transport_summary_for_responses_compatibility_mo
 }
 
 #[test]
+fn onboard_review_lines_surface_region_endpoint_note_for_minimax() {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.kind = mvp::config::ProviderKind::Minimax;
+
+    let lines = loongclaw_daemon::onboard_cli::render_onboard_review_lines_with_guidance(
+        &config,
+        None,
+        &[],
+        80,
+    );
+
+    assert!(
+        lines.iter().any(|line| line.contains("api.minimaxi.com"))
+            && lines.iter().any(|line| line.contains("api.minimax.io")),
+        "review screen should show the current and alternate MiniMax regional endpoints: {lines:#?}"
+    );
+}
+
+#[test]
 fn onboarding_success_summary_surfaces_transport_summary() {
     let mut config = mvp::config::LoongClawConfig::default();
     config.provider.kind = mvp::config::ProviderKind::Deepseek;
@@ -6359,6 +6381,24 @@ fn onboarding_success_summary_surfaces_transport_summary() {
             .iter()
             .any(|line| { line == "- transport: responses compatibility mode with chat fallback" }),
         "success summary should preserve the transport mode so imported Responses configs stay explainable: {lines:#?}"
+    );
+}
+
+#[test]
+fn onboarding_success_summary_surfaces_region_endpoint_note_for_zhipu() {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.kind = mvp::config::ProviderKind::Zhipu;
+
+    let path = PathBuf::from("/tmp/loongclaw-config.toml");
+    let summary =
+        loongclaw_daemon::onboard_cli::build_onboarding_success_summary(&path, &config, None);
+    let lines =
+        loongclaw_daemon::onboard_cli::render_onboarding_success_summary_with_width(&summary, 80);
+
+    let rendered = lines.join("\n");
+    assert!(
+        rendered.contains("open.bigmodel.cn") && rendered.contains("api.z.ai"),
+        "success summary should preserve region endpoint guidance for region-sensitive providers: {lines:#?}"
     );
 }
 

--- a/docs/plans/2026-03-17-provider-region-guidance-design.md
+++ b/docs/plans/2026-03-17-provider-region-guidance-design.md
@@ -1,0 +1,76 @@
+## Context
+
+`alpha-test` already has a strong provider abstraction:
+
+- provider profiles define defaults, auth env bindings, and transport family
+- onboard preflight surfaces credential, transport, and model-probe checks
+- doctor reuses the same transport and probe semantics for repair guidance
+
+The current gap is narrower: several providers have official region-specific
+entrypoints, but the active defaults collapse that choice into one host. When a
+valid key is used against the wrong regional host, operators often see `401`,
+`403`, or model-catalog probe failures that look like bad credentials even
+though the real issue is endpoint-region mismatch.
+
+## Root cause
+
+LoongClaw currently treats these region-sensitive providers as a single static
+base URL:
+
+- `minimax` defaults to `https://api.minimaxi.com`
+- `kimi` defaults to `https://api.moonshot.cn`
+- `zai` defaults to `https://api.z.ai`
+- `zhipu` defaults to `https://open.bigmodel.cn`
+
+Those defaults are internally coherent, but they hide the operator decision:
+"does this key belong to the global endpoint or the mainland China endpoint?"
+
+## Non-goals
+
+- do not split one provider into many new provider kinds
+- do not change request routing or failover semantics broadly
+- do not auto-probe alternate regions during runtime
+- do not warn on every healthy config just because a provider has multiple
+  official regions
+
+## Chosen approach
+
+Add lightweight region-endpoint guidance helpers in `ProviderConfig`, then reuse
+them in the existing operator surfaces:
+
+1. review and onboarding success summaries:
+   - show the current region endpoint choice clearly
+2. onboard and doctor model-probe failure messaging:
+   - append a targeted hint when the provider is region-sensitive
+3. doctor next steps:
+   - add a concrete `provider.base_url` adjustment step for those providers
+4. runtime auth rejection message path:
+   - when a region-sensitive provider returns `401` or `403`, append the same
+     region guidance so the live failure is actionable
+
+## Why this approach
+
+This keeps the fix aligned with the existing architecture:
+
+- provider knowledge stays in `config/provider.rs`
+- onboarding and doctor remain thin consumers of provider metadata
+- runtime behavior changes only in error presentation, not request semantics
+
+It also avoids the two bad extremes:
+
+- no provider-kind explosion
+- no opaque "try another region" prose duplicated across CLI layers
+
+## Initial provider scope
+
+The first pass should cover only providers with clear evidence of official
+global/CN endpoint variants:
+
+- `minimax`
+- `kimi`
+- `zai`
+- `zhipu`
+
+`bedrock` already has explicit region templating and existing guidance, so it
+does not need the same treatment. BytePlus and Volcengine remain path-family
+guidance problems in the current codebase, not endpoint-region toggle problems.

--- a/docs/plans/2026-03-17-provider-region-guidance-design.md
+++ b/docs/plans/2026-03-17-provider-region-guidance-design.md
@@ -40,8 +40,10 @@ them in the existing operator surfaces:
 
 1. review and onboarding success summaries:
    - show the current region endpoint choice clearly
-2. onboard and doctor model-probe failure messaging:
-   - append a targeted hint when the provider is region-sensitive
+2. onboard and doctor auth-style model-probe failure messaging:
+   - append a targeted hint only when the provider is region-sensitive and the
+     probe result is classified as an authentication or authorization rejection
+     (for example `401`/`403`-like failures)
 3. doctor next steps:
    - add a concrete `provider.base_url` adjustment step for those providers
 4. runtime auth rejection message path:

--- a/docs/plans/2026-03-17-provider-region-guidance-implementation-plan.md
+++ b/docs/plans/2026-03-17-provider-region-guidance-implementation-plan.md
@@ -1,0 +1,34 @@
+## Implementation plan
+
+1. Add failing tests first.
+   - `crates/app/src/config/provider.rs`
+   - `crates/daemon/src/onboard_cli.rs`
+   - `crates/daemon/src/doctor_cli.rs`
+   - `crates/app/src/provider/request_executor.rs`
+
+2. Add provider-level region guidance helpers.
+   - keep the data local to `config/provider.rs`
+   - support current endpoint note + alternate endpoint hint
+   - keep Bedrock on its existing templated path
+
+3. Reuse the helpers in operator-facing summaries.
+   - onboarding review digest
+   - onboarding success summary
+
+4. Reuse the helpers in failure surfaces.
+   - onboard model-probe failures
+   - doctor model-probe failures
+   - doctor next-step generation
+   - runtime `401/403` request errors
+
+5. Run targeted verification.
+   - unit tests for provider helpers
+   - targeted daemon/app tests for changed messaging
+   - broader Rust formatting and relevant test suites after targeted green
+
+6. Deliver GitHub artifacts.
+   - search for an existing tracking issue first
+   - open or reuse an issue in English using the repository template structure
+   - push the branch to the fork
+   - open a PR against `alpha-test` with template-compliant validation notes and
+     a closing clause

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-16T03:46:17Z
+- Generated at: 2026-03-17T08:38:17Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -13,7 +13,7 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3020 | 3600 | 580 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1478 | 3700 | 2222 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
-| provider_mod | `crates/app/src/provider/mod.rs` | 294 | 1000 | 706 | 7 | 20 | 13 | n/a | n/a | N/A | n/a |
+| provider_mod | `crates/app/src/provider/mod.rs` | 301 | 1000 | 699 | 8 | 20 | 12 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 312 | 650 | 338 | 15 | 16 | 1 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
@@ -40,7 +40,7 @@
 
 <!-- arch-hotspot key=spec_runtime lines=3020 functions=47 -->
 <!-- arch-hotspot key=spec_execution lines=1478 functions=23 -->
-<!-- arch-hotspot key=provider_mod lines=294 functions=7 -->
+<!-- arch-hotspot key=provider_mod lines=301 functions=8 -->
 <!-- arch-hotspot key=memory_mod lines=312 functions=15 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  Region-sensitive providers still collapsed to one official host in operator-facing flows, so valid MiniMax, Kimi, Z.ai, or Zhipu keys could fail with misleading `401` / `403` or model-probe errors when the configured host did not match the account region.
- Why it matters:
  first-run setup and repair flows looked like bad credentials or generic provider failure even when the real fix was a `provider.base_url` region switch.
- What changed:
  added provider-scoped region endpoint metadata, surfaced endpoint notes in onboarding review and success summaries, appended region retry hints to onboard/doctor/runtime auth-style failures, and added regression coverage for those paths.
- What did not change (scope boundary):
  no provider-kind split, no automatic region probing or switching, and no broader transport/request routing refactor.

## Linked Issues

- Closes #253
- Related #236

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
set -e
VERIFY_CARGO_HOME="$PWD/.cargo-home-provider-region-shared"
REAL_CARGO=<path-to-cargo-binary>
SHARED_CARGO_HOME=<existing-cargo-home>
SHARED_TARGET_DIR=<existing-loongclaw-target-cache>
mkdir -p "$VERIFY_CARGO_HOME"
for name in registry git; do
  if [ ! -e "$VERIFY_CARGO_HOME/$name" ]; then
    ln -s "$SHARED_CARGO_HOME/$name" "$VERIFY_CARGO_HOME/$name"
  fi
done
export CARGO_HOME="$VERIFY_CARGO_HOME"
export CARGO_TARGET_DIR="$SHARED_TARGET_DIR"
$REAL_CARGO fmt --all -- --check
$REAL_CARGO test --offline -j1 -p loongclaw-app region_endpoint -- --nocapture
$REAL_CARGO test --offline -j1 -p loongclaw-app render_status_failure_message_includes_region_hint_for_auth_rejection -- --nocapture
$REAL_CARGO test --offline -j1 -p loongclaw-app models_endpoint_resolution_for_supported_provider_profiles_is_stable -- --nocapture
$REAL_CARGO test --offline -j1 -p loongclaw-daemon region_endpoint -- --nocapture
$REAL_CARGO test --offline -j1 -p loongclaw-daemon provider_model_probe_failure_includes_region_hint -- --nocapture
$REAL_CARGO test --offline -j1 -p loongclaw-daemon provider_model_probe_failure_ -- --nocapture
$REAL_CARGO test --offline -j1 -p loongclaw-daemon transport_summary -- --nocapture

Result: all commands above exited successfully.
Local note: full workspace tests and clippy were not run here because the host currently had shared cargo lock contention and limited free disk; this verification reused an existing target cache and offline registry state to keep the touched paths covered without destabilizing the machine.
```

## User-visible / Operator-visible Changes

- `onboard` review and success summaries now show the current official region endpoint assumption plus the alternate official endpoint for MiniMax, Kimi, Z.ai, and Zhipu.
- `onboard`, `doctor`, and runtime `401` / `403` auth-style failures now point operators at `provider.base_url` when those providers can be region-bound.

## Failure Recovery

- Fast rollback or disable path:
  revert commit `2fbc012`, or set an explicit `provider.base_url` manually while reviewing the change.
- Observable failure symptoms reviewers should watch for:
  unexpected region-hint text on providers outside the intended MiniMax/Kimi/Z.ai/Zhipu set, or hints appearing on healthy non-auth failures.

## Reviewer Focus

- Check the provider-scoped metadata and note/hint rendering in `crates/app/src/config/provider.rs`.
- Check that onboarding, doctor, and runtime only consume the shared metadata and do not change request semantics.
- Check the new regression coverage around wrapped summary lines and auth/probe failure messaging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error messages, diagnostics, and doctor/onboarding flows now include region-specific endpoint guidance for supported providers (Minimax, Kimi, Zai, Zhipu) to aid auth-related troubleshooting.
  * Onboarding summaries and review output surface a “provider endpoint” line when applicable.

* **Documentation**
  * Added design and implementation planning docs describing provider-region guidance.

* **Tests**
  * Added unit and integration tests validating region-endpoint guidance appears in messages and onboarding flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->