### PR TITLE
fix(onboard): land reviewed auto follow-up after #240

### DIFF
--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -182,6 +182,7 @@ pub enum OnboardNonInteractiveWarningPolicy {
     AcceptedBySkipModelProbe,
     AcceptedByExplicitModel,
     AcceptedByPreferredModels,
+    RequiresExplicitModel,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -1039,11 +1040,14 @@ fn resolve_model_selection(
         return Err("model cannot be empty".to_owned());
     }
 
-    let default_model = resolve_onboarding_model_prompt_default(options, config);
     if options.non_interactive {
-        return Ok(default_model);
+        if let Some(model) = options.model.as_deref() {
+            return Ok(model.trim().to_owned());
+        }
+        return Ok(config.provider.configured_model_value());
     }
 
+    let default_model = resolve_onboarding_model_prompt_default(options, config);
     print_lines(
         ui,
         render_model_selection_screen_lines_with_style(
@@ -1074,13 +1078,14 @@ fn resolve_onboarding_model_prompt_default(
         return model;
     }
 
-    if config.provider.configured_model_value() == "auto"
+    let configured_model = config.provider.configured_model_value();
+    if configured_model.eq_ignore_ascii_case("auto")
         && let Some(model) = config.provider.kind.recommended_onboarding_model()
     {
         return model.to_owned();
     }
 
-    config.provider.configured_model_value()
+    configured_model
 }
 
 fn resolve_api_key_env_selection(
@@ -1433,7 +1438,7 @@ fn provider_model_probe_failure_check(
                 error.as_str(),
                 recommended_onboarding_model,
             ),
-            OnboardNonInteractiveWarningPolicy::Block,
+            OnboardNonInteractiveWarningPolicy::RequiresExplicitModel,
         ),
     };
 
@@ -3550,9 +3555,8 @@ fn render_preflight_summary_screen_lines_with_style(
     if has_attention {
         summary_lines
             .push(crate::onboard_presentation::preflight_attention_summary_line().to_owned());
-        if counts.fail > 0 {
-            summary_lines
-                .push(crate::onboard_presentation::preflight_probe_rerun_hint().to_owned());
+        if let Some(hint) = preflight_attention_hint_line(checks) {
+            summary_lines.push(hint.to_owned());
         }
     } else {
         summary_lines.push(crate::onboard_presentation::preflight_green_summary_line().to_owned());
@@ -3600,6 +3604,28 @@ fn render_preflight_summary_screen_lines_with_style(
         lines.extend(render_onboard_wrapped_display_lines(footer_lines, width));
     }
     lines
+}
+
+fn preflight_attention_hint_line(checks: &[OnboardCheck]) -> Option<&'static str> {
+    if checks.iter().any(|check| {
+        matches!(
+            check.non_interactive_warning_policy,
+            OnboardNonInteractiveWarningPolicy::RequiresExplicitModel
+        )
+    }) {
+        return Some(crate::onboard_presentation::preflight_explicit_model_rerun_hint());
+    }
+
+    if checks.iter().any(|check| {
+        matches!(
+            check.non_interactive_warning_policy,
+            OnboardNonInteractiveWarningPolicy::AcceptedBySkipModelProbe
+        )
+    }) {
+        return Some(crate::onboard_presentation::preflight_probe_rerun_hint());
+    }
+
+    None
 }
 
 pub fn render_write_confirmation_screen_lines(
@@ -5575,6 +5601,10 @@ mod tests {
 
         assert_eq!(check.name, "provider model probe");
         assert_eq!(check.level, OnboardCheckLevel::Fail);
+        assert_eq!(
+            check.non_interactive_warning_policy,
+            OnboardNonInteractiveWarningPolicy::RequiresExplicitModel
+        );
         assert!(
             check.detail.contains("deepseek-chat"),
             "reviewed providers should point users to the reviewed onboarding default when catalog probing is unavailable: {check:#?}"
@@ -5931,7 +5961,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_model_selection_prefills_minimax_recommended_model_non_interactively() {
+    fn resolve_model_selection_preserves_minimax_auto_non_interactively() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Minimax;
         config.provider.model = "auto".to_owned();
@@ -5960,8 +5990,8 @@ mod tests {
         .expect("resolve model selection");
 
         assert!(
-            selected == "MiniMax-M2.5",
-            "non-interactive onboarding should pick the provider-recommended explicit model for MiniMax instead of preserving auto: {selected:?}"
+            selected == "auto",
+            "non-interactive onboarding should preserve auto for MiniMax instead of silently rewriting the operator config to the reviewed default: {selected:?}"
         );
     }
 
@@ -6001,7 +6031,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_model_selection_prefills_deepseek_recommended_model_non_interactively() {
+    fn resolve_model_selection_preserves_deepseek_auto_non_interactively() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Deepseek;
         config.provider.model = "auto".to_owned();
@@ -6030,8 +6060,43 @@ mod tests {
         .expect("resolve model selection");
 
         assert!(
-            selected == "deepseek-chat",
-            "non-interactive onboarding should pick the provider-recommended explicit model for DeepSeek instead of preserving auto: {selected:?}"
+            selected == "auto",
+            "non-interactive onboarding should preserve auto for DeepSeek instead of silently rewriting the operator config to the reviewed default: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_model_selection_prefills_reviewed_model_for_mixed_case_auto_interactively() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "  AUTO  ".to_owned();
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_model_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect("resolve model selection");
+
+        assert_eq!(
+            selected, "deepseek-chat",
+            "interactive onboarding should treat mixed-case auto the same as auto when choosing a reviewed provider default"
         );
     }
 
@@ -6156,6 +6221,52 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("Esc") && line.contains("cancel")),
             "interactive preflight review should teach the exit gesture explicitly: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn preflight_summary_uses_explicit_model_guidance_for_reviewed_auto_failures() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "auto".to_owned();
+
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider rejected the model list".to_owned(),
+        );
+        let lines = render_preflight_summary_screen_lines(&[check], 80);
+
+        assert!(
+            lines.iter().any(|line| {
+                line.contains("rerun onboarding to choose a reviewed model")
+                    || line.contains("set provider.model / preferred_models explicitly")
+            }),
+            "reviewed auto-model failures should keep the explicit-model remediation visible in the summary: {lines:#?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .all(|line| !line.contains("--skip-model-probe")),
+            "reviewed auto-model failures should not suggest --skip-model-probe because that contradicts the explicit-model recovery path: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn preflight_summary_keeps_skip_model_probe_hint_for_skip_accepted_checks() {
+        let lines = render_preflight_summary_screen_lines(
+            &[OnboardCheck {
+                name: "provider model probe",
+                level: OnboardCheckLevel::Warn,
+                detail: "provider rejected the model list".to_owned(),
+                non_interactive_warning_policy:
+                    OnboardNonInteractiveWarningPolicy::AcceptedBySkipModelProbe,
+            }],
+            80,
+        );
+
+        assert!(
+            lines.iter().any(|line| line.contains("--skip-model-probe")),
+            "skip-model-probe-accepted checks should keep the rerun hint visible in the summary: {lines:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1719,10 +1719,11 @@ fn selected_provider_credential_env_field(
     match (matches_oauth, matches_api_key) {
         (true, false) => ProviderCredentialEnvField::OAuthAccessToken,
         (false, true) => ProviderCredentialEnvField::ApiKey,
-        _ => configured_provider_credential_env_binding(provider)
+        (true, true) => configured_provider_credential_env_binding(provider)
             .or_else(|| preferred_provider_credential_env_binding(provider))
             .map(|binding| binding.field)
             .unwrap_or(ProviderCredentialEnvField::ApiKey),
+        (false, false) => ProviderCredentialEnvField::ApiKey,
     }
 }
 
@@ -5724,6 +5725,27 @@ mod tests {
         assert_eq!(
             provider.api_key_env, None,
             "switching to the OpenAI oauth env should clear the stale api-key env binding"
+        );
+    }
+
+    #[test]
+    fn apply_selected_api_key_env_routes_unknown_openai_env_to_api_key_binding() {
+        let mut provider = mvp::config::ProviderConfig {
+            kind: mvp::config::ProviderKind::Openai,
+            oauth_access_token_env: Some("OPENAI_CODEX_OAUTH_TOKEN".to_owned()),
+            ..mvp::config::ProviderConfig::default()
+        };
+
+        apply_selected_api_key_env(&mut provider, "OPENAI_ALT_BEARER".to_owned());
+
+        assert_eq!(
+            provider.api_key_env.as_deref(),
+            Some("OPENAI_ALT_BEARER"),
+            "unknown env names should stay on the explicit api-key field instead of being silently rebound to oauth"
+        );
+        assert_eq!(
+            provider.oauth_access_token_env, None,
+            "switching to a custom env name should clear the stale oauth binding"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -183,6 +183,7 @@ pub enum OnboardNonInteractiveWarningPolicy {
     AcceptedByExplicitModel,
     AcceptedByPreferredModels,
     RequiresExplicitModel,
+    RequiresExplicitModelWithoutReviewedDefault,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -1438,7 +1439,11 @@ fn provider_model_probe_failure_check(
                 error.as_str(),
                 recommended_onboarding_model,
             ),
-            OnboardNonInteractiveWarningPolicy::RequiresExplicitModel,
+            if recommended_onboarding_model.is_some() {
+                OnboardNonInteractiveWarningPolicy::RequiresExplicitModel
+            } else {
+                OnboardNonInteractiveWarningPolicy::RequiresExplicitModelWithoutReviewedDefault
+            },
         ),
     };
 
@@ -3614,6 +3619,15 @@ fn preflight_attention_hint_line(checks: &[OnboardCheck]) -> Option<&'static str
         )
     }) {
         return Some(crate::onboard_presentation::preflight_explicit_model_rerun_hint());
+    }
+
+    if checks.iter().any(|check| {
+        matches!(
+            check.non_interactive_warning_policy,
+            OnboardNonInteractiveWarningPolicy::RequiresExplicitModelWithoutReviewedDefault
+        )
+    }) {
+        return Some(crate::onboard_presentation::preflight_explicit_model_only_rerun_hint());
     }
     None
 }
@@ -6238,6 +6252,32 @@ mod tests {
                 .iter()
                 .all(|line| !line.contains("--skip-model-probe")),
             "reviewed auto-model failures should not suggest --skip-model-probe because that contradicts the explicit-model recovery path: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn preflight_summary_uses_explicit_model_only_guidance_without_reviewed_default() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Custom;
+        config.provider.model = "auto".to_owned();
+
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider rejected the model list".to_owned(),
+        );
+        let lines = render_preflight_summary_screen_lines(&[check], 80);
+
+        assert!(
+            lines.iter().any(|line| {
+                line == crate::onboard_presentation::preflight_explicit_model_only_rerun_hint()
+            }),
+            "providers without a reviewed model should keep the summary hint aligned with the explicit-model-only recovery path: {lines:#?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .all(|line| !line.contains("choose a reviewed model")),
+            "providers without a reviewed model should not advertise a reviewed-model recovery path that does not exist: {lines:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -3615,16 +3615,6 @@ fn preflight_attention_hint_line(checks: &[OnboardCheck]) -> Option<&'static str
     }) {
         return Some(crate::onboard_presentation::preflight_explicit_model_rerun_hint());
     }
-
-    if checks.iter().any(|check| {
-        matches!(
-            check.non_interactive_warning_policy,
-            OnboardNonInteractiveWarningPolicy::AcceptedBySkipModelProbe
-        )
-    }) {
-        return Some(crate::onboard_presentation::preflight_probe_rerun_hint());
-    }
-
     None
 }
 
@@ -6252,12 +6242,12 @@ mod tests {
     }
 
     #[test]
-    fn preflight_summary_keeps_skip_model_probe_hint_for_skip_accepted_checks() {
+    fn preflight_summary_omits_skip_model_probe_rerun_hint_after_probe_is_already_skipped() {
         let lines = render_preflight_summary_screen_lines(
             &[OnboardCheck {
                 name: "provider model probe",
                 level: OnboardCheckLevel::Warn,
-                detail: "provider rejected the model list".to_owned(),
+                detail: "skipped by --skip-model-probe".to_owned(),
                 non_interactive_warning_policy:
                     OnboardNonInteractiveWarningPolicy::AcceptedBySkipModelProbe,
             }],
@@ -6265,8 +6255,10 @@ mod tests {
         );
 
         assert!(
-            lines.iter().any(|line| line.contains("--skip-model-probe")),
-            "skip-model-probe-accepted checks should keep the rerun hint visible in the summary: {lines:#?}"
+            lines.iter().all(|line| {
+                line.as_str() != crate::onboard_presentation::preflight_probe_rerun_hint()
+            }),
+            "preflight should not suggest rerunning with --skip-model-probe after the current run already skipped the probe: {lines:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_presentation.rs
+++ b/crates/daemon/src/onboard_presentation.rs
@@ -229,6 +229,10 @@ pub const fn preflight_probe_rerun_hint() -> &'static str {
     "- rerun with --skip-model-probe if your provider blocks model listing during setup"
 }
 
+pub const fn preflight_explicit_model_rerun_hint() -> &'static str {
+    "- rerun onboarding to choose a reviewed model, or set provider.model / preferred_models explicitly"
+}
+
 pub const fn preflight_continue_label() -> &'static str {
     "Continue anyway"
 }

--- a/crates/daemon/src/onboard_presentation.rs
+++ b/crates/daemon/src/onboard_presentation.rs
@@ -233,6 +233,10 @@ pub const fn preflight_explicit_model_rerun_hint() -> &'static str {
     "- rerun onboarding to choose a reviewed model, or set provider.model / preferred_models explicitly"
 }
 
+pub const fn preflight_explicit_model_only_rerun_hint() -> &'static str {
+    "- set provider.model / preferred_models explicitly before retrying"
+}
+
 pub const fn preflight_continue_label() -> &'static str {
     "Continue anyway"
 }

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -2234,6 +2234,10 @@ fn onboard_presentation_risk_preflight_and_write_copy_stays_canonical() {
         "- rerun with --skip-model-probe if your provider blocks model listing during setup"
     );
     assert_eq!(
+        loongclaw_daemon::onboard_presentation::preflight_explicit_model_rerun_hint(),
+        "- rerun onboarding to choose a reviewed model, or set provider.model / preferred_models explicitly"
+    );
+    assert_eq!(
         loongclaw_daemon::onboard_presentation::preflight_continue_label(),
         "Continue anyway"
     );
