### PR TITLE
kernel: add durable audit journal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ cargo test --workspace --all-features
 2. Implement the `ChannelAdapter` trait (`name`, `receive_batch`, `send_text`)
 3. Add a `run_your_channel()` function in `crates/app/src/channel/mod.rs` that:
    - Loads config
-   - Calls `bootstrap_kernel_context("channel-your-channel", DEFAULT_TOKEN_TTL_S)`
+   - Calls `bootstrap_kernel_context_with_config("channel-your-channel", DEFAULT_TOKEN_TTL_S, &config)`
    - Loops: receive messages → `process_inbound_with_provider(config, msg, Some(&ctx))` → send reply
 4. Wire the subcommand in `crates/daemon/src/main.rs`
 5. Add a feature flag in `crates/app/Cargo.toml`

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -823,7 +823,7 @@ mod tests {
     use super::*;
     use crate::channel::ChannelPlatform;
     use crate::config::{LoongClawConfig, ProviderConfig};
-    use crate::context::{DEFAULT_TOKEN_TTL_S, KernelContext, bootstrap_kernel_context};
+    use crate::context::{DEFAULT_TOKEN_TTL_S, KernelContext, bootstrap_test_kernel_context};
     use crate::tools::runtime_config::ToolRuntimeConfig;
     use axum::{
         Json, Router,
@@ -1508,7 +1508,7 @@ mod tests {
             .refresh_tenant_token()
             .await
             .expect("refresh tenant token before webhook test");
-        let kernel_ctx = bootstrap_kernel_context("feishu-webhook-test", DEFAULT_TOKEN_TTL_S)
+        let kernel_ctx = bootstrap_test_kernel_context("feishu-webhook-test", DEFAULT_TOKEN_TTL_S)
             .expect("bootstrap kernel context");
         let runtime = Arc::new(
             ChannelOperationRuntimeTracker::start(
@@ -1631,7 +1631,7 @@ mod tests {
             .expect("resolve feishu account");
         let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
         let kernel_ctx =
-            bootstrap_kernel_context("feishu-webhook-card-callback", DEFAULT_TOKEN_TTL_S)
+            bootstrap_test_kernel_context("feishu-webhook-card-callback", DEFAULT_TOKEN_TTL_S)
                 .expect("bootstrap kernel context");
         let runtime = Arc::new(
             ChannelOperationRuntimeTracker::start(
@@ -1737,9 +1737,11 @@ mod tests {
             .resolve_account(None)
             .expect("resolve feishu account");
         let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
-        let kernel_ctx =
-            bootstrap_kernel_context("feishu-webhook-card-callback-toast", DEFAULT_TOKEN_TTL_S)
-                .expect("bootstrap kernel context");
+        let kernel_ctx = bootstrap_test_kernel_context(
+            "feishu-webhook-card-callback-toast",
+            DEFAULT_TOKEN_TTL_S,
+        )
+        .expect("bootstrap kernel context");
         let runtime = Arc::new(
             ChannelOperationRuntimeTracker::start(
                 ChannelPlatform::Feishu,
@@ -1826,7 +1828,7 @@ mod tests {
             .expect("resolve feishu account");
         let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
         let kernel_ctx =
-            bootstrap_kernel_context("feishu-webhook-card-callback-card", DEFAULT_TOKEN_TTL_S)
+            bootstrap_test_kernel_context("feishu-webhook-card-callback-card", DEFAULT_TOKEN_TTL_S)
                 .expect("bootstrap kernel context");
         let runtime = Arc::new(
             ChannelOperationRuntimeTracker::start(
@@ -1917,7 +1919,7 @@ mod tests {
             .resolve_account(None)
             .expect("resolve feishu account");
         let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
-        let kernel_ctx = bootstrap_kernel_context(
+        let kernel_ctx = bootstrap_test_kernel_context(
             "feishu-webhook-card-callback-card-markdown",
             DEFAULT_TOKEN_TTL_S,
         )
@@ -2014,7 +2016,7 @@ mod tests {
             .resolve_account(None)
             .expect("resolve feishu account");
         let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
-        let kernel_ctx = bootstrap_kernel_context(
+        let kernel_ctx = bootstrap_test_kernel_context(
             "feishu-webhook-card-callback-card-with-toast",
             DEFAULT_TOKEN_TTL_S,
         )
@@ -2113,7 +2115,7 @@ mod tests {
             .resolve_account(None)
             .expect("resolve feishu account");
         let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
-        let kernel_ctx = bootstrap_kernel_context(
+        let kernel_ctx = bootstrap_test_kernel_context(
             "feishu-webhook-card-callback-card-markdown-with-toast",
             DEFAULT_TOKEN_TTL_S,
         )
@@ -2233,7 +2235,7 @@ mod tests {
             .resolve_account(None)
             .expect("resolve feishu account");
         let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
-        let kernel_ctx = bootstrap_kernel_context(
+        let kernel_ctx = bootstrap_test_kernel_context(
             "feishu-webhook-card-callback-invalid-toast",
             DEFAULT_TOKEN_TTL_S,
         )
@@ -2311,7 +2313,7 @@ mod tests {
             .resolve_account(None)
             .expect("resolve feishu account");
         let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
-        let kernel_ctx = bootstrap_kernel_context(
+        let kernel_ctx = bootstrap_test_kernel_context(
             "feishu-webhook-card-callback-invalid-card",
             DEFAULT_TOKEN_TTL_S,
         )
@@ -2385,9 +2387,11 @@ mod tests {
             .resolve_account(None)
             .expect("resolve feishu account");
         let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
-        let kernel_ctx =
-            bootstrap_kernel_context("feishu-webhook-card-callback-dedupe", DEFAULT_TOKEN_TTL_S)
-                .expect("bootstrap kernel context");
+        let kernel_ctx = bootstrap_test_kernel_context(
+            "feishu-webhook-card-callback-dedupe",
+            DEFAULT_TOKEN_TTL_S,
+        )
+        .expect("bootstrap kernel context");
         let runtime = Arc::new(
             ChannelOperationRuntimeTracker::start(
                 ChannelPlatform::Feishu,
@@ -2686,9 +2690,11 @@ mod tests {
             .resolve_account(None)
             .expect("resolve feishu account");
         let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
-        let kernel_ctx =
-            bootstrap_kernel_context("feishu-webhook-card-callback-failure", DEFAULT_TOKEN_TTL_S)
-                .expect("bootstrap kernel context");
+        let kernel_ctx = bootstrap_test_kernel_context(
+            "feishu-webhook-card-callback-failure",
+            DEFAULT_TOKEN_TTL_S,
+        )
+        .expect("bootstrap kernel context");
         let runtime = Arc::new(
             ChannelOperationRuntimeTracker::start(
                 ChannelPlatform::Feishu,

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -24,7 +24,7 @@ use crate::KernelContext;
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
 use crate::acp::{AcpConversationTurnOptions, AcpTurnProvenance};
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
-use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context};
+use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context_with_config};
 
 #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
 use super::config::{
@@ -924,9 +924,10 @@ where
         &context.config,
         Some(context.resolved_path.as_path()),
     );
-    let kernel_ctx = bootstrap_kernel_context(
+    let kernel_ctx = bootstrap_kernel_context_with_config(
         spec.family.runtime.serve_bootstrap_agent_id,
         DEFAULT_TOKEN_TTL_S,
+        &context.config,
     )?;
     let runtime_account_id = context.resolved.runtime_account_id().to_owned();
     let runtime_account_label = context.resolved.runtime_account_label().to_owned();
@@ -1003,7 +1004,11 @@ pub async fn run_telegram_channel(
             &context.config,
             Some(context.resolved_path.as_path()),
         );
-        let kernel_ctx = bootstrap_kernel_context("channel-telegram", DEFAULT_TOKEN_TTL_S)?;
+        let kernel_ctx = bootstrap_kernel_context_with_config(
+            "channel-telegram",
+            DEFAULT_TOKEN_TTL_S,
+            &context.config,
+        )?;
         let token = context.resolved.bot_token().ok_or_else(|| {
             "telegram bot token missing (set telegram.bot_token or env)".to_owned()
         })?;

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -11,7 +11,7 @@ use crate::acp::{
     AcpConversationTurnOptions, AcpTurnEventSink, JsonlAcpTurnEventSink,
     resolve_acp_backend_selection,
 };
-use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context};
+use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context_with_config};
 
 use super::config::{self, ConversationConfig, LoongClawConfig};
 #[cfg(feature = "memory-sqlite")]
@@ -289,7 +289,8 @@ async fn initialize_cli_turn_runtime(
     }
 
     crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
-    let kernel_ctx = bootstrap_kernel_context(kernel_scope, DEFAULT_TOKEN_TTL_S)?;
+    let kernel_ctx =
+        bootstrap_kernel_context_with_config(kernel_scope, DEFAULT_TOKEN_TTL_S, &config)?;
     let explicit_acp_request = options.requests_explicit_acp();
     let effective_bootstrap_mcp_servers = config
         .acp

--- a/crates/app/src/config/audit.rs
+++ b/crates/app/src/config/audit.rs
@@ -1,0 +1,83 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::shared::{default_loongclaw_home, expand_path};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditConfig {
+    #[serde(default)]
+    pub mode: AuditMode,
+    #[serde(default = "default_audit_path")]
+    pub path: String,
+    #[serde(default = "default_true")]
+    pub retain_in_memory: bool,
+}
+
+impl Default for AuditConfig {
+    fn default() -> Self {
+        Self {
+            mode: AuditMode::default(),
+            path: default_audit_path(),
+            retain_in_memory: default_true(),
+        }
+    }
+}
+
+impl AuditConfig {
+    pub fn resolved_path(&self) -> PathBuf {
+        expand_path(&self.path)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditMode {
+    InMemory,
+    Jsonl,
+    #[default]
+    Fanout,
+}
+
+impl AuditMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InMemory => "in_memory",
+            Self::Jsonl => "jsonl",
+            Self::Fanout => "fanout",
+        }
+    }
+}
+
+fn default_audit_path() -> String {
+    default_loongclaw_home()
+        .join("audit")
+        .join("events.jsonl")
+        .display()
+        .to_string()
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audit_config_defaults_to_fanout_under_loongclaw_home() {
+        let config = AuditConfig::default();
+
+        assert_eq!(config.mode, AuditMode::Fanout);
+        assert!(config.retain_in_memory);
+        assert!(config.path.ends_with(".loongclaw/audit/events.jsonl"));
+    }
+
+    #[test]
+    fn audit_mode_ids_are_stable() {
+        assert_eq!(AuditMode::InMemory.as_str(), "in_memory");
+        assert_eq!(AuditMode::Jsonl.as_str(), "jsonl");
+        assert_eq!(AuditMode::Fanout.as_str(), "fanout");
+    }
+}

--- a/crates/app/src/config/audit.rs
+++ b/crates/app/src/config/audit.rs
@@ -26,7 +26,11 @@ impl Default for AuditConfig {
 
 impl AuditConfig {
     pub fn resolved_path(&self) -> PathBuf {
-        expand_path(&self.path)
+        let trimmed = self.path.trim();
+        if trimmed.is_empty() {
+            return expand_path(&default_audit_path());
+        }
+        expand_path(trimmed)
     }
 }
 
@@ -79,5 +83,18 @@ mod tests {
         assert_eq!(AuditMode::InMemory.as_str(), "in_memory");
         assert_eq!(AuditMode::Jsonl.as_str(), "jsonl");
         assert_eq!(AuditMode::Fanout.as_str(), "fanout");
+    }
+
+    #[test]
+    fn audit_config_empty_path_falls_back_to_default_location() {
+        let config = AuditConfig {
+            path: "   ".to_owned(),
+            ..AuditConfig::default()
+        };
+
+        assert_eq!(
+            config.resolved_path(),
+            default_loongclaw_home().join("audit").join("events.jsonl")
+        );
     }
 }

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -1,3 +1,4 @@
+mod audit;
 mod channels;
 mod conversation;
 mod feishu_integration;
@@ -7,6 +8,8 @@ mod runtime;
 mod shared;
 mod tools;
 
+#[allow(unused_imports)]
+pub use audit::{AuditConfig, AuditMode};
 #[allow(unused_imports)]
 pub use channels::{
     ChannelAcpConfig, ChannelDefaultAccountSelection, ChannelDefaultAccountSelectionSource,

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::CliResult;
 
 use super::{
+    audit::AuditConfig,
     channels::{CliChannelConfig, FeishuChannelConfig, TelegramChannelConfig},
     conversation::ConversationConfig,
     feishu_integration::FeishuIntegrationConfig,
@@ -87,6 +88,8 @@ pub struct LoongClawConfig {
     pub external_skills: ExternalSkillsConfig,
     #[serde(default)]
     pub memory: MemoryConfig,
+    #[serde(default)]
+    pub audit: AuditConfig,
     #[serde(default)]
     pub acp: AcpConfig,
 }
@@ -2751,5 +2754,19 @@ model = "gpt-5"
         assert_eq!(parsed.tools.sessions, config.tools.sessions);
         assert_eq!(parsed.tools.messages, config.tools.messages);
         assert_eq!(parsed.tools.delegate, config.tools.delegate);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn audit_config_round_trips_mode_and_path_settings() {
+        let mut config = LoongClawConfig::default();
+        config.audit.mode = crate::config::AuditMode::Jsonl;
+        config.audit.path = "~/.loongclaw/audit/custom-events.jsonl".to_owned();
+        config.audit.retain_in_memory = false;
+
+        let encoded = encode_toml_config(&config).expect("encode config");
+        let parsed = toml::from_str::<LoongClawConfig>(&encoded).expect("parse encoded config");
+
+        assert_eq!(parsed.audit, config.audit);
     }
 }

--- a/crates/app/src/context.rs
+++ b/crates/app/src/context.rs
@@ -3,9 +3,11 @@ use std::sync::Arc;
 
 use loongclaw_contracts::CapabilityToken;
 use loongclaw_kernel::{
-    AuditSink, Capability, Clock, ExecutionRoute, HarnessKind, InMemoryAuditSink, LoongClawKernel,
-    StaticPolicyEngine, SystemClock, VerticalPackManifest,
+    AuditSink, Capability, Clock, ExecutionRoute, FanoutAuditSink, HarnessKind, InMemoryAuditSink,
+    JsonlAuditSink, LoongClawKernel, StaticPolicyEngine, SystemClock, VerticalPackManifest,
 };
+
+use crate::config::{AuditMode, LoongClawConfig};
 
 /// Default pack identifier used by MVP entry points.
 const MVP_PACK_ID: &str = "dev-automation";
@@ -41,14 +43,65 @@ impl KernelContext {
 /// Registers a default pack manifest with `InvokeTool`, `MemoryRead`, and
 /// `MemoryWrite` capabilities, then issues a long-lived token for the given
 /// `agent_id`.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn bootstrap_kernel_context(
     agent_id: &str,
     ttl_s: u64,
 ) -> Result<KernelContext, String> {
+    bootstrap_kernel_context_with_audit_sink(
+        agent_id,
+        ttl_s,
+        Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
+    )
+}
+
+pub(crate) fn bootstrap_kernel_context_with_config(
+    agent_id: &str,
+    ttl_s: u64,
+    config: &LoongClawConfig,
+) -> Result<KernelContext, String> {
+    bootstrap_kernel_context_with_audit_sink(agent_id, ttl_s, build_audit_sink(config)?)
+}
+
+fn build_audit_sink(config: &LoongClawConfig) -> Result<Arc<dyn AuditSink>, String> {
+    match config.audit.mode {
+        AuditMode::InMemory => Ok(Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>),
+        AuditMode::Jsonl => build_jsonl_audit_sink(config),
+        AuditMode::Fanout => {
+            let durable = build_jsonl_audit_sink(config)?;
+            if !config.audit.retain_in_memory {
+                return Ok(durable);
+            }
+
+            Ok(Arc::new(FanoutAuditSink::new(vec![
+                Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
+                durable,
+            ])) as Arc<dyn AuditSink>)
+        }
+    }
+}
+
+fn build_jsonl_audit_sink(config: &LoongClawConfig) -> Result<Arc<dyn AuditSink>, String> {
+    let path = config.audit.resolved_path();
+    JsonlAuditSink::new(path.clone())
+        .map(|sink| Arc::new(sink) as Arc<dyn AuditSink>)
+        .map_err(|error| {
+            format!(
+                "failed to initialize durable audit journal {}: {error}",
+                path.display()
+            )
+        })
+}
+
+fn bootstrap_kernel_context_with_audit_sink(
+    agent_id: &str,
+    ttl_s: u64,
+    audit_sink: Arc<dyn AuditSink>,
+) -> Result<KernelContext, String> {
     let mut kernel = LoongClawKernel::with_runtime(
         StaticPolicyEngine::default(),
         Arc::new(SystemClock) as Arc<dyn Clock>,
-        Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
+        audit_sink,
     );
 
     let pack = VerticalPackManifest {
@@ -107,4 +160,39 @@ pub(crate) fn bootstrap_kernel_context(
         kernel: Arc::new(kernel),
         token,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn bootstrap_kernel_context_with_config_writes_jsonl_audit_events() {
+        let tempdir = tempdir().expect("tempdir");
+        let audit_path = tempdir.path().join("audit").join("events.jsonl");
+        let mut config = LoongClawConfig::default();
+        config.audit.mode = AuditMode::Jsonl;
+        config.audit.path = audit_path.display().to_string();
+        config.audit.retain_in_memory = false;
+
+        let context = bootstrap_kernel_context_with_config("test-agent", 60, &config)
+            .expect("bootstrap with jsonl audit should succeed");
+
+        assert_eq!(context.agent_id(), "test-agent");
+
+        let journal = fs::read_to_string(&audit_path).expect("audit journal should exist");
+        assert_eq!(
+            journal.lines().count(),
+            1,
+            "token bootstrap should emit one audit event"
+        );
+        assert!(
+            journal.contains("\"TokenIssued\"") || journal.contains("\"token_id\""),
+            "bootstrap journal should capture token issuance"
+        );
+    }
 }

--- a/crates/app/src/context.rs
+++ b/crates/app/src/context.rs
@@ -38,13 +38,16 @@ impl KernelContext {
     }
 }
 
-/// Bootstrap a minimal kernel suitable for MVP entry points.
+/// Bootstrap a minimal in-memory kernel suitable for tests.
 ///
 /// Registers a default pack manifest with `InvokeTool`, `MemoryRead`, and
 /// `MemoryWrite` capabilities, then issues a long-lived token for the given
 /// `agent_id`.
-#[cfg_attr(not(test), allow(dead_code))]
-pub(crate) fn bootstrap_kernel_context(
+///
+/// Production-facing runtime entrypoints should prefer
+/// `bootstrap_kernel_context_with_config` so audit retention follows config.
+#[cfg(test)]
+pub(crate) fn bootstrap_test_kernel_context(
     agent_id: &str,
     ttl_s: u64,
 ) -> Result<KernelContext, String> {
@@ -74,8 +77,8 @@ fn build_audit_sink(config: &LoongClawConfig) -> Result<Arc<dyn AuditSink>, Stri
             }
 
             Ok(Arc::new(FanoutAuditSink::new(vec![
-                Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
                 durable,
+                Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
             ])) as Arc<dyn AuditSink>)
         }
     }
@@ -193,6 +196,32 @@ mod tests {
         assert!(
             journal.contains("\"TokenIssued\"") || journal.contains("\"token_id\""),
             "bootstrap journal should capture token issuance"
+        );
+    }
+
+    #[test]
+    fn bootstrap_kernel_context_with_config_writes_fanout_audit_events() {
+        let tempdir = tempdir().expect("tempdir");
+        let audit_path = tempdir.path().join("audit").join("events.jsonl");
+        let mut config = LoongClawConfig::default();
+        config.audit.mode = AuditMode::Fanout;
+        config.audit.path = audit_path.display().to_string();
+        config.audit.retain_in_memory = true;
+
+        let context = bootstrap_kernel_context_with_config("test-agent", 60, &config)
+            .expect("bootstrap with fanout audit should succeed");
+
+        assert_eq!(context.agent_id(), "test-agent");
+
+        let journal = fs::read_to_string(&audit_path).expect("audit journal should exist");
+        assert_eq!(
+            journal.lines().count(),
+            1,
+            "token bootstrap should emit one audit event"
+        );
+        assert!(
+            journal.contains("\"TokenIssued\"") || journal.contains("\"token_id\""),
+            "fanout journal should capture token issuance"
         );
     }
 }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1170,7 +1170,8 @@ fn test_config() -> LoongClawConfig {
 }
 
 fn test_kernel_context(agent_id: &str) -> KernelContext {
-    crate::context::bootstrap_kernel_context(agent_id, 60).expect("bootstrap test kernel context")
+    crate::context::bootstrap_test_kernel_context(agent_id, 60)
+        .expect("bootstrap test kernel context")
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1494,7 +1495,7 @@ async fn default_runtime_delegates_bootstrap_and_ingest_to_context_engine_with_k
         DefaultConversationRuntime::with_context_engine(RecordingLifecycleContextEngine {
             calls: calls.clone(),
         });
-    let kernel_ctx = crate::context::bootstrap_kernel_context("test-runtime-lifecycle", 60)
+    let kernel_ctx = crate::context::bootstrap_test_kernel_context("test-runtime-lifecycle", 60)
         .expect("bootstrap kernel context");
 
     let bootstrap = runtime
@@ -1531,7 +1532,7 @@ async fn default_runtime_delegates_subagent_lifecycle_to_context_engine_with_ker
         DefaultConversationRuntime::with_context_engine(RecordingLifecycleContextEngine {
             calls: calls.clone(),
         });
-    let kernel_ctx = crate::context::bootstrap_kernel_context("test-runtime-subagent", 60)
+    let kernel_ctx = crate::context::bootstrap_test_kernel_context("test-runtime-subagent", 60)
         .expect("bootstrap kernel context");
 
     runtime
@@ -1859,7 +1860,7 @@ async fn handle_turn_with_runtime_success_with_kernel_runs_lifecycle_hooks() {
         Ok("assistant-reply".to_owned()),
     );
     let coordinator = ConversationTurnCoordinator::new();
-    let kernel_ctx = crate::context::bootstrap_kernel_context("test-handle-turn-success", 60)
+    let kernel_ctx = crate::context::bootstrap_test_kernel_context("test-handle-turn-success", 60)
         .expect("bootstrap kernel context");
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -9197,7 +9198,7 @@ async fn load_discovery_first_event_summary_preserves_public_kernel_context_sign
 #[cfg(not(feature = "memory-sqlite"))]
 #[tokio::test]
 async fn persist_turn_without_memory_sqlite_is_noop_with_kernel_context() {
-    let ctx = crate::context::bootstrap_kernel_context("test-agent-no-memory", 60)
+    let ctx = crate::context::bootstrap_test_kernel_context("test-agent-no-memory", 60)
         .expect("bootstrap kernel context without memory-sqlite");
     let runtime = DefaultConversationRuntime::default();
     runtime

--- a/crates/kernel/src/audit.rs
+++ b/crates/kernel/src/audit.rs
@@ -1,3 +1,6 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 // Re-export data types from contracts
@@ -39,6 +42,101 @@ impl AuditSink for InMemoryAuditSink {
             .lock()
             .map_err(|_err| AuditError::Sink("audit mutex poisoned".to_owned()))?;
         guard.push(event);
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct JsonlAuditSink {
+    path: PathBuf,
+    write_lock: Mutex<()>,
+}
+
+impl JsonlAuditSink {
+    pub fn new(path: PathBuf) -> Result<Self, AuditError> {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent).map_err(|error| {
+                AuditError::Sink(format!(
+                    "failed to prepare audit journal parent directory `{}`: {error}",
+                    parent.display()
+                ))
+            })?;
+        }
+
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|error| {
+                AuditError::Sink(format!(
+                    "failed to open audit journal `{}`: {error}",
+                    path.display()
+                ))
+            })?;
+
+        Ok(Self {
+            path,
+            write_lock: Mutex::new(()),
+        })
+    }
+}
+
+impl AuditSink for JsonlAuditSink {
+    fn record(&self, event: AuditEvent) -> Result<(), AuditError> {
+        let _guard = self
+            .write_lock
+            .lock()
+            .map_err(|_error| AuditError::Sink("audit write mutex poisoned".to_owned()))?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .map_err(|error| {
+                AuditError::Sink(format!(
+                    "failed to open audit journal `{}` for append: {error}",
+                    self.path.display()
+                ))
+            })?;
+        let json_line = serde_json::to_string(&event).map_err(|error| {
+            AuditError::Sink(format!("failed to serialize audit event: {error}"))
+        })?;
+        file.write_all(json_line.as_bytes()).map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to write audit journal `{}`: {error}",
+                self.path.display()
+            ))
+        })?;
+        file.write_all(b"\n").map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to finalize audit journal `{}`: {error}",
+                self.path.display()
+            ))
+        })?;
+        Ok(())
+    }
+}
+
+pub struct FanoutAuditSink {
+    children: Vec<Arc<dyn AuditSink>>,
+}
+
+impl FanoutAuditSink {
+    #[must_use]
+    pub fn new(children: Vec<Arc<dyn AuditSink>>) -> Self {
+        Self { children }
+    }
+}
+
+impl AuditSink for FanoutAuditSink {
+    fn record(&self, event: AuditEvent) -> Result<(), AuditError> {
+        if let Some((last, rest)) = self.children.split_last() {
+            for sink in rest {
+                sink.record(event.clone())?;
+            }
+            last.record(event)?;
+        }
         Ok(())
     }
 }

--- a/crates/kernel/src/audit.rs
+++ b/crates/kernel/src/audit.rs
@@ -1,6 +1,6 @@
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 // Re-export data types from contracts
@@ -49,7 +49,7 @@ impl AuditSink for InMemoryAuditSink {
 #[derive(Debug)]
 pub struct JsonlAuditSink {
     path: PathBuf,
-    write_lock: Mutex<()>,
+    journal: Mutex<File>,
 }
 
 impl JsonlAuditSink {
@@ -65,7 +65,7 @@ impl JsonlAuditSink {
             })?;
         }
 
-        OpenOptions::new()
+        let journal = OpenOptions::new()
             .create(true)
             .append(true)
             .open(&path)
@@ -78,43 +78,69 @@ impl JsonlAuditSink {
 
         Ok(Self {
             path,
-            write_lock: Mutex::new(()),
+            journal: Mutex::new(journal),
         })
     }
 }
 
+fn serialize_audit_event_line(
+    event: &AuditEvent,
+    journal_path: &Path,
+) -> Result<Vec<u8>, AuditError> {
+    let mut encoded = serde_json::to_vec(event).map_err(|error| {
+        AuditError::Sink(format!(
+            "failed to serialize audit event for `{}`: {error}",
+            journal_path.display()
+        ))
+    })?;
+    encoded.push(b'\n');
+    Ok(encoded)
+}
+
 impl AuditSink for JsonlAuditSink {
     fn record(&self, event: AuditEvent) -> Result<(), AuditError> {
-        let _guard = self
-            .write_lock
+        let mut guard = self
+            .journal
             .lock()
-            .map_err(|_error| AuditError::Sink("audit write mutex poisoned".to_owned()))?;
-        let mut file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)
+            .map_err(|_error| AuditError::Sink("audit journal mutex poisoned".to_owned()))?;
+        let encoded = serialize_audit_event_line(&event, &self.path)?;
+
+        guard.lock().map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to lock audit journal `{}`: {error}",
+                self.path.display()
+            ))
+        })?;
+
+        let write_result = guard
+            .write_all(&encoded)
             .map_err(|error| {
                 AuditError::Sink(format!(
-                    "failed to open audit journal `{}` for append: {error}",
+                    "failed to append audit event to `{}`: {error}",
                     self.path.display()
                 ))
-            })?;
-        let json_line = serde_json::to_string(&event).map_err(|error| {
-            AuditError::Sink(format!("failed to serialize audit event: {error}"))
-        })?;
-        file.write_all(json_line.as_bytes()).map_err(|error| {
+            })
+            .and_then(|()| {
+                guard.flush().map_err(|error| {
+                    AuditError::Sink(format!(
+                        "failed to flush audit journal `{}`: {error}",
+                        self.path.display()
+                    ))
+                })
+            });
+
+        let unlock_result = guard.unlock().map_err(|error| {
             AuditError::Sink(format!(
-                "failed to write audit journal `{}`: {error}",
+                "failed to unlock audit journal `{}`: {error}",
                 self.path.display()
             ))
-        })?;
-        file.write_all(b"\n").map_err(|error| {
-            AuditError::Sink(format!(
-                "failed to finalize audit journal `{}`: {error}",
-                self.path.display()
-            ))
-        })?;
-        Ok(())
+        });
+
+        match (write_result, unlock_result) {
+            (Err(error), _) => Err(error),
+            (Ok(()), Err(error)) => Err(error),
+            (Ok(()), Ok(())) => Ok(()),
+        }
     }
 }
 
@@ -125,6 +151,10 @@ pub struct FanoutAuditSink {
 impl FanoutAuditSink {
     #[must_use]
     pub fn new(children: Vec<Arc<dyn AuditSink>>) -> Self {
+        assert!(
+            !children.is_empty(),
+            "fanout audit sink requires at least one child"
+        );
         Self { children }
     }
 }

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -26,8 +26,8 @@ pub use architecture::{
     ArchitecturePathReport,
 };
 pub use audit::{
-    AuditEvent, AuditEventKind, AuditSink, ExecutionPlane, InMemoryAuditSink, NoopAuditSink,
-    PlaneTier,
+    AuditEvent, AuditEventKind, AuditSink, ExecutionPlane, FanoutAuditSink, InMemoryAuditSink,
+    JsonlAuditSink, NoopAuditSink, PlaneTier,
 };
 pub use awareness::{CodebaseAwarenessConfig, CodebaseAwarenessEngine, CodebaseAwarenessSnapshot};
 pub use bootstrap::{

--- a/crates/kernel/src/tests.rs
+++ b/crates/kernel/src/tests.rs
@@ -1,19 +1,117 @@
 use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use proptest::prelude::*;
 use serde_json::json;
 
-use crate::audit::{AuditEventKind, InMemoryAuditSink};
+use crate::audit::{
+    AuditEvent, AuditEventKind, AuditSink, FanoutAuditSink, InMemoryAuditSink, JsonlAuditSink,
+};
 use crate::clock::FixedClock;
 use crate::contracts::{Capability, HarnessOutcome, TaskIntent};
-use crate::errors::{KernelError, PolicyError};
+use crate::errors::{AuditError, KernelError, PolicyError};
 use crate::kernel::LoongClawKernel;
 use crate::policy::{PolicyEngine, StaticPolicyEngine};
 use crate::task_supervisor::TaskSupervisor;
+use crate::{ExecutionPlane, PlaneTier};
 use crate::{Fault, TaskState};
 
 use crate::test_support::*;
+
+fn fresh_audit_temp_path(label: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    std::env::temp_dir().join(format!(
+        "loongclaw-kernel-audit-{label}-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+fn sample_audit_event(event_id: &str, timestamp_epoch_s: u64) -> AuditEvent {
+    AuditEvent {
+        event_id: event_id.to_owned(),
+        timestamp_epoch_s,
+        agent_id: Some("agent-audit".to_owned()),
+        kind: AuditEventKind::PlaneInvoked {
+            pack_id: "sales-intel".to_owned(),
+            plane: ExecutionPlane::Tool,
+            tier: PlaneTier::Core,
+            primary_adapter: "mvp-tools".to_owned(),
+            delegated_core_adapter: None,
+            operation: "shell.exec".to_owned(),
+            required_capabilities: vec![Capability::InvokeTool],
+        },
+    }
+}
+
+#[test]
+fn jsonl_audit_sink_appends_one_json_line_per_event() {
+    let path = fresh_audit_temp_path("jsonl");
+    let sink = JsonlAuditSink::new(path.clone()).expect("jsonl sink should initialize");
+
+    sink.record(sample_audit_event("evt-1", 100))
+        .expect("first event should record");
+    sink.record(sample_audit_event("evt-2", 101))
+        .expect("second event should record");
+
+    let contents = fs::read_to_string(&path).expect("audit journal should exist");
+    let lines = contents.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), 2, "expected one JSON line per audit event");
+
+    let first: AuditEvent =
+        serde_json::from_str(lines[0]).expect("first JSON line should decode into AuditEvent");
+    let second: AuditEvent =
+        serde_json::from_str(lines[1]).expect("second JSON line should decode into AuditEvent");
+    assert_eq!(first.event_id, "evt-1");
+    assert_eq!(second.event_id, "evt-2");
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn fanout_audit_sink_records_to_all_children() {
+    let path = fresh_audit_temp_path("fanout");
+    let memory = Arc::new(InMemoryAuditSink::default());
+    let jsonl = Arc::new(JsonlAuditSink::new(path.clone()).expect("jsonl sink should initialize"));
+    let sink = FanoutAuditSink::new(vec![
+        memory.clone() as Arc<dyn AuditSink>,
+        jsonl as Arc<dyn AuditSink>,
+    ]);
+
+    sink.record(sample_audit_event("evt-fanout", 200))
+        .expect("fanout sink should record");
+
+    let memory_events = memory.snapshot();
+    assert_eq!(
+        memory_events.len(),
+        1,
+        "in-memory sink should receive event"
+    );
+
+    let contents = fs::read_to_string(&path).expect("jsonl fanout sink should write file");
+    assert_eq!(
+        contents.lines().count(),
+        1,
+        "jsonl child should receive event"
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn jsonl_audit_sink_surfaces_io_errors() {
+    let path = fresh_audit_temp_path("jsonl-dir");
+    fs::create_dir(&path).expect("directory fixture should create");
+
+    let error = JsonlAuditSink::new(path.clone()).expect_err("directory path should fail");
+    assert!(matches!(error, AuditError::Sink(_)));
+
+    let _ = fs::remove_dir_all(path);
+}
 
 #[test]
 fn pack_validation_rejects_invalid_semver() {

--- a/crates/kernel/src/tests.rs
+++ b/crates/kernel/src/tests.rs
@@ -1,8 +1,10 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use proptest::prelude::*;
 use serde_json::json;
@@ -111,6 +113,50 @@ fn jsonl_audit_sink_surfaces_io_errors() {
     assert!(matches!(error, AuditError::Sink(_)));
 
     let _ = fs::remove_dir_all(path);
+}
+
+#[test]
+fn jsonl_audit_sink_waits_for_existing_file_lock_before_appending() {
+    let path = fresh_audit_temp_path("jsonl-lock");
+    let sink = JsonlAuditSink::new(path.clone()).expect("jsonl sink should initialize");
+    let external_lock = fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .expect("open external audit journal handle");
+    external_lock
+        .lock()
+        .expect("hold external audit journal lock");
+
+    let (tx, rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let result = sink.record(sample_audit_event("evt-locked", 202));
+        tx.send(result).expect("send audit result");
+    });
+
+    match rx.recv_timeout(Duration::from_millis(100)) {
+        Err(mpsc::RecvTimeoutError::Timeout) => {}
+        Ok(result) => panic!("audit write should block on external file lock, got {result:?}"),
+        Err(error) => panic!("audit write channel closed unexpectedly: {error:?}"),
+    }
+
+    external_lock
+        .unlock()
+        .expect("release external audit journal lock");
+    rx.recv_timeout(Duration::from_secs(1))
+        .expect("audit write should complete after lock release")
+        .expect("audit write should succeed after lock release");
+    handle.join().expect("join audit writer thread");
+
+    let contents = fs::read_to_string(&path).expect("audit journal should exist");
+    assert_eq!(contents.lines().count(), 1);
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+#[should_panic(expected = "fanout audit sink requires at least one child")]
+fn fanout_audit_sink_rejects_empty_children() {
+    let _ = FanoutAuditSink::new(Vec::new());
 }
 
 #[test]

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -30,7 +30,7 @@ Enforced by: CI (`verify` workflow). The optional `scripts/pre-commit` hook mirr
 ## Kernel Invariants
 
 1. **Token authorization is fail-closed** — if the policy engine cannot determine authorization (e.g., mutex poisoned), the operation is denied.
-2. **Audit events are never silently dropped** — all bootstrap paths use `InMemoryAuditSink` or better. `NoopAuditSink` is reserved for tests that explicitly don't need audit.
+2. **Audit events are never silently dropped** — production-shaped CLI chat, Telegram, and Feishu bootstraps default to `audit.mode = "fanout"`, which appends `~/.loongclaw/audit/events.jsonl` and can retain in-memory snapshots for local diagnostics. Test-only helpers may still use `InMemoryAuditSink`, and `NoopAuditSink` remains reserved for cases that explicitly do not need audit.
 3. **Pack registration is idempotent-safe** — duplicate pack IDs return `DuplicatePack` error, never silently overwrite.
 4. **Generation-based revocation is monotonic** — the revocation threshold only increases, never decreases.
 5. **TaskState transitions are irreversible from terminal states** — `Completed` and `Faulted` states cannot transition.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # LoongClaw Roadmap
 
-Last updated: 2026-03-16
+Last updated: 2026-03-17
 
 This roadmap is execution-focused. Every stage has:
 
@@ -405,8 +405,55 @@ Options:
 
 Trade-off: if D2 lands, this becomes test-only infrastructure. May not be worth optimizing independently.
 
+### D6: Retire governed/direct runtime drift
+
+`ConversationRuntimeBinding` and `ProviderRuntimeBinding` make governance explicit, but `Direct`
+still survives as a compatibility lane deeper in the runtime than the long-term architecture wants.
+The next kernel-first closure track should push direct behavior back toward ingress, compatibility
+wrappers, and tests, while keeping governed reads and governed side effects fail-closed where
+possible.
+
+Trade-off: improves architecture truthfulness and future maintainability, but must be executed in
+small bounded slices instead of one repo-wide kernelization patch.
+
+### D7: ACP control-plane hardening and recovery
+
+ACP is now a real control plane rather than an experiment, but too much lifecycle, observability,
+and backend transport behavior still concentrates in a few large hotspots. The next ACP work should
+focus on decomposition, stuck-turn recovery, cancel/close repair, and clearer observability before
+adding more surface breadth.
+
+Trade-off: lowers merge risk and control-plane debt, but requires disciplined ownership extraction
+instead of feature-driven growth inside large files.
+
+### D8: Shared execution security tiers
+
+The roadmap already names process sandbox profile tiers, but the wider runtime still needs one
+shared execution-tier vocabulary across process, browser, and WASM lanes. Without that, each lane
+risks growing its own security semantics and evidence model.
+
+Trade-off: the first slice should standardize the contract, not attempt a giant all-lane sandbox
+rewrite.
+
+### D9: First-party workflow packs on hardened primitives
+
+Once the runtime base is harder, LoongClaw should turn that into a small set of first-party
+workflow packs that prove the kernel's value in operator-facing tasks such as release/review work,
+issue triage, or channel support.
+
+Trade-off: this is the right productization direction, but it should follow runtime hardening
+instead of preceding it.
+
 ## Current Priority Order
 
-1. Stage 2 hardening: memory/timeout isolation + sandbox tiers
-2. Stage 2 hot-reload reliability: pre/post checks + rollback contract
-3. Stage 3 baseline: connector contract versioning and idempotent reconciliation
+1. Kernel-first runtime closure and direct-path retirement
+2. Persistent audit sink and query baseline (`#172`)
+3. ACP control-plane hardening and recovery
+4. Shared execution security tiers across process/browser/WASM lanes
+5. First-party workflow packs on hardened runtime primitives
+
+Execution package for this order:
+
+- `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-design.md`
+- `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-implementation-plan.md`
+- `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-github-backlog.md`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -447,7 +447,7 @@ instead of preceding it.
 ## Current Priority Order
 
 1. Kernel-first runtime closure and direct-path retirement
-2. Persistent audit sink and query baseline (`#172`)
+2. Persistent audit sink and query baseline
 3. ACP control-plane hardening and recovery
 4. Shared execution security tiers across process/browser/WASM lanes
 5. First-party workflow packs on hardened runtime primitives

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -54,9 +54,15 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 ### Audit System
 
 - 7 event kinds with atomic sequencing
-- In-memory only (TD-006) — lost on restart
+- Durable JSONL retention is available on production-shaped app bootstraps through `[audit]`
+  config (`in_memory`, `jsonl`, `fanout`)
+- CLI chat, Telegram, and Feishu runtime bootstraps now default to `fanout`, which appends
+  `~/.loongclaw/audit/events.jsonl` while retaining an in-memory snapshot lane for diagnostics
+- Operators can inspect recent entries with standard tooling such as
+  `tail -n 20 ~/.loongclaw/audit/events.jsonl`
 - No HMAC chain for tamper evidence (TD-007)
-- No persistent audit sink
+- Spec/demo helpers and explicit test seams may still opt into in-memory-only audit when
+  side-effect-free execution is required
 
 ### Compile-Time Constraints
 

--- a/docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-design.md
+++ b/docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-design.md
@@ -1,0 +1,377 @@
+# Alpha-Test Internal Runtime Hardening Design
+
+Date: 2026-03-17
+Branch: `docs/internal-runtime-hardening`
+Scope: choose the next internal hardening program for `alpha-test` and prepare it for clean GitHub issue/PR intake
+Status: approved internal roadmap and backlog direction
+
+## Problem
+
+`alpha-test` already looks more like a real kernel than most agent repositories:
+
+1. the architecture contract is explicit and mechanically enforced
+2. kernel capability, policy, and audit seams are real
+3. the repository already carries design docs, issue-first discipline, and CI parity gates
+
+That is the good news.
+
+The remaining risk is subtler and more important than adding one more feature surface. The branch
+still has a truthfulness gap between its strongest architectural claims and a few production-shaped
+runtime seams:
+
+1. [Core Beliefs](../design-docs/core-beliefs.md) says all execution paths are kernel-first with no
+   shadow paths, but the app runtime still normalizes explicit `Direct` compatibility lanes through
+   `ConversationRuntimeBinding` and `ProviderRuntimeBinding`.
+2. [Security](../SECURITY.md) explicitly says connector, ACP, and runtime-only analytics are still
+   not uniformly routed through the L1 policy chain.
+3. the kernel already owns a clean `AuditSink` seam, but
+   [`crates/kernel/src/audit.rs`](../../crates/kernel/src/audit.rs) is still in-memory only.
+4. the ACP control plane is real and valuable, but the complexity budget is now concentrated in a
+   few very large hotspots:
+   - `crates/app/src/acp/manager.rs` at 3063 lines
+   - `crates/app/src/acp/acpx.rs` at 2574 lines
+   - `crates/app/src/conversation/turn_coordinator.rs` at 8613 lines
+
+This is the wrong point to optimize for breadth. The next program should harden the runtime's
+truthfulness, evidence durability, and control-plane decomposition before LoongClaw spends more of
+its complexity budget on outward-facing product surfaces.
+
+## Goals
+
+1. Pick the next 4-5 internal workstreams that most improve runtime truthfulness and operator
+   confidence on `alpha-test`.
+2. Reuse the repository's existing design momentum instead of opening duplicate or contradictory
+   tracks.
+3. Turn that direction into GitHub-ready artifacts:
+   - a docs issue draft for this planning package
+   - one umbrella feature issue
+   - child issue drafts for new workstreams
+   - one PR draft for the current documentation package
+4. Keep the plan honest about what is already strong versus what is still soft.
+
+## Non-Goals
+
+1. Do not optimize README or external onboarding in this slice.
+2. Do not copy a competitor feature matrix into LoongClaw.
+3. Do not reopen already-closed broad policy work just because related gaps remain.
+4. Do not treat productization or workflow packs as the first next move.
+5. Do not redesign the entire repository in one mega-refactor.
+
+## Current State And Evidence
+
+### 1. Kernel direction is already strong
+
+The repository's kernel shape is not hypothetical:
+
+1. `crates/kernel/src/kernel.rs` is a real orchestration boundary for runtime, tool, memory, and
+   connector execution.
+2. the repository enforces the crate DAG and architecture boundaries mechanically
+3. `docs/design-docs/layered-kernel-design.md` already defines L1-L9 responsibilities with a clear
+   kernel-first bias
+
+This matters because the right next step is to finish the strongest story LoongClaw already has,
+not to pivot away from it.
+
+### 2. Explicit compatibility lanes still exist
+
+The branch has already improved from implicit `Option<&KernelContext>` ambiguity to explicit
+runtime bindings, but it has not fully retired governed-versus-direct drift:
+
+1. `crates/app/src/conversation/runtime_binding.rs` still models `ConversationRuntimeBinding` as
+   `Kernel` or `Direct`
+2. `crates/app/src/provider/runtime_binding.rs` does the same for provider execution
+3. `docs/SECURITY.md` still documents intentional non-uniform L1 coverage for connector, ACP, and
+   runtime-only analytics
+
+That is a valid compatibility position, but it is not yet the end-state architecture implied by
+the core beliefs.
+
+### 3. Durable audit is the clearest kernel evidence gap
+
+The audit seam is already well-shaped:
+
+1. `AuditSink` is small and kernel-owned
+2. kernel operations already propagate sink errors
+3. the repository already has a concrete design for durable audit in
+   `docs/plans/2026-03-15-persistent-audit-sink-design.md`
+
+The gap is not design ambiguity. The gap is that the durable path still has not landed, and issue
+`#172` is already open for it.
+
+### 4. ACP is strategically important but now needs hardening more than expansion
+
+The ACP pre-embed work is directionally correct. LoongClaw already distinguishes:
+
+1. ACP control plane
+2. ACP runtime backends such as ACPX
+3. explicit dispatch policy
+4. session-aware routing and observability
+
+That is the right shape. The risk is not "ACP should go away." The risk is that further ACP growth
+on top of the current file-size and recovery complexity will accumulate avoidable control-plane
+debt.
+
+### 5. Provider runtime decomposition is the right internal model to copy
+
+`crates/app/src/provider/mod.rs` is down to 294 lines because the provider runtime has already been
+decomposed into focused runtime and policy modules. That is a proof point inside this same branch:
+LoongClaw already knows how to reduce a large orchestration hotspot without losing behavior.
+
+ACP should follow that style instead of staying concentrated in one manager file and one backend
+file indefinitely.
+
+## External Calibration
+
+The comparison target is not a shopping list. It is a calibration exercise against the primary
+repository surfaces of these projects as seen on 2026-03-17:
+
+1. OpenClaw emphasizes a strong gateway/control-plane model, multi-channel session orchestration,
+   and ACP-aware runtime behavior.
+2. nanobot emphasizes radical simplicity and low implementation weight.
+3. NanoClaw emphasizes container isolation and understandable secure execution.
+4. ZeroClaw emphasizes a small Rust runtime with secure-by-default positioning.
+5. OpenFang emphasizes operator OS packaging, durable audit language, and prebuilt autonomous
+   capability packages.
+
+The useful inference is not "LoongClaw should become all of them." The useful inference is:
+
+1. LoongClaw already has stronger architecture governance than the lightweight clones.
+2. LoongClaw is directionally aligned with the strongest systems on kernel/runtime boundaries.
+3. LoongClaw still lags the strongest operator platforms on durable evidence, execution packaging,
+   and control-plane polish.
+
+That makes the next move clear: finish the kernel truth and runtime hardening first, then
+productize from a stronger base.
+
+## Approaches Considered
+
+### A. Product-surface-first push
+
+Prioritize workflow packs, browser-first UX, and operator-facing packaging immediately.
+
+Rejected.
+
+This would spend complexity on the most visible surfaces before the underlying execution truth is
+fully hardened. It risks building a glossy layer over runtime seams that are still intentionally
+soft.
+
+### B. Single-gap hardening only
+
+Do only one slice such as persistent audit or only one more runtime-binding fix.
+
+Rejected as the main program direction.
+
+Each slice is good on its own, but the repository now needs a coherent near-term program, not a
+pile of disconnected "good ideas."
+
+### C. Internal runtime hardening program
+
+Prioritize:
+
+1. kernel-first runtime closure
+2. durable audit retention and operator queryability
+3. ACP control-plane decomposition and recovery
+4. cross-lane execution tiers
+5. first-party workflow packs only after the runtime base is harder
+
+Recommended.
+
+This keeps LoongClaw on its strongest line of development and uses existing repo momentum instead
+of inventing a new identity mid-stream.
+
+## Decision
+
+Adopt Approach C.
+
+The next LoongClaw program should be an internal runtime hardening track with one umbrella issue
+and four primary child streams:
+
+1. Kernel-first runtime closure and direct-path retirement
+2. Persistent kernel audit sink and query baseline
+3. ACP control-plane lifecycle hardening and observability
+4. Cross-lane execution security tiers
+
+First-party workflow packs remain important, but only as the fifth stream after the runtime base is
+harder and more truthful.
+
+## Program Streams
+
+### Stream 1: Kernel-First Runtime Closure
+
+Priority: P0
+
+This stream exists to finish the architectural truth that the repo already claims.
+
+Target outcome:
+
+1. `Direct` remains only as an explicit compatibility seam at ingress, tests, or intentionally
+   unsupported paths
+2. deep orchestration code no longer silently slides from governed to direct behavior
+3. governed reads and governed side effects fail closed instead of silently re-entering shadow paths
+
+Likely file surfaces:
+
+1. `crates/app/src/conversation/runtime_binding.rs`
+2. `crates/app/src/provider/runtime_binding.rs`
+3. `crates/app/src/conversation/turn_coordinator.rs`
+4. `crates/app/src/conversation/session_history.rs`
+5. `crates/app/src/chat.rs`
+6. `docs/SECURITY.md`
+7. `ARCHITECTURE.md`
+
+Existing repo momentum to reuse:
+
+1. `docs/plans/2026-03-15-conversation-runtime-binding-design.md`
+2. `docs/plans/2026-03-15-conversation-lifecycle-kernelization-design.md`
+3. `docs/plans/2026-03-16-governed-runtime-path-hardening-design.md`
+4. `docs/plans/2026-03-15-provider-binding-normalization-design.md`
+
+Why it comes first:
+
+Because runtime truthfulness is the highest-value improvement LoongClaw can make before adding more
+operator surface area.
+
+### Stream 2: Persistent Audit Sink And Query Baseline
+
+Priority: P1
+
+This stream should reuse existing open issue `#172` rather than opening a duplicate.
+
+Target outcome:
+
+1. security-critical audit evidence survives restart
+2. production-shaped bootstraps stop defaulting to process-local-only evidence
+3. operators get a minimal local inspection/query surface
+
+Likely file surfaces:
+
+1. `crates/kernel/src/audit.rs`
+2. `crates/kernel/src/lib.rs`
+3. `crates/kernel/src/tests.rs`
+4. `crates/app/src/config/runtime.rs`
+5. `crates/app/src/context.rs`
+6. `crates/spec/src/kernel_bootstrap.rs`
+7. `docs/SECURITY.md`
+8. `docs/RELIABILITY.md`
+
+Why it is second:
+
+It is the cleanest kernel-owned evidence gap, the design is already written, and the issue is
+already open. It should move immediately after the kernel-closure umbrella is in place.
+
+### Stream 3: ACP Control-Plane Hardening And Recovery
+
+Priority: P2
+
+This stream is not about adding more ACP concepts. It is about making the existing ACP stack easier
+to reason about, recover, and observe.
+
+Target outcome:
+
+1. `AcpSessionManager` is decomposed into smaller ownership boundaries
+2. ACPX transport/process management is separated from control-plane semantics
+3. stuck-turn recovery, cancel/close repair, and status observability become explicit and testable
+4. ACP runtime events have a durable story instead of only a process-local one
+
+Likely file surfaces:
+
+1. `crates/app/src/acp/manager.rs`
+2. `crates/app/src/acp/acpx.rs`
+3. `crates/app/src/acp/backend.rs`
+4. `crates/app/src/acp/store.rs`
+5. `crates/app/src/conversation/turn_coordinator.rs`
+6. `docs/design-docs/acp-acpx-preembed.md`
+
+Why it is third:
+
+ACP is already strategically valuable. The next best move is hardening and decomposition, not more
+surface-area growth.
+
+### Stream 4: Cross-Lane Execution Security Tiers
+
+Priority: P3
+
+LoongClaw already names sandbox tiers in the roadmap, but the execution story still needs one
+shared tier model across process, browser, and WASM-style lanes.
+
+Target outcome:
+
+1. one vocabulary for `restricted`, `balanced`, and `trusted` execution
+2. policy defaults and runtime evidence are aligned across bridges
+3. browser/process/WASM lanes stop drifting into lane-specific security semantics
+
+Likely file surfaces:
+
+1. `crates/kernel/src/policy.rs`
+2. `crates/kernel/src/runtime.rs`
+3. bridge execution surfaces in `crates/spec`
+4. browser/runtime integration surfaces in `crates/daemon`
+5. `docs/SECURITY.md`
+6. `docs/ROADMAP.md`
+
+Why it is fourth:
+
+This is the right time to unify lane semantics, but only after kernel truth and durable evidence are
+stronger.
+
+### Stream 5: First-Party Workflow Packs
+
+Priority: P4
+
+This remains the right productization direction after the runtime base is harder.
+
+Target outcome:
+
+1. 2-3 first-party workflow packs that show the value of the kernel
+2. packs build on hardened execution, audit, and control-plane boundaries instead of compensating
+   for weak ones
+
+Possible starting packs:
+
+1. release/review operator pack
+2. issue triage and maintenance pack
+3. channel support or customer-ops pack
+
+Why it is last in this program:
+
+Because this is where LoongClaw should cash in the runtime investment, not where it should borrow
+against it.
+
+## Sequencing
+
+Recommended execution order:
+
+1. open one docs issue and ship the current planning PR
+2. open one umbrella runtime-hardening feature issue
+3. open a new Stream 1 issue because earlier broad policy-unification issue `#45` is closed
+4. reuse open issue `#172` for Stream 2
+5. open new issues for Stream 3 and Stream 4
+6. leave Stream 5 as a later issue after Streams 1-4 are underway
+
+## Why This Direction Is Better Than More Surface Breadth
+
+This program intentionally resists "slop debt."
+
+It does not propose:
+
+1. a large unscoped rewrite
+2. cargo-culted competitor features
+3. product breadth ahead of runtime truth
+4. duplicate issues for work that the repo is already tracking clearly
+
+Instead it builds on the repository's strongest qualities:
+
+1. kernel-first architecture
+2. strong design-doc culture
+3. explicit control over complexity growth
+4. a preference for small, composable, reviewable slices
+
+## Acceptance Criteria
+
+This design is successful if it produces and aligns all of the following:
+
+1. a written internal runtime hardening direction grounded in current repo evidence
+2. a prioritized execution order that explains why each stream is where it is
+3. explicit reuse of open issue `#172` and explicit non-reuse of closed issue `#45`
+4. GitHub-ready issue and PR drafts for the planning package and the next workstreams
+5. a roadmap update that reflects the same priority order

--- a/docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-github-backlog.md
+++ b/docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-github-backlog.md
@@ -1,0 +1,512 @@
+# Alpha-Test Internal Runtime Hardening GitHub Backlog
+
+This document prepares the current planning package and the next runtime-hardening streams for
+clean GitHub issue/PR submission.
+
+## Submission Order
+
+1. Open the docs issue below.
+2. Open the umbrella feature issue below.
+3. Open the new Stream 1 issue below.
+4. Reuse open issue `#172` for Stream 2.
+5. Open the Stream 3 and Stream 4 issues below.
+6. Open the docs PR using the draft at the end of this document.
+7. Leave the workflow-pack issue as deferred unless Streams 1-4 are already underway.
+
+## Existing Tracking To Reuse Or Avoid
+
+### Reuse
+
+- Issue `#172` is open:
+  `[Feature] Add persistent kernel audit sink and fanout boundary`
+
+### Do Not Reuse
+
+- Issue `#45` is closed:
+  `Policy Unification: five parallel security decision paths bypass the kernel policy chain`
+
+The remaining kernel-closure work is real, but it needs a new bounded follow-up issue instead of
+reopening a closed broad unification track.
+
+## Docs Issue Draft
+
+Route: `Documentation Improvement`
+
+Suggested title:
+
+```text
+[Docs]: Document the alpha-test internal runtime hardening roadmap and GitHub backlog
+```
+
+Suggested body:
+
+```text
+Area
+Docs / contributor workflow
+
+Summary
+The repository now has enough internal design momentum that the next runtime-hardening direction
+should be captured explicitly in-repo instead of remaining spread across separate plan documents
+and chat context.
+
+Current gap
+The branch already contains strong design work around conversation runtime bindings, governed
+runtime path hardening, persistent audit, provider runtime decomposition, and ACP pre-embed
+architecture. However, there is no single planning package that:
+- explains the next internal priority order
+- distinguishes which existing issues should be reused versus replaced
+- prepares GitHub-ready issue and PR copy for the next execution streams
+
+Proposed improvement
+Add a documentation package that includes:
+- one design doc for the internal runtime hardening direction
+- one implementation plan for turning that direction into execution tracks
+- one GitHub backlog document with issue/PR drafts
+- one roadmap update so the same priority order is visible from docs/ROADMAP.md
+
+Evidence / links
+- docs/plans/2026-03-16-governed-runtime-path-hardening-design.md
+- docs/plans/2026-03-15-persistent-audit-sink-design.md
+- docs/design-docs/acp-acpx-preembed.md
+- docs/ROADMAP.md
+
+Impact
+Maintainers and contributors can reason about the next internal priorities without reconstructing
+them from multiple plan files or chat history, and the next issue/PR intake becomes cleaner.
+```
+
+## Umbrella Feature Issue Draft
+
+Route: `Feature Request`
+
+Suggested title:
+
+```text
+[Feature]: Establish the alpha-test internal runtime hardening program
+```
+
+Suggested labels:
+
+```text
+enhancement
+triage
+area: kernel
+```
+
+Suggested body:
+
+```text
+Area
+Kernel / policy / approvals
+
+Problem statement
+alpha-test has a strong kernel-first architecture story, but the next internal priorities are
+still fragmented across several design docs and partially-implemented runtime seams. The repository
+needs one explicit program that clarifies what should land next and in what order.
+
+Proposed solution
+Adopt an internal runtime hardening program with the following priority order:
+- Stream 1: kernel-first runtime closure and direct-path retirement
+- Stream 2: persistent audit sink and query baseline
+- Stream 3: ACP control-plane hardening and recovery
+- Stream 4: cross-lane execution security tiers
+- Stream 5: first-party workflow packs after the runtime base is harder
+
+Non-goals / out of scope
+- README or external onboarding refresh
+- broad product-surface expansion before the runtime base is harder
+- reopening already-closed broad policy issues without a narrower bounded scope
+
+Alternatives considered
+- Product-surface-first expansion: rejected because it spends complexity before runtime truth is
+  stronger.
+- One-off hardening slices with no umbrella: rejected because it leaves priority and issue intake
+  fragmented.
+
+Acceptance criteria
+- The program priority order is documented in-repo and reflected in docs/ROADMAP.md
+- A new Stream 1 issue exists for kernel-first closure follow-up
+- Existing open issue #172 is explicitly reused for persistent audit
+- New issues exist for ACP hardening and execution tiers
+- Workflow packs remain explicitly deferred until the runtime base is harder
+
+Policy / security / breaking sensitivity
+Yes, this touches policy, security, or potentially breaking behavior
+
+Rollout / rollback notes
+Land this as documentation and issue-intake alignment first. Execute each stream as a separate PR
+series with normal CI parity and bounded reviewable slices.
+
+Impact
+Affected users: maintainers and internal contributors
+Frequency: every near-term architecture and runtime planning decision
+Consequence if missing: duplicated issues, drift between roadmap and code-level plans, and weaker
+execution discipline on alpha-test
+```
+
+## Stream 1 Issue Draft
+
+Route: `Feature Request`
+
+Suggested title:
+
+```text
+[Feature]: Retire shadow direct runtime paths behind kernel-bound compatibility seams
+```
+
+Suggested labels:
+
+```text
+enhancement
+triage
+area: conversation
+```
+
+Suggested body:
+
+```text
+Area
+Conversation / session runtime
+
+Problem statement
+alpha-test now makes conversation and provider governance explicit through
+ConversationRuntimeBinding and ProviderRuntimeBinding, but the runtime still carries intentional
+Direct compatibility paths deeper than the long-term architecture wants. This keeps a gap between
+the kernel-first design language and the actual governed-versus-direct execution story.
+
+Proposed solution
+Run the next bounded kernel-closure stream that:
+- pushes Direct back toward ingress, explicit compatibility wrappers, and tests
+- makes governed reads and governed side effects fail closed instead of silently re-entering direct
+  paths
+- refreshes security/architecture docs so they accurately describe the remaining compatibility seams
+
+Non-goals / out of scope
+- repo-wide kernelization in one PR
+- ACP redesign
+- durable audit implementation
+- workflow-pack or product-surface expansion
+
+Alternatives considered
+- Reuse closed issue #45: rejected because the remaining work is narrower and should not reopen a
+  closed broad policy-unification issue.
+- Add more telemetry without changing behavior: rejected because it improves observability without
+  improving architecture truthfulness.
+
+Acceptance criteria
+- A bounded first slice closes one more governed/direct drift seam
+- Direct behavior remains only where it is explicitly intended
+- Kernel-bound failure cases fail closed with tests
+- docs/SECURITY.md and related design docs stop over- or under-claiming the runtime contract
+
+Policy / security / breaking sensitivity
+Yes, this touches policy, security, or potentially breaking behavior
+
+Rollout / rollback notes
+Execute as reviewable slices over specific conversation/provider seams. Avoid a single giant
+cross-runtime patch.
+
+Impact
+Affected users: maintainers, runtime authors, and operators relying on kernel-first guarantees
+Frequency: every governed conversation or provider execution path
+Consequence if missing: continued architecture drift and harder future runtime hardening
+```
+
+## Stream 2 Tracking Note
+
+Do not open a new issue. Reuse open issue `#172`:
+
+```text
+[Feature] Add persistent kernel audit sink and fanout boundary
+```
+
+Optional refresh comment to add on `#172`:
+
+```text
+This issue is now part of the alpha-test internal runtime hardening program and remains the
+authoritative Stream 2 track. Follow-up planning now treats durable audit as the second priority
+after the new kernel-closure stream and before ACP control-plane hardening.
+```
+
+## Stream 3 Issue Draft
+
+Route: `Feature Request`
+
+Suggested title:
+
+```text
+[Feature]: Decompose the ACP control plane for recovery, observability, and lower merge risk
+```
+
+Suggested labels:
+
+```text
+enhancement
+triage
+area: acp
+```
+
+Suggested body:
+
+```text
+Area
+ACP control plane
+
+Problem statement
+The ACP architecture is now strategically important and directionally correct, but too much control
+plane behavior still lives in a few large hotspots such as crates/app/src/acp/manager.rs and
+crates/app/src/acp/acpx.rs. That raises merge risk, recovery risk, and observability complexity.
+
+Proposed solution
+Run an ACP hardening stream that:
+- decomposes manager responsibilities into smaller ownership boundaries
+- separates ACPX process/transport concerns from control-plane semantics
+- adds explicit stuck-turn recovery, cancel/close repair, and better status observability
+- keeps runtime-event handling on a path toward durable evidence instead of process-local-only state
+
+Non-goals / out of scope
+- broad new ACP feature expansion
+- moving ACP into provider or context-engine architecture
+- redesigning all ACP backends in one pass
+
+Alternatives considered
+- Keep adding features inside the current large files: rejected because it compounds control-plane
+  debt.
+- Collapse ACP back into other runtimes: rejected because the current architecture direction is
+  correct and should be hardened, not undone.
+
+Acceptance criteria
+- ACP manager/backend responsibilities are visibly smaller and easier to review
+- stuck-turn and repair semantics are explicit and tested
+- observability no longer depends on reconstructing backend-local behavior from large files
+- the first slice lands without broad ACP surface-area inflation
+
+Policy / security / breaking sensitivity
+Yes, this touches policy, security, or potentially breaking behavior
+
+Rollout / rollback notes
+Split by ownership boundary, not by random line ranges. Preserve current ACP behavior first, then
+tighten recovery and observability.
+
+Impact
+Affected users: maintainers and operators using ACP or ACPX-backed flows
+Frequency: every ACP session lifecycle and routed turn
+Consequence if missing: continued control-plane hotspot growth and harder future ACP evolution
+```
+
+## Stream 4 Issue Draft
+
+Route: `Feature Request`
+
+Suggested title:
+
+```text
+[Feature]: Introduce shared execution security tiers across process, browser, and WASM lanes
+```
+
+Suggested labels:
+
+```text
+enhancement
+triage
+area: kernel
+```
+
+Suggested body:
+
+```text
+Area
+Kernel / policy / approvals
+
+Problem statement
+The roadmap already points toward sandbox profile tiers, but the repository still needs one shared
+execution-tier model across process, browser, and WASM-style lanes. Without that, each lane risks
+growing its own security vocabulary and evidence semantics.
+
+Proposed solution
+Define and implement one shared execution-tier contract such as restricted/balanced/trusted across
+the main runtime lanes, with aligned policy defaults, runtime evidence, and documentation.
+
+Non-goals / out of scope
+- one giant sandbox rewrite
+- per-lane feature expansion unrelated to the shared tier model
+- replacing existing bounded runtime checks that are already correct
+
+Alternatives considered
+- Keep per-lane security semantics independent: rejected because it increases drift and weakens the
+  operator model.
+- Start with browser-only policy work: rejected because the contract should be shared before lane-
+  specific polish grows further.
+
+Acceptance criteria
+- one shared execution-tier vocabulary exists across the main runtime lanes
+- policy defaults and runtime evidence align with that vocabulary
+- at least one lane lands on the new tier model without breaking the others
+- docs/SECURITY.md and docs/ROADMAP.md reflect the shared contract
+
+Policy / security / breaking sensitivity
+Yes, this touches policy, security, or potentially breaking behavior
+
+Rollout / rollback notes
+Land the shared contract first, then migrate one lane at a time with bounded regressions.
+
+Impact
+Affected users: maintainers, runtime authors, and operators
+Frequency: every high-risk execution path
+Consequence if missing: policy drift and weaker cross-lane operator understanding
+```
+
+## Stream 5 Deferred Issue Draft
+
+Route: `Feature Request`
+
+Suggested title:
+
+```text
+[Feature]: Ship first-party workflow packs on the hardened alpha-test runtime base
+```
+
+Suggested labels:
+
+```text
+enhancement
+triage
+area: tools
+```
+
+Suggested body:
+
+```text
+Area
+Tools
+
+Problem statement
+LoongClaw needs a small set of first-party workflow packs that prove the value of the kernel and
+make the productization story concrete, but shipping them before the runtime base is harder would
+borrow against control-plane and evidence debt.
+
+Proposed solution
+After Streams 1-4 are underway, ship 2-3 first-party workflow packs built on the hardened runtime
+base, such as:
+- release/review operator workflows
+- issue triage and maintenance workflows
+- channel or customer-support workflows
+
+Non-goals / out of scope
+- moving this work ahead of the runtime-hardening streams
+- pack proliferation without strong runtime primitives underneath
+
+Alternatives considered
+- product-surface-first acceleration: rejected because the runtime base should harden first
+
+Acceptance criteria
+- workflow packs are explicitly treated as dependent on the hardened runtime base
+- the first pack set demonstrates kernel value without adding ad hoc runtime exceptions
+
+Policy / security / breaking sensitivity
+Not sure
+
+Rollout / rollback notes
+Open only after Streams 1-4 are underway or when the maintainers intentionally choose a
+productization checkpoint.
+
+Impact
+Affected users: future operators and downstream pack authors
+Frequency: depends on later productization cadence
+Consequence if missing: weaker proof of value after the runtime base is hardened
+```
+
+## Docs PR Draft
+
+Suggested title:
+
+```text
+docs: add alpha-test internal runtime hardening roadmap
+```
+
+Suggested body:
+
+````markdown
+## Summary
+
+- Problem:
+  The next internal runtime priorities on `alpha-test` were spread across multiple design docs and
+  were not yet packaged into a single issue/PR-ready planning bundle.
+- Why it matters:
+  Maintainers need one clean source of truth for the next internal hardening order, issue reuse,
+  and GitHub intake flow.
+- What changed:
+  Added a design doc, an implementation plan, a GitHub backlog document, and a roadmap update for
+  the alpha-test internal runtime hardening program.
+- What did not change (scope boundary):
+  No runtime behavior, code paths, CI rules, or external README flows changed in this PR.
+
+## Linked Issues
+
+- Closes #<docs-issue-id>
+- Related #<umbrella-runtime-hardening-issue-id>
+- Related #172
+
+## Change Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [x] Documentation
+- [ ] Security hardening
+- [ ] CI / workflow / release
+
+## Touched Areas
+
+- [ ] Kernel / policy / approvals
+- [ ] Contracts / protocol / spec
+- [ ] Daemon / CLI / install
+- [ ] Providers / routing
+- [ ] Tools
+- [ ] Browser automation
+- [ ] Channels / integrations
+- [ ] ACP / conversation / session runtime
+- [ ] Memory / context assembly
+- [ ] Config / migration / onboarding
+- [x] Docs / contributor workflow
+- [ ] CI / release / workflows
+
+## Risk Track
+
+- [x] Track A (routine / low-risk)
+- [ ] Track B (higher-risk / policy-impacting)
+
+## Validation
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- [x] `cargo test --workspace --locked`
+- [ ] `cargo test --workspace --all-features --locked`
+- [x] Relevant architecture / dep-graph / docs checks for touched areas
+- [ ] Additional scenario, benchmark, or manual checks when behavior changed
+
+Commands and evidence:
+
+```text
+cargo test --workspace --locked
+git diff -- docs/ROADMAP.md docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-design.md docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-implementation-plan.md docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-github-backlog.md
+```
+
+## User-visible / Operator-visible Changes
+
+- Adds one in-repo planning package that makes the next internal runtime priorities and issue intake
+  order explicit.
+
+## Failure Recovery
+
+- Fast rollback or disable path:
+  Revert this docs-only commit.
+- Observable failure symptoms reviewers should watch for:
+  Priority order drift between the new docs and existing roadmap/design documents.
+
+## Reviewer Focus
+
+- Verify the issue-reuse logic (`#172` reused, `#45` not reused)
+- Verify the priority order matches the code evidence in `alpha-test`
+- Verify the docs package does not imply runtime work already landed
+````

--- a/docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-implementation-plan.md
+++ b/docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-implementation-plan.md
@@ -1,0 +1,287 @@
+# Alpha-Test Internal Runtime Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Turn the `alpha-test` internal runtime hardening direction into a clean execution package:
+one design doc, one implementation plan, one GitHub backlog document, one roadmap update, and a
+submission order for the next code streams.
+
+**Architecture:** Reuse the repository's existing kernelization, audit, provider-runtime, and ACP
+design work instead of inventing a parallel planning stack. Keep this slice documentation-only, but
+make each next code stream specific enough that an engineer can pick it up without redoing the
+research.
+
+**Tech Stack:** Markdown docs, repository planning conventions, GitHub issue/PR templates, `rg`,
+`cargo test`, git diff
+
+---
+
+### Task 1: Lock the planning package in repo docs
+
+**Files:**
+- Create: `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-design.md`
+- Create: `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-implementation-plan.md`
+- Create: `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-github-backlog.md`
+- Modify: `docs/ROADMAP.md`
+
+**Step 1: Re-read the key evidence seams**
+
+Run:
+
+```bash
+rg -n "ConversationRuntimeBinding|ProviderRuntimeBinding|InMemoryAuditSink|AcpSessionManager|ACPX_BACKEND_ID|Current Priority Order" \
+  crates/app crates/kernel docs/ROADMAP.md docs/SECURITY.md
+```
+
+Expected: the binding, audit, ACP, and roadmap seams are fully enumerated before writing.
+
+**Step 2: Confirm the planning files exist**
+
+Run:
+
+```bash
+ls \
+  docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-design.md \
+  docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-implementation-plan.md \
+  docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-github-backlog.md
+```
+
+Expected: all three planning files exist.
+
+### Task 2: Align the repository roadmap with the same priority order
+
+**Files:**
+- Modify: `docs/ROADMAP.md`
+
+**Step 1: Update the roadmap timestamp and near-term priorities**
+
+Refresh `Last updated` and replace the old current-priority list with the internal runtime-hardening
+order:
+
+1. kernel-first runtime closure
+2. persistent audit sink and query baseline
+3. ACP control-plane hardening
+4. cross-lane execution tiers
+5. first-party workflow packs on hardened primitives
+
+**Step 2: Add the missing discussion items**
+
+Add short discussion entries for:
+
+1. governed/direct runtime closure
+2. ACP control-plane hardening
+3. execution security tiers
+4. first-party workflow packs
+
+Keep the prose short and execution-focused.
+
+**Step 3: Review the scoped roadmap diff**
+
+Run:
+
+```bash
+git diff -- docs/ROADMAP.md
+```
+
+Expected: only the intended priority and discussion updates are present.
+
+### Task 3: Prepare GitHub delivery for the planning package
+
+**Files:**
+- Create: `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-github-backlog.md`
+
+**Step 1: Draft the docs issue**
+
+Write one documentation-improvement issue draft for the current planning package so the docs PR has
+a clean issue to close.
+
+**Step 2: Draft the umbrella feature issue**
+
+Write one umbrella feature issue for the runtime hardening program itself.
+
+**Step 3: Reuse or replace tracking issues correctly**
+
+Document in the backlog that:
+
+1. issue `#172` should be reused for persistent audit because it is already open
+2. issue `#45` should not be reused because it is closed
+
+**Step 4: Draft the child issues and the docs PR body**
+
+Include:
+
+1. one new issue for kernel-first runtime closure
+2. one new issue for ACP control-plane hardening
+3. one new issue for execution security tiers
+4. one deferred issue for workflow packs
+5. one PR body that closes the docs issue and references the umbrella/runtime issues
+
+### Task 4: Define Stream 1 as the next code track
+
+**Files:**
+- Reference: `docs/plans/2026-03-15-conversation-runtime-binding-design.md`
+- Reference: `docs/plans/2026-03-15-conversation-lifecycle-kernelization-design.md`
+- Reference: `docs/plans/2026-03-16-governed-runtime-path-hardening-design.md`
+- Reference: `docs/plans/2026-03-15-provider-binding-normalization-design.md`
+- Modify next: `crates/app/src/conversation/runtime_binding.rs`
+- Modify next: `crates/app/src/provider/runtime_binding.rs`
+- Modify next: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify next: `crates/app/src/conversation/session_history.rs`
+- Modify next: `docs/SECURITY.md`
+
+**Step 1: Re-scope the remaining direct lanes**
+
+Run:
+
+```bash
+rg -n "ConversationRuntimeBinding::direct|ProviderRuntimeBinding::direct|no_kernel_context|Direct" \
+  crates/app/src
+```
+
+Expected: direct-mode compatibility seams are enumerated before opening the issue.
+
+**Step 2: Prepare the first code slice around one bounded seam**
+
+The first Stream 1 implementation should be a narrow bounded slice such as:
+
+1. one more governed/direct closure in conversation history or turn orchestration
+2. one provider-runtime governed seam
+3. one docs truthfulness refresh
+
+Do not open Stream 1 as a repo-wide mega-refactor.
+
+### Task 5: Treat Stream 2 as an immediate follow-on using the existing open issue
+
+**Files:**
+- Reference: `docs/plans/2026-03-15-persistent-audit-sink-design.md`
+- Reference: `docs/plans/2026-03-15-persistent-audit-sink-implementation-plan.md`
+- Modify next: `crates/kernel/src/audit.rs`
+- Modify next: `crates/app/src/context.rs`
+- Modify next: `crates/spec/src/kernel_bootstrap.rs`
+- Modify next: `docs/SECURITY.md`
+- Modify next: `docs/RELIABILITY.md`
+
+**Step 1: Verify issue reuse is explicit**
+
+The backlog document must say Stream 2 reuses issue `#172` and does not open a duplicate.
+
+**Step 2: Keep the first durable-audit slice query-light**
+
+Land the durable sink first. Query ergonomics may stay minimal in the first slice as long as
+operators can inspect and filter the retained evidence.
+
+### Task 6: Scope Stream 3 as decomposition and recovery, not capability expansion
+
+**Files:**
+- Reference: `docs/design-docs/acp-acpx-preembed.md`
+- Modify next: `crates/app/src/acp/manager.rs`
+- Modify next: `crates/app/src/acp/acpx.rs`
+- Modify next: `crates/app/src/acp/backend.rs`
+- Modify next: `crates/app/src/acp/store.rs`
+- Modify next: `crates/app/src/conversation/turn_coordinator.rs`
+
+**Step 1: Enumerate ACP ownership boundaries**
+
+Run:
+
+```bash
+rg -n "pub async fn|fn " crates/app/src/acp/manager.rs crates/app/src/acp/acpx.rs
+```
+
+Expected: the session lifecycle, actor queue, status, cancellation, and transport responsibilities
+are visible before decomposition starts.
+
+**Step 2: Open the issue around recovery and decomposition**
+
+The issue must emphasize:
+
+1. smaller ownership boundaries
+2. stuck-turn recovery and cancel/close repair
+3. better observability
+4. no new ACP surface-area inflation in the first slice
+
+### Task 7: Scope Stream 4 as one shared execution-tier model
+
+**Files:**
+- Modify next: `docs/SECURITY.md`
+- Modify next: `docs/ROADMAP.md`
+- Modify next: `crates/kernel/src/policy.rs`
+- Modify next: bridge execution surfaces in `crates/spec`
+- Modify next: browser/runtime surfaces in `crates/daemon`
+
+**Step 1: Enumerate the current lane-specific security words**
+
+Run:
+
+```bash
+rg -n "restricted|balanced|trusted|sandbox|wasm|browser|process_stdio|http_json" \
+  crates docs/SECURITY.md docs/ROADMAP.md
+```
+
+Expected: the current lane vocabulary and drift points are visible.
+
+**Step 2: Keep the first execution-tier issue architecture-first**
+
+Do not start with a giant sandbox rewrite. Start with one shared tier model and one lane at a
+time.
+
+### Task 8: Defer Stream 5 until Streams 1-4 are underway
+
+**Files:**
+- Create later: pack-specific docs, manifests, and product specs
+
+**Step 1: Keep workflow packs as a deferred issue**
+
+The backlog should explicitly label workflow packs as dependent on the hardened runtime base.
+
+**Step 2: Do not let workflow-pack enthusiasm reshuffle the runtime priorities**
+
+If a later PR adds a workflow pack before Streams 1-4 move, the reviewer should treat that as a
+priority-order violation unless it is purely exploratory.
+
+### Task 9: Run verification and prepare local delivery
+
+**Files:**
+- Modify: `docs/ROADMAP.md`
+- Create: `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-design.md`
+- Create: `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-implementation-plan.md`
+- Create: `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-github-backlog.md`
+
+**Step 1: Run workspace tests for clean baseline confidence**
+
+Run:
+
+```bash
+cargo test --workspace --locked
+```
+
+Expected: PASS.
+
+**Step 2: Review the scoped docs diff**
+
+Run:
+
+```bash
+git diff -- \
+  docs/ROADMAP.md \
+  docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-design.md \
+  docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-implementation-plan.md \
+  docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-github-backlog.md
+```
+
+Expected: only the planning package is present.
+
+**Step 3: Commit the planning package**
+
+Run:
+
+```bash
+git add \
+  docs/ROADMAP.md \
+  docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-design.md \
+  docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-implementation-plan.md \
+  docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-github-backlog.md
+git commit -m "docs: add alpha-test internal runtime hardening roadmap"
+```
+
+Expected: one clean docs-only commit is created on the worktree branch.

--- a/docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-implementation-plan.md
+++ b/docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-implementation-plan.md
@@ -1,7 +1,5 @@
 # Alpha-Test Internal Runtime Hardening Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Turn the `alpha-test` internal runtime hardening direction into a clean execution package:
 one design doc, one implementation plan, one GitHub backlog document, one roadmap update, and a
 submission order for the next code streams.
@@ -16,7 +14,7 @@ research.
 
 ---
 
-### Task 1: Lock the planning package in repo docs
+## Task 1: Lock the planning package in repo docs
 
 **Files:**
 - Create: `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-design.md`
@@ -48,7 +46,7 @@ ls \
 
 Expected: all three planning files exist.
 
-### Task 2: Align the repository roadmap with the same priority order
+## Task 2: Align the repository roadmap with the same priority order
 
 **Files:**
 - Modify: `docs/ROADMAP.md`
@@ -85,7 +83,7 @@ git diff -- docs/ROADMAP.md
 
 Expected: only the intended priority and discussion updates are present.
 
-### Task 3: Prepare GitHub delivery for the planning package
+## Task 3: Prepare GitHub delivery for the planning package
 
 **Files:**
 - Create: `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-github-backlog.md`
@@ -116,7 +114,7 @@ Include:
 4. one deferred issue for workflow packs
 5. one PR body that closes the docs issue and references the umbrella/runtime issues
 
-### Task 4: Define Stream 1 as the next code track
+## Task 4: Define Stream 1 as the next code track
 
 **Files:**
 - Reference: `docs/plans/2026-03-15-conversation-runtime-binding-design.md`
@@ -150,7 +148,7 @@ The first Stream 1 implementation should be a narrow bounded slice such as:
 
 Do not open Stream 1 as a repo-wide mega-refactor.
 
-### Task 5: Treat Stream 2 as an immediate follow-on using the existing open issue
+## Task 5: Treat Stream 2 as an immediate follow-on using the existing open issue
 
 **Files:**
 - Reference: `docs/plans/2026-03-15-persistent-audit-sink-design.md`
@@ -170,7 +168,7 @@ The backlog document must say Stream 2 reuses issue `#172` and does not open a d
 Land the durable sink first. Query ergonomics may stay minimal in the first slice as long as
 operators can inspect and filter the retained evidence.
 
-### Task 6: Scope Stream 3 as decomposition and recovery, not capability expansion
+## Task 6: Scope Stream 3 as decomposition and recovery, not capability expansion
 
 **Files:**
 - Reference: `docs/design-docs/acp-acpx-preembed.md`
@@ -200,7 +198,7 @@ The issue must emphasize:
 3. better observability
 4. no new ACP surface-area inflation in the first slice
 
-### Task 7: Scope Stream 4 as one shared execution-tier model
+## Task 7: Scope Stream 4 as one shared execution-tier model
 
 **Files:**
 - Modify next: `docs/SECURITY.md`
@@ -225,7 +223,7 @@ Expected: the current lane vocabulary and drift points are visible.
 Do not start with a giant sandbox rewrite. Start with one shared tier model and one lane at a
 time.
 
-### Task 8: Defer Stream 5 until Streams 1-4 are underway
+## Task 8: Defer Stream 5 until Streams 1-4 are underway
 
 **Files:**
 - Create later: pack-specific docs, manifests, and product specs
@@ -239,7 +237,7 @@ The backlog should explicitly label workflow packs as dependent on the hardened 
 If a later PR adds a workflow pack before Streams 1-4 move, the reviewer should treat that as a
 priority-order violation unless it is purely exploratory.
 
-### Task 9: Run verification and prepare local delivery
+## Task 9: Run verification and prepare local delivery
 
 **Files:**
 - Modify: `docs/ROADMAP.md`


### PR DESCRIPTION
## Summary

- add `JsonlAuditSink` and `FanoutAuditSink` to the kernel audit seam, with regression coverage for append ordering, fanout delivery, and fail-closed I/O errors
- add `[audit]` runtime config with `in_memory`, `jsonl`, and `fanout` modes plus the default journal path at `~/.loongclaw/audit/events.jsonl`
- wire production-shaped app bootstraps (CLI chat, Telegram, and Feishu serve paths) to use configured durable audit retention instead of silently defaulting to in-memory-only audit
- update security and reliability docs so the durable audit default and local inspection workflow match the shipped behavior

## Linked Issues

- Closes #172
- Closes #262
- Related #263
- Related #264
- Related #265
- Related #266

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked -- --test-threads=1`
- [x] `cargo test --workspace --all-features --locked -- --test-threads=1`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1
cargo clippy --workspace --all-targets --all-features -- -D warnings
./scripts/check_architecture_boundaries.sh
```

Additional behavior coverage:

- kernel unit tests for JSONL append ordering, fanout delivery, and I/O error propagation
- app tests for audit config TOML round-trip and bootstrap-driven JSONL journal creation
- crate-level regression runs for both `loongclaw-kernel` and `loongclaw-app`

## User-visible / Operator-visible Changes

- CLI chat, Telegram, and Feishu service bootstraps now persist audit events to `~/.loongclaw/audit/events.jsonl` by default
- operators can choose `[audit].mode = "in_memory" | "jsonl" | "fanout"`
- operators can inspect recent entries with `tail -n 20 ~/.loongclaw/audit/events.jsonl`

## Failure Recovery

- Fast rollback or disable path:
  Set `[audit].mode = "in_memory"` to keep the runtime side-effect free again, or revert commit `5842ac7`.
- Observable failure symptoms reviewers should watch for:
  bootstrap failures when the configured audit path is not writable, or missing journal lines after token issuance in CLI/channel startup paths.

## Reviewer Focus

- verify the new durable sinks preserve fail-closed semantics on write errors
- verify only production-shaped app bootstraps moved to configured durable retention while explicit test/demo seams remain in-memory
- verify the docs now match the shipped audit retention behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable audit modes: in-memory, JSONL (durable), and fanout.
  * Durable JSONL audit logging enabled by default (persistent events file plus in-memory diagnostics).
  * Audit configuration types now available for runtime configuration.

* **Documentation**
  * Updated reliability and security docs describing durable audit, default fanout behavior, and inspection guidance.
  * Roadmap and planning docs expanded for runtime hardening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->