### PR TITLE
Fix responses fallback for OpenAI-compatible gateway errors

### DIFF
--- a/crates/app/src/provider/contracts.rs
+++ b/crates/app/src/provider/contracts.rs
@@ -544,17 +544,21 @@ fn extract_error_string(error: &Value, field_names: &[&str]) -> Option<String> {
 }
 
 fn extract_error_message(error: &Value) -> Option<String> {
-    extract_error_string(error, &["message", "Message", "detail", "Detail"]).or_else(|| {
-        error
-            .get("details")
-            .and_then(Value::as_array)
-            .and_then(|details| {
-                details
-                    .iter()
-                    .filter_map(|detail| detail.get("message").and_then(value_to_trimmed_string))
-                    .find(|message| !message.is_empty())
-            })
-    })
+    extract_error_string(error, &["message", "Message", "detail", "Detail"])
+        .or_else(|| error.get("raw_body").and_then(value_to_trimmed_string))
+        .or_else(|| {
+            error
+                .get("details")
+                .and_then(Value::as_array)
+                .and_then(|details| {
+                    details
+                        .iter()
+                        .filter_map(|detail| {
+                            detail.get("message").and_then(value_to_trimmed_string)
+                        })
+                        .find(|message| !message.is_empty())
+                })
+        })
 }
 
 fn value_to_trimmed_string(value: &Value) -> Option<String> {

--- a/crates/app/src/provider/contracts.rs
+++ b/crates/app/src/provider/contracts.rs
@@ -774,6 +774,7 @@ mod tests {
         ProviderConfig, ProviderKind, ProviderReasoningExtraBodyModeConfig,
         ProviderToolSchemaModeConfig,
     };
+    use serde_json::json;
 
     #[test]
     fn capability_contract_matrix_is_provider_scoped() {
@@ -998,5 +999,16 @@ mod tests {
                 "unexpected payload adaptation axis for case `{name}` with error={error:?}",
             );
         }
+    }
+
+    #[test]
+    fn parse_provider_api_error_uses_raw_body_when_structured_message_is_absent() {
+        let parsed = parse_provider_api_error(&json!({
+            "raw_body": "error code: 502"
+        }));
+
+        assert_eq!(parsed.message.as_deref(), Some("error code: 502"));
+        assert_eq!(parsed.code, None);
+        assert_eq!(parsed.param, None);
     }
 }