@@ -4613,6 +4617,12 @@ fn onboard_preflight_screen_summarizes_status_counts_and_guidance() {
             .iter()
             .any(|line| line == "press Enter to use [n], cancel"),
         "preflight screen should make the safe default explicit when attention is still required: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .all(|line| !line.contains("--skip-model-probe")),
+        "generic failing preflight checks should not suggest --skip-model-probe unless the underlying recovery policy explicitly allows it: {lines:#?}"
     );
 }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -2328,6 +2328,10 @@ fn onboard_presentation_risk_preflight_and_write_copy_stays_canonical() {
         "- rerun onboarding to choose a reviewed model, or set provider.model / preferred_models explicitly"
     );
     assert_eq!(
+        loongclaw_daemon::onboard_presentation::preflight_explicit_model_only_rerun_hint(),
+        "- set provider.model / preferred_models explicitly before retrying"
+    );
+    assert_eq!(
         loongclaw_daemon::onboard_presentation::preflight_continue_label(),
         "Continue anyway"
     );

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -2724,10 +2724,7 @@ fn onboard_provider_selection_screen_includes_focus_title_and_choices() {
 
     let lines = loongclaw_daemon::onboard_cli::render_provider_selection_screen_lines(&plan, 80);
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW"),
-        "provider choice screen should use the compact LOONGCLAW header after the initial screen: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "provider choice screen");
     assert!(
         lines.iter().all(|line| !line.starts_with("██╗")),
         "provider choice screen should not re-render the large LOONGCLAW banner mid-onboarding: {lines:#?}"
@@ -3114,10 +3111,7 @@ fn onboard_current_setup_shortcut_screen_summarizes_existing_setup_and_choices()
     let lines =
         loongclaw_daemon::onboard_cli::render_continue_current_setup_screen_lines(&config, 80);
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW"),
-        "current-setup shortcut should use the compact LOONGCLAW header after the entry screen: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "current-setup shortcut");
     assert!(
         lines.iter().any(|line| line == "continue current setup"),
         "current-setup shortcut should use a focused title: {lines:#?}"
@@ -3214,10 +3208,7 @@ fn onboard_detected_setup_shortcut_screen_summarizes_starting_point_and_choices(
         80,
     );
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW"),
-        "detected-setup shortcut should use the compact LOONGCLAW header after the entry screen: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "detected-setup shortcut");
     assert!(
         lines
             .iter()
@@ -3375,10 +3366,7 @@ fn onboard_starting_point_selection_screen_uses_compact_header_and_detected_opti
         80,
     );
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW"),
-        "starting-point screen should use the compact LOONGCLAW header after the entry screen: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "starting-point screen");
     assert!(
         lines
             .iter()
@@ -3545,10 +3533,7 @@ fn onboard_single_detected_setup_preview_screen_uses_compact_follow_up_layout() 
         80,
     );
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW"),
-        "single detected-setup preview should use the compact LOONGCLAW header after the entry screen: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "single detected-setup preview");
     assert!(
         lines
             .iter()
@@ -4275,10 +4260,7 @@ fn onboard_personality_selection_screen_shows_native_personality_choices() {
 
     let lines = crate::onboard_cli::render_personality_selection_screen_lines(&config, 80);
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW"),
-        "personality screen should keep the compact LOONGCLAW header instead of re-showing the large banner: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "personality screen");
     assert!(
         lines.iter().all(|line| !line.starts_with("██╗")),
         "personality screen should not repeat the large LOONGCLAW banner mid-onboarding: {lines:#?}"
@@ -4335,10 +4317,7 @@ fn onboard_memory_profile_screen_shows_supported_profiles() {
 
     let lines = crate::onboard_cli::render_memory_profile_selection_screen_lines(&config, 80);
 
-    assert!(
-        lines[0].starts_with("LOONGCLAW"),
-        "memory-profile screen should keep the compact LOONGCLAW header instead of re-showing the large banner: {lines:#?}"
-    );
+    assert_compact_loongclaw_header(&lines, "memory-profile screen");
     assert!(
         lines.iter().any(|line| line == "choose memory profile"),
         "memory-profile screen should use a focused title: {lines:#?}"

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -779,6 +779,41 @@ async fn non_interactive_onboard_allows_explicit_skip_model_probe_warning() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn non_interactive_onboard_preserves_reviewed_auto_when_probe_is_skipped() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("non-interactive-reviewed-auto-skip-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+    unsafe {
+        std::env::set_var("DEEPSEEK_API_KEY", "test-deepseek-key");
+    }
+
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.provider = Some("deepseek".to_owned());
+    options.skip_model_probe = true;
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context =
+        loongclaw_daemon::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    loongclaw_daemon::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect("skip-model-probe should allow non-interactive onboarding to keep reviewed auto providers on auto");
+
+    let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
+    let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
+        .expect("load written onboarding config");
+    assert_eq!(config.provider.kind, mvp::config::ProviderKind::Deepseek);
+    assert_eq!(
+        config.provider.model, "auto",
+        "non-interactive onboarding should preserve model = auto when the operator did not explicitly pin a reviewed provider model"
+    );
+    assert!(
+        !raw.contains("model = \"deepseek-chat\""),
+        "skip-model-probe onboarding should not silently rewrite reviewed providers to the reviewed model: {raw}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn non_interactive_onboard_allows_explicit_model_probe_warning() {
     let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let root = unique_temp_path("non-interactive-explicit-model-warning-root");
@@ -816,6 +851,61 @@ async fn non_interactive_onboard_allows_explicit_model_probe_warning() {
                 && normalized.contains("authorization: bearer test-openai-key")
         }),
         "explicit-model warning path should still perform the model probe with resolved auth before allowing onboarding to continue: {requests:#?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_onboard_reports_reviewed_auto_probe_failure_without_rewriting_config() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("non-interactive-reviewed-auto-failure-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+
+    let (addr, server) = start_local_model_probe_server_with_models_response(
+        1,
+        "HTTP/1.1 401 Unauthorized",
+        r#"{"error":{"message":"No cookie auth credentials found"}}"#,
+    );
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.kind = mvp::config::ProviderKind::Deepseek;
+    config.provider.base_url = format!("http://{addr}");
+    config.provider.model = "auto".to_owned();
+    config.provider.api_key = Some("test-deepseek-key".to_owned());
+    mvp::config::write(Some(output.to_string_lossy().as_ref()), &config, true)
+        .expect("write existing config");
+    let original_body = std::fs::read_to_string(&output).expect("read original config");
+
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.force = true;
+    options.system_prompt = Some("force a pending write".to_owned());
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    let error = crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect_err("reviewed auto-model probe failures should block non-interactive onboarding until the model is pinned explicitly");
+
+    assert!(
+        error.contains("accept reviewed model `deepseek-chat`")
+            && error.contains("provider.model")
+            && error.contains("preferred_models"),
+        "reviewed auto-model probe failures should surface the actionable explicit-model remediation instead of a generic rerun hint: {error}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&output).expect("read config after blocked onboard"),
+        original_body,
+        "blocking reviewed auto-model probe failures should leave the existing auto config untouched"
+    );
+
+    let requests = server.join().expect("join local provider server");
+    assert!(
+        requests.iter().any(|request| {
+            let normalized = request.to_ascii_lowercase();
+            request.starts_with("GET /v1/models ")
+                && normalized.contains("authorization: bearer test-deepseek-key")
+        }),
+        "reviewed auto-model failures should still attempt the provider model probe before surfacing the actionable remediation: {requests:#?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Follow up on #240, which merged before the last reviewed-auto onboarding hardening landed on the PR branch.
- Keep reviewed providers on `model = auto` during non-interactive onboarding unless the operator explicitly pins a model, and keep unknown credential env overrides on the api-key field.
- Keep preflight guidance aligned with the explicit-model recovery path and add end-to-end regression coverage for skipped-probe auto writes plus blocked reviewed-auto probe failures.

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

## Risk Track

- [x] Track A (routine/low-risk)
- [ ] Track B (higher-risk/policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked -j1`
- [x] Additional scenario/benchmark checks (if applicable)

Additional checks:

- `cargo test --locked -j1 -p loongclaw-daemon onboard_cli::tests:: --lib`
- `cargo test --locked -j1 -p loongclaw-daemon onboard_preflight_screen_summarizes_status_counts_and_guidance --test integration`
- `cargo test --locked -j1 -p loongclaw-daemon non_interactive_onboard_allows_explicit_model_probe_warning --test integration`
- `cargo test --locked -j1 -p loongclaw-daemon non_interactive_onboard_allows_explicit_skip_model_probe_warning --test integration`
- `cargo test --locked -j1 -p loongclaw-daemon non_interactive_onboard_preserves_reviewed_auto_when_probe_is_skipped --test integration`
- `cargo test --locked -j1 -p loongclaw-daemon non_interactive_onboard_reports_reviewed_auto_probe_failure_without_rewriting_config --test integration`

## Linked Issues

Closes #236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better explicit-model handling in non-interactive onboarding and clearer preflight remediation hints.

* **Bug Fixes**
  * Model resolution now respects user-provided and configured model values and avoids unwanted config rewrites.
  * Improved credential-env selection for complex provider bindings.

* **Tests**
  * Added tests covering non-interactive onboarding, model-probe skipping/failure, and updated preflight hint expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->