### PR TITLE
refactor(conversation): close provider binding roundtrip seam

### DIFF
--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -591,14 +591,7 @@ where
         messages: &[Value],
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
-        provider::request_completion(
-            config,
-            messages,
-            provider::ProviderRuntimeBinding::from_optional_kernel_context(
-                binding.kernel_context(),
-            ),
-        )
-        .await
+        provider::request_completion(config, messages, provider_runtime_binding(binding)).await
     }
 
     async fn request_turn(
@@ -616,9 +609,7 @@ where
             turn_id,
             messages,
             tool_view,
-            provider::ProviderRuntimeBinding::from_optional_kernel_context(
-                binding.kernel_context(),
-            ),
+            provider_runtime_binding(binding),
         )
         .await
     }
@@ -713,6 +704,17 @@ where
     }
 }
 
+fn provider_runtime_binding(
+    binding: ConversationRuntimeBinding<'_>,
+) -> provider::ProviderRuntimeBinding<'_> {
+    match binding {
+        ConversationRuntimeBinding::Kernel(kernel_ctx) => {
+            provider::ProviderRuntimeBinding::kernel(kernel_ctx)
+        }
+        ConversationRuntimeBinding::Direct => provider::ProviderRuntimeBinding::direct(),
+    }
+}
+
 fn apply_system_prompt_addition(messages: &mut Vec<Value>, addition: Option<&str>) {
     let Some(addition) = addition
         .map(str::trim)
@@ -788,5 +790,30 @@ fn apply_tool_view_to_system_prompt(messages: &mut [Value], tool_view: &ToolView
             object.insert("content".to_owned(), Value::String(rewritten));
         }
         return;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TurnTestHarness;
+
+    #[test]
+    fn provider_runtime_binding_maps_direct_conversation_binding_to_direct() {
+        assert!(matches!(
+            provider_runtime_binding(ConversationRuntimeBinding::direct()),
+            provider::ProviderRuntimeBinding::Direct
+        ));
+    }
+
+    #[test]
+    fn provider_runtime_binding_maps_kernel_conversation_binding_to_kernel() {
+        let harness = TurnTestHarness::new();
+
+        assert!(matches!(
+            provider_runtime_binding(ConversationRuntimeBinding::kernel(&harness.kernel_ctx)),
+            provider::ProviderRuntimeBinding::Kernel(kernel_ctx)
+                if std::ptr::eq(kernel_ctx, &harness.kernel_ctx)
+        ));
     }
 }

--- a/crates/app/src/provider/runtime_binding.rs
+++ b/crates/app/src/provider/runtime_binding.rs
@@ -8,13 +8,6 @@ pub enum ProviderRuntimeBinding<'a> {
 }
 
 impl<'a> ProviderRuntimeBinding<'a> {
-    pub fn from_optional_kernel_context(kernel_ctx: Option<&'a KernelContext>) -> Self {
-        match kernel_ctx {
-            Some(kernel_ctx) => Self::Kernel(kernel_ctx),
-            None => Self::Direct,
-        }
-    }
-
     pub fn kernel(kernel_ctx: &'a KernelContext) -> Self {
         Self::Kernel(kernel_ctx)
     }

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,11 +1,11 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-16T03:46:17Z
+- Generated at: 2026-03-18T00:06:12Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
-- Boundary checks tracked: 3
+- Boundary checks tracked: 4
 - SLO status: PASS
 
 ## Hotspot Metrics
@@ -21,6 +21,7 @@
 |---|---|---|---|
 | memory_literals | PASS | n/a | memory operation literals are centralized in crates/app/src/memory/* |
 | provider_mod_helper_definitions | PASS | n/a | provider/mod.rs keeps payload, parse, and recovery helper implementations outside the top-level module |
+| conversation_provider_optional_binding_roundtrip | PASS | n/a | conversation/runtime.rs translates explicit conversation bindings into provider bindings without optional-kernel roundtrips |
 | spec_app_dependency | PASS | n/a | spec crate remains detached from app crate at the Cargo dependency boundary |
 
 ## SLO Assessment
@@ -44,4 +45,5 @@
 <!-- arch-hotspot key=memory_mod lines=312 functions=15 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
+<!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->
 <!-- arch-boundary key=spec_app_dependency status=PASS -->

--- a/scripts/architecture_budget_lib.sh
+++ b/scripts/architecture_budget_lib.sh
@@ -86,6 +86,7 @@ architecture_boundary_check_keys() {
   cat <<'BOUNDARIES'
 memory_literals
 provider_mod_helper_definitions
+conversation_provider_optional_binding_roundtrip
 spec_app_dependency
 BOUNDARIES
 }
@@ -116,6 +117,15 @@ architecture_spec_app_dependency_hits() {
   fi
 }
 
+architecture_conversation_provider_optional_binding_roundtrip_hits() {
+  local file="crates/app/src/conversation/runtime.rs"
+  if have_rg; then
+    rg -n 'ProviderRuntimeBinding::from_optional_kernel_context' "$file" || true
+  else
+    grep -En 'ProviderRuntimeBinding::from_optional_kernel_context' "$file" || true
+  fi
+}
+
 architecture_boundary_pass_summary() {
   case "$1" in
     memory_literals)
@@ -123,6 +133,9 @@ architecture_boundary_pass_summary() {
       ;;
     provider_mod_helper_definitions)
       echo "provider/mod.rs keeps payload, parse, and recovery helper implementations outside the top-level module"
+      ;;
+    conversation_provider_optional_binding_roundtrip)
+      echo "conversation/runtime.rs translates explicit conversation bindings into provider bindings without optional-kernel roundtrips"
       ;;
     spec_app_dependency)
       echo "spec crate remains detached from app crate at the Cargo dependency boundary"
@@ -141,6 +154,9 @@ architecture_boundary_fail_summary() {
     provider_mod_helper_definitions)
       echo "provider/mod.rs still defines payload, parse, or recovery helpers directly"
       ;;
+    conversation_provider_optional_binding_roundtrip)
+      echo "conversation/runtime.rs still rebuilds provider bindings from optional kernel context"
+      ;;
     spec_app_dependency)
       echo "spec crate depends on app crate directly"
       ;;
@@ -157,6 +173,9 @@ architecture_boundary_hits() {
       ;;
     provider_mod_helper_definitions)
       architecture_provider_mod_helper_definition_hits
+      ;;
+    conversation_provider_optional_binding_roundtrip)
+      architecture_conversation_provider_optional_binding_roundtrip_hits
       ;;
     spec_app_dependency)
       architecture_spec_app_dependency_hits


### PR DESCRIPTION
## Summary
- translate `ConversationRuntimeBinding` to `ProviderRuntimeBinding` explicitly at the conversation/provider seam
- stop rebuilding provider bindings from optional kernel context inside `conversation/runtime.rs`
- remove the now-unused provider optional-kernel helper and add regression coverage for this seam

## Why
This is a bounded first slice for #264. It closes one more governed/direct drift seam without widening the change into ACP or ingress wrapper cleanup.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p loongclaw-app provider_runtime_binding_maps --locked -- --test-threads=1`
- `LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh`
- `cargo test --workspace --locked -- --test-threads=1`
- `cargo test --workspace --all-features --locked -- --test-threads=1`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `./scripts/check_architecture_boundaries.sh`

Closes #264


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified runtime binding logic to use a single mapping approach between conversation and provider bindings.

* **Tests**
  * Added unit tests to validate binding mappings and kernel-context behavior.

* **Documentation**
  * Updated architecture drift report with a new binding roundtrip hotspot and timestamp.

* **Chores**
  * Extended architecture checks and scripts to track the new binding roundtrip case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->