### PR TITLE
feat: add built-in audit retention and inspection CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,6 +214,31 @@ cargo test --workspace --all-features
 See [docs/references/github-collaboration.md](docs/references/github-collaboration.md) for the
 current label baseline, issue routing, community paths, and review flow.
 
+## Developer Observability
+
+When you want an agent to help debug a repository issue or prepare review
+findings, start from the built-in observability surfaces instead of external
+skill setup:
+
+```bash
+loongclaw doctor --config ~/.loongclaw/config.toml
+loongclaw doctor --config ~/.loongclaw/config.toml --json
+loongclaw audit recent --config ~/.loongclaw/config.toml
+loongclaw audit summary --config ~/.loongclaw/config.toml
+loongclaw audit recent --config ~/.loongclaw/config.toml --json
+if [ -f ~/.loongclaw/audit/events.jsonl ]; then tail -n 20 ~/.loongclaw/audit/events.jsonl; else echo "audit journal is created on first audit write"; fi
+```
+
+The app runtime defaults to durable audit retention with
+`[audit].mode = "fanout"`, so security-critical audit events persist across
+restarts under `~/.loongclaw/audit/events.jsonl`. Use `doctor --fix` if you
+want LoongClaw to pre-create the audit journal directory before a debugging
+session. Reach for `audit recent` when you need the latest bounded event window
+and `audit summary` when you need a quick rollup before diving into raw JSONL.
+
+For Rust workspaces, keep one agent per worktree or target directory so cargo
+lock contention does not invalidate the debugging signal.
+
 ## PRs We Are Unlikely to Merge
 
 The following pull requests are unlikely to be accepted unless maintainers have explicitly aligned

