### PR TITLE
add fail-closed parallel tool batch execution to the conversation fast lane

### DIFF
--- a/crates/app/src/config/conversation.rs
+++ b/crates/app/src/config/conversation.rs
@@ -20,6 +20,10 @@ pub struct ConversationConfig {
     pub safe_lane_plan_execution_enabled: bool,
     #[serde(default = "default_fast_lane_max_tool_steps_per_turn")]
     pub fast_lane_max_tool_steps_per_turn: usize,
+    #[serde(default)]
+    pub fast_lane_parallel_tool_execution_enabled: bool,
+    #[serde(default = "default_fast_lane_parallel_tool_execution_max_in_flight")]
+    pub fast_lane_parallel_tool_execution_max_in_flight: usize,
     #[serde(default = "default_safe_lane_max_tool_steps_per_turn")]
     pub safe_lane_max_tool_steps_per_turn: usize,
     #[serde(default = "default_safe_lane_node_max_attempts")]
@@ -118,6 +122,9 @@ impl Default for ConversationConfig {
             hybrid_lane_enabled: default_true(),
             safe_lane_plan_execution_enabled: false,
             fast_lane_max_tool_steps_per_turn: default_fast_lane_max_tool_steps_per_turn(),
+            fast_lane_parallel_tool_execution_enabled: false,
+            fast_lane_parallel_tool_execution_max_in_flight:
+                default_fast_lane_parallel_tool_execution_max_in_flight(),
             safe_lane_max_tool_steps_per_turn: default_safe_lane_max_tool_steps_per_turn(),
             safe_lane_node_max_attempts: default_safe_lane_node_max_attempts(),
             safe_lane_plan_max_wall_time_ms: default_safe_lane_plan_max_wall_time_ms(),
@@ -280,6 +287,10 @@ impl ConversationConfig {
 
     pub fn fast_lane_max_tool_steps(&self) -> usize {
         self.fast_lane_max_tool_steps_per_turn.max(1)
+    }
+
+    pub fn fast_lane_parallel_tool_execution_max_in_flight(&self) -> usize {
+        self.fast_lane_parallel_tool_execution_max_in_flight.max(1)
     }
 
     pub fn safe_lane_max_tool_steps(&self) -> usize {
@@ -447,6 +458,10 @@ const fn default_turn_loop_max_discovery_followup_rounds() -> usize {
 
 const fn default_fast_lane_max_tool_steps_per_turn() -> usize {
     1
+}
+
+const fn default_fast_lane_parallel_tool_execution_max_in_flight() -> usize {
+    4
 }
 
 const fn default_safe_lane_max_tool_steps_per_turn() -> usize {
@@ -680,6 +695,16 @@ mod tests {
             ..ConversationConfig::default()
         };
         assert_eq!(too_large.tool_result_payload_summary_limit_chars(), 64_000);
+    }
+
+    #[test]
+    fn fast_lane_parallel_tool_execution_max_in_flight_is_clamped() {
+        let config = ConversationConfig {
+            fast_lane_parallel_tool_execution_max_in_flight: 0,
+            ..ConversationConfig::default()
+        };
+
+        assert_eq!(config.fast_lane_parallel_tool_execution_max_in_flight(), 1);
     }
 
     #[test]

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -1671,6 +1671,35 @@ tool_result_payload_summary_limit_chars = 4096
 
     #[test]
     #[cfg(feature = "config-toml")]
+    fn conversation_fast_lane_parallel_tool_execution_can_be_overridden_from_toml() {
+        let raw = r#"
+[conversation]
+fast_lane_parallel_tool_execution_enabled = true
+fast_lane_parallel_tool_execution_max_in_flight = 7
+"#;
+        let parsed =
+            toml::from_str::<LoongClawConfig>(raw).expect("parse conversation config should pass");
+        assert!(
+            parsed
+                .conversation
+                .fast_lane_parallel_tool_execution_enabled
+        );
+        assert_eq!(
+            parsed
+                .conversation
+                .fast_lane_parallel_tool_execution_max_in_flight,
+            7
+        );
+        assert_eq!(
+            parsed
+                .conversation
+                .fast_lane_parallel_tool_execution_max_in_flight(),
+            7
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
     fn conversation_health_thresholds_can_be_overridden_from_toml() {
         let raw = r#"
 [conversation]
@@ -1723,6 +1752,8 @@ safe_lane_health_replan_warn_threshold = 0.55
         assert!(config.hybrid_lane_enabled);
         assert!(!config.safe_lane_plan_execution_enabled);
         assert_eq!(config.fast_lane_max_tool_steps_per_turn, 1);
+        assert!(!config.fast_lane_parallel_tool_execution_enabled);
+        assert_eq!(config.fast_lane_parallel_tool_execution_max_in_flight, 4);
         assert_eq!(config.safe_lane_max_tool_steps_per_turn, 1);
         assert_eq!(config.safe_lane_node_max_attempts, 2);
         assert_eq!(config.safe_lane_plan_max_wall_time_ms, 30_000);

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -1800,6 +1800,31 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
 
     #[test]
     #[cfg(feature = "config-toml")]
+    fn write_template_includes_fast_lane_parallel_tool_execution_defaults() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let temp_dir = std::env::temp_dir().join(format!(
+            "loongclaw-template-fast-lane-parallel-execution-{unique}"
+        ));
+        std::fs::create_dir_all(&temp_dir).expect("create temp directory");
+        let config_path = temp_dir.join("config.toml");
+
+        write_template(Some(config_path.to_string_lossy().as_ref()), true)
+            .expect("write template should succeed");
+
+        let raw = std::fs::read_to_string(&config_path).expect("read template");
+        assert!(raw.contains("[conversation]"));
+        assert!(raw.contains("fast_lane_parallel_tool_execution_enabled = false"));
+        assert!(raw.contains("fast_lane_parallel_tool_execution_max_in_flight = 4"));
+
+        std::fs::remove_file(&config_path).ok();
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
     fn validate_file_returns_structured_diagnostics() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/app/src/conversation/analytics.rs
+++ b/crates/app/src/conversation/analytics.rs
@@ -411,6 +411,28 @@ pub struct DiscoveryFirstEventSummary {
     pub outcome_counts: BTreeMap<String, u32>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FastLaneToolBatchSegmentSnapshot {
+    pub segment_index: u32,
+    pub scheduling_class: String,
+    pub execution_mode: String,
+    pub intent_count: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FastLaneToolBatchEventSummary {
+    pub batch_events: u32,
+    pub latest_schema_version: Option<u32>,
+    pub latest_total_intents: Option<u32>,
+    pub latest_parallel_execution_enabled: Option<bool>,
+    pub latest_parallel_execution_max_in_flight: Option<u32>,
+    pub latest_parallel_safe_intents: Option<u32>,
+    pub latest_serial_only_intents: Option<u32>,
+    pub latest_parallel_segments: Option<u32>,
+    pub latest_sequential_segments: Option<u32>,
+    pub latest_segments: Vec<FastLaneToolBatchSegmentSnapshot>,
+}
+
 pub fn parse_conversation_event(content: &str) -> Option<ConversationEventRecord> {
     let parsed = serde_json::from_str::<Value>(content).ok()?;
     if parsed.get("type")?.as_str()? != "conversation_event" {
@@ -460,6 +482,22 @@ where
             continue;
         };
         fold_discovery_first_event_record(&record, &mut summary);
+    }
+
+    summary
+}
+
+pub fn summarize_fast_lane_tool_batch_events<'a, I>(contents: I) -> FastLaneToolBatchEventSummary
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut summary = FastLaneToolBatchEventSummary::default();
+
+    for content in contents {
+        let Some(record) = parse_conversation_event(content) else {
+            continue;
+        };
+        fold_fast_lane_tool_batch_event_record(&record, &mut summary);
     }
 
     summary
@@ -752,6 +790,30 @@ fn fold_discovery_first_event_record(
         }
         _ => {}
     }
+}
+
+fn fold_fast_lane_tool_batch_event_record(
+    record: &ConversationEventRecord,
+    summary: &mut FastLaneToolBatchEventSummary,
+) {
+    if record.event != "fast_lane_tool_batch" {
+        return;
+    }
+
+    summary.batch_events = summary.batch_events.saturating_add(1);
+    summary.latest_schema_version = read_u32_opt(&record.payload, "schema_version");
+    summary.latest_total_intents = read_u32_opt(&record.payload, "total_intents");
+    summary.latest_parallel_execution_enabled = record
+        .payload
+        .get("parallel_execution_enabled")
+        .and_then(Value::as_bool);
+    summary.latest_parallel_execution_max_in_flight =
+        read_u32_opt(&record.payload, "parallel_execution_max_in_flight");
+    summary.latest_parallel_safe_intents = read_u32_opt(&record.payload, "parallel_safe_intents");
+    summary.latest_serial_only_intents = read_u32_opt(&record.payload, "serial_only_intents");
+    summary.latest_parallel_segments = read_u32_opt(&record.payload, "parallel_segments");
+    summary.latest_sequential_segments = read_u32_opt(&record.payload, "sequential_segments");
+    summary.latest_segments = parse_fast_lane_tool_batch_segments(record.payload.get("segments"));
 }
 
 pub(crate) fn summarize_turn_checkpoint_history<'a, I>(
@@ -1309,6 +1371,33 @@ fn fold_session_governor_summary(
         read_u32_opt(governor, "recovery_success_streak_threshold");
 }
 
+fn parse_fast_lane_tool_batch_segments(
+    value: Option<&Value>,
+) -> Vec<FastLaneToolBatchSegmentSnapshot> {
+    value
+        .and_then(Value::as_array)
+        .map(|segments| {
+            segments
+                .iter()
+                .map(|segment| FastLaneToolBatchSegmentSnapshot {
+                    segment_index: read_u32_opt(segment, "segment_index").unwrap_or_default(),
+                    scheduling_class: segment
+                        .get("scheduling_class")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_owned(),
+                    execution_mode: segment
+                        .get("execution_mode")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_owned(),
+                    intent_count: read_u32_opt(segment, "intent_count").unwrap_or_default(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn read_u32_opt(value: &Value, key: &str) -> Option<u32> {
     value
         .get(key)
@@ -1337,6 +1426,93 @@ mod tests {
     fn parse_conversation_event_rejects_non_event_payloads() {
         assert!(parse_conversation_event("not-json").is_none());
         assert!(parse_conversation_event(r#"{"type":"tool_outcome"}"#).is_none());
+    }
+
+    #[test]
+    fn summarize_fast_lane_tool_batch_events_tracks_latest_batch_snapshot() {
+        let payloads = [
+            json!({
+                "type": "conversation_event",
+                "event": "fast_lane_tool_batch",
+                "payload": {
+                    "schema_version": 1,
+                    "total_intents": 2,
+                    "parallel_execution_enabled": true,
+                    "parallel_execution_max_in_flight": 2,
+                    "parallel_safe_intents": 2,
+                    "serial_only_intents": 0,
+                    "parallel_segments": 1,
+                    "sequential_segments": 0,
+                    "segments": [
+                        {
+                            "segment_index": 0,
+                            "scheduling_class": "parallel_safe",
+                            "execution_mode": "parallel",
+                            "intent_count": 2
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "fast_lane_tool_batch",
+                "payload": {
+                    "schema_version": 1,
+                    "total_intents": 3,
+                    "parallel_execution_enabled": true,
+                    "parallel_execution_max_in_flight": 3,
+                    "parallel_safe_intents": 2,
+                    "serial_only_intents": 1,
+                    "parallel_segments": 1,
+                    "sequential_segments": 1,
+                    "segments": [
+                        {
+                            "segment_index": 0,
+                            "scheduling_class": "parallel_safe",
+                            "execution_mode": "parallel",
+                            "intent_count": 2
+                        },
+                        {
+                            "segment_index": 1,
+                            "scheduling_class": "serial_only",
+                            "execution_mode": "sequential",
+                            "intent_count": 1
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+        ];
+
+        let summary = summarize_fast_lane_tool_batch_events(payloads.iter().map(String::as_str));
+
+        assert_eq!(summary.batch_events, 2);
+        assert_eq!(summary.latest_schema_version, Some(1));
+        assert_eq!(summary.latest_total_intents, Some(3));
+        assert_eq!(summary.latest_parallel_execution_enabled, Some(true));
+        assert_eq!(summary.latest_parallel_execution_max_in_flight, Some(3));
+        assert_eq!(summary.latest_parallel_safe_intents, Some(2));
+        assert_eq!(summary.latest_serial_only_intents, Some(1));
+        assert_eq!(summary.latest_parallel_segments, Some(1));
+        assert_eq!(summary.latest_sequential_segments, Some(1));
+        assert_eq!(
+            summary.latest_segments,
+            vec![
+                FastLaneToolBatchSegmentSnapshot {
+                    segment_index: 0,
+                    scheduling_class: "parallel_safe".to_owned(),
+                    execution_mode: "parallel".to_owned(),
+                    intent_count: 2,
+                },
+                FastLaneToolBatchSegmentSnapshot {
+                    segment_index: 1,
+                    scheduling_class: "serial_only".to_owned(),
+                    execution_mode: "sequential".to_owned(),
+                    intent_count: 1,
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/app/src/conversation/analytics.rs
+++ b/crates/app/src/conversation/analytics.rs
@@ -1379,19 +1379,19 @@ fn parse_fast_lane_tool_batch_segments(
         .map(|segments| {
             segments
                 .iter()
-                .map(|segment| FastLaneToolBatchSegmentSnapshot {
-                    segment_index: read_u32_opt(segment, "segment_index").unwrap_or_default(),
-                    scheduling_class: segment
-                        .get("scheduling_class")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default()
-                        .to_owned(),
-                    execution_mode: segment
-                        .get("execution_mode")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default()
-                        .to_owned(),
-                    intent_count: read_u32_opt(segment, "intent_count").unwrap_or_default(),
+                .filter_map(|segment| {
+                    Some(FastLaneToolBatchSegmentSnapshot {
+                        segment_index: read_u32_opt(segment, "segment_index")?,
+                        scheduling_class: segment
+                            .get("scheduling_class")
+                            .and_then(Value::as_str)?
+                            .to_owned(),
+                        execution_mode: segment
+                            .get("execution_mode")
+                            .and_then(Value::as_str)?
+                            .to_owned(),
+                        intent_count: read_u32_opt(segment, "intent_count")?,
+                    })
                 })
                 .collect()
         })
@@ -1512,6 +1512,50 @@ mod tests {
                     intent_count: 1,
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn summarize_fast_lane_tool_batch_events_ignores_malformed_segments() {
+        let payloads = [json!({
+            "type": "conversation_event",
+            "event": "fast_lane_tool_batch",
+            "payload": {
+                "schema_version": 1,
+                "total_intents": 2,
+                "parallel_execution_enabled": true,
+                "parallel_execution_max_in_flight": 2,
+                "parallel_safe_intents": 2,
+                "serial_only_intents": 0,
+                "parallel_segments": 1,
+                "sequential_segments": 0,
+                "segments": [
+                    null,
+                    [],
+                    {
+                        "segment_index": 99
+                    },
+                    {
+                        "segment_index": 1,
+                        "scheduling_class": "parallel_safe",
+                        "execution_mode": "parallel",
+                        "intent_count": 2
+                    }
+                ]
+            }
+        })
+        .to_string()];
+
+        let summary = summarize_fast_lane_tool_batch_events(payloads.iter().map(String::as_str));
+
+        assert_eq!(
+            summary.latest_segments,
+            vec![FastLaneToolBatchSegmentSnapshot {
+                segment_index: 1,
+                scheduling_class: "parallel_safe".to_owned(),
+                execution_mode: "parallel".to_owned(),
+                intent_count: 2,
+            }]
         );
     }
 

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -19,13 +19,15 @@ mod turn_loop;
 mod turn_shared;
 
 pub use analytics::{
-    ConversationEventRecord, DiscoveryFirstEventSummary, SafeLaneEventSummary, SafeLaneFinalStatus,
+    ConversationEventRecord, DiscoveryFirstEventSummary, FastLaneToolBatchEventSummary,
+    FastLaneToolBatchSegmentSnapshot, SafeLaneEventSummary, SafeLaneFinalStatus,
     SafeLaneHealthSignalSnapshot, SafeLaneMetricsSnapshot, SafeLaneToolOutputSnapshot,
     TurnCheckpointEventSummary, TurnCheckpointFailureStep, TurnCheckpointProgressStatus,
     TurnCheckpointRecoveryAction, TurnCheckpointRepairManualReason, TurnCheckpointRepairPlan,
     TurnCheckpointSessionState, TurnCheckpointStage, build_turn_checkpoint_repair_plan,
     parse_conversation_event, plan_turn_checkpoint_recovery, summarize_discovery_first_events,
-    summarize_safe_lane_events, summarize_turn_checkpoint_events,
+    summarize_fast_lane_tool_batch_events, summarize_safe_lane_events,
+    summarize_turn_checkpoint_events,
 };
 pub use context_engine::{
     AssembledConversationContext, CONTEXT_ENGINE_API_VERSION, ContextEngineBootstrapResult,

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -5030,6 +5030,150 @@ async fn handle_turn_with_runtime_safe_lane_honors_configured_tool_step_budget()
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_safe_lane_does_not_parallelize_fast_lane_batches_when_plan_path_is_disabled()
+ {
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+    use loongclaw_kernel::CoreToolAdapter;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use tokio::time::Duration;
+
+    struct OverlapDetectingToolAdapter {
+        in_flight: Arc<AtomicUsize>,
+        overlap_observed: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl CoreToolAdapter for OverlapDetectingToolAdapter {
+        fn name(&self) -> &str {
+            "overlap-detecting-tools"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, loongclaw_contracts::ToolPlaneError> {
+            let active = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            if active > 1 {
+                self.overlap_observed.store(true, Ordering::SeqCst);
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "path": request.payload.get("path").cloned().unwrap_or(Value::Null),
+                }),
+            })
+        }
+    }
+
+    let overlap_observed = Arc::new(AtomicBool::new(false));
+    let in_flight = Arc::new(AtomicUsize::new(0));
+
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(
+        StaticPolicyEngine::default(),
+        clock,
+        Arc::new(InMemoryAuditSink::default()),
+    );
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_tool_adapter(OverlapDetectingToolAdapter {
+        in_flight: in_flight.clone(),
+        overlap_observed: overlap_observed.clone(),
+    });
+    kernel
+        .set_default_core_tool_adapter("overlap-detecting-tools")
+        .expect("set default core tool adapter");
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+    let kernel_ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Executing deployment checks.".to_owned(),
+            tool_intents: vec![
+                provider_tool_intent(
+                    "file.read",
+                    json!({"path": "first.md"}),
+                    "session-safe-fast-lane-gating",
+                    "turn-safe-fast-lane-gating",
+                    "call-safe-fast-lane-gating-1",
+                ),
+                provider_tool_intent(
+                    "file.read",
+                    json!({"path": "second.md"}),
+                    "session-safe-fast-lane-gating",
+                    "turn-safe-fast-lane-gating",
+                    "call-safe-fast-lane-gating-2",
+                ),
+            ],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let mut config = test_config();
+    config.conversation.safe_lane_plan_execution_enabled = false;
+    config.conversation.safe_lane_max_tool_steps_per_turn = 2;
+    config
+        .conversation
+        .fast_lane_parallel_tool_execution_enabled = true;
+    config
+        .conversation
+        .fast_lane_parallel_tool_execution_max_in_flight = 2;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-safe-fast-lane-gating",
+            "deploy to production with secret token and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("safe lane turn should complete without fast-lane parallel execution");
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let checkpoint_payloads =
+        persisted_conversation_event_payloads_by_name(&persisted, "turn_checkpoint");
+    assert_eq!(
+        checkpoint_payloads.last().expect("turn_checkpoint payload")["checkpoint"]["lane"]["lane"],
+        "safe"
+    );
+    assert!(
+        reply
+            .lines()
+            .filter(|line| line.starts_with("[ok] "))
+            .count()
+            == 2,
+        "expected raw tool output for both tool calls, got: {reply}"
+    );
+    assert!(
+        !overlap_observed.load(Ordering::SeqCst),
+        "safe lane should not reuse fast-lane parallel execution"
+    );
+}
+
 #[tokio::test]
 async fn handle_turn_with_runtime_safe_lane_plan_path_bypasses_turn_step_limit() {
     let runtime = FakeRuntime::with_turn_and_completion(
@@ -7591,14 +7735,13 @@ async fn turn_engine_fails_closed_before_kernel_binding_error_for_later_core_int
 async fn turn_engine_parallel_safe_app_batch_executes_concurrently_in_source_order() {
     use async_trait::async_trait;
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use tokio::sync::Notify;
-    use tokio::time::{Duration, timeout};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use tokio::time::Duration;
 
     #[derive(Default)]
     struct ParallelSafeDispatcher {
         overlap_observed: AtomicBool,
-        second_started: Notify,
+        in_flight: AtomicUsize,
     }
 
     #[async_trait]
@@ -7615,15 +7758,12 @@ async fn turn_engine_parallel_safe_app_batch_executes_concurrently_in_source_ord
                 .and_then(Value::as_str)
                 .expect("marker should be present");
 
-            if marker == "second" {
-                self.second_started.notify_waiters();
-                tokio::time::sleep(Duration::from_millis(25)).await;
-            } else if timeout(Duration::from_millis(200), self.second_started.notified())
-                .await
-                .is_ok()
-            {
+            let active = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            if active > 1 {
                 self.overlap_observed.store(true, Ordering::SeqCst);
             }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
 
             Ok(ToolCoreOutcome {
                 status: "ok".to_owned(),
@@ -7726,13 +7866,131 @@ async fn turn_engine_parallel_safe_app_batch_executes_concurrently_in_source_ord
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_parallel_safe_app_batch_returns_failure_without_waiting_for_in_flight_work() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use tokio::time::Duration;
+
+    #[derive(Default)]
+    struct ParallelFailureDispatcher {
+        slow_completed: AtomicBool,
+        slow_started: AtomicBool,
+        in_flight: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for ParallelFailureDispatcher {
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> Result<ToolCoreOutcome, String> {
+            let marker = request
+                .payload
+                .get("marker")
+                .and_then(Value::as_str)
+                .expect("marker should be present");
+
+            match marker {
+                "slow" => {
+                    self.slow_started.store(true, Ordering::SeqCst);
+                    self.in_flight.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    self.slow_completed.store(true, Ordering::SeqCst);
+                    Ok(ToolCoreOutcome {
+                        status: "ok".to_owned(),
+                        payload: json!({
+                            "marker": marker,
+                            "tool_name": request.tool_name,
+                        }),
+                    })
+                }
+                "fail" => {
+                    while !self.slow_started.load(Ordering::SeqCst) {
+                        tokio::task::yield_now().await;
+                    }
+                    Err("parallel batch failure".to_owned())
+                }
+                other => panic!("unexpected marker `{other}`"),
+            }
+        }
+    }
+
+    let dispatcher = ParallelFailureDispatcher::default();
+    let engine = TurnEngine::with_parallel_tool_execution(2, 2_048, true, 2);
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![
+            provider_tool_intent(
+                "sessions_list",
+                json!({
+                    "marker": "slow",
+                }),
+                "root-session",
+                "turn-parallel-safe-batch-failure",
+                "call-parallel-safe-batch-failure-1",
+            ),
+            provider_tool_intent(
+                "sessions_list",
+                json!({
+                    "marker": "fail",
+                }),
+                "root-session",
+                "turn-parallel-safe-batch-failure",
+                "call-parallel-safe-batch-failure-2",
+            ),
+        ],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &dispatcher,
+            crate::conversation::ConversationRuntimeBinding::direct(),
+            None,
+        )
+        .await;
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    match result {
+        TurnResult::ToolError(failure) => {
+            assert_eq!(failure.code.as_str(), "app_tool_execution_failed");
+            assert!(
+                failure.reason.contains("parallel batch failure"),
+                "unexpected failure reason: {:?}",
+                failure.reason
+            );
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected ToolError(app_tool_execution_failed), got: {other:?}")
+        }
+    }
+
+    assert!(
+        !dispatcher.slow_completed.load(Ordering::SeqCst),
+        "parallel batch should cancel in-flight work once a deterministic failure is known"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn turn_engine_mixed_batch_parallelizes_parallel_safe_segments_without_crossing_serial_only_boundaries()
  {
     use async_trait::async_trait;
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use tokio::sync::Notify;
-    use tokio::time::{Duration, timeout};
+    use tokio::time::Duration;
 
     #[derive(Default)]
     struct SegmentedParallelDispatcher {
@@ -7742,8 +8000,8 @@ async fn turn_engine_mixed_batch_parallelizes_parallel_safe_segments_without_cro
         second_segment_started_before_serial_completed: AtomicBool,
         first_segment_completed: AtomicUsize,
         serial_completed: AtomicBool,
-        first_segment_second_started: Notify,
-        second_segment_second_started: Notify,
+        first_segment_in_flight: AtomicUsize,
+        second_segment_in_flight: AtomicUsize,
     }
 
     #[async_trait]
@@ -7762,20 +8020,21 @@ async fn turn_engine_mixed_batch_parallelizes_parallel_safe_segments_without_cro
 
             match marker {
                 "p1a" => {
-                    if timeout(
-                        Duration::from_millis(200),
-                        self.first_segment_second_started.notified(),
-                    )
-                    .await
-                    .is_ok()
-                    {
+                    let active = self.first_segment_in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    if active > 1 {
                         self.first_segment_overlap.store(true, Ordering::SeqCst);
                     }
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    self.first_segment_in_flight.fetch_sub(1, Ordering::SeqCst);
                     self.first_segment_completed.fetch_add(1, Ordering::SeqCst);
                 }
                 "p1b" => {
-                    self.first_segment_second_started.notify_waiters();
+                    let active = self.first_segment_in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    if active > 1 {
+                        self.first_segment_overlap.store(true, Ordering::SeqCst);
+                    }
                     tokio::time::sleep(Duration::from_millis(25)).await;
+                    self.first_segment_in_flight.fetch_sub(1, Ordering::SeqCst);
                     self.first_segment_completed.fetch_add(1, Ordering::SeqCst);
                 }
                 "serial" => {
@@ -7791,23 +8050,24 @@ async fn turn_engine_mixed_batch_parallelizes_parallel_safe_segments_without_cro
                         self.second_segment_started_before_serial_completed
                             .store(true, Ordering::SeqCst);
                     }
-                    if timeout(
-                        Duration::from_millis(200),
-                        self.second_segment_second_started.notified(),
-                    )
-                    .await
-                    .is_ok()
-                    {
+                    let active = self.second_segment_in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    if active > 1 {
                         self.second_segment_overlap.store(true, Ordering::SeqCst);
                     }
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    self.second_segment_in_flight.fetch_sub(1, Ordering::SeqCst);
                 }
                 "p2b" => {
                     if !self.serial_completed.load(Ordering::SeqCst) {
                         self.second_segment_started_before_serial_completed
                             .store(true, Ordering::SeqCst);
                     }
-                    self.second_segment_second_started.notify_waiters();
+                    let active = self.second_segment_in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    if active > 1 {
+                        self.second_segment_overlap.store(true, Ordering::SeqCst);
+                    }
                     tokio::time::sleep(Duration::from_millis(25)).await;
+                    self.second_segment_in_flight.fetch_sub(1, Ordering::SeqCst);
                 }
                 other => panic!("unexpected marker `{other}`"),
             }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -5008,16 +5008,19 @@ async fn handle_turn_with_runtime_fast_lane_batch_persist_failure_surfaces_runti
     let runtime_ops = audit
         .snapshot()
         .iter()
-        .filter_map(|event| match &event.kind {
-            loongclaw_kernel::AuditEventKind::PlaneInvoked {
+        .filter_map(|event| {
+            if let loongclaw_kernel::AuditEventKind::PlaneInvoked {
                 plane,
                 primary_adapter,
                 operation,
                 ..
-            } if *plane == loongclaw_contracts::ExecutionPlane::Runtime => {
+            } = &event.kind
+                && *plane == loongclaw_contracts::ExecutionPlane::Runtime
+            {
                 Some((primary_adapter.to_owned(), operation.to_owned()))
+            } else {
+                None
             }
-            _ => None,
         })
         .collect::<Vec<_>>();
     assert!(

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -7596,6 +7596,223 @@ async fn turn_engine_parallel_safe_app_batch_executes_concurrently_in_source_ord
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_mixed_batch_parallelizes_parallel_safe_segments_without_crossing_serial_only_boundaries()
+ {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use tokio::sync::Notify;
+    use tokio::time::{Duration, timeout};
+
+    #[derive(Default)]
+    struct SegmentedParallelDispatcher {
+        first_segment_overlap: AtomicBool,
+        second_segment_overlap: AtomicBool,
+        serial_started_before_first_segment_completed: AtomicBool,
+        second_segment_started_before_serial_completed: AtomicBool,
+        first_segment_completed: AtomicUsize,
+        serial_completed: AtomicBool,
+        first_segment_second_started: Notify,
+        second_segment_second_started: Notify,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for SegmentedParallelDispatcher {
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> Result<ToolCoreOutcome, String> {
+            let marker = request
+                .payload
+                .get("marker")
+                .and_then(Value::as_str)
+                .expect("marker should be present");
+
+            match marker {
+                "p1a" => {
+                    if timeout(
+                        Duration::from_millis(200),
+                        self.first_segment_second_started.notified(),
+                    )
+                    .await
+                    .is_ok()
+                    {
+                        self.first_segment_overlap.store(true, Ordering::SeqCst);
+                    }
+                    self.first_segment_completed.fetch_add(1, Ordering::SeqCst);
+                }
+                "p1b" => {
+                    self.first_segment_second_started.notify_waiters();
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    self.first_segment_completed.fetch_add(1, Ordering::SeqCst);
+                }
+                "serial" => {
+                    if self.first_segment_completed.load(Ordering::SeqCst) < 2 {
+                        self.serial_started_before_first_segment_completed
+                            .store(true, Ordering::SeqCst);
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    self.serial_completed.store(true, Ordering::SeqCst);
+                }
+                "p2a" => {
+                    if !self.serial_completed.load(Ordering::SeqCst) {
+                        self.second_segment_started_before_serial_completed
+                            .store(true, Ordering::SeqCst);
+                    }
+                    if timeout(
+                        Duration::from_millis(200),
+                        self.second_segment_second_started.notified(),
+                    )
+                    .await
+                    .is_ok()
+                    {
+                        self.second_segment_overlap.store(true, Ordering::SeqCst);
+                    }
+                }
+                "p2b" => {
+                    if !self.serial_completed.load(Ordering::SeqCst) {
+                        self.second_segment_started_before_serial_completed
+                            .store(true, Ordering::SeqCst);
+                    }
+                    self.second_segment_second_started.notify_waiters();
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                }
+                other => panic!("unexpected marker `{other}`"),
+            }
+
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "marker": marker,
+                    "tool_name": request.tool_name,
+                }),
+            })
+        }
+    }
+
+    let dispatcher = SegmentedParallelDispatcher::default();
+    let engine = TurnEngine::with_parallel_tool_execution(5, 2_048, true, 2);
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![
+            provider_tool_intent(
+                "sessions_list",
+                json!({
+                    "marker": "p1a",
+                }),
+                "root-session",
+                "turn-segmented-parallel-batch",
+                "call-segmented-parallel-batch-1",
+            ),
+            provider_tool_intent(
+                "sessions_list",
+                json!({
+                    "marker": "p1b",
+                }),
+                "root-session",
+                "turn-segmented-parallel-batch",
+                "call-segmented-parallel-batch-2",
+            ),
+            provider_tool_intent(
+                "session_status",
+                json!({
+                    "session_id": "root-session",
+                    "marker": "serial",
+                }),
+                "root-session",
+                "turn-segmented-parallel-batch",
+                "call-segmented-parallel-batch-3",
+            ),
+            provider_tool_intent(
+                "sessions_list",
+                json!({
+                    "marker": "p2a",
+                }),
+                "root-session",
+                "turn-segmented-parallel-batch",
+                "call-segmented-parallel-batch-4",
+            ),
+            provider_tool_intent(
+                "sessions_list",
+                json!({
+                    "marker": "p2b",
+                }),
+                "root-session",
+                "turn-segmented-parallel-batch",
+                "call-segmented-parallel-batch-5",
+            ),
+        ],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &dispatcher,
+            crate::conversation::ConversationRuntimeBinding::direct(),
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            let lines = text.lines().collect::<Vec<_>>();
+            assert_eq!(lines.len(), 5, "expected one line per tool result");
+            for (line, marker) in lines.iter().zip(["p1a", "p1b", "serial", "p2a", "p2b"]) {
+                let envelope = line
+                    .strip_prefix("[ok] ")
+                    .map(|payload| {
+                        serde_json::from_str::<Value>(payload)
+                            .expect("tool result envelope should be json")
+                    })
+                    .expect("line should keep [ok] prefix");
+                assert!(
+                    envelope["payload_summary"]
+                        .as_str()
+                        .expect("payload summary should be text")
+                        .contains(&format!("\"marker\":\"{marker}\"")),
+                    "expected output to stay in source order, got: {text}"
+                );
+            }
+        }
+        other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected FinalText, got: {other:?}")
+        }
+    }
+
+    assert!(
+        dispatcher.first_segment_overlap.load(Ordering::SeqCst),
+        "first parallel-safe segment should overlap instead of falling back to whole-batch serial execution"
+    );
+    assert!(
+        dispatcher.second_segment_overlap.load(Ordering::SeqCst),
+        "second parallel-safe segment should overlap instead of falling back to whole-batch serial execution"
+    );
+    assert!(
+        !dispatcher
+            .serial_started_before_first_segment_completed
+            .load(Ordering::SeqCst),
+        "serial-only intent should not start before the preceding parallel-safe segment fully completes"
+    );
+    assert!(
+        !dispatcher
+            .second_segment_started_before_serial_completed
+            .load(Ordering::SeqCst),
+        "parallel-safe segment after a serial-only intent should not start before that serial-only intent completes"
+    );
+}
+
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
 async fn default_app_tool_dispatcher_executes_session_wait_for_visible_terminal_child_session() {

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -60,6 +60,7 @@ struct FakeRuntime {
     turn_calls: Mutex<usize>,
     after_turn_calls: Mutex<Vec<(String, String, String, usize)>>,
     compact_calls: Mutex<Vec<(String, usize)>>,
+    persist_failure: Option<(String, String)>,
 }
 
 enum FakeTurnResponse {
@@ -572,6 +573,7 @@ impl FakeRuntime {
             turn_calls: Mutex::new(0),
             after_turn_calls: Mutex::new(Vec::new()),
             compact_calls: Mutex::new(Vec::new()),
+            persist_failure: None,
         }
     }
 
@@ -603,6 +605,11 @@ impl FakeRuntime {
 
     fn with_compact_result(mut self, result: Result<(), String>) -> Self {
         self.compact_result = result;
+        self
+    }
+
+    fn with_persist_failure_on_substring(mut self, needle: &str, error: &str) -> Self {
+        self.persist_failure = Some((needle.to_owned(), error.to_owned()));
         self
     }
 
@@ -1114,6 +1121,11 @@ impl ConversationRuntime for FakeRuntime {
         content: &str,
         _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<()> {
+        if let Some((needle, error)) = self.persist_failure.as_ref()
+            && content.contains(needle)
+        {
+            return Err(error.clone());
+        }
         #[cfg(feature = "memory-sqlite")]
         if let Some(config) = self.durable_memory_config.as_ref() {
             crate::memory::append_turn_direct(session_id, role, content, config)
@@ -4903,6 +4915,118 @@ async fn handle_turn_with_runtime_persists_fast_lane_tool_batch_event_for_mixed_
     assert_eq!(segments[2]["scheduling_class"], "parallel_safe");
     assert_eq!(segments[2]["execution_mode"], "parallel");
     assert_eq!(segments[2]["intent_count"], 2);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_fast_lane_batch_persist_failure_surfaces_runtime_audit() {
+    let mut config = test_config();
+    config.conversation.fast_lane_max_tool_steps_per_turn = 5;
+    config
+        .conversation
+        .fast_lane_parallel_tool_execution_enabled = true;
+    config
+        .conversation
+        .fast_lane_parallel_tool_execution_max_in_flight = 2;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    crate::memory::append_turn_direct(
+        "session-fast-lane-batch-persist-failure",
+        "user",
+        "hello",
+        &memory_config,
+    )
+    .expect("append user turn");
+    crate::memory::append_turn_direct(
+        "session-fast-lane-batch-persist-failure",
+        "assistant",
+        "done",
+        &memory_config,
+    )
+    .expect("append assistant turn");
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Inspecting session state.".to_owned(),
+            tool_intents: vec![
+                provider_tool_intent(
+                    "sessions_list",
+                    json!({}),
+                    "session-fast-lane-batch-persist-failure",
+                    "turn-fast-lane-batch-persist-failure",
+                    "call-fast-lane-batch-persist-failure-1",
+                ),
+                provider_tool_intent(
+                    "session_status",
+                    json!({
+                        "session_id": "session-fast-lane-batch-persist-failure",
+                    }),
+                    "session-fast-lane-batch-persist-failure",
+                    "turn-fast-lane-batch-persist-failure",
+                    "call-fast-lane-batch-persist-failure-2",
+                ),
+            ],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    )
+    .with_persist_failure_on_substring(
+        "\"event\":\"fast_lane_tool_batch\"",
+        "fast-lane batch persist failed",
+    );
+
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (kernel_ctx, _invocations) = build_kernel_context(audit.clone());
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-fast-lane-batch-persist-failure",
+            "inspect the session state and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("fast-lane turn should still succeed when batch event persistence fails");
+
+    assert!(
+        reply.contains("[ok] "),
+        "raw tool output request should preserve tool output, got: {reply}"
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads =
+        persisted_conversation_event_payloads_by_name(&persisted, "fast_lane_tool_batch");
+    assert!(
+        payloads.is_empty(),
+        "failed fast-lane batch persistence should not leave a partial event"
+    );
+
+    let runtime_ops = audit
+        .snapshot()
+        .iter()
+        .filter_map(|event| match &event.kind {
+            loongclaw_kernel::AuditEventKind::PlaneInvoked {
+                plane,
+                primary_adapter,
+                operation,
+                ..
+            } if *plane == loongclaw_contracts::ExecutionPlane::Runtime => {
+                Some((primary_adapter.to_owned(), operation.to_owned()))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        runtime_ops.iter().any(|(adapter, operation)| {
+            adapter == "conversation.fast_lane"
+                && operation == "conversation.fast_lane.fast_lane_tool_batch_persist_failed"
+        }),
+        "expected fast-lane batch persistence failure audit event, got: {runtime_ops:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -7245,6 +7245,357 @@ async fn turn_engine_routes_direct_binding_to_app_dispatcher() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_fails_closed_before_governed_approval_for_later_app_intent() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct ApprovalBarrierDispatcher {
+        executed: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for ApprovalBarrierDispatcher {
+        async fn maybe_require_approval(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            _intent: &crate::conversation::ToolIntent,
+            descriptor: &crate::tools::ToolDescriptor,
+            _kernel_ctx: Option<&crate::KernelContext>,
+        ) -> Result<Option<crate::conversation::turn_engine::ApprovalRequirement>, String> {
+            if descriptor.name == "delegate_async" {
+                return Ok(Some(
+                    crate::conversation::turn_engine::ApprovalRequirement {
+                        kind:
+                            crate::conversation::turn_engine::ApprovalRequirementKind::GovernedTool,
+                        reason: "operator approval required before running `delegate_async`"
+                            .to_owned(),
+                        rule_id: "governed_tool_requires_approval".to_owned(),
+                        tool_name: Some("delegate_async".to_owned()),
+                        approval_key: Some("tool:delegate_async".to_owned()),
+                        approval_request_id: Some("apr-test-approval-barrier".to_owned()),
+                    },
+                ));
+            }
+            Ok(None)
+        }
+
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.executed
+                .lock()
+                .expect("dispatcher executed lock")
+                .push(request.tool_name.clone());
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool_name": request.tool_name,
+                }),
+            })
+        }
+    }
+
+    let dispatcher = ApprovalBarrierDispatcher::default();
+    let engine = TurnEngine::new(2);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![
+            provider_tool_intent(
+                "sessions_list",
+                json!({}),
+                "root-session",
+                "turn-approval-barrier",
+                "call-approval-barrier-1",
+            ),
+            provider_tool_intent(
+                "delegate_async",
+                json!({
+                    "task": "inspect child task"
+                }),
+                "root-session",
+                "turn-approval-barrier",
+                "call-approval-barrier-2",
+            ),
+        ],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &dispatcher,
+            crate::conversation::ConversationRuntimeBinding::direct(),
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::NeedsApproval(requirement) => {
+            assert_eq!(requirement.tool_name.as_deref(), Some("delegate_async"));
+            assert_eq!(
+                requirement.approval_request_id.as_deref(),
+                Some("apr-test-approval-barrier")
+            );
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected NeedsApproval, got: {other:?}")
+        }
+    }
+
+    assert!(
+        dispatcher
+            .executed
+            .lock()
+            .expect("dispatcher executed lock")
+            .is_empty(),
+        "batch should fail closed before any earlier app tool executes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_fails_closed_before_kernel_binding_error_for_later_core_intent() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct KernelBarrierDispatcher {
+        executed: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for KernelBarrierDispatcher {
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.executed
+                .lock()
+                .expect("dispatcher executed lock")
+                .push(request.tool_name.clone());
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool_name": request.tool_name,
+                }),
+            })
+        }
+    }
+
+    let dispatcher = KernelBarrierDispatcher::default();
+    let engine = TurnEngine::new(2);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![
+            provider_tool_intent(
+                "sessions_list",
+                json!({}),
+                "root-session",
+                "turn-kernel-barrier",
+                "call-kernel-barrier-1",
+            ),
+            provider_tool_intent(
+                "file.read",
+                json!({
+                    "path": "README.md"
+                }),
+                "root-session",
+                "turn-kernel-barrier",
+                "call-kernel-barrier-2",
+            ),
+        ],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &dispatcher,
+            crate::conversation::ConversationRuntimeBinding::direct(),
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::ToolDenied(failure) => {
+            assert_eq!(failure.code.as_str(), "no_kernel_context");
+            assert_eq!(failure.reason.as_str(), "no_kernel_context");
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected ToolDenied(no_kernel_context), got: {other:?}")
+        }
+    }
+
+    assert!(
+        dispatcher
+            .executed
+            .lock()
+            .expect("dispatcher executed lock")
+            .is_empty(),
+        "batch should fail closed before any earlier app tool executes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_parallel_safe_app_batch_executes_concurrently_in_source_order() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::Notify;
+    use tokio::time::{Duration, timeout};
+
+    #[derive(Default)]
+    struct ParallelSafeDispatcher {
+        overlap_observed: AtomicBool,
+        second_started: Notify,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for ParallelSafeDispatcher {
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> Result<ToolCoreOutcome, String> {
+            let marker = request
+                .payload
+                .get("marker")
+                .and_then(Value::as_str)
+                .expect("marker should be present");
+
+            if marker == "second" {
+                self.second_started.notify_waiters();
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            } else if timeout(Duration::from_millis(200), self.second_started.notified())
+                .await
+                .is_ok()
+            {
+                self.overlap_observed.store(true, Ordering::SeqCst);
+            }
+
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "marker": marker,
+                    "tool_name": request.tool_name,
+                }),
+            })
+        }
+    }
+
+    let dispatcher = ParallelSafeDispatcher::default();
+    let engine = TurnEngine::with_parallel_tool_execution(2, 2_048, true, 2);
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![
+            provider_tool_intent(
+                "sessions_list",
+                json!({
+                    "marker": "first",
+                }),
+                "root-session",
+                "turn-parallel-safe-batch",
+                "call-parallel-safe-batch-1",
+            ),
+            provider_tool_intent(
+                "sessions_list",
+                json!({
+                    "marker": "second",
+                }),
+                "root-session",
+                "turn-parallel-safe-batch",
+                "call-parallel-safe-batch-2",
+            ),
+        ],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &dispatcher,
+            crate::conversation::ConversationRuntimeBinding::direct(),
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            let lines = text.lines().collect::<Vec<_>>();
+            assert_eq!(lines.len(), 2, "expected one line per tool result");
+
+            let first_envelope = lines[0]
+                .strip_prefix("[ok] ")
+                .map(|payload| {
+                    serde_json::from_str::<Value>(payload)
+                        .expect("first tool result envelope should be json")
+                })
+                .expect("first line should keep [ok] prefix");
+            let second_envelope = lines[1]
+                .strip_prefix("[ok] ")
+                .map(|payload| {
+                    serde_json::from_str::<Value>(payload)
+                        .expect("second tool result envelope should be json")
+                })
+                .expect("second line should keep [ok] prefix");
+
+            assert!(
+                first_envelope["payload_summary"]
+                    .as_str()
+                    .expect("first payload summary should be text")
+                    .contains("\"marker\":\"first\""),
+                "expected first output to stay in source order, got: {text}"
+            );
+            assert!(
+                second_envelope["payload_summary"]
+                    .as_str()
+                    .expect("second payload summary should be text")
+                    .contains("\"marker\":\"second\""),
+                "expected second output to stay in source order, got: {text}"
+            );
+        }
+        other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected FinalText, got: {other:?}")
+        }
+    }
+
+    assert!(
+        dispatcher.overlap_observed.load(Ordering::SeqCst),
+        "parallel-safe batch should overlap execution before finalizing source-ordered output"
+    );
+}
+
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
 async fn default_app_tool_dispatcher_executes_session_wait_for_visible_terminal_child_session() {

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -4776,6 +4776,135 @@ async fn handle_turn_with_runtime_honors_configured_tool_result_summary_limit_on
     );
 }
 
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_persists_fast_lane_tool_batch_event_for_mixed_segments() {
+    let mut config = test_config();
+    config.conversation.fast_lane_max_tool_steps_per_turn = 5;
+    config
+        .conversation
+        .fast_lane_parallel_tool_execution_enabled = true;
+    config
+        .conversation
+        .fast_lane_parallel_tool_execution_max_in_flight = 2;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    crate::memory::append_turn_direct(
+        "session-fast-lane-batch-event",
+        "user",
+        "hello",
+        &memory_config,
+    )
+    .expect("append user turn");
+    crate::memory::append_turn_direct(
+        "session-fast-lane-batch-event",
+        "assistant",
+        "done",
+        &memory_config,
+    )
+    .expect("append assistant turn");
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Inspecting session state.".to_owned(),
+            tool_intents: vec![
+                provider_tool_intent(
+                    "sessions_list",
+                    json!({}),
+                    "session-fast-lane-batch-event",
+                    "turn-fast-lane-batch-event",
+                    "call-fast-lane-batch-event-1",
+                ),
+                provider_tool_intent(
+                    "sessions_list",
+                    json!({}),
+                    "session-fast-lane-batch-event",
+                    "turn-fast-lane-batch-event",
+                    "call-fast-lane-batch-event-2",
+                ),
+                provider_tool_intent(
+                    "session_status",
+                    json!({
+                        "session_id": "session-fast-lane-batch-event",
+                    }),
+                    "session-fast-lane-batch-event",
+                    "turn-fast-lane-batch-event",
+                    "call-fast-lane-batch-event-3",
+                ),
+                provider_tool_intent(
+                    "sessions_list",
+                    json!({}),
+                    "session-fast-lane-batch-event",
+                    "turn-fast-lane-batch-event",
+                    "call-fast-lane-batch-event-4",
+                ),
+                provider_tool_intent(
+                    "sessions_list",
+                    json!({}),
+                    "session-fast-lane-batch-event",
+                    "turn-fast-lane-batch-event",
+                    "call-fast-lane-batch-event-5",
+                ),
+            ],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-fast-lane-batch-event",
+            "inspect the session state and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("mixed fast-lane batch turn should succeed");
+
+    assert!(
+        reply.contains("[ok] "),
+        "raw tool output request should preserve tool output, got: {reply}"
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads =
+        persisted_conversation_event_payloads_by_name(&persisted, "fast_lane_tool_batch");
+    assert_eq!(payloads.len(), 1, "expected one fast-lane batch event");
+
+    let payload = &payloads[0];
+    assert_eq!(payload["schema_version"], 1);
+    assert_eq!(payload["total_intents"], 5);
+    assert_eq!(payload["parallel_execution_enabled"], true);
+    assert_eq!(payload["parallel_execution_max_in_flight"], 2);
+    assert_eq!(payload["parallel_safe_intents"], 4);
+    assert_eq!(payload["serial_only_intents"], 1);
+    assert_eq!(payload["parallel_segments"], 2);
+    assert_eq!(payload["sequential_segments"], 1);
+
+    let segments = payload["segments"].as_array().expect("segments array");
+    assert_eq!(
+        segments.len(),
+        3,
+        "expected contiguous mixed-batch segments"
+    );
+    assert_eq!(segments[0]["segment_index"], 0);
+    assert_eq!(segments[0]["scheduling_class"], "parallel_safe");
+    assert_eq!(segments[0]["execution_mode"], "parallel");
+    assert_eq!(segments[0]["intent_count"], 2);
+    assert_eq!(segments[1]["segment_index"], 1);
+    assert_eq!(segments[1]["scheduling_class"], "serial_only");
+    assert_eq!(segments[1]["execution_mode"], "sequential");
+    assert_eq!(segments[1]["intent_count"], 1);
+    assert_eq!(segments[2]["segment_index"], 2);
+    assert_eq!(segments[2]["scheduling_class"], "parallel_safe");
+    assert_eq!(segments[2]["execution_mode"], "parallel");
+    assert_eq!(segments[2]["intent_count"], 2);
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn handle_turn_with_runtime_honors_configured_tool_result_summary_limit_on_safe_lane_plan() {
     use crate::test_support::TurnTestHarness;

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4348,12 +4348,17 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
     let payload_summary_limit_chars = config
         .conversation
         .tool_result_payload_summary_limit_chars();
-    let parallel_tool_execution_enabled = config
-        .conversation
-        .fast_lane_parallel_tool_execution_enabled;
-    let parallel_tool_execution_max_in_flight = config
-        .conversation
-        .fast_lane_parallel_tool_execution_max_in_flight();
+    let parallel_tool_execution_enabled = matches!(lane, ExecutionLane::Fast)
+        && config
+            .conversation
+            .fast_lane_parallel_tool_execution_enabled;
+    let parallel_tool_execution_max_in_flight = if parallel_tool_execution_enabled {
+        config
+            .conversation
+            .fast_lane_parallel_tool_execution_max_in_flight()
+    } else {
+        1
+    };
     let use_safe_lane_plan_path = preparation
         .lane_plan
         .should_use_safe_lane_plan_path(config, turn);

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4407,7 +4407,31 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
     };
 
     if let Some(trace) = fast_lane_tool_batch_trace.as_ref() {
-        emit_fast_lane_tool_batch_event(runtime, session_id, trace, binding).await;
+        if let Err(error) =
+            emit_fast_lane_tool_batch_event(runtime, session_id, trace, binding).await
+        {
+            eprintln!(
+                "warning: failed to persist fast-lane tool batch event for session {session_id} (total_intents={}, segments={}, max_in_flight={}): {error}",
+                trace.total_intents,
+                trace.segments.len(),
+                trace.parallel_execution_max_in_flight,
+            );
+            if let Some(ctx) = binding.kernel_context() {
+                let _ = ctx.kernel.record_audit_event(
+                    Some(ctx.agent_id()),
+                    AuditEventKind::PlaneInvoked {
+                        pack_id: ctx.pack_id().to_owned(),
+                        plane: ExecutionPlane::Runtime,
+                        tier: PlaneTier::Core,
+                        primary_adapter: "conversation.fast_lane".to_owned(),
+                        delegated_core_adapter: None,
+                        operation: "conversation.fast_lane.fast_lane_tool_batch_persist_failed"
+                            .to_owned(),
+                        required_capabilities: Vec::new(),
+                    },
+                );
+            }
+        }
     }
 
     ProviderTurnLaneExecution {
@@ -4897,15 +4921,15 @@ async fn emit_fast_lane_tool_batch_event<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     trace: &ToolBatchExecutionTrace,
     binding: ConversationRuntimeBinding<'_>,
-) {
-    let _ = persist_conversation_event(
+) -> CliResult<()> {
+    persist_conversation_event(
         runtime,
         session_id,
         "fast_lane_tool_batch",
         trace.as_event_payload(),
         binding,
     )
-    .await;
+    .await
 }
 
 async fn emit_turn_ingress_event<R: ConversationRuntime + ?Sized>(

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4406,32 +4406,24 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         }
     };
 
-    if let Some(trace) = fast_lane_tool_batch_trace.as_ref() {
-        if let Err(error) =
-            emit_fast_lane_tool_batch_event(runtime, session_id, trace, binding).await
-        {
-            eprintln!(
-                "warning: failed to persist fast-lane tool batch event for session {session_id} (total_intents={}, segments={}, max_in_flight={}): {error}",
-                trace.total_intents,
-                trace.segments.len(),
-                trace.parallel_execution_max_in_flight,
-            );
-            if let Some(ctx) = binding.kernel_context() {
-                let _ = ctx.kernel.record_audit_event(
-                    Some(ctx.agent_id()),
-                    AuditEventKind::PlaneInvoked {
-                        pack_id: ctx.pack_id().to_owned(),
-                        plane: ExecutionPlane::Runtime,
-                        tier: PlaneTier::Core,
-                        primary_adapter: "conversation.fast_lane".to_owned(),
-                        delegated_core_adapter: None,
-                        operation: "conversation.fast_lane.fast_lane_tool_batch_persist_failed"
-                            .to_owned(),
-                        required_capabilities: Vec::new(),
-                    },
-                );
-            }
-        }
+    if let Some(trace) = fast_lane_tool_batch_trace.as_ref()
+        && emit_fast_lane_tool_batch_event(runtime, session_id, trace, binding)
+            .await
+            .is_err()
+        && let Some(ctx) = binding.kernel_context()
+    {
+        let _ = ctx.kernel.record_audit_event(
+            Some(ctx.agent_id()),
+            AuditEventKind::PlaneInvoked {
+                pack_id: ctx.pack_id().to_owned(),
+                plane: ExecutionPlane::Runtime,
+                tier: PlaneTier::Core,
+                primary_adapter: "conversation.fast_lane".to_owned(),
+                delegated_core_adapter: None,
+                operation: "conversation.fast_lane.fast_lane_tool_batch_persist_failed".to_owned(),
+                required_capabilities: Vec::new(),
+            },
+        );
     }
 
     ProviderTurnLaneExecution {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4348,12 +4348,20 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
     let payload_summary_limit_chars = config
         .conversation
         .tool_result_payload_summary_limit_chars();
+    let parallel_tool_execution_enabled = config
+        .conversation
+        .fast_lane_parallel_tool_execution_enabled;
+    let parallel_tool_execution_max_in_flight = config
+        .conversation
+        .fast_lane_parallel_tool_execution_max_in_flight();
     let use_safe_lane_plan_path = preparation
         .lane_plan
         .should_use_safe_lane_plan_path(config, turn);
-    let engine = TurnEngine::with_tool_result_payload_summary_limit(
+    let engine = TurnEngine::with_parallel_tool_execution(
         preparation.lane_plan.max_tool_steps,
         payload_summary_limit_chars,
+        parallel_tool_execution_enabled,
+        parallel_tool_execution_max_in_flight,
     );
     let validation = if use_safe_lane_plan_path {
         TurnEngine::with_tool_result_payload_summary_limit(usize::MAX, payload_summary_limit_chars)

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -73,8 +73,8 @@ use super::turn_budget::{
     SafeLaneFailureRouteReason, SafeLaneReplanBudget,
 };
 use super::turn_engine::{
-    AppToolDispatcher, DefaultAppToolDispatcher, ProviderTurn, ToolIntent, TurnEngine, TurnFailure,
-    TurnFailureKind, TurnResult, TurnValidation,
+    AppToolDispatcher, DefaultAppToolDispatcher, ProviderTurn, ToolBatchExecutionTrace, ToolIntent,
+    TurnEngine, TurnFailure, TurnFailureKind, TurnResult, TurnValidation,
 };
 use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ReplyResolutionMode, ToolDrivenFollowupKind,
@@ -4369,9 +4369,9 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
     } else {
         engine.validate_turn_in_context(turn, &session_context)
     };
-    let (turn_result, safe_lane_terminal_route) = match validation {
-        Ok(TurnValidation::FinalText(text)) => (TurnResult::FinalText(text), None),
-        Err(failure) => (TurnResult::ToolDenied(failure), None),
+    let (turn_result, safe_lane_terminal_route, fast_lane_tool_batch_trace) = match validation {
+        Ok(TurnValidation::FinalText(text)) => (TurnResult::FinalText(text), None, None),
+        Err(failure) => (TurnResult::ToolDenied(failure), None, None),
         Ok(TurnValidation::ToolExecutionRequired) if use_safe_lane_plan_path => {
             let outcome = execute_turn_with_safe_lane_plan(
                 config,
@@ -4385,15 +4385,25 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
                 ingress,
             )
             .await;
-            (outcome.result, outcome.terminal_route)
+            (outcome.result, outcome.terminal_route, None)
         }
-        Ok(TurnValidation::ToolExecutionRequired) => (
-            engine
-                .execute_turn_in_context(turn, &session_context, &app_dispatcher, binding, ingress)
-                .await,
-            None,
-        ),
+        Ok(TurnValidation::ToolExecutionRequired) => {
+            let (result, trace) = engine
+                .execute_turn_in_context_with_trace(
+                    turn,
+                    &session_context,
+                    &app_dispatcher,
+                    binding,
+                    ingress,
+                )
+                .await;
+            (result, None, trace)
+        }
     };
+
+    if let Some(trace) = fast_lane_tool_batch_trace.as_ref() {
+        emit_fast_lane_tool_batch_event(runtime, session_id, trace, binding).await;
+    }
 
     ProviderTurnLaneExecution {
         lane,
@@ -4875,6 +4885,22 @@ async fn emit_safe_lane_event<R: ConversationRuntime + ?Sized>(
             },
         );
     }
+}
+
+async fn emit_fast_lane_tool_batch_event<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    trace: &ToolBatchExecutionTrace,
+    binding: ConversationRuntimeBinding<'_>,
+) {
+    let _ = persist_conversation_event(
+        runtime,
+        session_id,
+        "fast_lane_tool_batch",
+        trace.as_event_payload(),
+        binding,
+    )
+    .await;
 }
 
 async fn emit_turn_ingress_event<R: ConversationRuntime + ?Sized>(

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1420,19 +1420,14 @@ impl TurnEngine {
         .buffer_unordered(self.parallel_tool_execution_max_in_flight);
 
         while let Some((index, result)) = executions.next().await {
-            results.push((index, result));
-        }
-        results.sort_by_key(|(index, _)| *index);
-
-        let mut outputs = Vec::with_capacity(prepared.len());
-        for (_, result) in results {
             match result {
-                Ok(output) => outputs.push(output),
+                Ok(output) => results.push((index, output)),
                 Err(turn_result) => return Err(turn_result),
             }
         }
+        results.sort_by_key(|(index, _)| *index);
 
-        Ok(outputs)
+        Ok(results.into_iter().map(|(_, output)| output).collect())
     }
 
     async fn prepare_tool_intent<D: AppToolDispatcher + ?Sized>(

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1159,31 +1159,51 @@ impl TurnEngine {
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
     ) -> Result<Vec<String>, TurnResult> {
-        if self.should_execute_prepared_batch_in_parallel(prepared) {
-            self.execute_prepared_batch_in_parallel(
-                prepared,
-                session_context,
-                app_dispatcher,
-                binding,
-            )
-            .await
-        } else {
-            self.execute_prepared_batch_sequential(
-                prepared,
-                session_context,
-                app_dispatcher,
-                binding,
-            )
-            .await
+        if !self.parallel_tool_execution_enabled || prepared.len() <= 1 {
+            return self
+                .execute_prepared_batch_sequential(
+                    prepared,
+                    session_context,
+                    app_dispatcher,
+                    binding,
+                )
+                .await;
         }
-    }
 
-    fn should_execute_prepared_batch_in_parallel(&self, prepared: &[PreparedToolIntent]) -> bool {
-        self.parallel_tool_execution_enabled
-            && prepared.len() > 1
-            && prepared.iter().all(|prepared_intent| {
-                prepared_intent.scheduling_class == ToolSchedulingClass::ParallelSafe
-            })
+        let mut outputs = Vec::with_capacity(prepared.len());
+        let mut remaining = prepared;
+        while let Some((first, _)) = remaining.split_first() {
+            let scheduling_class = first.scheduling_class;
+            let segment_len = remaining
+                .iter()
+                .take_while(|prepared_intent| prepared_intent.scheduling_class == scheduling_class)
+                .count();
+            let (segment, rest) = remaining.split_at(segment_len);
+            let mut segment_outputs = match scheduling_class {
+                ToolSchedulingClass::ParallelSafe if segment.len() > 1 => {
+                    self.execute_prepared_batch_in_parallel(
+                        segment,
+                        session_context,
+                        app_dispatcher,
+                        binding,
+                    )
+                    .await?
+                }
+                ToolSchedulingClass::ParallelSafe | ToolSchedulingClass::SerialOnly => {
+                    self.execute_prepared_batch_sequential(
+                        segment,
+                        session_context,
+                        app_dispatcher,
+                        binding,
+                    )
+                    .await?
+                }
+            };
+            outputs.append(&mut segment_outputs);
+            remaining = rest;
+        }
+
+        Ok(outputs)
     }
 
     async fn execute_prepared_batch_sequential<D: AppToolDispatcher + ?Sized>(

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -904,6 +904,94 @@ pub struct TurnEngine {
     parallel_tool_execution_max_in_flight: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolBatchExecutionMode {
+    Sequential,
+    Parallel,
+}
+
+impl ToolBatchExecutionMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Sequential => "sequential",
+            Self::Parallel => "parallel",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PreparedBatchSegment {
+    len: usize,
+    scheduling_class: ToolSchedulingClass,
+    execution_mode: ToolBatchExecutionMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolBatchExecutionSegmentTrace {
+    pub segment_index: usize,
+    pub scheduling_class: ToolSchedulingClass,
+    pub execution_mode: ToolBatchExecutionMode,
+    pub intent_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolBatchExecutionTrace {
+    pub total_intents: usize,
+    pub parallel_execution_enabled: bool,
+    pub parallel_execution_max_in_flight: usize,
+    pub segments: Vec<ToolBatchExecutionSegmentTrace>,
+}
+
+impl ToolBatchExecutionTrace {
+    pub(crate) fn as_event_payload(&self) -> serde_json::Value {
+        let parallel_safe_intents = self
+            .segments
+            .iter()
+            .filter(|segment| segment.scheduling_class == ToolSchedulingClass::ParallelSafe)
+            .map(|segment| segment.intent_count)
+            .sum::<usize>();
+        let serial_only_intents = self
+            .segments
+            .iter()
+            .filter(|segment| segment.scheduling_class == ToolSchedulingClass::SerialOnly)
+            .map(|segment| segment.intent_count)
+            .sum::<usize>();
+        let parallel_segments = self
+            .segments
+            .iter()
+            .filter(|segment| segment.execution_mode == ToolBatchExecutionMode::Parallel)
+            .count();
+        let sequential_segments = self
+            .segments
+            .iter()
+            .filter(|segment| segment.execution_mode == ToolBatchExecutionMode::Sequential)
+            .count();
+
+        json!({
+            "schema_version": 1,
+            "total_intents": self.total_intents,
+            "parallel_execution_enabled": self.parallel_execution_enabled,
+            "parallel_execution_max_in_flight": self.parallel_execution_max_in_flight,
+            "parallel_safe_intents": parallel_safe_intents,
+            "serial_only_intents": serial_only_intents,
+            "parallel_segments": parallel_segments,
+            "sequential_segments": sequential_segments,
+            "segments": self
+                .segments
+                .iter()
+                .map(|segment| {
+                    json!({
+                        "segment_index": segment.segment_index,
+                        "scheduling_class": segment.scheduling_class.as_str(),
+                        "execution_mode": segment.execution_mode.as_str(),
+                        "intent_count": segment.intent_count,
+                    })
+                })
+                .collect::<Vec<_>>(),
+        })
+    }
+}
+
 #[derive(Debug, Clone)]
 struct PreparedToolIntent {
     intent: ToolIntent,
@@ -1124,9 +1212,28 @@ impl TurnEngine {
         binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
     ) -> TurnResult {
+        self.execute_turn_in_context_with_trace(
+            turn,
+            session_context,
+            app_dispatcher,
+            binding,
+            ingress,
+        )
+        .await
+        .0
+    }
+
+    pub(crate) async fn execute_turn_in_context_with_trace<D: AppToolDispatcher + ?Sized>(
+        &self,
+        turn: &ProviderTurn,
+        session_context: &SessionContext,
+        app_dispatcher: &D,
+        binding: ConversationRuntimeBinding<'_>,
+        ingress: Option<&ConversationIngressContext>,
+    ) -> (TurnResult, Option<ToolBatchExecutionTrace>) {
         match self.validate_turn_in_context(turn, session_context) {
-            Ok(TurnValidation::FinalText(text)) => return TurnResult::FinalText(text),
-            Err(failure) => return TurnResult::ToolDenied(failure),
+            Ok(TurnValidation::FinalText(text)) => return (TurnResult::FinalText(text), None),
+            Err(failure) => return (TurnResult::ToolDenied(failure), None),
             Ok(TurnValidation::ToolExecutionRequired) => {}
         }
 
@@ -1137,19 +1244,20 @@ impl TurnEngine {
                 .await
             {
                 Ok(prepared_intent) => prepared.push(prepared_intent),
-                Err(result) => return result,
+                Err(result) => return (result, None),
             }
         }
+        let trace = self.trace_prepared_batch(&prepared);
 
         let outputs = match self
             .execute_prepared_batch(&prepared, session_context, app_dispatcher, binding)
             .await
         {
             Ok(outputs) => outputs,
-            Err(result) => return result,
+            Err(result) => return (result, trace),
         };
 
-        TurnResult::FinalText(outputs.join("\n"))
+        (TurnResult::FinalText(outputs.join("\n")), trace)
     }
 
     async fn execute_prepared_batch<D: AppToolDispatcher + ?Sized>(
@@ -1159,39 +1267,23 @@ impl TurnEngine {
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
     ) -> Result<Vec<String>, TurnResult> {
-        if !self.parallel_tool_execution_enabled || prepared.len() <= 1 {
-            return self
-                .execute_prepared_batch_sequential(
-                    prepared,
-                    session_context,
-                    app_dispatcher,
-                    binding,
-                )
-                .await;
-        }
-
         let mut outputs = Vec::with_capacity(prepared.len());
         let mut remaining = prepared;
-        while let Some((first, _)) = remaining.split_first() {
-            let scheduling_class = first.scheduling_class;
-            let segment_len = remaining
-                .iter()
-                .take_while(|prepared_intent| prepared_intent.scheduling_class == scheduling_class)
-                .count();
-            let (segment, rest) = remaining.split_at(segment_len);
-            let mut segment_outputs = match scheduling_class {
-                ToolSchedulingClass::ParallelSafe if segment.len() > 1 => {
+        for segment in self.prepared_batch_segments(prepared) {
+            let (prepared_segment, rest) = remaining.split_at(segment.len);
+            let mut segment_outputs = match segment.execution_mode {
+                ToolBatchExecutionMode::Parallel => {
                     self.execute_prepared_batch_in_parallel(
-                        segment,
+                        prepared_segment,
                         session_context,
                         app_dispatcher,
                         binding,
                     )
                     .await?
                 }
-                ToolSchedulingClass::ParallelSafe | ToolSchedulingClass::SerialOnly => {
+                ToolBatchExecutionMode::Sequential => {
                     self.execute_prepared_batch_sequential(
-                        segment,
+                        prepared_segment,
                         session_context,
                         app_dispatcher,
                         binding,
@@ -1204,6 +1296,70 @@ impl TurnEngine {
         }
 
         Ok(outputs)
+    }
+
+    fn trace_prepared_batch(
+        &self,
+        prepared: &[PreparedToolIntent],
+    ) -> Option<ToolBatchExecutionTrace> {
+        if prepared.is_empty() {
+            return None;
+        }
+
+        Some(ToolBatchExecutionTrace {
+            total_intents: prepared.len(),
+            parallel_execution_enabled: self.parallel_tool_execution_enabled,
+            parallel_execution_max_in_flight: self.parallel_tool_execution_max_in_flight,
+            segments: self
+                .prepared_batch_segments(prepared)
+                .into_iter()
+                .enumerate()
+                .map(|(segment_index, segment)| ToolBatchExecutionSegmentTrace {
+                    segment_index,
+                    scheduling_class: segment.scheduling_class,
+                    execution_mode: segment.execution_mode,
+                    intent_count: segment.len,
+                })
+                .collect(),
+        })
+    }
+
+    fn prepared_batch_segments(
+        &self,
+        prepared: &[PreparedToolIntent],
+    ) -> Vec<PreparedBatchSegment> {
+        let mut segments = Vec::new();
+        let mut remaining = prepared;
+        while let Some((first, _)) = remaining.split_first() {
+            let scheduling_class = first.scheduling_class;
+            let len = remaining
+                .iter()
+                .take_while(|prepared_intent| prepared_intent.scheduling_class == scheduling_class)
+                .count();
+            segments.push(PreparedBatchSegment {
+                len,
+                scheduling_class,
+                execution_mode: self.segment_execution_mode(scheduling_class, len),
+            });
+            let (_, rest) = remaining.split_at(len);
+            remaining = rest;
+        }
+        segments
+    }
+
+    fn segment_execution_mode(
+        &self,
+        scheduling_class: ToolSchedulingClass,
+        segment_len: usize,
+    ) -> ToolBatchExecutionMode {
+        if self.parallel_tool_execution_enabled
+            && scheduling_class == ToolSchedulingClass::ParallelSafe
+            && segment_len > 1
+        {
+            ToolBatchExecutionMode::Parallel
+        } else {
+            ToolBatchExecutionMode::Sequential
+        }
     }
 
     async fn execute_prepared_batch_sequential<D: AppToolDispatcher + ?Sized>(

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures_util::stream::{self, StreamExt};
 use loongclaw_contracts::{KernelError, ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -17,9 +18,10 @@ use crate::session::repository::{
     NewApprovalRequestRecord, NewSessionRecord, SessionKind, SessionRepository, SessionState,
 };
 use crate::tools::{
-    ToolApprovalMode, ToolExecutionKind, ToolView, delegate_child_tool_view_for_config,
-    delegate_child_tool_view_for_config_with_delegate, governance_profile_for_descriptor,
-    runtime_tool_view, runtime_tool_view_for_config, tool_catalog,
+    ToolApprovalMode, ToolExecutionKind, ToolSchedulingClass, ToolView,
+    delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
+    governance_profile_for_descriptor, runtime_tool_view, runtime_tool_view_for_config,
+    tool_catalog,
 };
 
 use super::runtime::SessionContext;
@@ -898,13 +900,26 @@ async fn execute_tool_intent_via_kernel(
 pub struct TurnEngine {
     max_tool_steps: usize,
     tool_result_payload_summary_limit_chars: usize,
+    parallel_tool_execution_enabled: bool,
+    parallel_tool_execution_max_in_flight: usize,
+}
+
+#[derive(Debug, Clone)]
+struct PreparedToolIntent {
+    intent: ToolIntent,
+    request: ToolCoreRequest,
+    execution_kind: ToolExecutionKind,
+    scheduling_class: ToolSchedulingClass,
+    trusted_internal_context: bool,
 }
 
 impl TurnEngine {
     pub fn new(max_tool_steps: usize) -> Self {
-        Self::with_tool_result_payload_summary_limit(
+        Self::with_parallel_tool_execution(
             max_tool_steps,
             TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+            false,
+            1,
         )
     }
 
@@ -912,12 +927,28 @@ impl TurnEngine {
         max_tool_steps: usize,
         tool_result_payload_summary_limit_chars: usize,
     ) -> Self {
+        Self::with_parallel_tool_execution(
+            max_tool_steps,
+            tool_result_payload_summary_limit_chars,
+            false,
+            1,
+        )
+    }
+
+    pub fn with_parallel_tool_execution(
+        max_tool_steps: usize,
+        tool_result_payload_summary_limit_chars: usize,
+        parallel_tool_execution_enabled: bool,
+        parallel_tool_execution_max_in_flight: usize,
+    ) -> Self {
         Self {
             max_tool_steps,
             tool_result_payload_summary_limit_chars: tool_result_payload_summary_limit_chars.clamp(
                 MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
                 MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
             ),
+            parallel_tool_execution_enabled,
+            parallel_tool_execution_max_in_flight: parallel_tool_execution_max_in_flight.max(1),
         }
     }
 
@@ -1099,143 +1130,285 @@ impl TurnEngine {
             Ok(TurnValidation::ToolExecutionRequired) => {}
         }
 
-        let mut outputs = Vec::new();
+        let mut prepared = Vec::new();
         for intent in &turn.tool_intents {
-            let Some(resolved_tool) = crate::tools::resolve_tool_execution(&intent.tool_name)
-            else {
-                let reason = format!("tool_not_found: {}", intent.tool_name);
-                return TurnResult::policy_denied("tool_not_found", reason);
-            };
-            let injected = inject_internal_tool_ingress(
-                resolved_tool.canonical_name,
-                intent.args_json.clone(),
-                ingress,
-            );
-            let augmented_payload = augment_tool_payload_for_kernel(
-                resolved_tool.canonical_name,
-                injected.payload,
-                &session_context.session_id,
-            );
-            let request = ToolCoreRequest {
-                tool_name: resolved_tool.canonical_name.to_owned(),
-                payload: augmented_payload,
-            };
-            // When the provider wraps a discoverable App tool inside `tool.invoke`,
-            // the outer resolution yields ToolExecutionKind::Core (because `tool.invoke`
-            // itself is a core tool).  Rather than sending the wrapper through the kernel
-            // (which would reject App-typed inner tools), we unwrap the envelope here and
-            // route the inner tool through the App dispatcher path.
-            let (effective_execution_kind, effective_request, effective_intent) =
-                if resolved_tool.canonical_name == "tool.invoke" {
-                    match crate::tools::resolve_tool_invoke_request(&request) {
-                        Ok((inner_resolved, inner_request))
-                            if inner_resolved.execution_kind == ToolExecutionKind::App =>
-                        {
-                            // Build a synthetic intent that carries the inner tool name
-                            // so that approval preflight sees the real tool identity.
-                            let inner_intent = ToolIntent {
-                                tool_name: inner_resolved.canonical_name.to_owned(),
-                                args_json: inner_request.payload.clone(),
-                                source: intent.source.clone(),
-                                session_id: intent.session_id.clone(),
-                                turn_id: intent.turn_id.clone(),
-                                tool_call_id: intent.tool_call_id.clone(),
-                            };
-                            (ToolExecutionKind::App, inner_request, inner_intent)
-                        }
-                        _ => (resolved_tool.execution_kind, request, intent.clone()),
-                    }
-                } else {
-                    (resolved_tool.execution_kind, request, intent.clone())
-                };
+            match self
+                .prepare_tool_intent(intent, session_context, app_dispatcher, binding, ingress)
+                .await
+            {
+                Ok(prepared_intent) => prepared.push(prepared_intent),
+                Err(result) => return result,
+            }
+        }
 
-            let outcome = match effective_execution_kind {
-                ToolExecutionKind::Core => {
-                    let Some(kernel_ctx) = binding.kernel_context() else {
-                        return TurnResult::policy_denied("no_kernel_context", "no_kernel_context");
-                    };
-                    match execute_tool_intent_via_kernel(
-                        effective_request,
-                        kernel_ctx,
-                        injected.trusted_internal_context,
-                    )
-                    .await
-                    {
-                        Ok(outcome) => outcome,
-                        Err(failure) => return turn_result_from_tool_execution_failure(failure),
-                    }
-                }
-                ToolExecutionKind::App => {
-                    let effective_tool_name = effective_request.tool_name.as_str();
-                    let catalog = crate::tools::tool_catalog();
-                    let Some(descriptor) = catalog.resolve(effective_tool_name) else {
-                        let reason = format!("tool_descriptor_missing: {}", effective_tool_name);
-                        return TurnResult::non_retryable_tool_error(
-                            "tool_descriptor_missing",
-                            reason,
-                        );
-                    };
-                    let kernel_ctx = binding.kernel_context();
-                    match app_dispatcher
-                        .maybe_require_approval(
-                            session_context,
-                            &effective_intent,
-                            descriptor,
-                            kernel_ctx,
-                        )
-                        .await
-                    {
-                        Ok(Some(requirement)) => return TurnResult::NeedsApproval(requirement),
-                        Ok(None) => {}
-                        Err(reason) if reason.starts_with("app_tool_denied:") => {
-                            return TurnResult::policy_denied("app_tool_denied", reason);
-                        }
-                        Err(reason) => {
-                            return TurnResult::non_retryable_tool_error(
-                                "app_tool_preflight_failed",
-                                reason,
-                            );
-                        }
-                    }
+        let outputs = match self
+            .execute_prepared_batch(&prepared, session_context, app_dispatcher, binding)
+            .await
+        {
+            Ok(outputs) => outputs,
+            Err(result) => return result,
+        };
 
-                    match app_dispatcher
-                        .execute_app_tool(session_context, effective_request, binding)
-                        .await
-                    {
-                        Ok(outcome) => outcome,
-                        Err(reason) if reason.starts_with("tool_not_visible:") => {
-                            return TurnResult::policy_denied("tool_not_visible", reason);
-                        }
-                        Err(reason)
-                            if reason.starts_with("tool_not_found:")
-                                || reason.starts_with("app_tool_not_found:") =>
-                        {
-                            return TurnResult::policy_denied("tool_not_found", reason);
-                        }
-                        Err(reason) if reason.starts_with("app_tool_disabled:") => {
-                            return TurnResult::policy_denied("app_tool_disabled", reason);
-                        }
-                        Err(reason) if reason.starts_with("app_tool_denied:") => {
-                            return TurnResult::policy_denied("app_tool_denied", reason);
-                        }
-                        Err(reason) => {
-                            return TurnResult::non_retryable_tool_error(
-                                "app_tool_execution_failed",
-                                reason,
-                            );
-                        }
-                    }
-                }
-            };
+        TurnResult::FinalText(outputs.join("\n"))
+    }
 
+    async fn execute_prepared_batch<D: AppToolDispatcher + ?Sized>(
+        &self,
+        prepared: &[PreparedToolIntent],
+        session_context: &SessionContext,
+        app_dispatcher: &D,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> Result<Vec<String>, TurnResult> {
+        if self.should_execute_prepared_batch_in_parallel(prepared) {
+            self.execute_prepared_batch_in_parallel(
+                prepared,
+                session_context,
+                app_dispatcher,
+                binding,
+            )
+            .await
+        } else {
+            self.execute_prepared_batch_sequential(
+                prepared,
+                session_context,
+                app_dispatcher,
+                binding,
+            )
+            .await
+        }
+    }
+
+    fn should_execute_prepared_batch_in_parallel(&self, prepared: &[PreparedToolIntent]) -> bool {
+        self.parallel_tool_execution_enabled
+            && prepared.len() > 1
+            && prepared.iter().all(|prepared_intent| {
+                prepared_intent.scheduling_class == ToolSchedulingClass::ParallelSafe
+            })
+    }
+
+    async fn execute_prepared_batch_sequential<D: AppToolDispatcher + ?Sized>(
+        &self,
+        prepared: &[PreparedToolIntent],
+        session_context: &SessionContext,
+        app_dispatcher: &D,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> Result<Vec<String>, TurnResult> {
+        let mut outputs = Vec::with_capacity(prepared.len());
+        for prepared_intent in prepared {
+            let outcome = self
+                .execute_prepared_tool_intent(
+                    prepared_intent,
+                    session_context,
+                    app_dispatcher,
+                    binding,
+                )
+                .await?;
             outputs.push(format_tool_result_line_with_limit(
-                intent,
+                &prepared_intent.intent,
                 &outcome,
                 self.tool_result_payload_summary_limit_chars,
             ));
         }
+        Ok(outputs)
+    }
 
-        TurnResult::FinalText(outputs.join("\n"))
+    async fn execute_prepared_batch_in_parallel<D: AppToolDispatcher + ?Sized>(
+        &self,
+        prepared: &[PreparedToolIntent],
+        session_context: &SessionContext,
+        app_dispatcher: &D,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> Result<Vec<String>, TurnResult> {
+        let payload_summary_limit_chars = self.tool_result_payload_summary_limit_chars;
+        let mut results = Vec::with_capacity(prepared.len());
+        let mut executions = stream::iter(prepared.iter().cloned().enumerate().map(
+            |(index, prepared_intent)| async move {
+                let result = self
+                    .execute_prepared_tool_intent(
+                        &prepared_intent,
+                        session_context,
+                        app_dispatcher,
+                        binding,
+                    )
+                    .await
+                    .map(|outcome| {
+                        format_tool_result_line_with_limit(
+                            &prepared_intent.intent,
+                            &outcome,
+                            payload_summary_limit_chars,
+                        )
+                    });
+                (index, result)
+            },
+        ))
+        .buffer_unordered(self.parallel_tool_execution_max_in_flight);
+
+        while let Some((index, result)) = executions.next().await {
+            results.push((index, result));
+        }
+        results.sort_by_key(|(index, _)| *index);
+
+        let mut outputs = Vec::with_capacity(prepared.len());
+        for (_, result) in results {
+            match result {
+                Ok(output) => outputs.push(output),
+                Err(turn_result) => return Err(turn_result),
+            }
+        }
+
+        Ok(outputs)
+    }
+
+    async fn prepare_tool_intent<D: AppToolDispatcher + ?Sized>(
+        &self,
+        intent: &ToolIntent,
+        session_context: &SessionContext,
+        app_dispatcher: &D,
+        binding: ConversationRuntimeBinding<'_>,
+        ingress: Option<&ConversationIngressContext>,
+    ) -> Result<PreparedToolIntent, TurnResult> {
+        let Some(resolved_tool) = crate::tools::resolve_tool_execution(&intent.tool_name) else {
+            let reason = format!("tool_not_found: {}", intent.tool_name);
+            return Err(TurnResult::policy_denied("tool_not_found", reason));
+        };
+        let injected = inject_internal_tool_ingress(
+            resolved_tool.canonical_name,
+            intent.args_json.clone(),
+            ingress,
+        );
+        let augmented_payload = augment_tool_payload_for_kernel(
+            resolved_tool.canonical_name,
+            injected.payload,
+            &session_context.session_id,
+        );
+        let request = ToolCoreRequest {
+            tool_name: resolved_tool.canonical_name.to_owned(),
+            payload: augmented_payload,
+        };
+        let (effective_execution_kind, effective_request, effective_intent) =
+            if resolved_tool.canonical_name == "tool.invoke" {
+                match crate::tools::resolve_tool_invoke_request(&request) {
+                    Ok((inner_resolved, inner_request))
+                        if inner_resolved.execution_kind == ToolExecutionKind::App =>
+                    {
+                        let inner_intent = ToolIntent {
+                            tool_name: inner_resolved.canonical_name.to_owned(),
+                            args_json: inner_request.payload.clone(),
+                            source: intent.source.clone(),
+                            session_id: intent.session_id.clone(),
+                            turn_id: intent.turn_id.clone(),
+                            tool_call_id: intent.tool_call_id.clone(),
+                        };
+                        (ToolExecutionKind::App, inner_request, inner_intent)
+                    }
+                    _ => (resolved_tool.execution_kind, request, intent.clone()),
+                }
+            } else {
+                (resolved_tool.execution_kind, request, intent.clone())
+            };
+        let catalog = crate::tools::tool_catalog();
+        let Some(descriptor) = catalog.resolve(effective_request.tool_name.as_str()) else {
+            let reason = format!("tool_descriptor_missing: {}", effective_request.tool_name);
+            return Err(TurnResult::non_retryable_tool_error(
+                "tool_descriptor_missing",
+                reason,
+            ));
+        };
+        let scheduling_class = descriptor.scheduling_class();
+
+        match effective_execution_kind {
+            ToolExecutionKind::Core => {
+                if binding.kernel_context().is_none() {
+                    return Err(TurnResult::policy_denied(
+                        "no_kernel_context",
+                        "no_kernel_context",
+                    ));
+                }
+            }
+            ToolExecutionKind::App => {
+                let kernel_ctx = binding.kernel_context();
+                match app_dispatcher
+                    .maybe_require_approval(
+                        session_context,
+                        &effective_intent,
+                        descriptor,
+                        kernel_ctx,
+                    )
+                    .await
+                {
+                    Ok(Some(requirement)) => return Err(TurnResult::NeedsApproval(requirement)),
+                    Ok(None) => {}
+                    Err(reason) if reason.starts_with("app_tool_denied:") => {
+                        return Err(TurnResult::policy_denied("app_tool_denied", reason));
+                    }
+                    Err(reason) => {
+                        return Err(TurnResult::non_retryable_tool_error(
+                            "app_tool_preflight_failed",
+                            reason,
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(PreparedToolIntent {
+            intent: intent.clone(),
+            request: effective_request,
+            execution_kind: effective_execution_kind,
+            scheduling_class,
+            trusted_internal_context: injected.trusted_internal_context,
+        })
+    }
+
+    async fn execute_prepared_tool_intent<D: AppToolDispatcher + ?Sized>(
+        &self,
+        prepared_intent: &PreparedToolIntent,
+        session_context: &SessionContext,
+        app_dispatcher: &D,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> Result<ToolCoreOutcome, TurnResult> {
+        match prepared_intent.execution_kind {
+            ToolExecutionKind::Core => {
+                let Some(kernel_ctx) = binding.kernel_context() else {
+                    return Err(TurnResult::policy_denied(
+                        "no_kernel_context",
+                        "no_kernel_context",
+                    ));
+                };
+                execute_tool_intent_via_kernel(
+                    prepared_intent.request.clone(),
+                    kernel_ctx,
+                    prepared_intent.trusted_internal_context,
+                )
+                .await
+                .map_err(turn_result_from_tool_execution_failure)
+            }
+            ToolExecutionKind::App => match app_dispatcher
+                .execute_app_tool(session_context, prepared_intent.request.clone(), binding)
+                .await
+            {
+                Ok(outcome) => Ok(outcome),
+                Err(reason) if reason.starts_with("tool_not_visible:") => {
+                    Err(TurnResult::policy_denied("tool_not_visible", reason))
+                }
+                Err(reason)
+                    if reason.starts_with("tool_not_found:")
+                        || reason.starts_with("app_tool_not_found:") =>
+                {
+                    Err(TurnResult::policy_denied("tool_not_found", reason))
+                }
+                Err(reason) if reason.starts_with("app_tool_disabled:") => {
+                    Err(TurnResult::policy_denied("app_tool_disabled", reason))
+                }
+                Err(reason) if reason.starts_with("app_tool_denied:") => {
+                    Err(TurnResult::policy_denied("app_tool_denied", reason))
+                }
+                Err(reason) => Err(TurnResult::non_retryable_tool_error(
+                    "app_tool_execution_failed",
+                    reason,
+                )),
+            },
+        }
     }
 }
 

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -326,11 +326,17 @@ async fn evaluate_round_kernel(
     let current_tool_name_signature =
         had_tool_intents.then(|| tool_name_signature(&turn.tool_intents));
 
-    let engine = TurnEngine::with_tool_result_payload_summary_limit(
+    let engine = TurnEngine::with_parallel_tool_execution(
         policy.max_tool_steps_per_round,
         config
             .conversation
             .tool_result_payload_summary_limit_chars(),
+        config
+            .conversation
+            .fast_lane_parallel_tool_execution_enabled,
+        config
+            .conversation
+            .fast_lane_parallel_tool_execution_max_in_flight(),
     );
     let turn_result = match engine.validate_turn_in_context(turn, session_context) {
         Ok(TurnValidation::FinalText(text)) => TurnResult::FinalText(text),

--- a/crates/app/src/provider/shape.rs
+++ b/crates/app/src/provider/shape.rs
@@ -1547,6 +1547,66 @@ mod tests {
     }
 
     #[test]
+    fn provider_shape_discovery_followup_uses_first_lease_in_multiline_source_order() {
+        let first_summary = serde_json::to_string(&json!({
+            "query": "read repo file",
+            "results": [
+                {
+                    "tool_id": "file.read",
+                    "summary": "Read a UTF-8 text file from the configured workspace root and return contents.",
+                    "argument_hint": "path:string,offset?:integer,limit?:integer",
+                    "required_fields": ["path"],
+                    "required_field_groups": [["path"]],
+                    "lease": "lease-first"
+                }
+            ]
+        }))
+        .expect("encode first search payload summary");
+        let second_summary = serde_json::to_string(&json!({
+            "query": "read repo file again",
+            "results": [
+                {
+                    "tool_id": "file.read",
+                    "summary": "Read a UTF-8 text file from the configured workspace root and return contents.",
+                    "argument_hint": "path:string,offset?:integer,limit?:integer",
+                    "required_fields": ["path"],
+                    "required_field_groups": [["path"]],
+                    "lease": "lease-second"
+                }
+            ]
+        }))
+        .expect("encode second search payload summary");
+        let first_envelope = serde_json::to_string(&json!({
+            "status": "ok",
+            "tool": "tool.search",
+            "tool_call_id": "call-search-1",
+            "payload_summary": first_summary,
+            "payload_chars": 0,
+            "payload_truncated": false,
+        }))
+        .expect("encode first search envelope");
+        let second_envelope = serde_json::to_string(&json!({
+            "status": "ok",
+            "tool": "tool.search",
+            "tool_call_id": "call-search-2",
+            "payload_summary": second_summary,
+            "payload_chars": 0,
+            "payload_truncated": false,
+        }))
+        .expect("encode second search envelope");
+        let messages = vec![json!({
+            "role": "assistant",
+            "content": format!("[tool_result]\n[ok] {first_envelope}\n[ok] {second_envelope}"),
+        })];
+
+        let context = provider_tool_bridge_context_from_messages(&messages);
+        assert_eq!(
+            context.discoverable_leases.get("file.read"),
+            Some(&"lease-first".to_owned())
+        );
+    }
+
+    #[test]
     fn extract_provider_turn_handles_text_only() {
         let body = serde_json::json!({
             "choices": [{

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -2454,6 +2454,7 @@ mod tests {
                 .scheduling_class(),
             ToolSchedulingClass::ParallelSafe
         );
+        #[cfg(feature = "tool-file")]
         assert_eq!(
             catalog
                 .descriptor("file.read")
@@ -2461,6 +2462,7 @@ mod tests {
                 .scheduling_class(),
             ToolSchedulingClass::ParallelSafe
         );
+        #[cfg(feature = "tool-webfetch")]
         assert_eq!(
             catalog
                 .descriptor("web.fetch")

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -24,6 +24,15 @@ pub enum ToolSchedulingClass {
     ParallelSafe,
 }
 
+impl ToolSchedulingClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SerialOnly => "serial_only",
+            Self::ParallelSafe => "parallel_safe",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ToolGovernanceScope {
     Routine,

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -19,6 +19,12 @@ pub enum ToolAvailability {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum ToolSchedulingClass {
+    SerialOnly,
+    ParallelSafe,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ToolGovernanceScope {
     Routine,
     TopologyMutation,
@@ -103,6 +109,15 @@ pub fn governance_profile_for_descriptor(descriptor: &ToolDescriptor) -> ToolGov
     governance_profile_for_tool_name(descriptor.name)
 }
 
+pub fn scheduling_class_for_tool_name(tool_name: &str) -> ToolSchedulingClass {
+    match tool_name {
+        "tool.search" | "file.read" | "web.fetch" | "sessions_list" => {
+            ToolSchedulingClass::ParallelSafe
+        }
+        _ => ToolSchedulingClass::SerialOnly,
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ToolExposureClass {
     ProviderCore,
@@ -166,6 +181,10 @@ impl ToolDescriptor {
     pub fn is_discoverable(&self) -> bool {
         self.exposure == ToolExposureClass::Discoverable
     }
+
+    pub fn scheduling_class(&self) -> ToolSchedulingClass {
+        scheduling_class_for_tool_name(self.name)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -180,6 +199,7 @@ pub struct ToolCatalogEntry {
     pub exposure: ToolExposureClass,
     pub execution_kind: ToolExecutionKind,
     pub availability: ToolAvailability,
+    pub scheduling_class: ToolSchedulingClass,
 }
 
 impl ToolCatalogEntry {
@@ -906,6 +926,7 @@ fn descriptor_to_entry(descriptor: &ToolDescriptor) -> ToolCatalogEntry {
         exposure: descriptor.exposure,
         execution_kind: descriptor.execution_kind,
         availability: descriptor.availability,
+        scheduling_class: descriptor.scheduling_class(),
     }
 }
 
@@ -2412,5 +2433,45 @@ mod tests {
         let child_view = delegate_child_tool_view_for_config(&config);
 
         assert!(!child_view.contains("web.fetch"));
+    }
+
+    #[test]
+    fn scheduling_class_marks_parallel_safe_subset() {
+        let catalog = tool_catalog();
+        assert_eq!(
+            catalog
+                .descriptor("tool.search")
+                .expect("tool.search descriptor")
+                .scheduling_class(),
+            ToolSchedulingClass::ParallelSafe
+        );
+        assert_eq!(
+            catalog
+                .descriptor("file.read")
+                .expect("file.read descriptor")
+                .scheduling_class(),
+            ToolSchedulingClass::ParallelSafe
+        );
+        assert_eq!(
+            catalog
+                .descriptor("web.fetch")
+                .expect("web.fetch descriptor")
+                .scheduling_class(),
+            ToolSchedulingClass::ParallelSafe
+        );
+        assert_eq!(
+            catalog
+                .descriptor("sessions_list")
+                .expect("sessions_list descriptor")
+                .scheduling_class(),
+            ToolSchedulingClass::ParallelSafe
+        );
+        assert_eq!(
+            catalog
+                .descriptor("delegate_async")
+                .expect("delegate_async descriptor")
+                .scheduling_class(),
+            ToolSchedulingClass::SerialOnly
+        );
     }
 }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -45,7 +45,7 @@ mod web_fetch;
 
 pub use catalog::{
     ToolApprovalMode, ToolAvailability, ToolCatalog, ToolDescriptor, ToolExecutionKind,
-    ToolGovernanceProfile, ToolGovernanceScope, ToolRiskClass, ToolView,
+    ToolGovernanceProfile, ToolGovernanceScope, ToolRiskClass, ToolSchedulingClass, ToolView,
     delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
     governance_profile_for_descriptor, governance_profile_for_tool_name,
     planned_delegate_child_tool_view, planned_root_tool_view, runtime_tool_view,

--- a/docs/plans/2026-03-17-conversation-fast-lane-parallel-tool-batch-design.md
+++ b/docs/plans/2026-03-17-conversation-fast-lane-parallel-tool-batch-design.md
@@ -1,0 +1,230 @@
+# Conversation Fast-Lane Parallel Tool Batch Execution Design
+
+Date: 2026-03-17
+Branch: `issue-269-parallel-tool-batch-fast-lane`
+Issue: `#269`
+Scope: add a constrained, fail-closed parallel tool batch executor to the
+conversation fast lane without changing safe-lane plan execution
+
+## Problem
+
+`alpha-test` already models provider output as a `ProviderTurn` containing
+`Vec<ToolIntent>`, and provider shaping already extracts multiple tool intents
+from OpenAI, Anthropic, Bedrock, and responses-style payloads. The runtime,
+however, still executes those intents as a serial short-circuit loop in
+`TurnEngine`.
+
+That leaves three structural problems:
+
+1. multi-tool read-heavy turns pay avoidable latency because eligible calls
+   cannot run concurrently
+2. the runtime has no explicit batch contract for preflight, blocking
+   conditions, approval barriers, and result ordering
+3. the current serial loop can partially execute early intents before a later
+   approval or binding failure terminates the turn
+
+The third point matters as much as latency. A runtime that claims multi-tool
+support but lacks an explicit batch barrier invites ambiguous partial side
+effects.
+
+## Goals
+
+1. Add an explicit batch execution contract to the fast-lane conversation
+   runtime.
+2. Fail the whole batch before execution if any preflight condition blocks the
+   turn.
+3. Execute explicitly safe tools concurrently when the feature is enabled.
+4. Preserve assistant source-order output replay so follow-up payload handling
+   and discovery-first lease parsing remain stable.
+5. Keep the first iteration small, reviewable, and easy to disable.
+
+## Non-goals
+
+1. Do not redesign safe-lane plan execution in this slice.
+2. Do not parallelize governed approval flows or topology-mutating tools.
+3. Do not change the existing tool-result envelope format.
+4. Do not transplant the `spec/programmatic` scheduler implementation into
+   `app`.
+5. Do not widen `TurnEngine` into a persistence-aware conversation coordinator
+   in this slice.
+
+## Alternatives Considered
+
+### A. Keep the current executor and only raise tool-step limits
+
+Rejected. That permits more intents per turn, but it does not improve latency
+or solve the missing batch contract. It also leaves the partial-execution
+ambiguity untouched.
+
+### B. Add explicit batch phases plus per-tool scheduling metadata
+
+Recommended. This keeps the change local to the conversation fast lane while
+making the runtime semantics precise:
+
+1. sequential preflight across the batch
+2. fail-closed barrier before execution
+3. constrained concurrent execution for safe tools only
+4. source-order finalization
+
+### C. Reuse the `spec/programmatic` scheduler directly
+
+Rejected for this slice. The scheduler ideas are good and should inform the
+design, but pulling that implementation into `app` now would add too much scope
+and blur the boundary between spec orchestration and conversation runtime.
+
+## Decision
+
+Implement option B with a deliberately small contract:
+
+1. add fast-lane config gates for parallel execution
+2. add explicit scheduling metadata to the tool catalog
+3. refactor `TurnEngine` into `prepare -> execute -> finalize` phases
+4. run batches in parallel only when:
+   - the feature flag is enabled
+   - the batch has more than one intent
+   - every prepared intent is marked `ParallelSafe`
+5. fall back to prepared sequential execution for mixed or serial-only batches
+6. leave safe-lane plan execution unchanged
+
+## Proposed Design
+
+### 1. Constrained config surface
+
+Add two fast-lane-only config fields:
+
+1. `conversation.fast_lane_parallel_tool_execution_enabled = false`
+2. `conversation.fast_lane_parallel_tool_execution_max_in_flight = 4`
+
+These are intentionally separate from `turn_loop.max_tool_steps_per_round` and
+from safe-lane settings. The feature should remain opt-in and should not imply
+that the entire conversation runtime is now parallel-aware.
+
+Operators will still need to raise `fast_lane_max_tool_steps_per_turn` above `1`
+before any multi-tool fast-lane turn can execute.
+
+### 2. Tool-level scheduling metadata
+
+Add a small scheduling enum to the tool catalog:
+
+1. `SerialOnly`
+2. `ParallelSafe`
+
+This is intentionally smaller than a future resource-aware scheduler taxonomy.
+The first iteration only needs to distinguish "never batch in parallel" from
+"safe to parallelize in the fast lane".
+
+Initial `ParallelSafe` tools should stay narrow and read-oriented:
+
+1. `file.read`
+2. `tool.search`
+3. `web.fetch`
+4. `sessions_list`
+
+`sessions_list` is included because it is a read-only app tool that gives the
+test suite a controlled fast-lane app-path target without introducing runtime
+test hooks. Everything else remains `SerialOnly`.
+
+### 3. Explicit batch phases in `TurnEngine`
+
+Refactor `execute_turn_in_context(...)` around three internal phases.
+
+#### Phase A: prepare the whole batch
+
+For each intent, in assistant source order:
+
+1. resolve the tool and validate visibility
+2. inject ingress payload and browser/session scope augmentation
+3. unwrap `tool.invoke` into an inner app-tool request when needed
+4. determine the effective execution kind
+5. check kernel binding requirements for core tools
+6. run governed approval preflight for app tools
+7. derive the scheduling class from the resolved descriptor
+
+If any intent returns one of these blockers, the batch stops before execution:
+
+1. `tool_not_found`
+2. `tool_not_visible`
+3. `no_kernel_context`
+4. `NeedsApproval`
+5. policy denial
+6. descriptor/preflight failure
+
+That turns the current serial short-circuit loop into a true batch barrier.
+
+#### Phase B: execute prepared intents
+
+Execution uses one of two paths:
+
+1. prepared sequential path
+2. prepared parallel path
+
+The parallel path only activates when all prepared intents are
+`ParallelSafe`. Mixed batches fall back to sequential execution for the whole
+prepared list. That keeps the first implementation simple and predictable.
+
+Parallel execution uses bounded concurrency via `max_in_flight`, but final
+result collection is reconstructed in source order.
+
+#### Phase C: finalize in source order
+
+Formatting stays exactly the same as today:
+
+`[ok] {...}` or `[error] {...}` lines joined with `\n` in assistant source
+order.
+
+This is a compatibility contract, not an implementation detail. Follow-up
+payload reduction and discovery-first lease extraction already assume they can
+scan line-by-line while preserving assistant order.
+
+### 4. Failure semantics
+
+The batch contract for this slice is:
+
+1. preflight blockers fail closed before execution
+2. execution failures during the sequential path terminate immediately
+3. execution failures during the parallel path are collected, then surfaced in
+   source order using the existing `TurnResult` mapping
+
+Because phase 1 only parallelizes low-risk read-oriented tools, execution-time
+partial success is acceptable and bounded. We are not parallelizing mutating or
+approval-gated tools in this patch.
+
+### 5. Scope boundary on persistence
+
+`persist_tool_decision(...)` and `persist_tool_outcome(...)` already exist, but
+wiring them cleanly would require widening `TurnEngine`'s contract or adding a
+new batch report surface through the coordinator. That is a real follow-up, but
+it is intentionally out of scope here to keep this patch local to fast-lane
+execution semantics and regression coverage.
+
+## Expected Behavioral Outcome
+
+1. fast-lane turns can execute eligible multi-tool batches concurrently when
+   explicitly enabled
+2. a later approval or binding blocker no longer allows an earlier intent to
+   run first
+3. output ordering remains deterministic and source-aligned
+4. follow-up payload compaction and discovery-first lease parsing continue to
+   work with multi-line tool-result text
+5. safe-lane plan execution keeps its current behavior in this slice
+
+## Test Strategy
+
+Add focused regression coverage for:
+
+1. parallel-safe app-tool batches execute concurrently while preserving
+   source-order output
+2. a mixed batch with a later approval requirement fails before any earlier
+   intent executes
+3. a mixed batch with a later `no_kernel_context` blocker fails before any
+   earlier app intent executes
+4. config defaults and TOML overrides cover the new fast-lane parallel fields
+5. discovery-first lease parsing remains stable for multi-line tool-result
+   content in source order
+
+## Why This Slice Matters
+
+This is the smallest change that makes the conversation runtime honest about
+multi-tool execution. It closes a real semantics hole, improves latency for a
+safe subset of turns, and avoids dragging safe-lane or cross-crate scheduling
+unification into the same PR.

--- a/docs/plans/2026-03-17-conversation-fast-lane-parallel-tool-batch-implementation-plan.md
+++ b/docs/plans/2026-03-17-conversation-fast-lane-parallel-tool-batch-implementation-plan.md
@@ -1,0 +1,260 @@
+# Conversation Fast-Lane Parallel Tool Batch Execution Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to
+> implement this plan task-by-task.
+
+**Goal:** Add an opt-in, fail-closed parallel tool batch executor to the
+conversation fast lane while preserving source-order result replay and leaving
+safe-lane plan execution unchanged.
+
+**Architecture:** Keep the patch local to conversation config, tool catalog
+metadata, `TurnEngine`, and focused regression tests. Use explicit batch
+preflight and constrained scheduling metadata instead of hidden executor
+whitelists or a broad scheduler transplant.
+
+**Tech Stack:** Rust, Tokio tests, `loongclaw-app`, GitHub issue-first workflow
+
+---
+
+## Task 1: Lock the delivery artifacts before code
+
+**Files:**
+- Create: `docs/plans/2026-03-17-conversation-fast-lane-parallel-tool-batch-design.md`
+- Create: `docs/plans/2026-03-17-conversation-fast-lane-parallel-tool-batch-implementation-plan.md`
+
+**Step 1: Confirm the target seams**
+
+Run:
+- `rg -n "execute_turn_in_context|turn_loop.max_tool_steps_per_round|fast_lane_max_tool_steps_per_turn" crates/app/src/conversation crates/app/src/config`
+- `rg -n "ProviderTurn|Vec<ToolIntent>|parse_discovery_followup_leases_from_message_content" crates/app/src/conversation crates/app/src/provider`
+
+Expected: the serial fast-lane executor, the step-limit defaults, and the
+follow-up/discovery seams are all enumerated.
+
+**Step 2: Create the GitHub tracking issue**
+
+Open issue `#269` describing:
+- the current serial short-circuit execution model
+- the fail-closed batch barrier requirement
+- the fast-lane-only scope boundary
+
+Expected: issue exists before PR creation and will be linked by the PR body.
+
+## Task 2: Add RED config coverage
+
+**Files:**
+- Modify: `crates/app/src/config/conversation.rs`
+- Modify: `crates/app/src/config/mod.rs`
+- Modify: `crates/app/src/config/runtime.rs`
+
+**Step 1: Add new config fields and helper stubs**
+
+Add placeholders for:
+- `fast_lane_parallel_tool_execution_enabled`
+- `fast_lane_parallel_tool_execution_max_in_flight`
+
+Do not implement executor behavior yet.
+
+**Step 2: Add failing config tests**
+
+Cover:
+- stable defaults
+- TOML override for both fields
+- clamp behavior for `max_in_flight`
+- config template output includes the new defaults
+
+**Step 3: Run the config tests and confirm RED**
+
+Run:
+- `cargo test -p loongclaw-app --locked conversation_defaults_are_stable -- --exact`
+- `cargo test -p loongclaw-app --locked conversation_fast_lane_parallel_tool_execution_can_be_overridden_from_toml -- --exact`
+- `cargo test -p loongclaw-app --locked write_template_includes_fast_lane_parallel_tool_execution_defaults -- --exact`
+
+Expected: FAIL before the implementation is complete.
+
+## Task 3: Add RED batch-execution tests
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+- Modify: `crates/app/src/provider/shape.rs`
+
+**Step 1: Add a parallel execution regression test**
+
+Use a controlled custom `AppToolDispatcher` and a batch of two
+`sessions_list` intents to assert:
+- the second execution starts before the first finishes
+- final output lines stay in assistant source order
+
+**Step 2: Add a fail-closed approval-barrier regression**
+
+Use a batch with:
+- first intent: `sessions_list`
+- second intent: `delegate_async`
+
+Assert the turn returns `NeedsApproval` and the first app-tool intent never
+executes.
+
+**Step 3: Add a fail-closed kernel-binding regression**
+
+Use a batch with:
+- first intent: `sessions_list`
+- second intent: `file.read`
+- binding: `ConversationRuntimeBinding::Direct()`
+
+Assert the turn returns `ToolDenied("no_kernel_context")` and the first app
+intent never executes.
+
+**Step 4: Add a discovery-first compatibility regression**
+
+Extend the `provider/shape.rs` test coverage so multi-line `[tool_result]`
+assistant content with multiple `[ok]` envelopes preserves first-source-order
+lease selection.
+
+**Step 5: Run the targeted tests and confirm RED**
+
+Run:
+- `cargo test -p loongclaw-app --locked turn_engine_parallel_safe_app_batch_executes_concurrently_in_source_order -- --exact`
+- `cargo test -p loongclaw-app --locked turn_engine_parallel_batch_fails_closed_before_governed_approval -- --exact`
+- `cargo test -p loongclaw-app --locked turn_engine_parallel_batch_fails_closed_before_kernel_binding_error -- --exact`
+- `cargo test -p loongclaw-app --locked provider_shape_discovery_followup_uses_first_lease_in_multiline_source_order -- --exact`
+
+Expected: FAIL before executor changes land.
+
+## Task 4: Add scheduling metadata to the tool catalog
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+
+**Step 1: Define the scheduling enum**
+
+Add:
+- `ToolSchedulingClass::SerialOnly`
+- `ToolSchedulingClass::ParallelSafe`
+
+**Step 2: Thread scheduling metadata through descriptors**
+
+Extend `ToolDescriptor` and `ToolCatalogEntry` so the scheduling class is
+available from the resolved descriptor.
+
+**Step 3: Mark the initial safe subset**
+
+Set `ParallelSafe` for:
+- `file.read`
+- `tool.search`
+- `web.fetch`
+- `sessions_list`
+
+Leave everything else `SerialOnly`.
+
+**Step 4: Add or update catalog assertions**
+
+Add focused tests that lock the scheduling class for the intended safe subset
+and for a clearly serial-only tool such as `delegate_async`.
+
+## Task 5: Refactor `TurnEngine` into explicit batch phases
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+
+**Step 1: Add prepared batch data types**
+
+Introduce internal structs that capture:
+- original intent
+- effective intent after `tool.invoke` unwrap
+- effective request
+- execution kind
+- scheduling class
+
+**Step 2: Implement sequential batch preparation**
+
+Move all of these into a preflight phase:
+- resolution
+- ingress augmentation
+- `tool.invoke` unwrap
+- kernel binding requirement checks
+- app approval checks
+- scheduling classification
+
+Return an immediate `TurnResult` on the first blocker and do not execute any
+tool in that case.
+
+**Step 3: Implement prepared sequential execution**
+
+Keep a sequential executor for:
+- feature disabled
+- batch size `<= 1`
+- any batch containing a `SerialOnly` intent
+
+**Step 4: Implement prepared parallel execution**
+
+Execute prepared intents concurrently with bounded `max_in_flight`, but
+reconstruct the final output vector in assistant source order before formatting
+the final text.
+
+**Step 5: Keep existing output formatting**
+
+Reuse the current envelope formatting helpers so the final text remains newline
+joined `[status] {...}` entries.
+
+## Task 6: Make config drive the fast-lane executor
+
+**Files:**
+- Modify: `crates/app/src/config/conversation.rs`
+- Modify: `crates/app/src/config/mod.rs`
+- Modify: `crates/app/src/config/runtime.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs` only if needed for
+  wiring existing limits cleanly
+
+**Step 1: Finalize config defaults and helpers**
+
+Implement:
+- default `enabled = false`
+- default `max_in_flight = 4`
+- accessor clamp `max_in_flight.max(1)`
+
+**Step 2: Thread config into fast-lane engine construction**
+
+If `TurnEngine` needs constructor parameters for the new parallel settings,
+wire them from the fast-lane execution path only. Do not change safe-lane plan
+executor semantics in this slice.
+
+## Task 7: Verify, review, commit, and publish
+
+**Files:**
+- Modify only the scoped fast-lane/config/catalog/test/docs files
+
+**Step 1: Run targeted verification**
+
+Run:
+- `cargo test -p loongclaw-app --locked turn_engine_parallel_safe_app_batch_executes_concurrently_in_source_order -- --exact`
+- `cargo test -p loongclaw-app --locked turn_engine_parallel_batch_fails_closed_before_governed_approval -- --exact`
+- `cargo test -p loongclaw-app --locked turn_engine_parallel_batch_fails_closed_before_kernel_binding_error -- --exact`
+- `cargo test -p loongclaw-app --locked provider_shape_discovery_followup_uses_first_lease_in_multiline_source_order -- --exact`
+
+Expected: PASS
+
+**Step 2: Run broader package verification**
+
+Run:
+- `cargo fmt --all`
+- `cargo fmt --all -- --check`
+- `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
+- `cargo test -p loongclaw-app --all-features -- --test-threads=1`
+
+Expected: PASS
+
+**Step 3: Inspect scoped git state**
+
+Run:
+- `git status --short`
+- `git diff --cached --name-only`
+- `git diff --cached`
+
+Expected: only fast-lane parallel batch, config, catalog, tests, and plan/docs
+changes are staged.
+
+**Step 4: Commit and publish**
+
+Commit docs and implementation in scoped commits, push
+`issue-269-parallel-tool-batch-fast-lane`, open a PR, and include
+`Closes #269` in the PR body.


### PR DESCRIPTION
## Summary
- add a fail-closed batch preflight barrier in `TurnEngine` so later approval or kernel-binding blockers stop earlier tool intents from executing
- add opt-in fast-lane parallel tool batch execution for `ParallelSafe` tools with bounded concurrency and source-order finalization
- add conversation config, tool catalog scheduling metadata, compatibility coverage, and design/implementation plan docs for the fast-lane slice

## Testing
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/loongclaw-issue269-direct <redacted-cargo> clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/loongclaw-issue269-direct <redacted-cargo> test -p loongclaw-app --all-features -- --test-threads=1`

Closes #269


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in parallel tool execution in the fast-lane with configurable max in-flight (disabled by default; default = 4; clamped minimum = 1)
  * Tool scheduling classification (ParallelSafe vs SerialOnly) to enable concurrent execution of safe tools
  * Concurrent batch execution preserves source order, uses fail-closed preflight, and emits batch traces and summaries for observability

* **Documentation**
  * Design and implementation plans added for fast-lane parallel batch execution

* **Tests**
  * Extensive regression, integration, and config-template tests covering defaults, clamping, mixed batches, and failure modes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->