### PR TITLE
fix: drain stdin on exit to prevent shell command injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1997,6 +1997,7 @@ dependencies = [
  "chrono",
  "clap",
  "ed25519-dalek",
+ "libc",
  "loongclaw-app",
  "loongclaw-bench",
  "loongclaw-kernel",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -27,6 +27,10 @@ tool-file = ["loongclaw-app/tool-file"]
 tool-webfetch = ["loongclaw-app/tool-webfetch"]
 tool-browser = ["loongclaw-app/tool-browser"]
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+
 [dependencies]
 clap.workspace = true
 kernel = { package = "loongclaw-kernel", path = "../kernel" }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -2,8 +2,32 @@
 use clap::Parser;
 use loongclaw_daemon::*;
 
+/// Guard that flushes the terminal input queue on drop.
+///
+/// When a user pastes multi-line text at an interactive prompt, `read_line()`
+/// consumes only the first line. The remaining lines stay in the kernel's tty
+/// input queue (cooked mode). If the process exits without draining, the parent
+/// shell reads those lines as commands — a potential code execution vector.
+///
+/// This guard calls `tcflush(STDIN_FILENO, TCIFLUSH)` on drop to discard any
+/// unread input, covering all exit paths including early returns and panics.
+struct StdinGuard;
+
+impl Drop for StdinGuard {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        // SAFETY: tcflush is a POSIX function that discards unread terminal input.
+        // STDIN_FILENO is a well-defined constant. No memory or resource concerns.
+        unsafe {
+            libc::tcflush(libc::STDIN_FILENO, libc::TCIFLUSH);
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() {
+    let _stdin_guard = StdinGuard;
     let cli = Cli::parse();
     let result = match cli.command.unwrap_or(Commands::Demo) {
         Commands::Demo => run_demo().await,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -2,26 +2,35 @@
 use clap::Parser;
 use loongclaw_daemon::*;
 
-/// Guard that flushes the terminal input queue on drop.
+/// Discard any unread input from the terminal's tty input queue.
 ///
 /// When a user pastes multi-line text at an interactive prompt, `read_line()`
 /// consumes only the first line. The remaining lines stay in the kernel's tty
 /// input queue (cooked mode). If the process exits without draining, the parent
 /// shell reads those lines as commands — a potential code execution vector.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn flush_stdin() {
+    // SAFETY: tcflush is a POSIX function that discards unread terminal input.
+    // STDIN_FILENO is a well-defined constant. No memory or resource concerns.
+    unsafe {
+        libc::tcflush(libc::STDIN_FILENO, libc::TCIFLUSH);
+    }
+}
+
+#[cfg(not(unix))]
+fn flush_stdin() {}
+
+/// Guard that flushes the terminal input queue on drop.
 ///
-/// This guard calls `tcflush(STDIN_FILENO, TCIFLUSH)` on drop to discard any
-/// unread input, covering all exit paths including early returns and panics.
+/// Covers normal return and panic unwinding. For `process::exit()` paths,
+/// `flush_stdin()` must be called explicitly before exit since
+/// `process::exit()` does not run destructors.
 struct StdinGuard;
 
 impl Drop for StdinGuard {
-    #[allow(unsafe_code)]
     fn drop(&mut self) {
-        #[cfg(unix)]
-        // SAFETY: tcflush is a POSIX function that discards unread terminal input.
-        // STDIN_FILENO is a well-defined constant. No memory or resource concerns.
-        unsafe {
-            libc::tcflush(libc::STDIN_FILENO, libc::TCIFLUSH);
-        }
+        flush_stdin();
     }
 }
 
@@ -441,6 +450,7 @@ async fn main() {
         {
             eprintln!("error: {error}");
         }
+        flush_stdin();
         std::process::exit(2);
     }
 }


### PR DESCRIPTION
## Summary

- Add `StdinGuard` + `flush_stdin()` to drain unread terminal input on all exit paths
- Prevents multi-line text pasted at interactive onboard prompts from leaking into the parent shell as executable commands after process exit
- Root cause: `read_line()` in cooked mode consumes one line; remaining lines stay in the kernel tty input queue and survive `process::exit(2)`

## Scope

- [x] Small and focused
- [x] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

Security fix: stdin buffer leakage allows arbitrary text pasted at any interactive prompt to execute as shell commands in the parent shell after process exit. The fix adds `libc::tcflush(STDIN_FILENO, TCIFLUSH)` via:
1. A `Drop` guard (`StdinGuard`) for normal returns and panic unwinding
2. An explicit `flush_stdin()` call before `process::exit(2)` since `exit()` bypasses destructors

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [ ] Manual: run `loongclaw onboard --force`, paste multi-line text at prompt addendum step, cancel at preflight — verify no lines leak to parent shell

## Linked Issues

Closes #249