--- a/README.md
+++ b/README.md
@@ -226,7 +226,39 @@ cargo install --path crates/daemon
    loongclaw doctor --fix
    ```
 
+6. Inspect the retained audit window when you need debugging evidence:
+
+   ```bash
+   loongclaw audit recent --limit 20
+   loongclaw audit summary --limit 200 --json
+   ```
+
 Channel setup comes after the base CLI path is healthy.
+
+### Repository Observability
+
+LoongClaw ships a built-in developer observability lane for kernel-backed
+debugging and review. The app runtime writes audit events to
+`~/.loongclaw/audit/events.jsonl` by default with `[audit].mode = "fanout"`, so
+policy denials, token lifecycle events, and other security-critical evidence
+survive process restarts.
+
+```bash
+loongclaw doctor --config ~/.loongclaw/config.toml
+loongclaw doctor --config ~/.loongclaw/config.toml --json
+loongclaw audit recent --config ~/.loongclaw/config.toml
+loongclaw audit summary --config ~/.loongclaw/config.toml
+loongclaw audit recent --config ~/.loongclaw/config.toml --json
+if [ -f ~/.loongclaw/audit/events.jsonl ]; then tail -n 20 ~/.loongclaw/audit/events.jsonl; else echo "audit journal is created on first audit write"; fi
+```
+
+`doctor` now surfaces audit retention mode and journal directory readiness in
+addition to the existing runtime checks. For durable modes (`fanout` or
+`jsonl`), LoongClaw will create the journal directory on first write, and
+`doctor --fix` can pre-create it when you want a clean preflight. Use
+`audit recent` when you want the bounded last-N event window and
+`audit summary` when you want a compact kind/count rollup plus last-seen
+fields. Raw `tail` remains a fallback when you need the original JSONL lines.
 
 ## Configuration
 

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -2379,6 +2379,27 @@ model = "gpt-5"
 
     #[test]
     #[cfg(feature = "config-toml")]
+    fn write_default_config_includes_durable_audit_defaults() {
+        let path = unique_config_path("loongclaw-config-runtime-audit");
+        let path_string = path.display().to_string();
+
+        write(Some(&path_string), &LoongClawConfig::default(), true)
+            .expect("default config write should pass");
+
+        let raw = fs::read_to_string(&path).expect("read written config");
+        assert!(raw.contains("[audit]"));
+        assert!(raw.contains("mode = \"fanout\""));
+        assert!(raw.contains("path = "));
+
+        let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
+        assert_eq!(loaded.audit.mode, crate::config::AuditMode::Fanout);
+        assert!(loaded.audit.resolved_path().ends_with("audit/events.jsonl"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
     fn write_canonicalizes_provider_env_pointers_to_inline_env_references() {
         let path = unique_config_path("loongclaw-config-runtime-canonical-provider-env");
         let path_string = path.display().to_string();

--- a/crates/daemon/src/audit_cli.rs
+++ b/crates/daemon/src/audit_cli.rs
@@ -1,0 +1,1130 @@
+use std::collections::{BTreeMap, VecDeque};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use clap::Subcommand;
+
+use crate::kernel::{AuditEvent, AuditEventKind};
+use loongclaw_spec::CliResult;
+use serde_json::{Value, json};
+
+const MAX_AUDIT_WINDOW: usize = 10_000;
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum AuditCommands {
+    /// Print the last N retained audit events
+    Recent {
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+    },
+    /// Print a compact rollup over the last N retained audit events
+    Summary {
+        #[arg(long, default_value_t = 200)]
+        limit: usize,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct AuditCommandOptions {
+    pub config: Option<String>,
+    pub json: bool,
+    pub command: AuditCommands,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditCommandExecution {
+    pub resolved_config_path: String,
+    pub journal_path: String,
+    pub result: AuditCommandResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuditCommandResult {
+    Recent {
+        limit: usize,
+        events: Vec<AuditEvent>,
+    },
+    Summary {
+        limit: usize,
+        loaded_events: usize,
+        event_kind_counts: BTreeMap<String, usize>,
+        triage_counts: BTreeMap<String, usize>,
+        first_timestamp_epoch_s: Option<u64>,
+        last_event_id: Option<String>,
+        last_timestamp_epoch_s: Option<u64>,
+        last_agent_id: Option<String>,
+        last_triage_event_id: Option<String>,
+        last_triage_event_kind: Option<String>,
+        last_triage_timestamp_epoch_s: Option<u64>,
+        last_triage_agent_id: Option<String>,
+    },
+}
+
+pub fn run_audit_cli(options: AuditCommandOptions) -> CliResult<()> {
+    let as_json = options.json;
+    let execution = execute_audit_command(options)?;
+    if as_json {
+        let pretty = serde_json::to_string_pretty(&audit_cli_json(&execution))
+            .map_err(|error| format!("serialize audit CLI output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_audit_cli_text(&execution)?);
+    Ok(())
+}
+
+pub fn execute_audit_command(options: AuditCommandOptions) -> CliResult<AuditCommandExecution> {
+    let AuditCommandOptions {
+        config,
+        json: _,
+        command,
+    } = options;
+
+    let (limit, command_name) = match &command {
+        AuditCommands::Recent { limit } => (*limit, "audit recent"),
+        AuditCommands::Summary { limit } => (*limit, "audit summary"),
+    };
+    let limit = validate_audit_limit(limit, command_name)?;
+
+    let (resolved_path, config) = crate::mvp::config::load(config.as_deref())?;
+    let journal_path = config.audit.resolved_path();
+    let events = load_audit_event_window(&config.audit, &journal_path, limit)?;
+    let result = match command {
+        AuditCommands::Recent { limit } => AuditCommandResult::Recent { limit, events },
+        AuditCommands::Summary { limit } => summarize_audit_events(limit, &events),
+    };
+
+    Ok(AuditCommandExecution {
+        resolved_config_path: resolved_path.display().to_string(),
+        journal_path: journal_path.display().to_string(),
+        result,
+    })
+}
+
+pub fn audit_cli_json(execution: &AuditCommandExecution) -> Value {
+    match &execution.result {
+        AuditCommandResult::Recent { limit, events } => json!({
+            "command": "recent",
+            "config": execution.resolved_config_path,
+            "journal_path": execution.journal_path,
+            "limit": limit,
+            "loaded_events": events.len(),
+            "events": events,
+        }),
+        AuditCommandResult::Summary {
+            limit,
+            loaded_events,
+            event_kind_counts,
+            triage_counts,
+            first_timestamp_epoch_s,
+            last_event_id,
+            last_timestamp_epoch_s,
+            last_agent_id,
+            last_triage_event_id,
+            last_triage_event_kind,
+            last_triage_timestamp_epoch_s,
+            last_triage_agent_id,
+        } => json!({
+            "command": "summary",
+            "config": execution.resolved_config_path,
+            "journal_path": execution.journal_path,
+            "limit": limit,
+            "loaded_events": loaded_events,
+            "event_kind_counts": event_kind_counts,
+            "triage_counts": triage_counts,
+            "first_timestamp_epoch_s": first_timestamp_epoch_s,
+            "last_event_id": last_event_id,
+            "last_timestamp_epoch_s": last_timestamp_epoch_s,
+            "last_agent_id": last_agent_id,
+            "last_triage_event_id": last_triage_event_id,
+            "last_triage_event_kind": last_triage_event_kind,
+            "last_triage_timestamp_epoch_s": last_triage_timestamp_epoch_s,
+            "last_triage_agent_id": last_triage_agent_id,
+        }),
+    }
+}
+
+pub fn render_audit_cli_text(execution: &AuditCommandExecution) -> CliResult<String> {
+    let mut lines = Vec::new();
+    match &execution.result {
+        AuditCommandResult::Recent { limit, events } => {
+            lines.push(format!(
+                "audit recent config={} journal={} limit={} loaded_events={}",
+                execution.resolved_config_path,
+                execution.journal_path,
+                limit,
+                events.len()
+            ));
+            for event in events {
+                let detail = format_audit_event_detail(&event.kind);
+                lines.push(format!(
+                    "- ts={} event_id={} agent_id={} kind={} {}",
+                    event.timestamp_epoch_s,
+                    event.event_id,
+                    event.agent_id.as_deref().unwrap_or("-"),
+                    audit_event_kind_label(&event.kind),
+                    detail
+                ));
+            }
+        }
+        AuditCommandResult::Summary {
+            limit,
+            loaded_events,
+            event_kind_counts,
+            triage_counts,
+            first_timestamp_epoch_s,
+            last_event_id,
+            last_timestamp_epoch_s,
+            last_agent_id,
+            last_triage_event_id,
+            last_triage_event_kind,
+            last_triage_timestamp_epoch_s,
+            last_triage_agent_id,
+        } => {
+            lines.push(format!(
+                "audit summary config={} journal={} limit={} loaded_events={}",
+                execution.resolved_config_path, execution.journal_path, limit, loaded_events
+            ));
+            lines.push(format!(
+                "event_kind_counts={}",
+                format_equals_rollup(event_kind_counts)
+            ));
+            lines.push(format!(
+                "triage_counts={}",
+                format_equals_rollup(triage_counts)
+            ));
+            lines.push(format!(
+                "first_timestamp_epoch_s={}",
+                first_timestamp_epoch_s
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_owned())
+            ));
+            lines.push(format!(
+                "last_event_id={} last_timestamp_epoch_s={} last_agent_id={}",
+                last_event_id.as_deref().unwrap_or("-"),
+                last_timestamp_epoch_s
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_owned()),
+                last_agent_id.as_deref().unwrap_or("-")
+            ));
+            lines.push(format!(
+                "last_triage_event_id={} last_triage_event_kind={} last_triage_timestamp_epoch_s={} last_triage_agent_id={}",
+                last_triage_event_id.as_deref().unwrap_or("-"),
+                last_triage_event_kind.as_deref().unwrap_or("-"),
+                last_triage_timestamp_epoch_s
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_owned()),
+                last_triage_agent_id.as_deref().unwrap_or("-")
+            ));
+        }
+    }
+    Ok(lines.join("\n"))
+}
+
+fn validate_audit_limit(limit: usize, command_name: &str) -> CliResult<usize> {
+    if !(1..=MAX_AUDIT_WINDOW).contains(&limit) {
+        return Err(format!(
+            "{command_name} limit must be between 1 and {MAX_AUDIT_WINDOW}"
+        ));
+    }
+
+    Ok(limit)
+}
+
+fn load_audit_event_window(
+    audit: &crate::mvp::config::AuditConfig,
+    journal_path: &Path,
+    limit: usize,
+) -> CliResult<Vec<AuditEvent>> {
+    if !journal_path.exists() {
+        let hint = if audit.mode == crate::mvp::config::AuditMode::InMemory {
+            "durable audit retention is disabled because [audit].mode = \"in_memory\""
+        } else {
+            "journal is created on first audit write"
+        };
+        return Err(format!(
+            "audit journal not found at {} ({hint})",
+            journal_path.display()
+        ));
+    }
+    if !journal_path.is_file() {
+        return Err(format!(
+            "audit journal path {} exists but is not a file",
+            journal_path.display()
+        ));
+    }
+
+    let file = File::open(journal_path).map_err(|error| {
+        format!(
+            "open audit journal {} failed: {error}",
+            journal_path.display()
+        )
+    })?;
+    file.lock_shared().map_err(|error| {
+        format!(
+            "lock audit journal {} for reading failed: {error}",
+            journal_path.display()
+        )
+    })?;
+    let reader = BufReader::new(file);
+    let mut window = VecDeque::new();
+    for (index, line_result) in reader.lines().enumerate() {
+        let line_number = index + 1;
+        let line = line_result.map_err(|error| {
+            format!(
+                "read audit journal {} failed at line {}: {error}",
+                journal_path.display(),
+                line_number
+            )
+        })?;
+        let event = serde_json::from_str::<AuditEvent>(&line).map_err(|error| {
+            format!(
+                "decode audit journal {} failed at line {}: {error}",
+                journal_path.display(),
+                line_number
+            )
+        })?;
+        if window.len() == limit {
+            let _ = window.pop_front();
+        }
+        window.push_back(event);
+    }
+    Ok(window.into_iter().collect())
+}
+
+fn summarize_audit_events(limit: usize, events: &[AuditEvent]) -> AuditCommandResult {
+    let mut event_kind_counts = BTreeMap::new();
+    let mut triage_counts = BTreeMap::new();
+    for event in events {
+        let label = audit_event_kind_label(&event.kind).to_owned();
+        *event_kind_counts.entry(label).or_insert(0) += 1;
+        if let Some(triage_label) = triage_event_label(&event.kind) {
+            *triage_counts.entry(triage_label.to_owned()).or_insert(0) += 1;
+        }
+    }
+    let first = events.first();
+    let last = events.last();
+    let last_triage = events
+        .iter()
+        .rev()
+        .find(|event| triage_event_label(&event.kind).is_some());
+
+    AuditCommandResult::Summary {
+        limit,
+        loaded_events: events.len(),
+        event_kind_counts,
+        triage_counts,
+        first_timestamp_epoch_s: first.map(|event| event.timestamp_epoch_s),
+        last_event_id: last.map(|event| event.event_id.clone()),
+        last_timestamp_epoch_s: last.map(|event| event.timestamp_epoch_s),
+        last_agent_id: last.and_then(|event| event.agent_id.clone()),
+        last_triage_event_id: last_triage.map(|event| event.event_id.clone()),
+        last_triage_event_kind: last_triage
+            .map(|event| audit_event_kind_label(&event.kind).to_owned()),
+        last_triage_timestamp_epoch_s: last_triage.map(|event| event.timestamp_epoch_s),
+        last_triage_agent_id: last_triage.and_then(|event| event.agent_id.clone()),
+    }
+}
+
+fn triage_event_label(kind: &AuditEventKind) -> Option<&'static str> {
+    match kind {
+        AuditEventKind::AuthorizationDenied { .. } => Some("authorization_denied"),
+        AuditEventKind::ProviderFailover { .. } => Some("provider_failover"),
+        AuditEventKind::SecurityScanEvaluated { blocked: true, .. } => {
+            Some("security_scan_blocked")
+        }
+        AuditEventKind::TokenIssued { .. }
+        | AuditEventKind::TokenRevoked { .. }
+        | AuditEventKind::TaskDispatched { .. }
+        | AuditEventKind::ConnectorInvoked { .. }
+        | AuditEventKind::PlaneInvoked { .. }
+        | AuditEventKind::SecurityScanEvaluated { .. } => None,
+        _ => None,
+    }
+}
+
+fn audit_event_kind_label(kind: &AuditEventKind) -> &'static str {
+    match kind {
+        AuditEventKind::TokenIssued { .. } => "TokenIssued",
+        AuditEventKind::TokenRevoked { .. } => "TokenRevoked",
+        AuditEventKind::TaskDispatched { .. } => "TaskDispatched",
+        AuditEventKind::ConnectorInvoked { .. } => "ConnectorInvoked",
+        AuditEventKind::PlaneInvoked { .. } => "PlaneInvoked",
+        AuditEventKind::SecurityScanEvaluated { .. } => "SecurityScanEvaluated",
+        AuditEventKind::ProviderFailover { .. } => "ProviderFailover",
+        AuditEventKind::AuthorizationDenied { .. } => "AuthorizationDenied",
+        // AuditEventKind is non_exhaustive in loongclaw-contracts, so keep a visible
+        // fallback label instead of silently collapsing future variants into "Unknown".
+        _ => "UnknownAuditEventKind",
+    }
+}
+
+fn format_audit_event_detail(kind: &AuditEventKind) -> String {
+    match kind {
+        AuditEventKind::TokenIssued { token } => format!(
+            "pack_id={} token_id={} expires_at_epoch_s={}",
+            token.pack_id, token.token_id, token.expires_at_epoch_s
+        ),
+        AuditEventKind::TokenRevoked { token_id } => format!("token_id={token_id}"),
+        AuditEventKind::TaskDispatched {
+            pack_id,
+            task_id,
+            route,
+            ..
+        } => format!(
+            "pack_id={} task_id={} harness={:?} adapter={}",
+            pack_id,
+            task_id,
+            route.harness_kind,
+            route.adapter.as_deref().unwrap_or("-")
+        ),
+        AuditEventKind::ConnectorInvoked {
+            pack_id,
+            connector_name,
+            operation,
+            ..
+        } => format!(
+            "pack_id={} connector={} operation={}",
+            pack_id, connector_name, operation
+        ),
+        AuditEventKind::PlaneInvoked {
+            pack_id,
+            plane,
+            tier,
+            primary_adapter,
+            operation,
+            ..
+        } => format!(
+            "pack_id={} plane={:?} tier={:?} adapter={} operation={}",
+            pack_id, plane, tier, primary_adapter, operation
+        ),
+        AuditEventKind::SecurityScanEvaluated {
+            pack_id,
+            total_findings,
+            blocked,
+            ..
+        } => format!(
+            "pack_id={} total_findings={} blocked={}",
+            pack_id, total_findings, blocked
+        ),
+        AuditEventKind::ProviderFailover {
+            pack_id,
+            provider_id,
+            reason,
+            attempt,
+            max_attempts,
+            ..
+        } => format!(
+            "pack_id={} provider_id={} reason={} attempt={}/{}",
+            pack_id, provider_id, reason, attempt, max_attempts
+        ),
+        AuditEventKind::AuthorizationDenied {
+            pack_id,
+            token_id,
+            reason,
+        } => format!(
+            "pack_id={} token_id={} reason={}",
+            pack_id, token_id, reason
+        ),
+        _ => "detail unavailable for unknown/non-exhaustive audit event variant".to_owned(),
+    }
+}
+
+fn format_equals_rollup(counts: &BTreeMap<String, usize>) -> String {
+    if counts.is_empty() {
+        return "-".to_owned();
+    }
+    counts
+        .iter()
+        .map(|(label, count)| format!("{label}={count}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::fs::OpenOptions;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use crate::kernel::{AuditEvent, AuditEventKind, CapabilityToken, ExecutionPlane, PlaneTier};
+    use crate::mvp::test_support::ScopedEnv;
+
+    use super::*;
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        static UNIQUE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let counter = UNIQUE_COUNTER.fetch_add(1, Ordering::SeqCst);
+        std::env::temp_dir().join(format!("{prefix}-{}-{nanos}-{counter}", std::process::id()))
+    }
+
+    fn write_audit_config_with_mode(
+        root: &Path,
+        journal_path: &Path,
+        mode: crate::mvp::config::AuditMode,
+    ) -> PathBuf {
+        fs::create_dir_all(root).expect("create config root");
+        let config_path = root.join("loongclaw.toml");
+        let mut config = crate::mvp::config::LoongClawConfig::default();
+        config.audit.mode = mode;
+        config.audit.path = journal_path.display().to_string();
+        crate::mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+            .expect("write audit config");
+        config_path
+    }
+
+    fn write_audit_config(root: &Path, journal_path: &Path) -> PathBuf {
+        write_audit_config_with_mode(root, journal_path, crate::mvp::config::AuditMode::Fanout)
+    }
+
+    fn sample_audit_event(
+        event_id: &str,
+        timestamp_epoch_s: u64,
+        agent_id: Option<&str>,
+        kind: AuditEventKind,
+    ) -> AuditEvent {
+        AuditEvent {
+            event_id: event_id.to_owned(),
+            timestamp_epoch_s,
+            agent_id: agent_id.map(str::to_owned),
+            kind,
+        }
+    }
+
+    fn write_journal(path: &Path, events: &[AuditEvent]) {
+        let parent = path.parent().expect("journal path should have parent");
+        fs::create_dir_all(parent).expect("create journal parent");
+        let encoded = events
+            .iter()
+            .map(|event| serde_json::to_string(event).expect("serialize audit event"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(path, format!("{encoded}\n")).expect("write audit journal");
+    }
+
+    #[test]
+    fn audit_recent_execution_keeps_last_events_in_order() {
+        let root = unique_temp_dir("loongclaw-audit-cli-recent");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+        write_journal(
+            &journal_path,
+            &[
+                sample_audit_event(
+                    "evt-1",
+                    1_700_010_001,
+                    Some("agent-a"),
+                    AuditEventKind::TokenRevoked {
+                        token_id: "token-1".to_owned(),
+                    },
+                ),
+                sample_audit_event(
+                    "evt-2",
+                    1_700_010_002,
+                    Some("agent-b"),
+                    AuditEventKind::AuthorizationDenied {
+                        pack_id: "sales-intel".to_owned(),
+                        token_id: "token-2".to_owned(),
+                        reason: "missing capability".to_owned(),
+                    },
+                ),
+                sample_audit_event(
+                    "evt-3",
+                    1_700_010_003,
+                    Some("agent-c"),
+                    AuditEventKind::PlaneInvoked {
+                        pack_id: "sales-intel".to_owned(),
+                        plane: ExecutionPlane::Tool,
+                        tier: PlaneTier::Core,
+                        primary_adapter: "mvp-tools".to_owned(),
+                        delegated_core_adapter: None,
+                        operation: "tool.call".to_owned(),
+                        required_capabilities: Vec::new(),
+                    },
+                ),
+            ],
+        );
+
+        let execution = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: AuditCommands::Recent { limit: 2 },
+        })
+        .expect("execute audit recent");
+
+        assert_eq!(execution.journal_path, journal_path.display().to_string());
+        match execution.result {
+            AuditCommandResult::Recent { limit, events } => {
+                assert_eq!(limit, 2);
+                let ids = events
+                    .iter()
+                    .map(|event| event.event_id.as_str())
+                    .collect::<Vec<_>>();
+                assert_eq!(ids, vec!["evt-2", "evt-3"]);
+            }
+            other => panic!("unexpected audit command result: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn audit_recent_json_includes_loaded_events_and_journal_path() {
+        let root = unique_temp_dir("loongclaw-audit-cli-recent-json");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+        write_journal(
+            &journal_path,
+            &[sample_audit_event(
+                "evt-json",
+                1_700_010_010,
+                Some("agent-json"),
+                AuditEventKind::TokenRevoked {
+                    token_id: "token-json".to_owned(),
+                },
+            )],
+        );
+
+        let execution = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: true,
+            command: AuditCommands::Recent { limit: 5 },
+        })
+        .expect("execute audit recent");
+        let payload = audit_cli_json(&execution);
+
+        assert_eq!(payload["journal_path"], journal_path.display().to_string());
+        assert_eq!(payload["limit"], 5);
+        assert_eq!(payload["loaded_events"], 1);
+        assert_eq!(payload["events"][0]["event_id"], "evt-json");
+    }
+
+    #[test]
+    fn audit_recent_waits_for_existing_audit_journal_lock_before_reading() {
+        let root = unique_temp_dir("loongclaw-audit-cli-recent-lock");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+        write_journal(
+            &journal_path,
+            &[sample_audit_event(
+                "evt-lock",
+                1_700_010_020,
+                Some("agent-lock"),
+                AuditEventKind::TokenRevoked {
+                    token_id: "token-lock".to_owned(),
+                },
+            )],
+        );
+
+        let external_lock = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&journal_path)
+            .expect("open external audit journal handle");
+        external_lock
+            .lock()
+            .expect("hold external audit journal lock");
+
+        let (tx, rx) = mpsc::channel();
+        let config = config_path.display().to_string();
+        let handle = thread::spawn(move || {
+            let result = execute_audit_command(AuditCommandOptions {
+                config: Some(config),
+                json: false,
+                command: AuditCommands::Recent { limit: 10 },
+            });
+            tx.send(result).expect("send audit recent result");
+        });
+
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Ok(result) => {
+                panic!("audit recent should block on external journal lock, got {result:?}")
+            }
+            Err(error) => panic!("audit recent channel closed unexpectedly: {error:?}"),
+        }
+
+        external_lock
+            .unlock()
+            .expect("release external audit journal lock");
+        let execution = rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("audit recent should finish after lock release")
+            .expect("audit recent should succeed after lock release");
+        handle.join().expect("join audit recent reader");
+
+        match execution.result {
+            AuditCommandResult::Recent { events, .. } => {
+                assert_eq!(events.len(), 1);
+                assert_eq!(events[0].event_id, "evt-lock");
+            }
+            other => panic!("unexpected audit command result after lock release: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn audit_recent_rejects_zero_limit() {
+        let mut env = ScopedEnv::new();
+        env.set("HOME", unique_temp_dir("loongclaw-audit-cli-missing-home"));
+
+        let error = execute_audit_command(AuditCommandOptions {
+            config: None,
+            json: false,
+            command: AuditCommands::Recent { limit: 0 },
+        })
+        .expect_err("zero recent limit should fail");
+
+        assert!(error.contains("audit recent limit must be between 1 and 10000"));
+    }
+
+    #[test]
+    fn audit_recent_rejects_excessive_limit() {
+        let mut env = ScopedEnv::new();
+        env.set(
+            "HOME",
+            unique_temp_dir("loongclaw-audit-cli-large-limit-home"),
+        );
+
+        let error = execute_audit_command(AuditCommandOptions {
+            config: None,
+            json: false,
+            command: AuditCommands::Recent { limit: 10_001 },
+        })
+        .expect_err("excessive recent limit should fail");
+
+        assert!(error.contains("audit recent limit must be between 1 and 10000"));
+    }
+
+    #[test]
+    fn audit_recent_reports_missing_journal_with_first_write_hint() {
+        let root = unique_temp_dir("loongclaw-audit-cli-missing");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+
+        let error = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: AuditCommands::Recent { limit: 10 },
+        })
+        .expect_err("missing journal should fail");
+
+        assert!(error.contains("audit journal not found"));
+        assert!(error.contains("first audit write"));
+    }
+
+    #[test]
+    fn audit_recent_reports_in_memory_mode_when_journal_is_missing() {
+        let root = unique_temp_dir("loongclaw-audit-cli-in-memory");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config_with_mode(
+            &root,
+            &journal_path,
+            crate::mvp::config::AuditMode::InMemory,
+        );
+
+        let error = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: AuditCommands::Recent { limit: 10 },
+        })
+        .expect_err("missing in-memory journal should fail");
+
+        assert!(error.contains("audit journal not found"));
+        assert!(error.contains("durable audit retention is disabled"));
+        assert!(error.contains("[audit].mode = \"in_memory\""));
+    }
+
+    #[test]
+    fn audit_summary_rolls_up_event_kinds_and_last_seen_fields() {
+        let root = unique_temp_dir("loongclaw-audit-cli-summary");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+        write_journal(
+            &journal_path,
+            &[
+                sample_audit_event(
+                    "evt-1",
+                    1_700_010_100,
+                    Some("agent-a"),
+                    AuditEventKind::TokenIssued {
+                        token: CapabilityToken {
+                            token_id: "token-0".to_owned(),
+                            pack_id: "sales-intel".to_owned(),
+                            agent_id: "agent-a".to_owned(),
+                            allowed_capabilities: Default::default(),
+                            issued_at_epoch_s: 1_700_010_100,
+                            expires_at_epoch_s: 1_700_010_200,
+                            generation: 0,
+                        },
+                    },
+                ),
+                sample_audit_event(
+                    "evt-2",
+                    1_700_010_101,
+                    Some("agent-b"),
+                    AuditEventKind::AuthorizationDenied {
+                        pack_id: "sales-intel".to_owned(),
+                        token_id: "token-1".to_owned(),
+                        reason: "missing capability".to_owned(),
+                    },
+                ),
+                sample_audit_event(
+                    "evt-3",
+                    1_700_010_102,
+                    Some("agent-c"),
+                    AuditEventKind::ProviderFailover {
+                        pack_id: "sales-intel".to_owned(),
+                        provider_id: "openai".to_owned(),
+                        reason: "rate_limited".to_owned(),
+                        stage: "response".to_owned(),
+                        model: "gpt-5.1".to_owned(),
+                        attempt: 1,
+                        max_attempts: 3,
+                        status_code: Some(429),
+                        try_next_model: true,
+                        auto_model_mode: true,
+                        candidate_index: 0,
+                        candidate_count: 2,
+                    },
+                ),
+                sample_audit_event(
+                    "evt-4",
+                    1_700_010_103,
+                    Some("agent-d"),
+                    AuditEventKind::SecurityScanEvaluated {
+                        pack_id: "sales-intel".to_owned(),
+                        scanned_plugins: 1,
+                        total_findings: 2,
+                        high_findings: 1,
+                        medium_findings: 1,
+                        low_findings: 0,
+                        blocked: true,
+                        block_reason: Some("unsigned plugin".to_owned()),
+                        categories: vec!["signature".to_owned()],
+                        finding_ids: vec!["finding-1".to_owned()],
+                    },
+                ),
+                sample_audit_event(
+                    "evt-5",
+                    1_700_010_104,
+                    Some("agent-e"),
+                    AuditEventKind::PlaneInvoked {
+                        pack_id: "sales-intel".to_owned(),
+                        plane: ExecutionPlane::Runtime,
+                        tier: PlaneTier::Core,
+                        primary_adapter: "runtime".to_owned(),
+                        delegated_core_adapter: None,
+                        operation: "turn.complete".to_owned(),
+                        required_capabilities: Vec::new(),
+                    },
+                ),
+            ],
+        );
+
+        let execution = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: AuditCommands::Summary { limit: 10 },
+        })
+        .expect("execute audit summary");
+
+        match execution.result {
+            AuditCommandResult::Summary {
+                limit,
+                loaded_events,
+                event_kind_counts,
+                triage_counts,
+                first_timestamp_epoch_s,
+                last_event_id,
+                last_timestamp_epoch_s,
+                last_agent_id,
+                last_triage_event_id,
+                last_triage_event_kind,
+                last_triage_timestamp_epoch_s,
+                last_triage_agent_id,
+            } => {
+                assert_eq!(limit, 10);
+                assert_eq!(loaded_events, 5);
+                assert_eq!(
+                    event_kind_counts,
+                    BTreeMap::from([
+                        ("AuthorizationDenied".to_owned(), 1_usize),
+                        ("PlaneInvoked".to_owned(), 1_usize),
+                        ("ProviderFailover".to_owned(), 1_usize),
+                        ("SecurityScanEvaluated".to_owned(), 1_usize),
+                        ("TokenIssued".to_owned(), 1_usize),
+                    ])
+                );
+                assert_eq!(
+                    triage_counts,
+                    BTreeMap::from([
+                        ("authorization_denied".to_owned(), 1_usize),
+                        ("provider_failover".to_owned(), 1_usize),
+                        ("security_scan_blocked".to_owned(), 1_usize),
+                    ])
+                );
+                assert_eq!(first_timestamp_epoch_s, Some(1_700_010_100));
+                assert_eq!(last_event_id.as_deref(), Some("evt-5"));
+                assert_eq!(last_timestamp_epoch_s, Some(1_700_010_104));
+                assert_eq!(last_agent_id.as_deref(), Some("agent-e"));
+                assert_eq!(last_triage_event_id.as_deref(), Some("evt-4"));
+                assert_eq!(
+                    last_triage_event_kind.as_deref(),
+                    Some("SecurityScanEvaluated")
+                );
+                assert_eq!(last_triage_timestamp_epoch_s, Some(1_700_010_103));
+                assert_eq!(last_triage_agent_id.as_deref(), Some("agent-d"));
+            }
+            other => panic!("unexpected audit command result: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn audit_summary_ignores_non_blocking_security_scan_for_triage_rollups() {
+        let root = unique_temp_dir("loongclaw-audit-cli-summary-non-blocking-scan");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+        write_journal(
+            &journal_path,
+            &[
+                sample_audit_event(
+                    "evt-1",
+                    1_700_010_150,
+                    Some("agent-a"),
+                    AuditEventKind::AuthorizationDenied {
+                        pack_id: "sales-intel".to_owned(),
+                        token_id: "token-1".to_owned(),
+                        reason: "missing capability".to_owned(),
+                    },
+                ),
+                sample_audit_event(
+                    "evt-2",
+                    1_700_010_151,
+                    Some("agent-b"),
+                    AuditEventKind::SecurityScanEvaluated {
+                        pack_id: "sales-intel".to_owned(),
+                        scanned_plugins: 1,
+                        total_findings: 1,
+                        high_findings: 0,
+                        medium_findings: 1,
+                        low_findings: 0,
+                        blocked: false,
+                        block_reason: None,
+                        categories: vec!["signature".to_owned()],
+                        finding_ids: vec!["finding-1".to_owned()],
+                    },
+                ),
+                sample_audit_event(
+                    "evt-3",
+                    1_700_010_152,
+                    Some("agent-c"),
+                    AuditEventKind::PlaneInvoked {
+                        pack_id: "sales-intel".to_owned(),
+                        plane: ExecutionPlane::Runtime,
+                        tier: PlaneTier::Core,
+                        primary_adapter: "runtime".to_owned(),
+                        delegated_core_adapter: None,
+                        operation: "turn.complete".to_owned(),
+                        required_capabilities: Vec::new(),
+                    },
+                ),
+            ],
+        );
+
+        let execution = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: AuditCommands::Summary { limit: 10 },
+        })
+        .expect("execute audit summary");
+
+        match execution.result {
+            AuditCommandResult::Summary {
+                triage_counts,
+                last_triage_event_id,
+                last_triage_event_kind,
+                last_triage_timestamp_epoch_s,
+                last_triage_agent_id,
+                ..
+            } => {
+                assert_eq!(
+                    triage_counts,
+                    BTreeMap::from([("authorization_denied".to_owned(), 1_usize)])
+                );
+                assert_eq!(last_triage_event_id.as_deref(), Some("evt-1"));
+                assert_eq!(
+                    last_triage_event_kind.as_deref(),
+                    Some("AuthorizationDenied")
+                );
+                assert_eq!(last_triage_timestamp_epoch_s, Some(1_700_010_150));
+                assert_eq!(last_triage_agent_id.as_deref(), Some("agent-a"));
+            }
+            other => panic!("unexpected audit command result: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn audit_summary_rejects_excessive_limit() {
+        let mut env = ScopedEnv::new();
+        env.set(
+            "HOME",
+            unique_temp_dir("loongclaw-audit-cli-large-summary-limit-home"),
+        );
+
+        let error = execute_audit_command(AuditCommandOptions {
+            config: None,
+            json: false,
+            command: AuditCommands::Summary { limit: 10_001 },
+        })
+        .expect_err("excessive summary limit should fail");
+
+        assert!(error.contains("audit summary limit must be between 1 and 10000"));
+    }
+
+    #[test]
+    fn audit_summary_text_includes_triage_counts_and_last_seen_fields() {
+        let execution = AuditCommandExecution {
+            resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+            journal_path: "/tmp/audit/events.jsonl".to_owned(),
+            result: AuditCommandResult::Summary {
+                limit: 50,
+                loaded_events: 3,
+                event_kind_counts: BTreeMap::from([
+                    ("AuthorizationDenied".to_owned(), 2_usize),
+                    ("PlaneInvoked".to_owned(), 1_usize),
+                ]),
+                triage_counts: BTreeMap::from([
+                    ("authorization_denied".to_owned(), 2_usize),
+                    ("security_scan_blocked".to_owned(), 1_usize),
+                ]),
+                first_timestamp_epoch_s: Some(1_700_010_100),
+                last_event_id: Some("evt-3".to_owned()),
+                last_timestamp_epoch_s: Some(1_700_010_102),
+                last_agent_id: Some("agent-c".to_owned()),
+                last_triage_event_id: Some("evt-2".to_owned()),
+                last_triage_event_kind: Some("AuthorizationDenied".to_owned()),
+                last_triage_timestamp_epoch_s: Some(1_700_010_101),
+                last_triage_agent_id: Some("agent-b".to_owned()),
+            },
+        };
+
+        let rendered = render_audit_cli_text(&execution).expect("render audit summary");
+
+        assert!(rendered.contains("audit summary"));
+        assert!(rendered.contains("loaded_events=3"));
+        assert!(rendered.contains("first_timestamp_epoch_s=1700010100"));
+        assert!(rendered.contains("AuthorizationDenied=2"));
+        assert!(rendered.contains("PlaneInvoked=1"));
+        assert!(rendered.contains("triage_counts=authorization_denied=2,security_scan_blocked=1"));
+        assert!(rendered.contains("last_event_id=evt-3"));
+        assert!(rendered.contains("last_agent_id=agent-c"));
+        assert!(rendered.contains("last_triage_event_id=evt-2"));
+        assert!(rendered.contains("last_triage_event_kind=AuthorizationDenied"));
+        assert!(rendered.contains("last_triage_agent_id=agent-b"));
+    }
+
+    #[test]
+    fn audit_summary_json_includes_triage_fields() {
+        let execution = AuditCommandExecution {
+            resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+            journal_path: "/tmp/audit/events.jsonl".to_owned(),
+            result: AuditCommandResult::Summary {
+                limit: 25,
+                loaded_events: 2,
+                event_kind_counts: BTreeMap::from([
+                    ("AuthorizationDenied".to_owned(), 1_usize),
+                    ("PlaneInvoked".to_owned(), 1_usize),
+                ]),
+                triage_counts: BTreeMap::from([("authorization_denied".to_owned(), 1_usize)]),
+                first_timestamp_epoch_s: Some(1_700_010_200),
+                last_event_id: Some("evt-2".to_owned()),
+                last_timestamp_epoch_s: Some(1_700_010_201),
+                last_agent_id: Some("agent-b".to_owned()),
+                last_triage_event_id: Some("evt-1".to_owned()),
+                last_triage_event_kind: Some("AuthorizationDenied".to_owned()),
+                last_triage_timestamp_epoch_s: Some(1_700_010_200),
+                last_triage_agent_id: Some("agent-a".to_owned()),
+            },
+        };
+
+        let payload = audit_cli_json(&execution);
+
+        assert_eq!(payload["first_timestamp_epoch_s"], 1_700_010_200_u64);
+        assert_eq!(payload["triage_counts"]["authorization_denied"], 1);
+        assert_eq!(payload["last_triage_event_id"], "evt-1");
+        assert_eq!(payload["last_triage_event_kind"], "AuthorizationDenied");
+        assert_eq!(payload["last_triage_timestamp_epoch_s"], 1_700_010_200_u64);
+        assert_eq!(payload["last_triage_agent_id"], "agent-a");
+    }
+
+    #[test]
+    fn audit_summary_json_uses_empty_and_null_triage_fields_when_no_triage_events_exist() {
+        let execution = AuditCommandExecution {
+            resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+            journal_path: "/tmp/audit/events.jsonl".to_owned(),
+            result: AuditCommandResult::Summary {
+                limit: 10,
+                loaded_events: 1,
+                event_kind_counts: BTreeMap::from([("TokenIssued".to_owned(), 1_usize)]),
+                triage_counts: BTreeMap::new(),
+                first_timestamp_epoch_s: Some(1_700_010_300),
+                last_event_id: Some("evt-1".to_owned()),
+                last_timestamp_epoch_s: Some(1_700_010_300),
+                last_agent_id: Some("agent-a".to_owned()),
+                last_triage_event_id: None,
+                last_triage_event_kind: None,
+                last_triage_timestamp_epoch_s: None,
+                last_triage_agent_id: None,
+            },
+        };
+
+        let payload = audit_cli_json(&execution);
+
+        assert_eq!(
+            payload["triage_counts"].as_object(),
+            Some(&serde_json::Map::new())
+        );
+        assert_eq!(payload["last_triage_event_id"], Value::Null);
+        assert_eq!(payload["last_triage_event_kind"], Value::Null);
+        assert_eq!(payload["last_triage_timestamp_epoch_s"], Value::Null);
+        assert_eq!(payload["last_triage_agent_id"], Value::Null);
+    }
+
+    #[test]
+    fn audit_summary_text_uses_placeholders_when_no_triage_events_exist() {
+        let execution = AuditCommandExecution {
+            resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+            journal_path: "/tmp/audit/events.jsonl".to_owned(),
+            result: AuditCommandResult::Summary {
+                limit: 10,
+                loaded_events: 1,
+                event_kind_counts: BTreeMap::from([("TokenIssued".to_owned(), 1_usize)]),
+                triage_counts: BTreeMap::new(),
+                first_timestamp_epoch_s: Some(1_700_010_300),
+                last_event_id: Some("evt-1".to_owned()),
+                last_timestamp_epoch_s: Some(1_700_010_300),
+                last_agent_id: Some("agent-a".to_owned()),
+                last_triage_event_id: None,
+                last_triage_event_kind: None,
+                last_triage_timestamp_epoch_s: None,
+                last_triage_agent_id: None,
+            },
+        };
+
+        let rendered = render_audit_cli_text(&execution).expect("render audit summary");
+
+        assert!(rendered.contains("triage_counts=-"));
+        assert!(rendered.contains("last_triage_event_id=-"));
+        assert!(rendered.contains("last_triage_event_kind=-"));
+    }
+}

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -94,6 +94,19 @@ pub async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
         &mut fixes,
         "create memory directory",
     ));
+    checks.push(audit_retention_doctor_check(&config.audit));
+    if matches!(
+        config.audit.mode,
+        mvp::config::AuditMode::Jsonl | mvp::config::AuditMode::Fanout
+    ) {
+        let audit_path = config.audit.resolved_path();
+        let audit_parent = audit_path.parent().unwrap_or(Path::new("."));
+        checks.push(check_audit_journal_directory(
+            audit_parent,
+            options.fix,
+            &mut fixes,
+        ));
+    }
 
     if config
         .tools
@@ -258,6 +271,141 @@ fn check_directory_ready(
 fn check_channel_surfaces(config: &mvp::config::LoongClawConfig) -> Vec<DoctorCheck> {
     let snapshots = mvp::channel::channel_status_snapshots(config);
     build_channel_surface_checks(&snapshots)
+}
+
+fn audit_retention_doctor_check(audit: &mvp::config::AuditConfig) -> DoctorCheck {
+    let path = audit.resolved_path();
+    match audit.mode {
+        mvp::config::AuditMode::InMemory => DoctorCheck {
+            name: "audit retention".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: "audit.mode=in_memory; security-critical audit evidence is lost on restart"
+                .to_owned(),
+        },
+        mvp::config::AuditMode::Jsonl => durable_audit_retention_doctor_check(&path, "jsonl", None),
+        mvp::config::AuditMode::Fanout => durable_audit_retention_doctor_check(
+            &path,
+            "fanout",
+            if audit.retain_in_memory {
+                Some("durable journal + live in-memory snapshot")
+            } else {
+                Some("durable journal only")
+            },
+        ),
+    }
+}
+
+fn durable_audit_retention_doctor_check(
+    path: &Path,
+    mode: &'static str,
+    suffix: Option<&'static str>,
+) -> DoctorCheck {
+    if let Some(issue) = durable_audit_target_issue(path) {
+        return DoctorCheck {
+            name: "audit retention".to_owned(),
+            level: DoctorCheckLevel::Fail,
+            detail: format!("audit.mode={mode} -> {issue}"),
+        };
+    }
+
+    let mut detail = format!("audit.mode={mode} -> {}", path.display());
+    if let Some(suffix) = suffix {
+        detail.push_str(" (");
+        detail.push_str(suffix);
+        detail.push(')');
+    }
+
+    DoctorCheck {
+        name: "audit retention".to_owned(),
+        level: DoctorCheckLevel::Pass,
+        detail,
+    }
+}
+
+fn durable_audit_target_issue(path: &Path) -> Option<String> {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(error) => {
+            return Some(format!(
+                "failed to inspect audit journal {}: {error}",
+                path.display()
+            ));
+        }
+    };
+
+    if !metadata.is_file() {
+        return Some(format!(
+            "{} exists but is not a regular file",
+            path.display()
+        ));
+    }
+
+    if metadata.permissions().readonly() {
+        return Some(format!("{} exists but is not writable", path.display()));
+    }
+
+    None
+}
+
+fn check_audit_journal_directory(
+    directory: &Path,
+    fix: bool,
+    fixes: &mut Vec<String>,
+) -> DoctorCheck {
+    if directory.as_os_str().is_empty() {
+        return DoctorCheck {
+            name: "audit journal directory".to_owned(),
+            level: DoctorCheckLevel::Pass,
+            detail: "current working directory (journal file is created on first audit write)"
+                .to_owned(),
+        };
+    }
+
+    if directory.exists() {
+        if directory.is_dir() {
+            return DoctorCheck {
+                name: "audit journal directory".to_owned(),
+                level: DoctorCheckLevel::Pass,
+                detail: directory.display().to_string(),
+            };
+        }
+        return DoctorCheck {
+            name: "audit journal directory".to_owned(),
+            level: DoctorCheckLevel::Fail,
+            detail: format!("{} exists but is not a directory", directory.display()),
+        };
+    }
+
+    if !fix {
+        return DoctorCheck {
+            name: "audit journal directory".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: format!(
+                "{} is missing (rerun with --fix to create it, or let runtime create it on first audit write)",
+                directory.display()
+            ),
+        };
+    }
+
+    match fs::create_dir_all(directory) {
+        Ok(()) => {
+            fixes.push(format!(
+                "create audit journal directory: {}",
+                directory.display()
+            ));
+            DoctorCheck {
+                name: "audit journal directory".to_owned(),
+                level: DoctorCheckLevel::Pass,
+                detail: format!("created {}", directory.display()),
+            }
+        }
+        Err(error) => DoctorCheck {
+            name: "audit journal directory".to_owned(),
+            level: DoctorCheckLevel::Fail,
+            detail: format!("failed to create {}: {error}", directory.display()),
+        },
+    }
 }
 
 pub fn check_feishu_integration(
@@ -1284,6 +1432,28 @@ fn build_doctor_next_steps_with_path_env(
         }
     }
 
+    if checks
+        .iter()
+        .any(|check| check.name == "audit retention" && check.level == DoctorCheckLevel::Warn)
+    {
+        push_unique_step(
+            &mut steps,
+            "Switch to durable audit retention: set [audit].mode = \"fanout\"".to_owned(),
+        );
+    }
+
+    if checks
+        .iter()
+        .any(|check| check.name == "audit retention" && check.level == DoctorCheckLevel::Fail)
+    {
+        push_unique_step(
+            &mut steps,
+            format!(
+                "Point [audit].path at a writable journal file path, then re-run diagnostics: {rerun_command}"
+            ),
+        );
+    }
+
     if checks.iter().any(|check| {
         check.name == crate::browser_companion_diagnostics::BROWSER_COMPANION_INSTALL_CHECK_NAME
             && check.level != DoctorCheckLevel::Pass
@@ -1471,11 +1641,11 @@ fn push_unique_step(steps: &mut Vec<String>, step: String) {
 mod tests {
     #[cfg(unix)]
     use std::ffi::OsString;
+    use std::fs::Permissions;
     #[cfg(unix)]
     use std::io::Write;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
-    #[cfg(unix)]
     use std::path::{Path, PathBuf};
     #[cfg(unix)]
     use std::sync::MutexGuard;
@@ -1515,6 +1685,23 @@ mod tests {
     struct BrowserCompanionEnvGuard {
         _lock: MutexGuard<'static, ()>,
         saved_ready: Option<OsString>,
+    }
+
+    struct PermissionRestore {
+        path: PathBuf,
+        permissions: Permissions,
+    }
+
+    impl PermissionRestore {
+        fn new(path: PathBuf, permissions: Permissions) -> Self {
+            Self { path, permissions }
+        }
+    }
+
+    impl Drop for PermissionRestore {
+        fn drop(&mut self) {
+            let _ = std::fs::set_permissions(&self.path, self.permissions.clone());
+        }
     }
 
     #[cfg(unix)]
@@ -1928,6 +2115,121 @@ mod tests {
                 .any(|step| step.contains("provider.base_url")),
             "doctor next steps should not include a region endpoint adjustment for non-auth probe failures: {next_steps:#?}"
         );
+    }
+
+    #[test]
+    fn audit_retention_doctor_check_warns_for_in_memory_mode() {
+        let check = audit_retention_doctor_check(&mvp::config::AuditConfig {
+            mode: mvp::config::AuditMode::InMemory,
+            ..mvp::config::AuditConfig::default()
+        });
+
+        assert_eq!(check.name, "audit retention");
+        assert_eq!(check.level, DoctorCheckLevel::Warn);
+        assert!(check.detail.contains("lost on restart"));
+    }
+
+    #[test]
+    fn build_doctor_next_steps_guides_durable_audit_when_in_memory() {
+        let checks = vec![DoctorCheck {
+            name: "audit retention".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: "audit.mode=in_memory; security-critical audit evidence is lost on restart"
+                .to_owned(),
+        }];
+        let config_path = PathBuf::from("/tmp/loongclaw.toml");
+        let next_steps = build_doctor_next_steps_with_path_env(
+            &checks,
+            &config_path,
+            &mvp::config::LoongClawConfig::default(),
+            false,
+            None,
+        );
+
+        assert!(
+            next_steps
+                .iter()
+                .any(|step| step
+                    == "Switch to durable audit retention: set [audit].mode = \"fanout\""),
+            "doctor should recommend durable audit retention when audit remains in-memory: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_guides_fix_when_audit_path_is_invalid() {
+        let checks = vec![DoctorCheck {
+            name: "audit retention".to_owned(),
+            level: DoctorCheckLevel::Fail,
+            detail: "audit.mode=fanout -> /tmp/audit exists but is not a regular file".to_owned(),
+        }];
+        let config_path = PathBuf::from("/tmp/loongclaw.toml");
+        let next_steps = build_doctor_next_steps_with_path_env(
+            &checks,
+            &config_path,
+            &mvp::config::LoongClawConfig::default(),
+            false,
+            None,
+        );
+
+        assert!(
+            next_steps
+                .iter()
+                .any(|step| step.contains("Point [audit].path at a writable journal file path")),
+            "doctor should guide operators toward a writable audit journal target when durable audit retention is misconfigured: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn audit_journal_directory_check_accepts_bare_relative_filename() {
+        let mut fixes = Vec::new();
+        let audit_path = PathBuf::from("events.jsonl");
+        let directory = audit_path.parent().unwrap_or(Path::new("."));
+        let check = check_audit_journal_directory(directory, false, &mut fixes);
+
+        assert_eq!(check.name, "audit journal directory");
+        assert_eq!(check.level, DoctorCheckLevel::Pass);
+        assert!(check.detail.contains("current working directory"));
+        assert!(fixes.is_empty());
+    }
+
+    #[test]
+    fn audit_retention_doctor_check_fails_when_durable_path_is_directory() {
+        let temp_dir = browser_companion_temp_dir("audit-target-directory");
+        let check = audit_retention_doctor_check(&mvp::config::AuditConfig {
+            mode: mvp::config::AuditMode::Fanout,
+            path: temp_dir.display().to_string(),
+            retain_in_memory: true,
+        });
+
+        assert_eq!(check.name, "audit retention");
+        assert_eq!(check.level, DoctorCheckLevel::Fail);
+        assert!(check.detail.contains("not a regular file"));
+    }
+
+    #[test]
+    fn audit_retention_doctor_check_fails_when_durable_path_is_readonly_file() {
+        let temp_dir = browser_companion_temp_dir("audit-target-readonly");
+        let journal_path = temp_dir.join("events.jsonl");
+        std::fs::write(&journal_path, b"{}\n").expect("write audit journal fixture");
+        let original_permissions = std::fs::metadata(&journal_path)
+            .expect("audit journal metadata")
+            .permissions();
+        let mut permissions = original_permissions.clone();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&journal_path, permissions)
+            .expect("mark audit journal fixture readonly");
+        let _permission_restore =
+            PermissionRestore::new(journal_path.clone(), original_permissions);
+
+        let check = audit_retention_doctor_check(&mvp::config::AuditConfig {
+            mode: mvp::config::AuditMode::Jsonl,
+            path: journal_path.display().to_string(),
+            retain_in_memory: false,
+        });
+
+        assert_eq!(check.name, "audit retention");
+        assert_eq!(check.level, DoctorCheckLevel::Fail);
+        assert!(check.detail.contains("not writable"));
     }
 
     fn unique_temp_feishu_db(label: &str) -> String {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -37,6 +37,7 @@ pub use base64;
 pub use kernel;
 pub use sha2;
 
+pub mod audit_cli;
 mod browser_companion_diagnostics;
 pub mod browser_preview;
 mod cli_handoff;
@@ -353,6 +354,15 @@ pub enum Commands {
         /// Skip provider model probing during diagnostics
         #[arg(long, default_value_t = false)]
         skip_model_probe: bool,
+    },
+    /// Inspect the retained audit journal through a bounded CLI surface
+    Audit {
+        #[arg(long, global = true)]
+        config: Option<String>,
+        #[arg(long, global = true, default_value_t = false)]
+        json: bool,
+        #[command(subcommand)]
+        command: audit_cli::AuditCommands,
     },
     /// Manage installed external skills through an operator-facing CLI surface
     Skills {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -202,6 +202,15 @@ async fn main() {
             })
             .await
         }
+        Commands::Audit {
+            config,
+            json,
+            command,
+        } => audit_cli::run_audit_cli(audit_cli::AuditCommandOptions {
+            config,
+            json,
+            command,
+        }),
         Commands::Skills {
             config,
             json,

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -214,6 +214,63 @@ fn ask_cli_requires_message_flag() {
 }
 
 #[test]
+fn audit_cli_recent_parses_global_flags_after_subcommand() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "audit",
+        "recent",
+        "--config",
+        "/tmp/loongclaw.toml",
+        "--limit",
+        "25",
+        "--json",
+    ])
+    .expect("audit recent CLI should parse");
+
+    match cli.command {
+        Some(Commands::Audit {
+            config,
+            json,
+            command,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(json);
+            match command {
+                loongclaw_daemon::audit_cli::AuditCommands::Recent { limit } => {
+                    assert_eq!(limit, 25);
+                }
+                other => panic!("unexpected audit subcommand parsed: {other:?}"),
+            }
+        }
+        other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn audit_cli_summary_parses_limit_without_json() {
+    let cli = Cli::try_parse_from(["loongclaw", "audit", "summary", "--limit", "10"])
+        .expect("audit summary CLI should parse");
+
+    match cli.command {
+        Some(Commands::Audit {
+            config,
+            json,
+            command,
+        }) => {
+            assert_eq!(config, None);
+            assert!(!json);
+            match command {
+                loongclaw_daemon::audit_cli::AuditCommands::Summary { limit } => {
+                    assert_eq!(limit, 10);
+                }
+                other => panic!("unexpected audit subcommand parsed: {other:?}"),
+            }
+        }
+        other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
 fn resolve_validate_output_defaults_to_text() {
     let resolved = resolve_validate_output(false, None).expect("resolve default output");
     assert_eq!(resolved, ValidateConfigOutput::Text);

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -31,7 +31,7 @@ optional `scripts/pre-commit` hook mirrors these cargo gates locally.
 ## Kernel Invariants
 
 1. **Token authorization is fail-closed** — if the policy engine cannot determine authorization (e.g., mutex poisoned), the operation is denied.
-2. **Audit events are never silently dropped** — production-shaped CLI chat, Telegram, and Feishu bootstraps default to `audit.mode = "fanout"`, which appends `~/.loongclaw/audit/events.jsonl` and can retain in-memory snapshots for local diagnostics. `LoongClawKernel::new()` now defaults to `InMemoryAuditSink`, `spec` bootstrap/runner helpers intentionally use a named in-memory audit helper for side-effect-free snapshot reporting, and `NoopAuditSink` remains reserved for callers that explicitly opt into `new_without_audit(...)` or wire a noop sink themselves.
+2. **Audit events are never silently dropped** — kernel sinks fail closed on write errors instead of silently downgrading. Production app bootstraps default to `FanoutAuditSink` backed by `~/.loongclaw/audit/events.jsonl`, `LoongClawKernel::new()` defaults to `InMemoryAuditSink`, and spec/test/demo helpers may intentionally use explicit in-memory audit seams for side-effect-free reporting. `NoopAuditSink` remains reserved for callers that explicitly opt into `new_without_audit(...)` or wire a noop sink themselves.
 3. **Pack registration is idempotent-safe** — duplicate pack IDs return `DuplicatePack` error, never silently overwrite.
 4. **Generation-based revocation is monotonic** — the revocation threshold only increases, never decreases.
 5. **TaskState transitions are irreversible from terminal states** — `Completed` and `Faulted` states cannot transition.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -54,16 +54,11 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 ### Audit System
 
 - 7 event kinds with atomic sequencing
-- Durable JSONL retention is available on production-shaped app bootstraps through `[audit]`
-  config (`in_memory`, `jsonl`, `fanout`)
-- CLI chat, Telegram, and Feishu runtime bootstraps now default to `fanout`, which appends
-  `~/.loongclaw/audit/events.jsonl` while retaining an in-memory snapshot lane for diagnostics
-- Operators can inspect recent entries with standard tooling such as
-  `tail -n 20 ~/.loongclaw/audit/events.jsonl`
-- No HMAC chain for tamper evidence (TD-007)
-- `spec` bootstrap and spec-execution helpers intentionally default to a named in-memory audit
-  helper so side-effect-free harness/demo runs can still surface audit snapshots in `SpecRunReport`
+- Production app runtimes default to durable JSONL retention via `[audit].mode = "fanout"`
+- Default journal path: `~/.loongclaw/audit/events.jsonl`
+- `LoongClawKernel::new()` and spec/test/demo helpers may still opt into explicit in-memory audit seams when side-effect-free snapshot reporting is required
 - Explicit no-audit behavior remains opt-in only and should stay reserved for narrow fixture seams
+- No HMAC chain for tamper evidence (TD-007)
 
 ### Compile-Time Constraints
 


### PR DESCRIPTION
## Summary

- Problem:
  LoongClaw started retaining durable audit evidence again, but developers still had to remember the journal path and inspect raw JSONL manually. The existing PR copy was also still describing the discarded repo-debug-review workflow.
- Why it matters:
  repository debugging only improves if audit evidence both survives restarts and is inspectable through first-party commands instead of ad-hoc local helper setup.
- What changed:
  added config-backed durable audit retention and serialized JSONL writes, hardened `doctor` against false-green durable journal targets, wired production app bootstraps through the configured audit sink, extended `doctor` with audit retention and journal readiness checks, added `loongclaw audit recent` / `loongclaw audit summary`, enriched `audit summary` with triage counts, window bounds, and last-triage-event pointers, then closed the review follow-up gaps with regression coverage for `SecurityScanEvaluated { blocked: false }`, stable empty-triage JSON output, and corrected implementation-plan test commands.
- What did not change (scope boundary):
  no external-skill debugging workflow, no audit query DSL or indexed storage, no trace-id redesign, and no retention rotation or remote upload in this slice.

## Linked Issues

- Closes #258
- Related # n/a

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  this changes the default audit retention behavior for production-facing app bootstraps and adds a new first-party CLI reader over the retained journal.
- Rollout / guardrails:
  roll out on `alpha-test`; `doctor` surfaces retention posture and journal readiness, `audit summary` now highlights recent deny/block/failover signals, and `audit recent` / `audit summary` still fail with explicit hints when the journal is absent or durable retention is disabled.
- Rollback path:
  revert this PR, or opt the runtime back to `[audit].mode = "in_memory"` while investigating filesystem or environment issues.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
  - Passed.

cargo clippy -p loongclaw-daemon --all-targets --all-features -- -D warnings
  - Passed. Covers the current follow-up slice without broadening scope beyond daemon/CLI code.

cargo test -p loongclaw-daemon audit_summary_ -- --test-threads=1
  - Passed. Covers the triage-summary follow-up gap directly, including the new `blocked: false` negative control and empty/no-triage JSON stability assertions.

cargo test -p loongclaw-daemon audit -- --test-threads=1
  - Passed. Covers doctor audit guidance, invalid durable journal target preflight, and audit recent/summary text and JSON behavior, including the new summary triage fields.

cargo test -p loongclaw-daemon --all-features audit_ -- --test-threads=1
  - Passed. Confirms the summary triage additions remain correct under the full daemon feature set.

cargo test -p loongclaw-daemon --test integration audit_cli_ -- --test-threads=1
  - Passed. Covers top-level CLI parsing for `audit recent` and `audit summary`.
```

