### PR TITLE
fix(onboard): finish removing bracket-style default input syntax

### DIFF
--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -47,7 +47,37 @@ pub trait OnboardUi {
         label: &str,
         options: &[SelectOption],
         default: Option<usize>,
-    ) -> CliResult<usize>;
+    ) -> CliResult<usize> {
+        let default = validate_select_one_state(options.len(), default)?;
+        loop {
+            let input = if let Some(default_index) = default {
+                self.prompt_with_default(label, &(default_index + 1).to_string())?
+            } else {
+                self.prompt_required(label)?
+            };
+            let trimmed = input.trim();
+            if let Ok(selected) = trimmed.parse::<usize>()
+                && (1..=options.len()).contains(&selected)
+            {
+                return Ok(selected - 1);
+            }
+            if let Some(index) = options
+                .iter()
+                .position(|option| option.slug.eq_ignore_ascii_case(trimmed))
+            {
+                return Ok(index);
+            }
+            self.print_line(&format!(
+                "invalid selection. enter a number between 1 and {}, or one of: {}",
+                options.len(),
+                options
+                    .iter()
+                    .map(|option| option.slug.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))?;
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -89,7 +119,7 @@ impl OnboardUi for StdioOnboardUi {
     }
 
     fn prompt_with_default(&mut self, label: &str, default: &str) -> CliResult<String> {
-        print!("{label} [{default}]: ");
+        print!("{}", render_prompt_with_default_text(label, default));
         io::stdout()
             .flush()
             .map_err(|error| format!("flush stdout failed: {error}"))?;
@@ -161,7 +191,7 @@ impl OnboardUi for StdioOnboardUi {
             }
             println!();
             let prompt_text = match default {
-                Some(idx) => format!("{label} (default {}):", idx + 1),
+                Some(idx) => render_prompt_with_default_text(label, &(idx + 1).to_string()),
                 None => format!("{label}: "),
             };
             print!("{prompt_text}");
@@ -3467,7 +3497,7 @@ fn render_onboard_option_lines(options: &[OnboardScreenOption], width: usize) ->
         };
         lines.extend(
             mvp::presentation::render_wrapped_text_line_with_continuation(
-                &format!("[{}] ", option.key),
+                &render_onboard_option_prefix(&option.key),
                 "    ",
                 &format!("{}{}", option.label, suffix),
                 width,
@@ -3486,7 +3516,15 @@ fn render_onboard_option_lines(options: &[OnboardScreenOption], width: usize) ->
 }
 
 fn render_default_choice_footer_line(key: &str, description: &str) -> String {
-    format!("press Enter to use [{key}], {description}")
+    format!("press Enter to use default {key}, {description}")
+}
+
+fn render_prompt_with_default_text(label: &str, default: &str) -> String {
+    format!("{label} (default: {default}): ")
+}
+
+fn render_onboard_option_prefix(key: &str) -> String {
+    format!("{key}) ")
 }
 
 fn render_default_input_hint_line(description: impl AsRef<str>) -> String {
@@ -6636,6 +6674,95 @@ mod tests {
             error.contains("default selection index"),
             "invalid default index should be reported clearly: {error}"
         );
+    }
+
+    #[test]
+    fn default_choice_footer_avoids_bracket_default_syntax() {
+        assert_eq!(
+            render_default_choice_footer_line("1", "keep current setup"),
+            "press Enter to use default 1, keep current setup"
+        );
+    }
+
+    #[test]
+    fn prompt_with_default_text_avoids_bracket_default_syntax() {
+        assert_eq!(
+            render_prompt_with_default_text("Setup path", "1"),
+            "Setup path (default: 1): "
+        );
+    }
+
+    #[test]
+    fn render_onboard_option_lines_avoid_bracketed_choice_tokens() {
+        let lines = render_onboard_option_lines(
+            &[OnboardScreenOption {
+                key: "1".to_owned(),
+                label: "Keep current setup".to_owned(),
+                detail_lines: vec!["reuse the detected setup".to_owned()],
+                recommended: true,
+            }],
+            80,
+        );
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("1) Keep current setup (recommended)")),
+            "choice rows should present plain option markers instead of bracket wrappers: {lines:#?}"
+        );
+        assert!(
+            lines.iter().all(|line| !line.contains("[1]")),
+            "choice rows should not imply that brackets are part of the expected input syntax: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn onboard_ui_select_one_default_impl_accepts_slug_input() {
+        struct FallbackSelectUi {
+            input: Option<String>,
+        }
+
+        impl OnboardUi for FallbackSelectUi {
+            fn print_line(&mut self, _line: &str) -> CliResult<()> {
+                Ok(())
+            }
+
+            fn prompt_with_default(&mut self, _label: &str, _default: &str) -> CliResult<String> {
+                Ok(self.input.take().unwrap_or_default())
+            }
+
+            fn prompt_required(&mut self, _label: &str) -> CliResult<String> {
+                Ok(self.input.take().unwrap_or_default())
+            }
+
+            fn prompt_confirm(&mut self, _message: &str, default: bool) -> CliResult<bool> {
+                Ok(default)
+            }
+        }
+
+        let mut ui = FallbackSelectUi {
+            input: Some("friendly_collab".to_owned()),
+        };
+        let options = vec![
+            SelectOption {
+                label: "calm engineering".to_owned(),
+                slug: "calm_engineering".to_owned(),
+                description: String::new(),
+                recommended: true,
+            },
+            SelectOption {
+                label: "friendly collab".to_owned(),
+                slug: "friendly_collab".to_owned(),
+                description: String::new(),
+                recommended: false,
+            },
+        ];
+
+        let index = ui
+            .select_one("Personality", &options, Some(0))
+            .expect("default trait implementation should accept slug input");
+
+        assert_eq!(index, 1);
     }
 
     #[test]

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -56,26 +56,10 @@ pub trait OnboardUi {
                 self.prompt_required(label)?
             };
             let trimmed = input.trim();
-            if let Ok(selected) = trimmed.parse::<usize>()
-                && (1..=options.len()).contains(&selected)
-            {
-                return Ok(selected - 1);
-            }
-            if let Some(index) = options
-                .iter()
-                .position(|option| option.slug.eq_ignore_ascii_case(trimmed))
-            {
+            if let Some(index) = parse_select_one_input(trimmed, options) {
                 return Ok(index);
             }
-            self.print_line(&format!(
-                "invalid selection. enter a number between 1 and {}, or one of: {}",
-                options.len(),
-                options
-                    .iter()
-                    .map(|option| option.slug.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ))?;
+            self.print_line(&render_select_one_invalid_input_message(options))?;
         }
     }
 }
@@ -215,15 +199,10 @@ impl OnboardUi for StdioOnboardUi {
                 println!("Please select an option.");
                 continue;
             }
-            match trimmed.parse::<usize>() {
-                Ok(n) if n >= 1 && n <= options.len() => return Ok(n - 1),
-                _ => {
-                    println!(
-                        "Invalid selection. Enter a number between 1 and {}.",
-                        options.len()
-                    );
-                }
+            if let Some(index) = parse_select_one_input(trimmed, options) {
+                return Ok(index);
             }
+            println!("{}", render_select_one_invalid_input_message(options));
         }
     }
 }
