### PR TITLE
fix: drain stdin between onboard prompts to prevent multiline paste corruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1997,6 +1997,7 @@ dependencies = [
  "chrono",
  "clap",
  "ed25519-dalek",
+ "libc",
  "loongclaw-app",
  "loongclaw-bench",
  "loongclaw-kernel",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -27,6 +27,10 @@ tool-file = ["loongclaw-app/tool-file"]
 tool-webfetch = ["loongclaw-app/tool-webfetch"]
 tool-browser = ["loongclaw-app/tool-browser"]
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+
 [dependencies]
 clap.workspace = true
 kernel = { package = "loongclaw-kernel", path = "../kernel" }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -2,8 +2,32 @@
 use clap::Parser;
 use loongclaw_daemon::*;
 
+/// Guard that flushes the terminal input queue on drop.
+///
+/// When a user pastes multi-line text at an interactive prompt, `read_line()`
+/// consumes only the first line. The remaining lines stay in the kernel's tty
+/// input queue (cooked mode). If the process exits without draining, the parent
+/// shell reads those lines as commands — a potential code execution vector.
+///
+/// This guard calls `tcflush(STDIN_FILENO, TCIFLUSH)` on drop to discard any
+/// unread input, covering all exit paths including early returns and panics.
+struct StdinGuard;
+
+impl Drop for StdinGuard {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        // SAFETY: tcflush is a POSIX function that discards unread terminal input.
+        // STDIN_FILENO is a well-defined constant. No memory or resource concerns.
+        unsafe {
+            libc::tcflush(libc::STDIN_FILENO, libc::TCIFLUSH);
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() {
+    let _stdin_guard = StdinGuard;
     let cli = Cli::parse();
     let result = match cli.command.unwrap_or(Commands::Demo) {
         Commands::Demo => run_demo().await,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -2,26 +2,35 @@
 use clap::Parser;
 use loongclaw_daemon::*;
 
-/// Guard that flushes the terminal input queue on drop.
+/// Discard any unread input from the terminal's tty input queue.
 ///
 /// When a user pastes multi-line text at an interactive prompt, `read_line()`
 /// consumes only the first line. The remaining lines stay in the kernel's tty
 /// input queue (cooked mode). If the process exits without draining, the parent
 /// shell reads those lines as commands — a potential code execution vector.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn flush_stdin() {
+    // SAFETY: tcflush is a POSIX function that discards unread terminal input.
+    // STDIN_FILENO is a well-defined constant. No memory or resource concerns.
+    unsafe {
+        libc::tcflush(libc::STDIN_FILENO, libc::TCIFLUSH);
+    }
+}
+
+#[cfg(not(unix))]
+fn flush_stdin() {}
+
+/// Guard that flushes the terminal input queue on drop.
 ///
-/// This guard calls `tcflush(STDIN_FILENO, TCIFLUSH)` on drop to discard any
-/// unread input, covering all exit paths including early returns and panics.
+/// Covers normal return and panic unwinding. For `process::exit()` paths,
+/// `flush_stdin()` must be called explicitly before exit since
+/// `process::exit()` does not run destructors.
 struct StdinGuard;
 
 impl Drop for StdinGuard {
-    #[allow(unsafe_code)]
     fn drop(&mut self) {
-        #[cfg(unix)]
-        // SAFETY: tcflush is a POSIX function that discards unread terminal input.
-        // STDIN_FILENO is a well-defined constant. No memory or resource concerns.
-        unsafe {
-            libc::tcflush(libc::STDIN_FILENO, libc::TCIFLUSH);
-        }
+        flush_stdin();
     }
 }
 
@@ -441,6 +450,7 @@ async fn main() {
         {
             eprintln!("error: {error}");
         }
+        flush_stdin();
         std::process::exit(2);
     }
 }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -67,6 +67,26 @@ impl OnboardRuntimeContext {
 #[derive(Debug, Default)]
 struct StdioOnboardUi;
 
+/// Discard any remaining lines in the terminal's tty input queue.
+///
+/// When a user pastes multi-line text at a single-line prompt, `read_line()`
+/// consumes only the first line. Remaining lines stay in the kernel's tty input
+/// queue and would be silently consumed by subsequent `read_line()` calls,
+/// corrupting downstream prompts. This function discards those leftover lines
+/// between prompts.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn drain_stdin_line_buffer() {
+    // SAFETY: tcflush is a POSIX function that discards unread terminal input.
+    // STDIN_FILENO is a well-defined constant. No memory or resource concerns.
+    unsafe {
+        libc::tcflush(libc::STDIN_FILENO, libc::TCIFLUSH);
+    }
+}
+
+#[cfg(not(unix))]
+fn drain_stdin_line_buffer() {}
+
 impl OnboardUi for StdioOnboardUi {
     fn print_line(&mut self, line: &str) -> CliResult<()> {
         println!("{line}");
@@ -82,6 +102,7 @@ impl OnboardUi for StdioOnboardUi {
         io::stdin()
             .read_line(&mut line)
             .map_err(|error| format!("read stdin failed: {error}"))?;
+        drain_stdin_line_buffer();
         let trimmed = line.trim();
         if trimmed.is_empty() {
             return Ok(default.to_owned());
@@ -98,6 +119,7 @@ impl OnboardUi for StdioOnboardUi {
         io::stdin()
             .read_line(&mut line)
             .map_err(|error| format!("read stdin failed: {error}"))?;
+        drain_stdin_line_buffer();
         Ok(line.trim().to_owned())
     }
 
@@ -111,6 +133,7 @@ impl OnboardUi for StdioOnboardUi {
         io::stdin()
             .read_line(&mut line)
             .map_err(|error| format!("read stdin failed: {error}"))?;
+        drain_stdin_line_buffer();
         let value = line.trim().to_ascii_lowercase();
         if value.is_empty() {
             return Ok(default);


### PR DESCRIPTION
## Summary

- Adds `drain_stdin_line_buffer()` using `tcflush(TCIFLUSH)` and calls it after every `read_line()` in `StdioOnboardUi` (`prompt_with_default`, `prompt_required`, `prompt_confirm`)
- When a user pastes multiline text at any single-line onboard prompt, leftover lines no longer leak into subsequent prompts
- Complements the exit-time `StdinGuard` from #249 (which prevents post-exit shell injection but not intra-session corruption)

## Test plan

- [ ] `loongclaw onboard --force` → paste two lines at "Prompt addendum" step → verify second line does NOT appear in next prompt
- [ ] Verify single-line input still works normally at every step
- [ ] Verify non-interactive mode (`--non-interactive`) is unaffected

Closes #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal input handling on Unix systems to ensure clean state during daemon operations and user prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->