Before / after behavior:

- Before:
  developers could retain audit evidence after the earlier config-backed sink work, but built-in inspection still ended at `doctor` plus manual `tail` over `~/.loongclaw/audit/events.jsonl`.
- After:
  developers can inspect the bounded recent event window with `loongclaw audit recent` and use `loongclaw audit summary` as the first triage stop, with compact kind counts, deny/block/failover rollups, window bounds, and a last-triage-event pointer, while `doctor` continues to surface retention posture and directory readiness.

Regression coverage:

- explicit durable path: app audit persistence tests write to configured JSONL paths and daemon tests read back from configured journal files.
- fallback path: app config tests cover empty-path fallback to the default audit location under `LOONGCLAW_HOME`.
- boundary values: daemon tests cover `--limit 0`, missing journal hints, invalid durable journal directory/file targets, `SecurityScanEvaluated { blocked: false }` as a negative control, stable empty/no-triage text placeholders and JSON null/object fields, and the `[audit].mode = "in_memory"` missing-journal path.

## User-visible / Operator-visible Changes

- production-facing app bootstraps now retain audit evidence durably by default under `~/.loongclaw/audit/events.jsonl` with `[audit].mode = "fanout"`.
- `loongclaw doctor` now reports audit retention posture and journal-directory readiness, and fails preflight when a durable journal target is an invalid file path.
- developers can inspect recent retained events with `loongclaw audit recent`, and `loongclaw audit summary` now surfaces compact triage counts, first/last window timestamps, and the last triage event pointer.

## Failure Recovery

- Fast rollback or disable path:
  revert this PR, or switch `[audit].mode` back to `"in_memory"` while debugging an environment-specific filesystem issue.
- Observable failure symptoms reviewers should watch for:
  missing journal creation under durable modes, interleaved JSONL records, misleading doctor readiness output, or audit CLI decode failures on a supposedly well-formed journal.

## Reviewer Focus

- validate `crates/kernel/src/audit.rs` for durable sink fanout and concurrent JSONL append behavior.
- validate `crates/app/src/config/audit.rs` and `crates/app/src/context.rs` for config-backed bootstrap defaults and journal-path resolution.
- validate `crates/daemon/src/doctor_cli.rs` and `crates/daemon/src/audit_cli.rs` for clear operator guidance, bounded journal reads, and stable summary output.