--- a/crates/app/src/provider/request_dispatch_runtime.rs
+++ b/crates/app/src/provider/request_dispatch_runtime.rs
@@ -262,9 +262,7 @@ fn should_fallback_responses_to_chat_completions(
     status_code: u16,
     error: &ProviderApiError,
 ) -> bool {
-    if provider.responses_fallback_provider().is_none()
-        || !matches!(status_code, 400 | 404 | 405 | 415 | 422)
-    {
+    if provider.responses_fallback_provider().is_none() {
         return false;
     }
 
@@ -276,6 +274,19 @@ fn should_fallback_responses_to_chat_completions(
         || message.contains("rate limit")
         || message.contains("insufficient quota")
     {
+        return false;
+    }
+
+    let compatibility_status = matches!(status_code, 400 | 404 | 405 | 415 | 422);
+    let gateway_rejection = matches!(status_code, 500 | 502 | 503 | 504)
+        && (message.contains("bad gateway")
+            || message.contains("gateway timeout")
+            || message.contains("upstream")
+            || message.contains("proxy")
+            || message.contains("error code: 502")
+            || message.contains("error code: 503")
+            || message.contains("error code: 504"));
+    if !compatibility_status && !gateway_rejection {
         return false;
     }
 
@@ -308,5 +319,9 @@ fn should_fallback_responses_to_chat_completions(
         || message.contains("unsupported parameter `instructions`")
         || message.contains("unsupported parameter: `instructions`");
 
-    mentions_chat_endpoint || rejects_responses_input || requires_messages || textual_messages_hint
+    gateway_rejection
+        || mentions_chat_endpoint
+        || rejects_responses_input
+        || requires_messages
+        || textual_messages_hint
 }

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -2020,7 +2020,7 @@ async fn responses_turn_does_not_fallback_for_generic_gateway_failures() {
         "generic gateway failures should not trigger chat-completions fallback: {requests:#?}"
     );
     assert!(
-        requests.len() >= 1,
+        !requests.is_empty(),
         "the test server should observe at least the initial responses request"
     );
 }

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -1958,6 +1958,73 @@ async fn responses_turn_falls_back_to_chat_completions_for_compatible_endpoints(
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn responses_turn_does_not_fallback_for_generic_gateway_failures() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider listener");
+    let addr = listener.local_addr().expect("local addr");
+    let server = std::thread::spawn(move || {
+        let mut requests = Vec::new();
+        for _ in 0..3 {
+            let (mut stream, _) = listener.accept().expect("accept local provider request");
+            let mut request_buf = [0_u8; 8192];
+            let len = stream.read(&mut request_buf).expect("read request");
+            let request = String::from_utf8_lossy(&request_buf[..len]).to_string();
+            requests.push(request.clone());
+
+            let body =
+                r#"{"error":{"message":"temporary backend outage while handling the request"}}"#;
+            let response = format!(
+                "HTTP/1.1 502 Bad Gateway\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        }
+        requests
+    });
+
+    let config = test_config(ProviderConfig {
+        kind: ProviderKind::Deepseek,
+        base_url: format!("http://{addr}"),
+        model: "deepseek-chat".to_owned(),
+        wire_api: crate::config::ProviderWireApi::Responses,
+        api_key: Some("deepseek-test-key".to_owned()),
+        ..ProviderConfig::default()
+    });
+
+    let error = request_turn(
+        &config,
+        "session-provider-test",
+        "turn-provider-test",
+        &[json!({
+            "role": "user",
+            "content": "turn ping"
+        })],
+        ProviderRuntimeBinding::direct(),
+    )
+    .await
+    .expect_err("generic gateway failures should stay on the same transport and eventually fail");
+
+    assert!(
+        error.contains("status 502"),
+        "the surfaced error should still report the gateway failure: {error}"
+    );
+
+    let requests = server.join().expect("join local provider server");
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.starts_with("POST /v1/responses ")),
+        "generic gateway failures should not trigger chat-completions fallback: {requests:#?}"
+    );
+    assert!(
+        requests.len() >= 1,
+        "the test server should observe at least the initial responses request"
+    );
+}
+
 #[test]
 fn model_request_error_includes_parseable_failover_snapshot_payload() {
     let error = build_model_request_error(

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -1721,6 +1721,127 @@ requires_openai_auth = true
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn import_cli_applies_codex_source_and_imported_turn_falls_back_from_responses_gateway_502() {
+    let temp_root = unique_temp_dir("codex-turn-fallback-gateway-502");
+    let home = temp_root.join("home");
+    std::fs::create_dir_all(home.join(".codex")).expect("create fake home codex dir");
+    let output_path = temp_root.join("loongclaw-config.toml");
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider test listener");
+    let addr = listener.local_addr().expect("local addr");
+    let server = std::thread::spawn(move || {
+        let mut requests = Vec::new();
+        for _ in 0..4 {
+            let (mut stream, _) = listener.accept().expect("accept local provider request");
+            let mut request_buf = [0_u8; 8192];
+            let len = stream.read(&mut request_buf).expect("read request");
+            let request = String::from_utf8_lossy(&request_buf[..len]).to_string();
+            requests.push(request.clone());
+
+            let (status_line, body) = if request.starts_with("POST /v1/responses ") {
+                ("HTTP/1.1 502 Bad Gateway", "error code: 502".to_owned())
+            } else if request.starts_with("POST /v1/chat/completions ") {
+                (
+                    "HTTP/1.1 200 OK",
+                    r#"{"choices":[{"message":{"role":"assistant","content":"gateway fallback ok"}}]}"#
+                        .to_owned(),
+                )
+            } else {
+                (
+                    "HTTP/1.1 404 Not Found",
+                    r#"{"error":{"message":"unexpected request"}}"#.to_owned(),
+                )
+            };
+
+            let response = format!(
+                "{status_line}
+Content-Type: application/json
+Content-Length: {}
+Connection: close
+
+{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        }
+        requests
+    });
+
+    std::fs::write(
+        home.join(".codex/config.toml"),
+        format!(
+            r#"
+model_provider = "sub2api"
+model = "openai/gpt-5.1-codex"
+
+[model_providers.sub2api]
+base_url = "http://{addr}"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+        ),
+    )
+    .expect("write fake codex config");
+
+    let _env_guard = ImportEnvironmentGuard::set(&[
+        ("HOME", Some(home.to_string_lossy().as_ref())),
+        ("OPENAI_API_KEY", Some("test-openai-key")),
+    ]);
+
+    loongclaw_daemon::import_cli::run_import_cli(
+        loongclaw_daemon::import_cli::ImportCommandOptions {
+            output: Some(output_path.display().to_string()),
+            force: false,
+            preview: false,
+            apply: true,
+            json: false,
+            from: Some("codex".to_owned()),
+            source_path: None,
+            provider: None,
+            include: Vec::new(),
+            exclude: Vec::new(),
+        },
+    )
+    .await
+    .expect("codex import should apply cleanly");
+
+    let (_, imported) = mvp::config::load(Some(output_path.to_string_lossy().as_ref()))
+        .expect("load imported config");
+    let turn = mvp::provider::request_turn(
+        &imported,
+        "import-codex-session",
+        "import-codex-turn",
+        &[json!({
+            "role": "user",
+            "content": "ping"
+        })],
+        mvp::provider::ProviderRuntimeBinding::direct(),
+    )
+    .await
+    .expect(
+        "imported config should fallback from Responses to chat-completions when the compatibility endpoint rejects Responses behind a 502 shim",
+    );
+    assert_eq!(turn.assistant_text, "gateway fallback ok");
+
+    let requests = server.join().expect("join local provider server");
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.starts_with("POST /v1/responses ")),
+        "turn path should attempt the imported Responses endpoint before fallback: {requests:#?}"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.starts_with("POST /v1/chat/completions ")),
+        "turn path should retry through the imported chat_completions endpoint after the 502 compatibility rejection: {requests:#?}"
+    );
+}
+
 #[test]
 fn import_cli_provider_selection_requires_explicit_choice_for_unresolved_recommended_plan() {
     let mut recommended = sample_import_candidate();

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -1755,12 +1755,7 @@ async fn import_cli_applies_codex_source_and_imported_turn_falls_back_from_respo
             };
 
             let response = format!(
-                "{status_line}
-Content-Type: application/json
-Content-Length: {}
-Connection: close
-
-{}",
+                "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                 body.len(),
                 body
             );


### PR DESCRIPTION
## Summary

- Problem: imported Codex configs can preserve `wire_api = "responses"` for OpenAI-compatible providers whose compatibility shims reject real `/v1/responses` turns with gateway-style `502/503/504` errors.
- Why it matters: onboarding/import advertises "responses compatibility mode with chat fallback", but runtime only fell back for a narrow set of 4xx compatibility errors, so first-turn requests could still hard fail after a seemingly successful import.
- What changed: provider error extraction now uses `raw_body` when structured message fields are empty, fallback classification now treats gateway-style compatibility rejections as eligible for chat-completions fallback, and daemon integration coverage now exercises the imported Codex config path through a `502 Bad Gateway` shim.
- What did not change (scope boundary): this does not broaden general 5xx retry behavior, change provider selection, or alter onboarding defaults outside the existing responses-to-chat fallback path.

## Linked Issues

- Closes #252
- Related #N/A

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo fmt --all --check
cargo test -p loongclaw-daemon import_cli_applies_codex_source_and_imported_turn_falls_back_from_responses -- --nocapture

- fmt check passed after formatting the touched files.
- the filtered daemon integration run passed both the existing 4xx fallback regression and the new 502 gateway regression.
- the new integration test restores HOME and OPENAI_API_KEY through ImportEnvironmentGuard so process-global env state stays scoped to the test.
```

## User-visible / Operator-visible Changes

- Imported OpenAI-compatible configs now retry through `/v1/chat/completions` when a Responses compatibility shim rejects `/v1/responses` with gateway-style `502/503/504` errors.

## Failure Recovery

- Fast rollback or disable path: revert this commit or force `transport = "chat_completions"` in the imported config for affected providers.
- Observable failure symptoms reviewers should watch for: unintended fallback on unrelated 5xx errors that do not represent compatibility shims.

## Reviewer Focus

- `crates/app/src/provider/request_dispatch_runtime.rs` gateway rejection predicate and its scope guard.
- `crates/app/src/provider/contracts.rs` `raw_body` extraction behavior.
- `crates/daemon/tests/integration/import_cli.rs` regression coverage for imported config plus env restoration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message extraction with enhanced fallback logic for better error reporting.
  * Strengthened gateway fallback mechanism to handle 5xx status codes and upstream errors more robustly.

* **Tests**
  * Added test coverage for 502 Bad Gateway scenarios to verify proper fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->