@@ -244,6 +223,29 @@ fn validate_select_one_state(
         ));
     }
     Ok(default)
+}
+
+fn parse_select_one_input(trimmed: &str, options: &[SelectOption]) -> Option<usize> {
+    if let Ok(selected) = trimmed.parse::<usize>()
+        && (1..=options.len()).contains(&selected)
+    {
+        return Some(selected - 1);
+    }
+    options
+        .iter()
+        .position(|option| option.slug.eq_ignore_ascii_case(trimmed))
+}
+
+fn render_select_one_invalid_input_message(options: &[SelectOption]) -> String {
+    format!(
+        "invalid selection. enter a number between 1 and {}, or one of: {}",
+        options.len(),
+        options
+            .iter()
+            .map(|option| option.slug.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
 fn resolve_select_one_eof(default: Option<usize>) -> CliResult<usize> {
@@ -3495,10 +3497,12 @@ fn render_onboard_option_lines(options: &[OnboardScreenOption], width: usize) ->
         } else {
             ""
         };
+        let prefix = render_onboard_option_prefix(&option.key);
+        let continuation = " ".repeat(prefix.chars().count());
         lines.extend(
             mvp::presentation::render_wrapped_text_line_with_continuation(
-                &render_onboard_option_prefix(&option.key),
-                "    ",
+                &prefix,
+                &continuation,
                 &format!("{}{}", option.label, suffix),
                 width,
             ),
@@ -5650,39 +5654,6 @@ mod tests {
             }
             Ok(matches!(value.as_str(), "y" | "yes"))
         }
-
-        fn select_one(
-            &mut self,
-            _label: &str,
-            options: &[SelectOption],
-            default: Option<usize>,
-        ) -> CliResult<usize> {
-            let default = validate_select_one_state(options.len(), default)?;
-            match self.inputs.pop_front() {
-                Some(value) => {
-                    let value = ensure_onboard_input_not_cancelled(value)?;
-                    let trimmed = value.trim();
-                    if trimmed.is_empty() {
-                        return default
-                            .ok_or_else(|| "no default for required selection".to_owned());
-                    }
-                    let n: usize = trimmed
-                        .parse()
-                        .map_err(|_err| format!("invalid test selection input: {trimmed}"))?;
-                    if n >= 1 && n <= options.len() {
-                        Ok(n - 1)
-                    } else {
-                        Err(format!(
-                            "test selection {n} out of range 1..={}",
-                            options.len()
-                        ))
-                    }
-                }
-                None => {
-                    default.ok_or_else(|| "missing test input for required selection".to_owned())
-                }
-            }
-        }
     }
 
     struct BrowserCompanionEnvGuard {
@@ -6717,6 +6688,34 @@ mod tests {
     }
 
     #[test]
+    fn render_onboard_option_lines_align_wrapped_labels_with_option_prefix() {
+        let lines = render_onboard_option_lines(
+            &[OnboardScreenOption {
+                key: "friendly_collab".to_owned(),
+                label: "friendly collab keeps longer wrapped labels aligned".to_owned(),
+                detail_lines: Vec::new(),
+                recommended: false,
+            }],
+            28,
+        );
+        let continuation = lines
+            .iter()
+            .find(|line| line.starts_with(' ') && !line.trim().is_empty())
+            .expect("wrapped option labels should emit a continuation line");
+
+        assert!(
+            continuation.starts_with(
+                &" ".repeat(
+                    render_onboard_option_prefix("friendly_collab")
+                        .chars()
+                        .count()
+                )
+            ),
+            "wrapped option labels should continue under the label text instead of snapping back to a fixed indent: {lines:#?}"
+        );
+    }
+
+    #[test]
     fn onboard_ui_select_one_default_impl_accepts_slug_input() {
         struct FallbackSelectUi {
             input: Option<String>,
@@ -6761,6 +6760,31 @@ mod tests {
         let index = ui
             .select_one("Personality", &options, Some(0))
             .expect("default trait implementation should accept slug input");
+
+        assert_eq!(index, 1);
+    }
+
+    #[test]
+    fn test_onboard_ui_select_one_accepts_slug_input() {
+        let mut ui = TestOnboardUi::with_inputs(["friendly_collab"]);
+        let options = vec![
+            SelectOption {
+                label: "calm engineering".to_owned(),
+                slug: "calm_engineering".to_owned(),
+                description: String::new(),
+                recommended: true,
+            },
+            SelectOption {
+                label: "friendly collab".to_owned(),
+                slug: "friendly_collab".to_owned(),
+                description: String::new(),
+                recommended: false,
+            },
+        ];
+
+        let index = ui
+            .select_one("Personality", &options, Some(0))
+            .expect("test ui should stay aligned with shared slug-selection behavior");
 
         assert_eq!(index, 1);
     }

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -261,17 +261,19 @@ impl loongclaw_daemon::onboard_cli::OnboardUi for ScriptedOnboardUi {
         if trimmed.is_empty() {
             return default.ok_or_else(|| "no default for required selection".to_owned());
         }
-        let n: usize = trimmed
-            .parse()
-            .map_err(|_err| format!("invalid scripted selection input: {trimmed}"))?;
-        if n >= 1 && n <= options.len() {
-            Ok(n - 1)
-        } else {
-            Err(format!(
+        if let Ok(n) = trimmed.parse::<usize>() {
+            if n >= 1 && n <= options.len() {
+                return Ok(n - 1);
+            }
+            return Err(format!(
                 "scripted selection {n} out of range 1..={}",
                 options.len()
-            ))
+            ));
         }
+        options
+            .iter()
+            .position(|option| option.slug.eq_ignore_ascii_case(trimmed))
+            .ok_or_else(|| format!("invalid scripted selection input: {trimmed}"))
     }
 }
 
@@ -391,6 +393,36 @@ fn default_non_interactive_onboard_options(
         system_prompt: None,
         skip_model_probe: false,
     }
+}
+
+#[test]
+fn scripted_onboard_ui_select_one_accepts_slug_input() {
+    let mut ui = ScriptedOnboardUi::new(["friendly_collab"]);
+    let options = vec![
+        loongclaw_daemon::onboard_cli::SelectOption {
+            label: "calm engineering".to_owned(),
+            slug: "calm_engineering".to_owned(),
+            description: String::new(),
+            recommended: true,
+        },
+        loongclaw_daemon::onboard_cli::SelectOption {
+            label: "friendly collab".to_owned(),
+            slug: "friendly_collab".to_owned(),
+            description: String::new(),
+            recommended: false,
+        },
+    ];
+
+    let index = loongclaw_daemon::onboard_cli::OnboardUi::select_one(
+        &mut ui,
+        "Personality",
+        &options,
+        Some(0),
+    )
+    .expect("scripted selection should accept slug input so integration tests stay aligned");
+
+    assert_eq!(index, 1);
+    assert_eq!(ui.transcript(), vec!["SELECT Personality".to_owned()]);
 }
 
 #[test]
@@ -2701,7 +2733,7 @@ fn onboard_entry_screen_compacts_to_plain_wordmark_on_narrow_width() {
         "narrow layout should keep the primary entry choice readable: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line == "    (recommended)"),
+        lines.iter().any(|line| line == "   (recommended)"),
         "narrow layout should still surface the recommendation marker when the longer label wraps: {lines:#?}"
     );
 }
@@ -4070,7 +4102,7 @@ fn onboard_starting_point_selection_screen_wraps_long_option_labels_and_details(
     assert!(
         lines
             .iter()
-            .any(|line| line == "    ~/.codex/agents/loongclaw/config.toml"),
+            .any(|line| line == "   ~/.codex/agents/loongclaw/config.toml"),
         "starting-point screen should continue long option labels on an indented line: {lines:#?}"
     );
     assert!(

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -207,7 +207,8 @@ impl loongclaw_daemon::onboard_cli::OnboardUi for ScriptedOnboardUi {
         label: &str,
         default: &str,
     ) -> loongclaw_daemon::CliResult<String> {
-        self.outputs.push(format!("PROMPT {label} [{default}]"));
+        self.outputs
+            .push(format!("PROMPT {label} (default: {default})"));
         let value = self.next_input(label)?;
         if value.trim().is_empty() {
             return Ok(default.to_owned());
@@ -1684,17 +1685,17 @@ fn onboard_risk_screen_uses_brand_header_and_continue_cancel_options() {
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("[y] Continue onboarding")),
+            .any(|line| line.contains("y) Continue onboarding")),
         "risk screen should show the affirmative path explicitly: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line.contains("[n] Cancel")),
+        lines.iter().any(|line| line.contains("n) Cancel")),
         "risk screen should keep cancellation explicit: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .any(|line| line == "press Enter to use [n], cancel"),
+            .any(|line| line == "press Enter to use default n, cancel"),
         "risk screen should make the safe default explicit on the screen itself: {lines:#?}"
     );
 }
@@ -2655,13 +2656,13 @@ fn onboard_entry_screen_uses_compact_header_and_detected_setup_digest() {
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("[2] Use detected starting point (recommended)")),
+            .any(|line| line.contains("2) Use detected starting point (recommended)")),
         "entry screen should keep the detected-setup path visible and recommended: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .any(|line| line == "press Enter to use [2], the detected starting point"),
+            .any(|line| line == "press Enter to use default 2, the detected starting point"),
         "entry screen should make the recommended default path explicit instead of hiding it only in the prompt default: {lines:#?}"
     );
 }
@@ -2696,7 +2697,7 @@ fn onboard_entry_screen_compacts_to_plain_wordmark_on_narrow_width() {
     assert!(
         lines
             .iter()
-            .any(|line| line == "[1] Use detected starting point"),
+            .any(|line| line == "1) Use detected starting point"),
         "narrow layout should keep the primary entry choice readable: {lines:#?}"
     );
     assert!(
@@ -2993,7 +2994,7 @@ fn onboard_provider_selection_screen_shows_default_enter_choice_when_provider_is
     assert!(
         lines
             .iter()
-            .any(|line| line == "press Enter to use [openai], the OpenAI provider"),
+            .any(|line| line == "press Enter to use default openai, the OpenAI provider"),
         "provider choice screen should make the resolved default provider explicit instead of relying only on the prompt default: {lines:#?}"
     );
 }
@@ -3035,13 +3036,13 @@ fn onboard_provider_selection_screen_uses_profile_ids_for_same_kind_choices() {
     let lines = loongclaw_daemon::onboard_cli::render_provider_selection_screen_lines(&plan, 80);
 
     assert!(
-        lines.iter().any(|line| line == "[openai-gpt-5] OpenAI"),
+        lines.iter().any(|line| line == "openai-gpt-5) OpenAI"),
         "same-kind provider choices should expose the stable profile id instead of only the provider kind: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .any(|line| line == "[openai-o4-mini] OpenAI (recommended)"),
+            .any(|line| line == "openai-o4-mini) OpenAI (recommended)"),
         "only the resolved default profile should be marked recommended when same-kind choices coexist: {lines:#?}"
     );
     assert!(
@@ -3059,7 +3060,7 @@ fn onboard_provider_selection_screen_uses_profile_ids_for_same_kind_choices() {
     assert!(
         lines
             .iter()
-            .any(|line| line == "press Enter to use [openai-o4-mini], the OpenAI provider"),
+            .any(|line| line == "press Enter to use default openai-o4-mini, the OpenAI provider"),
         "the Enter shortcut should point at the concrete default profile id, not only the provider kind: {lines:#?}"
     );
     assert!(
@@ -3317,19 +3318,17 @@ fn onboard_current_setup_shortcut_screen_summarizes_existing_setup_and_choices()
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("[1] Keep current setup (recommended)")),
+            .any(|line| line.contains("1) Keep current setup (recommended)")),
         "current-setup shortcut should make the keep-as-is path primary: {lines:#?}"
     );
     assert!(
-        lines
-            .iter()
-            .any(|line| line.contains("[2] Adjust settings")),
+        lines.iter().any(|line| line.contains("2) Adjust settings")),
         "current-setup shortcut should keep an explicit path into detailed edits: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .any(|line| line == "press Enter to use [1], keep current setup"),
+            .any(|line| line == "press Enter to use default 1, keep current setup"),
         "current-setup shortcut should make the fast-lane default explicit on the screen: {lines:#?}"
     );
 }
@@ -3422,7 +3421,7 @@ fn onboard_detected_setup_shortcut_screen_summarizes_starting_point_and_choices(
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("[1] Use detected starting point (recommended)")),
+            .any(|line| line.contains("1) Use detected starting point (recommended)")),
         "detected-setup shortcut should make the detected fast lane primary: {lines:#?}"
     );
     assert!(
@@ -3438,15 +3437,13 @@ fn onboard_detected_setup_shortcut_screen_summarizes_starting_point_and_choices(
         "detected-setup shortcut should not imply that review is skipped entirely: {lines:#?}"
     );
     assert!(
-        lines
-            .iter()
-            .any(|line| line.contains("[2] Adjust settings")),
+        lines.iter().any(|line| line.contains("2) Adjust settings")),
         "detected-setup shortcut should keep an explicit path into detailed edits: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .any(|line| line == "press Enter to use [1], the detected starting point"),
+            .any(|line| line == "press Enter to use default 1, the detected starting point"),
         "detected-setup shortcut should make the fast-lane default explicit on the screen: {lines:#?}"
     );
 }
@@ -3560,7 +3557,7 @@ fn onboard_starting_point_selection_screen_uses_compact_header_and_detected_opti
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("[1] suggested starting point (recommended)")),
+            .any(|line| line.contains("1) suggested starting point (recommended)")),
         "starting-point screen should promote the suggested starting point first: {lines:#?}"
     );
     assert!(
@@ -3576,7 +3573,7 @@ fn onboard_starting_point_selection_screen_uses_compact_header_and_detected_opti
     assert!(
         lines
             .iter()
-            .any(|line| line == "press Enter to use [1], the suggested starting point"),
+            .any(|line| line == "press Enter to use default 1, the suggested starting point"),
         "starting-point screen should make the default Enter behavior explicit when a suggested starting point is available: {lines:#?}"
     );
 }
@@ -4003,10 +4000,10 @@ fn onboard_starting_point_selection_screen_prioritizes_richer_direct_sources() {
     .join("\n");
 
     let environment_index = joined
-        .find("[1] your current environment")
+        .find("1) your current environment")
         .expect("environment option should render first when it covers more setup domains");
     let codex_index = joined
-        .find("[2] Codex config at ~/.codex/config.toml")
+        .find("2) Codex config at ~/.codex/config.toml")
         .expect("codex option should render after the richer environment candidate");
 
     assert!(
@@ -4039,10 +4036,10 @@ fn onboard_starting_point_selection_screen_prefers_explicit_config_sources_when_
     .join("\n");
 
     let codex_index = joined
-        .find("[1] Codex config at ~/.codex/config.toml")
+        .find("1) Codex config at ~/.codex/config.toml")
         .expect("codex option should render first when direct-source coverage is tied");
     let environment_index = joined
-        .find("[2] your current environment")
+        .find("2) your current environment")
         .expect("environment option should render after codex when coverage is tied");
 
     assert!(
@@ -4067,7 +4064,7 @@ fn onboard_starting_point_selection_screen_wraps_long_option_labels_and_details(
         loongclaw_daemon::onboard_cli::render_starting_point_selection_screen_lines(&[codex], 48);
 
     assert!(
-        lines.iter().any(|line| line == "[1] Codex config at"),
+        lines.iter().any(|line| line == "1) Codex config at"),
         "starting-point screen should wrap long option labels instead of overflowing them: {lines:#?}"
     );
     assert!(
@@ -4706,23 +4703,23 @@ fn onboard_existing_config_write_screen_offers_replace_backup_and_cancel() {
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("[o] Replace existing config")),
+            .any(|line| line.contains("o) Replace existing config")),
         "existing-config write screen should keep the replace path visible: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("[b] Create backup and replace")),
+            .any(|line| line.contains("b) Create backup and replace")),
         "existing-config write screen should keep the safer backup path visible: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line.contains("[c] Cancel")),
+        lines.iter().any(|line| line.contains("c) Cancel")),
         "existing-config write screen should keep cancellation explicit: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .any(|line| line == "press Enter to use [c], cancel"),
+            .any(|line| line == "press Enter to use default c, cancel"),
         "existing-config write screen should make the safe default explicit on the screen itself: {lines:#?}"
     );
 }
@@ -4783,19 +4780,17 @@ fn onboard_preflight_screen_summarizes_status_counts_and_guidance() {
         "preflight screen should explain the decision context when warnings or failures exist: {lines:#?}"
     );
     assert!(
-        lines
-            .iter()
-            .any(|line| line.contains("[y] Continue anyway")),
+        lines.iter().any(|line| line.contains("y) Continue anyway")),
         "preflight screen should show the continue path explicitly when attention is still required: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line.contains("[n] Cancel")),
+        lines.iter().any(|line| line.contains("n) Cancel")),
         "preflight screen should keep the cancel path explicit when checks are not green: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .any(|line| line == "press Enter to use [n], cancel"),
+            .any(|line| line == "press Enter to use default n, cancel"),
         "preflight screen should make the safe default explicit when attention is still required: {lines:#?}"
     );
     assert!(
@@ -4821,17 +4816,17 @@ fn onboard_preflight_screen_omits_continue_cancel_choices_when_all_checks_are_gr
     assert!(
         lines
             .iter()
-            .all(|line| !line.contains("[y] Continue anyway")),
+            .all(|line| !line.contains("y) Continue anyway")),
         "fully green preflight should not render a continue-anyway choice that will never be asked: {lines:#?}"
     );
     assert!(
-        lines.iter().all(|line| !line.contains("[n] Cancel")),
+        lines.iter().all(|line| !line.contains("n) Cancel")),
         "fully green preflight should not render a cancellation choice that does not apply on this screen: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .all(|line| line.as_str() != "press Enter to use [n], cancel"),
+            .all(|line| line.as_str() != "press Enter to use default n, cancel"),
         "fully green preflight should not show a default-cancel hint when the flow proceeds automatically: {lines:#?}"
     );
 }
@@ -4941,13 +4936,13 @@ fn onboard_write_confirmation_screen_shows_target_path_and_write_choice() {
         "write-confirm screen should remind users when they are writing despite warnings: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line.contains("[y] Write config")),
+        lines.iter().any(|line| line.contains("y) Write config")),
         "write-confirm screen should show the affirmative path explicitly: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .any(|line| line == "press Enter to use [y], write config"),
+            .any(|line| line == "press Enter to use default y, write config"),
         "write-confirm screen should make the default write action explicit instead of relying only on the prompt suffix: {lines:#?}"
     );
 }
@@ -5240,7 +5235,7 @@ requires_openai_auth = true
 
     let joined = transcript.join("\n");
     assert!(
-        joined.contains("[2] Codex config at"),
+        joined.contains("2) Codex config at"),
         "the Codex candidate should remain selectable by the same index it shows on screen: {transcript:#?}"
     );
     assert!(

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -4455,8 +4455,12 @@ fn onboard_personality_selection_screen_shows_native_personality_choices() {
         "personality screen should surface the native prompt-pack progress step: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line.contains("[friendly_collab]")),
-        "personality screen should show the canonical friendly_collab selector: {lines:#?}"
+        lines.iter().any(|line| line.contains("friendly_collab)")),
+        "personality screen should keep the canonical friendly_collab selector visible without bracket syntax: {lines:#?}"
+    );
+    assert!(
+        lines.iter().all(|line| !line.contains("[friendly_collab]")),
+        "personality screen should not imply that brackets are part of the expected selector syntax: {lines:#?}"
     );
 }
 
@@ -4512,8 +4516,14 @@ fn onboard_memory_profile_screen_shows_supported_profiles() {
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("[profile_plus_window]")),
-        "memory-profile screen should show the canonical profile_plus_window selector: {lines:#?}"
+            .any(|line| line.contains("profile_plus_window)")),
+        "memory-profile screen should keep the canonical profile_plus_window selector visible without bracket syntax: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .all(|line| !line.contains("[profile_plus_window]")),
+        "memory-profile screen should not imply that brackets are part of the expected selector syntax: {lines:#?}"
     );
 }
 


### PR DESCRIPTION
## summary

- carry forward the numbered-selection and stdin-drain baseline from #260
- remove the remaining bracket-style default syntax from shared onboarding prompts, option lists, and default footer hints
- keep selector parsing aligned across the shared `OnboardUi` default path, the stdio ui, and the scripted test helpers so slug-based input stays consistent
- align wrapped option continuations with the rendered option prefix width and extend regression coverage for the narrow-width layout

## validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p loongclaw-daemon`

## traceability

- closes #248
- related: #247
- follow-up to #260
- compatible with #273, which continues the deeper multiline prompt-capture hardening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding selections now accept option slugs (case-insensitive) as well as numeric choices; empty input still uses the default.

* **UI/Style**
  * Prompts and option lines reformatted to show default text and plain numeric prefixes for clearer readability.

* **Tests**
  * Added and updated tests validating slug-based selection and the revised prompt/option wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->